### PR TITLE
[tests only] Use macOS 13 for colima, update colima

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         webserver: [nginx-fpm]
         tests: [ test ]
-        os: [ macos-12 ]
+        os: [ macos-13 ]
         no-bind-mounts: ['false']
       fail-fast: true
 
@@ -70,7 +70,7 @@ jobs:
       - name: Homebrew cache/restore
         uses: actions/cache@v3
         env:
-          cache-name: cache-homebrew-cache-12
+          cache-name: cache-homebrew-cache-13
         with:
           path: ~/Library/Caches/Homebrew
           key: ${{ runner.os }}-build-${{ env.cache-name }}
@@ -84,9 +84,8 @@ jobs:
       - name: Lima cache/restore
         uses: actions/cache@v3
         env:
-          cache-name: cache-lima-12
+          cache-name: cache-lima-13
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.lima
           key: ${{ runner.os }}-build-${{ env.cache-name }}
           restore-keys: |

--- a/.github/workflows/macos-colima-setup.sh
+++ b/.github/workflows/macos-colima-setup.sh
@@ -5,11 +5,6 @@ set -eu -o pipefail
 sudo chown -R ${USER} /usr/local/*
 brew update >/dev/null
 
-# After colima 0.5.0 it's best to redo the colima image completely
-if (colima version | grep "colima version 0.5.0"); then
-  colima delete -f
-fi
-
 # colima has golang as dependency, so is going to install go anyway.
 # So we have to get rid of it somehow.
 brew uninstall go@1.15 || true
@@ -31,7 +26,7 @@ sudo security authorizationdb write com.apple.trust-settings.admin allow
 # Github actions macOS runners have 14BG RAM so might as well use it.
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
 echo "====== Starting colima ======"
-colima start --cpu 3 --memory 6
+colima start --cpu 3 --memory 6 --vm-type=qemu --mount-type=sshfs --dns=1.1.1.1
 
 # I haven't been able to get mkcert-trusted certs in there, not sure why
 # You can't answer the security prompt, but that's what the


### PR DESCRIPTION
## The Issue

* Colima should be running on macOS 13
* Colima needs upgrade to 0.5.5 and cache clean



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4951"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

