### PR TITLE
Simplify and optimize util.TimeTrack

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
@@ -24,7 +23,7 @@ import (
 // TestCustomCommands does basic checks to make sure custom commands work OK.
 func TestCustomCommands(t *testing.T) {
 	assert := asrt.New(t)
-	runTime := util.TimeTrack(time.Now(), t.Name())
+	runTime := util.TimeTrackC(t.Name())
 
 	origDir, _ := os.Getwd()
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -114,7 +114,7 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 		}
 
 		if globalconfig.DdevGlobalConfig.InstrumentationOptIn && versionconstants.SegmentKey != "" && globalconfig.IsInternetActive() && len(fullCommand) > 1 {
-			runTime := util.TimeTrack(time.Now(), "Instrumentation")
+			defer util.TimeTrackC("Instrumentation")()
 			// Try to get default instrumentationApp from current directory if not already set
 			if instrumentationApp == nil {
 				app, err := ddevapp.NewApp("", false)
@@ -128,7 +128,6 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 			}
 			ddevapp.SetInstrumentationBaseTags()
 			ddevapp.SendInstrumentationEvents(event)
-			runTime()
 		}
 	},
 }

--- a/cmd/ddev/main.go
+++ b/cmd/ddev/main.go
@@ -1,15 +1,14 @@
 package main
 
 import (
+	"os"
+
 	"github.com/ddev/ddev/cmd/ddev/cmd"
 	"github.com/ddev/ddev/pkg/util"
-	"os"
-	"time"
 )
 
 func main() {
-	runTime := util.TimeTrack(time.Now(), "main()")
-	defer runTime()
+	defer util.TimeTrack()()
 
 	// Prevent running as root for most cases
 	// We really don't want ~/.ddev to have root ownership, breaks things.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -56,8 +56,7 @@ func init() {
 
 // NewApp creates a new DdevApp struct with defaults set and overridden by any existing config.yml.
 func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("ddevapp.NewApp(%s)", appRoot))
-	defer runTime()
+	defer util.TimeTrackC(fmt.Sprintf("ddevapp.NewApp(%s)", appRoot))()
 
 	app := &DdevApp{}
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -3,7 +3,6 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
-	"github.com/ddev/ddev/pkg/dockerutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -11,22 +10,20 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Masterminds/semver/v3"
-
+	. "github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/versionconstants"
-	"github.com/stretchr/testify/require"
-
-	. "github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/google/uuid"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // isSemver returns true if a string is a semantic version.
@@ -752,8 +749,7 @@ func TestConfigOverrideDetection(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s ConfigOverrideDetection", site.Name))
-	runTime()
+	defer util.TimeTrackC(fmt.Sprintf("%s ConfigOverrideDetection", site.Name))()
 
 	// Copy test overrides into the project .ddev directory
 	for _, item := range []string{"nginx", "nginx_full", "apache", "php", "mysql"} {
@@ -804,7 +800,6 @@ func TestConfigOverrideDetection(t *testing.T) {
 		assert.NotContains(stdout, "nginx-site.conf")
 	}
 	assert.Contains(stdout, "Custom configuration is updated")
-	runTime()
 }
 
 // TestPHPOverrides tests to make sure that PHP overrides work in all webservers.
@@ -827,7 +822,7 @@ func TestPHPOverrides(t *testing.T) {
 		err = os.Chdir(origDir)
 		assert.NoError(err)
 	})
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	testcommon.ClearDockerEnv()
 	err = app.Init(site.Dir)
@@ -929,7 +924,7 @@ func TestExtraPackages(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -1010,7 +1005,7 @@ func TestTimezoneConfig(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", t.Name(), site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", t.Name(), site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -1075,7 +1070,7 @@ func TestComposerVersionConfig(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", t.Name(), site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", t.Name(), site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -1125,7 +1120,7 @@ func TestCustomBuildDockerfiles(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s TestCustomBuildDockerfiles", site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s TestCustomBuildDockerfiles", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)

--- a/pkg/ddevapp/container_test.go
+++ b/pkg/ddevapp/container_test.go
@@ -2,13 +2,13 @@ package ddevapp_test
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/util"
-	asrt "github.com/stretchr/testify/assert"
 	"os"
 	"strings"
 	"testing"
-	"time"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/util"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // Test to make sure that the user provisioned in the container has
@@ -26,8 +26,7 @@ func TestUserProvisioningInContainer(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
-	defer runTime()
+	defer util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))()
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -146,8 +146,7 @@ func (app *DdevApp) GetType() string {
 // Init populates DdevApp config based on the current working directory.
 // It does not start the containers.
 func (app *DdevApp) Init(basePath string) error {
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("app.Init(%s)", basePath))
-	defer runTime()
+	defer util.TimeTrackC(fmt.Sprintf("app.Init(%s)", basePath))()
 
 	newApp, err := NewApp(basePath, true)
 	if err != nil {
@@ -1588,8 +1587,7 @@ type ExecOpts struct {
 func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	app.DockerEnv()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("app.Exec %v", opts))
-	defer runTime()
+	defer util.TimeTrackC(fmt.Sprintf("app.Exec %v", opts))()
 
 	if opts.Cmd == "" && len(opts.RawCmd) == 0 {
 		return "", "", fmt.Errorf("no command provided")
@@ -2185,13 +2183,12 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 	if globalconfig.DdevGlobalConfig.NoBindMounts {
 		// If we're not using bind-mounts, we have to copy the snapshot back into
 		// the host project's .ddev/db_snapshots directory
-		elapsed := util.TimeTrack(time.Now(), "CopySnapshotFromContainer")
+		defer util.TimeTrackC("CopySnapshotFromContainer")()
 		// Copy snapshot back to the host
 		err = dockerutil.CopyFromContainer(GetContainerName(app, "db"), path.Join(containerSnapshotDir, snapshotFile), app.GetConfigPath("db_snapshots"))
 		if err != nil {
 			return "", err
 		}
-		elapsed()
 	} else {
 		// But if we are using bind-mounts, we can just copy it to where the snapshot is
 		// mounted into the db container (/mnt/ddev_config/db_snapshots)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -459,7 +459,7 @@ func TestDdevStart(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStart", site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s DdevStart", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -592,7 +592,7 @@ func TestDdevStartCustomEntrypoint(t *testing.T) {
 	site := TestSites[0]
 	origDir, _ := os.Getwd()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStart", site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s DdevStart", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -654,7 +654,7 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 	app := &ddevapp.DdevApp{}
 
 	for _, site := range TestSites {
-		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStartMultipleHostnames", site.Name))
+		runTime := util.TimeTrackC(fmt.Sprintf("%s DdevStartMultipleHostnames", site.Name))
 		testcommon.ClearDockerEnv()
 
 		err := app.Init(site.Dir)
@@ -827,8 +827,7 @@ func TestDdevNoProjectMount(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", t.Name(), site.Name))
-	defer runTime()
+	defer util.TimeTrackC(fmt.Sprintf("%s %s", t.Name(), site.Name))()
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -906,7 +905,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 		globalconfig.DdevGlobalConfig.XdebugIDELocation = ""
 		_ = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 	})
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", app.Name, t.Name()))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", app.Name, t.Name()))
 
 	_ = os.Chdir(app.AppRoot)
 
@@ -1065,7 +1064,7 @@ func TestDdevXhprofEnabled(t *testing.T) {
 	err = fileutil.TemplateStringToFile("<?php\nphpinfo();\n", nil, filepath.Join(app.AppRoot, "index.php"))
 	require.NoError(t, err)
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", app.Name, t.Name()))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", app.Name, t.Name()))
 
 	// Does not work with php5.6 anyway (SEGV), for resource conservation
 	// skip older unsupported versions
@@ -1160,7 +1159,7 @@ func TestDdevMysqlWorks(t *testing.T) {
 	app := &ddevapp.DdevApp{}
 
 	site := TestSites[0]
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevMysqlWorks", site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s DdevMysqlWorks", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -1287,7 +1286,7 @@ func TestDdevImportDB(t *testing.T) {
 
 	site := TestSites[0]
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
@@ -1608,7 +1607,7 @@ func TestDdevAllDatabases(t *testing.T) {
 	origDir, _ := os.Getwd()
 
 	site := TestSites[0]
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
@@ -1807,7 +1806,7 @@ func TestDdevExportDB(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevExportDB", site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s DdevExportDB", site.Name))
 
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
@@ -2005,7 +2004,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 	for i, site := range TestSites {
 		switchDir := site.Chdir()
 		defer switchDir()
-		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevFullSiteSetup", site.Name))
+		runTime := util.TimeTrackC(fmt.Sprintf("%s DdevFullSiteSetup", site.Name))
 		t.Logf("== BEGIN TestDdevFullSiteSetup for %s (%d)\n", site.Name, i)
 		testcommon.ClearDockerEnv()
 		err := app.Init(site.Dir)
@@ -2144,7 +2143,7 @@ func TestWriteableFilesDirectory(t *testing.T) {
 	origDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}
 	site := TestSites[0]
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s TestWritableFilesDirectory", site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s TestWritableFilesDirectory", site.Name))
 
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
@@ -2280,7 +2279,7 @@ func TestDdevImportFilesDir(t *testing.T) {
 			t.Logf("== SKIP TestDdevImportFilesDir for %s (FilesTarballURL and FilesZipballURL are not provided)\n", site.Name)
 			continue
 		}
-		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+		runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 		t.Logf("== BEGIN TestDdevImportFilesDir for %s\n", site.Name)
 
 		testcommon.ClearDockerEnv()
@@ -2340,7 +2339,7 @@ func TestDdevImportFiles(t *testing.T) {
 		}
 
 		t.Logf("== BEGIN TestDdevImportFiles for %s\n", site.Name)
-		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+		runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 		testcommon.ClearDockerEnv()
 		err := app.Init(site.Dir)
@@ -2420,7 +2419,7 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 
 	for _, site := range TestSites {
 		switchDir := site.Chdir()
-		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+		runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 		t.Logf("== BEGIN TestDdevImportFilesCustomUploadDir for %s\n", site.Name)
 
 		testcommon.ClearDockerEnv()
@@ -2482,7 +2481,7 @@ func TestDdevExec(t *testing.T) {
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevExec", site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s DdevExec", site.Name))
 
 	// Make a dummy service out of busybox
 	err := fileutil.CopyFile(filepath.Join(testDir, "testdata", t.Name(), "docker-compose.busybox.yaml"), filepath.Join(site.Dir, ".ddev", "docker-compose.busybox.yaml"))
@@ -2628,7 +2627,7 @@ func TestDdevLogs(t *testing.T) {
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevLogs", site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s DdevLogs", site.Name))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -2677,7 +2676,7 @@ func TestDdevPause(t *testing.T) {
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStop", site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s DdevStop", site.Name))
 
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
@@ -3279,7 +3278,7 @@ func TestGetAllURLs(t *testing.T) {
 	assert := asrt.New(t)
 
 	site := TestSites[0]
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s GetAllURLs", site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s GetAllURLs", site.Name))
 
 	testcommon.ClearDockerEnv()
 	app := new(ddevapp.DdevApp)
@@ -3343,7 +3342,7 @@ func TestPHPWebserverType(t *testing.T) {
 		if site.Type == nodeps.AppTypeDjango4 || site.Type == nodeps.AppTypePython {
 			continue
 		}
-		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+		runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 		app := new(ddevapp.DdevApp)
 
@@ -3413,7 +3412,7 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 
 	assert := asrt.New(t)
 
-	runTime := util.TimeTrack(time.Now(), t.Name())
+	runTime := util.TimeTrackC(t.Name())
 
 	site := TestSites[0]
 	app := new(ddevapp.DdevApp)
@@ -3517,7 +3516,7 @@ func TestCaptureLogs(t *testing.T) {
 	assert := asrt.New(t)
 
 	site := TestSites[0]
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s CaptureLogs", site.Name))
+	defer util.TimeTrackC(fmt.Sprintf("%s CaptureLogs", site.Name))()
 
 	app := ddevapp.DdevApp{}
 
@@ -3533,8 +3532,6 @@ func TestCaptureLogs(t *testing.T) {
 
 	err = app.Stop(true, false)
 	assert.NoError(err)
-
-	runTime()
 }
 
 // TestNFSMount tests ddev start functionality with nfs_mount_enabled: true
@@ -3558,7 +3555,7 @@ func TestNFSMount(t *testing.T) {
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	err := app.Init(site.Dir)
 	assert.NoError(err)
@@ -3687,8 +3684,7 @@ func TestHostDBPort(t *testing.T) {
 		t.Skip("Skipping test on colima because of constant port problems")
 	}
 	assert := asrt.New(t)
-	runTime := util.TimeTrack(time.Now(), t.Name())
-	defer runTime()
+	defer util.TimeTrackC(t.Name())()
 	origDir, _ := os.Getwd()
 
 	site := TestSites[0]
@@ -3790,8 +3786,7 @@ func TestPortSpecifications(t *testing.T) {
 		t.Skip("Skipping on WSL2 because of inconsistent docker behavior acquiring ports")
 	}
 	assert := asrt.New(t)
-	runTime := util.TimeTrack(time.Now(), fmt.Sprint("TestPortSpecifications"))
-	defer runTime()
+	defer util.TimeTrackC("TestPortSpecifications")()
 	testDir, _ := os.Getwd()
 
 	site0 := TestSites[0]
@@ -3876,8 +3871,7 @@ func TestPortSpecifications(t *testing.T) {
 // It's only here for profiling at this point
 func TestDdevGetProjects(t *testing.T) {
 	assert := asrt.New(t)
-	runTime := util.TimeTrack(time.Now(), fmt.Sprint(t.Name()))
-	defer runTime()
+	defer util.TimeTrackC(t.Name())()
 
 	apps, err := ddevapp.GetProjects(false)
 	assert.NoError(err)

--- a/pkg/ddevapp/hardened_test.go
+++ b/pkg/ddevapp/hardened_test.go
@@ -2,6 +2,10 @@ package ddevapp_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
@@ -10,10 +14,6 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
 )
 
 // TestHardenedStart makes sure we can do a start and basic use with hardened images
@@ -34,7 +34,7 @@ func TestHardenedStart(t *testing.T) {
 		t.Skip("Skipping test because mutagen is enabled")
 	}
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s DdevStart", site.Name))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s DdevStart", site.Name))
 
 	ddevapp.PowerOff()
 

--- a/pkg/ddevapp/hooks_test.go
+++ b/pkg/ddevapp/hooks_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/testcommon"
@@ -22,7 +21,7 @@ func TestProcessHooks(t *testing.T) {
 	origDir, _ := os.Getwd()
 	// We don't get the expected task debug output without DDEV_DEBUG
 	t.Setenv("DDEV_DEBUG", "true")
-	runTime := util.TimeTrack(time.Now(), t.Name())
+	runTime := util.TimeTrackC(t.Name())
 
 	testcommon.ClearDockerEnv()
 	app, err := ddevapp.NewApp(site.Dir, true)

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -5,6 +5,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -14,11 +20,6 @@ import (
 	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/denisbrodbeck/machineid"
 	"gopkg.in/segmentio/analytics-go.v3"
-	"os"
-	"runtime"
-	"strconv"
-	"strings"
-	"time"
 )
 
 var hashedHostID string
@@ -41,8 +42,7 @@ func GetInstrumentationUser() string {
 
 // SetInstrumentationBaseTags sets the basic always-used tags for Segment
 func SetInstrumentationBaseTags() {
-	runTime := util.TimeTrack(time.Now(), "SetInstrumentationBaseTags")
-	defer runTime()
+	defer util.TimeTrack()()
 
 	if globalconfig.DdevGlobalConfig.InstrumentationOptIn {
 		dockerVersion, _ := dockerutil.GetDockerVersion()
@@ -78,8 +78,7 @@ func getProjectHash(projectName string) string {
 
 // SetInstrumentationAppTags creates app-specific tags for Segment
 func (app *DdevApp) SetInstrumentationAppTags() {
-	runTime := util.TimeTrack(time.Now(), "SetInstrumentationAppTags")
-	defer runTime()
+	defer util.TimeTrack()()
 
 	ignoredProperties := []string{"approot", "hostname", "hostnames", "name", "router_status_log", "shortroot"}
 
@@ -138,8 +137,7 @@ func SegmentEvent(client analytics.Client, hashedID string, event string) error 
 
 // SendInstrumentationEvents does the actual send to segment
 func SendInstrumentationEvents(event string) {
-	runTime := util.TimeTrack(time.Now(), "SendInstrumentationEvents")
-	defer runTime()
+	defer util.TimeTrack()()
 
 	if globalconfig.DdevGlobalConfig.InstrumentationOptIn && globalconfig.IsInternetActive() {
 		client, _ := analytics.NewWithConfig(versionconstants.SegmentKey, analytics.Config{

--- a/pkg/ddevapp/instrumentation_test.go
+++ b/pkg/ddevapp/instrumentation_test.go
@@ -2,14 +2,14 @@ package ddevapp_test
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
-	"time"
 )
 
 // TestSetInstrumentationAppTags checks to see that tags are properly set
@@ -19,7 +19,7 @@ func TestSetInstrumentationAppTags(t *testing.T) {
 	assert := asrt.New(t)
 
 	site := TestSites[0]
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	testcommon.ClearDockerEnv()
 	app := new(ddevapp.DdevApp)

--- a/pkg/ddevapp/list.go
+++ b/pkg/ddevapp/list.go
@@ -2,6 +2,9 @@ package ddevapp
 
 import (
 	"bytes"
+	"strings"
+	"time"
+
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
@@ -10,8 +13,6 @@ import (
 	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
-	"strings"
-	"time"
 )
 
 // ListCommandSettings conains all filters and settings of the `ddev list` command
@@ -38,8 +39,7 @@ type ListCommandSettings struct {
 // wrapTableText if true the text is wrapped instead of truncated to fit the row length
 // continuousSleepTime is the time between reports
 func List(settings ListCommandSettings) {
-	runTime := util.TimeTrack(time.Now(), "ddev list")
-	defer runTime()
+	defer util.TimeTrack()()
 
 	var out bytes.Buffer
 

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -2,6 +2,13 @@ package ddevapp_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
@@ -10,12 +17,6 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
-	"testing"
-	"time"
 )
 
 // TestMutagenSimple tests basic mutagen functionality
@@ -40,7 +41,7 @@ func TestMutagenSimple(t *testing.T) {
 
 	err := site.Prepare()
 	require.NoError(t, err)
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	err = app.Init(site.Dir)
 	assert.NoError(err)
@@ -176,7 +177,7 @@ func TestMutagenConfigChange(t *testing.T) {
 
 	err := site.Prepare()
 	require.NoError(t, err)
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s %s", site.Name, t.Name()))
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
 
 	err = app.Init(site.Dir)
 	assert.NoError(err)

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -1,6 +1,10 @@
 package ddevapp_test
 
 import (
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
@@ -9,10 +13,6 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"strings"
-	"testing"
-	"time"
 )
 
 // TestNodeJSVersions whether we can configure nodejs versions
@@ -26,7 +26,7 @@ func TestNodeJSVersions(t *testing.T) {
 	origDir, _ := os.Getwd()
 	_ = os.Chdir(site.Dir)
 
-	runTime := util.TimeTrack(time.Now(), t.Name())
+	runTime := util.TimeTrackC(t.Name())
 
 	testcommon.ClearDockerEnv()
 	app, err := ddevapp.NewApp(site.Dir, true)

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -94,7 +93,7 @@ func TestWriteDrushConfig(t *testing.T) {
 	origDir, _ := os.Getwd()
 
 	for _, site := range TestSites {
-		runTime := util.TimeTrack(time.Now(), fmt.Sprintf("%s WriteDrushrc", site.Name))
+		runTime := util.TimeTrackC(fmt.Sprintf("%s WriteDrushrc", site.Name))
 
 		testcommon.ClearDockerEnv()
 

--- a/pkg/ddevapp/snapshot_test.go
+++ b/pkg/ddevapp/snapshot_test.go
@@ -1,7 +1,13 @@
 package ddevapp_test
 
 import (
-	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/ddev/ddev/pkg/archive"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -9,12 +15,6 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 	assert2 "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
-	"testing"
-	"time"
 )
 
 // TestDdevSnapshotCleanup tests creating a snapshot and deleting it.
@@ -25,7 +25,7 @@ func TestDdevSnapshotCleanup(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
-	runTime := util.TimeTrack(time.Now(), fmt.Sprintf("TestDdevSnapshotCleanup"))
+	runTime := util.TimeTrackC("TestDdevSnapshotCleanup")
 
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
@@ -70,7 +70,7 @@ func TestGetLatestSnapshot(t *testing.T) {
 	err := os.Chdir(site.Dir)
 	assert.NoError(err)
 
-	runTime := util.TimeTrack(time.Now(), t.Name())
+	runTime := util.TimeTrackC(t.Name())
 
 	testcommon.ClearDockerEnv()
 	err = app.Init(site.Dir)
@@ -128,7 +128,7 @@ func TestGetLatestSnapshot(t *testing.T) {
 func TestDdevRestoreSnapshot(t *testing.T) {
 	assert := assert2.New(t)
 
-	runTime := util.TimeTrack(time.Now(), t.Name())
+	runTime := util.TimeTrackC(t.Name())
 	origDir, _ := os.Getwd()
 	site := TestSites[0]
 

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
@@ -26,7 +25,7 @@ func TestSSHAuth(t *testing.T) {
 	origDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}
 
-	runTime := util.TimeTrack(time.Now(), t.Name())
+	runTime := util.TimeTrackC(t.Name())
 
 	//  Add a docker-compose service that has ssh server and mounted authorized_keys
 	site := TestSites[0]

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -482,10 +482,9 @@ func GetContainerHealth(container *docker.APIContainers) (string, string) {
 // ComposeWithStreams executes a docker-compose command but allows the caller to specify
 // stdin/stdout/stderr
 func ComposeWithStreams(composeFiles []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, action ...string) error {
-	var arg []string
+	defer util.TimeTrack()()
 
-	runTime := util.TimeTrack(time.Now(), "dockerutil.ComposeWithStreams")
-	defer runTime()
+	var arg []string
 
 	_, err := DownloadDockerComposeIfNeeded()
 	if err != nil {
@@ -614,8 +613,7 @@ func GetContainerEnv(key string, container docker.APIContainers) string {
 // constraints. See https://godoc.org/github.com/Masterminds/semver#hdr-Checking_Version_Constraints
 // for examples defining version constraints.
 func CheckDockerVersion(versionConstraint string) error {
-	runTime := util.TimeTrack(time.Now(), "CheckDockerVersion()")
-	defer runTime()
+	defer util.TimeTrack()()
 
 	currentVersion, err := GetDockerVersion()
 	if err != nil {
@@ -663,8 +661,7 @@ func CheckDockerVersion(versionConstraint string) error {
 // CheckDockerCompose determines if docker-compose is present and executable on the host system. This
 // relies on docker-compose being somewhere in the user's $PATH.
 func CheckDockerCompose() error {
-	runTime := util.TimeTrack(time.Now(), "CheckDockerComposeVersion()")
-	defer runTime()
+	defer util.TimeTrack()()
 
 	_, err := DownloadDockerComposeIfNeeded()
 	if err != nil {
@@ -1245,7 +1242,7 @@ func CopyIntoVolume(sourcePath string, volumeName string, targetSubdir string, u
 
 	containerName := "CopyIntoVolume_" + nodeps.RandomString(12)
 
-	track := util.TimeTrack(time.Now(), "CopyIntoVolume "+sourcePath+" "+volumeName)
+	track := util.TimeTrackC("CopyIntoVolume " + sourcePath + " " + volumeName)
 	containerID, _, err := RunSimpleContainer(versionconstants.GetWebImage(), containerName, []string{"sh", "-c", "mkdir -p " + targetSubdirFullPath + " && sleep infinity"}, nil, nil, []string{volumeName + ":" + volPath}, "0", false, true, map[string]string{"com.ddev.site-name": ""}, nil)
 	if err != nil {
 		return err

--- a/pkg/util/debug.go
+++ b/pkg/util/debug.go
@@ -1,0 +1,78 @@
+package util
+
+import (
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/sirupsen/logrus"
+)
+
+// TimeTrack determines the amount of time a function takes to return. Timer
+// starts when it is called. The printed name is determined from the calling
+// function. It returns an anonymous function that, when called, will print
+// the elapsed run time.
+//
+// It only tracks if DDEV_VERBOSE is set.
+//
+// Usage:
+//
+//	defer util.TimeTrack()()
+//
+// or
+//
+//	tracker := util.TimeTrack()
+//	...
+//	tracker()
+func TimeTrack() func() {
+	if globalconfig.DdevVerbose {
+		// Determine name from calling function.
+		var name string
+
+		if counter, _, _, success := runtime.Caller(1); !success {
+			name = "<failed to determine caller name>"
+		} else {
+			name = runtime.FuncForPC(counter).Name() + "()"
+		}
+
+		return timeTrack(&name)
+	}
+
+	return func() {}
+}
+
+// TimeTrackC determines the amount of time a function takes to return. Timer
+// starts when it is called. The customName parameter is printed. It returns an
+// anonymous function that, when called, will print the elapsed run time.
+//
+// It only tracks if DDEV_VERBOSE is set.
+//
+// Usage:
+//
+//	defer util.TimeTrackC("a custom name")()
+//
+// or
+//
+//	tracker := util.TimeTrackC("a custom name")
+//	...
+//	tracker()
+func TimeTrackC(customName string) func() {
+	if globalconfig.DdevVerbose {
+		return timeTrack(&customName)
+	}
+
+	return func() {}
+}
+
+// timeTrack is the internal helper for the exported time track functions.
+func timeTrack(name *string) func() {
+	start := time.Now()
+
+	// Print message and return func. Printf is avoided to minimize impact.
+	logrus.Print("PERF: enter " + *name + " at " + start.Format("15:04:05.000000000"))
+
+	return func() {
+		logrus.Print("PERF: exit " + *name + " at " + time.Now().Format("15:04:05.000000000") + " after " + strconv.FormatInt(time.Since(start).Milliseconds(), 10) + "ms")
+	}
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/jedib0t/go-pretty/v6/text"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
@@ -207,23 +206,6 @@ func FindBashPath() string {
 		}
 	}
 	return windowsBashPath
-}
-
-// TimeTrack determines the amount of time a function takes to return. Timing starts when it is called.
-// It returns an anonymous function that, when called, will print the elapsed run time.
-// It tracks if DDEV_VERBOSE is set
-func TimeTrack(start time.Time, name string) func() {
-	if globalconfig.DdevVerbose {
-		logrus.Printf("starting %s at %v\n", name, start.Format("15:04:05.000000000"))
-		return func() {
-			if globalconfig.DdevVerbose {
-				elapsed := time.Since(start)
-				logrus.Printf("PERF: %s took %.2fs", name, elapsed.Seconds())
-			}
-		}
-	}
-	return func() {
-	}
 }
 
 // ElapsedTime is an easy way to report how long something took.


### PR DESCRIPTION
## The Issue

The util.TimeTrack() function has currently a parameter start which was always set to time.Now() and can therefor set directly in the function instead which will reduce the impact a bit and simplify the usage. Also in many cases the name parameter was manually set to the calling function name which is also error prone.

With this patch, the TimeTrack functionallity was moved to a dedicated file in the same package and two functions are now available, one without parameters where the calling function name is retrieved with the help of the runtime package and a second with a name parameter to individually set a name e.g. used for tests. Source documentation was extended to also show a simpler one line usage which is apropriate in most cases. Also some minor optimization are done like avoiding the expensive format functions e.g. Printf. Finally the outputed messages are streamlined to increase visibility.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4924"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

