### PR TITLE
[docs] Change link to TYPO3 docs to point to main

### DIFF
--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -125,4 +125,4 @@ baseVariants:
     condition: 'applicationContext == "Development/DDEV"'
 ```
 
-See also [TYPO3 Documentation](https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/SiteHandling/BaseVariants.html).
+See also [TYPO3 Documentation](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/SiteHandling/BaseVariants.html).


### PR DESCRIPTION
Rendering of main branch was not working yesterday so we had to switch to latest version. Because it is working again we finally can switch to main branch like discussed in #4988.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/4992"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

