### PR TITLE
Bump mutagen to 0.17.1

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -63,9 +63,9 @@ docker volume rm ddev-global-cache >/dev/null 2>&1 || true
 # Make sure we start with mutagen daemon off.
 unset MUTAGEN_DATA_DIRECTORY
 if [ -f ~/.ddev/bin/mutagen -o -f ~/.ddev/bin/mutagen.exe ]; then
+  MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a
   MUTAGEN_DATA_DIRECTORY=~/.mutagen ~/.ddev/bin/mutagen daemon stop || true
   MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
-  MUTAGEN_DATA_DIRECTORRY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a
 fi
 if command -v killall >/dev/null ; then
   killall mutagen || true

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -50,7 +50,7 @@ var BUILDINFO = "BUILDINFO should have new info"
 // MutagenVersion is filled with the version we find for mutagen in use
 var MutagenVersion = ""
 
-const RequiredMutagenVersion = "0.16.0"
+const RequiredMutagenVersion = "0.17.1"
 
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {


### PR DESCRIPTION
## The Issue

Mutagen has moved along since last we bumped it. Let's see how it does with 0.17.1

## TODO

- [x] Are there upgrade instructions we need to add? Should we be testing for mutagen version when deciding whether we have a working situation or not? One test showed `[/Users/testbot/.ddev/bin/mutagen sync list TestPkgDrupal9] failed: exit status 1 output=Error: unable to connect to daemon: client/daemon version mismatch (daemon restart recommended)`
 

<br class="Apple-interchange-newline">

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4939"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

