### PR TITLE
feat: add support for MariaDB 10.11 LTS

### DIFF
--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -10,11 +10,11 @@ CURRENT_ARCH=$(shell ../get_arch.sh)
 # So has to explicitly declare anything it might need from there (like SHELL)
 SHELL = /bin/bash
 
-BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_both mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mariadb_10.7_both mariadb_10.8_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.31
+BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_both mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mariadb_10.7_both mariadb_10.8_both mariadb_10.11_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.31
 TEST_TARGETS=$(shell if [ "$(CURRENT_ARCH)" = "amd64" ] ; then \
-	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
+	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mariadb_10.11_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
 	else \
-	  echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mysql_5.7_test mysql_8.0_test"; \
+	  echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mariadb_10.11_test mysql_5.7_test mysql_8.0_test"; \
   	fi )
 
 container: build
@@ -30,6 +30,7 @@ mariadb_10.5: mariadb_10.5_both
 mariadb_10.6: mariadb_10.6_both
 mariadb_10.7: mariadb_10.7_both
 mariadb_10.8: mariadb_10.8_both
+mariadb_10.11: mariadb_10.11_both
 
 mysql_5.5: mysql_5.5_amd64
 mysql_5.6: mysql_5.6_amd64

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -83,7 +83,7 @@ The type and version of the database engine the project should use.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | MariaDB 10.4 | Can be MariaDB 5.5–10.8, MySQL 5.5–8.0, or PostgreSQL 9–15.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats.
+| :octicons-file-directory-16: project | MariaDB 10.4 | Can be MariaDB 5.5–10.8 or 10.11, MySQL 5.5–8.0, or PostgreSQL 9–15.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats.
 
 ## `dbimage_extra_packages`
 

--- a/docs/content/users/extend/database-types.md
+++ b/docs/content/users/extend/database-types.md
@@ -1,13 +1,13 @@
 # Database Server Types
 
-DDEV supports most versions of MariaDB, MySQL, and PostgreSQL database servers.
+DDEV supports many versions of the MariaDB, MySQL, and PostgreSQL database servers.
 
-The default database type is MariaDB, and the default version is currently 10.4, but you can use nearly any MariaDB versions 5.5-10.8 or 10.11, MySQL 5.5-8.0, and Postgres 9-15.
+The default database type is MariaDB, and the default version is currently 10.4, but you can use MariaDB versions 5.5-10.8 and 10.11, MySQL 5.5-8.0, and Postgres 9-15. (New LTS versions of each of these are typically added soon after release. The very old versions are kept for compatibility with older projects.)
 
 You could set these using the [`ddev config`](../usage/commands.md#config) command like this:
 
 - `ddev config --database=mysql:5.7`
-- `ddev config --database=mariadb:10.6`
+- `ddev config --database=mariadb:10.11`
 - `ddev config --database=postgres:14`.
 
 Or by editing the [`database`](../configuration/config.md#database) setting in `.ddev/config.yaml`:
@@ -21,7 +21,7 @@ database:
 ```yaml
 database:
   type: mariadb
-  version: 10.6
+  version: 10.11
 ```
 
 ```yaml

--- a/docs/content/users/extend/database-types.md
+++ b/docs/content/users/extend/database-types.md
@@ -2,7 +2,7 @@
 
 DDEV supports most versions of MariaDB, MySQL, and PostgreSQL database servers.
 
-The default database type is MariaDB, and the default version is currently 10.4, but you can use nearly any MariaDB versions 5.5-10.8, MySQL 5.5-8.0, and Postgres 9-15.
+The default database type is MariaDB, and the default version is currently 10.4, but you can use nearly any MariaDB versions 5.5-10.8 or 10.11, MySQL 5.5-8.0, and Postgres 9-15.
 
 You could set these using the [`ddev config`](../usage/commands.md#config) command like this:
 

--- a/pkg/ddevapp/db.go
+++ b/pkg/ddevapp/db.go
@@ -39,7 +39,7 @@ func dbTypeVersionFromString(in string) string {
 	postgresStyle := regexp.MustCompile(`^[0-9]+$`)
 	postgresV9Style := regexp.MustCompile(`^9\.?`)
 	oldStyle := regexp.MustCompile(`^[0-9]+\.[0-9]$`)
-	newStyleV119 := regexp.MustCompile(`^(mysql|mariadb)_[0-9]+\.[0-9]$`)
+	newStyleV119 := regexp.MustCompile(`^(mysql|mariadb)_[0-9]+\.[0-9][0-9]?$`)
 
 	if newStyleV119.MatchString(in) {
 		idType = "current"

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1597,7 +1597,7 @@ func TestDdevAllDatabases(t *testing.T) {
 	dbVersions = nodeps.RemoveItemFromSlice(dbVersions, "postgres:9")
 	//Use a smaller list if GOTEST_SHORT
 	if os.Getenv("GOTEST_SHORT") != "" {
-		dbVersions = []string{"postgres:10", "postgres:11", "postgres:14", "mariadb:10.3", "mariadb:10.4", "mariadb:10.6", "mysql:8.0", "mysql:5.7"}
+		dbVersions = []string{"postgres:10", "postgres:14", "mariadb:10.3", "mariadb:10.4", "mariadb:10.11", "mysql:8.0", "mysql:5.7"}
 		t.Logf("Using limited set of database servers because GOTEST_SHORT is set (%v)", dbVersions)
 	}
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -20,10 +20,10 @@ const ConfigInstructions = `
 # webimage: <docker_image>  # nginx/php docker image.
 
 # database:
-#   type: <dbtype> # mysql, mariadb
-#   version: <version> # database version, like "10.3" or "8.0"
-# Note that mariadb_version or mysql_version from v1.18 and earlier
-# will automatically be converted to this notation with just a "ddev config --auto"
+#   type: <dbtype> # mysql, mariadb, postgres
+#   version: <version> # database version, like "10.4" or "8.0"
+#   mariadb versions can be 5.5-10.8 and 10.11, mysql versions can be 5.5-8.0
+#   postgres versions can be 9-15.
 
 # router_http_port: <port>  # Port to be used for http (defaults to port 80)
 # router_https_port: <port> # Port for https (defaults to 443)

--- a/pkg/nodeps/mariadb_values.go
+++ b/pkg/nodeps/mariadb_values.go
@@ -7,28 +7,30 @@ const MariaDBDefaultVersion = MariaDB104
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
-	MariaDB55:  true,
-	MariaDB100: true,
-	MariaDB101: true,
-	MariaDB102: true,
-	MariaDB103: true,
-	MariaDB104: true,
-	MariaDB105: true,
-	MariaDB106: true,
-	MariaDB107: true,
-	MariaDB108: true,
+	MariaDB55:   true,
+	MariaDB100:  true,
+	MariaDB101:  true,
+	MariaDB102:  true,
+	MariaDB103:  true,
+	MariaDB104:  true,
+	MariaDB105:  true,
+	MariaDB106:  true,
+	MariaDB107:  true,
+	MariaDB108:  true,
+	MariaDB1011: true,
 }
 
 // MariaDB Versions
 const (
-	MariaDB55  = "5.5"
-	MariaDB100 = "10.0"
-	MariaDB101 = "10.1"
-	MariaDB102 = "10.2"
-	MariaDB103 = "10.3"
-	MariaDB104 = "10.4"
-	MariaDB105 = "10.5"
-	MariaDB106 = "10.6"
-	MariaDB107 = "10.7"
-	MariaDB108 = "10.8"
+	MariaDB55   = "5.5"
+	MariaDB100  = "10.0"
+	MariaDB101  = "10.1"
+	MariaDB102  = "10.2"
+	MariaDB103  = "10.3"
+	MariaDB104  = "10.4"
+	MariaDB105  = "10.5"
+	MariaDB106  = "10.6"
+	MariaDB107  = "10.7"
+	MariaDB108  = "10.8"
+	MariaDB1011 = "10.11"
 )

--- a/pkg/nodeps/mariadb_values_darwin_arm64.go
+++ b/pkg/nodeps/mariadb_values_darwin_arm64.go
@@ -5,26 +5,28 @@ const MariaDBDefaultVersion = MariaDB104
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
-	MariaDB101: true,
-	MariaDB102: true,
-	MariaDB103: true,
-	MariaDB104: true,
-	MariaDB105: true,
-	MariaDB106: true,
-	MariaDB107: true,
-	MariaDB108: true,
+	MariaDB101:  true,
+	MariaDB102:  true,
+	MariaDB103:  true,
+	MariaDB104:  true,
+	MariaDB105:  true,
+	MariaDB106:  true,
+	MariaDB107:  true,
+	MariaDB108:  true,
+	MariaDB1011: true,
 }
 
 // MariaDB Versions
 const (
-	MariaDB55  = "5.5"
-	MariaDB100 = "10.0"
-	MariaDB101 = "10.1"
-	MariaDB102 = "10.2"
-	MariaDB103 = "10.3"
-	MariaDB104 = "10.4"
-	MariaDB105 = "10.5"
-	MariaDB106 = "10.6"
-	MariaDB107 = "10.7"
-	MariaDB108 = "10.8"
+	MariaDB55   = "5.5"
+	MariaDB100  = "10.0"
+	MariaDB101  = "10.1"
+	MariaDB102  = "10.2"
+	MariaDB103  = "10.3"
+	MariaDB104  = "10.4"
+	MariaDB105  = "10.5"
+	MariaDB106  = "10.6"
+	MariaDB107  = "10.7"
+	MariaDB108  = "10.8"
+	MariaDB1011 = "10.11"
 )

--- a/pkg/nodeps/mariadb_values_linux_arm64.go
+++ b/pkg/nodeps/mariadb_values_linux_arm64.go
@@ -5,26 +5,28 @@ const MariaDBDefaultVersion = MariaDB104
 
 // ValidMariaDBVersions is the versions of MariaDB that are valid
 var ValidMariaDBVersions = map[string]bool{
-	MariaDB101: true,
-	MariaDB102: true,
-	MariaDB103: true,
-	MariaDB104: true,
-	MariaDB105: true,
-	MariaDB106: true,
-	MariaDB107: true,
-	MariaDB108: true,
+	MariaDB101:  true,
+	MariaDB102:  true,
+	MariaDB103:  true,
+	MariaDB104:  true,
+	MariaDB105:  true,
+	MariaDB106:  true,
+	MariaDB107:  true,
+	MariaDB108:  true,
+	MariaDB1011: true,
 }
 
 // MariaDB Versions
 const (
-	MariaDB55  = "5.5"
-	MariaDB100 = "10.0"
-	MariaDB101 = "10.1"
-	MariaDB102 = "10.2"
-	MariaDB103 = "10.3"
-	MariaDB104 = "10.4"
-	MariaDB105 = "10.5"
-	MariaDB106 = "10.6"
-	MariaDB107 = "10.7"
-	MariaDB108 = "10.8"
+	MariaDB55   = "5.5"
+	MariaDB100  = "10.0"
+	MariaDB101  = "10.1"
+	MariaDB102  = "10.2"
+	MariaDB103  = "10.3"
+	MariaDB104  = "10.4"
+	MariaDB105  = "10.5"
+	MariaDB106  = "10.6"
+	MariaDB107  = "10.7"
+	MariaDB108  = "10.8"
+	MariaDB1011 = "10.11"
 )

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -24,7 +24,7 @@ var WebTag = "20230504_fix_log_in_web_extra_daemons" // Note that this can be ov
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20230423_fix_postgres_stretch"
+var BaseDBTag = "20230512_mariadb_10_11"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Issue
Currently, the latest supported MariaDB Version to 10.8. The newest (LTS) version of MariaDB is 10.11.

Note: In #4894 are comments about only supporting MariaDB LTS Releases, that's why 10.9 and 10.10 are not added.

## How This PR Solves The Issue

- Add MariaDB 10.11 to `containers/ddev-dbserver/Makefile`
- Add MariaDB 10.11 to allowed config options

## Manual Testing Instructions

- [ ] `ddev config --database=mariadb:10.11` (New project, or delete project, or migrate)
- [ ] Make sure it works

## Automated Testing Overview

I'm not sure whether there are automated tests for changes like this. If so, I'd of course look into that and adapt them accordingly.

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

Fixes #4894 

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4902"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

