### PR TITLE
Overwrite copies of embedded files if they're empty on target filesystem

### DIFF
--- a/pkg/fileutil/embed.go
+++ b/pkg/fileutil/embed.go
@@ -24,8 +24,11 @@ func CopyEmbedAssets(fsys embed.FS, sourceDir string, targetDir string) error {
 		} else {
 			localPath := filepath.Join(targetDir, d.Name())
 
+			// We can overwrite the file if it has the #ddev-generated
+			// or if it is an empty file.
 			sigFound, err := FgrepStringInFile(localPath, nodeps.DdevFileSignature)
-			if sigFound || err != nil {
+			s, _ := os.Stat(localPath)
+			if sigFound || (s != nil && s.Size() == 0) || err != nil {
 				content, err := fsys.ReadFile(sourcePath)
 				if err != nil {
 					return err


### PR DESCRIPTION
## The Issue

Users have occasionally reported having empty shell commands like `launch` on their system (~/.ddev/commands/host/launch). It's unknown how this happens, perhaps no space available.

https://stackoverflow.com/questions/75801233/problems-with-ddev-after-upgrade-to-1-21-6-launch-file-empty

## How This PR Solves The Issue

On empty file, overwrite it. This doesn't solve the original problem, but will fix on `ddev restart` if there's available disk space

## Manual Testing Instructions

`rm ~/.ddev/commands/host/launch && touch ~/.ddev/commands/host/launch && ddev start` - `ddev launch` should work again.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4775"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

