### PR TITLE
Bump traefik to 2.10

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -33,7 +33,7 @@ var DBAImg = "phpmyadmin"
 var DBATag = "5" // Note that this can be overridden by make
 
 const TraditionalRouterImage = "ddev/ddev-router:20230415_move_docker_to_ddev"
-const TraefikRouterImage = "traefik:v2.9"
+const TraefikRouterImage = "traefik:v2.10"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"


### PR DESCRIPTION
## The Issue

Traefik is now at 2.10, so we might as well use it.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4946"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

