### PR TITLE
WIP: Do not split web-environment-add, allow comma in environment variable content

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -65,8 +65,7 @@ func handleGlobalConfig(cmd *cobra.Command, _ []string) {
 		if env == "" {
 			globalconfig.DdevGlobalConfig.WebEnvironment = []string{}
 		} else {
-			envspl := strings.Split(env, ",")
-			conc := append(globalconfig.DdevGlobalConfig.WebEnvironment, envspl...)
+			conc := append(globalconfig.DdevGlobalConfig.WebEnvironment, env)
 			// Convert to a hashmap to remove duplicate values.
 			hashmap := make(map[string]string)
 			for i := 0; i < len(conc); i++ {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -557,8 +557,7 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	if cmd.Flag("web-environment-add").Changed {
 		env := strings.TrimSpace(webEnvironmentLocal)
 		if env != "" {
-			envspl := strings.Split(env, ",")
-			conc := append(app.WebEnvironment, envspl...)
+			conc := append(app.WebEnvironment, env)
 			// Convert to a hashmap to remove duplicate values.
 			hashmap := make(map[string]string)
 			for i := 0; i < len(conc); i++ {


### PR DESCRIPTION
#4791

That's one possible way, but it changes already existing behavior.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4792"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

