### PR TITLE
[docs] Fix empty tip in additional services/add-ons

### DIFF
--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -47,7 +47,7 @@ Add-ons marked with '*' are official, maintained DDEV add-ons.
 ```
 
 !!!tip
-If you need a service not provided here, see [Defining an Additional Service with Docker Compose](custom-compose-files.md).
+    If you need a service not provided here, see [Defining an Additional Service with Docker Compose](custom-compose-files.md).
 
 Officially-supported add-ons:
 


### PR DESCRIPTION
## The Issue

Noticed a tip callout that was visually broken:

<img width="700" alt="Screen Shot 2023-03-14 at 02 04 04 PM@2x" src="https://user-images.githubusercontent.com/2488775/225162284-9d4a01ec-f7ea-4075-aa83-aa63a0864d36.png">

The git blame identifies _me_ as the culprit, so it’s unrelated to the more recent whitespace issues.

## How This PR Solves The Issue

This indents the text so the tip appears like it’s supposed to:

<img width="700" alt="Screen Shot 2023-03-14 at 04 10 07 PM@2x" src="https://user-images.githubusercontent.com/2488775/225162315-4930fad6-179f-45e9-89e4-03b98065846d.png">

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect [the automatic build](https://ddev--4751.org.readthedocs.build/en/4751/users/extend/additional-services/).

## Automated Testing Overview

n/a

## Related Issue Link(s)

n/a

## Release/Deployment Notes

n/a



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4751"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

