### PR TITLE
mysql:5.7 snapshot restore can take longer, fixes #4933

### DIFF
--- a/containers/ddev-dbserver/files/healthcheck.sh
+++ b/containers/ddev-dbserver/files/healthcheck.sh
@@ -25,8 +25,7 @@ fi
 # It means snapshot restore is in progress
 if killall -0 mariabackup 2>/dev/null || killall -0 xtrabackup 2>/dev/null ; then
   printf "currently restoring snapshot"
-  touch /tmp/healthy
-  exit 0
+  exit 2
 fi
 
 # If we can now access the server, we're healthy and ready

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -381,6 +381,10 @@ func drupal8PostStartAction(app *DdevApp) error {
 
 func drupalPostStartAction(app *DdevApp) error {
 	if isDrupal9App(app) || isDrupal10App(app) {
+		err := app.Wait([]string{nodeps.DBContainer})
+		if err != nil {
+			return err
+		}
 		// pg_trm extension is required in Drupal9.5+
 		if app.Database.Type == nodeps.Postgres {
 			stdout, stderr, err := app.Exec(&ExecOpts{
@@ -396,7 +400,7 @@ func drupalPostStartAction(app *DdevApp) error {
 		if app.Database.Type == nodeps.MariaDB || app.Database.Type == nodeps.MySQL {
 			stdout, stderr, err := app.Exec(&ExecOpts{
 				Service:   "db",
-				Cmd:       `mysql -e "SET GLOBAL TRANSACTION ISOLATION LEVEL READ COMMITTED;" 2>/dev/null`,
+				Cmd:       `mysql -uroot -proot -e "SET GLOBAL TRANSACTION ISOLATION LEVEL READ COMMITTED;"`,
 				NoCapture: false,
 			})
 			if err != nil {

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -24,7 +24,7 @@ var WebTag = "20230509_gitpod_output" // Note that this can be overridden by mak
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20230512_mariadb_10_11"
+var BaseDBTag = "20230519_fix_mysql_snapshot_restore"
 
 // DBAImg defines the default phpmyadmin image tag used for applications.
 var DBAImg = "phpmyadmin"


### PR DESCRIPTION
## The Issue

* #4933
* https://github.com/ddev/ddev/issues/3748 (Note that I used the github actions builder to push the db image; it will be interesting to see if perhaps this problem is resolved; there is an automated test to catch it, but we should look.)

## How This PR Solves The Issue

It seems that mysql:5.7 takes a little longer to get the server started, and this may result in different results on different platforms. 

* The db container's healthcheck should have been saying "not ready" during snapshot restore, instead it was returning 0 implying healthy. 
* We weren't capturing the stderr properly, and having it helps a lot. 
* On mysql you have to have root privs to do the required `SET GLOBAL TRANSACTION ISOLATION LEVEL READ COMMITTED;`

## Manual Testing Instructions

* Using a Drupal9+ project, with mysql:5.7 and mysql:8.0 databases, `ddev snapshot && ddev snapshot restore --latest`

## Automated Testing Overview

This doesn't add anything new, although it's worth considering testing snapshots with mysql:5.7



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4934"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

