### PR TITLE
Use env.default instead of env.example

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -159,7 +159,7 @@ ddev config global --web-environment-add="MY_ENV_VAR=someval
 You can use the `--web-environment` flag to overwrite existing values rather than adding them.
 
 !!!warning "Don’t check in sensitive values!"
-    Sensitive variables like API keys should not be checked in with your project. Typically you might use an `.env` file and _not_ check that in, but offer `.env.example` with expected keys that don’t have values. Some use global configuration for sensitive values, as that’s not normally checked in either.
+    Sensitive variables like API keys should not be checked in with your project. Typically you might use an `.env` file and _not_ check that in, but offer `.env.default` with expected keys that don’t have values. Some use global configuration for sensitive values, as that’s not normally checked in either.
 
 ### Altering the In-Container `$PATH`
 


### PR DESCRIPTION
The docs should specify `env.default` for the value-less environmental variables file as this is a more standard name and `env.example` is gitignored by ddev by default, and it doesn't make sense that the user should have to override the gitignore to follow the instructions in the docs.

## The Issue

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4811"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

