### PR TITLE
Fix wrong TYPO3 settings path if composer_root is used, fixes #4545

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -129,20 +129,21 @@ func getTypo3Hooks() []byte {
 
 // setTypo3SiteSettingsPaths sets the paths to settings files for templating
 func setTypo3SiteSettingsPaths(app *DdevApp) {
-	settingsFileBasePath := filepath.Join(app.AppRoot, app.ComposerRoot)
 	var settingsFilePath, localSettingsFilePath string
 
 	if isTypo3v12OrHigher(app) {
+		settingsFileBasePath := filepath.Join(app.AppRoot, app.ComposerRoot)
 		settingsFilePath = filepath.Join(settingsFileBasePath, "config", "system", "settings.php")
 		localSettingsFilePath = filepath.Join(settingsFileBasePath, "config", "system", "additional.php")
 	} else if isTypo3App(app) {
-		settingsFilePath = filepath.Join(settingsFileBasePath, app.Docroot, "typo3conf", "LocalConfiguration.php")
-		localSettingsFilePath = filepath.Join(settingsFileBasePath, app.Docroot, "typo3conf", "AdditionalConfiguration.php")
+		settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
+		settingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "LocalConfiguration.php")
+		localSettingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "AdditionalConfiguration.php")
 	} else {
 		// As long as TYPO3 is not installed, the file paths are set to the
 		// AppRoot to avoid the creation of the .gitignore in the wrong location.
-		settingsFilePath = filepath.Join(settingsFileBasePath, "LocalConfiguration.php")
-		localSettingsFilePath = filepath.Join(settingsFileBasePath, "AdditionalConfiguration.php")
+		settingsFilePath = filepath.Join(app.AppRoot, "LocalConfiguration.php")
+		localSettingsFilePath = filepath.Join(app.AppRoot, "AdditionalConfiguration.php")
 	}
 
 	// Update file paths


### PR DESCRIPTION
## The Issue

If composer_root is set for TYPO3 v11 or lower the settings path is wrong calculated. TYPO3 v12 or higher is not affected.

## How This PR Solves The Issue

The correct path calculated from the docroot is now used and composer_root is ignored for TYPO3 v11 or lower.

## Manual Testing Instructions

Setup a TYPO3 v11 or lower and set the composer_root. See linked issue for more information.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

Fixes 
* #4545

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4835"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

