### PR TITLE
[tests only] Fix TestPHPOverrides for Windows Mutagen, fixes #4875

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -861,6 +861,8 @@ func TestPHPOverrides(t *testing.T) {
 		t.Fatalf("============== logs from app.StartAndWait() ==============\n%s\n", logs)
 	}
 
+	err = app.MutagenSyncFlush()
+	require.NoError(t, err, "failed to flush mutagen sync")
 	_, _ = testcommon.EnsureLocalHTTPContent(t, "http://"+app.GetHostname()+"/phpinfo.php", `max_input_time</td><td class="v">999`, 60)
 
 }

--- a/pkg/ddevapp/traefik_test.go
+++ b/pkg/ddevapp/traefik_test.go
@@ -51,6 +51,9 @@ func TestTraefikSimple(t *testing.T) {
 	err = app.StartAndWait(5)
 	require.NoError(t, err)
 
+	err = app.MutagenSyncFlush()
+	require.NoError(t, err, "failed to flush mutagen sync")
+
 	desc, err := app.Describe(false)
 	assert.True(desc["use_traefik"].(bool))
 


### PR DESCRIPTION
## The Issue

* #4875 

Trying to make tests work on Windows Mutagen again.

## How This PR Solves The Issue

* It seems that for Windows, the app.Start() didn't cause a mutagen flush in some situations. Adding the flush seems to make TestPHPOverrides work OK.
* Turned off macos-nfs for PRs, which will save some testing resources. 


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4968"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

