### PR TITLE
20230502 hakre secure apt gpg

### DIFF
--- a/.github/devcontainers/src/install-ddev/install.sh
+++ b/.github/devcontainers/src/install-ddev/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null
-echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list
+curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/ddev.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list
 sudo apt update >/dev/null && sudo apt install -y ddev xdg-utils >/dev/null
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: Build Test for Configure
+on:
+  push:
+jobs:
+  configure:
+    runs-on: ubuntu-latest
+    env:
+      EXTRA_PATH: ${{ github.workspace }}/node_modules/.bin
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: sudo apt-get install -y aspell
+      - run: ./configure
+      - run: make -O -j ci

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ nbproject/
 .idea
 *.orig
 *.rej
+
+# node/npm
+/node_modules
+/package*.json

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -5,8 +5,8 @@ USER root
 
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
 
-RUN curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null
-RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list
+RUN curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/ddev.gpg > /dev/null
+RUN echo "deb [signed-by=/usr/share/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list
 
 RUN apt-get update >/dev/null && sudo apt-get install -y aspell autojump ddev file mysql-client netcat nodejs python3-pip telnet >/dev/null
 

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -52,6 +52,7 @@ FSTYPE
 Flags
 FQDNs
 Fritzbox
+GPG
 GUI
 GUIs
 Get

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ mkdocs-serve:
 
 # Best to install markdown-link-check locally with "npm install -g markdown-link-check"
 markdown-link-check:
-	@echo "markdown-link-check: "
+	@echo "markdown-link-check: "; \
 	if command -v markdown-link-check >/dev/null 2>&1 ; then \
 		find docs *.md -type f -name "*.md" -print0 | xargs -0 -n 1 -P 0 sh -c 'markdown-link-check -q -c markdown-link-check.json "$$@" 2>&1 || exit 255' sh ;\
 	else \

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ mkdocs-serve:
 markdown-link-check:
 	@echo "markdown-link-check: "
 	if command -v markdown-link-check >/dev/null 2>&1 ; then \
-  		find docs *.md -name "*.md" -exec markdown-link-check -q -c markdown-link-check.json {} \; 2>&1  ;\
+		find docs *.md -type f -name "*.md" -print0 | xargs -0 -n 1 -P 0 sh -c 'markdown-link-check -q -c markdown-link-check.json "$$@" 2>&1 || exit 255' sh ;\
 	else \
 		echo "Skipping markdown-link-check because it is not installed"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export PATH := $(EXTRA_PATH):$(PATH)
 
 BUILD_BASE_DIR ?= $(PWD)
 
-GOTMP=.gotmp
+GOTMP = .gotmp
 SHELL = /bin/bash
 PWD = $(shell pwd)
 GOFILES = $(shell find $(SRC_DIRS) -type f)
@@ -137,7 +137,7 @@ setup:
 # Required static analysis targets used in circleci - these cause fail if they don't work
 staticrequired: setup golangci-lint markdownlint mkdocs pyspelling
 
-# Best to install markdownlint-cli locally with "npm install -g markdownlint-cli"
+# Best to install markdownlint locally with "npm install -g markdownlint-cli"
 markdownlint:
 	@echo "markdownlint: "
 	@CMD="markdownlint *.md docs/content 2>&1"; \
@@ -145,17 +145,17 @@ markdownlint:
 	if command -v markdownlint >/dev/null 2>&1 ; then \
 		$$CMD; \
 	else \
-		echo "Skipping markdownlint as not installed"; \
+		echo "Skipping markdownlint because it is not installed"; \
 	fi
 
 # Best to install mkdocs locally with "sudo pip3 install -r docs/mkdocs-pip-requirements"
 mkdocs:
 	@echo "mkdocs: "
 	@CMD="mkdocs -q build -d /tmp/mkdocsbuild"; \
-	if command -v mkdocs >/dev/null 2>&1; then \
+	if command -v mkdocs >/dev/null 2>&1 ; then \
 		$$CMD ; \
 	else \
-		echo "Not running mkdocs because it's not installed"; \
+		echo "Skipping mkdocs because it is not installed"; \
 	fi
 
 # To see what the docs build will be, you can use `make mkdocs-serve`
@@ -169,16 +169,16 @@ mkdocs-serve:
 		docker run -it -p 8000:8000 -v "${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs; \
 	fi
 
-# Install markdown-link-check locally with "npm install -g markdown-link-check"
+# Best to install markdown-link-check locally with "npm install -g markdown-link-check"
 markdown-link-check:
 	@echo "markdown-link-check: "
-	if command -v markdown-link-check >/dev/null 2>&1; then \
+	if command -v markdown-link-check >/dev/null 2>&1 ; then \
   		find docs *.md -name "*.md" -exec markdown-link-check -q -c markdown-link-check.json {} \; 2>&1  ;\
 	else \
-		echo "Not running markdown-link-check because it's not installed"; \
+		echo "Skipping markdown-link-check because it is not installed"; \
 	fi
 
-# Best to install pyspelling locally with "sudo -H pip3 install pyspelling pymdown-extensions". Also requries aspell, `sudo apt-get install aspell"
+# Best to install pyspelling locally with "sudo -H pip3 install pyspelling pymdown-extensions". Also requires aspell locally with "sudo apt-get install aspell"
 pyspelling:
 	@echo "pyspelling: "
 	@CMD="pyspelling --config .spellcheck.yml"; \
@@ -186,10 +186,10 @@ pyspelling:
 	if command -v pyspelling >/dev/null 2>&1 ; then \
 		$$CMD; \
 	else \
-		echo "Not running pyspelling because it's not installed"; \
+		echo "Skipping pyspelling because it is not installed"; \
 	fi
 
-# Install textlint locally with `npm install -g textlint textlint-filter-rule-comments textlint-rule-no-todo textlint-rule-stop-words textlint-rule-terminology`
+# Best to install textlint locally with "npm install -g textlint textlint-filter-rule-comments textlint-rule-no-todo textlint-rule-stop-words textlint-rule-terminology"
 textlint:
 	@echo "textlint: "
 	@CMD="textlint {README.md,version-history.md,docs/**}"; \
@@ -197,7 +197,7 @@ textlint:
 	if command -v textlint >/dev/null 2>&1 ; then \
 		$$CMD; \
 	else \
-		echo "textlint is not installed"; \
+		echo "Skipping textlint because it is not installed"; \
 	fi
 
 darwin_amd64_signed: $(GOTMP)/bin/darwin_amd64/ddev
@@ -213,13 +213,13 @@ darwin_arm64_signed: $(GOTMP)/bin/darwin_arm64/ddev
 	fi
 
 darwin_amd64_notarized: darwin_amd64_signed
-	@if [ -z "$(DDEV_MACOS_APP_PASSWORD)" ]; then echo "Skipping notarizing ddev for macOS, no DDEV_MACOS_APP_PASSWORD provided"; else \
+	@if [ -z "$(DDEV_MACOS_APP_PASSWORD)" ] ; then echo "Skipping notarizing ddev for macOS, no DDEV_MACOS_APP_PASSWORD provided"; else \
 		set -o errexit -o pipefail; \
 		echo "Notarizing $(GOTMP)/bin/darwin_amd64/ddev ..." ; \
 		curl -sSL -f https://raw.githubusercontent.com/ddev/signing_tools/master/macos_notarize.sh | bash -s -  --app-specific-password=$(DDEV_MACOS_APP_PASSWORD) --apple-id=notarizer@localdev.foundation --primary-bundle-id=com.ddev.ddev --target-binary="$(GOTMP)/bin/darwin_amd64/ddev" ; \
 	fi
 darwin_arm64_notarized: darwin_arm64_signed
-	@if [ -z "$(DDEV_MACOS_APP_PASSWORD)" ]; then echo "Skipping notarizing ddev for macOS, no DDEV_MACOS_APP_PASSWORD provided"; else \
+	@if [ -z "$(DDEV_MACOS_APP_PASSWORD)" ] ; then echo "Skipping notarizing ddev for macOS, no DDEV_MACOS_APP_PASSWORD provided"; else \
 		set -o errexit -o pipefail; \
 		echo "Notarizing $(GOTMP)/bin/darwin_arm64/ddev ..." ; \
 		curl -sSL -f https://raw.githubusercontent.com/ddev/signing_tools/master/macos_notarize.sh | bash -s - --app-specific-password=$(DDEV_MACOS_APP_PASSWORD) --apple-id=notarizer@localdev.foundation --primary-bundle-id=com.ddev.ddev --target-binary="$(GOTMP)/bin/darwin_arm64/ddev" ; \
@@ -263,10 +263,10 @@ golangci-lint:
 	@echo "golangci-lint: "
 	@CMD="golangci-lint run $(GOLANGCI_LINT_ARGS) $(SRC_AND_UNDER)"; \
 	set -eu -o pipefail; \
-	if command -v golangci-lint >/dev/null 2>&1; then \
+	if command -v golangci-lint >/dev/null 2>&1 ; then \
 		$$CMD; \
 	else \
-		echo "Skipping golanci-lint as not installed"; \
+		echo "Skipping golanci-lint because it is not installed"; \
 	fi
 
 version:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ GOTMP = .gotmp
 SHELL = /bin/bash
 PWD = $(shell pwd)
 GOFILES = $(shell find $(SRC_DIRS) -type f)
-.PHONY: darwin_amd64 darwin_arm64 darwin_amd64_notarized darwin_arm64_notarized darwin_arm64_signed darwin_amd64_signed linux_amd64 linux_arm64 linux_arm windows_amd64 windows_arm64 setup
+CI_GOALS = mkdocs markdownlint markdown-link-check pyspelling textlint
+.PHONY: darwin_amd64 darwin_arm64 darwin_amd64_notarized darwin_arm64_notarized darwin_arm64_signed darwin_amd64_signed linux_amd64 linux_arm64 linux_arm windows_amd64 windows_arm64 setup ci $(CI_GOALS)
 
 # Expands SRC_DIRS into the common golang ./dir/... format for "all below"
 SRC_AND_UNDER = $(patsubst %,./%/...,$(SRC_DIRS))
@@ -136,6 +137,9 @@ setup:
 
 # Required static analysis targets used in circleci - these cause fail if they don't work
 staticrequired: setup golangci-lint markdownlint mkdocs pyspelling
+
+## ci : make all CI_GOALS: markdownlint, mkdocs, markdown-link-check, pyspelling and textlint.
+ci: $(CI_GOALS)
 
 # Best to install markdownlint locally with "npm install -g markdownlint-cli"
 markdownlint:
@@ -273,6 +277,10 @@ version:
 	@echo VERSION:$(VERSION)
 
 clean: bin-clean
+
+.PHONY: realclean
+realclean: clean
+	rm -rf node_modules package.json package-lock.json
 
 bin-clean:
 	@rm -rf bin

--- a/configure
+++ b/configure
@@ -1,0 +1,54 @@
+#! /bin/sh
+
+go="go"
+npm="npm"
+python="python"
+sed="sed"
+
+# Print configuration
+printf >&2 'go: %s\n' "$($go version)"
+printf >&2 'npm: %s (node %s)\n' "$($npm --version)" "$(node --version)"
+printf >&2 'python: %s\n' "$($python --version)"
+
+printf >&2 '.envrc: %s\n' "$(file .envrc)"
+printf >&2 'VIRTUAL_ENV=%s\n' "$VIRTUAL_ENV"
+printf >&2 'NVM_BIN=%s\n' "$NVM_BIN"
+
+# Print utility installation instructions from Makefile
+$sed -n -e '/^# Best to install /p' Makefile
+
+# Configure python dependencies (pip)
+setup_python()
+{
+  (set -x
+  $python -m pip install --upgrade pip
+  $python -m pip install wheel
+  $python -m pip install -r docs/mkdocs-pip-requirements
+  $python -m pip install pyspelling pymdown-extensions
+  ) | $sed -e '/^Requirement already satisfied: /d'
+}
+
+# Configure node dependencies (npm)
+setup_nodejs()
+{
+  (set -x
+  $npm install --save-dev \
+      markdownlint-cli \
+      markdown-link-check \
+      textlint textlint-filter-rule-comments textlint-rule-no-todo textlint-rule-stop-words textlint-rule-terminology
+  )
+}
+
+setup_python &
+setup_nodejs &
+wait
+
+# Show utility versions and pathnames from Makefile
+PATH="$PWD/node_modules/.bin:$PATH"
+utils=$($sed -n -e 's/^\(# Best to install \)\([^ ]\+\)\( locally .*$\)/\2/p' Makefile)
+for util in $utils; do
+  printf '%-30s: %s\n' "$util --version" "$("$util" --version 2>&1)"
+  if command -v "$util" >/dev/null; then
+    printf '%-30s: %s\n' "$util pathname" "$(command -v "$util" 2>&1)"
+  fi
+done

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -56,8 +56,8 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 11. Install basics in WSL2:
 
     ```bash
-    curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null
-    echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
+    curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/ddev.gpg > /dev/null
+    echo "deb [signed-by=/usr/share/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
     # Update package information and install DDEV
     sudo apt update && sudo apt install -y ddev
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -60,16 +60,22 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ```bash
     # Add DDEV’s GPG key to your keyring
-    curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null
+    curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/ddev.gpg > /dev/null
 
     # Add DDEV releases to your package repository
-    echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
+    echo "deb [signed-by=/usr/share/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
 
     # Update package information and install DDEV
     sudo apt update && sudo apt install -y ddev
     ```
 
     ??? "Need to remove a previously-installed variant?"
+        If you previously stored the GPG key in `/etc/apt/trusted.gpg.d/ddev.gpg`, you can move it to the new location `/usr/share/keyrings/ddev.gpg`, but you should definitely delete it from the old location.
+
+        ```
+        sudo rm -f /etc/apt/trusted.gpg.d/ddev.gpg
+        ```
+
         If you previously used DDEV’s [install script](#install-script), you can remove that version:
 
         ```
@@ -251,8 +257,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     12. Install DDEV:
 
         ```bash
-        curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null
-        echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
+        curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/ddev.gpg > /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
         sudo apt update && sudo apt install -y ddev
         ```
 
@@ -299,10 +305,10 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     1. [Open any repository](https://www.gitpod.io/docs/getting-started) using Gitpod and run the following:
         ```bash
         # Add DDEV’s GPG key to your keyring
-        curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null
+        curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/ddev.gpg > /dev/null
 
         # Add DDEV releases to your package repository
-        echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
+        echo "deb [signed-by=/usr/share/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
 
 
         # Update package information and install DDEV

--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -37,6 +37,15 @@
       "headers": {
         "Accept-Encoding": "zstd, br, gzip, deflate"
       }
+    },
+    {
+      "urls": [
+        "gaurav-nelson/github-action-markdown-link-check#182 - Add cookie support between redirects",
+        "https://twitter.com"
+      ],
+      "headers": {
+        "cookie": "guest_id_marketing=v1%123456789012345678; guest_id_ads=v1%123456789012345678; personalization_id=\"v1_aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g/dj1kUXc0dzlXZ1hjUQ==\"; guest_id=v1%123456789012345678"
+      }
     }
   ],
 

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -44,8 +44,8 @@ mkcert -install
 $env:CAROOT="$(mkcert -CAROOT)"
 setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
-wsl -u root -e bash -c "rm -f /etc/apt/trusted.gpg.d/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null"
-wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
+wsl -u root -e bash -c "rm -f /usr/share/keyrings/ddev.gpg /etc/apt/trusted.gpg.d/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /usr/share/keyrings/ddev.gpg > /dev/null"
+wsl -u root -e bash -c 'echo deb [signed-by=/usr/share/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
 wsl -u root -e bash -c "apt update && apt install -y ddev wslu"
 wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
 

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -46,8 +46,8 @@ wsl -u root mkdir -p /etc/apt/keyrings
 wsl -u root bash -c "rm -f /etc/apt/keyrings/docker.gpg && mkdir -p /etc/apt/keyrings && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg"
 wsl -u root -e bash -c 'echo deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu  $(lsb_release -cs) stable | tee /etc/apt/sources.list.d/docker.list > /dev/null 2>&1'
 
-wsl -u root -e bash -c "rm -f /etc/apt/trusted.gpg.d/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null"
-wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
+wsl -u root -e bash -c "rm -f /usr/share/keyrings/ddev.gpg /etc/apt/trusted.gpg.d/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /usr/share/keyrings/ddev.gpg > /dev/null"
+wsl -u root -e bash -c 'echo deb [signed-by=/usr/share/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
 wsl -u root -e bash -c "apt update && apt install -y ddev docker-ce docker-ce-cli containerd.io wslu"
 wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
 wsl bash -c 'sudo usermod -aG docker $USER'


### PR DESCRIPTION
## The Issue

## How This PR Solves The Issue

By the changes in the last commit.

## Manual Testing Instructions

Boot a new Debian or Ubuntu box and install ddev according to the changed instructions.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

Coverage should not have changed.

Testing is building the documentation.

On Ubuntu:

~~~
$ ./configure
...
$ make -O -j ci
...
~~~

## Related Issue Link(s)

#4960

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

There is a new `./configure` script installing the Python / NodeJS dependencies in the Makefiles' CI_GOALS. These are accessible via `make ci` and can run in parallel. 


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4961"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

