### PR TITLE
Improve install_ddev.sh by making it create /usr/local/bin, replaces #4747 [skip ci]

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -31,7 +31,9 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     !!!tip
         The install script works on macOS, Linux, and Windows WSL2.
 
-    Run the [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) to install or update DDEV. It downloads, verifies, and sets up the `ddev` binary:
+    The [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) is an alternate way to install or upgrade DDEV. It downloads, verifies, and sets up the `ddev` binary.
+
+    To install or update DDEV:
 
     ```
     curl -fsSL https://ddev.com/install.sh | bash

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -10,7 +10,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ### Homebrew
 
-    [Homebrew](https://brew.sh/) is the easiest way to install and upgrade DDEV:
+    We recommend [Homebrew](https://brew.sh/) because it’s the easiest and most reliable way to install and upgrade DDEV:
 
     ```bash
     brew install ddev/ddev/ddev
@@ -30,8 +30,6 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     !!!tip
         The install script works on macOS, Linux, and Windows WSL2.
-
-    We recommend Homebrew because it’s the easiest and most reliable way to install and upgrade DDEV.
 
     Run the [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) to install or update DDEV. It downloads, verifies, and sets up the `ddev` binary:
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -31,6 +31,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     !!!tip
         The install script works on macOS, Linux, and Windows WSL2.
 
+    We recommend Homebrew for installation on macOS, but the install script is an alternate technique.
 
     Run the [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) to install or update DDEV. It downloads, verifies, and sets up the `ddev` binary:
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -31,7 +31,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     !!!tip
         The install script works on macOS, Linux, and Windows WSL2.
 
-    We recommend Homebrew for installation on macOS, but the install script is an alternate technique.
+    We recommend Homebrew because it’s the easiest and most reliable way to install and upgrade DDEV.
 
     Run the [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) to install or update DDEV. It downloads, verifies, and sets up the `ddev` binary:
 

--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -8,6 +8,8 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+if [ ! -d /usr/local/bin ]; then echo 'using sudo to mkdir missing /usr/local/bin' && sudo mkdir -p /usr/local/bin; fi
+
 GITHUB_OWNER=${GITHUB_OWNER:-ddev}
 ARTIFACTS="ddev mkcert macos_ddev_nfs_setup.sh"
 TMPDIR=/tmp
@@ -197,5 +199,7 @@ if command -v mkcert >/dev/null; then
   printf "${YELLOW}Running mkcert -install, which may request your sudo password.'.${RESET}\n"
   mkcert -install
 fi
+
+hash -r
 
 printf "${GREEN}ddev is now installed. Run \"ddev\" and \"ddev --version\" to verify your installation and see usage.${RESET}\n"


### PR DESCRIPTION
## The Issue

* #4747

1. If /usr/local/bin doesn't exist, the install_ddev.sh fails. In M1 macs, that directory doesn't necessarily exist, although it has always existed almost everywhere else.
2. The docs may not make clear that the script installation is an *alternate* 

## How This PR Solves The Issue

* Add creation of /usr/local/bin to the script
* Minor tweak to install doc

## Manual Testing Instructions

1. Temporarily remove /usr/local/bin, `sudo mv /usr/local/bin /usr/local/bin.bak`
2. Run the updated script from this PR, 
`curl -fsSL https://raw.githubusercontent.com/rfay/ddev/90f9d72e02591df1fd1fcc75fa5401bad6aa4113/scripts/install_ddev.sh
 | bash `
3. Put your system back together, `sudo mv /usr/local/bin /usr/local/bin.test && sudo mv /usr/local/bin.bak /usr/local/bin`

## Automated Testing Overview

No testing is done on this.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4752"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

