### PR TITLE
Fix sources.list for Debian stretch (needed for Postgres 9-11)

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -940,6 +940,7 @@ redirect_stderr=true
 		// because of awkward changes to $DBIMAGE. Postgres 11 will be EOL Nov 2023
 		if nodeps.ArrayContainsString([]string{nodeps.Postgres9, nodeps.Postgres10, nodeps.Postgres11}, app.Database.Version) {
 			extraDBContent = extraDBContent + `
+RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' -e 's/security.debian.org/archive.debian.org/g' -e '/stretch-updates/d' /etc/apt/sources.list
 RUN rm -f /etc/apt/sources.list.d/pgdg.list
 RUN echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list
 RUN apt-get update || true


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/issues/4999

## How This PR Solves The Issue

Adds links to archive.debian.org (found a solution [here](https://stackoverflow.com/a/76095392/8097891)).

## Manual Testing Instructions

`ddev config --database=postgres:9 && ddev start` (and the `postgres:10` and `postgres:11`) Then `ddev psql`

## Automated Testing Overview

The tests for `postgres:10` and `postgres:11` were added in https://github.com/ddev/ddev/pull/4394, but looking at the recent PRs, I do not see any build failures.


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5000"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

