### PR TITLE
Fix instructions about restoring snapshots

### DIFF
--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -92,12 +92,12 @@ ddev snapshot
 Creating database snapshot d9_20220107124831-mariadb_10.3.gz
 Created database snapshot d9_20220107124831-mariadb_10.3.gz
 
-ddev snapshot restore d9_20220107124831-mariadb_10.3.gz
+ddev snapshot restore d9_20220107124831
 Stopping db container for snapshot restore of 'd9_20220107124831-mariadb_10.3.gz'...
 Restored database snapshot d9_20220107124831-mariadb_10.3.gz
 ```
 
-Snapshots are stored as gzipped files in the project’s `.ddev/db_snapshots` directory, and the file created for a snapshot can be renamed as necessary. For example, if you rename the above `d9_20220107124831-mariadb_10.3.gz` file to `working-before-migration-mariadb_10.3.gz`, then you can use `ddev snapshot restore working-before-migration-mariadb_10.3.gz`. (The description of the database type and version—`mariadb_10.3`, for example—must remain intact.)
+Snapshots are stored as gzipped files in the project’s `.ddev/db_snapshots` directory, and the file created for a snapshot can be renamed as necessary. For example, if you rename the above `d9_20220107124831-mariadb_10.3.gz` file to `working-before-migration-mariadb_10.3.gz`, then you can use `ddev snapshot restore working-before-migration`. (The description of the database type and version — `mariadb_10.3`, for example — must remain intact.)
 To restore the latest snapshot add the `--latest` flag (`ddev snapshot restore --latest`).
 
 List snapshots for an existing project with `ddev snapshot --list`. (Add the `--all` option for an exhaustive list; `ddev snapshot --list --all`.) You can remove all of them with `ddev snapshot --cleanup`, or remove a single snapshot with `ddev snapshot --cleanup --name <snapshot-name>`.


### PR DESCRIPTION
## The Issue
 #4778

## How This PR Solves The Issue
Corrects the falsy instructions

## Manual Testing Instructions
1. Create a snapshot
2. Input file name without db type, db version and file extension
3. See that it works.

## Automated Testing Overview

No tests needed, its only about docs.

## Related Issue Link(s)

## Release/Deployment Notes

Not related to deployment.