### PR TITLE
Expand files before processing so we can check #ddev-generated, fixes #4253

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -287,7 +287,12 @@ ddev get --remove ddev-someaddonname
 		if len(s.ProjectFiles) > 0 {
 			util.Success("\nInstalling project-level components:")
 		}
-		for _, file := range s.ProjectFiles {
+
+		projectFiles, err := fileutil.ExpandFilesAndDirectories(extractedDir, s.ProjectFiles)
+		if err != nil {
+			util.Failed("Unable to expand files and directories: %v", err)
+		}
+		for _, file := range projectFiles {
 			file := os.ExpandEnv(file)
 			src := filepath.Join(extractedDir, file)
 			dest := app.GetConfigPath(file)
@@ -298,14 +303,19 @@ ddev get --remove ddev-someaddonname
 				}
 				util.Success("%c %s", '\U0001F44D', file)
 			} else {
-				util.Warning("NOT overwriting file/directory %s. The #ddev-generated signature was not found in the file, so it will not be overwritten. You can just remove the file and use ddev get again if you want it to be replaced: %v", dest, err)
+				util.Warning("NOT overwriting %s. The #ddev-generated signature was not found in the file, so it will not be overwritten. You can just remove the file and use ddev get again if you want it to be replaced: %v", dest, err)
 			}
 		}
 		globalDotDdev := filepath.Join(globalconfig.GetGlobalDdevDir())
 		if len(s.GlobalFiles) > 0 {
 			util.Success("\nInstalling global components:")
 		}
-		for _, file := range s.GlobalFiles {
+
+		globalFiles, err := fileutil.ExpandFilesAndDirectories(extractedDir, s.GlobalFiles)
+		if err != nil {
+			util.Failed("Unable to expand global files and directories: %v", err)
+		}
+		for _, file := range globalFiles {
 			file := os.ExpandEnv(file)
 			src := filepath.Join(extractedDir, file)
 			dest := filepath.Join(globalDotDdev, file)
@@ -318,7 +328,7 @@ ddev get --remove ddev-someaddonname
 				}
 				util.Success("%c %s", '\U0001F44D', file)
 			} else {
-				util.Warning("NOT overwriting file/directory %s. The #ddev-generated signature was not found in the file, so it will not be overwritten. You can just remove the file and use ddev get again if you want it to be replaced: %v", dest, err)
+				util.Warning("NOT overwriting %s. The #ddev-generated signature was not found in the file, so it will not be overwritten. You can just remove the file and use ddev get again if you want it to be replaced: %v", dest, err)
 			}
 		}
 		origDir, _ := os.Getwd()
@@ -514,6 +524,7 @@ func getDdevDescription(action string) string {
 	return ""
 }
 
+// renderRepositoryList renders the found list of repositories
 func renderRepositoryList(repos []*github.Repository) string {
 	var out bytes.Buffer
 

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -293,7 +293,6 @@ ddev get --remove ddev-someaddonname
 			util.Failed("Unable to expand files and directories: %v", err)
 		}
 		for _, file := range projectFiles {
-			file := os.ExpandEnv(file)
 			src := filepath.Join(extractedDir, file)
 			dest := app.GetConfigPath(file)
 			if err = fileutil.CheckSignatureOrNoFile(dest, nodeps.DdevFileSignature); err == nil {
@@ -316,7 +315,6 @@ ddev get --remove ddev-someaddonname
 			util.Failed("Unable to expand global files and directories: %v", err)
 		}
 		for _, file := range globalFiles {
-			file := os.ExpandEnv(file)
 			src := filepath.Join(extractedDir, file)
 			dest := filepath.Join(globalDotDdev, file)
 

--- a/cmd/ddev/cmd/get_test.go
+++ b/cmd/ddev/cmd/get_test.go
@@ -83,8 +83,8 @@ func TestCmdGet(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(exists, "the file with no ddev-generated.txt should not have been replaced")
 
-	assert.Contains(out, fmt.Sprintf("NOT overwriting file/directory %s", app.GetConfigPath("file-with-no-ddev-generated.txt")))
-	assert.Contains(out, fmt.Sprintf("NOT overwriting file/directory %s", filepath.Join(globalconfig.GetGlobalDdevDir(), "file-with-no-ddev-generated.txt")))
+	assert.Contains(out, fmt.Sprintf("NOT overwriting %s", app.GetConfigPath("file-with-no-ddev-generated.txt")))
+	assert.Contains(out, fmt.Sprintf("NOT overwriting %s", filepath.Join(globalconfig.GetGlobalDdevDir(), "file-with-no-ddev-generated.txt")))
 }
 
 // TestCmdGetComplex tests advanced usages

--- a/cmd/ddev/cmd/get_test.go
+++ b/cmd/ddev/cmd/get_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"testing"
 
@@ -124,6 +125,11 @@ func TestCmdGetComplex(t *testing.T) {
 		assert.NoError(err)
 	})
 
+	// create no-ddev-generated.txt so we make sure we get warning about it.
+	_ = os.MkdirAll(app.GetConfigPath("extra"), 0755)
+	_, err = os.Create(app.GetConfigPath("extra/no-ddev-generated.txt"))
+	require.NoError(t, err)
+
 	out, err := exec.RunHostCommand(DdevBin, "get", filepath.Join(origDir, "testdata", t.Name(), "recipe"))
 	require.NoError(t, err, "out=%s", out)
 
@@ -139,6 +145,13 @@ func TestCmdGetComplex(t *testing.T) {
 	// Make sure that environment variable interpolation happened. If it did, we'll have the one file
 	// we're looking for.
 	assert.FileExists(app.GetConfigPath(fmt.Sprintf("junk_%s_%s.txt", runtime.GOOS, runtime.GOARCH)))
+	info, err := os.Stat(app.GetConfigPath("extra/no-ddev-generated.txt"))
+	require.NoError(t, err, "stat of no-ddev-generated.txt failed")
+	assert.True(info.Size() == 0)
+
+	assert.Contains(out, "👍 extra/has-ddev-generated.txt")
+	assert.NotContains(out, "👍 extra/no-ddev-generated.txt")
+	assert.Regexp(regexp.MustCompile(`NOT overwriting [^ ]*`+"extra/no-ddev-generated.txt"), out)
 }
 
 // TestCmdGetInstalled tests `ddev get --installed` and `ddev get --remove`

--- a/cmd/ddev/cmd/testdata/TestCmdGetComplex/recipe/extra/has-ddev-generated.txt
+++ b/cmd/ddev/cmd/testdata/TestCmdGetComplex/recipe/extra/has-ddev-generated.txt
@@ -1,0 +1,1 @@
+#ddev-generated

--- a/cmd/ddev/cmd/testdata/TestCmdGetComplex/recipe/extra/no-ddev-generated.txt
+++ b/cmd/ddev/cmd/testdata/TestCmdGetComplex/recipe/extra/no-ddev-generated.txt
@@ -1,0 +1,1 @@
+There's no ddev generated in this file

--- a/cmd/ddev/cmd/testdata/TestCmdGetComplex/recipe/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdGetComplex/recipe/install.yaml
@@ -31,7 +31,7 @@ pre_install_actions:
 
 project_files:
 - junk_${GOOS}_${GOARCH}.txt
-
+- extra
 
 global_files:
 

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -90,7 +90,7 @@ The `install.yaml` is a simple YAML file with a few main sections:
 * `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
 * `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
 * `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s root directory.
-* `removal_actions`: an array of bash statements or scripts to be executed when the add-on is being removed with `ddev get --remove`.
+* `removal_actions`: an array of Bash statements or scripts to be executed when the add-on is being removed with `ddev get --remove`.
 * `yaml_read_files`: a map of `name: file` of YAML files to be read from the target project’s root directory. The contents of these YAML files may be used as templated actions within `pre_install_actions` and `post_install_actions`.
 
 In any stanza of `pre_install_actions` and `post_install_actions` you can:

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -90,6 +90,7 @@ The `install.yaml` is a simple YAML file with a few main sections:
 * `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
 * `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
 * `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s root directory.
+* `removal_actions`: an array of bash statements or scripts to be executed when the add-on is being removed with `ddev get --remove`.
 * `yaml_read_files`: a map of `name: file` of YAML files to be read from the target project’s root directory. The contents of these YAML files may be used as templated actions within `pre_install_actions` and `post_install_actions`.
 
 In any stanza of `pre_install_actions` and `post_install_actions` you can:
@@ -128,11 +129,10 @@ Go templating resources:
 * [Lots of intro to Golang templates](https://www.google.com/search?q=golang+templates+intro&oq=golang+templates+intro&aqs=chrome..69i57j0i546l4.3161j0j4&sourceid=chrome&ie=UTF-8)
 * [masterminds/sprig](http://masterminds.github.io/sprig/) extra functions.
 
-## Additional services in ddev-contrib (MongoDB, Elasticsearch, etc)
+## Additional services in ddev-contrib
 
-Commonly-used services will be migrated from the [ddev-contrib](https://github.com/ddev/ddev-contrib) repository to individual, tested, supported repositories, but the repository already has a wealth of additional examples and instructions:
+Commonly-used services will be migrated from the [ddev-contrib](https://github.com/ddev/ddev-contrib) repository to individual, tested, supported repositories, but the repository still has a wealth of additional examples and instructions:
 
-* **Headless Chrome**: See [Headless Chrome for Behat Testing](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/headless-chrome)
 * **Old PHP Versions to Run Old Sites**: See [Old PHP Versions](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/old_php)
 * **RabbitMQ**: See [RabbitMQ](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/rabbitmq)
 * **TYPO3 Solr Integration**: See [TYPO3 Solr](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/typo3-solr)

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -504,6 +504,7 @@ func FindFilenameInDirectory(basePath string, fileNames []string) (dirName strin
 
 // FindFilesInDirectory takes a list of files/directories and expands it into a
 // a list of files only
+// environment variables in list are expanded
 func ExpandFilesAndDirectories(dir string, paths []string) ([]string, error) {
 	var expanded []string
 	origPwd, _ := os.Getwd()
@@ -515,6 +516,7 @@ func ExpandFilesAndDirectories(dir string, paths []string) ([]string, error) {
 		return nil, err
 	}
 	for _, path := range paths {
+		path = os.ExpandEnv(path)
 		info, err := os.Stat(path)
 		if err != nil {
 			return nil, err

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -501,3 +501,40 @@ func FindFilenameInDirectory(basePath string, fileNames []string) (dirName strin
 
 	return dirName, err
 }
+
+// FindFilesInDirectory takes a list of files/directories and expands it into a
+// a list of files only
+func ExpandFilesAndDirectories(dir string, paths []string) ([]string, error) {
+	var expanded []string
+	origPwd, _ := os.Getwd()
+	defer func() {
+		_ = os.Chdir(origPwd)
+	}()
+	err := os.Chdir(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+		if info.IsDir() {
+			err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if !d.IsDir() {
+					expanded = append(expanded, path)
+				}
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			expanded = append(expanded, path)
+		}
+	}
+	return expanded, nil
+}


### PR DESCRIPTION
## The Issue

* #4253 

## How This PR Solves The Issue

* Expand directories found in both ProjectFiles and GlobalFiles before using them, so we process only files
* Improve testing to cover this

## Manual Testing Instructions

Use a sample add-on that has a directory in it; make sure #ddev-generated is respected in files in that directory.


## Automated Testing Overview

TestCmdGetComplex is updated to handle this situation.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4932"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

