### PR TITLE
[docs] Typo in port numbers in example

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -92,7 +92,7 @@ web_extra_exposed_ports:
     https_port: 9999
 ```
 
-The configuration below would expose a Node.js server running in the `web` container on port 3000 as `https://<project>.ddev.site:4000` and a “something” server running in the web container on port 4000 as `https://<project>.ddev.site:4000`:
+The configuration below would expose a Node.js server running in the `web` container on port 3000 as `https://<project>.ddev.site:3000` and a “something” server running in the web container on port 4000 as `https://<project>.ddev.site:4000`:
 
 ```yaml
 web_extra_exposed_ports:


### PR DESCRIPTION
## The Issue

This example says both services would be exposed on port 4000

## How This PR Solves The Issue

Correct small typo

## Manual Testing Instructions

n/a

## Automated Testing Overview

n/a

## Related Issue Link(s)

n/a

## Release/Deployment Notes

n/a

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4761"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

