### PR TITLE
Fixed minor bug in symlink creation code.

### DIFF
--- a/docs/content/users/extend/in-container-configuration.md
+++ b/docs/content/users/extend/in-container-configuration.md
@@ -14,7 +14,7 @@ DDEV looks for the `homeadditions` directory both in the global `~/.ddev/homeadd
 Usage examples:
 
 * If you use Git inside the container, you may want to symlink your `~/.gitconfig` into `~/.ddev/homeadditions` or the project’s `.ddev/homeadditions` so that in-container `git` commands use whatever username and email you’ve configured on your host machine. For example, `ln -s ~/.gitconfig ~/.ddev/homeadditions/.gitconfig`.
-* If you use SSH inside the container and want to use your `.ssh/config`, consider `mkdir -p ~/.ddev/homeadditions/.ssh && ln -s ~/.ssh/config ~/.ddev/homeadditions/.ssh/config`. Some people will be able to symlink their entire `.ssh` directory, `ln -s ~/.ssh ~/.ddev/homeadditions/ssh`. If you provide your own `.ssh/config` though, please make sure it includes these lines:
+* If you use SSH inside the container and want to use your `.ssh/config`, consider `mkdir -p ~/.ddev/homeadditions/.ssh && ln -s ~/.ssh/config ~/.ddev/homeadditions/.ssh/config`. Some people will be able to symlink their entire `.ssh` directory, `ln -s ~/.ssh ~/.ddev/homeadditions/.ssh`. If you provide your own `.ssh/config` though, please make sure it includes these lines:
 
     ```
     UserKnownHostsFile=/home/.ssh-agent/known_hosts


### PR DESCRIPTION
Fixing a missing dot in `ln -s ~/.ssh ~/.ddev/homeadditions/ssh` (should be `.ssh`).

-mike

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4823"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

