### PR TITLE
[docs] Fix formatting and phrasing

### DIFF
--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -15,13 +15,13 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
     ## Mutagen
 
     If you’re on macOS or Windows, you can skip everything else here and enable Mutagen:
-    
+
     ```
     ddev config global --mutagen-enabled
     ```
 
     ### What Mutagen Does
-    
+
     The [Mutagen](https://mutagen.io) asynchronous caching feature is the best way to improve DDEV’s web-serving performance on macOS and Windows, and we recommend it for most projects. It can be significantly faster than NFS, massively faster than plain Docker or Colima, and it makes filesystem watchers (`fsnotify`/`inotify`) work correctly.
 
     Mutagen decouples in-container reads and writes from reads and writes on the host machine, so each can enjoy near-native speed. A change on the host gets changed “pretty soon” in the container, and a change in the container gets updated “pretty soon” on the host; neither filesystem is stuck waiting on the other one. This “pretty soon” means, however, that there’s a brief window where files on the host may not exactly match the files inside the container—so files that manage to change in both places can lead to conflicts.
@@ -29,9 +29,9 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
     Docker bind-mounts, the traditional approach to getting your code into DDEV’s web container, check every file access against the file on the host. Docker’s way of doing these checks macOS and Windows is not very performant, even with NFS. Linux and Linux-like systems are faster because Docker provides native file-access performance.
 
     While Mutagen works fine and has automated tests for Linux and Windows WSL2, it may not be worth enabling on those systems since it won’t make the dramatic difference it does on macOS and Windows.
-    
+
     Another major advantage of Mutagen over NFS is that it supports filesystem notifications, so file-watchers on both the host and inside the container will be notified when changes occur. This is a great advantage for many development tools, which otherwise have to poll for changes at greater expense. Instead, they can be notified via normal `inotify`/`fsnotify` techniques.
-    
+
     ### Enabling and Disabling Mutagen
 
     !!!warning "Don’t Install Mutagen"
@@ -42,12 +42,12 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
     If you’d rather use Mutagen on a specific project, run [`ddev stop`](../usage/commands.md#stop), enable it with `ddev config --mutagen-enabled`, and [`ddev start`](../usage/commands.md#start) again.
 
     You can’t disable Mutagen on individual projects if it’s enabled globally.
-    
+
     To stop using Mutagen on a project, run `ddev mutagen reset && ddev config --mutagen-enabled=false`.
-    
+
     The `nfs-mount-enabled` feature is automatically turned off if you’re using Mutagen.
-    
-    
+
+
 
     ### Mutagen and User-Generated Uploads
 
@@ -55,63 +55,64 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
 
     If you have a non-standard location for user-generated files, like `private/fileadmin` with the deprecated `typo3-secure-web` approach, you should override the project defaults by setting `upload_dir` in `.ddev/config.yaml` and pointing it at the correct directory. This will allow Mutagen to sync correctly.
 
-    If you change the `upload_dir` do a `ddev mutagen reset` to let mutagen know about the changed behavior.
+    If you change the `upload_dir`, run `ddev mutagen reset` to let Mutagen know about the changed behavior.
 
     ### Mutagen Integration Caveats
- 
+
     If you run into an issue with Mutagen, please try to recreate and report it via a [support channel](../support.md)!
 
     Mutagen has generally been great for those using it, but it’s good to be aware of its trade-offs:
 
-    * **It’s not the right choice for every project.**  
+    * **It’s not the right choice for every project.**<br>
     Filesystem consistency has been excellent with Mutagen, but performance is its specialty. If consistency is your highest priority, then there are reasons to be cautious. Two-way sync is a very difficult computational problem, and problems *may* surface.
-    * **If you take control of the `mutagen.yml` file and make changes to it, do a `ddev mutagen reset` after making changes.**
-    * **Avoid file changes when DDEV is stopped.**  
+    * **Reset if you change `mutagen.yml`.**<br>
+    If you take control of the `mutagen.yml` file and make changes to it, run `ddev mutagen reset` after making changes.
+    * **Avoid file changes when DDEV is stopped.**<br>
     If you change files—checking out a different branch, removing a file—while DDEV is stopped, Mutagen has no way to know about it. When you start again, it will get the files that are stored and bring them back to the host. If you *do* change files while DDEV is stopped, run `ddev mutagen reset` before restarting the project so Mutagen only starts with awareness of the host’s file contents.
-    * **It modestly increases disk usage.**  
+    * **It modestly increases disk usage.**<br>
     Mutagen integration increases the size of your project code’s disk usage, because the code exists both on your computer *and* inside a Docker volume. (As of DDEV v1.19+, this does not include your file upload directory, so normally it’s not too intrusive.) Take care that you have enough overall disk space, and that on macOS you’ve allocated enough file space in Docker Desktop. For projects before DDEV v1.19, if you have a large amount of data like user-generated content that doesn’t need syncing (i.e. `fileadmin` for TYPO3 or `sites/default/files` for Drupal), you can [exclude specific directories from getting synced](#advanced-mutagen-configuration-options) and use a regular Docker mount for them instead. As of v1.19, this is handled automatically and these files are not Mutagen-synced.
-    * **Beware simultaneous changes to the same file in both filesystems.**  
+    * **Beware simultaneous changes to the same file in both filesystems.**<br>
     As we pointed out above, any project likely to change the same file on the host *and* inside the container may encounter conflicts.
-    * **Massive changes can cause problems.**  
+    * **Massive changes can cause problems.**<br>
     Massive file changes on the host or in the container are the most likely to introduce issues. This integration has been tested extensively with major changes introduced by `ddev composer` and `ddev composer create`, but be aware of this issue. Changing Git branches, `npm install`, `yarn install`, or a script that deletes huge sections of the synced data are related behaviors that should raise caution. Again, use `ddev mutagen reset` before restarting the project if you want to be sure Mutagen starts out looking at the host machine’s files.
-    * **Mutagen is asynchronous.**  
+    * **Mutagen is asynchronous.**<br>
     A massive change in either filesystem can result in lag as all changed files are handled. You can use `ddev mutagen monitor` to get a better look at what’s happening.
-    * **You can manually trigger a sync.**  
-    [`ddev start`](../usage/commands.md#start) and [`ddev stop`](../usage/commands.md#stop) automatically force a Mutagen sync. You can cause an explicit sync with `ddev mutagen sync` and see syncing status with [`ddev mutagen status`](../usage/commands.md#mutagen-status). 
-    * **Be mindful of in-container Composer actions.**  
+    * **You can manually trigger a sync.**<br>
+    [`ddev start`](../usage/commands.md#start) and [`ddev stop`](../usage/commands.md#stop) automatically force a Mutagen sync. You can cause an explicit sync with `ddev mutagen sync` and see syncing status with [`ddev mutagen status`](../usage/commands.md#mutagen-status).
+    * **Be mindful of in-container Composer actions.**<br>
     If you run Composer actions inside the container with [`ddev ssh`](../usage/commands.md#ssh), it’s a good idea to run [`ddev mutagen sync`](../usage/commands.md#mutagen-sync) and make sure they’re synced as soon as possible. Most people won’t notice the difference and Mutagen will get it synced soon enough.
-    * **Perform big Git operations on the host side.**  
+    * **Perform big Git operations on the host side.**<br>
     Git actions that change lots of files, like switching branches, are best done on the host side and not inside the container. You may want to do an explicit `ddev mutagen sync` command after doing something like that to be sure all changes are picked up quickly.
-    * **Share projects carefully with non-Mutagen users.**  
+    * **Share projects carefully with non-Mutagen users.**<br>
     If you share a project with some users that want Mutagen, perhaps on macOS, and other users that don’t want or need it, perhaps on WSL2, don’t check in `.ddev/config.yaml`’s [`mutagen_enabled: true`](../configuration/config.md#mutagen_enabled). Instead, either use global Mutagen configuration or add a not-checked-in, project-level `.ddev/config.mutagen.yaml` just to include `mutagen_enabled: true` in it. That way, only users with that file will have Mutagen enabled.
-    * **Windows symlinks have some Mutagen restrictions**.  
+    * **Windows symlinks have some Mutagen restrictions.**<br>
     On macOS and Linux (including WSL2) the default `.ddev/mutagen/mutagen.yml` chooses the `posix-raw` type of symlink handling. (See [mutagen docs](https://mutagen.io/documentation/synchronization/symbolic-links)). This basically means any symlink created will try to sync, regardless of whether it’s valid in the other environment. Mutagen, however, does not support `posix-raw` on traditional Windows, so DDEV uses the `portable` symlink mode. The result is that on Windows, using Mutagen, symlinks must be strictly limited to relative links that are inside the Mutagen section of the project.
-    * **It’s a filesystem feature. Make backups!**  
+    * **It’s a filesystem feature. Make backups!**<br>
     If we’ve learned anything from computer file-storage adventures, it’s that backups are always a good idea!
 
     ### Syncing After `git checkout`
 
     In general, it’s best practice on most projects to do significant Git operations on the host, but they can be disruptive to the sync. It’s easy to add a Git post-checkout hook to do a `ddev mutagen sync` operation though. Add a `.git/hooks/post-checkout` file to your project and make it executable with `chmod +x .git/hooks/post-checkout`:
-    
+
     ```bash
     #!/bin/bash
     ddev mutagen sync || true
     ```
 
     ### Syncing After `yarn`, `npm`, and `pnpm` Actions
-    
+
     Actions by those programs can also set off massive filesystem changes.
-    
+
     You should run [`ddev mutagen sync`](../usage/commands.md#mutagen-sync) in order to get things into sync, or simply wait.
-    
+
     <a name="mutagen-config"></a>
-    
+
     ### Advanced Mutagen Configuration Options
-    
+
     The Mutagen project provides [extensive configuration options](https://mutagen.io/documentation/introduction/configuration).
-    
+
     Each DDEV project includes a `.ddev/mutagen/mutagen.yml` file by default, with basic defaults you can override if you remove the `#ddev-generated` line at the beginning of the file.
-    
+
     If you edit the `.ddev/mutagen/mutagen.yml` file:
 
     * Remove the `#ddev-generated` line
@@ -124,7 +125,7 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
     For example, if you want the `stored-binaries` subdirectory of the project to be available inside the container, but don’t need Mutagen to be syncing it, you can use normal Docker bind-mounting for that subdirectory:
 
     1. Take over the `.ddev/mutagen/mutagen.yml` by removing the `#ddev-generated` line.
-    2. Add `/stored-binaries` to the excluded paths:  
+    2. Add `/stored-binaries` to the excluded paths:
         ```yaml
             ignore:
               paths:
@@ -135,7 +136,7 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
         services:
           web:
             volumes:
-              - "./stored-binaries:/var/www/html/stored-binaries" 
+              - "./stored-binaries:/var/www/html/stored-binaries"
         ```
 
     ### Troubleshooting Mutagen Sync Issues
@@ -172,11 +173,11 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
     ### Mutagen Strategies and Design Considerations
 
     Mutagen provides enormous speed boosts in everyday usage, but it’s trying desperately under the hood to keep container changes reflected on the host and vice versa.
-    
+
     DDEV mounts a fast Docker volume onto `/var/www/html` inside the `web` container, then delegates to the Mutagen daemon (on the host). That daemon has the job of keeping all host project contents in sync with the contents of the Docker volume.
-    
+
     Consistency is a high priority for DDEV’s integration, which tries at key points to make sure everything is completely consistent and in sync.
-    
+
     The Mutagen daemon’s life cycle and sync sessions are something like this:
 
     1. On `ddev start`, the Mutagen agent will be started if it’s not already running.
@@ -184,7 +185,7 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
     3. On `ddev stop` and `ddev pause`, the sync session is flushed to ensure consistency, then paused.
 
     A synchronous flush happens after any `ddev composer` command, since Composer may cause massive changes to the filesystem inside the container that need to be synced before operation continues.
-    
+
     If you need to reset everything for a project, you can do it with `ddev mutagen reset`, which starts the Mutagen session from scratch and removes the Docker volume so it can be recreated from scratch.
 
     ### Safe to Use with Other Mutagen Installations
@@ -194,9 +195,9 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
 === "NFS"
 
     ## NFS
-    
+
     !!!warning "macOS Ventura may not work with NFS"
-    
+
         A bug in macOS Ventura means that NFS mounting doesn't work for many projects, so Mutagen is recommended instead. Follow [issue](https://github.com/ddev/ddev/issues/4122) for details.
 
 
@@ -209,41 +210,41 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
     1. Make sure DDEV is already working and you can use it.
     2. Use the script below for your OS to configure the NFS server and exports files.
     3. Test that NFS is working correctly by using [`ddev debug nfsmount`](../usage/commands.md#debug-nfsmount) in a project directory. The first line should report something like “Successfully accessed NFS mount of /path/to/project”.
-    4. Enable NFS mounting globally with `ddev config global --nfs-mount-enabled`.  
+    4. Enable NFS mounting globally with `ddev config global --nfs-mount-enabled`.
     You can also configure NFS mounting on a per-project basis with `ddev config --nfs-mount-enabled` in the project directory, but this is unusual. If NFS mounting is turned on globally, it overrides any local project settings for NFS.
     5. [`ddev start`](../usage/commands.md#start) your project and make sure it works normally. Use [`ddev describe`](../usage/commands.md#describe) to verify that NFS mounting is being used. The NFS status is near the top of the output of `ddev describe`.
 
     !!!tip "Skip step 2 if you’re already using NFS!"
-        If you’re already using NFS with Vagrant on macOS, for example, and you already have a number of exports, the default home directory export here won’t work—you’ll have overlaps in your `/etc/exports`. Or on Windows, you may want to use an NFS server other than [Winnfsd](https://github.com/winnfsd/winnfsd) like the [Allegro NFS Server](https://nfsforwindows.com).  
+        If you’re already using NFS with Vagrant on macOS, for example, and you already have a number of exports, the default home directory export here won’t work—you’ll have overlaps in your `/etc/exports`. Or on Windows, you may want to use an NFS server other than [Winnfsd](https://github.com/winnfsd/winnfsd) like the [Allegro NFS Server](https://nfsforwindows.com).
 
         The recommendations and scripts below are for getting started if, like most people, you *don’t* already use NFS.
 
     === "macOS NFS Setup"
-    
+
         Download, inspect, make executable, and run [macos_ddev_nfs_setup.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/macos_ddev_nfs_setup.sh):
-        
+
         ```
         curl -O https://raw.githubusercontent.com/ddev/ddev/master/scripts/macos_ddev_nfs_setup.sh && chmod +x macos_ddev_nfs_setup.sh && ./macos_ddev_nfs_setup.sh
         ```
-        
+
         This one-time setup stops running DDEV projects, adds your home directory to the `/etc/exports` config file that `nfsd` uses, and enables `nfsd` to run on your computer.
-        
+
         **This shares your home directory via NFS to any NFS client on your computer,** so it’s critical to consider security issues. You can make the shares in `/etc/exports` more limited, as long as they don’t overlap. NFS doesn’t allow overlapping exports.
-        
+
         If your DDEV projects are set up outside your home directory, you’ll need to add a line to `/etc/exports` for that share as well:
 
         1. Run `sudo vi /etc/exports`.
         2. Copy the line the script just created (`/System/Volumes/Data/Users/username -alldirs -mapall=<your_user_id>:20 localhost`).
-        3. Edit to add the additional path, e.g:  
+        3. Edit to add the additional path, e.g:
         `/Volumes/SomeExternalDrive -alldirs -mapall=<your_uid>:20 localhost`.
-        
+
         #### macOS Full Disk Access for Special Directories
 
-        * If your projects are in a subdirectory of the `~/Documents` or `~/Desktop` directories, or on an external drive, you must grant “Full Disk Access” privilege to `/sbin/nfsd` in *System Preferences* → *Security & Privacy* → *Privacy*. In the *Full Disk Access* section, click the “+” and add `/sbin/nfsd`:  
+        * If your projects are in a subdirectory of the `~/Documents` or `~/Desktop` directories, or on an external drive, you must grant “Full Disk Access” privilege to `/sbin/nfsd` in *System Preferences* → *Security & Privacy* → *Privacy*. In the *Full Disk Access* section, click the “+” and add `/sbin/nfsd`:
 
             ![Adding /sbin/nfsd to Full Disk Access](../../images/sbin-nfsd-selection.png)
-        
-            You should then see `nfsd` in the list:  
+
+            You should then see `nfsd` in the list:
 
             ![Enabling full disk access for nfsd](../../images/nfsd-full-disk-access.png)
 
@@ -272,14 +273,14 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
             ```
 
     === "Windows NFS Setup"
-    
+
         The executable components required for Windows NFS, `winnfsd` and `nssm`, are packaged with the DDEV Windows Installer in each release. If you’ve used the Windows installer, they’re ready to go.
-        
+
         To enable `winnfsd` as a service, please download, inspect and run `windows_ddev_nfs_setup.sh` created by the installer at `C:\Program Files\ddev\windows_ddev_nfs_setup.sh`.
-        
-        You can also download this [directly from the GitHub repository](https://raw.githubusercontent.com/ddev/ddev/master/scripts/windows_ddev_nfs_setup.sh)) in a Git Bash session on Windows. If your DDEV projects are set up outside your home directory, you’ll need to edit `~/.ddev/nfs_exports.txt` (created by the script) and restart the service with  
+
+        You can also download this [directly from the GitHub repository](https://raw.githubusercontent.com/ddev/ddev/master/scripts/windows_ddev_nfs_setup.sh)) in a Git Bash session on Windows. If your DDEV projects are set up outside your home directory, you’ll need to edit `~/.ddev/nfs_exports.txt` (created by the script) and restart the service with
         `sudo nssm restart nfsd`.
-        
+
         !!!warning "Firewall Issues"
             On Windows 10/11 you’ll likely have to allow `winnfsd` to bypass the Windows Defender Firewall. If you’re getting a timeout with no information after [`ddev start`](../usage/commands.md#start), try going to *Windows Defender Firewall* → *Allow an app or feature through Windows Defender Firewall*, *Change Settings*, *Allow another app*. Then choose `C:\Program Files\ddev\winnfsd.exe`, assuming that’s where `winnfsd` is installed.
 
@@ -310,7 +311,7 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
         3. In another window, in a DDEV project directory, run [`ddev debug nfsmount`](../usage/commands.md#debug-nfsmount) to see if it can mount successfully. (The project doesn’t need to be started.) If `ddev debug nfsmount` is successful, then everything is probably going to work.
         4. Confirm `~/.ddev/nfs_exports.txt` has a line that includes your project directories, then run `sudo nssm start nfsd` and `nssm status nfsd`. The status command should show `SERVICE_RUNNING`.
         5. These [nssm](https://nssm.cc/) commands may be useful: `nssm help`, `sudo nssm start nfsd`, `sudo nssm stop nfsd`, `nssm status nfsd`, `sudo nssm edit nfsd` (pops up a window that may be hidden), and `sudo nssm remove nfsd` (also pops up a window, doesn’t work predictably if you haven’t already stopped the service).
-        6. `nssm` logs failures and what it’s doing to the system event log. Run Event Viewer and filter events:  
+        6. `nssm` logs failures and what it’s doing to the system event log. Run Event Viewer and filter events:
             ![Windows Event Viewer](../../images/windows-event-viewer.png)
         7. Please make sure you’ve excluded `winnfsd` from the Windows Defender Firewall per the installation instructions above.
         8. On Windows 10/11 Pro you can visit *Turn Windows features on or off* and enable *Services for NFS* → *Client for NFS*. The `showmount -e` command will then show available exports on the current machine. This can help find out if a conflicting server is running or identifying a problem with exports.


### PR DESCRIPTION
## The Issue

This is a late followup review of #4723, to “run” commands and make sure the summarize+explain list formatting is consistent.

## How This PR Solves The Issue

It also adds `<br>` elements, since the deliberate two-space line breaks (`  `) are stripped out after #4712—which is still an improvement since so many docs PRs get snagged on whitespace issues. I’m positive I have more deliberate line breaks scattered around that will get removed, but nobody will be injured.

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the [automatic build](https://ddev--4739.org.readthedocs.build/en/4739/users/install/performance/).

## Automated Testing Overview

n/a

## Related Issue Link(s)

- #4723
- #4712

## Release/Deployment Notes

n/a


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4739"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

