### PR TITLE
Separate "build" from "up" stages in DDEV Start()

### DIFF
--- a/cmd/ddev/cmd/debug-refresh.go
+++ b/cmd/ddev/cmd/debug-refresh.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -40,10 +41,10 @@ var DebugRefreshCmd = &cobra.Command{
 		}
 
 		util.Debug("Executing docker-compose -f %s build --no-cache", app.DockerComposeFullRenderedYAMLPath())
-		_, _, err = dockerutil.ComposeCmd([]string{app.DockerComposeFullRenderedYAMLPath()}, "build", "--no-cache")
-
+		out, stderr, err := dockerutil.ComposeCmd([]string{app.DockerComposeFullRenderedYAMLPath()}, "build", "--no-cache")
+		output.UserOut.Printf("docker-compose build output:\n%s\n\n", out)
 		if err != nil {
-			util.Failed("Failed to execute docker-compose -f %s build --no-cache: %v", err)
+			util.Failed("Failed to execute docker-compose -f %s build --no-cache: %v; stderr=\n%s\n\n", err, stderr)
 		}
 		err = app.Restart()
 		if err != nil {

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -114,4 +114,4 @@ It can be complicated to figure out what’s going on when building a Dockerfile
 
 1. Use [`ddev ssh`](../usage/commands.md#ssh) first of all to pioneer the steps you want to take. You can do all the things you need to do there and see if it works. If you’re doing something that affects PHP, you may need to `sudo killall -USR2 php-fpm` for it to take effect.
 2. Put the steps you pioneered into `.ddev/web-build/Dockerfile` as above.
-3. If you can’t figure out what’s failing or why, then `ddev debug refresh` will show the full output of teh build process. You can also `export DDEV_VERBOSE=true && ddev start` to see what’s happening during the Dockerfile build during `ddev start`.
+3. If you can’t figure out what’s failing or why, then `ddev debug refresh` will show the full output of the build process. You can also `export DDEV_VERBOSE=true && ddev start` to see what’s happening during the Dockerfile build during `ddev start`.

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -114,4 +114,4 @@ It can be complicated to figure out what’s going on when building a Dockerfile
 
 1. Use [`ddev ssh`](../usage/commands.md#ssh) first of all to pioneer the steps you want to take. You can do all the things you need to do there and see if it works. If you’re doing something that affects PHP, you may need to `sudo killall -USR2 php-fpm` for it to take effect.
 2. Put the steps you pioneered into `.ddev/web-build/Dockerfile` as above.
-3. If you can’t figure out what’s failing or why, then `~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml build web --no-cache --progress=plain` to see what’s happening during the Dockerfile build.
+3. If you can’t figure out what’s failing or why, then `ddev debug refresh` will show the full output of teh build process. You can also `export DDEV_VERBOSE=true && ddev start` to see what’s happening during the Dockerfile build during `ddev start`.

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -24,6 +24,10 @@ Things might go wrong! In addition to this page, consider checking [Stack Overfl
 
     If that starts up fine, there may be an issue specifically with the project you’re trying to start.
 
+!!!tip "DDEV_DEBUG and DDEV_VERBOSE Environment Variables"
+
+    You can `export DDEV_DEBUG=true` to get more output from DDEV when it's executing any command. In rare cases even `export DDEV_VERBOSE=true` may give you useful information, but it's mostly valuable to developers, as it's very verbose.
+
 !!!tip "Using DDEV with Other Development Environments"
 
     DDEV uses your system’s port 80 and 443 by default when projects are running. If you’re using another local development environment (like Lando or Docksal or a native setup), you can either stop the other environment or configure DDEV to use different ports. See [troubleshooting](troubleshooting.md#unable-listen) for more detailed problem-solving. It’s easiest to stop the other environment when you want to use DDEV, and stop DDEV when you want to use the other environment.

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -26,7 +26,9 @@ Things might go wrong! In addition to this page, consider checking [Stack Overfl
 
 !!!tip "DDEV_DEBUG and DDEV_VERBOSE Environment Variables"
 
-    You can `export DDEV_DEBUG=true` to get more output from DDEV when it's executing any command. In rare cases even `export DDEV_VERBOSE=true` may give you useful information, but it's mostly valuable to developers, as it's very verbose.
+    You can `export DDEV_DEBUG=true` to get more output from DDEV when it's executing any command. 
+
+    `export DDEV_VERBOSE=true` may also give you useful information, but it's mostly valuable to DDEV developers, as it's very verbose. However, it outputs complete information about the Dockerfile build stage of `ddev start`, so can help when debugging Dockerfile problems.
 
 !!!tip "Using DDEV with Other Development Environments"
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1176,7 +1176,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 
 	// Build extra layers on web and db images if necessary
 	progress := "quiet"
-	if globalconfig.DdevDebug {
+	if globalconfig.DdevVerbose {
 		progress = "auto"
 	}
 	util.Debug("Executing docker-compose -f %s build --progress=%s", app.DockerComposeFullRenderedYAMLPath(), progress)
@@ -1184,7 +1184,9 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	if err != nil {
 		return fmt.Errorf("docker-compose build failed: %v, output='%s', stderr='%s'", err, out, stderr)
 	}
-	util.Debug("docker-compose build output:\n%s\n\n", out)
+	if globalconfig.DdevVerbose {
+		util.Debug("docker-compose build output:\n%s\n\n", out)
+	}
 
 	util.Debug("Executing docker-compose -f %s up -d", app.DockerComposeFullRenderedYAMLPath())
 	_, _, err = dockerutil.ComposeCmd([]string{app.DockerComposeFullRenderedYAMLPath()}, "up", "-d")
@@ -1304,7 +1306,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		util.Warning("Failed waiting for web/db containers to become ready: %v", err)
 	}
 
-	if globalconfig.DdevDebug {
+	if globalconfig.DdevVerbose {
 		out, err = app.CaptureLogs("web", true, "200")
 		if err != nil {
 			util.Warning("Unable to capture logs from web container: %v", err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1306,7 +1306,11 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 
 	if globalconfig.DdevDebug {
 		out, err = app.CaptureLogs("web", true, "200")
-		util.Debug("docker-compose up output:\n%s\n\n", out)
+		if err != nil {
+			util.Warning("Unable to capture logs from web container: %v", err)
+		} else {
+			util.Debug("docker-compose up output:\n%s\n\n", out)
+		}
 	}
 
 	// WebExtraDaemons have to be started after mutagen sync is done, because so often

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -67,7 +67,9 @@ func Success(format string, a ...interface{}) {
 // Output controlled by DDEV_DEBUG environment variable
 func Debug(format string, a ...interface{}) {
 	if globalconfig.DdevDebug {
-		output.UserOut.Debugf(format, a...)
+		n := time.Now()
+		s := fmt.Sprintf(format, a...)
+		output.UserOut.Debugf("%s %s", n.Format("2006-01-02T15:04:05.999"), s)
 	}
 }
 


### PR DESCRIPTION
## The Issue

People sometimes struggle with debugging .web-build/Dockerfile.* items because it doesn't give good output unless there's an error. 

## How This PR Solves The Issue

* With `export DDEV_VERBOSE=true` `ddev start` shows the output of the build stage and also the full output of the "up" stage, including start.sh, etc.
* `ddev debug refresh` always shows the output of the build stage. 
* Added `DDEV_VERBOSE=true` to the troubleshooting.md page. 
* Added unconditional timestamp to util.Debug() output

## TODO

- [x] Change docs to say DDEV_VERBOSE shows build info
- [x] DDEV_VERBOSE add to docs about debugging Dockerfile

## Manual Testing Instructions

- [x] `export DDEV_VERBOSE=true && ddev start`
- [x] Compare start time to previous versions


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4919"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

