### PR TITLE
[docs] Requirements: reduce tab width, eliminate redundancy

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -14,14 +14,13 @@ These environments can be extended, version controlled, and shared, so you can t
 === "macOS"
 
     ### macOS
-    
+
     Runs natively on ARM64 (Apple Silicon) and AMD64 machines.
 
+    * macOS Big Sur (11) or higher
     * RAM: 8GB
     * Storage: 256GB
     * [Colima](https://github.com/abiosoft/colima) or [Docker Desktop](https://www.docker.com/products/docker-desktop/)
-    * Colima and Docker Desktop both require macOS Big Sur (11) or higher.
-    * On macOS with either Colima or Docker Desktop most users will want to enable Mutagen for best performance, `ddev config global --mutagen-enabled`
 
 === "Windows WSL2"
 
@@ -50,7 +49,7 @@ These environments can be extended, version controlled, and shared, so you can t
     * RAM: 8GB
     * Storage: 256GB
 
-=== "Gitpod and GitHub Codespaces"
+=== "Gitpod & Codespaces"
 
     ### Gitpod and GitHub Codespaces
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -17,7 +17,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
     Runs natively on ARM64 (Apple Silicon) and AMD64 machines.
 
-    * macOS Big Sur (11) or higher
+    * macOS Big Sur (11) or higher ([mostly](./users/usage/faq.md#can-i-run-ddev-on-an-older-mac))
     * RAM: 8GB
     * Storage: 256GB
     * [Colima](https://github.com/abiosoft/colima) or [Docker Desktop](https://www.docker.com/products/docker-desktop/)

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -17,7 +17,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
     Runs natively on ARM64 (Apple Silicon) and AMD64 machines.
 
-    * macOS Big Sur (11) or higher ([mostly](./users/usage/faq.md#can-i-run-ddev-on-an-older-mac))
+    * macOS Big Sur (11) or higher, [mostly](./users/usage/faq.md#can-i-run-ddev-on-an-older-mac)
     * RAM: 8GB
     * Storage: 256GB
     * [Colima](https://github.com/abiosoft/colima) or [Docker Desktop](https://www.docker.com/products/docker-desktop/)

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -21,7 +21,7 @@ DDEV works nearly anywhere Docker will run, including macOS, Windows 10/11 Pro/E
 
 Probably! You’ll need to install an older, unsupported version of Docker Desktop—but you can likely use it to run the latest DDEV version.
 
-Check out [rkoller’s Stack Overflow answer](https://stackoverflow.com/a/69964995/897279) for a walk through the process.
+Check out [this Stack Overflow answer](https://stackoverflow.com/a/69964995/897279) for a walk through the process.
 
 ### Do I need to install PHP, Composer, nginx, or Node.js/npm on my workstation?
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -17,6 +17,12 @@ DDEV works nearly anywhere Docker will run, including macOS, Windows 10/11 Pro/E
 * It’s focused directly on running containers.
 * It’s fast and stable.
 
+### Can I run DDEV on an older Mac?
+
+Probably! You’ll need to install an older, unsupported version of Docker Desktop—but you can likely use it to run the latest DDEV version.
+
+Check out [rkoller’s Stack Overflow answer](https://stackoverflow.com/a/69964995/897279) for a walk through the process.
+
 ### Do I need to install PHP, Composer, nginx, or Node.js/npm on my workstation?
 
 No. These tools live inside DDEV’s Docker containers, so you only need to [install Docker](../install/docker-installation.md) and [install DDEV](../install/ddev-installation.md). This is especially handy for Windows users where there’s more friction getting these things installed.
@@ -37,7 +43,7 @@ The [`ddev describe`](../usage/commands.md#describe) command includes database c
 │            │      │                               │ or 'root/root'     │
 ```
 
-Inside your project container, where the app itself is running, the database hostname is `db`  
+Inside your project container, where the app itself is running, the database hostname is `db`
 (**not** `127.0.0.1`) and the port is the default for your database engine—`3306` for MySQL/MariaDB, `5432` for PostgreSQL.
 
 Outside your project’s web container, for example a database GUI on your workstation, the hostname is `localhost` and the port is unique to that project. In the example above, it’s `63161`.
@@ -211,7 +217,7 @@ DDEV doesn’t have control over your computer’s name resolution, so it doesn�
 
 ### How can I configure a project with the defaults without hitting <kbd>RETURN</kbd> a bunch of times?
 
-Use `ddev config --auto` to set the docroot and project type based on the discovered code.  
+Use `ddev config --auto` to set the docroot and project type based on the discovered code.
 If anything in `.ddev/config.yaml` is wrong, you can edit that directly or use [`ddev config`](../usage/commands.md#config) commands to update settings.
 
 ## Getting Involved


### PR DESCRIPTION
## The Issue

A few minor things about this page amount to cruft:

1. The “Gitpod and GitHub Codespaces” tab requires horizontal paging when it doesn’t need to.
2. The macOS requirements instruct the reader to enable Mutagen, which is neither a requirement nor anything they have to install. (I brought that up [here](https://github.com/ddev/ddev/pull/4694#discussion_r1125190704) but I think that got lost.)
3. The macOS version requirement applies to both Colima and Docker Desktop, so calling them both out is redundant.

<img width="600" alt="Screen Shot 2023-03-10 at 04 34 42 PM@2x" src="https://user-images.githubusercontent.com/2488775/224453816-5e780e1c-5e05-4de3-8354-5eae6c578042.png">

## How This PR Solves The Issue

1. Whittles the tab name down to “Gitpod & Codespaces”, which fits great and is more consistent with the [DDEV Installation](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/) page.
2. Removes the Mutagen comment/instruction from requirements. It’s an explicit step in [Colima’s Docker install sequence](https://ddev.readthedocs.io/en/latest/users/install/docker-installation/#colima), a recommendation in [Docker Desktop’s](https://ddev.readthedocs.io/en/latest/users/install/docker-installation/#docker-desktop-for-mac), and mentioned again in the [macOS DDEV Installation](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/) instructions.
3. Pares down the OS version requirement line and moves it to the top since any other details are probably a non-starter an old OS. (Edge cases could be covered in the FAQ.)

<img width="600" alt="Screen Shot 2023-03-10 at 04 35 30 PM@2x" src="https://user-images.githubusercontent.com/2488775/224453884-9cc7b0b0-01dc-4a2b-b6c9-d6d719470f05.png">

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the [automatic build](https://ddev--4740.org.readthedocs.build/en/4740/).

## Automated Testing Overview

n/a

## Related Issue Link(s)

Discussed partially in #4694.

## Release/Deployment Notes

n/a


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4740"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

