### PR TITLE
[docs] Document exposing additional non-HTTP ports on web

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -122,6 +122,7 @@ TablePlus
 Traefik
 TravisCI
 UAC
+UDP
 Unshare
 Usage
 Use
@@ -130,6 +131,7 @@ Uz
 VCS
 Ventura
 VM
+VNC
 VPN
 VPNs
 WAMP

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -111,7 +111,7 @@ web_extra_exposed_ports:
 
 ## Exposing Extra Non-HTTP Ports
 
-While the `web_extra_exposed_ports` gracefully handles running multiple ddev projects at the same time, it can't forward  ports for non-HTTP TCP or UDP daemons. Instead, ports can be added in a `docker-compose.*.yaml` file. This file does not need to specify an additional services. For example, this configuration exposes port 5900 for a VNC server.
+While the `web_extra_exposed_ports` gracefully handles running multiple DDEV projects at the same time, it can't forward ports for non-HTTP TCP or UDP daemons. Instead, ports can be added in a `docker-compose.*.yaml` file. This file does not need to specify an additional services. For example, this configuration exposes port 5900 for a VNC server.
 
 In `.ddev/docker-compose.vnc.yaml`:
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -118,9 +118,9 @@ In `.ddev/docker-compose.vnc.yaml`:
 ```yaml
 version: '3.6'
 services:
-    web:
-        ports:
-            - "5900:5900"
+  web:
+    ports:
+      - "5900:5900"
 ```
 
 If multiple projects declare the same port, only the first project will be able to start successfully. Consider making services like this disabled by default, especially if they aren't needed in day to day use.

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -109,6 +109,22 @@ web_extra_exposed_ports:
 !!!warning "Fill in all three fields even if you don’t intend to use the `https_port`!"
     If you don’t add `https_port`, then it default to `0` and `ddev-router` will fail to start.
 
+## Exposing Extra Non-HTTP Ports
+
+While the `web_extra_exposed_ports` gracefully handles running multiple ddev projects at the same time, it can't forward  ports for non-HTTP TCP or UDP daemons. Instead, ports can be added in a `docker-compose.*.yaml` file. This file does not need to specify an additional services. For example, this configuration exposes port 5900 for a VNC server.
+
+In `.ddev/docker-compose.vnc.yaml`:
+
+```yaml
+version: '3.6'
+services:
+    web:
+        ports:
+            - "5900:5900"
+```
+
+If multiple projects declare the same port, only the first project will be able to start successfully. Consider making services like this disabled by default, especially if they aren't needed in day to day use.
+
 ## Providing Custom Environment Variables to a Container
 
 You can set custom environment variables in several places:


### PR DESCRIPTION
## The Issue

It wasn't clear to me that a services file could _only_ modify the web service, without declaring an additional container to run. When I first started trying to figure this out, I looked on this page so it's where I've added the new docs.

## How This PR Solves The Issue

A new section on exposing non-HTTP ports.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4736"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

