### PR TITLE
Fix GetRouterHTTP*Port() to use defaults if empty

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -452,6 +452,11 @@ func (app *DdevApp) GetWebserverType() string {
 // GetRouterHTTPPort returns app's router http port
 func (app *DdevApp) GetRouterHTTPPort() string {
 	port := app.RouterHTTPPortGlobal
+	// TODO: This default setting should be done in creation of the
+	// globalconfig.DdevGlobalCOnfig
+	if port == "" {
+		port = nodeps.DdevDefaultRouterHTTPPort
+	}
 	if app.RouterHTTPPort != "" {
 		port = app.RouterHTTPPort
 	}
@@ -461,6 +466,11 @@ func (app *DdevApp) GetRouterHTTPPort() string {
 // GetRouterHTTPSPort returns app's router https port
 func (app *DdevApp) GetRouterHTTPSPort() string {
 	port := app.RouterHTTPSPortGlobal
+	// TODO: This default setting should be done in creation of the
+	// globalconfig.DdevGlobalCOnfig
+	if port == "" {
+		port = nodeps.DdevDefaultRouterHTTPSPort
+	}
 	if app.RouterHTTPSPort != "" {
 		port = app.RouterHTTPSPort
 	}


### PR DESCRIPTION
## The Issue

We had [consistent failures](https://buildkite.com/ddev/ddev-windows-mutagen/builds/4064#0188c267-bc9c-4cbb-87a0-a0016166daa7) of TestPretestAndEnv on Windows/Mutagen (traditional Windows)

It turns out that this situation is where the global config has empty values for router_http_port. I'm not sure why it gets that on Windows, but a default should be set anyway.

This was introduced in 
* https://github.com/ddev/ddev/pull/4640

## How This PR Solves The Issue

Set the default in GetRouterHTTPPort() etc.

## TODO:

The actual default global setting should be being set in constructor/New() when we're building the DdevGlobalConfig. That is being worked on for other reasons in https://github.com/ddev/ddev/pull/4983 - so we should set those there and then we can remove the default-setting behavior here. 
