### PR TITLE
Enclose exported environment variable values with quotes, fixes #3499

### DIFF
--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -424,34 +424,51 @@ func (p *Provider) Read(configPath string) error {
 		return err
 	}
 
+	// Convert yaml file byte slice into string for easier handling
 	s := string(source)
 
+	// Check for double-quoted values
 	r := regexp.MustCompile(`:\ *".*?"`)
 	quotedVarMatches := r.FindAllStringSubmatch(s, -1)
 	if len(quotedVarMatches) > 0 {
+
+		// Enclose found double-quoted values with single quotes
 		for _, v := range quotedVarMatches {
+			// Convert string slice of match into string
 			qvm := strings.Join(v, "")
+			// Find first and last double quotes in the matched value
 			i := strings.Index(qvm, "\"")
 			li := strings.LastIndex(qvm, "\"")
+			// Add single quotes around double-quoted value
 			enclosedQuotes := qvm[:i] + strings.Replace(qvm[i:], "\"", "'\"", 1)
 			enclosedQuotes = enclosedQuotes + strings.Replace(qvm[li:], "\"", "'", 1)
 
+			// Replace old matched value with new enclosed value in the string holding the yaml
 			s = strings.Replace(s, qvm, enclosedQuotes, 1)
 		}
 	} else {
+		// Check for single-quoted values
 		r := regexp.MustCompile(`:\ *'.*?'`)
 		quotedVarMatches = r.FindAllStringSubmatch(s, -1)
+
+		// Enclose found single-quoted values with double quotes
 		for _, v := range quotedVarMatches {
+			// Convert string slice of match into string
 			qvm := strings.Join(v, "")
+			// Find first and last single quotes in the matched value
 			i := strings.Index(qvm, "'")
 			li := strings.LastIndex(qvm, "'")
+			// Add double quotes around single-quoted value
 			enclosedQuotes := qvm[:i] + strings.Replace(qvm[i:], "'", "\"'", 1)
 			enclosedQuotes = enclosedQuotes + strings.Replace(qvm[li:], "'", "\"", 1)
 
+			// Replace old matched value with new enclosed value in the string holding the yaml
 			s = strings.Replace(s, qvm, enclosedQuotes, 1)
 		}
 	}
 
+	// Take the updated string holding the yaml
+	// Convert it into a byte slice and replace back into the source to be parsed/unmarshalled
 	source = []byte(s)
 
 	// Read config values from file.

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -489,7 +489,7 @@ func (p *Provider) injectedEnvironment() string {
 	if len(p.EnvironmentVariables) > 0 {
 		s = "export "
 		for k, v := range p.EnvironmentVariables {
-			s = s + fmt.Sprintf(" %s=\"%s\" ", k, v)
+			s = s + fmt.Sprintf(" %s=%s ", k, v)
 		}
 	}
 	return s

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/drud/ddev/pkg/output"
+
 	"fmt"
 
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -440,7 +442,7 @@ func (p *Provider) injectedEnvironment() string {
 	if len(p.EnvironmentVariables) > 0 {
 		s = "export "
 		for k, v := range p.EnvironmentVariables {
-			s = s + fmt.Sprintf(" %s=%s ", k, v)
+			s = s + fmt.Sprintf(" %s=\"%s\" ", k, v)
 		}
 	}
 	return s

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -1,15 +1,13 @@
 package ddevapp
 
 import (
-	"github.com/ddev/ddev/pkg/output"
 	"fmt"
+	"github.com/ddev/ddev/pkg/output"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
-	"github.com/drud/ddev/pkg/fileutil"
-	"github.com/drud/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/util"
 

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -9,11 +9,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/drud/ddev/pkg/output"
-
-	"fmt"
-
 	"github.com/drud/ddev/pkg/fileutil"
+	"github.com/drud/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/util"
 

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -2,15 +2,14 @@ package ddevapp
 
 import (
 	"github.com/ddev/ddev/pkg/output"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/drud/ddev/pkg/fileutil"
 	"github.com/drud/ddev/pkg/output"
-
-	"fmt"
-
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/util"
 

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/drud/ddev/pkg/fileutil"
@@ -421,53 +420,6 @@ func (p *Provider) Read(configPath string) error {
 		return err
 	}
 
-	// Convert yaml file byte slice into string for easier handling
-	s := string(source)
-
-	// Check for double-quoted values
-	r := regexp.MustCompile(`:\ *".*?"`)
-	quotedVarMatches := r.FindAllStringSubmatch(s, -1)
-	if len(quotedVarMatches) > 0 {
-
-		// Enclose found double-quoted values with single quotes
-		for _, v := range quotedVarMatches {
-			// Convert string slice of match into string
-			qvm := strings.Join(v, "")
-			// Find first and last double quotes in the matched value
-			i := strings.Index(qvm, "\"")
-			li := strings.LastIndex(qvm, "\"")
-			// Add single quotes around double-quoted value
-			enclosedQuotes := qvm[:i] + strings.Replace(qvm[i:], "\"", "'\"", 1)
-			enclosedQuotes = enclosedQuotes + strings.Replace(qvm[li:], "\"", "'", 1)
-
-			// Replace old matched value with new enclosed value in the string holding the yaml
-			s = strings.Replace(s, qvm, enclosedQuotes, 1)
-		}
-	} else {
-		// Check for single-quoted values
-		r := regexp.MustCompile(`:\ *'.*?'`)
-		quotedVarMatches = r.FindAllStringSubmatch(s, -1)
-
-		// Enclose found single-quoted values with double quotes
-		for _, v := range quotedVarMatches {
-			// Convert string slice of match into string
-			qvm := strings.Join(v, "")
-			// Find first and last single quotes in the matched value
-			i := strings.Index(qvm, "'")
-			li := strings.LastIndex(qvm, "'")
-			// Add double quotes around single-quoted value
-			enclosedQuotes := qvm[:i] + strings.Replace(qvm[i:], "'", "\"'", 1)
-			enclosedQuotes = enclosedQuotes + strings.Replace(qvm[li:], "'", "\"", 1)
-
-			// Replace old matched value with new enclosed value in the string holding the yaml
-			s = strings.Replace(s, qvm, enclosedQuotes, 1)
-		}
-	}
-
-	// Take the updated string holding the yaml
-	// Convert it into a byte slice and replace back into the source to be parsed/unmarshalled
-	source = []byte(s)
-
 	// Read config values from file.
 	err = yaml.Unmarshal(source, &p.ProviderInfo)
 	if err != nil {
@@ -487,8 +439,9 @@ func (p *Provider) Validate() error {
 func (p *Provider) injectedEnvironment() string {
 	s := "true"
 	if len(p.EnvironmentVariables) > 0 {
-		s = "export "
+		s = "export"
 		for k, v := range p.EnvironmentVariables {
+			v = strings.Replace(v, " ", "\\ ", -1)
 			s = s + fmt.Sprintf(" %s=%s ", k, v)
 		}
 	}

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -492,7 +492,7 @@ func (p *Provider) injectedEnvironment() string {
 	if len(p.EnvironmentVariables) > 0 {
 		s = "export "
 		for k, v := range p.EnvironmentVariables {
-			s = s + fmt.Sprintf(" %s=%s ", k, v)
+			s = s + fmt.Sprintf(" %s=\"%s\" ", k, v)
 		}
 	}
 	return s

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -439,7 +439,7 @@ func (p *Provider) injectedEnvironment() string {
 	if len(p.EnvironmentVariables) > 0 {
 		s = "export"
 		for k, v := range p.EnvironmentVariables {
-			v = strings.Replace(v, " ", "\\ ", -1)
+			v = strings.Replace(v, " ", `\ `, -1)
 			s = s + fmt.Sprintf(" %s=%s ", k, v)
 		}
 	}


### PR DESCRIPTION
## The Issue
Environment variables are exported inline with no delimiter between one value and the next variable.

## How This PR Solves The Issue
Encloses variable values with quotes to note beginning and end of values.

## Manual Testing Instructions

- Create a custom provider configuration

```
environment_variables:
  test: "variable with spaces"

auth_command:
  command: |
    set -eu -o pipefail

db_pull_command:
  command: |
    # set -x # You can enable bash debugging output by uncommenting
    set -eu -o pipefail
    echo ${test}

files_pull_command:
  command: |
    # set -x   # You can enable bash debugging output by uncommenting
    set -eu -o pipefail
    echo ${test}
  service: web
```

- Add a variable (as above) which contains a space in the value
- Echo the variable in a command (as above)
- Run with `ddev pull test -y --skip-import`

### Expected behavior
The complete string should be available in the bash commands

```
Authenticating... 
Obtaining database... 
variable with spaces
Skipping database import. 
Obtaining files... 
variable with spaces
Skipping files import. 
Pull succeeded. 
```

## Automated Testing Overview
None.

## Related Issue Link(s)
#3499




<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4594"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4594"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

