### PR TITLE
Don't override project type php by detected app, fixes #4403

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -443,7 +443,7 @@ func handleMainConfigArgs(cmd *cobra.Command, args []string, app *ddevapp.DdevAp
 	}
 
 	switch {
-	case (app.Type == "" || app.Type == nodeps.AppTypePHP) && (projectTypeArg == "" || projectTypeArg == detectedApptype): // Found an app, matches passed-in or no apptype passed
+	case (app.Type == "") && (projectTypeArg == "" || projectTypeArg == detectedApptype): // Found an app, matches passed-in or no apptype passed
 		projectTypeArg = detectedApptype
 		app.Type = projectTypeArg
 		if app.Type == nodeps.AppTypePHP {


### PR DESCRIPTION
## The Issue

* #4403 
* DDEV's config command will override project type "php" if any app like WordPress or Drupal is detected.

## How This PR Solves The Issue

As suggested in #4403 it applies the detected app type only if there is no type specified yet.

## Manual Testing Instructions

–

## Automated Testing Overview

`TestConfigMaintainProjectTypePhp` creates a common DDEV project with type "php" and creates a `{DOC_ROOT}/wp-settings.php` file to mimic a WordPress installation. Then it runs a `ddev config` command to change an arbitrary value (the PHP version in this case) and finally verifies that the project type is still set to "php".


## Related Issue Link(s)

* #1919
* #4403

## Release/Deployment Notes

–

