### PR TITLE
[docs] Mention not to use --vm-type with Colima on pre-Ventura

### DIFF
--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -21,6 +21,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     ```
     colima start --cpu 4 --memory 6 --disk 100 --vm-type=qemu --mount-type=sshfs --dns=1.1.1.1
     ```
+    (On macOS versions before Ventura, omit the `--vm-type=qemu` flag as it doesn't work on older OS versions.)
     4. After [installing DDEV](ddev-installation.md), configure your system to use Mutagen—essential for DDEV with Colima—with `ddev config global --mutagen-enabled`.
 
     After the initial run above, you can use `colima start` or use `colima start -e` to edit the configuration file. Run `colima status` at any time to check Colima’s status.


### PR DESCRIPTION
## The Issue

The `--vm-type` arg doesn't work on Colima on OSs before Ventura. 

## How This PR Solves The Issue

Say so.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4937"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

