### PR TITLE
Set laravel PHP default to 8.1, fixes #4651

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -202,7 +202,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
             mkdir my-laravel-app
             cd my-laravel-app
             ddev config --project-type=laravel --docroot=public --create-docroot --php-version=8.1
-            ddev composer create --prefer-dist --no-install --no-scripts laravel/laravel
+            ddev composer create --prefer-dist --no-install --no-scripts laravel/laravel -y
             ddev composer install
             ddev exec "php artisan key:generate"
             ddev launch

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -201,7 +201,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
             ```bash
             mkdir my-laravel-app
             cd my-laravel-app
-            ddev config --project-type=laravel --docroot=public --create-docroot
+            ddev config --project-type=laravel --docroot=public --create-docroot --php-version=8.1
             ddev composer create --prefer-dist --no-install --no-scripts laravel/laravel
             ddev composer install
             ddev exec "php artisan key:generate"
@@ -211,7 +211,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
             ```bash
             git clone <your-laravel-repo>
             cd <your-laravel-project>
-            ddev config --project-type=laravel --docroot=public --create-docroot
+            ddev config --project-type=laravel --docroot=public --create-docroot --php-version=8.1
             ddev start
             ddev composer install
             ddev exec "php artisan key:generate"

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -93,7 +93,7 @@ func init() {
 		},
 
 		nodeps.AppTypeLaravel: {
-			appTypeDetect: isLaravelApp, postStartAction: laravelPostStartAction, configOverrideAction: nil,
+			appTypeDetect: isLaravelApp, postStartAction: laravelPostStartAction, configOverrideAction: laravelConfigOverrideAction,
 		},
 
 		nodeps.AppTypeMagento: {

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -69,7 +69,7 @@ func TestPostConfigAction(t *testing.T) {
 		nodeps.AppTypeDrupal8:   nodeps.PHP74,
 		nodeps.AppTypeDrupal9:   nodeps.PHPDefault,
 		nodeps.AppTypeDrupal10:  nodeps.PHP81,
-		nodeps.AppTypeLaravel:   nodeps.PHPDefault,
+		nodeps.AppTypeLaravel:   nodeps.PHP81,
 		nodeps.AppTypeMagento:   nodeps.PHP74,
 		nodeps.AppTypeMagento2:  nodeps.PHP81,
 		nodeps.AppTypeWordPress: nodeps.PHPDefault,

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -188,9 +188,9 @@ var (
 			FullSiteTarballURL:            "",
 			Type:                          nodeps.AppTypeLaravel,
 			Docroot:                       "public",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/", Expect: "Laravel Components"},
-			DynamicURI:                    testcommon.URIWithExpect{URI: "/api/status-code/200", Expect: "indicates that the request has succeeded."},
-			FilesImageURI:                 "/images/200.jpg",
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/", Expect: "Laravel News"},
+			//DynamicURI:                    testcommon.URIWithExpect{URI: "/api/status-code/200", Expect: "indicates that the request has succeeded."},
+			FilesImageURI: "/images/200.jpg",
 		},
 		// 10: shopware6
 		{

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -179,18 +179,18 @@ var (
 		// 9: laravel
 		{
 			Name:                          "TestPkgLaravel",
-			SourceURL:                     "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/ddev-lumen-testapp.tar.gz",
-			ArchiveInternalExtractionPath: "ddev-lumen-testapp/",
+			SourceURL:                     "https://github.com/ddev/test-laravel/archive/refs/tags/10.0.5.2.tar.gz",
+			ArchiveInternalExtractionPath: "test-laravel-10.0.5.2/",
 			FilesTarballURL:               "",
 			FilesZipballURL:               "",
-			DBTarURL:                      "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/ddev-lumen-testapp_sql.tar.gz",
-			DBZipURL:                      "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/ddev-lumen-testapp_sql.zip",
+			DBTarURL:                      "https://github.com/ddev/test-laravel/releases/download/10.0.5.2/db.sql.tar.gz",
+			DBZipURL:                      "",
 			FullSiteTarballURL:            "",
 			Type:                          nodeps.AppTypeLaravel,
 			Docroot:                       "public",
-			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/", Expect: "Laravel News"},
-			//DynamicURI:                    testcommon.URIWithExpect{URI: "/api/status-code/200", Expect: "indicates that the request has succeeded."},
-			FilesImageURI: "/images/200.jpg",
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/static/", Expect: "This is a static HTML page"},
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "Second message"},
+			FilesImageURI:                 "/static/sample-1.jpg",
 		},
 		// 10: shopware6
 		{

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -64,3 +64,9 @@ func laravelPostStartAction(app *DdevApp) error {
 
 	return nil
 }
+
+// laravelConfigOverrideAction overrides php_version for laravel, requires PHP8.1
+func laravelConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP81
+	return nil
+}


### PR DESCRIPTION
## The Issue

Laravel 10 requires PHP 8.1:
* #4651 

## How This PR Solves The Issue

* Change default version in code
* For now, change docs to show explicit --php-version

## Manual Testing Instructions

* Test with laravel
* Test quickstart



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4653"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

