### PR TITLE
[docs] Fix moved link in spf13/cobra

### DIFF
--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -174,7 +174,7 @@ The following fields can be used for a flag definition:
 * `Type`: possible values are `bool`, `string`, `int`, `uint` (defaults to `bool`)
 * `DefValue`: default value for usage message
 * `NoOptDefVal`: default value, if the flag is on the command line without any options
-* `Annotations`: used by cobra.Command Bash autocomplete code (see <https://github.com/spf13/cobra/blob/master/bash_completions.md>)
+* `Annotations`: used by cobra.Command Bash autocomplete code (see <https://github.com/spf13/cobra/blob/main/site/content/completions/bash.md>)
 
 ### “ProjectTypes” Annotation
 


### PR DESCRIPTION
## The Issue

spf13/cobra moved their docs around in https://github.com/spf13/cobra/commit/dcb405a9399ed307eaa0e50f5cb1c290c8979dd4

This broke our link checking. 

Fix it.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5004"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

