### PR TITLE
Proper fish completion file extension

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -194,7 +194,7 @@ brews:
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"
         zsh_completion.install "ddev_zsh_completion.sh" => "ddev"
-        fish_completion.install "ddev_fish_completion.sh" => "ddev"
+        fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
 
   test: |
@@ -229,7 +229,7 @@ brews:
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"
         zsh_completion.install "ddev_zsh_completion.sh" => "ddev"
-        fish_completion.install "ddev_fish_completion.sh" => "ddev"
+        fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
 
   test: |


### PR DESCRIPTION
I was trying to understand why the fish completions were not working and this was the reason, it needs to be suffixed with .fish.

https://fishshell.com/docs/current/completions.html#where-to-put-completions

Duplicate of from https://github.com/ddev/homebrew-ddev/pull/48.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4973"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

