### PR TITLE
Reorganize ngrok flags for ddev share

### DIFF
--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -13,9 +13,9 @@ import (
 var DdevShareCommand = &cobra.Command{
 	Use:   "share [project]",
 	Short: "Share project on the internet via ngrok.",
-	Long:  `Use "ddev share" or add on extra ngrok commands, like "ddev share --basic-auth username:pass1234". Although a few ngrok commands are supported directly, any ngrok flag can be added in the ngrok_args section of .ddev/config.yaml. Requires a free or paid account on ngrok.com; use the "ngrok authtoken" command to set up ngrok.`,
+	Long:  `Requires a free or paid account on ngrok.com, use the "ngrok config add-authtoken <token>" command to set up ngrok. Although a subdomain flag is supported directly, any ngrok flag can be added in the ngrok_args section of .ddev/config.yaml.`,
 	Example: `ddev share
-ddev share --basic-auth username:pass1234
+ddev share --subdomain mysite
 ddev share myproject`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 1 {
@@ -91,5 +91,5 @@ ddev share myproject`,
 
 func init() {
 	RootCmd.AddCommand(DdevShareCommand)
-	DdevShareCommand.Flags().String("subdomain", "", `ngrok --subdomain argument, as in "ngrok --subdomain my-subdomain:, requires paid ngrok.com account"`)
+	DdevShareCommand.Flags().String("subdomain", "", `requires a paid ngrok account, works as in "ngrok http --subdomain mysite"`)
 }

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -279,7 +279,10 @@ Extra flags for [configuring ngrok](https://ngrok.com/docs/ngrok-agent/config) w
 | -- | -- | --
 | :octicons-file-directory-16: project | `` |
 
-Example: `--basic-auth username:pass1234`.
+Example: `--subdomain mysite --basic-auth username:pass1234`.
+
+!!!warning
+    Some ngrok flags, like `--subdomain` require a paid ngrok account.
 
 ## `no_bind_mounts`
 

--- a/docs/content/users/topics/sharing.md
+++ b/docs/content/users/topics/sharing.md
@@ -16,7 +16,7 @@ There are at least three different ways to share a running DDEV project outside 
 
 `ddev share` proxies the project via [ngrok](https://ngrok.com), and it’s by far the easiest way to solve the problem of sharing your project with others on your team or around the world. It’s built into DDEV and “just works” for most people, and requires a free or paid [ngrok.com](https://ngrok.com) account. All you do is run `ddev share` and then give the resultant URL to your collaborator or use it on your mobile device. [Read the basic how-to from DrupalEasy](https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok) or run `ddev share -h` for more.
 
-There are CMSes that make this a little harder, especially WordPress and Magento 2. Both of those only respond to a single base URL, and that URL is coded into the database, so it makes this a little harder. For both of these I recommend paying ngrok the $5/month for a [basic plan](https://ngrok.com/pricing) so you can use a stable subdomain with ngrok.
+There are CMSes that make this a little harder, especially WordPress and Magento 2. Both of those only respond to a single base URL, and that URL is coded into the database, so it makes this a little harder. For both of these I recommend paying ngrok the $8/month for a [personal plan](https://ngrok.com/pricing), so you can use a stable subdomain with ngrok.
 
 ### Setting up a Stable ngrok Subdomain
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1087,9 +1087,6 @@ ddev share
 # Share the current project with ngrok, using subdomain `foo.*`
 ddev share --subdomain foo
 
-# Share the current project using ngrok’s basic-auth argument
-ddev share --basic-auth username:pass1234
-
 # Share my-project with ngrok
 ddev share my-project
 ```

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -159,9 +159,9 @@ const ConfigInstructions = `
 # If you prefer you can change this to "ddev.local" to preserve
 # pre-v1.9 behavior.
 
-# ngrok_args: --basic-auth username:pass1234
+# ngrok_args: --subdomain mysite --basic-auth username:pass1234
 # Provide extra flags to the "ngrok http" command, see
-# https://ngrok.com/docs#http or run "ngrok http -h"
+# https://ngrok.com/docs/ngrok-agent/config or run "ngrok http -h"
 
 # disable_settings_management: false
 # If true, ddev will not create CMS-specific settings files like


### PR DESCRIPTION
## The Issue

The documentation contains a non-existent `--basic-auth` flag for `ddev share`.

## How This PR Solves The Issue

This PR reverts changes made in #3875.

I also changed the `ddev share --help`. There was a lot of text, I cleaned it up.

## Manual Testing Instructions

Check `ddev share --help` and share a test website.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- https://github.com/ddev/ddev/pull/4719
- https://github.com/ddev/ddev/pull/3875

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4766"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

