### PR TITLE
[docs] Move mkcert to the top for Linux [skip ci]

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -45,6 +45,15 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ## Linux
 
+    ### Locally-trusted certificate with mkcert
+
+    Modern browsers require valid certificates, which mkcert can create. Firefox users [may get prompted](https://github.com/FiloSottile/mkcert/issues/50) for `Password or Pin for "NSS Certificate DB` which is the Firefox Master pin. Install it, and then run this:
+
+    ```bash
+    # Initialize mkcert
+    mkcert -install
+    ```
+
     ### Debian/Ubuntu
 
     DDEV’s Debian and RPM packages work with `apt` and `yum` repositories and most variants that use them, including Windows WSL2:
@@ -92,9 +101,6 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ```bash
     # Install DDEV
     yay -S ddev-bin
-
-    # Initialize mkcert
-    mkcert -install
     ```
 
     ### Homebrew (AMD64 only)
@@ -102,9 +108,6 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ```bash
     # Install DDEV using Homebrew
     brew install ddev/ddev/ddev
-
-    # Initialize mkcert
-    mkcert -install
     ```
 
     <!-- we’re using HTML here to customize the #install-script-linux anchor -->

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -47,7 +47,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### Locally-trusted certificate with mkcert
 
-    Modern browsers require valid certificates, which mkcert can create. Firefox users [may get prompted](https://github.com/FiloSottile/mkcert/issues/50) for `Password or Pin for "NSS Certificate DB` which is the Firefox Master pin. Install mkcert, and then run this:
+    Modern browsers require valid certificates, which mkcert can create. [Install mkcert](https://github.com/FiloSottile/mkcert#installation), and then run this:
 
     ```bash
     # Initialize mkcert

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -47,7 +47,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### Locally-trusted certificate with mkcert
 
-    Modern browsers require valid certificates, which mkcert can create. Firefox users [may get prompted](https://github.com/FiloSottile/mkcert/issues/50) for `Password or Pin for "NSS Certificate DB` which is the Firefox Master pin. Install it, and then run this:
+    Modern browsers require valid certificates, which mkcert can create. Firefox users [may get prompted](https://github.com/FiloSottile/mkcert/issues/50) for `Password or Pin for "NSS Certificate DB` which is the Firefox Master pin. Install mkcert, and then run this:
 
     ```bash
     # Initialize mkcert


### PR DESCRIPTION
Solves #4912.

## The Issue

The mkcert command is placed at the bottom, under the Arch Linux section, but it is a requirement for all Linux installations. 

## How This PR Solves The Issue

It moves the mkcert info to the beginning of the Linux section, since it is a requirement for all Linux installations. Repeating it under each Linux distro would break with the DRY principle.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4914"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

