### PR TITLE
Bump docker-compose to v2.18.1

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1899,7 +1899,7 @@ func (app *DdevApp) DockerEnv() {
 
 	envVars := map[string]string{
 		// The compose project name can no longer contain dots; must be lower-case
-		"COMPOSE_PROJECT_NAME":          strings.ToLower("ddev-" + strings.Replace(app.Name, `.`, "", -1)),
+		"COMPOSE_PROJECT_NAME":           strings.ToLower("ddev-" + strings.Replace(app.Name, `.`, "", -1)),
 		"COMPOSE_CONVERT_WINDOWS_PATHS":  "true",
 		"COMPOSER_EXIT_ON_PATCH_FAILURE": "1",
 		"DDEV_SITENAME":                  app.Name,

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1898,9 +1898,8 @@ func (app *DdevApp) DockerEnv() {
 	}
 
 	envVars := map[string]string{
-		// The compose project name can no longer contain dots
-		// https://github.com/compose-spec/compose-go/pull/197
-		"COMPOSE_PROJECT_NAME":           "ddev-" + strings.Replace(app.Name, `.`, "", -1),
+		// The compose project name can no longer contain dots; must be lower-case
+		"COMPOSE_PROJECT_NAME":          strings.ToLower("ddev-" + strings.Replace(app.Name, `.`, "", -1)),
 		"COMPOSE_CONVERT_WINDOWS_PATHS":  "true",
 		"COMPOSER_EXIT_ON_PATCH_FAILURE": "1",
 		"DDEV_SITENAME":                  app.Name,

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -612,7 +612,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.18.0"
+var RequiredDockerComposeVersion = "v2.18.1"
 
 // GetRequiredDockerComposeVersion returns the version of docker-compose we need
 // based on the compiled version, or overrides in globalconfig, like

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -612,7 +612,7 @@ var DockerComposeVersion = ""
 
 // This is var instead of const so it can be changed in test, but should not otherwise be touched.
 // Otherwise we can't test if the version on the machine is equal to version required
-var RequiredDockerComposeVersion = "v2.15.1"
+var RequiredDockerComposeVersion = "v2.18.0"
 
 // GetRequiredDockerComposeVersion returns the version of docker-compose we need
 // based on the compiled version, or overrides in globalconfig, like


### PR DESCRIPTION
## The Issue

Time to catch up to current docker-compose version

## How This PR Solves The Issue

Bump to composer 2.18.1

See also
* https://github.com/ddev/ddev/issues/4727



## Manual Testing Instructions

Use it. 



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4917"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

