### PR TITLE
[release] Fix broken tarball filename [skip ci]

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -130,10 +130,7 @@ archives:
   - ddev_fish_completion.sh
   format: tar.gz
   name_template: >-
-    {{ .ProjectName }}_
-    {{- if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-
-    {{- .Arch }}.
-    v{{- .Version }}
+    {{ .ProjectName }}_{{- if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{- .Arch }}.v{{- .Version }}
   format_overrides:
   - goos: windows
     format: zip


### PR DESCRIPTION
## The Issue

Working on the new goreleaser stuff in 
* https://github.com/ddev/ddev/pull/4808

I seem to have ended up with a space in the middle of the filename in the homebrew stuff. This fixes that.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4815"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

