### PR TITLE
[docs] Quickstart for ExpressionEngine

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -46,6 +46,7 @@ ExecStart
 ExecStop
 Execute
 Executes
+ExpressionEngine
 FPATH
 FSTYPE
 Flags
@@ -677,6 +678,7 @@ you
 your
 yoursite
 zcompdump
+zipfile
 zsh
 zshrc
 zxf

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -678,7 +678,6 @@ you
 your
 yoursite
 zcompdump
-zipfile
 zsh
 zshrc
 zxf

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -149,6 +149,40 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
         ddev launch
         ```
 
+=== "ExpressionEngine"
+
+    ## ExpressionEngine
+
+    === "ExpressionEngine Zipfile Download"
+
+        Download the ExpressionEngine code from [ExpressionEngine.com](https://expressionengine.com/), then:
+
+        ```bash
+        mkdir my-ee && cd my-ee
+        unzip /path/to/ee-zipfile.zip
+        ddev config # Accept the defaults
+        ddev start
+        ddev launch /admin.php
+        ```
+
+        In the `admin.php` setup, use "db" for the "DB Server Address", "DB Name", "DB Username", and "DB Password"
+
+        Visit your site.
+
+    === "ExpressionEngine Git Checkout"
+
+        ```bash
+        git clone https://github.com/ExpressionEngine/ExpressionEngine # for example
+        cd ExpressionEngine
+        ddev config # Accept the defaults
+        ddev start
+        ddev composer install
+        touch system/user/config/config.php
+        echo "EE_INSTALL_MODE=TRUE" >.env.php
+        ddev start
+        ddev launch /admin.php  # Use DB Server = "db", everything else "db"
+        ```
+
 === "Laravel"
 
     ## Laravel

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -185,7 +185,8 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
         ddev launch /admin.php  # Open installation wizard in browser
         ```
 
-When the installation wizard prompts for database settings, enter `db` for the _DB Server Address_, _DB Name_, _DB Username_, and _DB Password_.
+        When the installation wizard prompts for database settings, enter `db` for the _DB Server Address_, _DB Name_, _DB Username_, and _DB Password_.
+
 === "Laravel"
 
     ## Laravel

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -155,7 +155,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
 
     === "ExpressionEngine ZIP File Download"
 
-        Download the ExpressionEngine code from [ExpressionEngine.com](https://expressionengine.com/), then follow these steps based on the [official installation instructions](https://docs.expressionengine.com/latest/installation/installation.html):
+        Download the ExpressionEngine code from [expressionengine.com](https://expressionengine.com/), then follow these steps based on the [official installation instructions](https://docs.expressionengine.com/latest/installation/installation.html):
 
         ```bash
         mkdir my-ee && cd my-ee

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -153,7 +153,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
 
     ## ExpressionEngine
 
-    === "ExpressionEngine Zipfile Download"
+    === "ExpressionEngine ZIP File Download"
 
         Download the ExpressionEngine code from [ExpressionEngine.com](https://expressionengine.com/), then:
 
@@ -162,10 +162,10 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
         unzip /path/to/ee-zipfile.zip
         ddev config # Accept the defaults
         ddev start
-        ddev launch /admin.php
+        ddev launch /admin.php # Open installation wizard in browser
         ```
 
-        In the `admin.php` setup, use "db" for the "DB Server Address", "DB Name", "DB Username", and "DB Password"
+        When the installation wizard prompts for database settings, enter `db` for the _DB Server Address_, _DB Name_, _DB Username_, and _DB Password_.
 
         Visit your site.
 
@@ -180,9 +180,10 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
         touch system/user/config/config.php
         echo "EE_INSTALL_MODE=TRUE" >.env.php
         ddev start
-        ddev launch /admin.php  # Use DB Server = "db", everything else "db"
+        ddev launch /admin.php  # Open installation wizard in browser
         ```
 
+When the installation wizard prompts for database settings, enter `db` for the _DB Server Address_, _DB Name_, _DB Username_, and _DB Password_.
 === "Laravel"
 
     ## Laravel

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -155,7 +155,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
 
     === "ExpressionEngine ZIP File Download"
 
-        Download the ExpressionEngine code from [ExpressionEngine.com](https://expressionengine.com/), then:
+        Download the ExpressionEngine code from [ExpressionEngine.com](https://expressionengine.com/), then follow these steps based on the [official installation instructions](https://docs.expressionengine.com/latest/installation/installation.html):
 
         ```bash
         mkdir my-ee && cd my-ee
@@ -170,6 +170,8 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
         Visit your site.
 
     === "ExpressionEngine Git Checkout"
+
+        Follow these steps based on the [ExpressionEngine Git Repository README.md](https://github.com/ExpressionEngine/ExpressionEngine#how-to-install):
 
         ```bash
         git clone https://github.com/ExpressionEngine/ExpressionEngine # for example


### PR DESCRIPTION
## The Issue

Add a quickstart for [ExpressionEngine](https://expressionengine.com/)

## How This PR Solves The Issue

Shows zipfile and git checkout approaches.

## Manual Testing Instructions

Try it out

## Concerns

* We need to find a better way to add more quickstarts. Django4 is soon to come, and the tab approach just doesn't scale.


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4777"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

