### PR TITLE
[tests only] Only run circleci on master branch updates, not PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,9 +518,11 @@ workflows:
 #        ignore:
 #          - gh-pages
     - lx_arm64_fpm_test:
-      branches:
-        ignore:
-          - gh-pages
+        filters:
+          branches:
+            only: master
+            ignore:
+              - gh-pages
 #    - lx_arm64_container_test
 #        requires:
 #        - build


### PR DESCRIPTION
## The Issue

We don't really need to run full linux/arm64 build on CircleCI for every PR. We can save some money by not doing that.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4984"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

