### PR TITLE
[docs] Debug environment variable suggestions

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -114,4 +114,4 @@ It can be complicated to figure out what’s going on when building a Dockerfile
 
 1. Use [`ddev ssh`](../usage/commands.md#ssh) first of all to pioneer the steps you want to take. You can do all the things you need to do there and see if it works. If you’re doing something that affects PHP, you may need to `sudo killall -USR2 php-fpm` for it to take effect.
 2. Put the steps you pioneered into `.ddev/web-build/Dockerfile` as above.
-3. If you can’t figure out what’s failing or why, then `ddev debug refresh` will show the full output of the build process. You can also `export DDEV_VERBOSE=true && ddev start` to see what’s happening during the Dockerfile build during `ddev start`.
+3. If you can’t figure out what’s failing or why, running `ddev debug refresh` will show the full output of the build process. You can also run `export DDEV_VERBOSE=true && ddev start` to see what’s happening during the `ddev start` Dockerfile build.

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -24,7 +24,6 @@ Things might go wrong! In addition to this page, consider checking [Stack Overfl
 
     If that starts up fine, there may be an issue specifically with the project you’re trying to start.
 
-
 !!!tip "Using DDEV with Other Development Environments"
 
     DDEV uses your system’s port 80 and 443 by default when projects are running. If you’re using another local development environment (like Lando or Docksal or a native setup), you can either stop the other environment or configure DDEV to use different ports. See [troubleshooting](troubleshooting.md#unable-listen) for more detailed problem-solving. It’s easiest to stop the other environment when you want to use DDEV, and stop DDEV when you want to use the other environment.

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -24,15 +24,16 @@ Things might go wrong! In addition to this page, consider checking [Stack Overfl
 
     If that starts up fine, there may be an issue specifically with the project you’re trying to start.
 
-!!!tip "DDEV_DEBUG and DDEV_VERBOSE Environment Variables"
-
-    You can `export DDEV_DEBUG=true` to get more output from DDEV when it's executing any command. 
-
-    `export DDEV_VERBOSE=true` may also give you useful information, but it's mostly valuable to DDEV developers, as it's very verbose. However, it outputs complete information about the Dockerfile build stage of `ddev start`, so can help when debugging Dockerfile problems.
 
 !!!tip "Using DDEV with Other Development Environments"
 
     DDEV uses your system’s port 80 and 443 by default when projects are running. If you’re using another local development environment (like Lando or Docksal or a native setup), you can either stop the other environment or configure DDEV to use different ports. See [troubleshooting](troubleshooting.md#unable-listen) for more detailed problem-solving. It’s easiest to stop the other environment when you want to use DDEV, and stop DDEV when you want to use the other environment.
+
+### Debug Environment Variables
+
+Two environment variables meant for DDEV developemnt may also be useful for broader troubleshooting: `DDEV_DEBUG` and `DDEV_VERBOSE`. When enabled, they’ll output more information when DDEV is executing a command. `DDEV_VERBOSE` can be particularly helpful debugging Dockerfile problems because it outputs complete information about the Dockerfile build stage within the `ddev start` command.
+
+You can set either one in your current session by running `export DDEV_DEBUG=true` and `export DDEV_VERBOSE=true`.
 
 <a name="unable-listen"></a>
 

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -31,7 +31,7 @@ Things might go wrong! In addition to this page, consider checking [Stack Overfl
 
 ### Debug Environment Variables
 
-Two environment variables meant for DDEV developemnt may also be useful for broader troubleshooting: `DDEV_DEBUG` and `DDEV_VERBOSE`. When enabled, they’ll output more information when DDEV is executing a command. `DDEV_VERBOSE` can be particularly helpful debugging Dockerfile problems because it outputs complete information about the Dockerfile build stage within the `ddev start` command.
+Two environment variables meant for DDEV development may also be useful for broader troubleshooting: `DDEV_DEBUG` and `DDEV_VERBOSE`. When enabled, they’ll output more information when DDEV is executing a command. `DDEV_VERBOSE` can be particularly helpful debugging Dockerfile problems because it outputs complete information about the Dockerfile build stage within the `ddev start` command.
 
 You can set either one in your current session by running `export DDEV_DEBUG=true` and `export DDEV_VERBOSE=true`.
 


### PR DESCRIPTION
## The Issue

I didn’t get a chance to review 
* #4919 before it merged and there are a few opportunities to improve the docs that came with it:

- It’s best to reiterate in every case, provided it doesn’t interrupt the reading flow, that commands are meant to be run. This is especially true when someone’s troubleshooting and we want them to be successful without knowing [their technical comfort level](https://ddev.readthedocs.io/en/stable/developers/writing-style-guide/#beginner-friendly-expert-compatible) with what’s going on.
- A callout was added with a heading that [didn’t summarize the contents](https://ddev.readthedocs.io/en/stable/developers/writing-style-guide/#use-tips) as much as label them, and it gave excessive emphasis to something that...
    - a) From its own language, is less useful to _everyone_ and meant for DDEV developers.
    - b) Appeared ahead of, and thus took attention away from, another callout more broadly applicable to a beginner troubleshooting. (Stacking callouts is usually indicative of a flow problem with too much noise.)
    - c) Includes material for a different audience; existing troubleshooting steps seem careful and beginner-friendly, and this callout talks about a Dockerfile build process that abruptly assumes a different level of prerequisite knowledge—with no qualifying introduction or explanatory language.

## How This PR Solves The Issue

This PR refines the newly-added docs and moves the callout into a subsection.

This doesn’t fix the audience-shift problem (c), but it moves the callout to a subheading in that first section, with a concise heading to describe what it covers. It also rewords the contents of the callout to topically introduce the environment variables with gentler context that’s hopefully just as accurate.

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the automatic build:

- https://ddev--4949.org.readthedocs.build/en/4949/users/extend/customizing-images/#debugging-the-dockerfile-build
- https://ddev--4949.org.readthedocs.build/en/4949/users/usage/troubleshooting/#debug-environment-variables

## Automated Testing Overview

n/a

## Related Issue Link(s)

#4919

## Release/Deployment Notes

n/a


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4949"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

