### PR TITLE
add link to "Testing a PR" to PR build

### DIFF
--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -20,7 +20,7 @@ jobs:
           const run_id = ${{github.event.workflow_run.id}};
           const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
           const pull_user_id = ${{github.event.sender.id}};
-          
+
           const issue_number = await (async () => {
             const pulls = await github.pulls.list({owner, repo});
             for await (const {data} of github.paginate.iterator(pulls)) {
@@ -36,7 +36,7 @@ jobs:
           } else {
             return core.error(`No matching pull request found`);
           }
-          
+
           const {data: {artifacts}} = await github.actions.listWorkflowRunArtifacts({owner, repo, run_id});
           if (!artifacts.length) {
             return core.error(`No artifacts found`);

--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -45,7 +45,9 @@ jobs:
           for (const art of artifacts) {
             body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
           }
-          
+
+          body += `\n\n See [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr)`;
+
           const {data: comments} = await github.issues.listComments({repo, owner, issue_number});
           const existing_comment = comments.find((c) => c.user.login === 'github-actions[bot]');
           if (existing_comment) {


### PR DESCRIPTION
## The Issue

"PR builds" automatically generate binaries for each platform. However, we don't offer any further help on what to do.

## How This PR Solves The Issue

We have a section in the docs, [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr).

This PR adds a link to the docs to help developers get started. 

## Release/Deployment Notes

I think something short and "simple" works best here. The docs should be "source of truth" and offer expanded details.

