### PR TITLE
[docs] Update credsStore to Colima to avoid DDEV start errors

### DIFF
--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -39,11 +39,8 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     #### Migrating Projects from Docker Desktop to Colima
 
-    !!!tip "Docker Desktop may have left a bad config.json"
-        Remove the `credsStore` line in `~/.docker/config.json` if you have trouble.
-
-    1. Open Docker's `config.json` file (`~/.docker/config.json`)
-    2. Remove the `credsStore` line.
+    !!!tip "Docker Desktop may have left a bad `config.json`"
+        Remove the `credsStore` line in `~/.docker/config.json` if you have trouble running `ddev start` with a project you’ve migrated.
 
     Move your project databases from Docker Desktop to Colima:
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -39,6 +39,12 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     #### Migrating Projects from Docker Desktop to Colima
 
+    !!!tip "Change credential storage from Dev Desktop to Colima"
+        Update credential storage to Colima to avoid ddev start errors
+
+    1. Open to edit Docker's `config.json` file (ex: `~/.docker/config.json`)
+    2. Change the `credsStore` value to `colima`
+
     Move your project databases from Docker Desktop to Colima:
 
     1. Make sure all your projects are listed in [`ddev list`](../usage/commands.md#list).

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -39,11 +39,11 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     #### Migrating Projects from Docker Desktop to Colima
 
-    !!!tip "Change credential storage from Dev Desktop to Colima"
-        Update credential storage to Colima to avoid ddev start errors
+    !!!tip "Docker Desktop may have left a bad config.json"
+        Remove the `credsStore` line in `~/.docker/config.json` if you have trouble.
 
-    1. Open to edit Docker's `config.json` file (ex: `~/.docker/config.json`)
-    2. Change the `credsStore` value to `colima`
+    1. Open Docker's `config.json` file (`~/.docker/config.json`)
+    2. Remove the `credsStore` line.
 
     Move your project databases from Docker Desktop to Colima:
 


### PR DESCRIPTION
## The Issue
When switching from Docker Desktop and installing colima and docker via homebrew, following this documentation here, I ran into the following issue when running `ddev start` on my project.

```
', stderr='failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to create LLB definition: rpc error: code = Unknown desc = error getting credentials - err: docker-credential-desktop resolves to executable in current directory (./docker-credential-desktop), out: ``' 
```

DDev was still looking for a docker desktop file, despite it being fully uninstalled.

## How This PR Solves The Issue
This PR updates documentation to provide a configuration tip when migrating from Docker Desktop to Colima. 
The `.docker/config.json` should to be updated to:

```
{
        "auths": {},
        "credsStore": "colima",
        "currentContext": "colima"
}
```

## Manual Testing Instructions
PR does not change code; testing should follow the steps added to documentation for installation.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)
https://stackoverflow.com/questions/67642620/docker-credential-desktop-not-installed-or-not-available-in-path#comment132716686_68202428

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4790"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

