### PR TITLE
PHP_IDE_CONFIG was set to empty instead of unset, breaking PhpStorm

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/conf.d/supervisor.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/conf.d/supervisor.conf
@@ -2,7 +2,6 @@
 logfile=/var/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
 pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-environment=PHP_IDE_CONFIG=""
 
 [eventlistener:child_exit_monitor]
 command=/usr/local/bin/kill_supervisor.py

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -18,7 +18,7 @@ var SegmentKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20230417_presync_web_mutagen" // Note that this can be overridden by make
+var WebTag = "20230426_fix_xdebug_PHP_IDE_CONFIG" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

In 
* https://github.com/ddev/ddev/pull/4830

PHP_IDE_CONFIG got set to an empty value for php-fpm, breaking PhpStorm, which seems not to treat that the same as a nonexistent value. PhpStorm complains about not being able to parse it.

## How This PR Solves The Issue

Make sure that PHP_IDE_CONFIG is unset for php-fpm, as it always has been

## Manual Testing Instructions

Just use xdebug!

## Automated Testing Overview

Improve TestDdevXdebugEnabled()



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4851"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

