### PR TITLE
Drupal: Enable verbose error logging

### DIFF
--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -52,3 +52,6 @@ $config['symfony_mailer.mailer_transport.sendmail']['configuration']['user']='';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['pass']='';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['host']='localhost';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['port']='1025';
+
+// Tell Drupal to provide verbose error logs.
+$config['system.logging']['error_level'] = 'verbose';

--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -53,5 +53,6 @@ $config['symfony_mailer.mailer_transport.sendmail']['configuration']['pass']='';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['host']='localhost';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['port']='1025';
 
-// Tell Drupal to provide verbose error logs.
+// Enable verbose logging for errors.
+// https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode
 $config['system.logging']['error_level'] = 'verbose';

--- a/pkg/ddevapp/drupal/drupal7/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal7/settings.ddev.php
@@ -29,3 +29,7 @@ $databases['default']['default'] = array(
 );
 
 $drupal_hash_salt = '{{ $config.HashSalt }}';
+
+// Enable verbose logging for errors.
+// https://www.drupal.org/docs/7/creating-custom-modules/show-all-errors-while-developing
+$conf['error_level'] = 2;

--- a/pkg/ddevapp/drupal/drupal8/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal8/settings.ddev.php
@@ -61,3 +61,6 @@ $config['swiftmailer.transport']['smtp_host'] = '127.0.0.1';
 $config['swiftmailer.transport']['smtp_port'] = '1025';
 $config['swiftmailer.transport']['smtp_encryption'] = '0';
 
+// Enable verbose logging for errors.
+// https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode
+$config['system.logging']['error_level'] = 'verbose';

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -58,3 +58,7 @@ $config['swiftmailer.transport']['transport'] = 'smtp';
 $config['swiftmailer.transport']['smtp_host'] = '127.0.0.1';
 $config['swiftmailer.transport']['smtp_port'] = '1025';
 $config['swiftmailer.transport']['smtp_encryption'] = '0';
+
+// Enable verbose logging for errors.
+// https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode
+$config['system.logging']['error_level'] = 'verbose';


### PR DESCRIPTION
This change updates the settings to have the system logging error level set to verbose to ensure errors are a bit more clear.

## The Issue

By default, Drupal set up through DDEV will not provide clear messages when an error occurs.

## How This PR Solves The Issue

This changes the error_level to be verbose so Drupal reports something a bit more clear.

## Manual Testing Instructions

Install Drupal with DDEV. Run it.

## Automated Testing Overview

No automated testing needed here.

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4689"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

