### PR TITLE
Shopware nginx config: Allow Shopware Installer to run

### DIFF
--- a/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
@@ -50,7 +50,7 @@ server {
     }
 
     # pass the PHP scripts to FastCGI server listening on socket
-    location ~ \.php$ {
+    location ~ ^/(index|shopware-installer\.phar)\.php(/|$) {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php-fpm.sock;


### PR DESCRIPTION
## The Issue

Nginx by default cannot route `foo.phar.php/foo` to the actual file `foo.phar.php`. It thinks foo.phar.php is a folder. 
This is not required to be applied on Apache2 or Caddy as it just works 

## How This PR Solves The Issue

Use location to forward `shopware-installer.phar.php` always to that actual file.

See also https://github.com/hetzneronline/community-content/pull/569

## Manual Testing Instructions

- Download the Installer [here](https://github.com/shopware/web-installer/releases/)
- Drop it in a document root
- Open it and see that next pages does not load or CSS/JS is missing

## Automated Testing Overview

You could request the CSS/JS inside

## Related Issue Link(s)


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4769"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

