### PR TITLE
See if Pantheon integration can be partially without ssh, fixes #4882

### DIFF
--- a/docs/content/users/providers/pantheon.md
+++ b/docs/content/users/providers/pantheon.md
@@ -21,7 +21,7 @@ If you have DDEV installed, and have an active Pantheon account with an active s
 
 3. On the Pantheon dashboard for the site, make sure that at least one backup has been created. (When you need to refresh what you pull, create a new backup.)
 
-4. Make sure your public SSH key is configured in Pantheon under *Account* → *SSH Keys*.
+4. For `ddev push pantheon` make sure your public SSH key is configured in Pantheon under *Account* → *SSH Keys*.
 
 5. Check out the project codebase from Pantheon. Enable the “Git Connection Mode” and use `git clone` to check out the code locally.
 

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
@@ -18,7 +18,7 @@
 #
 # 3. On the pantheon dashboard, make sure that at least one backup has been created. (When you need to refresh what you pull, do a new backup.)
 #
-# 4. Make sure your public ssh key is configured in Pantheon (Account->SSH Keys)
+# 4. For `ddev push pantheon` sure your public ssh key is configured in Pantheon (Account->SSH Keys)
 #
 # 5. Check out project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
 #

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
@@ -46,7 +46,6 @@ environment_variables:
 auth_command:
   command: |
     set -eu -o pipefail
-    ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     if ! command -v drush >/dev/null ; then echo "Please make sure your project contains drush, ddev composer require drush/drush" && exit 1; fi
     if [ -z "${TERMINUS_MACHINE_TOKEN:-}" ]; then echo "Please make sure you have set TERMINUS_MACHINE_TOKEN in ~/.ddev/global_config.yaml" && exit 1; fi
     terminus auth:login --machine-token="${TERMINUS_MACHINE_TOKEN}" || ( echo "terminus auth login failed, check your TERMINUS_MACHINE_TOKEN" && exit 1 )
@@ -73,6 +72,7 @@ files_pull_command:
 db_push_command:
   command: |
     set -x   # You can enable bash debugging output by uncommenting
+    ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     set -eu -o pipefail
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null;
@@ -83,6 +83,7 @@ db_push_command:
 files_push_command:
   command: |
     set -x   # You can enable bash debugging output by uncommenting
+    ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     set -eu -o pipefail
     ls ${DDEV_FILES_DIR} >/dev/null # This just refreshes stale NFS if possible
     drush rsync -y @self:%files @${project}:%files

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -273,7 +273,7 @@ func setupSSHKey(t *testing.T, privateKey string, expectScriptDir string) error 
 	require.NoError(t, err)
 	out, err := exec.RunHostCommand("expect", filepath.Join(expectScriptDir, "ddevauthssh.expect"), DdevBin, "./sshtest")
 	require.NoError(t, err, "out=%s", out)
-	require.Contains(t, string(out), "Identity added:")
+	require.Contains(t, out, "Identity added:")
 	return nil
 }
 


### PR DESCRIPTION
## The Issue

* #4882

It seems that most Pantheon operations don't require ssh, at least the pull ones.

## How This PR Solves The Issue

Try it without, get it to pass tests

## Manual Testing Instructions

Try
* `ddev pantheon pull`
* `ddev pantheon push`

## Automated Testing Overview

Minor changes to TestPantheonPush



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4883"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

