### PR TITLE
Fix Traefik trying to load Traefik plugin files as dynamic configurations, fixes #4758

### DIFF
--- a/pkg/ddevapp/router_Dockerfile_template
+++ b/pkg/ddevapp/router_Dockerfile_template
@@ -5,5 +5,5 @@ FROM $BASE_IMAGE
 
 {{ if .UseTraefik }}
 RUN apk add bash vim curl htop
-WORKDIR /mnt/ddev-global-cache/traefik/config
+WORKDIR /mnt/ddev-global-cache/traefik
 {{ end }}


### PR DESCRIPTION
## The Issue

* #4758 

When adding Traefik plugins to the static configuration, Traefik will automatically download the files of the plugin in the working directory. 

Switching the `WORKDIR` of the router Docker image will prevent adding unwanted YAML files to the dynamic configuration directory, which would be loaded automatically by Traefik.

See https://github.com/ddev/ddev/issues/4758. 

## How This PR Solves The Issue

It changes the `WORKDIR` of the Traefik based router image. 

## Manual Testing Instructions

1. Add a plugin to Traefik in its static configuration `~/.ddev/traefik/static_config.yaml`:
```yaml
experimental:
  plugins:
    htransformation:
      moduleName: "github.com/tomMoulard/htransformation"
      version: "v0.2.7"
```
2. Restart the ddev-router container
3. Traefik **does not** try to load YAML files from the plugin as dynamic configuration
4. Traefik works correctly

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

Fix #4758.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
- Fix Traefik trying to load Traefik plugin files as dynamic configurations



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4759"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

