### PR TITLE
[tests only] Make TestHostDBPort more stable

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3772,8 +3772,7 @@ func TestHostDBPort(t *testing.T) {
 			_, _ = exec.RunHostCommand(DdevBin, "debug", "fix-commands")
 			out, err := exec.RunHostCommand(DdevBin, "showport")
 			assert.NoError(err)
-			lines := strings.Split(out, "\n")
-			assert.EqualValues("DDEV_HOST_DB_PORT="+dbPortStr, strings.Trim(lines[0], "\r\n"), "dbType=%s, out=%s, err=%v", dbType, out, err)
+			assert.Contains(out, "DDEV_HOST_DB_PORT="+dbPortStr, "dbType=%s, out=%s, err=%v", dbType, out, err)
 		}
 	}
 }


### PR DESCRIPTION
There maybe additional debug output which currently will break the test. This change makes the test more stable by only verifying the expected string is printed somewhere in the output and does not longer expect to be found at a predefined position.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4987"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

