### PR TITLE
[docs] Adjusted the FAQ 'communication between projects faq'

### DIFF
--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -72,7 +72,7 @@ services:
         external_links:
             - "ddev-router:projectb.ddev.site"
 ```
-This lets the ddev-router know that project A can access the web container on project B's DDEV-url. If you are using other hostnames or `project_tld`, you will need to adjust the `projecb.ddev.site` value.
+This lets the `ddev-router` know that project A can access the web container on project B's DDEV URL. If you are using other hostnames or `project_tld`, you will need to adjust the `projectb.ddev.site` value.
 
 ### Can I run DDEV with other development environments at the same time?
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -68,9 +68,9 @@ Let’s say we have two projects, for example: project A, and project B. In proj
 
 ```yaml
 services:
-    web:
-        external_links:
-            - "ddev-router:projectb.ddev.site"
+  web:
+    external_links:
+      - "ddev-router:projectb.ddev.site"
 ```
 This lets the `ddev-router` know that project A can access the web container on project B's DDEV URL. If you are using other hostnames or `project_tld`, you will need to adjust the `projectb.ddev.site` value.
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -72,6 +72,7 @@ services:
     external_links:
       - "ddev-router:projectb.ddev.site"
 ```
+
 This lets the `ddev-router` know that project A can access the web container on project B's DDEV URL. If you are using other hostnames or `project_tld`, you will need to adjust the `projectb.ddev.site` value.
 
 ### Can I run DDEV with other development environments at the same time?

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -64,7 +64,7 @@ You can use [`ddev mysql`](../usage/commands.md#mysql) or `ddev psql` to execute
 
 Yes, this is commonly required for situations like Drupal migrations. For the `web` container to access the `db` container of another project, use `ddev-<projectname>-db` as the hostname of the other project.
 
-Let’s say we have two projects, for example: project A, and project B. In project A, use `mysql -h ddev-projectb-db` to access the database server of project B. For HTTP/S communication (i.e. API calls) you can 1) access the web container of project B directly with the hostname `ddev-<projectb>-web` and port 80 or 443: `curl https://ddev-projectb-web` or 2) Add a `.ddev/docker-compose.communicate.yaml` to project A for accessing the other project B via the official FQDN.
+Let’s say we have two projects, for example: project A, and project B. In project A, use `mysql -h ddev-projectb-db` to access the database server of project B. For HTTP/S communication (i.e. API calls) you can 1) access the web container of project B directly with the hostname `ddev-<projectb>-web` and port 80 or 443: `curl https://ddev-projectb-web` or 2) Add a `.ddev/docker-compose.communicate.yaml` to project A to access project B via the official FQDN.
 
 ```yaml
 services:


### PR DESCRIPTION
## The Issue
* It wasn't really clear where to put the `docker-compose.communicate.yaml` file directly
* Fixed the syntax of the example, it had wrong indentation

## How This PR Solves The Issue
* Added a bit more context
* Fixed the indentation

## Manual Testing Instructions
- None, as this is for the docs

## Automated Testing Overview
- None, as this is for the docs

## Related Issue Link(s)
- None, I fixed this as I saw it

## Release/Deployment Notes
- None, as this is for the docs

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4757"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

