### PR TITLE
Fix copy pasta in ddev mutagen monitor [skip ci]

### DIFF
--- a/cmd/ddev/cmd/mutagen-monitor.go
+++ b/cmd/ddev/cmd/mutagen-monitor.go
@@ -10,7 +10,7 @@ import (
 var MutagenMonitorCmd = &cobra.Command{
 	Use:     "monitor",
 	Short:   "Monitor mutagen status",
-	Example: `"ddev mutagen sync", "ddev mutagen monitor <projectname>"`,
+	Example: `"ddev mutagen monitor", "ddev mutagen monitor <projectname>"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := ""
 		if len(args) > 1 {


### PR DESCRIPTION
## The Issue

`ddev mutagen monitor` had some copy pasta in the help.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4909"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

