### PR TITLE
Introduce versioned addons and add-on removal, fixes #3555, fixes #3919

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -351,10 +351,8 @@ ddev get --remove my-addon,
 // createManifestFile creates a manifest file for the addon
 func createManifestFile(app *ddevapp.DdevApp, addonName string, repository string, downloadedRelease string, desc installDesc) error {
 	// Create a manifest file
-	// TODO: Provide some kind of manifest even when we don't have a release
 	manifest := addonManifest{
-		Name: addonName,
-		// TODO: Provide something equivalent if we don't have owner/repo
+		Name:         addonName,
 		Repository:   repository,
 		Version:      downloadedRelease,
 		InstallDate:  time.Now().Format(time.RFC3339),

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -67,7 +67,9 @@ ddev get /path/to/tarball.tar.gz
 ddev get --list
 ddev get --list --all
 ddev get --installed
-ddev get --remove my-addon,
+ddev get --remove someaddonname,
+ddev get --remove someowner/ddev-someaddonname,
+ddev get --remove ddev-someaddonname
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		officialOnly := true

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -603,7 +603,7 @@ func removeAddon(app *ddevapp.DdevApp, addonName string, dict map[string]interfa
 
 	manifestFile := filepath.Join(metadataDir, addonName, "manifest.yaml")
 	if !fileutil.FileExists(manifestFile) {
-		util.Failed("The add-on '%s' does not seem to have a manifest file; please upgrade it.\nUse `ddev get --installed to see installed add-ons.\nIf yours is not there it may have been installed before DDEV v1.22.0\nUse 'ddev get' to update it.", addonName, manifestFile)
+		util.Failed("The add-on '%s' does not seem to have a manifest file; please upgrade it.\nUse `ddev get --installed to see installed add-ons.\nIf yours is not there it may have been installed before DDEV v1.22.0.\nUse 'ddev get' to update it.", addonName)
 	}
 	manifestString, err := fileutil.ReadFileIntoString(manifestFile)
 	if err != nil {

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -603,7 +603,7 @@ func removeAddon(app *ddevapp.DdevApp, addonName string, dict map[string]interfa
 
 	manifestFile := filepath.Join(metadataDir, addonName, "manifest.yaml")
 	if !fileutil.FileExists(manifestFile) {
-		util.Failed("No manifest file '%s' exists", manifestFile)
+		util.Failed("The add-on '%s' does not seem to have a manifest file; please upgrade it.\nUse `ddev get --installed to see installed add-ons.\nIf yours is not there it may have been installed before DDEV v1.22.0\nUse 'ddev get' to update it.", addonName, manifestFile)
 	}
 	manifestString, err := fileutil.ReadFileIntoString(manifestFile)
 	if err != nil {

--- a/cmd/ddev/cmd/get_test.go
+++ b/cmd/ddev/cmd/get_test.go
@@ -186,6 +186,17 @@ func TestCmdGetInstalled(t *testing.T) {
 
 	assert.Equal(memcachedManifest["Version"], installedManifests["memcached"]["Version"])
 	assert.Equal(redisManifest["Version"], installedManifests["redis"]["Version"])
+
+	// Now try the remove using other techniques (full repo name, partial repo name)
+	for _, n := range []string{"ddev/ddev-redis", "ddev-redis", "redis"} {
+		out, err = exec.RunHostCommand(DdevBin, "get", "ddev/ddev-redis", "--json-output")
+		require.NoError(t, err, "failed ddev get %s: %v (output='%s')", n, err, out)
+		out, err = exec.RunHostCommand(DdevBin, "get", "--remove", n)
+		require.NoError(t, err, "unable to ddev get --remove %s: %v, output='%s'", n, err, out)
+	}
+	// Now make sure we put it back so it can be removed in cleanu
+	out, err = exec.RunHostCommand(DdevBin, "get", "ddev/ddev-redis")
+	assert.NoError(err, "unable to ddev get redis: %v, output='%s'", err, out)
 }
 
 // getManifestFromLogs returns the manifest built from 'raw' section of

--- a/cmd/ddev/cmd/get_test.go
+++ b/cmd/ddev/cmd/get_test.go
@@ -31,13 +31,10 @@ func TestCmdGet(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		_, err = exec.RunHostCommand(DdevBin, "service", "disable", "memcached")
+		_, err = exec.RunHostCommand(DdevBin, "get", "--remove", "memcached")
 		assert.NoError(err)
-		_, err = exec.RunHostCommand(DdevBin, "service", "disable", "example")
+		_, err = exec.RunHostCommand(DdevBin, "get", "--remove", "example")
 		assert.NoError(err)
-
-		_ = os.RemoveAll(app.GetConfigPath(fmt.Sprintf("docker-compose.%s.yaml", "memcached")))
-		_ = os.RemoveAll(app.GetConfigPath(fmt.Sprintf("docker-compose.%s.yaml", "example")))
 
 		err = os.Chdir(origDir)
 		assert.NoError(err)
@@ -87,7 +84,6 @@ func TestCmdGet(t *testing.T) {
 
 	assert.Contains(out, fmt.Sprintf("NOT overwriting file/directory %s", app.GetConfigPath("file-with-no-ddev-generated.txt")))
 	assert.Contains(out, fmt.Sprintf("NOT overwriting file/directory %s", filepath.Join(globalconfig.GetGlobalDdevDir(), "file-with-no-ddev-generated.txt")))
-
 }
 
 // TestCmdGetComplex tests advanced usages
@@ -143,4 +139,86 @@ func TestCmdGetComplex(t *testing.T) {
 	// Make sure that environment variable interpolation happened. If it did, we'll have the one file
 	// we're looking for.
 	assert.FileExists(app.GetConfigPath(fmt.Sprintf("junk_%s_%s.txt", runtime.GOOS, runtime.GOARCH)))
+}
+
+// TestCmdGetInstalled tests `ddev get --installed` and `ddev get --remove`
+func TestCmdGetInstalled(t *testing.T) {
+	if os.Getenv("DDEV_RUN_GET_TESTS") != "true" {
+		t.Skip("Skipping because DDEV_RUN_GET_TESTS is not set")
+	}
+	assert := asrt.New(t)
+
+	origDir, _ := os.Getwd()
+	site := TestSites[0]
+	err := os.Chdir(site.Dir)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, err = exec.RunHostCommand(DdevBin, "get", "--remove", "memcached")
+		assert.NoError(err)
+		_, err = exec.RunHostCommand(DdevBin, "get", "--remove", "redis")
+		assert.NoError(err)
+
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		err = os.RemoveAll(filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/web/global-touched"))
+		assert.NoError(err)
+	})
+
+	out, err := exec.RunHostCommand(DdevBin, "get", "ddev/ddev-memcached", "--json-output")
+	require.NoError(t, err, "failed ddev get ddev/ddev-memcached: %v (output='%s')", err, out)
+
+	memcachedManifest := getManifestFromLogs(t, out)
+	require.NoError(t, err)
+
+	out, err = exec.RunHostCommand(DdevBin, "get", "ddev/ddev-redis", "--json-output")
+	require.NoError(t, err, "failed ddev get ddev/ddev-redis: %v (output='%s')", err, out)
+
+	redisManifest := getManifestFromLogs(t, out)
+	require.NoError(t, err)
+
+	installedOutput, err := exec.RunHostCommand(DdevBin, "get", "--installed", "--json-output")
+	require.NoError(t, err, "failed ddev get --installed --json-output: %v (output='%s')", err, installedOutput)
+	installedManifests := getManifestMapFromLogs(t, installedOutput)
+
+	require.NotEmptyf(t, memcachedManifest["Version"], "memcached manifest is empty: %v", memcachedManifest)
+	require.NotEmptyf(t, redisManifest["Version"], "redis manifest is empty: %v", redisManifest)
+
+	assert.Equal(memcachedManifest["Version"], installedManifests["memcached"]["Version"])
+	assert.Equal(redisManifest["Version"], installedManifests["redis"]["Version"])
+}
+
+// getManifestFromLogs returns the manifest built from 'raw' section of
+// ddev get <project> -j output
+func getManifestFromLogs(t *testing.T, jsonOut string) map[string]interface{} {
+	assert := asrt.New(t)
+
+	logItems, err := unmarshalJSONLogs(jsonOut)
+	require.NoError(t, err)
+	data := logItems[len(logItems)-1]
+	assert.EqualValues(data["level"], "info")
+
+	m, ok := data["raw"].(map[string]interface{})
+	require.True(t, ok)
+	return m
+}
+
+// getManifestMapFromLogs returns the manifest array built from 'raw' section of
+// ddev get --installed -j output
+func getManifestMapFromLogs(t *testing.T, jsonOut string) map[string]map[string]interface{} {
+	assert := asrt.New(t)
+
+	logItems, err := unmarshalJSONLogs(jsonOut)
+	require.NoError(t, err)
+	data := logItems[len(logItems)-1]
+	assert.EqualValues(data["level"], "info")
+
+	m, ok := data["raw"].([]interface{})
+	require.True(t, ok)
+	masterMap := map[string]map[string]interface{}{}
+	for _, item := range m {
+		itemMap := item.(map[string]interface{})
+		masterMap[itemMap["Name"].(string)] = itemMap
+	}
+	return masterMap
 }

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -67,6 +67,10 @@ Officially-supported add-ons:
 * [Selenium Standalone Chrome](https://github.com/ddev/ddev-selenium-standalone-chrome): `ddev get ddev/ddev-selenium-standalone-chrome`.
 * [Varnish](https://github.com/ddev/ddev-varnish): `ddev get ddev/ddev-varnish`.
 
+## Viewing and Removing Installed Add-Ons
+
+Add-ons installed in DDEV v1.22+ are versioned and can be viewed with `ddev get --installed`. Add-ons can be removed with `ddev get --remove <addonname>`. If you have add-ons that were installed before v1.22, just re-add them with `ddev get <addonname>` and they will be versioned and available in `ddev get --installed`.
+
 ## Creating an Additional Service for `ddev get`
 
 Anyone can create an add-on for `ddev get`. See [this screencast](https://www.youtube.com/watch?v=fPVGpKGr0f4) and instructions in [`ddev-addon-template`](https://github.com/ddev/ddev-addon-template):

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -69,7 +69,7 @@ Officially-supported add-ons:
 
 ## Viewing and Removing Installed Add-Ons
 
-Add-ons installed in DDEV v1.22+ are versioned and can be viewed with `ddev get --installed`. Add-ons can be removed with `ddev get --remove <addonname>`. If you have add-ons that were installed before v1.22, just re-add them with `ddev get <addonname>` and they will be versioned and available in `ddev get --installed`.
+Add-ons installed in DDEV v1.22+ are versioned and can be viewed by running `ddev get --installed`. You can remove an add-on by running `ddev get --remove <addonname>`. If you have add-ons that were installed before v1.22, re-add them with `ddev get <addonname>` and they will be versioned and available in `ddev get --installed`.
 
 ## Creating an Additional Service for `ddev get`
 

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -19,6 +19,9 @@ A project’s `.ddev` directory can be intimidating at first, so let’s take a 
     You may have some directories or files that aren’t listed here, likely added by custom services.  
     For example, if you see a `solr` directory, it probably pertains to a custom Solr [add-on service](../extend/additional-services.md).
 
+`addon-metadata` directory
+: Contains metadata about add-on services that have been added to the project. This allows commands like `ddev get --installed` and `ddev get --remove` to work, see [Viewing and removing add-ons](../extend/additional-services.md#viewing-and-removing-installed-add-ons).
+
 `apache` directory
 : Default Apache configuration when using `webserver_type: apache-fpm`, which [can be customized](../extend/customization-extendibility.md#providing-custom-apache-configuration).
 

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -12,6 +12,7 @@ Type `ddev` or `ddev -h` in a terminal window to see the available DDEV [command
 * [`ddev stop`](../usage/commands.md#stop) stops a project and removes its memory usage (but does not throw away any data).
 * [`ddev poweroff`](../usage/commands.md#poweroff) stops all resources that DDEV is using and stops the Mutagen daemon if it’s running.
 * [`ddev delete`](../usage/commands.md#delete) destroys the database and DDEV’s knowledge of the project without touching your code.
+* [`ddev get`](../usage/commands.md#get) adds an add-on service.
 
 ## Lots of Other Commands
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -577,7 +577,7 @@ Flags:
 
 Environment variables:
 
-* `DDEV_GITHUB_TOKEN`: A [GitHub token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) may be used for `ddev get` requests (which result in GitHub API queries). It's unusual for casual users to need this, but if you're doing lots of `ddev get` requests you may run into rate limiting. The token you use requires no privileges at all. Example: 
+* `DDEV_GITHUB_TOKEN`: A [GitHub token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) may be used for `ddev get` requests (which result in GitHub API queries). It's unusual for casual users to need this, but if you're doing lots of `ddev get` requests you may run into rate limiting. The token you use requires no privileges at all. Example:
 
 ```bash
 export DDEV_GITHUB_TOKEN=<your github token>

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -573,6 +573,7 @@ Flags:
 * `--list`: List official add-ons. (default `true`)
 * `--installed`: List installed add-ons
 * `--remove <add-on>`: Remove an installed add-on
+* `--version <version>`: Specify a version to download
 * `--verbose`, `-v`: Output verbose error information with Bash `set -x` (default `false`)
 
 Environment variables:
@@ -598,6 +599,9 @@ ddev get ddev/ddev-redis
 
 # Get debug info about `ddev get` failure
 ddev get ddev/ddev-redis --verbose
+
+# Download the official Redis add-on, version v1.0.4
+ddev get ddev/ddev-redis --version v1.0.4
 
 # Download the Drupal 9 Solr add-on from its v0.0.5 release tarball
 ddev get https://github.com/ddev/ddev-drupal9-solr/archive/refs/tags/v0.0.5.tar.gz

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -615,8 +615,11 @@ ddev get /path/to/tarball.tar.gz
 # View installed add-ons
 ddev get --installed
 
-# Remove an add-on
+# Remove an add-on can be done with the full name, the short name of repo
+# or with owner/repo format
 ddev get --remove redis
+ddev get --remove ddev-redis
+ddev get --remove ddev/ddev-redis
 ```
 
 In general, you can run `ddev get` multiple times without doing any damage. Updating an add-on can be done by running `ddev get <add-on-name>`. If you have changed an add-on file and removed the `#ddev-generated` marker in the file, that file will not be touched and DDEV will let you know about it.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -571,7 +571,18 @@ Flags:
 
 * `--all`: List unofficial *and* official add-ons. (default `true`)
 * `--list`: List official add-ons. (default `true`)
+* `--installed`: List installed add-ons
+* `--remove <add-on>`: Remove an installed add-on
 * `--verbose`, `-v`: Output verbose error information with Bash `set -x` (default `false`)
+
+Environment variables:
+
+* `DDEV_GITHUB_TOKEN`: A [GitHub token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) may be used for `ddev get` requests (which result in GitHub API queries). It's unusual for casual users to need this, but if you're doing lots of `ddev get` requests you may run into rate limiting. The token you use requires no privileges at all. Example: 
+
+```bash
+export DDEV_GITHUB_TOKEN=<your github token>
+ddev get --list --all
+```
 
 Example:
 
@@ -596,7 +607,15 @@ ddev get /path/to/package
 
 # Copy an add-on from a tarball in another directory
 ddev get /path/to/tarball.tar.gz
+
+# View installed add-ons
+ddev get --installed
+
+# Remove an add-on
+ddev get --remove redis
 ```
+
+In general, you can `ddev get` an add-on multiple times without doing any damage; Updating an add-on can be done with just `ddev get <add-on-name>`. If you have changed an add-on file and removed the `#ddev-generated` marker in the file, that file will not be touched and DDEV will let you know about it.
 
 ## `heidisql`
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -619,7 +619,7 @@ ddev get --installed
 ddev get --remove redis
 ```
 
-In general, you can `ddev get` an add-on multiple times without doing any damage; Updating an add-on can be done with just `ddev get <add-on-name>`. If you have changed an add-on file and removed the `#ddev-generated` marker in the file, that file will not be touched and DDEV will let you know about it.
+In general, you can run `ddev get` multiple times without doing any damage. Updating an add-on can be done by running `ddev get <add-on-name>`. If you have changed an add-on file and removed the `#ddev-generated` marker in the file, that file will not be touched and DDEV will let you know about it.
 
 ## `heidisql`
 

--- a/pkg/ddevapp/list_test.go
+++ b/pkg/ddevapp/list_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
-	assert2 "github.com/stretchr/testify/assert"
+	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
 	"regexp"
@@ -22,7 +22,7 @@ func TestListWithoutDir(t *testing.T) {
 		t.Skip("Skipping because unreliable on Windows and can't be used with mutagen")
 	}
 	// Set up tests and give ourselves a working directory.
-	assert := assert2.New(t)
+	assert := asrt.New(t)
 	testcommon.ClearDockerEnv()
 	origDir, _ := os.Getwd()
 


### PR DESCRIPTION
## The Issue

* #3555 
* #3919 

## How This PR Solves The Issue

Adds versioning, get by version, and removal

## TODO

- [ ] Add a heuristic to allow guessing or searching for the `name`, so people don't get confused if they `ddev get --remove ddev-redis` or `ddev get --remove ddev/ddev-redis` instead of `ddev get --remove redis`. Options include searching the existing add-ons for a match or using. a heuristic (truncating ddev-redis to "redis" for example).

## Manual Testing Instructions

- [x] `ddev get <whatever>`
- [x] `ddev get <whatever> --version <v1.x.x>`
- [x] `ddev get --installed`
- [x] `ddev get --remove <addonname>`

## Automated Testing Overview

Adds TestCmdGetInstalled()



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4891"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

