### PR TITLE
[docs] Exclude twitter.com/search from link check

### DIFF
--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -22,6 +22,9 @@
       "pattern": "^https://.*blackfire.io"
     },
     {
+      "pattern": "^https://twitter.com/search"
+    },
+    {
       "pattern": "^https://www.cyberciti.biz/"
     },
     {


### PR DESCRIPTION

## The Issue

The links check for twitter.com/search always fails.

Stop doing it.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4892"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

