### PR TITLE
Allow add-ons to declare dependencies, fixes #4717

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -277,8 +277,8 @@ ddev get --remove ddev-someaddonname
 				util.Failed("Unable to gather manifests: %v", err)
 			}
 			for _, dep := range s.Dependencies {
-				if _, ok := m[dep]; ok {
-					util.Failed("The add-on '%s' declares a dependency on '%s'; Please ddev get %s first", s.Name, dep, dep)
+				if _, ok := m[dep]; !ok {
+					util.Failed("The add-on '%s' declares a dependency on '%s'; Please ddev get %s first.", s.Name, dep, dep)
 				}
 			}
 		}

--- a/cmd/ddev/cmd/testdata/TestCmdGetDependencies/dependency_recipe/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdGetDependencies/dependency_recipe/install.yaml
@@ -1,0 +1,1 @@
+name: dependency_recipe

--- a/cmd/ddev/cmd/testdata/TestCmdGetDependencies/depender_recipe/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdGetDependencies/depender_recipe/install.yaml
@@ -1,0 +1,3 @@
+name: depender_recipe
+dependencies:
+  - dependency_recipe

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -89,6 +89,7 @@ The `install.yaml` is a simple YAML file with a few main sections:
 * `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s root directory.
 * `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
 * `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
+* `dependencies`: an array of add-ons that this add-on depends on.
 * `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s root directory.
 * `removal_actions`: an array of Bash statements or scripts to be executed when the add-on is being removed with `ddev get --remove`.
 * `yaml_read_files`: a map of `name: file` of YAML files to be read from the target project’s root directory. The contents of these YAML files may be used as templated actions within `pre_install_actions` and `post_install_actions`.
@@ -131,10 +132,10 @@ Go templating resources:
 
 ## Additional services in ddev-contrib
 
-Commonly-used services will be migrated from the [ddev-contrib](https://github.com/ddev/ddev-contrib) repository to individual, tested, supported repositories, but the repository still has a wealth of additional examples and instructions:
+Commonly-used services are being migrated from the [ddev-contrib](https://github.com/ddev/ddev-contrib) repository to individual, tested, supported add-on repositories, but the repository still has a wealth of additional examples and instructions:
 
 * **Old PHP Versions to Run Old Sites**: See [Old PHP Versions](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/old_php)
 * **RabbitMQ**: See [RabbitMQ](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/rabbitmq)
 * **TYPO3 Solr Integration**: See [TYPO3 Solr](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/typo3-solr)
 
-Your pull requests to integrate other services are welcome at [ddev-contrib](https://github.com/ddev/ddev-contrib).
+Your pull requests to integrate other services are welcome at [ddev-contrib](https://github.com/ddev/ddev-contrib), but creating a supported add-on is preferred.

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -138,4 +138,4 @@ Commonly-used services are being migrated from the [ddev-contrib](https://github
 * **RabbitMQ**: See [RabbitMQ](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/rabbitmq)
 * **TYPO3 Solr Integration**: See [TYPO3 Solr](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/typo3-solr)
 
-Your pull requests to integrate other services are welcome at [ddev-contrib](https://github.com/ddev/ddev-contrib), but creating a supported add-on is preferred.
+While we welcome requests to integrate other services at [ddev-contrib](https://github.com/ddev/ddev-contrib), we encourage creating a supported add-on that’s more beneficial to the community.


### PR DESCRIPTION
## The Issue

* #4717 

## How This PR Solves The Issue

* Add `dependencies` key to install.yaml
* On `ddev get`, if the target add-on requires a dependency, check before allowing get (and ask for dependency to be installed if not)
* On `ddev get --remove` explain to people that the dependency *might* need to be removed.

## Manual Testing Instructions

Try out these steps. You'll likely want a manually checked out add-on to add `dependencies` to.

## Automated Testing Overview

Added TestCmdGetDependencies



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4941"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

