### PR TITLE
Update gitpod base to get docker buildx [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ddev/ddev-gitpod-base:20230415
+image: ddev/ddev-gitpod-base:20230512
 tasks:
   - name: build-run
     init: |

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-base as workspace-base
+FROM gitpod/workspace-base:latest as workspace-base
 SHELL ["/bin/bash", "-c"]
 
 USER root


### PR DESCRIPTION
## The Issue

The base image for use with gitpod got out of date; especially ours didn't have `docker buildx`, whereas the upstream has added it. 

## How This PR Solves The Issue

Push new image, use new image.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4906"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

