### PR TITLE
[tests only] Make sure to kill mutagen daemon

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -63,7 +63,7 @@ docker volume rm ddev-global-cache >/dev/null 2>&1 || true
 # Make sure we start with mutagen daemon off.
 unset MUTAGEN_DATA_DIRECTORY
 if [ -f ~/.ddev/bin/mutagen -o -f ~/.ddev/bin/mutagen.exe ]; then
-  MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a
+  MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a || true
   MUTAGEN_DATA_DIRECTORY=~/.mutagen ~/.ddev/bin/mutagen daemon stop || true
   MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
 fi


### PR DESCRIPTION
## The Issue

In test.sh (buildkite) we need to make sure the mutagen daemon has been stopped. 

## How This PR Solves The Issue

Allow `|| true` after trying to stop it. 



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4943"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

