### PR TITLE
[tests only] Use new platform.sh target site for testing

### DIFF
--- a/pkg/ddevapp/providerPlatform_test.go
+++ b/pkg/ddevapp/providerPlatform_test.go
@@ -26,11 +26,11 @@ import (
  * defined in the constants below.
  */
 
-const platformTestSiteID = "lago3j23xu2w6"
+const platformTestSiteID = "5bviezdszcmrg"
 const platformPullTestSiteEnvironment = "platform-pull"
 const platformPushTestSiteEnvironment = "platform-push"
 
-const platformPullSiteURL = "https://master-7rqtwti-lago3j23xu2w6.eu-3.platformsh.site/"
+const platformPullSiteURL = "https://platform-pull-7tsp6cq-5bviezdszcmrg.ca-1.platformsh.site/"
 const platformSiteExpectation = "Super easy vegetarian pasta"
 
 // Note that these tests won't run with GitHub actions on a forked PR.


### PR DESCRIPTION
## The Issue

The Platform.sh project that we were previously using for `TestPullPlatform` and `TestPushPlatform` is on a region (EU-3) 
 that is not considered stable (it's a testing platform) and it's more expensive and higher CO2 than the CA-1  region

## How This PR Solves The Issue

I moved the test project to CA-1, and gave the user that has access to the old one access to the new project.

This changes the project used by the test. 

