### PR TITLE
improve tableplus connection view

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -14,7 +14,7 @@ driver=mysql
 if [[ $dbtype == "postgres" ]]; then
     driver=$dbtype
 fi
-query="${driver}://db:db@127.0.0.1:${DDEV_HOST_DB_PORT}/db"
+query="${driver}://db:db@127.0.0.1:${DDEV_HOST_DB_PORT}/db?statusColor=00325a&enviroment=DDEV"
 
 set -x
 open "$query" -a "/Applications/TablePlus.app/Contents/MacOS/TablePlus"


### PR DESCRIPTION
with latest tableplus version a connection label and color will be shown prominently in the header bar. By default it is gray and shows "PRODUCTION" for these ddev connections.

This change labels them as "DDEV" and sets the color to ddev's key color so you don't get confused whether it's a PROD connection or a DDEV connection.

See example: ![ddev tableplus](https://r.b71a.de/Igz6FHB7.png)

Reference: https://twitter.com/TablePlus/status/1631300835530665985?s=20





<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4692"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

