### PR TITLE
Changed network.go to support the DDEV_GITHUB_TOKEN in DownloadFile

### DIFF
--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -27,8 +27,17 @@ func DownloadFile(destPath string, url string, progressBar bool) (err error) {
 	}
 	defer CheckClose(out)
 
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+
+	// check for github token - used for private addon repositories
+	githubToken := os.Getenv("DDEV_GITHUB_TOKEN")
+	if githubToken != "" {
+		request.Header.Add("Authorization", "Bearer "+githubToken)
+	}
+
 	// Get the data
-	resp, err := http.Get(url)
+	resp, err := http.DefaultClient.Do(request)
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## The Issue

The get command is actually already supporting the DDEV_GITHUB_TOKEN (see https://github.com/ddev/ddev/blob/master/cmd/ddev/cmd/get.go#L371 ) though for purposes of the github download limit. 

But while the get function passes through the initial github requests where the releases of the repo are detected, it breaks when trying to download the packaged release:

```
$ DDEV_GITHUB_TOKEN=github-token ddev get name/of-addon

Unable to download name/of-addon: Unable to download https://api.github.com/repos/name/of-addon/tarball/1.0.0: download link https://api.github.com/repos/name/of-addon/tarball/1.0.0 returned wrong status code: got 404 want 200

```

## How This PR Solves The Issue

I changed the http request method to support the bearer authentication for downloading the tarball

## Manual Testing Instructions

Using the DDEV get command on a private github repository will crash regardless of the set DDEV_GITHUB_TOKEN variable.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4832"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

