### PR TITLE
Add basic-auth flag to ngrok

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -438,6 +438,7 @@ nfsd
 nfsmount
 nginx
 ngrok
+ngrok's
 node
 nodejs
 noerrors

--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -45,6 +45,13 @@ ddev share myproject`,
 			if app.NgrokArgs != "" {
 				ngrokArgs = append(ngrokArgs, strings.Split(app.NgrokArgs, " ")...)
 			}
+			if cmd.Flags().Changed("basic-auth") {
+				auth, err := cmd.Flags().GetString("basic-auth")
+				if err != nil {
+					util.Failed("unable to get --basic-auth flag: %v", err)
+				}
+				ngrokArgs = append(ngrokArgs, "--basic-auth="+auth)
+			}
 			if cmd.Flags().Changed("subdomain") {
 				sub, err := cmd.Flags().GetString("subdomain")
 				if err != nil {
@@ -91,5 +98,6 @@ ddev share myproject`,
 
 func init() {
 	RootCmd.AddCommand(DdevShareCommand)
-	DdevShareCommand.Flags().String("subdomain", "", `ngrok --subdomain argument, as in "ngrok --subdomain my-subdomain:, requires paid ngrok.com account"`)
+	DdevShareCommand.Flags().String("basic-auth", "", `ngrok --basic-auth argument, as in "ngrok http --basic-auth username:pass1234"`)
+	DdevShareCommand.Flags().String("subdomain", "", `ngrok --subdomain argument, as in "ngrok http --subdomain my-subdomain", requires paid ngrok.com account`)
 }

--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -13,7 +13,7 @@ import (
 var DdevShareCommand = &cobra.Command{
 	Use:   "share [project]",
 	Short: "Share project on the internet via ngrok.",
-	Long:  `Use "ddev share" or add on extra ngrok commands, like "ddev share --basic-auth username:pass1234". Although a few ngrok commands are supported directly, any ngrok flag can be added in the ngrok_args section of .ddev/config.yaml. Requires a free or paid account on ngrok.com; use the "ngrok authtoken" command to set up ngrok.`,
+	Long:  `Requires a free or paid account on ngrok.com, use the "ngrok config add-authtoken <token>" command to set up ngrok. Although a few ngrok commands are supported directly, any ngrok flag can be added in the ngrok_args section of .ddev/config.yaml.`,
 	Example: `ddev share
 ddev share --basic-auth username:pass1234
 ddev share myproject`,
@@ -98,6 +98,6 @@ ddev share myproject`,
 
 func init() {
 	RootCmd.AddCommand(DdevShareCommand)
-	DdevShareCommand.Flags().String("basic-auth", "", `ngrok --basic-auth argument, as in "ngrok http --basic-auth username:pass1234"`)
-	DdevShareCommand.Flags().String("subdomain", "", `ngrok --subdomain argument, as in "ngrok http --subdomain my-subdomain", requires paid ngrok.com account`)
+	DdevShareCommand.Flags().String("basic-auth", "", `works as in "ngrok http --basic-auth username:pass1234"`)
+	DdevShareCommand.Flags().String("subdomain", "", `requires a paid ngrok account, works as in "ngrok http --subdomain mysite"`)
 }

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -281,6 +281,9 @@ Extra flags for [configuring ngrok](https://ngrok.com/docs/ngrok-agent/config) w
 
 Example: `--basic-auth username:pass1234`.
 
+!!!warning
+    Some ngrok flags, such as `--subdomain`, require a paid ngrok account.
+
 ## `no_bind_mounts`
 
 Whether to not use Docker bind mounts.

--- a/docs/content/users/topics/sharing.md
+++ b/docs/content/users/topics/sharing.md
@@ -16,7 +16,7 @@ There are at least three different ways to share a running DDEV project outside 
 
 `ddev share` proxies the project via [ngrok](https://ngrok.com), and it’s by far the easiest way to solve the problem of sharing your project with others on your team or around the world. It’s built into DDEV and “just works” for most people, and requires a free or paid [ngrok.com](https://ngrok.com) account. All you do is run `ddev share` and then give the resultant URL to your collaborator or use it on your mobile device. [Read the basic how-to from DrupalEasy](https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok) or run `ddev share -h` for more.
 
-There are CMSes that make this a little harder, especially WordPress and Magento 2. Both of those only respond to a single base URL, and that URL is coded into the database, so it makes this a little harder. For both of these I recommend paying ngrok the $8/month for a [personal plan](https://ngrok.com/pricing), so you can use a stable subdomain with ngrok.
+CMSes like WordPress and Magento 2 make this a little harder by only responding to a single base URL that’s coded into the database. ngrok’s $8/month [personal plan](https://ngrok.com/pricing) allows you to use a persistent subdomain so you won’t have to frequently change the base URL.
 
 ### Setting up a Stable ngrok Subdomain
 

--- a/docs/content/users/topics/sharing.md
+++ b/docs/content/users/topics/sharing.md
@@ -16,7 +16,7 @@ There are at least three different ways to share a running DDEV project outside 
 
 `ddev share` proxies the project via [ngrok](https://ngrok.com), and it’s by far the easiest way to solve the problem of sharing your project with others on your team or around the world. It’s built into DDEV and “just works” for most people, and requires a free or paid [ngrok.com](https://ngrok.com) account. All you do is run `ddev share` and then give the resultant URL to your collaborator or use it on your mobile device. [Read the basic how-to from DrupalEasy](https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok) or run `ddev share -h` for more.
 
-There are CMSes that make this a little harder, especially WordPress and Magento 2. Both of those only respond to a single base URL, and that URL is coded into the database, so it makes this a little harder. For both of these I recommend paying ngrok the $5/month for a [basic plan](https://ngrok.com/pricing) so you can use a stable subdomain with ngrok.
+There are CMSes that make this a little harder, especially WordPress and Magento 2. Both of those only respond to a single base URL, and that URL is coded into the database, so it makes this a little harder. For both of these I recommend paying ngrok the $8/month for a [personal plan](https://ngrok.com/pricing), so you can use a stable subdomain with ngrok.
 
 ### Setting up a Stable ngrok Subdomain
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1079,6 +1079,7 @@ ddev service enable solr
 
 Flags:
 
+* `--basic-auth`: Username and password, separated by a colon.
 * `--subdomain`: Subdomain to use with paid ngrok account.
 
 Example:

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -161,7 +161,7 @@ const ConfigInstructions = `
 
 # ngrok_args: --basic-auth username:pass1234
 # Provide extra flags to the "ngrok http" command, see
-# https://ngrok.com/docs#http or run "ngrok http -h"
+# https://ngrok.com/docs/ngrok-agent/config or run "ngrok http -h"
 
 # disable_settings_management: false
 # If true, ddev will not create CMS-specific settings files like


### PR DESCRIPTION
## The Issue

The documentation includes an [example](https://ddev.readthedocs.io/en/stable/users/usage/commands/#share) for ngrok:

```bash
# Share the current project using ngrok’s basic-auth argument
ddev share --basic-auth username:pass1234
```

The same example is provided by the `ddev help` command:
```bash
$ ddev help share
Use "ddev share" or add on extra ngrok commands, like "ddev share --basic-auth username:pass1234". Although a few ngrok commands are supported directly, any ngrok flag can be added in the ngrok_args section of .ddev/config.yaml. Requires a free or paid account on ngrok.com; use the "ngrok authtoken" command to set up ngrok.

Usage:
  ddev share [project] [flags]

Examples:
ddev share
ddev share --basic-auth username:pass1234
ddev share myproject

Flags:
  -h, --help               help for share
      --subdomain string   ngrok --subdomain argument, as in "ngrok --subdomain my-subdomain:, requires paid ngrok.com account"

Global Flags:
  -j, --json-output   If true, user-oriented output will be in JSON format.
```

But when you run it:
```
$ ddev share --basic-auth username:pass1234 
Error: unknown flag: --basic-auth
Usage:
  ddev share [project] [flags]
...
```

## How This PR Solves The Issue

Adds `--basic-auth` flag to the `ddev share` command.

## Manual Testing Instructions

```bash
ddev start
ddev share --basic-auth username:pass1234
```

## Related Issue Link(s)

* https://github.com/ddev/ddev/pull/3875

The same functionality can be achieved by running:
```bash
ddev config --ngrok-args '--basic-auth username:pass1234'
ddev share
```


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4719"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

