### PR TITLE
[tests only] TestPantheonPull: Remove stray quote, give more info

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
       MAKE_TARGET: "test"
       TESTARGS: "-failfast"
       DDEV_ACQUIA_SSH_KEY: ${{ secrets.DDEV_ACQUIA_SSH_KEY }}
-      DDEV_PANTHEON_SSH_KEY: ${{ secrets.DDEV_PANTHEON_SSH_KEY }}"
+      DDEV_PANTHEON_SSH_KEY: ${{ secrets.DDEV_PANTHEON_SSH_KEY }}
 
     steps:
       - uses: actions/checkout@v3

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -280,7 +280,7 @@ func setupSSHKey(t *testing.T, privateKey string, expectScriptDir string) error 
 	err = os.WriteFile(filepath.Join("sshtest", "id_rsa_test"), []byte(privateKey), 0600)
 	require.NoError(t, err)
 	out, err := exec.RunHostCommand("expect", filepath.Join(expectScriptDir, "ddevauthssh.expect"), DdevBin, "./sshtest")
-	require.NoError(t, err)
+	require.NoError(t, err, "out=%s", out)
 	require.Contains(t, string(out), "Identity added:")
 	return nil
 }

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -281,7 +281,7 @@ func setupSSHKey(t *testing.T, privateKey string, expectScriptDir string) error 
 func TestPantheonDoMonthlyPush(t *testing.T) {
 	// Pantheon freezes inactive sites, so why not do a commit when we run to prevent that?
 	_, _, day := time.Now().Date()
-	if day != 10 {
+	if day != 11 {
 		t.Skipf("It's not the right day to do pantheon code push.")
 	}
 
@@ -297,6 +297,7 @@ func TestPantheonDoMonthlyPush(t *testing.T) {
 		t.Skipf("No DDEV_PANTHEON_SSH_KEY env var has been set. Skipping %v", t.Name())
 	}
 	sshkey = strings.Replace(sshkey, "<SPLIT>", "\n", -1)
+	sshkey = strings.Replace(sshkey, "\n ", "\n", -1)
 
 	webEnvSave := globalconfig.DdevGlobalConfig.WebEnvironment
 	globalconfig.DdevGlobalConfig.WebEnvironment = []string{"TERMINUS_MACHINE_TOKEN=" + token}

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -281,7 +281,7 @@ func setupSSHKey(t *testing.T, privateKey string, expectScriptDir string) error 
 func TestPantheonDoMonthlyPush(t *testing.T) {
 	// Pantheon freezes inactive sites, so why not do a commit when we run to prevent that?
 	_, _, day := time.Now().Date()
-	if day != 11 {
+	if day != 10 {
 		t.Skipf("It's not the right day to do pantheon code push.")
 	}
 

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -37,14 +37,9 @@ const pantheonPushGitURL = "ssh://codeserver.dev.d32c631e-c998-480f-93bc-7c36e6a
 // TestPantheonPull ensures we can pull from pantheon.
 func TestPantheonPull(t *testing.T) {
 	token := ""
-	sshkey := ""
 	if token = os.Getenv("DDEV_PANTHEON_API_TOKEN"); token == "" {
 		t.Skipf("No DDEV_PANTHEON_API_TOKEN env var has been set. Skipping %v", t.Name())
 	}
-	if sshkey = os.Getenv("DDEV_PANTHEON_SSH_KEY"); sshkey == "" {
-		t.Skipf("No DDEV_PANTHEON_SSH_KEY env var has been set. Skipping %v", t.Name())
-	}
-	sshkey = strings.Replace(sshkey, "<SPLIT>", "\n", -1)
 
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
@@ -61,9 +56,6 @@ func TestPantheonPull(t *testing.T) {
 	err = os.MkdirAll(filepath.Join(siteDir, "sites/default"), 0777)
 	require.NoError(t, err)
 	err = os.Chdir(siteDir)
-	require.NoError(t, err)
-
-	err = setupSSHKey(t, sshkey, filepath.Join(origDir, "testdata", t.Name()))
 	require.NoError(t, err)
 
 	app, err := NewApp(siteDir, true)


### PR DESCRIPTION
## The Issue

TestPantheonPull and related Pantheon tests are failing, apparently due to bad SSH key

## How This PR Solves The Issue

* Remove stray quote
* Give more information at failure time in test.

