### PR TITLE
[docs] Fix up ExecRaw spellcheck trouble

### DIFF
--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -218,11 +218,11 @@ If your container command should run from the directory you are running the comm
 
 Example: `## HostWorkingDir: true`
 
-### “ExecRaw” Annotation (Container Commands Only)
+### `ExecRaw` Annotation (Container Commands Only)
 
 Use `ExecRaw: true` to pass command arguments directly to the container as-is.
 
-For example, when ExecRaw is true, `ddev yarn --help` returns the help for `yarn`, not DDEV's help for the `ddev yarn` command.
+For example, when `ExecRaw` is true, `ddev yarn --help` returns the help for `yarn`, not DDEV's help for the `ddev yarn` command.
 
 We recommend  using this annotation for all container commands. The default behavior is retained to avoid breaking existing commands.
 


### PR DESCRIPTION
## The Issue

ExecRaw started causing spellcheck trouble. I probably pulled something when tests hadn't finished.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4744"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

