### PR TITLE
Stop testing TestDdevXdebugenabled on Docker Desktop until it works [skip ci]

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -862,6 +862,9 @@ func TestDdevXdebugEnabled(t *testing.T) {
 	if dockerutil.IsColima() && os.Getenv("DDEV_TEST_COLIMA_ANYWAY") != "true" {
 		t.Skip("Skipping on Colima because this test doesn't work although manual testing works")
 	}
+	if dockerutil.IsWSL2() && dockerutil.IsDockerDesktop() {
+		t.Skip("Skipping on WSL2/Docker Desktop because this test doesn't work although manual testing works")
+	}
 	assert := asrt.New(t)
 
 	origDir, _ := os.Getwd()


### PR DESCRIPTION

## The Issue

Since Docker Desktop 4.19.0 we're unable to get successful testing of TestDdevXdebugEnabled on Docker Desktop/WSL2. 

Seems to be related to
* https://github.com/docker/for-win/issues/13463

Disable the test on DD/WSL2 for now.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4910"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

