### PR TITLE
Revert indentation specifier from editorconfig settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,9 +8,13 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_style = space
-indent_size = 4
+# Forcing indent to 4 seems to break lots of things, like
+# embedded yaml in markdown.
+# indent_size = 4
 insert_final_newline = true
-trim_trailing_whitespace = true
+# Lots of editors and practices leave trailing whitespace
+# that does no harm.
+#trim_trailing_whitespace = true
 
 # GO files
 [*.go]

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,8 +12,6 @@ indent_style = space
 # embedded yaml in markdown.
 # indent_size = 4
 insert_final_newline = true
-# Lots of editors and practices leave trailing whitespace
-# that does no harm.
 trim_trailing_whitespace = true
 
 # GO files

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ indent_style = space
 insert_final_newline = true
 # Lots of editors and practices leave trailing whitespace
 # that does no harm.
-#trim_trailing_whitespace = true
+trim_trailing_whitespace = true
 
 # GO files
 [*.go]

--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: rojopolis/spellcheck-github-actions@v0
         name: Spellcheck
       - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+      - uses: snow-actions/eclint@v1.0.1
+        name: eclint
+        with:
+          args: 'check'
       - name: Run markdownlint on docs
         uses: docker://avtodev/markdown-lint:v1
         with:

--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -29,10 +29,6 @@ jobs:
       - uses: rojopolis/spellcheck-github-actions@v0
         name: Spellcheck
       - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-      - uses: snow-actions/eclint@v1.0.1
-        name: eclint
-        with:
-          args: 'check'
       - name: Run markdownlint on docs
         uses: docker://avtodev/markdown-lint:v1
         with:

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -109,7 +109,7 @@ To build multi-platform images you must `docker buildx create --use` as a one-ti
 
 ```markdown
 cd containers/ddev-webserver
-make push VERSION=<tag> 
+make push VERSION=<tag>
 ```
 
 If you’re pushing to a repo other than the one wired into the Makefile (like `drud/ddev-webserver`):

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -48,7 +48,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 5. Open WSL2 and check out [ddev/ddev](https://github.com/ddev/ddev).
 6. As normal user, run `.github/workflows/linux-setup.sh`.
 7. `export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH
-   echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc`
+    echo "export PATH=/home/linuxbrew/.linuxbrew/bin:$PATH" >>~/.bashrc`
 
 8. As root user, add sudo capability with `echo "ALL ALL=NOPASSWD: ALL" >/etc/sudoers.d/all && chmod 440 /etc/sudoers.d/all`.
 9. Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/master/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
@@ -69,10 +69,10 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 13. The buildkite/hooks/environment file must be updated to contain the Docker pull credentials:
 
     ```bash
-       #!/bin/bash
-       export DOCKERHUB_PULL_USERNAME=druddockerpullaccount
-       export DOCKERHUB_PULL_PASSWORD=xxx
-       set -e
+        #!/bin/bash
+        export DOCKERHUB_PULL_USERNAME=druddockerpullaccount
+        export DOCKERHUB_PULL_PASSWORD=xxx
+        set -e
     ```
 
 14. Verify that `buildkite-agent` is running.
@@ -101,7 +101,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     sudo apt update && sudo apt install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
     sudo usermod -aG docker $USER
-   ```
+    ```
 
 4. Configure buildkite agent in /etc/buildkite-agent:
     * tags="os=wsl2,architecture=amd64,dockertype=wsl2"
@@ -109,11 +109,11 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
     * Create `/etc/buildkite-agent/hooks/environment` and set to executable with contents:
 
     ```
-       #!/bin/bash
-       export DOCKERHUB_PULL_USERNAME=druddockerpullaccount
-       export DOCKERHUB_PULL_PASSWORD=xxx
-       set -e
-   ```
+        #!/bin/bash
+        export DOCKERHUB_PULL_USERNAME=druddockerpullaccount
+        export DOCKERHUB_PULL_PASSWORD=xxx
+        set -e
+    ```
 
 5. Run `.buildkite/sanetestbot.sh`
 
@@ -136,10 +136,10 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 12. The buildkite/hooks/environment file must be updated to contain the Docker pull credentials:
 
     ```bash
-       #!/bin/bash
-       export DOCKERHUB_PULL_USERNAME=druddockerpullaccount
-       export DOCKERHUB_PULL_PASSWORD=xxx
-       set -e
+        #!/bin/bash
+        export DOCKERHUB_PULL_USERNAME=druddockerpullaccount
+        export DOCKERHUB_PULL_PASSWORD=xxx
+        set -e
     ```
 
 13. Run `brew services start buildkite-agent`.

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -63,9 +63,9 @@ The following “Repository secret” environment variables must be added to <ht
 ### Post-Release Tasks
 
 1. After the release has been created, the new gitpod image must be pushed.
-   1. `cd .gitpod/images && DOCKER_TAG="<YYMMDD>" ./push.sh`
-   2. PR to update `.gitpod.yml` with the new image.
-   3. PR to update [ddev-gitpod-launcher](https://github.com/ddev/ddev-gitpod-launcher) with the new image.
+    1. `cd .gitpod/images && DOCKER_TAG="<YYMMDD>" ./push.sh`
+    2. PR to update `.gitpod.yml` with the new image.
+    3. PR to update [ddev-gitpod-launcher](https://github.com/ddev/ddev-gitpod-launcher) with the new image.
 
 ## Pushing Docker Images with the GitHub Actions Workflow
 

--- a/docs/content/developers/writing-style-guide.md
+++ b/docs/content/developers/writing-style-guide.md
@@ -1,6 +1,6 @@
 # Writing Style Guide
 
-This page formalizes the writing conventions we aspire to use in the documentation.  
+This page formalizes the writing conventions we aspire to use in the documentation.
 It’s a living statement of intent and a reference for all contributors.
 
 ## Voice and Tone
@@ -68,7 +68,7 @@ We “run” commands. We don’t “do” them, and the command itself is not a
 
 ### Use Active Third Person
 
-Avoid impersonal language featuring unknown individuals or shadowy organizations.  
+Avoid impersonal language featuring unknown individuals or shadowy organizations.
 “It is recommended,” for example, could be a warmer “we recommend” or “Laravel users recommend”.
 
 Write on behalf of the community and not yourself—use “we” and not “I”.
@@ -149,7 +149,7 @@ DDEV is a product and `ddev` is a binary or console command. DDEV should always 
 
 #### Products, Organizations, and Protocols
 
-When in doubt, honor whatever name a product or organization uses in its official materials.  
+When in doubt, honor whatever name a product or organization uses in its official materials.
 Use backticks to differentiate between a product and command, just like DDEV vs. `ddev`.
 
 | Write This 👍 | Not This ❌

--- a/docs/content/users/configuration/hooks.md
+++ b/docs/content/users/configuration/hooks.md
@@ -86,7 +86,7 @@ Advanced usages may require running commands directly with explicit arguments. T
 ```yaml
 hooks:
   post-start:
-  - exec: 
+  - exec:
     exec_raw: [ls, -lR, /var/www/html]
 ```
 

--- a/docs/content/users/debugging-profiling/blackfire-profiling.md
+++ b/docs/content/users/debugging-profiling/blackfire-profiling.md
@@ -27,7 +27,7 @@ The Blackfire CLI is built into the web container, so you don’t need to instal
       - BLACKFIRE_CLIENT_TOKEN=00cee15-xxxxx1
     ```
 
-   You can also do this with `ddev config global --web-environment-add="BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>,BLACKFIRE_CLIENT_ID=<id>,BLACKFIRE_CLIENT_TOKEN=<token>"`, but any existing environment variables will be deleted.
+  You can also do this with `ddev config global --web-environment-add="BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>,BLACKFIRE_CLIENT_ID=<id>,BLACKFIRE_CLIENT_TOKEN=<token>"`, but any existing environment variables will be deleted.
 2. [`ddev start`](../usage/commands.md#start).
 3. `ddev blackfire on`.
 4. Click the “Blackfire” browser extension to profile.

--- a/docs/content/users/debugging-profiling/step-debugging.md
+++ b/docs/content/users/debugging-profiling/step-debugging.md
@@ -11,7 +11,7 @@ All IDEs basically work the same, listening on a port and reacting when they’r
 
 **Key facts:**
 
-* Enable Xdebug by running [`ddev xdebug`](../usage/commands.md#xdebug) or `ddev xdebug on` from your project directory.  
+* Enable Xdebug by running [`ddev xdebug`](../usage/commands.md#xdebug) or `ddev xdebug on` from your project directory.
 It will remain enabled until you start or restart the project.
 * Disable Xdebug for better performance when not debugging with `ddev xdebug off`.
 * `ddev xdebug status` will show Xdebug’s current status.
@@ -41,7 +41,7 @@ For more background on Xdebug, see [Xdebug documentation](https://xdebug.org/doc
 
 PhpStorm [zero-configuration debugging](https://confluence.jetbrains.com/display/PhpStorm/Zero-configuration+Web+Application+Debugging+with+Xdebug+and+PhpStorm) will automatically detect a connection and offer to create a “server” that maps your workstation files to the container. This means you only have to:
 
-1. Toggle the “Start Listening for PHP Debug Connections” button:  
+1. Toggle the “Start Listening for PHP Debug Connections” button:
     ![Start listening for debug connections button](../../images/phpstorm-listen-for-debug-connections.png)
 2. Set a breakpoint.
 3. Visit a page that should stop in the breakpoint you set.
@@ -57,11 +57,11 @@ When using this zero-configuration option:
 PhpStorm [run/debug configurations](https://www.jetbrains.com/help/phpstorm/creating-and-editing-run-debug-configurations.html) require more setup but may be easier and more flexible for some people.
 
 1. Under the *Run* menu select *Edit configurations*.
-2. Click the *+* in the upper left and choose *PHP Web Application* to create a configuration.  
+2. Click the *+* in the upper left and choose *PHP Web Application* to create a configuration.
 Give it a reasonable name.
 3. Create a “server” for the project. Make sure *Name* is exactly the same as your host (e.g. `my-site.ddev.site`):
     ![PhpStorm server creation](../../images/phpstorm-config-server-config.png)
-4. Add file mappings for the files on the server.  
+4. Add file mappings for the files on the server.
 Click on the local repo path and add `/var/www/html` as the *Absolute path on the server* and your repository root as the path on the host.
 5. Set an appropriate breakpoint.
 6. Start debugging by clicking the “debug” button, which will launch a page in your browser:
@@ -116,7 +116,7 @@ Here are basic steps to take to sort out any difficulty:
 * Set a breakpoint at the first executable line of your `index.php`.
 * Tell your IDE to start listening. (PhpStorm: click the telephone button, VS Code: run the debugger.)
 * Use `curl` or a browser to create a web request. For example, `curl https://d9.ddev.site`.
-* If the IDE doesn’t respond, take a look at `ddev logs`. A message like this means Xdebug inside the container can’t make a connection to port 9003:  
+* If the IDE doesn’t respond, take a look at `ddev logs`. A message like this means Xdebug inside the container can’t make a connection to port 9003:
 
     > PHP message: Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9003 (through xdebug.client_host/xdebug.client_port)
 

--- a/docs/content/users/extend/in-container-configuration.md
+++ b/docs/content/users/extend/in-container-configuration.md
@@ -20,7 +20,7 @@ Usage examples:
     UserKnownHostsFile=/home/.ssh-agent/known_hosts
     StrictHostKeyChecking=no
     ```
-  
+
 * If you need to add a script or other executable component into the project (or global configuration), you can put it in the project or global `.ddev/homeadditions/bin` directory and `~/bin/<script` will be created inside the container. This is useful for adding a script to one project or every project, or for overriding standard scripts, as `~/bin` is first in the `$PATH` in the `web` container.
 * If you use private, password-protected Composer repositories with [Satis](https://composer.github.io/satis/), for example, and use a global `auth.json`, you might want to `mkdir -p ~/.ddev/homeadditions/.composer && ln -s ~/.composer/auth.json ~/.ddev/homeadditions/.composer/auth.json`, but be careful that you exclude it from getting checked in by using a `.gitignore` or equivalent.
 * You can add small scripts to the `.bashrc.d` directory and they will be executed on [`ddev ssh`](../usage/commands.md#ssh). For example, add a `~/.ddev/homeadditions/.bashrc.d/whereami` containing `echo "I am in the $(hostname) container"` and (after `ddev restart`) when you `ddev ssh` that will be executed.

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -65,14 +65,14 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     ```bash
     sudo apt update && sudo apt upgrade
     ```
-    
+
     !!!tip "Removing Previous Install Methods"
         If you previously used DDEV’s [install script](#install-script), you can remove that version:
 
         ```
         sudo rm -f /usr/local/bin/ddev /usr/local/bin/mkcert /usr/local/bin/*ddev_nfs_setup.sh
         ```
-    
+
         If you previously [installed DDEV with Homebrew](#homebrew), you can run `brew unlink ddev` to get rid of the Homebrew version.
 
     ### Fedora, Red Hat, etc.
@@ -114,16 +114,16 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ### Important Considerations for WSL2 and DDEV
 
-    * WSL2 is supported on Windows 10 and 11.  
-      All Windows 10/11 editions, including Windows 10 Home support WSL2.
-    * WSL2 offers a faster, smoother experience.  
-      It’s vastly more performant, and you’re less likely to have obscure Windows problems.
-    * Projects should live in the Linux filesystem.  
-      WSL2’s Linux filesystem (e.g. `/home/<your_username>`) is much faster, so keep your projects there and **not** in the slower Windows filesystem (`/mnt/c`).
-    * Custom hostnames are managed via the Windows hosts file, not within WSL2.  
-      DDEV attempts to manage custom hostnames via the Windows-side hosts file—usually at `C:\Windows\system32\drivers\etc\hosts`—and it can only do this if it’s installed on the Windows side. (DDEV inside WSL2 uses `ddev.exe` on the Windows side as a proxy to update the Windows hosts file.) If `ddev.exe --version` shows the same version as `ddev --version` you’re all set up. Otherwise, install DDEV on Windows using `choco upgrade -y ddev` or by downloading and running the Windows installer. (The WSL2 scripts below install DDEV on the Windows side, taking care of that for you.) If you frequently run into Windows UAC Escalation, you can calm it down by running `gsudo.exe cache on` and `gsudo.exe config CacheMode auto`, see [gsudo docs](https://github.com/gerardog/gsudo#credentials-cache).
-    * WSL2 is not the same as Docker Desktop’s WSL2 engine.  
-      Using WSL2 to install and run DDEV is not the same as using Docker Desktop’s WSL2 engine, which itself runs in WSL2, but can serve applications running in both traditional Windows and inside WSL2.
+    * WSL2 is supported on Windows 10 and 11.
+    All Windows 10/11 editions, including Windows 10 Home support WSL2.
+    * WSL2 offers a faster, smoother experience.
+    It’s vastly more performant, and you’re less likely to have obscure Windows problems.
+    * Projects should live in the Linux filesystem.
+    WSL2’s Linux filesystem (e.g. `/home/<your_username>`) is much faster, so keep your projects there and **not** in the slower Windows filesystem (`/mnt/c`).
+    * Custom hostnames are managed via the Windows hosts file, not within WSL2.
+    DDEV attempts to manage custom hostnames via the Windows-side hosts file—usually at `C:\Windows\system32\drivers\etc\hosts`—and it can only do this if it’s installed on the Windows side. (DDEV inside WSL2 uses `ddev.exe` on the Windows side as a proxy to update the Windows hosts file.) If `ddev.exe --version` shows the same version as `ddev --version` you’re all set up. Otherwise, install DDEV on Windows using `choco upgrade -y ddev` or by downloading and running the Windows installer. (The WSL2 scripts below install DDEV on the Windows side, taking care of that for you.) If you frequently run into Windows UAC Escalation, you can calm it down by running `gsudo.exe cache on` and `gsudo.exe config CacheMode auto`, see [gsudo docs](https://github.com/gerardog/gsudo#credentials-cache).
+    * WSL2 is not the same as Docker Desktop’s WSL2 engine.
+    Using WSL2 to install and run DDEV is not the same as using Docker Desktop’s WSL2 engine, which itself runs in WSL2, but can serve applications running in both traditional Windows and inside WSL2.
 
     The WSL2 install process involves:
 
@@ -140,7 +140,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     The provided PowerShell script can do most of the work for you, or you can handle these things manually. (This script works with the built-in PowerShell v5, but not with the newer v7.)
 
     In all cases:
-    
+
     1. Install WSL2 with an Ubuntu distro.
 
         * Install WSL with
@@ -152,16 +152,16 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
         * Visit the Microsoft Store and install the *updated* ["Windows Subsystem for Linux"](https://apps.microsoft.com/store/detail/windows-subsystem-for-linux/9P9TQF7MRM4R) and click "Open". It will likely prompt you for a username and password for the Ubuntu WSL2 instance it creates.
 
-        * Verify that you now have an Ubuntu distro set as default by running `wsl.exe -l -v` 
+        * Verify that you now have an Ubuntu distro set as default by running `wsl.exe -l -v`
 
-        If you already have WSL2 but don't have an Ubuntu distro, install one by running `wsl.exe --install Ubuntu`. 
+        If you already have WSL2 but don't have an Ubuntu distro, install one by running `wsl.exe --install Ubuntu`.
 
         If that doesn't work for you, see the [manual installation](https://docs.microsoft.com/en-us/windows/wsl/install-manual) and linked [troubleshooting](https://docs.microsoft.com/en-us/windows/wsl/troubleshooting#installation-issues).
 
-    2. In an administrative PowerShell (5) run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_inside.ps1) by executing: 
+    2. In an administrative PowerShell (5) run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_inside.ps1) by executing:
 
         ```powershell
-        Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; 
+        Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
         iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_inside.ps1'))
         ```
     3. In *Windows Update Settings* → *Advanced Options* enable *Receive updates for other Microsoft products*. You may want to occasionally run `wsl.exe --update` as well.
@@ -172,9 +172,9 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     This scripted installation prepares your default WSL2 Ubuntu distro for use with Docker Desktop. It is designed to be able to run multiple times without breaking anything.
 
-    You can do these things manually, or you can do most of it with the provided PowerShell (5) script. 
+    You can do these things manually, or you can do most of it with the provided PowerShell (5) script.
     In all cases:
-    
+
     1. Install WSL2 with an Ubuntu distro. On a system without WSL2, run:
         ```powershell
         wsl --install
@@ -182,10 +182,10 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
         Verify that you have an Ubuntu distro set as the default default with `wsl -l -v`.
 
-        If you already have WSL2 but don't have an Ubuntu distro, install one with `wsl --install Ubuntu`. 
+        If you already have WSL2 but don't have an Ubuntu distro, install one with `wsl --install Ubuntu`.
 
         If that doesn't work for you, see the [manual installation](https://docs.microsoft.com/en-us/windows/wsl/install-manual) and linked [troubleshooting](https://docs.microsoft.com/en-us/windows/wsl/troubleshooting#installation-issues).
-        
+
         If you prefer to use another Ubuntu distro, install it and set it as default. For example, `wsl --set-default Ubuntu-22.04`.
 
     2. Visit the Microsoft Store and install the updated "Windows Subsystem for Linux", then click *Open*. It will likely prompt you for a username and password for the Ubuntu WSL2 instance it creates.
@@ -198,7 +198,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     7. In an administrative `PowerShell` (5) run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_desktop.ps1) by executing:
 
         ```powershell
-        Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; 
+        Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
         iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_desktop.ps1'))
         ```
     8. In *Windows Update Settings* → *Advanced Options* enable *Receive updates for other Microsoft products*. You may want to occasionally run `wsl.exe --update` as well.
@@ -212,7 +212,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     1. Install [Chocolatey](https://chocolatey.org/install):
         ```powershell
-        Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; 
+        Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
         iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))`
         ```
     2. In an administrative PowerShell: `choco install -y ddev mkcert`
@@ -282,9 +282,9 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     1. [Open any repository](https://www.gitpod.io/docs/getting-started) using Gitpod, run `brew install ddev/ddev/ddev`, and use DDEV!
         * You can install your web app there, or import a database.
         * You may want to implement one of the `ddev pull` provider integrations to pull from a hosting provider or an upstream source.
-    2. Use the [ddev-gitpod-launcher](https://drud.github.io/ddev-gitpod-launcher/) form to launch a repository.  
+    2. Use the [ddev-gitpod-launcher](https://drud.github.io/ddev-gitpod-launcher/) form to launch a repository.
         You’ll provide a source repository and click a button to open a newly-established environment. You can specify a companion artifacts repository and automatically load `db.sql.gz` and `files.tgz` from it. (More details in the [repository’s README](https://github.com/ddev/ddev-gitpod-launcher/blob/main/README.md).)
-    3. Save the following link to your bookmark bar: <a href="javascript: if %28 %2Fbitbucket%2F.test %28 window.location.host %29 %20 %29 %20%7B%20paths%3Dwindow.location.pathname.split %28 %22%2F%22 %29 %3B%20repo%3D%5Bwindow.location.origin%2C%20paths%5B1%5D%2C%20paths%5B2%5D%5D.join %28 %22%2F%22 %29 %20%7D%3B%20if %28 %2Fgithub.com%7Cgitlab.com%2F.test %28 window.location.host %29  %29 %20%7Brepo%20%3D%20window.location.href%7D%3B%20if%20 %28 repo %29 %20%7Bwindow.location.href%20%3D%20%22https%3A%2F%2Fgitpod.io%2F%23DDEV_REPO%3D%22%20%2B%20encodeURIComponent %28 repo %29 %20%2B%20%22%2CDDEV_ARTIFACTS%3D%22%20%2B%20encodeURIComponent %28 repo %29 %20%2B%20%22-artifacts%2Fhttps%3A%2F%2Fgithub.com%2Fddev%2Fddev-gitpod-launcher%2F%22%7D%3B">Open in ddev-gitpod</a>.  
+    3. Save the following link to your bookmark bar: <a href="javascript: if %28 %2Fbitbucket%2F.test %28 window.location.host %29 %20 %29 %20%7B%20paths%3Dwindow.location.pathname.split %28 %22%2F%22 %29 %3B%20repo%3D%5Bwindow.location.origin%2C%20paths%5B1%5D%2C%20paths%5B2%5D%5D.join %28 %22%2F%22 %29 %20%7D%3B%20if %28 %2Fgithub.com%7Cgitlab.com%2F.test %28 window.location.host %29  %29 %20%7Brepo%20%3D%20window.location.href%7D%3B%20if%20 %28 repo %29 %20%7Bwindow.location.href%20%3D%20%22https%3A%2F%2Fgitpod.io%2F%23DDEV_REPO%3D%22%20%2B%20encodeURIComponent %28 repo %29 %20%2B%20%22%2CDDEV_ARTIFACTS%3D%22%20%2B%20encodeURIComponent %28 repo %29 %20%2B%20%22-artifacts%2Fhttps%3A%2F%2Fgithub.com%2Fddev%2Fddev-gitpod-launcher%2F%22%7D%3B">Open in ddev-gitpod</a>.
         It’s easiest to drag the link into your bookmarks. When you’re on a Git repository, click the bookmark to open it with DDEV in Gitpod. It does the same thing as the second option, but it works on non-Chrome browsers and you can use native browser keyboard shortcuts.
 
     It can be complicated to get private databases and files into Gitpod, so in addition to the launchers, the [`git` provider example](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/git.yaml.example) demonstrates pulling a database and files without complex setup or permissions. This was created explicitly for Gitpod integration, because in Gitpod you typically already have access to private Git repositories, which are a fine place to put a starter database and files. Although [ddev-gitpod-launcher](https://drud.github.io/ddev-gitpod-launcher/) and the web extension provide the capability, you may want to integrate a Git provider—or one of the [other providers](https://github.com/ddev/ddev/tree/master/pkg/ddevapp/dotddev_assets/providers)—for each project.
@@ -312,21 +312,21 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
             "ghcr.io/ddev/ddev/install-ddev:latest": {}
         },
         "portsAttributes": {
-          "3306": {
+        "3306": {
             "label": "database"
-          },
-          "8027": {
+        },
+        "8027": {
             "label": "mailhog"
-          },
-          "8036": {
+        },
+        "8036": {
             "label": "phpmyadmin"
-          },
-          "8080": {
+        },
+        "8080": {
             "label": "web http"
-          },
-          "8443": {
+        },
+        "8443": {
             "label": "web https"
-          }
+        }
         },
         "postCreateCommand": "bash -c 'ddev config global --omit-containers=ddev-router && ddev config --auto && ddev debug download-images'"
     }
@@ -345,6 +345,6 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     * Download and extract the latest [DDEV release](https://github.com/ddev/ddev/releases) for your architecture.
     * Move `ddev` to `/usr/local/bin` with `mv ddev /usr/local/bin/` (may require `sudo`), or another directory in your `$PATH` as preferred.
     * Run `ddev` to test your installation. You should see DDEV’s command usage output.
-    * As a one-time initialization, run `mkcert -install`, which may require your `sudo` password.  
-    
+    * As a one-time initialization, run `mkcert -install`, which may require your `sudo` password.
+
         If you don’t have `mkcert` installed, download the [latest release](https://github.com/FiloSottile/mkcert/releases) for your architecture and `sudo mv <downloaded_file> /usr/local/bin/mkcert && sudo chmod +x /usr/local/bin/mkcert`.

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -14,19 +14,19 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     !!!tip "Wait ... Colima?"
         Yes! See *Why do you recommend Colima over Docker Desktop on macOS?* in [the FAQ](../usage/faq.md).
-    
+
     1. Run `docker help` to make sure you’ve got the Docker client installed. If you get an error, install it with [Homebrew](https://brew.sh) by running `brew install docker`.
     2. Install Colima with `brew install colima` or one of the other [installation options](https://github.com/abiosoft/colima/blob/main/docs/INSTALL.md).
-    3. Start Colima with 4 CPUs, 6GB memory, 100GB storage, and Cloudflare DNS, adjusting as needed:  
+    3. Start Colima with 4 CPUs, 6GB memory, 100GB storage, and Cloudflare DNS, adjusting as needed:
     ```
     colima start --cpu 4 --memory 6 --disk 100 --vm-type=qemu --mount-type=sshfs --dns=1.1.1.1
     ```
     4. After [installing DDEV](ddev-installation.md), configure your system to use Mutagen—essential for DDEV with Colima—with `ddev config global --mutagen-enabled`.
-    
+
     After the initial run above, you can use `colima start` or use `colima start -e` to edit the configuration file. Run `colima status` at any time to check Colima’s status.
-    
+
     When your computer restarts, you’ll need to `colima start` again. This will eventually be automated in later versions of Colima.
-    
+
     !!!tip "Colima disk allocation"
         We recommend allocating lots of storage for Colima because there’s no easy way to increase the size later (see [GitHub comment](https://github.com/abiosoft/colima/issues/398#issuecomment-1449801811) for a step-by-step guide to resize disk images with `qemu`). You can reduce usage by running `ddev clean`, and killing off disk images by running `docker rm -f $(docker ps -aq) && docker rmi -f $(docker images -q)`. If you have to rebuild your Colima instance, use the technique described below for migrating from Docker Desktop.
 
@@ -44,7 +44,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     1. Make sure all your projects are listed in [`ddev list`](../usage/commands.md#list).
     2. In Docker Desktop, [`ddev snapshot --all`](../usage/commands.md#snapshot).
     3. After starting Colima, start each project and [`ddev snapshot restore --latest`](../usage/commands.md#snapshot-restore).
-    
+
     ### Docker Desktop for Mac
 
     Docker Desktop for Mac can be installed via Homebrew (`brew install homebrew/cask/docker`) or can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has long been supported by DDEV and has extensive automated testing.
@@ -96,7 +96,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     ## Gitpod
 
-    With [Gitpod](https://www.gitpod.io) you don’t have to install anything at all. Docker is all set up for you. 
+    With [Gitpod](https://www.gitpod.io) you don’t have to install anything at all. Docker is all set up for you.
 
 === "Codespaces"
 

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -128,15 +128,15 @@ Mutagen can offer a big performance boost on macOS and Windows. It’s fast and 
     2. Add `/stored-binaries` to the excluded paths:
         ```yaml
             ignore:
-              paths:
+            paths:
                 - "/stored-binaries"
         ```
     3. Add a `.ddev/docker-compose.bindmount.yaml`:
         ```yaml
         services:
-          web:
+        web:
             volumes:
-              - "./stored-binaries:/var/www/html/stored-binaries"
+            - "./stored-binaries:/var/www/html/stored-binaries"
         ```
 
     ### Troubleshooting Mutagen Sync Issues

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -29,23 +29,23 @@ Shells like bash and zsh need help to do this though, they have to know what the
     On Debian and Yum based systems, using `apt install ddev` you should find that `bash`, `zsh`, and `fish` completions are automatically installed.
 
     Manual installation is easy though, the completion script is exactly the same, it’s just that you have to download and install it yourself. Each system may have a slightly different technique, and you’ll need to figure it out. On Debian/Ubuntu, manually install like this:
-      
-     1. Download the completion files and extract them with 
-         ```bash
-         VERSION=v1.21.1
-         curl -sSLf https://github.com/ddev/ddev/releases/download/${VERSION}/ddev_shell_completion_scripts.${VERSION}.tar.gz
-         tar -zxf ddev_shell_completion_scripts.${VERSION}.tar.gz
-         ```
-     2. Then `sudo mkdir -p /usr/share/bash-completion/completions && sudo cp ddev_bash_completion.sh /usr/share/bash-completion/completions/ddev`. This deploys the `ddev_bash_completion.sh` script where it needs to be. Again, every Linux distro has a different technique, and you may have to figure yours out.
 
-     If you installed DDEV using `apt install` then the `ddev_bash_completion.sh` file is already available in `/usr/bin/ddev_bash_completion.sh`. Starting with DDEV v1.21.2 this will be automatically installed into `/usr/share/bash-completion/completions`.
+    1. Download the completion files and extract them with
+        ```bash
+        VERSION=v1.21.1
+        curl -sSLf https://github.com/ddev/ddev/releases/download/${VERSION}/ddev_shell_completion_scripts.${VERSION}.tar.gz
+        tar -zxf ddev_shell_completion_scripts.${VERSION}.tar.gz
+        ```
+    2. Then `sudo mkdir -p /usr/share/bash-completion/completions && sudo cp ddev_bash_completion.sh /usr/share/bash-completion/completions/ddev`. This deploys the `ddev_bash_completion.sh` script where it needs to be. Again, every Linux distro has a different technique, and you may have to figure yours out.
+
+    If you installed DDEV using `apt install` then the `ddev_bash_completion.sh` file is already available in `/usr/bin/ddev_bash_completion.sh`. Starting with DDEV v1.21.2 this will be automatically installed into `/usr/share/bash-completion/completions`.
 
 === "Oh-My-Zsh"
 
     ## Oh-My-Zsh
 
     If you installed zsh with Homebrew, DDEV’s completions will be automatically installed when you `brew install ddev/ddev/ddev`.
-    
+
     Otherwise, Oh-My-Zsh may be set up very differently in different places, so as a power `zsh` user you’ll need to put `ddev_bash_completion.sh` (see tar archive download above) where it belongs. `echo $fpath` will show you the places that it’s most likely to belong. An obvious choice is `~/.oh-my-zsh/completions`; if that exists, so you can run `mkdir -p ~/.oh-my-zsh/completions && cp ddev_zsh_completion.sh ~/.oh-my-zsh/completions/_ddev`, then `autoload -Uz compinit && compinit`.
 
 === "Fish"

--- a/docs/content/users/project.md
+++ b/docs/content/users/project.md
@@ -3,7 +3,7 @@
 Once [DDEV’s installed](./install/ddev-installation.md), setting up a new project should be quick:
 
 1. Clone or create the code for your project.
-2. `cd` into the project directory and run [`ddev config`](./usage/commands.md#config) to initialize a DDEV project.  
+2. `cd` into the project directory and run [`ddev config`](./usage/commands.md#config) to initialize a DDEV project.
 3. Run [`ddev start`](./usage/commands.md#start) to spin up the project.
 4. Run [`ddev launch`](./usage/commands.md#launch) to open your project in a browser.
 

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -28,8 +28,8 @@ web_environment:
 
         ```yaml
         web_environment:
-          - PLATFORM_PROJECT=nf4amudfn23biyourproject
-          - PLATFORM_ENVIRONMENT=main
+        - PLATFORM_PROJECT=nf4amudfn23biyourproject
+        - PLATFORM_ENVIRONMENT=main
         ```
 
     * Or with a command from your terminal:

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -415,7 +415,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
         // Include for DDEV-managed settings in wp-config-ddev.php.
         $ddev_settings = dirname(__FILE__) . '/wp-config-ddev.php';
         if (is_readable($ddev_settings) && !defined('DB_USER')) {
-          require_once($ddev_settings);
+        require_once($ddev_settings);
         }
         ```
 
@@ -483,7 +483,7 @@ Run [`ddev list`](../users/usage/commands.md#list) or `ddev list --active-only` 
 ➜  ddev list
 NAME          TYPE     LOCATION                   URL(s)                                STATUS
 d8git         drupal8  ~/workspace/d8git          <https://d8git.ddev.local>              running
-                                                  <http://d8git.ddev.local>
+                                                <http://d8git.ddev.local>
 hobobiker     drupal6  ~/workspace/hobobiker.com                                        stopped
 
 ```
@@ -493,7 +493,7 @@ hobobiker     drupal6  ~/workspace/hobobiker.com                                
 ➜  ddev list --active-only
 NAME     TYPE     LOCATION             URL(s)                      STATUS
 drupal8  drupal8  ~/workspace/drupal8  <http://drupal8.ddev.site>   running
-                                       <https://drupal8.ddev.site>
+                                        <https://drupal8.ddev.site>
 
 ```
 

--- a/docs/content/users/topics/hosting.md
+++ b/docs/content/users/topics/hosting.md
@@ -12,13 +12,13 @@ This may be appropriate for small or abandoned sites that have special requireme
 Here’s how to try it for yourself:
 
 1. Install DDEV on an internet-connected Linux server. (You’re responsible for your firewall and maintenance of the server!)
-2. On Debian/Ubuntu, you can set up a simple firewall with  
+2. On Debian/Ubuntu, you can set up a simple firewall with
 `ufw allow 80 && ufw allow 443 && ufw allow 22 && ufw enable`.
 3. Point DNS for the site you’re going to host to the server.
 4. Before proceeding, your system and your project must be accessible on the internet on port 80 and your project DNS name (`myproject.example.com`) must resolve to the appropriate server.
 5. Configure your project with [`ddev config`](../usage/commands.md#config).
 6. Import your database and files using [`ddev import-db`](../usage/commands.md#import-db) and [`ddev import-files`](../usage/commands.md#import-files).
-7. Tell DDEV to listen on all network interfaces, omit phpMyAdmin and its SSH agent, use hardened images, and enable Let’s Encrypt:  
+7. Tell DDEV to listen on all network interfaces, omit phpMyAdmin and its SSH agent, use hardened images, and enable Let’s Encrypt:
 
     ```
     ddev config global --router-bind-all-interfaces --omit-containers=dba,ddev-ssh-agent --use-hardened-images --use-letsencrypt --letsencrypt-email=you@example.com`
@@ -29,7 +29,7 @@ Here’s how to try it for yourself:
 
     ```
     if ($http_x_forwarded_proto = "http") {
-      return 301 https://$host$request_uri;
+    return 301 https://$host$request_uri;
     }
     ```
 
@@ -72,7 +72,7 @@ You may have to restart DDEV with `ddev poweroff && ddev start --all` if Let’s
     ExecStart=/usr/local/bin/ddev start --all
     RemainAfterExit=true
     ExecStop=/usr/local/bin/ddev poweroff
-    
+
     [Install]
     WantedBy=multi-user.target
     ```

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -1,6 +1,6 @@
 # How DDEV Works
 
-DDEV is a [Go](https://go.dev) application that stores its configuration in [files on your workstation](#directory-tour).  
+DDEV is a [Go](https://go.dev) application that stores its configuration in [files on your workstation](#directory-tour).
 It uses those blueprints to mount your project files into [Docker containers](#container-architecture) that facilitate the operation of a local development environment.
 
 DDEV writes and uses [docker-compose](https://docs.docker.com/compose/) files for you, which is a detail you can cheerfully ignore unless you’re Docker-curious or [defining your own services](../extend/custom-compose-files.md).
@@ -16,7 +16,7 @@ The [global configuration directory](#global-files) is used to keep track of you
 A project’s `.ddev` directory can be intimidating at first, so let’s take a look at what lives in there.
 
 !!!tip "Yours May Differ Slightly"
-    You may have some directories or files that aren’t listed here, likely added by custom services.  
+    You may have some directories or files that aren’t listed here, likely added by custom services.
     For example, if you see a `solr` directory, it probably pertains to a custom Solr [add-on service](../extend/additional-services.md).
 
 `apache` directory

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -14,19 +14,19 @@ While this reduces setup time for new users, makes it easier to try out a CMS, a
 
 There are several ways to back off DDEV’s CMS settings management:
 
-1. **Take control of files by removing the `#ddev-generated` comment.**  
+1. **Take control of files by removing the `#ddev-generated` comment.**
 DDEV will automatically update any it’s added containing a `#ddev-generated` comment. This means you don’t need to touch that file, but also that any changes you make will be overwritten. As soon as you remove the comment, DDEV will ignore that file and leave you fully in control over it. (Don’t forget to check it into version control!)
 
     !!!tip "Reversing the change"
         If you change your mind and want DDEV to take over the file again, delete it and run [`ddev start`](../usage/commands.md#start). DDEV will recreate its own version, which you may want to remove from your Git project.
 
-2. **Disable settings management.**  
+2. **Disable settings management.**
 You can tell DDEV to use a specific project type without creating settings files by either setting [`disable_settings_management`](../configuration/config.md#disable_settings_management) to `true` or running [`ddev config --disable-settings-management`](../configuration/config.md#type).
 
-3. **Switch to the generic PHP project type.**  
+3. **Switch to the generic PHP project type.**
 If you don’t want DDEV’s CMS-specific settings, you can switch your project to the generic `php` type by editing [`type: php`](../configuration/config.md#type) in the project’s settings or running [`ddev config --project-type=php`](../usage/commands.md#config). DDEV will no longer create or tweak any settings files. You’ll lose any perks from the nginx configuration for the CMS, but you can always customize [nginx settings](../extend/customization-extendibility.md#custom-nginx-configuration) or [Apache settings](../extend/customization-extendibility.md#custom-apache-configuration) separately.
 
-4. **Un-set the `$IS_DDEV_PROJECT` environment variable.**  
+4. **Un-set the `$IS_DDEV_PROJECT` environment variable.**
 This environment variable is set `true` by default in DDEV’s environment, and can be used to fence off DDEV-specific behavior. When it’s empty, the important parts of `settings.ddev.php` and `AdditionalSettings.php` (for TYPO3) are not executed. This means that DDEV’s `settings.ddev.php` won’t be invoked if it somehow ends up in a production environment or in a non-DDEV local development environment.
 
 !!!tip "Ignore `.ddev/.gitignore`"
@@ -61,16 +61,16 @@ $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml'
 
         ```php
         /**
-         * DDEV environments will have $databases (and other settings) set
-         * by an auto-generated file. Make alterations here for this site
-         * in a multisite environment.
-         */
+        * DDEV environments will have $databases (and other settings) set
+        * by an auto-generated file. Make alterations here for this site
+        * in a multisite environment.
+        */
         elseif (getenv('IS_DDEV_PROJECT') == 'true') {
-          /**
-           * Alter database settings and credentials for DDEV environment.
-           * Includes loading the DDEV-generated `default/settings.ddev.php`.
-           */
-          include $app_root . '/' . $site_path . '/settings.databases.ddev.inc';
+        /**
+            * Alter database settings and credentials for DDEV environment.
+            * Includes loading the DDEV-generated `default/settings.ddev.php`.
+            */
+        include $app_root . '/' . $site_path . '/settings.databases.ddev.inc';
         }
         ```
 
@@ -78,14 +78,14 @@ $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml'
 
         ```php
         /**
-         * Fetch DDEV-generated database credentials and other settings.
-         */
+        * Fetch DDEV-generated database credentials and other settings.
+        */
         require $app_root . '/sites/default/settings.ddev.php';
-        
+
         /*
-         * Alter default database for this site. `settings.ddev.php` will have 
-         * “reset” this to 'db'.
-         */
+        * Alter default database for this site. `settings.ddev.php` will have
+        * “reset” this to 'db'.
+        */
         $databases['default']['default']['database'] = 'site_name';
         ```
 
@@ -93,10 +93,10 @@ $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml'
 
         ```yaml
         web_environment:
-          # Make DDEV Drush shell PIDs last for entire life of the container
-          # so `ddev drush site:set @alias` persists for all Drush connections.
-          # https://chrisfromredfin.dev/posts/drush-use-ddev/
-          - DRUSH_SHELL_PID=PERMANENT
+        # Make DDEV Drush shell PIDs last for entire life of the container
+        # so `ddev drush site:set @alias` persists for all Drush connections.
+        # https://chrisfromredfin.dev/posts/drush-use-ddev/
+        - DRUSH_SHELL_PID=PERMANENT
         ```
 
 ### TYPO3 Specifics

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -7,7 +7,7 @@ DDEV provides lots of flexibility for managing your databases between your local
 
 ## Database Imports
 
-Import a database with one command, from one of the following file formats:  
+Import a database with one command, from one of the following file formats:
 **.sql, .sql.gz, .mysql, .mysql.gz, .tar, .tar.gz, and .zip**.
 
 Here’s an example of a database import using DDEV:

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -58,7 +58,7 @@ Use [`ddev composer`](../usage/commands.md#composer) (Composer inside the contai
 * On some older configurations of Docker Desktop for Windows, symlinks are created in the container as “simulated symlinks”, or XSym files. These special text files behave as symlinks inside the container (on CIFS filesystem), but appear as simple text files on the Windows host. (On the CIFS filesystem used by Docker for Windows, inside the container, there is no capability to create real symlinks even though Windows now has this capability.)
 * DDEV attempts to clean up for this situation. Since Windows 10/11+ (in developer mode) can create real symlinks, DDEV scans your repository after a `ddev composer` command and attempts to convert XSym files into real symlinks. On older versions of Windows 10, it can only do this if your Windows 10 workstation is set to “Developer Mode”.
 * To enable developer mode on Windows 10/11+, search for “developer” in settings:
-    ![Finding developer mode](../../images/developer-mode-1.png)  
+    ![Finding developer mode](../../images/developer-mode-1.png)
     ![Setting developer mode](../../images/developer-mode-2.png)
 
 ## Email Capture and Review (MailHog)

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -125,7 +125,7 @@ On Windows CMD, use [sysinternals tcpview](https://docs.microsoft.com/en-us/sysi
   TCP    127.0.0.1:80           0.0.0.0:0              LISTENING       5760
   TCP    127.0.0.1:8025         0.0.0.0:0              LISTENING       5760
   TCP    127.0.0.1:8036         0.0.0.0:0              LISTENING       5760
-  
+
 > tasklist | findstr "5760"
 com.docker.backend.exe        5760 Services                   0      9,536 K
 ```
@@ -173,7 +173,7 @@ If you get a 404 with “No input file specified” (nginx) or a 403 with “For
 
 If `ddev start` fails, it’s most often because the `web` or `db` container fails to start. In this case, the error message from `ddev start` says something like “Failed to start <project>: db container failed: log=, err=container exited, please use 'ddev logs -s db' to find out why it failed”. You can`ddev logs -s db` to find out what happened.
 
-If you see any variant of “no space left on device” in the logs when using Docker Desktop, it means you have to increase or clean up Docker’s file space. Increase the “Disk image size” setting under “Resources” in Docker’s Preferences:  
+If you see any variant of “no space left on device” in the logs when using Docker Desktop, it means you have to increase or clean up Docker’s file space. Increase the “Disk image size” setting under “Resources” in Docker’s Preferences:
 ![Docker disk space](../../images/docker-disk-image-size.png)
 
 If you see “no space left on device” on Linux, it most likely means your filesystem is full.


### PR DESCRIPTION
## The Issue

In 
* #4712 

@gilbertsoft made some very reasonable improvements to the .editorconfig, but they've been causing some trouble in a number of places.

* Embedded yaml in codeblocks in yaml gets 4-space (and ugly) indentation
* Lots of failures are getting shown with existing stuff that gets edited and the editor magically removes trailing spaces.


## How This PR Solves The Issue

* Don't force the 4-space indentation (remove indent_size)
* Clean up trailing spaces in our Markdown files so the current restriction about trailing spaces doesn't trigger on Markdown at least. 



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4745"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

