### PR TITLE
[docs] Use standard notation for ExecRaw

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -41,6 +41,7 @@ DrupalEasy
 Dump
 Enable
 EndeavourOS
+ExecRaw
 ExecStart
 ExecStop
 Execute

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -218,7 +218,7 @@ If your container command should run from the directory you are running the comm
 
 Example: `## HostWorkingDir: true`
 
-### `ExecRaw` Annotation (Container Commands Only)
+### "ExecRaw" Annotation (Container Commands Only)
 
 Use `ExecRaw: true` to pass command arguments directly to the container as-is.
 


### PR DESCRIPTION
## The Issue

* https://github.com/ddev/ddev/pull/4744#discussion_r1133308470

ExecRaw was done differently than everything else on the section.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4746"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

