### PR TITLE
Add “just simply” link to the writing style guide

### DIFF
--- a/docs/content/developers/writing-style-guide.md
+++ b/docs/content/developers/writing-style-guide.md
@@ -30,7 +30,7 @@ Omit extraneous explanation or decorative language that doesn’t help the reade
 
 ### Avoid “Just” and “Easy”
 
-Try not to use language that may talk down to the reader. You may intend for “it’s easy” to be reassuring, but it’s a subjective judgment that can convince someone struggling that they’re doing it wrong. Things could instead be “straightforward” if they’re without nuance, “simple” if they don’t involve complex actions or concepts, or “quick” if they involve one or two steps that’d be fast even on someone’s worst day with the slowest-imaginable machine.
+Try not to use language that [may talk down to the reader](https://justsimply.dev/). You may intend for “it’s easy” to be reassuring, but it’s a subjective judgment that can convince someone struggling that they’re doing it wrong. Things could instead be “straightforward” if they’re without nuance, “simple” if they don’t involve complex actions or concepts, or “quick” if they involve one or two steps that’d be fast even on someone’s worst day with the slowest-imaginable machine.
 
 Similarly, “just do X” suggests that “X” should be easy or obvious. Most of the time “just” can be omitted and everyone wins.
 


### PR DESCRIPTION
This adds an excellent link to the “avoid just and it’s easy” section of the writing style guide that further describes the problem and potential solutions with that sort of language.

Here’s a direct link to it in the preview build: https://ddev--4903.org.readthedocs.build/en/4903/developers/writing-style-guide/#avoid-just-and-easy

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4903"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

