### PR TITLE
Improve .editorconfig [skip ci]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,8 +5,16 @@ root = true
 
 # Unix-style newlines with a newline ending every file
 [*]
+charset = utf-8
 end_of_line = lf
+indent_style = space
+indent_size = 4
 insert_final_newline = true
+trim_trailing_whitespace = true
+
+# GO files
+[*.go]
+indent_style = tab
 
 # Makefile
 [Makefile]


### PR DESCRIPTION
## The Issue

Some essential settings are missing and the editor defaults are used instead which could lead to differences with the various editors.

## How This PR Solves The Issue

This patch introduces important default settings to avoid differences with the various editors.