### PR TITLE
[docs] Clarification for some MacOS users using install_ddev.sh and missing /usr/local/bin

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -30,7 +30,9 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     !!!tip
         The install script works on macOS, Linux, and Windows WSL2.
-
+    
+    !!!tip
+        You may find that on fresh macOS installs, the `/usr/local/bin` folder does not exist and the script will fail. Create it with `sudo mkdir /usr/local/bin` first and then run the script again.
 
     Run the [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) to install or update DDEV. It downloads, verifies, and sets up the `ddev` binary:
 


### PR DESCRIPTION
## The Issue

Surprising script failure on a fresh MacOS install.

## How This PR Solves The Issue

Provides guidance on this issue.

## Manual Testing Instructions

n/a

## Automated Testing Overview

Documentation change only.

## Related Issue Link(s)

n/a

## Release/Deployment Notes

n/a

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4747"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

