### PR TITLE
[docs] Fix Magento 2 quickstart for Magento 2.4.6, fixes #4762

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -220,10 +220,12 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
     ddev start
     ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition -y
     rm -f app/etc/env.php
+
     # Change the base-url below to your project's URL
-    ddev magento setup:install --base-url='https://ddev-magento2.ddev.site/' --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db --elasticsearch-host=elasticsearch --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=admin123 --language=en_US
+    ddev magento setup:install --base-url='https://ddev-magento2.ddev.site/' --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db --elasticsearch-host=elasticsearch --search-engine=elasticsearch7 --elasticsearch-port=9200 --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=admin123 --language=en_US
+
     ddev magento deploy:mode:set developer
-    ddev magento module:disable Magento_TwoFactorAuth
+    ddev magento module:disable Magento_TwoFactorAuth Magento_AdminAdobeImsTwoFactorAuth
     ddev config --disable-settings-management=false
     ```
 


### PR DESCRIPTION
- Add elasticsearch engine to options
- Define elasticsearch port
- Disable depending new Magento_AdminAdobeImsTwoFactorAuth module

See issue: #4762 


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4767"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

