### PR TITLE
[tests only] dockerutils_test TestMain should only delete existing test container

### DIFF
--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -37,6 +37,10 @@ func testMain(m *testing.M) int {
 	_ = os.Setenv("DDEV_NONINTERACTIVE", "true")
 	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
 
+	labels := map[string]string{
+		"com.ddev.site-name": testContainerName,
+	}
+
 	// prep docker container for docker util tests
 	imageExists, err := ImageExistsLocally(versionconstants.GetWebImage())
 	if err != nil {
@@ -51,7 +55,7 @@ func testMain(m *testing.M) int {
 		}
 	}
 
-	foundContainer, _ := FindContainerByLabels(map[string]string{"com.ddev.site-name": testContainerName})
+	foundContainer, _ := FindContainerByLabels(labels)
 
 	if foundContainer != nil {
 		err = RemoveContainer(foundContainer.ID)
@@ -67,11 +71,15 @@ func testMain(m *testing.M) int {
 		return 3
 	}
 	defer func() {
-		err = RemoveContainer(containerID)
-		if err != nil {
-			logOutput.Errorf("-- FAIL: dockerutils_test failed to remove test container: %v", err)
+		foundContainer, _ := FindContainerByLabels(labels)
+		if foundContainer != nil {
+			err = RemoveContainer(foundContainer.ID)
+			if err != nil {
+				logOutput.Errorf("-- FAIL: dockerutils_test failed to remove test container: %v", err)
+			}
 		}
 	}()
+
 	log.Printf("ContainerWait at %v", time.Now())
 	out, err := ContainerWait(60, map[string]string{"com.ddev.site-name": testContainerName})
 	log.Printf("ContainerWait returrned at %v out='%s' err='%v'", time.Now(), out, err)


### PR DESCRIPTION

## The Issue

In a recent update the logic was changed in the testMain of dockerutils_test; it may or may not have to clean up the test container, but it should use the correct test container. 

I was seeing this output sometimes in tests:

`[580](https://github.com/ddev/ddev/actions/runs/4990360031/jobs/8935458261?pr=4866#step:9:581)time="2023-05-16T09:50:34Z" level=error msg="-- FAIL: dockerutils_test failed to remove test container: No such container: 3578dd127b77350566d800ec43c2ac63485d8ebedcbccb5bfa4f3ce390e15bb6"`




<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4916"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

