### PR TITLE
[aur] Add mkcert dependency to ddev-edge-bin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -331,6 +331,7 @@ aurs:
   git_url: '{{ .Env.AUR_EDGE_GIT_URL }}'
   depends:
   - docker
+  - mkcert
   optdepends:
   - 'bash-completion: subcommand completion support'
 


### PR DESCRIPTION
Follow-up PR for `ddev-edge-bin`

Thanks to @Data5tream for noticing the missing dependency.

Related PR:

- https://github.com/ddev/ddev/pull/4887

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4890"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

