### PR TITLE
`ddev debug test` should not try to work in subdir of project [skip ci]

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -38,8 +38,11 @@ ddev debug configyaml | grep -v web_environment
 PROJECT_DIR=../${PROJECT_NAME}
 echo "======= Creating dummy project named  ${PROJECT_NAME} in ${PROJECT_DIR} ========="
 
+set -eu
 mkdir -p "${PROJECT_DIR}/web" || (echo "Unable to create test project at ${PROJECT_DIR}/web, please check ownership and permissions" && exit 2 )
 cd "${PROJECT_DIR}" || exit 3
+ddev config --project-type=php --docroot=web >/dev/null 2>&1  || (printf "\n\nPlease run 'ddev debug test' in the root of the existing project where you're having trouble.\n\n" && exit 4)
+set +eu
 
 echo -n "OS Information: " && uname -a
 command -v sw_vers >/dev/null && sw_vers
@@ -80,7 +83,6 @@ cat <<END >web/index.php
   printf("Success accessing database... %s\n", \$mysqli->host_info);
   print "ddev is working. You will want to delete this project with 'ddev delete -Oy ${PROJECT_NAME}'\n";
 END
-ddev config --project-type=php --docroot=web
 trap cleanup EXIT
 
 ddev start -y || ( \

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -220,7 +220,7 @@ Example: `## HostWorkingDir: true`
 
 ### “ExecRaw” Annotation (Container Commands Only)
 
-Use `ExecRaw: true` to pass command arguments directly to the container as-is. 
+Use `ExecRaw: true` to pass command arguments directly to the container as-is.
 
 For example, when ExecRaw is true, `ddev yarn --help` returns the help for `yarn`, not DDEV's help for the `ddev yarn` command.
 


### PR DESCRIPTION
## The Issue

@JurriaanK found that `ddev debug test` had unpredictable and incorrect results when run in a subdirectory of a project.

Don't allow it to run unless in root of project.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4743"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

