### PR TITLE
Revert full-project Dockerfile context, fixes #4727

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -78,7 +78,7 @@ RUN chmod -R ugo+rw $COMPOSER_HOME
 ENV COMPOSER_HOME=""
 ```
 
-**Remember that the Dockerfile is normally building a Docker image that will be used later with DDEV.** At the time the Dockerfile is executing, your code by default is not mounted and the container is not running, it’s just being built. So for example, an `npm install` in `/var/www/html` will not do anything useful because the code is not there at image building time. However, you use `RUN` in the context of your codebase using something like `RUN --mount=type=bind,source=.,target=/var/www/html cp /var/www/html/index.php /var/tmp/` would mount your code and make it available at the normal `/var/www/html` mount. However, you can't make changes to the mounted code, so things like an early `npm install` wouldn't work, although `npm install -g` would work.
+**Remember that the Dockerfile is building a Docker image that will be used later with DDEV.** At the time the Dockerfile is executing, your code is not mounted and the container is not running, the image is just being built. So for example, an `npm install` in `/var/www/html` will not do anything to your project because the code is not there at image building time.
 
 ### Build Time Environment Variables
 

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -85,8 +85,7 @@ services:
   web:
     container_name: {{ .Plugin }}-${DDEV_SITENAME}-web
     build:
-      context: '../'
-      dockerfile: './.ddev/.webimageBuild/Dockerfile'
+      context: '{{ .WebBuildContext }}'
       args:
         BASE_IMAGE: $DDEV_WEBIMAGE
         username: '{{ .Username }}'

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -767,7 +767,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		Username:              username,
 		UID:                   uid,
 		GID:                   gid,
-		WebBuildContext:       "../",
+		WebBuildContext:       "./.webimageBuild",
 		DBBuildContext:        "./.dbimageBuild",
 		AutoRestartContainers: globalconfig.DdevGlobalConfig.AutoRestartContainers,
 		FailOnHookFail:        app.FailOnHookFail || app.FailOnHookFailGlobal,
@@ -904,14 +904,14 @@ redirect_stderr=true
 		if err != nil {
 			return "", fmt.Errorf("failed to write .webimageBuild/%s.conf: %v", appStart.Name, err)
 		}
-		extraWebContent = extraWebContent + fmt.Sprintf("\nADD .ddev/.webimageBuild/%s.conf /etc/supervisor/conf.d\n", appStart.Name)
+		extraWebContent = extraWebContent + fmt.Sprintf("\nADD %s.conf /etc/supervisor/conf.d\n", appStart.Name)
 	}
 	if len(supervisorGroup) > 0 {
 		err = os.WriteFile(app.GetConfigPath(".webimageBuild/webextradaemons.conf"), []byte("[group:webextradaemons]\nprograms="+strings.Join(supervisorGroup, ",")), 0755)
 		if err != nil {
 			return "", fmt.Errorf("failed to write .webimageBuild/webextradaemons.conf: %v", err)
 		}
-		extraWebContent = extraWebContent + "\nADD .ddev/.webimageBuild/webextradaemons.conf /etc/supervisor/conf.d\n"
+		extraWebContent = extraWebContent + "\nADD webextradaemons.conf /etc/supervisor/conf.d\n"
 	}
 
 	err = WriteBuildDockerfile(app.GetConfigPath(".webimageBuild/Dockerfile"), app.GetConfigPath("web-build"), app.WebImageExtraPackages, app.ComposerVersion, extraWebContent)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1129,30 +1129,14 @@ func TestCustomBuildDockerfiles(t *testing.T) {
 	assert.NoError(err)
 
 	t.Cleanup(func() {
+		runTime()
 		err = app.Stop(true, false)
 		assert.NoError(err)
 		err = os.RemoveAll(app.GetConfigPath("web-build"))
 		assert.NoError(err)
 		err = os.RemoveAll(app.GetConfigPath("db-build"))
 		assert.NoError(err)
-		runTime()
 	})
-
-	// web-build Dockerfile.test - slightly different from db-build because of
-	// different context; this tests to see that the code can be mounted from context to
-	// /var/www/html and we can access index.php in docroot
-	err = WriteImageDockerfile(app.GetConfigPath("web-build/Dockerfile.test1"), []byte(fmt.Sprintf(`
-ADD .ddev/web-build/junkfile /
-RUN --mount=type=bind,source=.,target=/var/www/html cp /var/www/html/%s/index.php /var/tmp/%s-index.php
-RUN touch /var/tmp/`+"added-by-web-test1.txt", app.Docroot, t.Name())))
-	require.NoError(t, err)
-
-	// db-build Dockerfile.test - slightly different from web-build because of
-	// different context
-	err = WriteImageDockerfile(app.GetConfigPath("db-build/Dockerfile.test1"), []byte(`
-ADD junkfile /
-RUN touch /var/tmp/`+"added-by-db-test1.txt"))
-	require.NoError(t, err)
 
 	// Create simple dockerfiles that just touch /var/tmp/added-by-<container>txt
 	for _, item := range []string{"web", "db"} {
@@ -1163,6 +1147,10 @@ RUN touch /var/tmp/`+"added-by-"+item+".txt"))
 		assert.NoError(err)
 		// Add also Dockerfile.* alternatives
 		// Last one includes previously recommended ARG/FROM that needs to be removed
+		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test1"), []byte(`
+ADD junkfile /
+RUN touch /var/tmp/`+"added-by-"+item+"-test1.txt"))
+		assert.NoError(err)
 
 		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test2"), []byte(`
 RUN touch /var/tmp/`+"added-by-"+item+"-test2.txt"))

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1220,11 +1220,6 @@ RUN touch /var/tmp/running-php-${DDEV_PHP_VERSION}
 		Cmd: fmt.Sprintf("ls /var/tmp/running-php-%s >/dev/null", app.PHPVersion),
 	})
 	assert.NoError(err)
-
-	_, _, err = app.Exec(&ExecOpts{
-		Cmd: fmt.Sprintf("ls /var/tmp/%s-index.php >/dev/null", t.Name()),
-	})
-	assert.NoError(err)
 }
 
 // TestConfigLoadingOrder verifies that configs load in lexicographical order


### PR DESCRIPTION
## The Issue

* #4727

## How This PR Solves The Issue

Revert the feature that allowed using entire project for context

## Manual Testing Instructions

Use `ADD <somefile> /var/tmp` in a custom .ddev/web-build/Dockerfile. It should get added.
Use `ADD .ddev/web-build/<somefile /var/tmp` - it should fail.

## Automated Testing Overview

The customizations to tests that were added to that feature were removed.

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4728"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

