### PR TITLE
[docs][tests] Stop checking blackfire.io since it's inconsistent

### DIFF
--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -19,6 +19,9 @@
       "pattern": "^https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok"
     },
     {
+      "pattern": "^https://.*blackfire.io"
+    },
+    {
       "pattern": "^https://www.cyberciti.biz/"
     },
     {


### PR DESCRIPTION
## The Issue

In the links check for docs, *blackfire.io* is quite inconsistent, returning a variety of failure or redirect results.

Stop checking those links.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4876"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

