### PR TITLE
project type filter for `ddev list` command (`ddev list --type=`)

### DIFF
--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -15,7 +15,9 @@ var ListCmd = &cobra.Command{
 	Aliases: []string{"l", "ls"},
 	Example: `ddev list
 ddev list --active-only
-ddev list -A`,
+ddev list -A
+ddev list --type=drupal8
+ddev list -t drupal8`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ddevapp.List(listCommandSettings)
 	},

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -5,17 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// continuous, if set, makes list continuously output
-var continuous bool
-
-// activeOnly, if set, shows only running projects
-var activeOnly bool
-
-// continuousSleepTime is time to sleep between reads with --continuous
-var continuousSleepTime = 1
-
-// wrapListTable allow that the text in the table of ddev list wraps instead of cutting it to fit the terminal width
-var wrapListTableText bool
+var ListCommandSettings = ddevapp.ListCommandSettings{}
 
 // ListCmd represents the list command
 var ListCmd = &cobra.Command{
@@ -27,15 +17,16 @@ var ListCmd = &cobra.Command{
 ddev list --active-only
 ddev list -A`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ddevapp.List(activeOnly, continuous, wrapListTableText, continuousSleepTime)
+		ddevapp.List(ListCommandSettings)
 	},
 }
 
 func init() {
-	ListCmd.Flags().BoolVarP(&activeOnly, "active-only", "A", false, "If set, only currently active projects will be displayed.")
-	ListCmd.Flags().BoolVarP(&continuous, "continuous", "", false, "If set, project information will be emitted until the command is stopped.")
-	ListCmd.Flags().BoolVarP(&wrapListTableText, "wrap-table", "W", false, "Display table with wrapped text if required.")
-	ListCmd.Flags().IntVarP(&continuousSleepTime, "continuous-sleep-interval", "I", 1, "Time in seconds between ddev list --continuous output lists.")
+	ListCmd.Flags().BoolVarP(&ListCommandSettings.ActiveOnly, "active-only", "A", false, "If set, only currently active projects will be displayed.")
+	ListCmd.Flags().BoolVarP(&ListCommandSettings.Continuous, "continuous", "", false, "If set, project information will be emitted until the command is stopped.")
+	ListCmd.Flags().BoolVarP(&ListCommandSettings.WrapTableText, "wrap-table", "W", false, "Display table with wrapped text if required.")
+	ListCmd.Flags().StringVarP(&ListCommandSettings.TypeFilter, "type", "t", "", "Show only projects of this type")
+	ListCmd.Flags().IntVarP(&ListCommandSettings.ContinuousSleepTime, "continuous-sleep-interval", "I", 1, "Time in seconds between ddev list --continuous output lists.")
 
 	RootCmd.AddCommand(ListCmd)
 }

--- a/cmd/ddev/cmd/list.go
+++ b/cmd/ddev/cmd/list.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var ListCommandSettings = ddevapp.ListCommandSettings{}
+var listCommandSettings = ddevapp.ListCommandSettings{}
 
 // ListCmd represents the list command
 var ListCmd = &cobra.Command{
@@ -17,16 +17,16 @@ var ListCmd = &cobra.Command{
 ddev list --active-only
 ddev list -A`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ddevapp.List(ListCommandSettings)
+		ddevapp.List(listCommandSettings)
 	},
 }
 
 func init() {
-	ListCmd.Flags().BoolVarP(&ListCommandSettings.ActiveOnly, "active-only", "A", false, "If set, only currently active projects will be displayed.")
-	ListCmd.Flags().BoolVarP(&ListCommandSettings.Continuous, "continuous", "", false, "If set, project information will be emitted until the command is stopped.")
-	ListCmd.Flags().BoolVarP(&ListCommandSettings.WrapTableText, "wrap-table", "W", false, "Display table with wrapped text if required.")
-	ListCmd.Flags().StringVarP(&ListCommandSettings.TypeFilter, "type", "t", "", "Show only projects of this type")
-	ListCmd.Flags().IntVarP(&ListCommandSettings.ContinuousSleepTime, "continuous-sleep-interval", "I", 1, "Time in seconds between ddev list --continuous output lists.")
+	ListCmd.Flags().BoolVarP(&listCommandSettings.ActiveOnly, "active-only", "A", false, "If set, only currently active projects will be displayed.")
+	ListCmd.Flags().BoolVarP(&listCommandSettings.Continuous, "continuous", "", false, "If set, project information will be emitted until the command is stopped.")
+	ListCmd.Flags().BoolVarP(&listCommandSettings.WrapTableText, "wrap-table", "W", false, "Display table with wrapped text if required.")
+	ListCmd.Flags().StringVarP(&listCommandSettings.TypeFilter, "type", "t", "", "Show only projects of this type")
+	ListCmd.Flags().IntVarP(&listCommandSettings.ContinuousSleepTime, "continuous-sleep-interval", "I", 1, "Time in seconds between ddev list --continuous output lists.")
 
 	RootCmd.AddCommand(ListCmd)
 }

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -85,6 +85,18 @@ func TestCmdList(t *testing.T) {
 
 	}
 
+	// Now filter the list by the type of the first running test app
+	jsonOut, err = exec.RunHostCommand(DdevBin, "list", "-j", "--type", TestSites[0].Type)
+	assert.NoError(err, "error running ddev list: %v output=%s", err, out)
+	siteList = getTestingSitesFromList(t, jsonOut)
+	assert.GreaterOrEqual(len(siteList), 1)
+
+	// Now filter the list by a not existing type
+	jsonOut, err = exec.RunHostCommand(DdevBin, "list", "-j", "--type", "not-existing-type")
+	assert.NoError(err, "error running ddev list: %v output=%s", err, out)
+	siteList = getTestingSitesFromList(t, jsonOut)
+	assert.Equal(0, len(siteList))
+
 	// Stop the first app
 	out, err = exec.RunHostCommand(DdevBin, "stop", TestSites[0].Name)
 	assert.NoError(err, "error running ddev stop %v: %v output=%s", TestSites[0].Name, err, out)
@@ -102,12 +114,6 @@ func TestCmdList(t *testing.T) {
 	assert.NoError(err, "error running ddev list: %v output=%s", err, out)
 	siteList = getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(TestSites), len(siteList))
-
-	// Now filter the list by a not existing type
-	jsonOut, err = exec.RunHostCommand(DdevBin, "list", "-j", "--type", "not-existing-type")
-	assert.NoError(err, "error running ddev list: %v output=%s", err, out)
-	siteList = getTestingSitesFromList(t, jsonOut)
-	assert.Equal(0, len(siteList))
 
 	// Leave firstApp running for other tests
 	out, err = exec.RunHostCommand(DdevBin, "start", "-y", TestSites[0].Name)

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -103,6 +103,12 @@ func TestCmdList(t *testing.T) {
 	siteList = getTestingSitesFromList(t, jsonOut)
 	assert.Equal(len(TestSites), len(siteList))
 
+	// Now filter the list by a not existing type
+	jsonOut, err = exec.RunHostCommand(DdevBin, "list", "-j", "--type", "not-existing-type")
+	assert.NoError(err, "error running ddev list: %v output=%s", err, out)
+	siteList = getTestingSitesFromList(t, jsonOut)
+	assert.Equal(0, len(siteList))
+
 	// Leave firstApp running for other tests
 	out, err = exec.RunHostCommand(DdevBin, "start", "-y", TestSites[0].Name)
 	assert.NoError(err, "error running ddev start: %v output=%s", err, out)

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -718,7 +718,7 @@ ddev list
 # List all running projects
 ddev list --active-only
 
-# List all wordpress
+# List all WordPress projects
 ddev list --type wordpress
 ```
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -706,6 +706,7 @@ Flags:
 * `--active-only`, `-A`: If set, only currently active projects will be displayed.
 * `--continuous`: If set, project information will be emitted until the command is stopped.
 * `--continuous-sleep-interval`, `-I`: Time in seconds between `ddev list --continuous` output lists. (default `1`)
+* `--type`, `-t`: Show only projects of this type (e.g. `drupal8`, `wordpress`, `php`).
 * `--wrap-table`, `-W`: Display table with wrapped text if required.
 
 Example:
@@ -716,6 +717,9 @@ ddev list
 
 # List all running projects
 ddev list --active-only
+
+# List all wordpress
+ddev list --type wordpress
 ```
 
 ## `logs`

--- a/pkg/ddevapp/list_test.go
+++ b/pkg/ddevapp/list_test.go
@@ -104,5 +104,11 @@ func TestListWithoutDir(t *testing.T) {
 // TestDdevList tests the ddevapp.List() functionality
 // It's only here for profiling at this point.
 func TestDdevList(_ *testing.T) {
-	ddevapp.List(true, false, true, 1)
+	ddevapp.List(ddevapp.ListCommandSettings{
+		ActiveOnly:          true,
+		Continuous:          false,
+		WrapTableText:       true,
+		ContinuousSleepTime: 1,
+		TypeFilter:          "",
+	})
 }

--- a/pkg/ddevapp/project.go
+++ b/pkg/ddevapp/project.go
@@ -1,0 +1,1 @@
+package ddevapp


### PR DESCRIPTION
## The Issue
As a user of many different local installed ddev projects I want to filter the `ddev list` output. Currently we have the `only-active` flag available.
Additionally we could filter by project type.

## How This PR Solves The Issue
The PR restructures the parameters of the list command into a struct. This prepares the command to get additional filters in the future like tags.

## Manual Testing Instructions
Run the `ddev list` command with new filter option `-t` or `--type` and set a project type

Example: `ddev list -t php` or `ddev list -t magento2`.

The filter can be combined with active only filter. 
`ddev list -A -t php`

## Automated Testing Overview
I added a simple test which filters by a not existing type. Currently I am looking for a good way to test also the project type filter by an existing type.



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/4613"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4613"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

