### PR TITLE
Change docker-compose to v2.15.1 for problems in #4727

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -612,7 +612,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.16.0"
+var RequiredDockerComposeVersion = "v2.15.1"
 
 // GetRequiredDockerComposeVersion returns the version of docker-compose we need
 // based on the compiled version, or overrides in globalconfig, like


### PR DESCRIPTION
## The Issue

* #4727 

@mkalkbrenner reports that his project is super slow to start (the docker build phase takes forever) in a particular project with mounted files, and it only happens with docker-compose versions after 2.15.1.

## How This PR Solves The Issue

Go to docker-compose 2.15.1 for now.

## Followup

We need to find out why docker-compose 2.16.0 is a problem, so we'll have to have a reproduction scenario, and we'll have to `git bisect` the docker-compose build to do a reasonable bug report for them.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4734"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

