### PR TITLE
[docs] Dockerfile Tutorial on installing into ~/.cache

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -108,6 +108,18 @@ RUN make install
 RUN echo "extension=${extension}.so" > /etc/php/${DDEV_PHP_VERSION}/mods-available/${extension}.ini
 ```
 
+## Installing into the home directory
+
+The in-container home directory is rebuilt on `ddev restart` so if you have something that installs into the home directory (like `~/.cache`) you'll want to switch users in the Dockerfile. In this example, `npx playwright install` installs a number of things into `~/.cache`, so we'll switch to the proper user before executing it, and switch back to the `root` user after installation to avoid surprises with any other Dockerfile that may follow.
+
+```Dockerfile
+RUN npm install --global spidergram
+USER $username
+RUN npx playwright install
+RUN npx playwright install-deps
+USER root
+```
+
 ### Debugging the Dockerfile Build
 
 It can be complicated to figure out what’s going on when building a Dockerfile, and even more complicated when you’re seeing it go by as part of [`ddev start`](../usage/commands.md#start).

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -110,12 +110,11 @@ RUN echo "extension=${extension}.so" > /etc/php/${DDEV_PHP_VERSION}/mods-availab
 
 ## Installing into the home directory
 
-The in-container home directory is rebuilt on `ddev restart` so if you have something that installs into the home directory (like `~/.cache`) you'll want to switch users in the Dockerfile. In this example, `npx playwright install` installs a number of things into `~/.cache`, so we'll switch to the proper user before executing it, and switch back to the `root` user after installation to avoid surprises with any other Dockerfile that may follow.
+The in-container home directory is rebuilt when you run `ddev restart`, so if you have something that installs into the home directory (like `~/.cache`) you'll want to switch users in the Dockerfile. In this example, `npx playwright install` installs a number of things into `~/.cache`, so we'll switch to the proper user before executing it, and switch back to the `root` user after installation to avoid surprises with any other Dockerfile that may follow.
 
 ```Dockerfile
-RUN npm install --global spidergram
 USER $username
-# This is just an example of creating something in the home directory
+# This is an example of creating a file in the home directory
 RUN touch ~/${username}-was-here
 # `npx playwright` installs lots of things in ~/.cache
 RUN npx playwright install

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -115,6 +115,9 @@ The in-container home directory is rebuilt on `ddev restart` so if you have some
 ```Dockerfile
 RUN npm install --global spidergram
 USER $username
+# This is just an example of creating something in the home directory
+RUN touch ~/${username}-was-here
+# `npx playwright` installs lots of things in ~/.cache
 RUN npx playwright install
 RUN npx playwright install-deps
 USER root


### PR DESCRIPTION

## The Issue

Although `$username` is provided and documented, it's not shown the many ways we can use it. Add an example.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4969"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

