### PR TITLE
Ignore specified yaml files that don't exist, fixes #4774

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -178,13 +178,13 @@ ddev get --list --all
 
 			yamlMap[name], err = util.YamlFileToMap(fullpath)
 			if err != nil {
-				util.Failed("unable to import yaml file %s: %v", fullpath, err)
+				util.Warning("unable to import yaml file %s: %v", fullpath, err)
 			}
 		}
 		for k, v := range map[string]string{"DdevGlobalConfig": globalconfig.GetGlobalConfigPath(), "DdevProjectConfig": app.GetConfigPath("config.yaml")} {
 			yamlMap[k], err = util.YamlFileToMap(v)
 			if err != nil {
-				util.Failed("unable to read file %s", v)
+				util.Warning("unable to read file %s", v)
 			}
 		}
 


### PR DESCRIPTION
## The Issue

* #4774 

## How This PR Solves The Issue

Warn, but don't fail, on missing .platform (or other) yaml files mentioned in install.yaml

## Manual Testing Instructions

* Remove .platform/routes.yaml and then `ddev get ddev/ddev-platformsh`. `ddev start`. Make sure things work.

