### PR TITLE
[docs] Minor docs for apt/yum package management

### DIFF
--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -186,7 +186,7 @@ The Linux `apt` and `yum/rpm` packages are built and pushed by the `nfpms` and `
 
 * The actual packages are served by [gemfury.com](https://gemfury.com/).
 * The name of the organization in GemFury is [`drud`](`https://manage.fury.io/dashboard/drud`).
-* `rfay`, `mattstein`, and `gilbertsoft` are authorized as owners on this dashboard.
-* The `pkg.ddev.com` domain name is set up as a custom alias for our package repositories, see [manage.fury.io/manage/drud/domains](https://manage.fury.io/manage/drud/domains). (Users do not see `drud` anywhere. Although we could have moved to a new organization for this, the existing repositories contain all the historical versions so it made sense to be less disruptive.)
+* [Randy Fay](https://github.com/rfay), [Matt Stein](https://github.com/mattstein), and [Simon Gillis](https://github.com/gilbertsoft) are authorized as owners on this dashboard.
+* The `pkg.ddev.com` domain name is set up as a custom alias for our package repositories; see [manage.fury.io/manage/drud/domains](https://manage.fury.io/manage/drud/domains). (Users do not see `drud` anywhere. Although we could have moved to a new organization for this, the existing repositories contain all the historical versions so it made sense to be less disruptive.)
 * The `pkg.ddev.com` `CNAME` is managed in CloudFlare because `ddev.com` is managed there.
-* The fury.io tokens are shared in DDEV shared 1Password account.
+* The fury.io tokens are in DDEV’s shared 1Password account.

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -179,3 +179,14 @@ This is done automatically by the release build on a dedicated Windows test runn
 
 !!!tip "We shouldn’t use this high-security keyfob approach to signing on the next go-around with the certs."
     It’s way too difficult to manage, and the Safenet software is atrocious.
+
+## APT and YUM/RPM Package Management
+
+The Linux `apt` and `yum/rpm` packages are built and pushed by the `nfpms` and `furies` sections of the [.goreleaser.yml](https://github.com/ddev/ddev/blob/master/.goreleaser.yml).
+
+* The actual packages are served by [gemfury.com](https://gemfury.com/).
+* The name of the organization in GemFury is [`drud`](`https://manage.fury.io/dashboard/drud`).
+* `rfay`, `mattstein`, and `gilbertsoft` are authorized as owners on this dashboard.
+* The `pkg.ddev.com` domain name is set up as a custom alias for our package repositories, see [manage.fury.io/manage/drud/domains](https://manage.fury.io/manage/drud/domains). (Users do not see `drud` anywhere. Although we could have moved to a new organization for this, the existing repositories contain all the historical versions so it made sense to be less disruptive.)
+* The `pkg.ddev.com` `CNAME` is managed in CloudFlare because `ddev.com` is managed there.
+* The fury.io tokens are shared in DDEV shared 1Password account.

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -185,8 +185,8 @@ This is done automatically by the release build on a dedicated Windows test runn
 The Linux `apt` and `yum`/`rpm` packages are built and pushed by the `nfpms` and `furies` sections of the [.goreleaser.yml](https://github.com/ddev/ddev/blob/master/.goreleaser.yml) file.
 
 * The actual packages are served by [gemfury.com](https://gemfury.com/).
-* The name of the organization in GemFury is [`drud`](`https://manage.fury.io/dashboard/drud`).
+* The name of the organization in GemFury is `drud`, managed at `https://manage.fury.io/dashboard/drud`.
 * [Randy Fay](https://github.com/rfay), [Matt Stein](https://github.com/mattstein), and [Simon Gillis](https://github.com/gilbertsoft) are authorized as owners on this dashboard.
-* The `pkg.ddev.com` domain name is set up as a custom alias for our package repositories; see [manage.fury.io/manage/drud/domains](https://manage.fury.io/manage/drud/domains). (Users do not see `drud` anywhere. Although we could have moved to a new organization for this, the existing repositories contain all the historical versions so it made sense to be less disruptive.)
+* The `pkg.ddev.com` domain name is set up as a custom alias for our package repositories; see `https://manage.fury.io/manage/drud/domains`. (Users do not see `drud` anywhere. Although we could have moved to a new organization for this, the existing repositories contain all the historical versions so it made sense to be less disruptive.)
 * The `pkg.ddev.com` `CNAME` is managed in CloudFlare because `ddev.com` is managed there.
 * The fury.io tokens are in DDEV’s shared 1Password account.

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -182,7 +182,7 @@ This is done automatically by the release build on a dedicated Windows test runn
 
 ## APT and YUM/RPM Package Management
 
-The Linux `apt` and `yum/rpm` packages are built and pushed by the `nfpms` and `furies` sections of the [.goreleaser.yml](https://github.com/ddev/ddev/blob/master/.goreleaser.yml).
+The Linux `apt` and `yum`/`rpm` packages are built and pushed by the `nfpms` and `furies` sections of the [.goreleaser.yml](https://github.com/ddev/ddev/blob/master/.goreleaser.yml) file.
 
 * The actual packages are served by [gemfury.com](https://gemfury.com/).
 * The name of the organization in GemFury is [`drud`](`https://manage.fury.io/dashboard/drud`).


### PR DESCRIPTION
## The Issue

Our setup for apt/yum package management wasn't adequately explained.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4825"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

