### PR TITLE
Shut down supervisord on start in case it's running

### DIFF
--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -39,8 +39,8 @@ func TestCmdStart(t *testing.T) {
 		assert.Equal(ddevapp.SiteRunning, statusDesc, "The status description should be \"running\", but %s status description is: %s", app.GetName(), statusDesc)
 	}
 
-	// Pause all sites.
-	_, err = exec.RunCommand(DdevBin, []string{"pause", "--all"})
+	// Stop all sites.
+	_, err = exec.RunCommand(DdevBin, []string{"stop", "--all"})
 	assert.NoError(err)
 
 	// Build start command startMultipleArgs

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -109,7 +109,7 @@ RUN mkdir -p "/opt/phpstorm-coverage" && \
 
 RUN curl --fail -sSL --output /usr/local/bin/acli https://github.com/acquia/cli/releases/latest/download/acli.phar && chmod 777 /usr/local/bin/acli
 
-RUN curl --fail -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/backdrop-drush-extension.zip -o /tmp/backdrop-drush-extension.zip && unzip -o /tmp/backdrop-drush-extension.zip -d /var/tmp/backdrop_drush_commands && rm /tmp/backdrop-drush-extension.zip
+RUN curl --fail -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/backdrop-drush-extension.zip -o /tmp/backdrop-drush-extension.zip && unzip -o /tmp/backdrop-drush-extension.zip -d /var/tmp/backdrop_drush_commands && chmod -R ugo+w /var/tmp/backdrop_drush_commands && rm /tmp/backdrop-drush-extension.zip
 
 RUN mkdir -p /etc/nginx/sites-enabled /var/log/apache2 /var/run/apache2 /var/lib/apache2/module/enabled_by_admin /var/lib/apache2/module/disabled_by_admin && \
     touch /var/log/php-fpm.log && \
@@ -218,7 +218,7 @@ RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/la
 ADD ddev-webserver-prod-files /
 RUN phpdismod blackfire xhprof
 
-RUN curl --fail -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/backdrop-drush-extension.zip -o /tmp/backdrop-drush-extension.zip && unzip -o /tmp/backdrop-drush-extension.zip -d /var/tmp/backdrop_drush_commands
+RUN curl --fail -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/backdrop-drush-extension.zip -o /tmp/backdrop-drush-extension.zip && unzip -o /tmp/backdrop-drush-extension.zip -d /var/tmp/backdrop_drush_commands && chmod -R ugo+w /tmp/backdrop_drush_commands && rm /tmp/backdrop-drush-extension.zip
 
 RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/run/apache2 /var/lib/apache2/module/enabled_by_admin /var/lib/apache2/module/disabled_by_admin && \
     touch /var/log/php-fpm.log && \

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -218,7 +218,7 @@ RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/la
 ADD ddev-webserver-prod-files /
 RUN phpdismod blackfire xhprof
 
-RUN curl --fail -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/backdrop-drush-extension.zip -o /tmp/backdrop-drush-extension.zip && unzip -o /tmp/backdrop-drush-extension.zip -d /var/tmp/backdrop_drush_commands && chmod -R ugo+w /tmp/backdrop_drush_commands && rm /tmp/backdrop-drush-extension.zip
+RUN curl --fail -sSL https://github.com/backdrop-contrib/drush/releases/download/${BACKDROP_DRUSH_VERSION}/backdrop-drush-extension.zip -o /tmp/backdrop-drush-extension.zip && unzip -o /tmp/backdrop-drush-extension.zip -d /var/tmp/backdrop_drush_commands && chmod -R ugo+w /var/tmp/backdrop_drush_commands && rm /tmp/backdrop-drush-extension.zip
 
 RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/run/apache2 /var/lib/apache2/module/enabled_by_admin /var/lib/apache2/module/disabled_by_admin && \
     touch /var/log/php-fpm.log && \

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/apache.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/apache.conf
@@ -1,7 +1,7 @@
 [program:apache2]
 stopwaitsecs = 20
 startretries=10
-stopsignal = TERM
+stopsignal = WINCH
 command=/usr/sbin/apache2ctl -D "FOREGROUND"
 # Great hints at https://advancedweb.hu/supervisor-with-docker-lessons-learned/
 killasgroup=true
@@ -9,8 +9,6 @@ stopasgroup=true
 priority=6
 stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
-stderr_logfile=/proc/1/fd/2
-stderr_logfile_maxbytes=0
 redirect_stderr=true
-exitcodes=0,1
+exitcodes=0
 startsecs=1 # Must stay up 1 sec

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/gunicorn.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/gunicorn.conf
@@ -4,6 +4,4 @@ command = bash -c "cd /var/www/html/${DDEV_DOCROOT} && python /usr/local/bin/sta
 priority=5
 stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
-stderr_logfile=/proc/1/fd/2
-stderr_logfile_maxbytes=0
 redirect_stderr=true

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/php-fpm.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/php-fpm.conf
@@ -3,6 +3,4 @@ command = /usr/sbin/php-fpm --nodaemonize --force-stderr --allow-to-run-as-root
 priority=5
 stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
-stderr_logfile=/proc/1/fd/2
-stderr_logfile_maxbytes=0
 redirect_stderr=true

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/supervisord-nginx-fpm.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/supervisord-nginx-fpm.conf
@@ -6,6 +6,4 @@ command=/usr/sbin/nginx
 priority=10
 stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
-stderr_logfile=/proc/1/fd/2
-stderr_logfile_maxbytes=0
 redirect_stderr=true

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/supervisord-nginx-gunicorn.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/supervisord-nginx-gunicorn.conf
@@ -6,6 +6,4 @@ command=/usr/sbin/nginx
 priority=10
 stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
-stderr_logfile=/proc/1/fd/2
-stderr_logfile_maxbytes=0
 redirect_stderr=true

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -4,6 +4,9 @@ set -o errexit nounset pipefail
 
 rm -f /tmp/healthy
 
+# If supervisord happens to be running (ddev start when already running) then kill it off
+supervisorctl shutdown || true
+
 export DDEV_WEB_ENTRYPOINT=/mnt/ddev_config/web-entrypoint.d
 
 source /functions.sh

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -59,7 +59,7 @@ fi
 
 if [ "$DDEV_PROJECT_TYPE" = "backdrop" ] ; then
     # Start can be executed when the container is already running.
-    mkdir -p ~/.drush/commands && ln -s /var/tmp/backdrop_drush_commands ~/.drush/commands/backdrop
+    mkdir -p ~/.drush/commands && ln -sf /var/tmp/backdrop_drush_commands ~/.drush/commands/backdrop
 fi
 
 if [ "${DDEV_PROJECT_TYPE}" = "drupal6" ] || [ "${DDEV_PROJECT_TYPE}" = "drupal7" ] || [ "${DDEV_PROJECT_TYPE}" = "backdrop" ]; then

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -5,7 +5,11 @@ set -o errexit nounset pipefail
 rm -f /tmp/healthy
 
 # If supervisord happens to be running (ddev start when already running) then kill it off
-supervisorctl shutdown || true
+if pkill -0 supervisord; then
+  supervisorctl stop all || true
+  supervisorctl shutdown || true
+fi
+rm -f /var/run/supervisor.sock
 
 export DDEV_WEB_ENTRYPOINT=/mnt/ddev_config/web-entrypoint.d
 

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -4,6 +4,9 @@ set -o errexit nounset pipefail
 
 rm -f /tmp/healthy
 
+# If supervisord happens to be running (ddev start when already running) then kill it off
+supervisorctl shutdown || true
+
 export DDEV_WEB_ENTRYPOINT=/mnt/ddev_config/web-entrypoint.d
 
 source /functions.sh

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -59,7 +59,7 @@ fi
 
 if [ "$DDEV_PROJECT_TYPE" = "backdrop" ] ; then
     # Start can be executed when the container is already running.
-    mkdir -p ~/.drush/commands && ln -s /var/tmp/backdrop_drush_commands ~/.drush/commands/backdrop
+    mkdir -p ~/.drush/commands && ln -sf /var/tmp/backdrop_drush_commands ~/.drush/commands/backdrop
 fi
 
 if [ "${DDEV_PROJECT_TYPE}" = "drupal6" ] || [ "${DDEV_PROJECT_TYPE}" = "drupal7" ] || [ "${DDEV_PROJECT_TYPE}" = "backdrop" ]; then

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -5,7 +5,11 @@ set -o errexit nounset pipefail
 rm -f /tmp/healthy
 
 # If supervisord happens to be running (ddev start when already running) then kill it off
-supervisorctl shutdown || true
+if pkill -0 supervisord; then
+  supervisorctl stop all || true
+  supervisorctl shutdown || true
+fi
+rm -f /var/run/supervisor.sock
 
 export DDEV_WEB_ENTRYPOINT=/mnt/ddev_config/web-entrypoint.d
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2077,7 +2077,10 @@ func TestDdevFullSiteSetup(t *testing.T) {
 
 		// Test static content.
 		if site.Safe200URIWithExpectation.URI != "" {
-			_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetPrimaryURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+			_, err = testcommon.EnsureLocalHTTPContent(t, app.GetPrimaryURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+			if err != nil {
+				util.Warning("err: %v", err)
+			}
 		}
 		// Test dynamic URL + database content.
 		// With nginx-gunicorn, the auto-detect and reload of new settings files

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -18,7 +18,7 @@ var SegmentKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20230426_xdebug_discover" // Note that this can be overridden by make
+var WebTag = "20230427_kill_supervisord" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

We had intermittent failures in automated testing on TestCmdStart.

This seems to have been a result of the unusual behavior in that test: Pause all, then start all.

With the new start.sh setup, this could mean that the container wasn't being started from scratch, so supervisord was possibly already running.

The actual problem we saw was only with webserver_type=apache-fpm; apache2 not starting successfully, perhaps because it hasn't stopped properly.

## How This PR Solves The Issue

* `supervisorctl shutdown` at beginning of start.sh
* Use proper graceful termination signal for apache2

## Manual Testing Instructions

Try `ddev start` with apache-fpm, and then `ddev start`.

Try `ddev pause` and `ddev start`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4856"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

