### PR TITLE
Update `craftcms` project type defaults

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -57,6 +57,8 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
         ddev launch
         ```
 
+    Craft CMS projects use PHP 8.1 and MySQL 8.0, by default. You can override these settings during setup with [`config` command flags](./usage/commands.md#config) or after setup via the [configuration files](./configuration/config.md).
+
     !!!tip "Upgrading or using a generic project type?"
         If you previously set up DDEV in a Craft project using the generic `php` project type, update the `type:` setting in `.ddev/config.yaml` to `craftcms`, then run [`ddev restart`](../users/usage/commands.md#restart) apply the changes.
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -69,7 +69,7 @@ func init() {
 		},
 
 		nodeps.AppTypeCraftCms: {
-			uploadDir: nil, importFilesAction: craftCmsImportFilesAction, appTypeDetect: isCraftCmsApp, configOverrideAction: nil, postConfigAction: nil, postStartAction: craftCmsPostStartAction,
+			uploadDir: nil, importFilesAction: craftCmsImportFilesAction, appTypeDetect: isCraftCmsApp, configOverrideAction: craftCmsConfigOverrideAction, postConfigAction: nil, postStartAction: craftCmsPostStartAction,
 		},
 
 		nodeps.AppTypeDjango4: {

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -153,3 +153,9 @@ func craftCmsPostStartAction(app *DdevApp) error {
 
 	return nil
 }
+
+func craftCmsConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP81
+	app.Database = DatabaseDesc{nodeps.MySQL, nodeps.MySQL80}
+	return nil
+}


### PR DESCRIPTION
The Craft team is gradually shifting its priority to MySQL support over MariaDB, and would prefer this as the default.

This PR also changes the default PHP version to 8.1. New projects/config can still choose their database driver and PHP version via the `--database` and `--php-version` flags, if the user desires.

## The Issue

MariaDB has slowly drifted away from being a drop-in replacement for MySQL, and this has resulted in some frustration from our community, as well as an increased support burden.

## How This PR Solves The Issue

We implemented a new `craftCmsConfigOverrideAction` function that sets the `PHPVersion` and `Database` properties for the current `DdevApp`, using predefined constants. This function is assigned to the project type’s `configOverrideAction` so it runs during setup.

## Manual Testing Instructions

The current recommended `config` command…
```bash
mkdir ddev-default-db-test
cd ddev-default-db-test
ddev config --project-type=craftcms --docroot=web --create-docroot
```

…should now produce output like this:

```yaml
name: ddev-default-db-test
type: craftcms
docroot: web
php_version: "8.1"
webserver_type: nginx-fpm
# ...
database:
    type: mysql
    version: "8.0"
```

Overrides should still be reflected in the resolved config file, so this command…

```sh
ddev config --project-type=craftcms --docroot=web --create-docroot --php-version=8.0 --database=mariadb:10.4
```

…produces this output:

```yaml
name: ddev-default-db-test
type: craftcms
docroot: web
php_version: "8.0"
# ...
database:
    type: mariadb
    version: "10.4"
```

## Automated Testing Overview

No automated tests have been added.

## Related Issue Link(s)

None

## Release/Deployment Notes

- Craft CMS projects now default to PHP 8.1 and MySQL 8.0.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4907"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

