### PR TITLE
settings.php - Invert logic to reduce disk reads if non-ddev environment

### DIFF
--- a/pkg/ddevapp/drupal/backdrop/settings.php
+++ b/pkg/ddevapp/drupal/backdrop/settings.php
@@ -436,7 +436,7 @@ $settings['backdrop_drupal_compatibility'] = TRUE;
  */
 
 // Automatically generated include for settings managed by ddev.
-if (file_exists(__DIR__ . '/settings.ddev.php') && getenv('IS_DDEV_PROJECT') == 'true') {
+if (getenv('IS_DDEV_PROJECT') == 'true' && file_exists(__DIR__ . '/settings.ddev.php')) {
   include __DIR__ . '/settings.ddev.php';
 }
 

--- a/pkg/ddevapp/drupal/drupal10/settings.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.php
@@ -757,7 +757,7 @@ $settings['entity_update_backup'] = TRUE;
 $settings['migrate_node_migrate_type_classic'] = FALSE;
 
 // Automatically generated include for settings managed by ddev.
-if (file_exists(__DIR__ . '/settings.ddev.php') && getenv('IS_DDEV_PROJECT') == 'true') {
+if (getenv('IS_DDEV_PROJECT') == 'true' && file_exists(__DIR__ . '/settings.ddev.php')) {
   include __DIR__ . '/settings.ddev.php';
 }
 

--- a/pkg/ddevapp/drupal/drupal6/settings.php
+++ b/pkg/ddevapp/drupal/drupal6/settings.php
@@ -257,6 +257,6 @@ ini_set('url_rewriter.tags',        '');
 # );
 
 // Automatically generated include for settings managed by ddev.
-if (file_exists(__DIR__ . '/settings.ddev.php') && getenv('IS_DDEV_PROJECT') == 'true') {
+if (getenv('IS_DDEV_PROJECT') == 'true' && file_exists(__DIR__ . '/settings.ddev.php')) {
   include __DIR__ . '/settings.ddev.php';
 }

--- a/pkg/ddevapp/drupal/drupal7/settings.php
+++ b/pkg/ddevapp/drupal/drupal7/settings.php
@@ -661,6 +661,6 @@ $conf['file_scan_ignore_directories'] = array(
 );
 
 // Automatically generated include for settings managed by ddev.
-if (file_exists(__DIR__ . '/settings.ddev.php') && getenv('IS_DDEV_PROJECT') == 'true') {
+if (getenv('IS_DDEV_PROJECT') == 'true' && file_exists(__DIR__ . '/settings.ddev.php')) {
   include __DIR__ . '/settings.ddev.php';
 }

--- a/pkg/ddevapp/drupal/drupal8/settings.php
+++ b/pkg/ddevapp/drupal/drupal8/settings.php
@@ -779,7 +779,7 @@ $settings['entity_update_backup'] = TRUE;
 $settings['migrate_node_migrate_type_classic'] = FALSE;
 
 // Automatically generated include for settings managed by ddev.
-if (file_exists(__DIR__ . '/settings.ddev.php') && getenv('IS_DDEV_PROJECT') == 'true') {
+if (getenv('IS_DDEV_PROJECT') == 'true' && file_exists(__DIR__ . '/settings.ddev.php')) {
   include __DIR__ . '/settings.ddev.php';
 }
 

--- a/pkg/ddevapp/drupal/drupal9/settings.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.php
@@ -757,7 +757,7 @@ $settings['entity_update_backup'] = TRUE;
 $settings['migrate_node_migrate_type_classic'] = FALSE;
 
 // Automatically generated include for settings managed by ddev.
-if (file_exists(__DIR__ . '/settings.ddev.php') && getenv('IS_DDEV_PROJECT') == 'true') {
+if (getenv('IS_DDEV_PROJECT') == 'true' && file_exists(__DIR__ . '/settings.ddev.php')) {
   include __DIR__ . '/settings.ddev.php';
 }
 

--- a/pkg/ddevapp/wordpress/wp-config.php
+++ b/pkg/ddevapp/wordpress/wp-config.php
@@ -28,7 +28,7 @@ defined( 'ABSPATH' ) || define( 'ABSPATH', dirname( __FILE__ ) . '/{{ $config.Ab
 
 // Include for settings managed by ddev.
 $ddev_settings = dirname( __FILE__ ) . '/wp-config-ddev.php';
-if ( is_readable( $ddev_settings ) && ! defined( 'DB_USER' ) && getenv( 'IS_DDEV_PROJECT' ) == 'true' ) {
+if ( ! defined( 'DB_USER' ) && getenv( 'IS_DDEV_PROJECT' ) == 'true' && is_readable( $ddev_settings ) ) {
 	require_once( $ddev_settings );
 }
 


### PR DESCRIPTION
This solves https://github.com/ddev/ddev/issues/4838

## The Issue

## How This PR Solves The Issue
It inverts the logic, thus on non-ddev environments, it will not read the disk unneeded.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4843"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

