### PR TITLE
[docs] Shorten install script URL

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -35,13 +35,13 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     Run the [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) to install or update DDEV. It downloads, verifies, and sets up the `ddev` binary:
 
     ```
-    curl -fsSL https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh | bash
+    curl -fsSL https://ddev.com/install.sh | bash
     ```
 
     You can include a `-s <version>` argument to install a specific release or a prerelease version:
 
     ```
-    curl -fsSL https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh | bash -s v1.21.4
+    curl -fsSL https://ddev.com/install.sh | bash -s v1.21.4
     ```
 
     We recommend [enabling Mutagen](performance.md#mutagen) for the best performance; enable with [`ddev config global --mutagen-enabled`](../usage/commands.md#config).

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1016,7 +1016,7 @@ Example:
 →  ddev self-upgrade
 
 DDEV appears to have been installed with install_ddev.sh, you can run that script again to update.
-curl -fsSL https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh | bash
+curl -fsSL https://ddev.com/install.sh | bash
 ```
 
 ## `sequelace`

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -147,7 +147,7 @@ You can use the [`self-upgrade`](../usage/commands.md#self-upgrade) command for 
 If you’re using Homebrew, first run `brew unlink ddev` to get rid of the version you have there. Then use one of these options:
 
 1. Download the version you want from the [releases page](https://github.com/ddev/ddev/releases) and place it in your `$PATH`.
-2. Use the [install_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want v1.18.3-alpha1, run `curl -fsSL https://ddev.com/install.sh | bash -s v1.18.3-alpha1`.
+2. Use the [install_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want v1.18.3-alpha1, run `curl -fsSL https://ddev.com/install.sh | bash -s v1.21.5`.
 3. On Debian/Ubuntu/WSL2 with DDEV installed via apt, you can run `sudo apt update && sudo apt install ddev=<version>`, for example `sudo apt install ddev=1.21.1`.
 4. If you want the very latest, unreleased version of DDEV, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD`.
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -136,7 +136,7 @@ You can use the [`self-upgrade`](../usage/commands.md#self-upgrade) command for 
 * On macOS or Linux (including WSL2) if you installed using the [install_ddev.sh script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) you just run it again:
     <!-- markdownlint-disable -->
     ```
-    curl -fsSL https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh | bash
+    curl -fsSL https://ddev.com/install.sh | bash
     ```
     <!-- markdownlint-restore -->
 * On traditional Windows, you likely installed with Chocolatey or by downloading the installer package. You can upgrade with `choco upgrade ddev` or by visiting the [releases](https://github.com/ddev/ddev/releases) page and downloading the installer. Both techniques will work.
@@ -147,7 +147,7 @@ You can use the [`self-upgrade`](../usage/commands.md#self-upgrade) command for 
 If you’re using Homebrew, first run `brew unlink ddev` to get rid of the version you have there. Then use one of these options:
 
 1. Download the version you want from the [releases page](https://github.com/ddev/ddev/releases) and place it in your `$PATH`.
-2. Use the [install_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want v1.18.3-alpha1, run `curl -fsSL https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh | bash -s v1.18.3-alpha1`.
+2. Use the [install_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want v1.18.3-alpha1, run `curl -fsSL https://ddev.com/install.sh | bash -s v1.18.3-alpha1`.
 3. On Debian/Ubuntu/WSL2 with DDEV installed via apt, you can run `sudo apt update && sudo apt install ddev=<version>`, for example `sudo apt install ddev=1.21.1`.
 4. If you want the very latest, unreleased version of DDEV, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD`.
 


### PR DESCRIPTION
## The Issue

I realized looking at #4722 that a shorter install script URL would be easier to read. It’s long enough that it gets cut off and adding line breaks doesn’t solve the problem; the second example can’t illustrate usage until you’ve scrolled horizontally:

<img src="https://user-images.githubusercontent.com/2488775/224440991-5e05a50a-a446-439e-b8d1-12e6be10e04f.png" width="600" alt="Screenshot emphasizing curl install instructions that extend beyond the visible area of their code block" />

## How This PR Solves The Issue

This shortens it to rely on a 302 redirect from ddev.com, which functions exactly the same:

<img width="600" alt="Screenshot of the same area as above, where a raw.githubusercontent.com URL is replaced with a much shorter ddev.com one" src="https://user-images.githubusercontent.com/2488775/224441270-307006a0-13e0-4fa1-a1d9-d190eb3fc340.png">

This _only_ changes examples using `curl -fsSL`, because I haven’t tested others in the docs (PowerShell) and don’t want to break anything.

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the [automatic build](https://ddev--4738.org.readthedocs.build/en/4738/users/install/ddev-installation/).

## Automated Testing Overview

n/a

## Related Issue Link(s)

Not an issue, but supported by [this redirect](https://github.com/ddev/ddev.com-front-end/blob/main/public/_redirects#L14) from ddev.com.

## Release/Deployment Notes

n/a


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4738"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

