### PR TITLE
add mkcert to arch dependencies, fixes #4884

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -293,6 +293,7 @@ aurs:
   git_url: '{{ .Env.AUR_STABLE_GIT_URL }}'
   depends:
   - docker
+  - mkcert
   optdepends:
   - 'bash-completion: subcommand completion support'
 


### PR DESCRIPTION
## The Issue

* #4884 

[`mkcert`](https://archlinux.org/packages/community/x86_64/mkcert/) dependency is missing in the aur package.

## How This PR Solves The Issue

This PR adds `mkcert` as a dependency.

## Manual Testing Instructions

## Automated Testing Overview

This PR does not affect any code

## Related Issue Link(s)

Fixes #4884 

## Release/Deployment Notes

This should not affect anything else

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4887"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

