### PR TITLE
Automate Laravel MailHog capture configuration

### DIFF
--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -57,6 +57,7 @@ func laravelPostStartAction(app *DdevApp) error {
 		"DB_PASSWORD":   "db",
 		"DB_CONNECTION": dbConnection,
 		"MAIL_HOST":     "127.0.0.1",
+		"MAIL_PORT":     "1025",
 	}
 	err = WriteProjectEnvFile(envFilePath, envMap, envText)
 	if err != nil {

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -56,6 +56,7 @@ func laravelPostStartAction(app *DdevApp) error {
 		"DB_USERNAME":   "db",
 		"DB_PASSWORD":   "db",
 		"DB_CONNECTION": dbConnection,
+		"MAIL_HOST":     "127.0.0.1"
 	}
 	err = WriteProjectEnvFile(envFilePath, envMap, envText)
 	if err != nil {

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -56,7 +56,7 @@ func laravelPostStartAction(app *DdevApp) error {
 		"DB_USERNAME":   "db",
 		"DB_PASSWORD":   "db",
 		"DB_CONNECTION": dbConnection,
-		"MAIL_HOST":     "127.0.0.1"
+		"MAIL_HOST":     "127.0.0.1",
 	}
 	err = WriteProjectEnvFile(envFilePath, envMap, envText)
 	if err != nil {


### PR DESCRIPTION
## The Issue

Laravel requires additional configuration to work with DDEV's Mailhog.

With current setup, sending an email results in the following exception:

```php
   Symfony\Component\Mailer\Exception\TransportException  Connection could not be established with host "mailpit:1025": stream_socket_client(): php_network_getaddresses: getaddrinfo for mailpit failed: Temporary failure in name resolution.
```

## How This PR Solves The Issue

This PR add `MAIL_HOST=127.0.0.1` to the project's `.env`.

## Manual Testing Instructions

1. Follow quickstart guide for a Laravel project. You should see the Laravel "Welcome page"
1. Launch Mailhog to watch for email:

    ```shell
    ddev launch -m
    ```

1. Enter "tinker mode" by typing the following command:

    ```shell
    ddev artisan tinker
    ```

1. Copy and past (or type) the following command into "tinker mode". This will attempt to send an email which should be caught by Mailhog.:

    ```php
    Illuminate\Support\Facades\Mail::raw('Hello World!', function($msg) {$msg->to('example@example.com')->subject('Test Email'); });
    ```

1. Type `exit` to exit "tinker mode".

Note: if you make changes to `.env` (or any php file), you need to exit and re-enter "tinker mode" for changes to apply. 


## Related Issue Link(s)
Fixes #4821

## Release/Deployment Notes

Recent versions of DDEV automate the database settings, so it seems consistent to include the mail server.

Developers are free to opt out of DDEV managing this using currently documented best practises.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4822"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

