### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @ddev/development
+README.md @ddev/documentation
+/docs/ @ddev/documentation


### PR DESCRIPTION
This PR suggests a [CODEOWNERS file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), which is a GitHub convention for specifying individual ownership/interest in parts of a repository.

The proposed file uses freshly-added [DDEV organization teams](https://github.com/orgs/ddev/teams) (Development and Documentation) rather than individual usernames, so those teams can be modified as necessary and referenced by a handle. This should encourage tidy team organization and serve as a useful shorthand particularly if CODEOWNERS are designated in additional repositories.

Ultimately the file designates Randy (`@ddev/development`) as the global owner of everything (`*`), and Matt (`@ddev/documentation`) as the owner of `README.md` and the contents of the `/docs/` folder. With this file in place, PR reviews will be suggested accordingly.

I strictly designated myself [over here](https://github.com/ddev/ddev.com-front-end/commit/46df48d8eb10f355666834e8c3ab1d66f04fdb84) until that project gets settled since it really is me, and not an imaginary documentation team, that best knows that project having created it recently.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4764"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

