### PR TITLE
ddev get --list --all should return all repos, fixes #4795

### DIFF
--- a/.buildkite/macos-m1.yml
+++ b/.buildkite/macos-m1.yml
@@ -12,6 +12,7 @@
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds
       BUILDKIT_PROGRESS: plain
       DDEV_TEST_SHARE_CMD: "true"
+      DDEV_RUN_GET_TESTS: "true"
       # M1 has some NFS failures (TestComposer, TestProcessHooks, TestNFSMount) and  as of 2021-02-18; test without NFS by default
 #      DDEV_TEST_USE_NFSMOUNT: true
     parallelism: 1

--- a/cmd/ddev/cmd/get_test.go
+++ b/cmd/ddev/cmd/get_test.go
@@ -18,6 +18,9 @@ import (
 
 // TestCmdGet tests various `ddev get` commands .
 func TestCmdGet(t *testing.T) {
+	if os.Getenv("DDEV_RUN_GET_TESTS") != "true" {
+		t.Skip("Skipping because DDEV_RUN_GET_TESTS is not set")
+	}
 	assert := asrt.New(t)
 
 	origDir, _ := os.Getwd()
@@ -89,6 +92,10 @@ func TestCmdGet(t *testing.T) {
 
 // TestCmdGetComplex tests advanced usages
 func TestCmdGetComplex(t *testing.T) {
+	if os.Getenv("DDEV_RUN_GET_TESTS") != "true" {
+		t.Skip("Skipping because DDEV_RUN_GET_TESTS is not set")
+	}
+
 	assert := asrt.New(t)
 
 	origDir, _ := os.Getwd()


### PR DESCRIPTION
## The Issue

* #4795 

## How This PR Solves The Issue

Make it properly handle pages... and start with a larger number

## Manual Testing Instructions

`ddev get --list --all`

## Automated Testing Overview

* Changed to only run ddev TestCmdGet tests on mac M1, since Github always breaks tests when we run multiple places



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4819"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

