### PR TITLE
[tests only] Fix broken TestDdevExec on CircleCI arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     working_directory: ~/ddev
     environment:
       DDEV_NONINTERACTIVE: "true"
@@ -37,7 +37,7 @@ jobs:
 
   lx_amd64_fpm_test:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: nginx-fpm
@@ -90,7 +90,7 @@ jobs:
 
   lx_arm64_fpm_test:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: arm.medium
     working_directory: ~/ddev
     environment:
@@ -213,7 +213,7 @@ jobs:
 
   lx_apache_fpm_test:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     working_directory: ~/ddev
     environment:
       DDEV_TEST_WEBSERVER_TYPE: apache-fpm
@@ -248,7 +248,7 @@ jobs:
 
   lx_nfsmount_test:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     working_directory: ~/ddev
     environment:
       DDEV_TEST_USE_NFSMOUNT: true
@@ -270,7 +270,7 @@ jobs:
         # Now build using the regular ddev-only technique - this results in a fully clean set of executables.
     # Run the built-in ddev tests with the executables just built.
     - run:
-        # CircleCI image ubuntu-2004:202101-01 has umask 002, which results in
+        # CircleCI image ubuntu-2204:202101-01 has umask 002, which results in
         # default perms 700 for new directories, which doesn't seem to work with NFS
         command: umask u=rwx,g=rwx,o=rx && make -s test EXTRA_PATH=/home/linuxbrew/.linuxbrew/bin
         name: ddev tests
@@ -285,7 +285,7 @@ jobs:
 
   staticrequired:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     working_directory: ~/ddev
     environment:
     steps:
@@ -304,7 +304,7 @@ jobs:
 
   lx_amd64_container_test:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     working_directory: ~/ddev
     environment:
       GOTEST_SHORT: true
@@ -346,7 +346,7 @@ jobs:
 
   lx_arm64_container_test:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     resource_class: arm.medium
     working_directory: ~/ddev
     environment:
@@ -400,7 +400,7 @@ jobs:
 
   artifacts:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2204:current
     working_directory: ~/ddev
     steps:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew


### PR DESCRIPTION
## The Issue

CircleCI arm64 test has been failing on TestDdevExec

## How This PR Solves The Issue

See if Ubuntu 22.04 fixes it.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4810"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

