### PR TITLE
Bump drush8 to 8.4.12, fixes #4189

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -41,7 +41,7 @@ ENV DDEV_PHP_VERSION=$PHP_DEFAULT_VERSION
 ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4 php8.0 php8.1 php8.2"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 ENV YQ_VERSION=v4.30.5
-ENV DRUSH_VERSION=8.4.8
+ENV DRUSH_VERSION=8.4.12
 ENV NODE_LTS=16
 # composer normally screams about running as root, we don't need that.
 ENV COMPOSER_ALLOW_SUPERUSER 1

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM drud/ddev-php-base:v1.21.5 as ddev-webserver-base
+FROM drud/ddev-php-base:20230315_drush8 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -18,7 +18,7 @@ var SegmentKey = ""
 var WebImg = "drud/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.21.5" // Note that this can be overridden by make
+var WebTag = "20230315_drush8" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "drud/ddev-dbserver"


### PR DESCRIPTION
## The Issue

* #4189 
* #1999
* https://github.com/drush-ops/drush/issues/4979

We've been unable to use latest drush8 for quite some time due to that issue.

## How This PR Solves The Issue

Drush 8.4.12 hopes to solve the issue.

## Manual Testing Instructions

Use drush in a Drupal 7 project. Review the previous issues.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4754"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

