### PR TITLE
[docs] Try to fix canonical blackfire links

### DIFF
--- a/containers/ddev-webserver/README.md
+++ b/containers/ddev-webserver/README.md
@@ -10,7 +10,7 @@ This is a Dockerfile to build a container image for DDEV’s web container.
 * [Drush](http://www.drush.org) (from the production container)
 * [PHIVE](https://phar.io/) (from the production container)
 * [WP-CLI](http://www.wp-cli.org) (from the production container)
-* [Blackfire CLI](https://blackfire.io/docs/cookbooks/profiling-http-via-cli)
+* [Blackfire CLI](https://blackfire.io/docs/profiling-cookbooks/profiling-http-via-cli)
 * [Mailhog](https://github.com/mailhog/MailHog)
 * npm
 * yarn

--- a/docs/content/users/debugging-profiling/blackfire-profiling.md
+++ b/docs/content/users/debugging-profiling/blackfire-profiling.md
@@ -1,6 +1,6 @@
 # Blackfire Profiling
 
-DDEV has built-in [Blackfire](https://blackfire.io) integration.
+DDEV has built-in [Blackfire](https://www.blackfire.io/) integration.
 
 ## Basic Blackfire Usage (Using Browser Plugin)
 


### PR DESCRIPTION
## The Issue

Links failure in blackfire references in docs

## How This PR Solves The Issue

Move more to canonical versions so no redirect happens



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4874"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

