### PR TITLE
Don't override database prefix in settings.ddev.php

### DIFF
--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -23,7 +23,6 @@ type BackdropSettings struct {
 	DatabaseHost     string
 	DatabaseDriver   string
 	DatabasePort     string
-	DatabasePrefix   string
 	HashSalt         string
 	Signature        string
 	SiteSettings     string
@@ -44,7 +43,6 @@ func NewBackdropSettings(app *DdevApp) *BackdropSettings {
 		DatabaseHost:     "ddev-" + app.Name + "-db",
 		DatabaseDriver:   "mysql",
 		DatabasePort:     GetExposedPort(app, "db"),
-		DatabasePrefix:   "",
 		HashSalt:         util.RandString(64),
 		Signature:        nodeps.DdevFileSignature,
 		SiteSettings:     "settings.php",

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -27,7 +27,6 @@ type DrupalSettings struct {
 	DatabaseHost     string
 	DatabaseDriver   string
 	DatabasePort     string
-	DatabasePrefix   string
 	HashSalt         string
 	Signature        string
 	SitePath         string
@@ -50,7 +49,6 @@ func NewDrupalSettings(app *DdevApp) *DrupalSettings {
 		DatabaseHost:     "db",
 		DatabaseDriver:   "mysql",
 		DatabasePort:     GetExposedPort(app, "db"),
-		DatabasePrefix:   "",
 		HashSalt:         util.RandString(64),
 		Signature:        nodeps.DdevFileSignature,
 		SitePath:         path.Join("sites", "default"),

--- a/pkg/ddevapp/drupal/backdrop/settings.ddev.php
+++ b/pkg/ddevapp/drupal/backdrop/settings.ddev.php
@@ -17,7 +17,6 @@ if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == "true")) {
 }
 
 $database = "$driver://{{ $config.DatabaseUsername }}:{{ $config.DatabasePassword }}@$host:$port/{{ $config.DatabaseName }}";
-$database_prefix = '{{ $config.DatabasePrefix }}';
 
 $settings['update_free_access'] = FALSE;
 $settings['hash_salt'] = '{{ $config.HashSalt }}';

--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -18,14 +18,12 @@ if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
   $port = {{ $config.DBPublishedPort }};
 }
 
-$databases['default']['default'] = array(
-  'database' => "{{ $config.DatabaseName }}",
-  'username' => "{{ $config.DatabaseUsername }}",
-  'password' => "{{ $config.DatabasePassword }}",
-  'host' => $host,
-  'driver' => $driver,
-  'port' => $port,
-);
+$databases['default']['default']['database'] = "{{ $config.DatabaseName }}";
+$databases['default']['default']['username'] = "{{ $config.DatabaseUsername }}";
+$databases['default']['default']['password'] = "{{ $config.DatabasePassword }}";
+$databases['default']['default']['host'] = $host;
+$databases['default']['default']['driver'] = $driver;
+$databases['default']['default']['port'] = $port;
 
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 

--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -25,7 +25,6 @@ $databases['default']['default'] = array(
   'host' => $host,
   'driver' => $driver,
   'port' => $port,
-  'prefix' => "{{ $config.DatabasePrefix }}",
 );
 
 $settings['hash_salt'] = '{{ $config.HashSalt }}';

--- a/pkg/ddevapp/drupal/drupal7/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal7/settings.ddev.php
@@ -18,14 +18,12 @@ if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
   $port = {{ $config.DBPublishedPort }};
 }
 
-$databases['default']['default'] = array(
-  'database' => "{{ $config.DatabaseName }}",
-  'username' => "{{ $config.DatabaseUsername }}",
-  'password' => "{{ $config.DatabasePassword }}",
-  'host' => $host,
-  'driver' => $driver,
-  'port' => $port,
-);
+$databases['default']['default']['database'] = "{{ $config.DatabaseName }}";
+$databases['default']['default']['username'] = "{{ $config.DatabaseUsername }}";
+$databases['default']['default']['password'] = "{{ $config.DatabasePassword }}";
+$databases['default']['default']['host'] = $host;
+$databases['default']['default']['driver'] = $driver;
+$databases['default']['default']['port'] = $port;
 
 $drupal_hash_salt = '{{ $config.HashSalt }}';
 

--- a/pkg/ddevapp/drupal/drupal7/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal7/settings.ddev.php
@@ -25,7 +25,6 @@ $databases['default']['default'] = array(
   'host' => $host,
   'driver' => $driver,
   'port' => $port,
-  'prefix' => "{{ $config.DatabasePrefix }}",
 );
 
 $drupal_hash_salt = '{{ $config.HashSalt }}';

--- a/pkg/ddevapp/drupal/drupal8/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal8/settings.ddev.php
@@ -18,14 +18,12 @@ if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
   $port = {{ $config.DBPublishedPort }};
 }
 
-$databases['default']['default'] = array(
-  'database' => "{{ $config.DatabaseName }}",
-  'username' => "{{ $config.DatabaseUsername }}",
-  'password' => "{{ $config.DatabasePassword }}",
-  'host' => $host,
-  'driver' => $driver,
-  'port' => $port,
-);
+$databases['default']['default']['database'] = "{{ $config.DatabaseName }}";
+$databases['default']['default']['username'] = "{{ $config.DatabaseUsername }}";
+$databases['default']['default']['password'] = "{{ $config.DatabasePassword }}";
+$databases['default']['default']['host'] = $host;
+$databases['default']['default']['driver'] = $driver;
+$databases['default']['default']['port'] = $port;
 
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 

--- a/pkg/ddevapp/drupal/drupal8/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal8/settings.ddev.php
@@ -25,7 +25,6 @@ $databases['default']['default'] = array(
   'host' => $host,
   'driver' => $driver,
   'port' => $port,
-  'prefix' => "{{ $config.DatabasePrefix }}",
 );
 
 $settings['hash_salt'] = '{{ $config.HashSalt }}';

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -18,14 +18,12 @@ if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
   $port = {{ $config.DBPublishedPort }};
 }
 
-$databases['default']['default'] = array(
-  'database' => "{{ $config.DatabaseName }}",
-  'username' => "{{ $config.DatabaseUsername }}",
-  'password' => "{{ $config.DatabasePassword }}",
-  'host' => $host,
-  'driver' => $driver,
-  'port' => $port,
-);
+$databases['default']['default']['database'] = "{{ $config.DatabaseName }}";
+$databases['default']['default']['username'] = "{{ $config.DatabaseUsername }}";
+$databases['default']['default']['password'] = "{{ $config.DatabasePassword }}";
+$databases['default']['default']['host'] = $host;
+$databases['default']['default']['driver'] = $driver;
+$databases['default']['default']['port'] = $port;
 
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -25,7 +25,6 @@ $databases['default']['default'] = array(
   'host' => $host,
   'driver' => $driver,
   'port' => $port,
-  'prefix' => "{{ $config.DatabasePrefix }}",
 );
 
 $settings['hash_salt'] = '{{ $config.HashSalt }}';


### PR DESCRIPTION
## The Issue

In Drupal settings.ddev.php we set the database prefix to ''. This overrides what might be set in the settings.php, and there's no need for it.

## How This PR Solves The Issue

Stop setting the database prefix at all.

## Manual Testing Instructions

Set database prefix in settings.php before the include of settings.ddev.php. See if things work with a project that has a prefix in the db.

## Automated Testing Overview

No changes.

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4781"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

