### PR TITLE
Add PATH_INFO CGI variable to nginx config.

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/sites-enabled/nginx-site-default.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/sites-enabled/nginx-site-default.conf
@@ -39,6 +39,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;


### PR DESCRIPTION
## The Problem/Issue/Bug:

When using SimpleSAMLphp inside a ddev project with nginx, it crashes because it cannot find the `$_SERVER['PATH_INFO']` variable, which is expected to be set. This is documented at https://simplesamlphp.org/docs/1.17/simplesamlphp-install#configuring-nginx

## How this PR Solves The Problem:

The `PATH_INFO` variable will be passed from nginx to PHP.

This should have no side effects on other platforms as they don't use the `PATH_INFO` variable

## Manual Testing Instructions:

Check `phpinfo();` after applying the fix to see that `$_SERVER['PATH_INFO']` is present and correct in the PHP Variables section

(or set up SimpleSAMLphp inside a ddev project, but that is non trivial)

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

#3854

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4001"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

