### PR TITLE
Recreate mutagen sync session when mutagen.yml changes, fixes #4753

### DIFF
--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -39,7 +39,7 @@ func TestCmdAuthSSH(t *testing.T) {
 		assert.NoError(err)
 		err = os.Chdir(origDir)
 		assert.NoError(err)
-		err = dockerutil.RemoveContainer("test-cmd-ssh-server", 10)
+		err = dockerutil.RemoveContainer("test-cmd-ssh-server")
 		assert.NoError(err)
 	})
 

--- a/cmd/ddev/cmd/debug-nfsmount.go
+++ b/cmd/ddev/cmd/debug-nfsmount.go
@@ -33,7 +33,7 @@ var DebugNFSMountCmd = &cobra.Command{
 		}
 		oldContainer, err := dockerutil.FindContainerByName(containerName)
 		if err == nil && oldContainer != nil {
-			err = dockerutil.RemoveContainer(oldContainer.ID, 20)
+			err = dockerutil.RemoveContainer(oldContainer.ID)
 			if err != nil {
 				util.Failed("Failed to remove existing test container %s: %v", containerName, err)
 			}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -976,7 +976,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 
 	if app.IsMutagenEnabled() {
 		if ok, volumeExists, info := CheckMutagenVolumeSyncCompatibility(app); !ok {
-			util.Debug("mutagen sync session and docker volume are in incompatible status: '%s', Removing mutagen sync session '%s' and docker volume %s", info, MutagenSyncName(app.Name), GetMutagenVolumeName(app))
+			util.Debug("mutagen sync session, configuration, and docker volume are in incompatible status: '%s', Removing mutagen sync session '%s' and docker volume %s", info, MutagenSyncName(app.Name), GetMutagenVolumeName(app))
 			terminateErr := TerminateMutagenSync(app)
 			if terminateErr != nil {
 				util.Warning("Unable to terminate mutagen sync %s: %v", MutagenSyncName(app.Name), err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -982,6 +982,14 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 				util.Warning("Unable to terminate mutagen sync %s: %v", MutagenSyncName(app.Name), err)
 			}
 			if volumeExists {
+				// Remove mounting container if necessary.
+				container, err := dockerutil.FindContainerByName("ddev-" + app.Name + "-web")
+				if err == nil && container != nil {
+					err = dockerutil.RemoveContainer(container.ID)
+					if err != nil {
+						return fmt.Errorf(`Unable to remove web container, please 'ddev restart': %v`, err)
+					}
+				}
 				removeVolumeErr := dockerutil.RemoveVolume(GetMutagenVolumeName(app))
 				if removeVolumeErr != nil {
 					return fmt.Errorf(`Unable to remove mismatched mutagen docker volume '%s'. Please use 'ddev restart' or 'ddev mutagen reset': %v`, GetMutagenVolumeName(app), removeVolumeErr)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -977,6 +977,10 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	if app.IsMutagenEnabled() {
 		if ok, volumeExists, info := CheckMutagenVolumeSyncCompatibility(app); !ok {
 			util.Debug("mutagen sync session, configuration, and docker volume are in incompatible status: '%s', Removing mutagen sync session '%s' and docker volume %s", info, MutagenSyncName(app.Name), GetMutagenVolumeName(app))
+			err = SyncAndPauseMutagenSession(app)
+			if err != nil {
+				util.Warning("Unable to SyncAndPauseMutagenSession() %s: %v", MutagenSyncName(app.Name), err)
+			}
 			terminateErr := TerminateMutagenSync(app)
 			if terminateErr != nil {
 				util.Warning("Unable to terminate mutagen sync %s: %v", MutagenSyncName(app.Name), err)

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -420,21 +420,12 @@ func (app *DdevApp) MutagenStatus() (status string, shortResult string, mapResul
 func (app *DdevApp) GetMutagenSyncID() (id string, err error) {
 	syncName := MutagenSyncName(app.Name)
 
-	fullJSONResult, err := exec.RunHostCommandSeparateStreams(globalconfig.GetMutagenPath(), "sync", "list", "--template", `{{ json (index . 0) }}`, syncName)
+	identifier, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "list", `--template='{{ range . }}{{ .Identifier }}{{ break }}{{ end }}'`, syncName)
 	if err != nil {
-		return "", err
-	}
-	session := make(map[string]interface{})
-	err = json.Unmarshal([]byte(fullJSONResult), &session)
-	if err != nil {
-		return "", fmt.Errorf("unable to unmarshall mutagen session json result: %v", err)
+		return "", fmt.Errorf("failed RunHostCommand, output='%s': %v", identifier, err)
 	}
 
-	if id, ok := session["identifier"].(string); ok {
-		return id, nil
-	}
-
-	return "", nil
+	return identifier, nil
 }
 
 // MutagenSyncFlush performs a mutagen sync flush, waits for result, and checks for errors

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -156,8 +156,8 @@ func TestMutagenSimple(t *testing.T) {
 
 // TestMutagenConfigChange tests mutagen new session creation on mutagen.yml change
 func TestMutagenConfigChange(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TestMutagenConfigChange takes too long on Windows, skipping")
+	if runtime.GOOS != "darwin" {
+		t.Skip("TestMutagenConfigChange runs only on nacOS (without Colima), skipping")
 	}
 	assert := asrt.New(t)
 

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -36,7 +36,7 @@ func PowerOff() {
 	})
 	if err == nil {
 		for _, c := range containers {
-			err = dockerutil.RemoveContainer(c.ID, 10)
+			err = dockerutil.RemoveContainer(c.ID)
 			if err != nil {
 				util.Warning("Failed to remove container %s", c.Names[0])
 			}

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -55,7 +55,7 @@ func StopRouterIfNoContainers() error {
 	}
 
 	if !containersRunning {
-		err = dockerutil.RemoveContainer(nodeps.RouterContainer, 0)
+		err = dockerutil.RemoveContainer(nodeps.RouterContainer)
 		if err != nil {
 			if _, ok := err.(*docker.NoSuchContainer); !ok {
 				return err
@@ -75,7 +75,7 @@ func StartDdevRouter() error {
 	// starts over again.
 	router, err := FindDdevRouter()
 	if router != nil && err == nil && router.State != "running" {
-		err = dockerutil.RemoveContainer(nodeps.RouterContainer, 0)
+		err = dockerutil.RemoveContainer(nodeps.RouterContainer)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -180,7 +180,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 		if err != nil || dbContainer == nil {
 			return fmt.Errorf("no container found for db; err=%v", err)
 		}
-		err = dockerutil.RemoveContainer(dbContainer.ID, 20)
+		err = dockerutil.RemoveContainer(dbContainer.ID)
 		if err != nil {
 			return fmt.Errorf("failed to remove db container: %v", err)
 		}

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -74,7 +74,7 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 // RemoveSSHAgentContainer brings down the ddev-ssh-agent if it's running.
 func RemoveSSHAgentContainer() error {
 	// Stop the container if it exists
-	err := dockerutil.RemoveContainer(globalconfig.DdevSSHAgentContainer, 0)
+	err := dockerutil.RemoveContainer(globalconfig.DdevSSHAgentContainer)
 	if err != nil {
 		if _, ok := err.(*docker.NoSuchContainer); !ok {
 			return err

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -136,7 +136,7 @@ func TestSshAuthConfigOverride(t *testing.T) {
 
 	// Remove the ddev-ssh-agent, since the start code simply checks to see if it's
 	// running and doesn't restart it if it's running
-	_ = dockerutil.RemoveContainer("ddev-ssh-agent", 0)
+	_ = dockerutil.RemoveContainer("ddev-ssh-agent")
 
 	testcommon.ClearDockerEnv()
 

--- a/pkg/ddevapp/testdata/TestMutagenConfigChange/mutagen.yml
+++ b/pkg/ddevapp/testdata/TestMutagenConfigChange/mutagen.yml
@@ -1,0 +1,38 @@
+#ddev-generated
+# To override this file remove the line above
+# and add your own configuration. If you override it you will
+# probably want to check it in.
+# Please do `ddev mutagen reset` after changing the file.
+# See ddev mutagen docs at
+# https://ddev.readthedocs.io/en/latest/users/install/performance/
+# For detailed information about mutagen configuration options, see
+# https://mutagen.io/documentation/introduction/configuration
+sync:
+  defaults:
+    mode: "two-way-resolved"
+    stageMode: "neighboring"
+    ignore:
+      paths:
+      # The top-level .git directory is ignored because where possible it's mounted
+      # into the container with a traditional docker bind-mount
+      - "/.git"
+
+      - "/.tarballs"
+      - "/.ddev/db_snapshots"
+      - "/.ddev/.importdb*"
+      - ".DS_Store"
+      - ".idea"
+      {{ if .UploadDir }}
+      - "/{{ .UploadDir }}"
+      {{ end }}
+
+      # You can also exclude other directories from mutagen-syncing
+      # For example /var/www/html/var does not need to sync in TYPO3
+      # so you can add:
+      # - "/var"
+      # vcs like .git can be ignored for safety, but then some
+      # composer operations may fail if they use dev versions/git.
+      # vcs: true
+    symlink:
+      mode: "{{ .SymlinkMode }}"
+

--- a/pkg/ddevapp/testdata/TestMutagenConfigChange/mutagen.yml
+++ b/pkg/ddevapp/testdata/TestMutagenConfigChange/mutagen.yml
@@ -1,12 +1,4 @@
-#ddev-generated
-# To override this file remove the line above
-# and add your own configuration. If you override it you will
-# probably want to check it in.
-# Please do `ddev mutagen reset` after changing the file.
-# See ddev mutagen docs at
-# https://ddev.readthedocs.io/en/latest/users/install/performance/
-# For detailed information about mutagen configuration options, see
-# https://mutagen.io/documentation/introduction/configuration
+# Simple testing mutagen.yml
 sync:
   defaults:
     mode: "two-way-resolved"
@@ -22,17 +14,6 @@ sync:
       - "/.ddev/.importdb*"
       - ".DS_Store"
       - ".idea"
-      {{ if .UploadDir }}
-      - "/{{ .UploadDir }}"
-      {{ end }}
 
-      # You can also exclude other directories from mutagen-syncing
-      # For example /var/www/html/var does not need to sync in TYPO3
-      # so you can add:
-      # - "/var"
-      # vcs like .git can be ignored for safety, but then some
-      # composer operations may fail if they use dev versions/git.
-      # vcs: true
     symlink:
-      mode: "{{ .SymlinkMode }}"
-
+      mode: "posix-raw"

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -841,7 +841,7 @@ func RunSimpleContainer(image string, name string, cmd []string, entrypoint []st
 
 	if removeContainerAfterRun {
 		// nolint: errcheck
-		defer RemoveContainer(container.ID, 20)
+		defer RemoveContainer(container.ID)
 	}
 	err = client.StartContainer(container.ID, nil)
 	if err != nil {
@@ -877,7 +877,7 @@ func RunSimpleContainer(image string, name string, cmd []string, entrypoint []st
 }
 
 // RemoveContainer stops and removes a container
-func RemoveContainer(id string, _ uint) error {
+func RemoveContainer(id string) error {
 	client := GetDockerClient()
 
 	err := client.RemoveContainer(docker.RemoveContainerOptions{ID: id, Force: true})
@@ -1240,7 +1240,7 @@ func CopyIntoVolume(sourcePath string, volumeName string, targetSubdir string, u
 		return err
 	}
 	// nolint: errcheck
-	defer RemoveContainer(containerID, 0)
+	defer RemoveContainer(containerID)
 
 	err = CopyIntoContainer(sourcePath, containerName, targetSubdirFullPath, exclusion)
 

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -55,7 +55,7 @@ func testMain(m *testing.M) int {
 	foundContainer, _ := FindContainerByLabels(map[string]string{"com.ddev.site-name": testContainerName})
 
 	if foundContainer != nil {
-		err = RemoveContainer(foundContainer.ID, 30)
+		err = RemoveContainer(foundContainer.ID)
 		if err != nil {
 			logOutput.Errorf("-- FAIL: dockerutils_test TestMain failed to remove container %s: %v", foundContainer.ID, err)
 			return 5
@@ -99,7 +99,7 @@ func testMain(m *testing.M) int {
 		return 2
 	}
 	defer func() {
-		err = RemoveContainer(container.ID, 10)
+		err = RemoveContainer(container.ID)
 		if err != nil {
 			logOutput.Errorf("-- FAIL: dockerutils_test failed to remove test container: %v", err)
 		}
@@ -182,13 +182,13 @@ func TestContainerWait(t *testing.T) {
 	_ = RemoveContainersByLabels(labels)
 	cID, _, err := RunSimpleContainer(versionconstants.BusyboxImage, t.Name()+util.RandString(5), []string{"ls"}, nil, nil, nil, "0", false, true, labels)
 	t.Cleanup(func() {
-		_ = RemoveContainer(cID, 0)
+		_ = RemoveContainer(cID)
 	})
 	require.NoError(t, err)
 	_, err = ContainerWait(5, labels)
 	assert.Error(err)
 	assert.Contains(err.Error(), "container exited")
-	_ = RemoveContainer(cID, 0)
+	_ = RemoveContainer(cID)
 
 	// If we run a container that does not have a healthcheck
 	// it should be found as good immediately
@@ -196,7 +196,7 @@ func TestContainerWait(t *testing.T) {
 	_ = RemoveContainersByLabels(labels)
 	cID, _, err = RunSimpleContainer(versionconstants.BusyboxImage, t.Name()+util.RandString(5), []string{"sleep", "60"}, nil, nil, nil, "0", false, true, labels)
 	t.Cleanup(func() {
-		_ = RemoveContainer(cID, 0)
+		_ = RemoveContainer(cID)
 	})
 	require.NoError(t, err)
 	_, err = ContainerWait(5, labels)
@@ -210,13 +210,13 @@ func TestContainerWait(t *testing.T) {
 	_ = RemoveContainersByLabels(labels)
 	cID, _, err = RunSimpleContainer(ddevWebserver, t.Name()+util.RandString(5), []string{"sleep", "5"}, nil, []string{"DDEV_WEBSERVER_TYPE=nginx-fpm"}, nil, "0", false, true, labels)
 	t.Cleanup(func() {
-		_ = RemoveContainer(cID, 0)
+		_ = RemoveContainer(cID)
 	})
 	require.NoError(t, err)
 	_, err = ContainerWait(3, labels)
 	assert.Error(err)
 	assert.Contains(err.Error(), "timed out without becoming healthy")
-	_ = RemoveContainer(cID, 0)
+	_ = RemoveContainer(cID)
 
 	// If we run a container that *does* have a healthcheck but it's not healthy for a while
 	// then ContainerWait should detect failure early, but should succeed later
@@ -224,7 +224,7 @@ func TestContainerWait(t *testing.T) {
 	_ = RemoveContainersByLabels(labels)
 	cID, _, err = RunSimpleContainer(ddevWebserver, t.Name()+util.RandString(5), []string{"bash", "-c", "sleep 5 && /start.sh"}, nil, []string{"DDEV_WEBSERVER_TYPE=nginx-fpm"}, nil, "0", false, true, labels)
 	t.Cleanup(func() {
-		_ = RemoveContainer(cID, 0)
+		_ = RemoveContainer(cID)
 	})
 	require.NoError(t, err)
 	_, err = ContainerWait(3, labels)
@@ -267,7 +267,7 @@ func TestComposeWithStreams(t *testing.T) {
 
 	container, _ := FindContainerByName(t.Name())
 	if container != nil {
-		_ = RemoveContainer(container.ID, 20)
+		_ = RemoveContainer(container.ID)
 	}
 
 	// Use the current actual web container for this, so replace in base docker-compose file
@@ -355,7 +355,7 @@ func TestFindContainerByName(t *testing.T) {
 	c, err := FindContainerByName(containerName)
 	assert.NoError(err)
 	if err == nil && c != nil {
-		err = RemoveContainer(c.ID, 0)
+		err = RemoveContainer(c.ID)
 		assert.NoError(err)
 	}
 
@@ -364,7 +364,7 @@ func TestFindContainerByName(t *testing.T) {
 	assert.NoError(err)
 
 	defer func() {
-		_ = RemoveContainer(cID, 0)
+		_ = RemoveContainer(cID)
 	}()
 
 	// Now find the container by name
@@ -372,7 +372,7 @@ func TestFindContainerByName(t *testing.T) {
 	assert.NoError(err)
 	require.NotNil(t, c)
 	// Remove it
-	err = RemoveContainer(c.ID, 0)
+	err = RemoveContainer(c.ID)
 	assert.NoError(err)
 
 	// Verify that we no longer find it.

--- a/pkg/fileutil/file_hash.go
+++ b/pkg/fileutil/file_hash.go
@@ -1,0 +1,31 @@
+package fileutil
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"github.com/ddev/ddev/pkg/util"
+	"io"
+	"os"
+)
+
+// FileHash returns string of hash of filePath passed in
+func FileHash(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		err = file.Close()
+		if err != nil {
+			util.Warning("unable to close file: %v", err)
+		}
+	}()
+
+	hash := sha1.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	sum := hash.Sum(nil)
+
+	return fmt.Sprintf("%x", sum), nil
+}

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -1,0 +1,65 @@
+package fileutil_test
+
+import (
+	"fmt"
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/ddev/ddev/pkg/versionconstants"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFileHash is a unit test for FileHash()
+func TestFileHash(t *testing.T) {
+	assert := asrt.New(t)
+
+	testCases := []struct {
+		content string
+	}{
+		{"This is a test file for FileHash function."},
+		{"Another test case with different content."},
+		{"Test file with special characters: !@#$%^&*()_+-=[]{};':\"|,.<>?"},
+	}
+
+	for i, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			tmpDir := testcommon.CreateTmpDir("TestFileHash_" + util.RandString(10))
+			t.Cleanup(func() {
+				err := os.RemoveAll(tmpDir)
+				assert.NoError(err)
+			})
+			testFile := filepath.Join(tmpDir, fmt.Sprintf("TestFileHash_%d", i))
+			err := fileutil.TemplateStringToFile(tc.content, nil, testFile)
+			require.NoError(t, err)
+
+			expectedHash, err := computeSha1Sum(testFile)
+			require.NoError(t, err)
+
+			result, err := fileutil.FileHash(testFile)
+			require.NoError(t, err)
+
+			require.Equal(t, expectedHash, result)
+		})
+	}
+}
+
+// computeSha1Sum uses external tool (sha1sum for example) to compute shasum
+func computeSha1Sum(filePath string) (string, error) {
+	dir := filepath.Dir(filePath)
+	fileName := filepath.Base(filePath)
+	_, out, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"sha1sum", path.Join("/var/tmp/checkdir/", fileName)}, nil, nil, []string{dir + ":" + "/var/tmp/checkdir"}, "0", true, false, nil)
+
+	if err != nil {
+		return "", err
+	}
+
+	hash := strings.Split(out, " ")[0]
+	return hash, nil
+}

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -39,7 +39,7 @@ func TestFileHash(t *testing.T) {
 			err := fileutil.TemplateStringToFile(tc.content, nil, testFile)
 			require.NoError(t, err)
 
-			expectedHash, err := computeSha1Sum(testFile)
+			expectedHash, err := externalComputeSha1Sum(testFile)
 			require.NoError(t, err)
 
 			result, err := fileutil.FileHash(testFile)
@@ -50,8 +50,8 @@ func TestFileHash(t *testing.T) {
 	}
 }
 
-// computeSha1Sum uses external tool (sha1sum for example) to compute shasum
-func computeSha1Sum(filePath string) (string, error) {
+// externalComputeSha1Sum uses external tool (sha1sum for example) to compute shasum
+func externalComputeSha1Sum(filePath string) (string, error) {
 	dir := filepath.Dir(filePath)
 	fileName := filepath.Base(filePath)
 	_, out, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"sha1sum", path.Join("/var/tmp/checkdir/", fileName)}, nil, nil, []string{dir + ":" + "/var/tmp/checkdir"}, "0", true, false, nil)

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -188,7 +188,9 @@ func OsTempDir() (string, error) {
 	return tmpDir, nil
 }
 
-// CreateTmpDir creates a temporary directory and returns its path as a string.
+// CreateTmpDir creates a temporary directory in the homoedir
+// and returns its path as a string. It's important that it's in
+// homedir since Colima doesn't mount things outside that.
 func CreateTmpDir(prefix string) string {
 	baseTmpDir := filepath.Join(homedir.Get(), "tmp", "ddevtest")
 	_ = os.MkdirAll(baseTmpDir, 0755)


### PR DESCRIPTION
## The Issue

* #4753 

A sync session can outlive the mutagen.yml file, as it's not checked again after creation

## How This PR Solves The Issue

* Add a label to the mutagen sync session with the SHA1 hash of the existing mutagen.yml
* On start, check to see if the hash remains the same
* If not, recreate the sync session (and volume)

## Manual Testing Instructions

- [x] `ddev start` and review the mutagen sync identifier (`ddev mutagen st -l | grep Identifier`)
- [x] Change mutagen.yml (make sure to remove #ddev-generated)
- [x] `ddev restart` and verify that you have a new mutagen sync session (`ddev mutagen sync st -l | grep Identifier`)
- [x] `ddev restart` without changes and verify you have the same session identifier now

## Automated Testing Overview

Added TestMutagenConfigChange and TestFileHash

## Release/Deployment Notes

* It may be wise for people to `ddev mutagen reset` on the new release. 




<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4837"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

