### PR TITLE
[docs] Clarify how you upgrade DDEV

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -4,7 +4,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
 ## Upgrading
 
-Upgrading DDEV is basically the same process as installing it, because you're upgrading the `ddev` binary that talks with Docker. You can update this file like other software on your system, whether it’s with a package manager or traditional installer.
+Upgrading DDEV is basically the same process as installing it, because you’re upgrading the `ddev` binary that talks with Docker. You can update this file like other software on your system, whether it’s with a package manager or traditional installer.
 
 === "macOS"
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -2,7 +2,9 @@
 
 Once you’ve [installed a Docker provider](docker-installation.md), you’re ready to install DDEV!
 
-Installing and upgrading DDEV are nearly the same thing, because you're upgrading the `ddev` binary that talks with Docker. You can update this file like other software on your system, whether it’s with a package manager or traditional installer.
+## Upgrading
+
+Upgrading DDEV is basically the same process as installing it, because you're upgrading the `ddev` binary that talks with Docker. You can update this file like other software on your system, whether it’s with a package manager or traditional installer.
 
 === "macOS"
 


### PR DESCRIPTION
## The Issue

It is not immediately apparent that the installation page in the docs contains upgrading instructions. 

## How This PR Solves The Issue

This PR makes it clear as crystal by adding a heading, which can additionally be linked to at https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/#upgrading

<img width="713" alt="Screenshot 2023-03-06 at 18 55 09" src="https://user-images.githubusercontent.com/57572400/223291219-63dfe689-c425-4a94-b827-83d960c0c031.png">

## Testing

Affects only one page of the docs, no testing required.

## Release/Deployment Notes

> Added an “Upgrading” heading to the installation page for clarity.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4722"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

