### PR TITLE
[docs] Fix typo "without touching to your code" -> "without touching your code"

### DIFF
--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -11,7 +11,7 @@ Type `ddev` or `ddev -h` in a terminal window to see the available DDEV [command
 * [`ddev exec <command>`](../usage/commands.md#exec) executes a command inside the web container.
 * [`ddev stop`](../usage/commands.md#stop) stops a project and removes its memory usage (but does not throw away any data).
 * [`ddev poweroff`](../usage/commands.md#poweroff) stops all resources that DDEV is using and stops the Mutagen daemon if it’s running.
-* [`ddev delete`](../usage/commands.md#delete) destroys the database and DDEV’s knowledge of the project without touching to your code.
+* [`ddev delete`](../usage/commands.md#delete) destroys the database and DDEV’s knowledge of the project without touching your code.
 
 ## Lots of Other Commands
 


### PR DESCRIPTION
Changes `without touching to your code` -> `without touching your code`

## The Issue

Simple grammatical typo

## How This PR Solves The Issue

Removes unnecessary word "to"

## Manual Testing Instructions

n/a

## Automated Testing Overview

n/a

## Related Issue Link(s)

## Release/Deployment Notes

Documentation only



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4756"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

