### PR TITLE
Only run wsl2-docker-desktop on master

### DIFF
--- a/.buildkite/wsl2-docker-desktop.yml
+++ b/.buildkite/wsl2-docker-desktop.yml
@@ -7,6 +7,7 @@
       - "os=wsl2"
       - "architecture=amd64"
       - "dockertype=dockerforwindows"
+    branches: "master"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds


### PR DESCRIPTION
## The Issue

WSL2 Docker Desktop crashes so often that it doesn't make sense to run it for every PR/commit. Let's just run it against master. 



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4930"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

