### PR TITLE
[mostly tests only] TestDdevExec was failing on WSL2-docker-inside

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2590,10 +2590,9 @@ func TestDdevExec(t *testing.T) {
 		Service: "busybox",
 		Cmd:     "ls",
 	}
-	_, _, err = app.Exec(&simpleOpts)
-	assert.Error(err)
-	assert.Contains(err.Error(), "not currently running")
-	assert.Contains(err.Error(), "state=exited")
+	stdout, stderr, err := app.Exec(&simpleOpts)
+	require.Error(t, err, "stdout='%s', stderr='%s'", stdout, stderr)
+	require.True(t, strings.Contains(err.Error(), "not currently running") || strings.Contains(err.Error(), "is not running") || strings.Contains(err.Error(), "state=exited"), "stdout='%s', stderr='%s'", stdout, stderr)
 
 	err = client.RemoveContainer(docker.RemoveContainerOptions{ID: bbc.ID, Force: true})
 	assert.NoError(err)
@@ -2603,7 +2602,7 @@ func TestDdevExec(t *testing.T) {
 	assert.Contains(err.Error(), "state=doesnotexist")
 
 	// Test use of RawCmd, should see the single quotes in there
-	stdout, stderr, err := app.Exec(&ddevapp.ExecOpts{
+	stdout, stderr, err = app.Exec(&ddevapp.ExecOpts{
 		RawCmd: []string{"bash", "-c", `echo '"hi there"'`},
 	})
 	assert.NoError(err)


### PR DESCRIPTION
## The Issue

Perhaps docker 24.0.0/24.0.1 has a bit different behavior wrt exiting containers; this may be timing related also.

## How This PR Solves The Issue

TestDdevExec was failing on wsl2-docker-inside, perhaps because of new behavior of Docker 24.0.0

## Manual Testing Instructions

Automated testing should do the job.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4935"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

