### PR TITLE
Bump .gitpod.yml to 20230310 [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: drud/ddev-gitpod-base:20230305
+image: drud/ddev-gitpod-base:20230310
 tasks:
   - name: build-run
     init: |


### PR DESCRIPTION
Standard post-release maintenance - bump gitpod.yml

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4737"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

