### PR TITLE
[docs] Show details about GitHub PAT for package management

### DIFF
--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -46,7 +46,7 @@ The following “Repository secret” environment variables must be added to <ht
 * Update `ddev/ddev-webserver` to use the new version of `ddev/ddev-php-base` and push it with the proper tag.
 * Make sure the Docker images are all tagged and pushed.
 * Make sure [`pkg/versionconstants/versionconstants.go`](https://github.com/ddev/ddev/blob/master/pkg/versionconstants/versionconstants.go) is all set to point to the new images and tests have been run.
-* If the [`devcontainer-feature.json`](https://github.com/ddev/ddev/blob/master/.github/devcontainers/src/install-ddev/devcontainer-feature.json) (for GitHub Codespaces) needs to be updated, use the [`devcontainer` CLI](https://github.com/devcontainers/cli):
+* If the [`devcontainer-feature.json`](https://github.com/ddev/ddev/blob/master/.github/devcontainers/src/install-ddev/devcontainer-feature.json) (for GitHub Codespaces) needs to be updated, use the [`devcontainer` CLI](https://github.com/devcontainers/cli) and a GITHUB_TOKEN that has power to manage packages, like `https://github.com/settings/tokens/1121534855` (`Package management token - see https://ddev.readthedocs.io/en/latest/developers/release-management/#prerelease-tasks`):
 
     ```bash
     cd .github/devcontainers/source


### PR DESCRIPTION
## The Issue

I couldn't figure out where the (expired) package management PAT was used. But it was already documented.

## How This PR Solves The Issue

Give more context about it.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4971"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

