### PR TITLE
[docs] Fix markdown in profiling doc page

### DIFF
--- a/docs/content/users/debugging-profiling/blackfire-profiling.md
+++ b/docs/content/users/debugging-profiling/blackfire-profiling.md
@@ -28,6 +28,7 @@ The Blackfire CLI is built into the web container, so you don’t need to instal
     ```
 
   You can also do this with `ddev config global --web-environment-add="BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>,BLACKFIRE_CLIENT_ID=<id>,BLACKFIRE_CLIENT_TOKEN=<token>"`, but any existing environment variables will be deleted.
+  
 2. [`ddev start`](../usage/commands.md#start).
 3. `ddev blackfire on`.
 4. Click the “Blackfire” browser extension to profile.

--- a/docs/content/users/debugging-profiling/blackfire-profiling.md
+++ b/docs/content/users/debugging-profiling/blackfire-profiling.md
@@ -27,7 +27,7 @@ The Blackfire CLI is built into the web container, so you don’t need to instal
       - BLACKFIRE_CLIENT_TOKEN=00cee15-xxxxx1
     ```
 
-  You can also do this with `ddev config global --web-environment-add="BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>,BLACKFIRE_CLIENT_ID=<id>,BLACKFIRE_CLIENT_TOKEN=<token>"`, but any existing environment variables will be deleted.
+    You can also do this with `ddev config global --web-environment-add="BLACKFIRE_SERVER_ID=<id>,BLACKFIRE_SERVER_TOKEN=<token>,BLACKFIRE_CLIENT_ID=<id>,BLACKFIRE_CLIENT_TOKEN=<token>"`, but any existing environment variables will be deleted.
   
 2. [`ddev start`](../usage/commands.md#start).
 3. `ddev blackfire on`.


### PR DESCRIPTION
## The Issue
Here's how steps numbers section looks a bit broken:
<img width="786" alt="Screenshot 2023-04-05 at 19 47 25" src="https://user-images.githubusercontent.com/3918875/230151324-32abbf91-c02b-4a03-8a54-a34465f7dffd.png">

## How This PR Solves The Issue
Well, it looks now as initended.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4806"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

