### PR TITLE
[docs] Add Axiom Repobeats contributor overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Run `ddev` to see all the [commands](https://ddev.readthedocs.io/en/latest/users
 
 See “How can I contribute to DDEV?” in the [FAQ](https://ddev.readthedocs.io/en/latest/users/usage/faq/), and the [Contributing](CONTRIBUTING.md) page.
 
+![Overview of GitHub contributions](https://repobeats.axiom.co/api/embed/941b040a17921e974655fc01d7735aa350a53603.svg "Repobeats analytics image")
+
 ## Wonderful Sponsors
 
 [<img src="images/Platformsh_Logo_DDEV.jpg" alt="Platform.sh" width="200">](https://platform.sh)


### PR DESCRIPTION
This adds a [Repobeats](https://repobeats.axiom.co) overview to DDEV’s readme to transparently demonstrate the project activity that I think is one of its strengths. It keeps itself up to date and acknowledges contributors.

I deliberately placed it in the _Contributing_ section because it’s relevant there, and I don’t think it should live at the top and distract from a description of what DDEV is that’s for everyone.

![Screen Shot 2023-04-19 at 10 31 04 AM@2x](https://user-images.githubusercontent.com/2488775/233154954-a67836b0-471c-4e39-a7a8-7fce5d03e6f5.png)