### PR TITLE
Fix broken ddev debug migrate-database, fixes #4800

### DIFF
--- a/cmd/ddev/cmd/debug-migrate-database_test.go
+++ b/cmd/ddev/cmd/debug-migrate-database_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/nodeps"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDebugMigrateDatabase checks to see if we can migrate database
+// This does only a trivial change between two mariadb versions
+func TestDebugMigrateDatabase(t *testing.T) {
+	assert := asrt.New(t)
+
+	origDir, _ := os.Getwd()
+
+	site := TestSites[0]
+	_ = os.Chdir(site.Dir)
+
+	app, err := ddevapp.NewApp(site.Dir, false)
+	assert.NoError(err)
+
+	app.Database.Type = nodeps.MariaDB
+	app.Database.Version = nodeps.MariaDB104
+
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+
+		err = app.Stop(true, false)
+		assert.NoError(err)
+	})
+
+	err = app.Start()
+	require.NoError(t, err)
+
+	out, _, err := app.Exec(&ddevapp.ExecOpts{
+		Service: "db",
+		Cmd:     `mysql -N -e 'SELECT VERSION();'`,
+	})
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(out, nodeps.MariaDB104))
+
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
+		Service: "db",
+		Cmd:     fmt.Sprintf(`mysql -e 'CREATE TABLE IF NOT EXISTS example_table (name VARCHAR(255) NOT NULL); INSERT INTO example_table (name) VALUES ("%s");'`, t.Name()),
+	})
+	require.NoError(t, err)
+
+	// Try a migration
+	out, err = exec.RunHostCommand(DdevBin, "debug", "migrate-database", "mariadb:10.8")
+	require.NoError(t, err, "failed to migrate database; out='%s'", out)
+
+	require.Contains(t, out, "database was converted to mariadb:10.8")
+
+	// Make sure our inserted data is still there
+	out, _, err = app.Exec(&ddevapp.ExecOpts{
+		Service: "db",
+		Cmd:     fmt.Sprintf(`mysql -N -e 'SELECT name FROM example_table WHERE name = "%s";'`, t.Name()),
+	})
+	require.NoError(t, err)
+	require.Contains(t, out, t.Name())
+
+	// Make sure we have the expected new version
+	out, _, err = app.Exec(&ddevapp.ExecOpts{
+		Service: "db",
+		Cmd:     `mysql -N  -e 'SELECT VERSION();'`,
+	})
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(out, nodeps.MariaDB108))
+}

--- a/cmd/ddev/cmd/testdata/TestDebugMigrateDatabase/users.sql
+++ b/cmd/ddev/cmd/testdata/TestDebugMigrateDatabase/users.sql
@@ -1,0 +1,55 @@
+-- MySQL dump 10.13  Distrib 5.5.54, for debian-linux-gnu (x86_64)
+--
+-- Host: db    Database: data
+-- ------------------------------------------------------
+-- Server version	5.7.17-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `users`
+--
+
+DROP TABLE IF EXISTS `users`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `users` (
+  `uid` int(10) unsigned NOT NULL,
+  `uuid` varchar(128) CHARACTER SET ascii NOT NULL,
+  `langcode` varchar(12) CHARACTER SET ascii NOT NULL,
+  PRIMARY KEY (`uid`),
+  UNIQUE KEY `user_field__uuid__value` (`uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='The base table for user entities.';
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `users`
+--
+
+LOCK TABLES `users` WRITE;
+/*!40000 ALTER TABLE `users` DISABLE KEYS */;
+set autocommit=0;
+INSERT INTO `users` VALUES (0,'13751eca-19cf-41c2-90d4-9363f3a07c45','en'),(1,'186efa0a-8aa3-4eeb-90ce-6302fb9c4e07','en');
+/*!40000 ALTER TABLE `users` ENABLE KEYS */;
+UNLOCK TABLES;
+commit;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2017-05-31 14:03:34

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1290,9 +1290,6 @@ func PrepDdevDirectory(app *DdevApp) error {
 		}
 	}
 
-	// The .downloads directory shouldn't have anything in it to begin with.
-	_ = os.RemoveAll(app.GetConfigPath(".downloads"))
-
 	err = os.MkdirAll(filepath.Join(dir, "web-entrypoint.d"), 0755)
 	if err != nil {
 		return err


### PR DESCRIPTION
## The Issue

* #4800

## How This PR Solves The Issue

Don't delete the .ddev/.downloads directory on start

## Manual Testing Instructions

Just use `ddev debug migrate-database`

## Automated Testing Overview

Added TestDebugMigrateDatabase




<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4818"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

