### PR TITLE
Add debugging output to GetHostDockerInternalIP() for #4803

### DIFF
--- a/docs/content/users/debugging-profiling/step-debugging.md
+++ b/docs/content/users/debugging-profiling/step-debugging.md
@@ -108,7 +108,7 @@ The basic thing to understand about Xdebug is that it’s a network protocol. Yo
 
 Here are basic steps to take to sort out any difficulty:
 
-* Delete existing PhpStorm "servers" in settings, or recreate the vscode launch.json exactly as shown in the instructions here.
+* Delete existing PhpStorm "servers" in settings, or recreate VS Code’s `launch.json` file exactly as shown in the instructions here.
 * Remember the port in play is port 9003.
 * Reboot your computer.
 * If you're running WSL2 and have PhpStorm running inside WSL2 (the Linux version of PhpStorm) then `ddev config global --xdebug-ide-location=wsl2`.
@@ -116,7 +116,7 @@ Here are basic steps to take to sort out any difficulty:
 * Use `ddev xdebug on` to enable Xdebug when you want it, and `ddev xdebug off` when you’re done with it.
 * Set a breakpoint at the first executable line of your `index.php`.
 * Tell your IDE to start listening. (PhpStorm: click the telephone button, VS Code: run the debugger.)
-* Use `curl` or a browser to create a web request. For example, `curl https://d9.ddev.site` or just `ddev exec curl localhost`.
+* Use `curl` or a browser to create a web request. For example, `curl https://d9.ddev.site` or run `ddev exec curl localhost`.
 * If the IDE doesn’t respond, take a look at `ddev logs`. A message like this means Xdebug inside the container can’t make a connection to port 9003:
 
     > PHP message: Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9003 (through xdebug.client_host/xdebug.client_port)
@@ -130,4 +130,4 @@ Here are basic steps to take to sort out any difficulty:
 * Set a breakpoint in the first relevant line of your `index.php` and then visit the site in a browser. It should stop at that first line.
 * If you’re using PhpStorm inside WSL2 (or perhaps other Linux configurations), go to *Help* → *Edit Custom VM Options* and add an additional line: `-Djava.net.preferIPv4Stack=true` This makes PhpStorm listen for Xdebug using IPv4; the Linux version of PhpStorm seems to default to using only IPv6.
 * If you’re on WSL2 using Docker Desktop, make sure that the `docker` command is the one provided by Docker Desktop. `ls -l $(which docker)` should show a link to `/mnt/wsl/docker-desktop...`. If you’re on WSL2 using Docker installed inside WSL2, make sure that `ls -l $(which docker)` is *not* a link to `/mnt/wsl`.
-* You can `export DDEV_DEBUG=true` and `ddev start` to get information about how `host.docker.internal` is figured out; this can help in some situations, especially with WSL2. (`host.docker.internal` inside the web container is where Xdebug thinks it should connect to your IDE. You can see what it is set to with `ddev exec ping host.docker.internal`.)
+* You can run `export DDEV_DEBUG=true` and `ddev start` to get information about how `host.docker.internal` is figured out, which can help in some situations especially with WSL2. (`host.docker.internal` inside the web container is where Xdebug thinks it should connect to your IDE. You can see what it is set to by running `ddev exec ping host.docker.internal`.)

--- a/docs/content/users/debugging-profiling/step-debugging.md
+++ b/docs/content/users/debugging-profiling/step-debugging.md
@@ -108,6 +108,7 @@ The basic thing to understand about Xdebug is that it’s a network protocol. Yo
 
 Here are basic steps to take to sort out any difficulty:
 
+* Delete existing PhpStorm "servers" in settings, or recreate the vscode launch.json exactly as shown in the instructions here.
 * Remember the port in play is port 9003.
 * Reboot your computer.
 * If you're running WSL2 and have PhpStorm running inside WSL2 (the Linux version of PhpStorm) then `ddev config global --xdebug-ide-location=wsl2`.
@@ -115,7 +116,7 @@ Here are basic steps to take to sort out any difficulty:
 * Use `ddev xdebug on` to enable Xdebug when you want it, and `ddev xdebug off` when you’re done with it.
 * Set a breakpoint at the first executable line of your `index.php`.
 * Tell your IDE to start listening. (PhpStorm: click the telephone button, VS Code: run the debugger.)
-* Use `curl` or a browser to create a web request. For example, `curl https://d9.ddev.site`.
+* Use `curl` or a browser to create a web request. For example, `curl https://d9.ddev.site` or just `ddev exec curl localhost`.
 * If the IDE doesn’t respond, take a look at `ddev logs`. A message like this means Xdebug inside the container can’t make a connection to port 9003:
 
     > PHP message: Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9003 (through xdebug.client_host/xdebug.client_port)
@@ -129,3 +130,4 @@ Here are basic steps to take to sort out any difficulty:
 * Set a breakpoint in the first relevant line of your `index.php` and then visit the site in a browser. It should stop at that first line.
 * If you’re using PhpStorm inside WSL2 (or perhaps other Linux configurations), go to *Help* → *Edit Custom VM Options* and add an additional line: `-Djava.net.preferIPv4Stack=true` This makes PhpStorm listen for Xdebug using IPv4; the Linux version of PhpStorm seems to default to using only IPv6.
 * If you’re on WSL2 using Docker Desktop, make sure that the `docker` command is the one provided by Docker Desktop. `ls -l $(which docker)` should show a link to `/mnt/wsl/docker-desktop...`. If you’re on WSL2 using Docker installed inside WSL2, make sure that `ls -l $(which docker)` is *not* a link to `/mnt/wsl`.
+* You can `export DDEV_DEBUG=true` and `ddev start` to get information about how `host.docker.internal` is figured out; this can help in some situations, especially with WSL2. (`host.docker.internal` inside the web container is where Xdebug thinks it should connect to your IDE. You can see what it is set to with `ddev exec ping host.docker.internal`.)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1069,39 +1069,48 @@ func GetHostDockerInternalIP() (string, error) {
 	case nodeps.IsIPAddress(globalconfig.DdevGlobalConfig.XdebugIDELocation):
 		// If the IDE is actually listening inside container, then localhost/127.0.0.1 should work.
 		hostDockerInternal = globalconfig.DdevGlobalConfig.XdebugIDELocation
+		util.Debug("host.docker.internal=%s derived from globalconfig.DdevGlobalConfig.XdebugIDELocation", hostDockerInternal)
 
 	case globalconfig.DdevGlobalConfig.XdebugIDELocation == globalconfig.XdebugIDELocationContainer:
 		// If the IDE is actually listening inside container, then localhost/127.0.0.1 should work.
 		hostDockerInternal = "127.0.0.1"
+		util.Debug("host.docker.internal=%s because globalconfig.DdevGlobalConfig.XdebugIDELocation=%s", hostDockerInternal, globalconfig.XdebugIDELocationContainer)
 
 	case IsColima():
 		// Lima just specifies this as a named explicit IP address at this time
 		// see https://github.com/lima-vm/lima/blob/master/docs/network.md#host-ip-19216852
 		hostDockerInternal = "192.168.5.2"
+		util.Debug("host.docker.internal=%s because running on Colima", hostDockerInternal)
 
 	// Gitpod has docker 20.10+ so the docker-compose has already gotten the host-gateway
 	case nodeps.IsGitpod():
+		util.Debug("host.docker.internal='%s' because on Gitpod", hostDockerInternal)
 		break
 	case nodeps.IsCodespaces():
+		util.Debug("host.docker.internal='%s' because on Codespaces", hostDockerInternal)
 		break
 
 	case IsWSL2() && IsDockerDesktop():
 		// If IDE is on Windows, return; we don't have to do anything.
+		util.Debug("host.docker.internal='%s' because IsWSL2 and IsDockerDesktop", hostDockerInternal)
 		break
 
 	case IsWSL2() && globalconfig.DdevGlobalConfig.XdebugIDELocation == globalconfig.XdebugIDELocationWSL2:
 		// If IDE is inside WSL2 then the normal linux processing should work
+		util.Debug("host.docker.internal='%s' because globalconfig.DdevGlobalConfig.XdebugIDELocation=%s", hostDockerInternal, globalconfig.XdebugIDELocationWSL2)
 		break
 
 	case IsWSL2() && !IsDockerDesktop():
 		// If IDE is on Windows, we have to parse /etc/resolv.conf
 		hostDockerInternal = wsl2ResolvConfNameserver()
+		util.Debug("host.docker.internal='%s' because IsWSL2 and !IsDockerDesktop; received from resolv.conf", hostDockerInternal)
 
 	// Docker on linux doesn't define host.docker.internal
 	// so we need to go get the bridge IP address
 	// Docker Desktop) defines host.docker.internal itself.
 	case runtime.GOOS == "linux":
 		// In docker 20.10+, host.docker.internal is already taken care of by extra_hosts in docker-compose
+		util.Debug("host.docker.internal='%s' runtime.GOOS==linux and docker 20.10+", hostDockerInternal)
 		break
 	}
 
@@ -1173,6 +1182,7 @@ func wsl2ResolvConfNameserver() string {
 		}
 		// We just grepped it so no need to check error
 		etcResolv, _ := fileutil.ReadFileIntoString("/etc/resolv.conf")
+		util.Debug("resolv.conf=%s", etcResolv)
 
 		nameserverRegex := regexp.MustCompile(`nameserver *([0-9\.]*)`)
 		//nameserverRegex.ReplaceAllFunc([]byte(etcResolv), []byte(`$1`))


### PR DESCRIPTION
## The Issue

* #4803 
* https://github.com/ddev/ddev/issues/3772#issuecomment-1505090962

## How This PR Solves The Issue

Capture information on how host.docker.internal is generated; To see where it comes from, `export DDEV_DEBUG=true` and then `ddev start`


## TODO

- [ ] Add xdebug.discover_client_host=1 to the standard xdebug config; it should usually help.
- [ ] Reread the troubleshooting docs.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4813"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

