### PR TITLE
[docs] Add precomposed sponsor logos to readme [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,4 @@ See “How can I contribute to DDEV?” in the [FAQ](https://ddev.readthedocs.io
 
 ## Wonderful Sponsors
 
-[<img src="images/Platformsh_Logo_DDEV.jpg" alt="Platform.sh" width="200">](https://platform.sh)
-[<img src="images/tag1-logo.svg" alt="Tag1" width="80">](https://tag1.com)
-[<img src="images/agaric-logo-stacked.svg" alt="Agaric" width="50">](https://agaric.coop/)
-[<img src="images/b13-logo.png" alt="b13" width="50">](https://b13.com/)
-[<img src="images/gizra-logo.png" alt="Gizra" width="50">](https://gizra.com/)
-[<img src="images/oliver-wand.jpeg" alt="Oliver Wand" width="50">](https://github.com/wandoliver)
-[<img src="images/centarro-logo.png" alt="Centarro" width="50">](https://www.centarro.io/)
-[<img src="images/drupaleasy-logo.png" alt="DrupalEasy" width="180">](https://www.drupaleasy.com/)
-[<img src="images/redfin-logo.png" alt="Redfin Solutions" width="50">](https://redfinsolutions.com/)
-[<img src="images/macstadium-logo.png" alt="MacStadium" width="100">](https://www.macstadium.com)
-[<img src="images/lullabot-lockup-logo.svg" alt="Lullabot" width="150">](https://www.lullabot.com)
-[<img src="images/craft-cms-logo.svg" alt="Craft CMS" width="150">](https://craftcms.com/)
-[<img src="images/undpaul_logo.svg" alt="undpaul" width=150>](https://undpaul.de)
-[<img src="images/1X_Logo_RGB_Red_4.png" alt="1xINTERNET" width="150">](https://1xinternet.de)
+![DDEV featured sponsor logos](https://ddev.com/resources/featured-sponsors.svg)


### PR DESCRIPTION
## The Issue

Related to [#44](https://github.com/ddev/ddev.com-front-end/issues/44) and [#46](https://github.com/ddev/ddev.com-front-end/issues/46), sponsors could be promoted with more care in several places.

## How This PR Solves The Issue

This replaces individual sponsor logos in the readme with a programmatically precomposed SVG, so all logos are pulled from the ddev.com front end and hopefully easier to maintain.

GitHub doesn’t facilitate linking from embedded SVGs, but clicking on it will directly open the asset where the links do work.

![Before and after comparison of the readme logos](https://user-images.githubusercontent.com/2488775/234447241-a54fc20d-301a-4f85-aeca-2a9d3c5e8e36.png)

While the dark mode presentation isn’t exactly stunning, it’s at least more uniform as a result:

![Before and after comparison of the readme logos in dark mode](https://user-images.githubusercontent.com/2488775/234447273-f95f101f-c54a-4148-bd09-a98b64e2ccc0.png)

## Manual Testing Instructions

Examine the readme [over here](https://github.com/mattstein/ddev/tree/docs/readme-sponsors-svg#wonderful-sponsors), I guess.

## Automated Testing Overview

n/a

## Related Issue Link(s)

- https://github.com/ddev/ddev.com-front-end/issues/44
- https://github.com/ddev/ddev.com-front-end/issues/46

## Release/Deployment Notes

n/a


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4850"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

