### PR TITLE
feat: allow multiple upload dirs, fixes #4190, fixes #4796, fixes #5047

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // Define flags for the config command
@@ -60,9 +61,6 @@ var (
 
 	// showConfigLocation, if set, causes the command to show the config location.
 	showConfigLocation bool
-
-	// uploadDirArg allows a user to set the project's upload directory, the destination directory for import-files.
-	uploadDirArg string
 
 	// webserverTypeArgs allows a user to set the project's webserver type
 	webserverTypeArg string
@@ -231,7 +229,10 @@ func init() {
 	ConfigCommand.Flags().StringVar(&webEnvironmentLocal, "web-environment-add", "", `Append environment variables to the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"`)
 	ConfigCommand.Flags().BoolVar(&createDocroot, "create-docroot", false, "Prompts ddev to create the docroot if it doesn't exist")
 	ConfigCommand.Flags().BoolVar(&showConfigLocation, "show-config-location", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
-	ConfigCommand.Flags().StringVar(&uploadDirArg, "upload-dir", "", "Sets the project's upload directory, the destination directory of the import-files command.")
+	ConfigCommand.Flags().StringSlice("upload-dirs", []string{}, "Sets the project's upload directories, the destination directories of the import-files command.")
+	ConfigCommand.Flags().Lookup("upload-dirs").NoOptDefVal = "false"
+	ConfigCommand.Flags().StringSlice("upload-dir", []string{}, "Sets the project's upload directories, the destination directories of the import-files command.")
+	_ = ConfigCommand.Flags().MarkDeprecated("upload-dir", "please use --upload-dirs instead")
 	ConfigCommand.Flags().StringVar(&webserverTypeArg, "webserver-type", "", "Sets the project's desired webserver type: nginx-fpm/apache-fpm/nginx-gunicorn")
 	ConfigCommand.Flags().StringVar(&webImageArg, "web-image", "", "Sets the web container image")
 	ConfigCommand.Flags().BoolVar(&webImageDefaultArg, "web-image-default", false, "Sets the default web container image for this ddev version")
@@ -257,22 +258,22 @@ func init() {
 
 	// projectname flag exists for backwards compatability.
 	ConfigCommand.Flags().StringVar(&projectNameArg, "projectname", "", projectNameUsage)
-	err = ConfigCommand.Flags().MarkDeprecated("projectname", "The --projectname flag is deprecated in favor of --project-name")
+	err = ConfigCommand.Flags().MarkDeprecated("projectname", "please use --project-name instead")
 	util.CheckErr(err)
 
 	// apptype flag exists for backwards compatability.
 	ConfigCommand.Flags().StringVar(&projectTypeArg, "projecttype", "", projectTypeUsage)
-	err = ConfigCommand.Flags().MarkDeprecated("projecttype", "The --projecttype flag is deprecated in favor of --project-type")
+	err = ConfigCommand.Flags().MarkDeprecated("projecttype", "please use --project-type instead")
 	util.CheckErr(err)
 
 	// apptype flag exists for backwards compatibility.
 	ConfigCommand.Flags().StringVar(&projectTypeArg, "apptype", "", projectTypeUsage+" This is the same as --project-type and is included only for backwards compatibility.")
-	err = ConfigCommand.Flags().MarkDeprecated("apptype", "The apptype flag is deprecated in favor of --project-type")
+	err = ConfigCommand.Flags().MarkDeprecated("apptype", "please use --project-type instead")
 	util.CheckErr(err)
 
 	// sitename flag exists for backwards compatibility.
 	ConfigCommand.Flags().StringVar(&projectNameArg, "sitename", "", projectNameUsage+" This is the same as project-name and is included only for backwards compatibility")
-	err = ConfigCommand.Flags().MarkDeprecated("sitename", "The sitename flag is deprecated in favor of --project-name")
+	err = ConfigCommand.Flags().MarkDeprecated("sitename", "please use --project-name instead")
 	util.CheckErr(err)
 
 	ConfigCommand.Flags().String("webimage-extra-packages", "", "A comma-delimited list of Debian packages that should be added to web container when the project is started")
@@ -296,6 +297,7 @@ func init() {
 	ConfigCommand.Flags().String("database", "", fmt.Sprintf(`Specify the database type:version to use. Defaults to mariadb:%s`, nodeps.MariaDBDefaultVersion))
 	ConfigCommand.Flags().String("nodejs-version", "", fmt.Sprintf(`Specify the nodejs version to use if you don't want the default NodeJS %s`, nodeps.NodeJSDefault))
 	ConfigCommand.Flags().Int("default-container-timeout", 120, `default time in seconds that ddev waits for all containers to become ready on start`)
+
 	RootCmd.AddCommand(ConfigCommand)
 
 	// Add hidden pantheon subcommand for people who have it in their fingers
@@ -620,9 +622,8 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 		app.Database.Version = parts[1]
 	}
 
-	if uploadDirArg != "" {
-		app.UploadDir = uploadDirArg
-	}
+	handleUploadDirsFlag(app, cmd.Flag("upload-dir"))
+	handleUploadDirsFlag(app, cmd.Flag("upload-dirs"))
 
 	if webserverTypeArg != "" {
 		app.WebserverType = webserverTypeArg
@@ -684,4 +685,27 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	}
 
 	return nil
+}
+
+func handleUploadDirsFlag(app *ddevapp.DdevApp, flag *pflag.Flag) {
+	if flag.Changed {
+		uploadDirsRaw := flag.Value.(pflag.SliceValue).GetSlice()
+
+		var uploadDirs any
+		uploadDirs = uploadDirsRaw
+
+		if len(uploadDirsRaw) == 1 {
+			uploadDirsBool, err := strconv.ParseBool(uploadDirsRaw[0])
+
+			if err == nil {
+				if uploadDirsBool {
+					util.Failed("Incorrect value for --%s: %v", flag.Name, uploadDirsBool)
+				}
+
+				uploadDirs = uploadDirsBool
+			}
+		}
+
+		app.UploadDirs = uploadDirs
+	}
 }

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -211,7 +211,7 @@ func TestConfigSetValues(t *testing.T) {
 		fmt.Sprintf("--no-project-mount=%t", noProjectMount),
 		"--additional-hostnames", additionalHostnames,
 		"--additional-fqdns", additionalFQDNs,
-		"--upload-dir", uploadDir,
+		fmt.Sprintf("--upload-dirs=\"%s\"", uploadDir),
 		"--webserver-type", webserverType,
 		"--web-image", webImage,
 		"--web-working-dir", webWorkingDir,
@@ -259,7 +259,7 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Equal(noProjectMount, app.NoProjectMount)
 	assert.Equal(additionalHostnamesSlice, app.AdditionalHostnames)
 	assert.Equal(additionalFQDNsSlice, app.AdditionalFQDNs)
-	assert.Equal(uploadDir, app.UploadDir)
+	assert.Equal(uploadDir, app.GetUploadDir())
 	assert.Equal(webserverType, app.WebserverType)
 	assert.Equal(webImage, app.WebImage)
 	assert.Equal(webWorkingDir, app.WorkingDir["web"])

--- a/cmd/ddev/cmd/debug-capabilities.go
+++ b/cmd/ddev/cmd/debug-capabilities.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 // DebugCapabilitiesCmd implements the ddev debug capabilities command
@@ -25,6 +26,7 @@ var DebugCapabilitiesCmd = &cobra.Command{
 			"migrate-database",
 			"web-start-hooks",
 			"add-on-versioning",
+			"multiple-upload-dirs",
 		}
 		output.UserOut.WithField("raw", capabilities).Print(strings.Join(capabilities, "\n"))
 	},

--- a/cmd/ddev/cmd/export-db.go
+++ b/cmd/ddev/cmd/export-db.go
@@ -90,7 +90,7 @@ func NewExportDBCmd() *cobra.Command {
 	cmd.Flags().Bool("bzip2", false, "Use bzip2 compression")
 
 	// Backward compatibility
-	cmd.Flags().String("target-db", "db", "Path to a SQL dump file to export to")
+	cmd.Flags().String("target-db", "db", cmd.Flags().Lookup("database").Usage)
 	_ = cmd.Flags().MarkDeprecated("target-db", "please use --database instead")
 
 	_ = cmd.Flags().MarkShorthandDeprecated("z", "please use --gzip instead")

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -104,17 +104,17 @@ func NewImportDBCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("file", "f", "", "Path to a SQL dump in `.sql`, `.tar`, `.tar.gz`, `.tgz`, `.bz2`, `.xx`, or `.zip` format")
+	cmd.Flags().StringP("file", "f", "", "Path to a SQL dump in `.sql`, `.tar`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip` format")
 	cmd.Flags().String("extract-path", "", "Path to extract within the archive")
 	cmd.Flags().StringP("database", "d", "db", "Target database to import into")
 	cmd.Flags().Bool("no-drop", false, "Do not drop the database before importing")
 	cmd.Flags().Bool("no-progress", false, "Do not output progress")
 
 	// Backward compatibility
-	cmd.Flags().String("src", "", "Path to a SQL dump in `.sql`, `.tar`, `.tar.gz`, `.tgz`, `.bz2`, `.xx`, or `.zip` format")
+	cmd.Flags().String("src", "", cmd.Flags().Lookup("file").Usage)
 	_ = cmd.Flags().MarkDeprecated("src", "please use --file instead")
 
-	cmd.Flags().String("target-db", "db", "Target database to import into")
+	cmd.Flags().String("target-db", "db", cmd.Flags().Lookup("database").Usage)
 	_ = cmd.Flags().MarkDeprecated("target-db", "please use --database instead")
 
 	cmd.Flags().BoolP("progress", "p", true, "Display a progress bar during import")

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -11,8 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var sourcePath string
-var extPath string
+var (
+	target     string
+	sourcePath string
+	extPath    string
+)
 
 // ImportFileCmd represents the `ddev import-db` command.
 var ImportFileCmd = &cobra.Command{
@@ -30,8 +33,8 @@ provided if it is not located at the top-level of the archive. If the
 destination directory exists, it will be replaced with the assets being
 imported.
 
-The destination directory can be configured in your project's config.yaml
-under the upload_dir key. If no custom upload directory is defined, the app
+The destination directories can be configured in your project's config.yaml
+under the upload_dirs key. If no custom upload directory is defined, the app
 type's default upload directory will be used.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		dockerutil.EnsureDdevNetwork()
@@ -65,7 +68,7 @@ type's default upload directory will be used.`,
 			promptForExtPath(&extPath)
 		}
 
-		if err = app.ImportFiles(importPath, extPath); err != nil {
+		if err = app.ImportFiles(target, importPath, extPath); err != nil {
 			util.Failed("Failed to import files for %s: %v", app.GetName(), err)
 		}
 
@@ -108,7 +111,8 @@ func promptForExtPath(val *string) {
 }
 
 func init() {
-	ImportFileCmd.Flags().StringVarP(&sourcePath, "src", "", "", "Provide the path to the source directory or tar/tar.gz/tgz/zip archive of files to import")
-	ImportFileCmd.Flags().StringVarP(&extPath, "extract-path", "", "", "If provided asset is an archive, optionally provide the path to extract within the archive.")
+	ImportFileCmd.Flags().StringVarP(&target, "target", "t", "", "Target upload dir, defaults to the first upload dir")
+	ImportFileCmd.Flags().StringVar(&sourcePath, "src", "", "Provide the path to the source directory or tar/tar.gz/tgz/zip archive of files to import")
+	ImportFileCmd.Flags().StringVar(&extPath, "extract-path", "", "If provided asset is an archive, optionally provide the path to extract within the archive")
 	RootCmd.AddCommand(ImportFileCmd)
 }

--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -6,74 +6,115 @@ import (
 	"github.com/ddev/ddev/pkg/appimport"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/heredoc"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
 
-var (
-	target     string
-	sourcePath string
-	extPath    string
-)
+// NewImportFileCmd initialized and return the `ddev import-db` command.
+func NewImportFileCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import-files",
+		Short: "Pull the uploaded files directory of an existing project to the default public upload directory of your project",
+		Long: heredoc.Doc(`
+			Pull the uploaded files directory of an existing project to the default
+			public upload directory of your project. The files can be provided as a
+			directory path or an archive in .tar, .tar.gz, .tar.xz, .tar.bz2, .tgz, or .zip format. For the
+			.zip and tar formats, the path to a directory within the archive can be
+			provided if it is not located at the top-level of the archive. If the
+			destination directory exists, it will be replaced with the assets being
+			imported.
 
-// ImportFileCmd represents the `ddev import-db` command.
-var ImportFileCmd = &cobra.Command{
-	Use: "import-files",
-	Example: `ddev import-files --src=/path/to/files.tar.gz
-ddev import-files --src=/path/to/dir
-ddev import-files --src=/path/to/files.tar.xz
-ddev import-files --src=/path/to/files.tar.bz2`,
-	Short: "Pull the uploaded files directory of an existing project to the default public upload directory of your project.",
-	Long: `Pull the uploaded files directory of an existing project to the default
-public upload directory of your project. The files can be provided as a
-directory path or an archive in .tar, .tar.gz, .tar.xz, .tar.bz2, .tgz, or .zip format. For the
-.zip and tar formats, the path to a directory within the archive can be
-provided if it is not located at the top-level of the archive. If the
-destination directory exists, it will be replaced with the assets being
-imported.
-
-The destination directories can be configured in your project's config.yaml
-under the upload_dirs key. If no custom upload directory is defined, the app
-type's default upload directory will be used.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		dockerutil.EnsureDdevNetwork()
-	},
-	Args: cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		app, err := ddevapp.GetActiveApp("")
-		if err != nil {
-			util.Failed("Failed to import files: %v", err)
-		}
-
-		var showExtPathPrompt bool
-		if sourcePath == "" {
-			// Ensure we prompt for extraction path if an archive is provided, while still allowing
-			// non-interactive use of --src flag without providing a --extract-path flag.
-			if extPath == "" {
-				showExtPathPrompt = true
+			The destination directories can be configured in your project's config.yaml
+			under the upload_dirs key. If no custom upload directory is defined, the app
+			type's default upload directory will be used.
+		`),
+		Example: heredoc.DocI2S(`
+			ddev import-files --src=/path/to/files.tar.gz
+			ddev import-files --src=/path/to/dir
+			ddev import-files --src=/path/to/files.tar.xz
+			ddev import-files --src=/path/to/files.tar.bz2
+			ddev import-files --src=.tarballs/files.tar.xz --target=../private
+			ddev import-files --src=.tarballs/files.tar.gz --target=sites/default/files
+		`),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			dockerutil.EnsureDdevNetwork()
+		},
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := ddevapp.GetActiveApp("")
+			if err != nil {
+				return fmt.Errorf("unable to get project: %v", err)
 			}
 
-			promptForFileSource(&sourcePath)
-		}
+			target, err := cmd.Flags().GetString("target")
+			if err != nil {
+				return err
+			}
 
-		importPath, isArchive, err := appimport.ValidateAsset(sourcePath, "files")
-		if err != nil {
-			util.Failed("Failed to import files for %s: %v", app.GetName(), err)
-		}
+			sourcePath, err := cmd.Flags().GetString("source")
+			if err != nil {
+				return err
+			}
 
+			if !cmd.Flags().Lookup("source").Changed && cmd.Flags().Lookup("src").Changed {
+				sourcePath, err = cmd.Flags().GetString("src")
+				if err != nil {
+					return err
+				}
+			}
+
+			extractPath, err := cmd.Flags().GetString("extract-path")
+			if err != nil {
+				return err
+			}
+
+			return importFilesRun(app, target, sourcePath, extractPath)
+		},
+	}
+
+	cmd.Flags().StringP("target", "t", "", "Target upload dir, defaults to the first upload dir")
+	cmd.Flags().StringP("source", "s", "", "Path to the source directory or source archive in `.tar`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip` format")
+	cmd.Flags().String("extract-path", "", "Path to extract within the archive")
+
+	// Backward compatibility
+	cmd.Flags().String("src", "", cmd.Flags().Lookup("source").Usage)
+	_ = cmd.Flags().MarkDeprecated("src", "please use --source or -s instead")
+
+	return cmd
+}
+
+func importFilesRun(app *ddevapp.DdevApp, uploadDir, sourcePath, extractPath string) error {
+	var showExtPathPrompt bool
+	if sourcePath == "" {
 		// Ensure we prompt for extraction path if an archive is provided, while still allowing
 		// non-interactive use of --src flag without providing a --extract-path flag.
-		if isArchive && showExtPathPrompt {
-			promptForExtPath(&extPath)
+		if extractPath == "" {
+			showExtPathPrompt = true
 		}
 
-		if err = app.ImportFiles(target, importPath, extPath); err != nil {
-			util.Failed("Failed to import files for %s: %v", app.GetName(), err)
-		}
+		promptForFileSource(&sourcePath)
+	}
 
-		util.Success("Successfully imported files for %v", app.GetName())
-	},
+	importPath, isArchive, err := appimport.ValidateAsset(sourcePath, "files")
+	if err != nil {
+		return fmt.Errorf("failed to import files for %s: %v", app.GetName(), err)
+	}
+
+	// Ensure we prompt for extraction path if an archive is provided, while still allowing
+	// non-interactive use of --src flag without providing a --extract-path flag.
+	if isArchive && showExtPathPrompt {
+		promptForExtractPath(&extractPath)
+	}
+
+	if err = app.ImportFiles(uploadDir, importPath, extractPath); err != nil {
+		return fmt.Errorf("failed to import files for %s: %v", app.GetName(), err)
+	}
+
+	util.Success("Successfully imported files for %v", app.GetName())
+
+	return nil
 }
 
 const importPathPrompt = `Provide the path to the source directory or archive you wish to import.`
@@ -100,8 +141,8 @@ func promptForFileSource(val *string) {
 const extPathPrompt = `You provided an archive. Do you want to extract from a specific path in your
 archive? You may leave this blank if you wish to use the full archive contents.`
 
-// promptForExtPath prompts the user for the internal extraction path of an archive.
-func promptForExtPath(val *string) {
+// promptForExtractPath prompts the user for the internal extraction path of an archive.
+func promptForExtractPath(val *string) {
 	output.UserOut.Println(extPathPrompt)
 
 	// An empty string is acceptable in this case, indicating
@@ -111,8 +152,5 @@ func promptForExtPath(val *string) {
 }
 
 func init() {
-	ImportFileCmd.Flags().StringVarP(&target, "target", "t", "", "Target upload dir, defaults to the first upload dir")
-	ImportFileCmd.Flags().StringVar(&sourcePath, "src", "", "Provide the path to the source directory or tar/tar.gz/tgz/zip archive of files to import")
-	ImportFileCmd.Flags().StringVar(&extPath, "extract-path", "", "If provided asset is an archive, optionally provide the path to extract within the archive")
-	RootCmd.AddCommand(ImportFileCmd)
+	RootCmd.AddCommand(NewImportFileCmd())
 }

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -454,11 +454,11 @@ The `php` and `python` types don’t attempt [CMS configuration](../../users/qui
 
 ## `upload_dirs`
 
-Paths from the project’s docroot to the user-generated files directory targeted by `ddev import-files`.
+Paths from the project’s docroot to the user-generated files directory targeted by `ddev import-files`. Can be be outside the docroot but must be within the project directory e.g. `../private`.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | |
+| :octicons-file-directory-16: project | | A list of directories or `false` to disable warnings for project types without any default e.g. `php`.
 
 ## `use_dns_when_possible`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -452,9 +452,9 @@ The DDEV-specific project type.
 
 The `php` and `python` types don’t attempt [CMS configuration](../../users/quickstart.md) or settings file management and can work with any project.
 
-## `upload_dir`
+## `upload_dirs`
 
-Path from the project’s docroot to the user-generated files directory targeted by `ddev import-files`.
+Paths from the project’s docroot to the user-generated files directory targeted by `ddev import-files`.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -92,7 +92,8 @@ A number of environment variables are provided to these command scripts. These a
 Useful variables for container scripts are:
 
 * `DDEV_DOCROOT`: Relative path from approot to docroot
-* `DDEV_FILES_DIR`: Directory of user-uploaded files
+* `DDEV_FILES_DIR`: *Deprecated*, first directory of user-uploaded files
+* `DDEV_FILES_DIRS`: Comma-separated list of directories of user-uploaded files
 * `DDEV_HOSTNAME`: Comma-separated list of FQDN hostnames
 * `DDEV_MUTAGEN_ENABLED`: `true` if Mutagen is enabled
 * `DDEV_PHP_VERSION`: Current PHP version

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -50,7 +50,7 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
 
     ### Mutagen and User-Generated Uploads
 
-    When Mutagen is enabled, DDEV attempts to exclude user-generated files in `upload_dirs`—when it exists—from syncing. It does this by using a bind-mount in the generated docker-compose configuration, and excluding the directory from syncing in `.ddev/mutagen/mutagen.yml`.
+    When Mutagen is enabled, DDEV attempts to exclude user-generated files in `upload_dirs` (if they exist) from syncing. It does this by using a bind-mount in the generated docker-compose configuration, and excluding the directories from syncing in `.ddev/mutagen/mutagen.yml`.
 
     If you have a non-standard location for user-generated files, like `private/fileadmin` with the deprecated `typo3-secure-web` approach, you should override the project defaults by setting `upload_dirs` in `.ddev/config.yaml` and pointing it at the correct directory. This will allow Mutagen to sync correctly.
 

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -50,11 +50,11 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
 
     ### Mutagen and User-Generated Uploads
 
-    When Mutagen is enabled, DDEV attempts to exclude user-generated files in `upload_dir`—when it exists—from syncing. It does this by using a bind-mount in the generated docker-compose configuration, and excluding the directory from syncing in `.ddev/mutagen/mutagen.yml`.
+    When Mutagen is enabled, DDEV attempts to exclude user-generated files in `upload_dirs`—when it exists—from syncing. It does this by using a bind-mount in the generated docker-compose configuration, and excluding the directory from syncing in `.ddev/mutagen/mutagen.yml`.
 
-    If you have a non-standard location for user-generated files, like `private/fileadmin` with the deprecated `typo3-secure-web` approach, you should override the project defaults by setting `upload_dir` in `.ddev/config.yaml` and pointing it at the correct directory. This will allow Mutagen to sync correctly.
+    If you have a non-standard location for user-generated files, like `private/fileadmin` with the deprecated `typo3-secure-web` approach, you should override the project defaults by setting `upload_dirs` in `.ddev/config.yaml` and pointing it at the correct directory. This will allow Mutagen to sync correctly.
 
-    If you change the `upload_dir`, run `ddev mutagen reset` to let Mutagen know about the changed behavior.
+    If you change the `upload_dirs`, run `ddev mutagen reset` to let Mutagen know about the changed behavior.
 
     ### Mutagen Integration Caveats
 

--- a/docs/content/users/providers/index.md
+++ b/docs/content/users/providers/index.md
@@ -20,7 +20,7 @@ Each provider recipe is a file named `<provider>.yaml` and consists of several m
 * `files_pull_command`: A script that determines how DDEV can get user-generated files from upstream. Its job is to copy the files from upstream to `/var/www/html/.ddev/.downloads/files`. If nothing has to be done to obtain the files, this step can run `true`.
 * `files_import_command`: (optional) A script that imports the downloaded files. There are a number of situations where it’s messy to push a directory of files around, and one can put it directly where it’s needed. The [localfile example](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) uses this technique.
 * `db_push_command`: A script that determines how DDEV should push a database. Its job is to take a gzipped database dump from `/var/www/html/.ddev/.downloads/db.sql.gz` and load it on the hosting provider.
-* `files_push_command`: A script that determines how DDEV push user-generated files to upstream. Its job is to copy the files from the project’s user-files directory (`$DDEV_FILES_DIR`) to the correct place on the upstream provider.
+* `files_push_command`: A script that determines how DDEV push user-generated files to upstream. Its job is to copy the files from the project’s user-files directories (`$DDEV_FILES_DIRS`) to the correct places on the upstream provider.
 
 The [environment variables provided to custom commands](../extend/custom-commands.md#environment-variables-provided) are also available for use in these recipes.
 

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -58,12 +58,15 @@ ddev export-db >/tmp/db.sql.gz
 
 To import static file assets for a project, such as uploaded images and documents, use the command [`ddev import-files`](../usage/commands.md#import-files). This command will prompt you to specify the location of your import asset, then import the assets into the project’s upload directory. To define a custom upload directory, set the [`upload_dirs`](../configuration/config.md#upload_dirs) config option. If no custom upload directory is defined, the default will be used:
 
-* For Drupal projects, this is the `sites/default/files` directory.
-* For WordPress projects, this is the `wp-content/uploads` directory.
-* For TYPO3 projects, this is the `fileadmin` directory.
-* For Backdrop projects, this is the `files` .
+* For Backdrop projects, this is the `files`.
+* For Drupal projects, these are the `sites/default/files` and `../private` directories.
 * For Magento 1 projects, this is the `media` directory.
 * For Magento 2 projects, this is the `pub/media` directory.
+* For Shopware projects, this is the `media` directory.
+* For TYPO3 projects, this is the `fileadmin` directory.
+* For WordPress projects, this is the `wp-content/uploads` directory.
+
+Other project types need a custom configuration to be able to use this command.
 
 ```bash
 ddev import-files
@@ -77,9 +80,13 @@ Successfully imported files for drupal8
 
 It can also import a directory containing static assets.
 
-If you want to use `import-files` without answering prompts, use the `--src` flag to provide the path to the import asset. If you’re importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag. Example:
+If you want to use `import-files` without answering prompts, use the `--source` or `-s` flag to provide the path to the import asset. If you’re importing an archive, and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--source` flag. Example:
 
-`ddev import-files --src=/tmp/files.tgz`
+`ddev import-files --source=/tmp/files.tgz`
+
+With multiple `upload_dirs` defined if you want to import to another upload dir than the first one, use the `--target` or `-t` flag to provide the path to the desired upload dir.
+
+`ddev import-files --target=../private --source=/tmp/files.tgz`
 
 See `ddev help import-files` for more examples.
 

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -56,7 +56,7 @@ ddev export-db >/tmp/db.sql.gz
 
 ## `ddev import-files`
 
-To import static file assets for a project, such as uploaded images and documents, use the command [`ddev import-files`](../usage/commands.md#import-files). This command will prompt you to specify the location of your import asset, then import the assets into the project’s upload directory. To define a custom upload directory, set the [`upload_dir`](../configuration/config.md#upload_dir) config option. If no custom upload directory is defined, the default will be used:
+To import static file assets for a project, such as uploaded images and documents, use the command [`ddev import-files`](../usage/commands.md#import-files). This command will prompt you to specify the location of your import asset, then import the assets into the project’s upload directory. To define a custom upload directory, set the [`upload_dirs`](../configuration/config.md#upload_dirs) config option. If no custom upload directory is defined, the default will be used:
 
 * For Drupal projects, this is the `sites/default/files` directory.
 * For WordPress projects, this is the `wp-content/uploads` directory.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -202,7 +202,7 @@ Flags:
 * `--project-type`: Provide the project type: `backdrop`, `drupal10`, `drupal6`, `drupal7`, `drupal8`, `drupal9`, `laravel`, `magento`, `magento2`, `php`, `shopware6`, `typo3`, `wordpress`. This is autodetected and this flag is necessary only to override the detection.
 * `--show-config-location`: Output the location of the `config.yaml` file if it exists, or error that it doesn’t exist.
 * `--timezone`: Specify timezone for containers and PHP, like `Europe/London` or `America/Denver` or `GMT` or `UTC`.
-* `--upload-dir`: Sets the project’s upload directory, the destination directory of the import-files command.
+* `--upload-dirs`: Sets the project’s upload directories, the destination directories of the import-files command.
 * `--use-dns-when-possible`: Use DNS for hostname resolution instead of `/etc/hosts` when possible. (default `true`)
 * `--web-environment`: Set the environment variables in the web container: `--web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"`
 * `--web-environment-add`: Append environment variables to the web container: `--web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"`

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -656,7 +656,7 @@ Flags:
 
 * `--database`, `-d`: Target database to import into (default `"db"`)
 * `--extract-path`: Path to extract within the archive
-* `--file`, `-f`: Path to a SQL dump in `.sql`, `.tar`, `.tar.gz`, `.tgz`, `.bz2`, `.xx`, or `.zip` format
+* `--file`, `-f`: Path to a SQL dump in `.sql`, `.tar`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip` format
 * `--no-drop`: Do not drop the database before importing
 * `--no-progress`: Do not output progress
 
@@ -691,17 +691,24 @@ Pull the uploaded files directory of an existing project to the default [public 
 
 Flags:
 
-* `--extract-path`: If provided asset is an archive, optionally provide the path to extract within the archive.
-* `--src`: Provide the path to the source directory or archive to import. (Archive can be `.tar`, `.tar.gz`, `.tar.xz`, `.tar.bz2`, `.tgz`, or `.zip`.)
+* `--extract-path`: Path to extract within the archive.
+* `--source`, `-s`: Path to the source directory or source archive in `.tar`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, or `.zip` format.
+* `--target`, `-t`: Target upload dir, defaults to the first upload dir.
 
 Example:
 
 ```shell
-# Extract+import `/path/to/files.tar.gz` to the project’s upload directory
-ddev import-files --src=/path/to/files.tar.gz
+# Extract+import `/path/to/files.tar.gz` to the project’s first upload directory
+ddev import-files --source=/path/to/files.tar.gz
 
-# Import `/path/to/dir` contents to the project’s upload directory
-ddev import-files --src=/path/to/dir
+# Import `/path/to/dir` contents to the project’s first upload directory
+ddev import-files --source=/path/to/dir
+
+# Import `.tarballs/files.tar.xz` contents to the project’s `../private` upload directory
+ddev import-files --src=.tarballs/files.tar.xz --target=../private
+
+# Import `/path/to/dir` contents to the project’s `sites/default/files` upload directory
+ddev import-files -s=.tarballs/files.tar.gz -t=sites/default/files
 ```
 
 ## `launch`

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -133,26 +133,26 @@ services:
         target: /tmp/project_mutagen
         volume:
           nocopy: true
+      {{- end }}
 
-      {{ end }}
-      {{ if .NoBindMounts }}
-      - "ddev-config:/mnt/ddev_config"
-      {{ else }}
-      - ".:/mnt/ddev_config:ro"
-      - "./xhprof:/usr/local/bin/xhprof:ro"
-        {{ if .MutagenEnabled }}
-          {{ if .ContainerUploadDir }}
-      - {{ .HostUploadDir }}:{{ .ContainerUploadDir }}:rw
-          {{ end }} {{/* end if .ContainerUploadDir */}}
-          {{ if .GitDirMount }}
+      {{- if .NoBindMounts }}
+      - ddev-config:/mnt/ddev_config
+      {{- else }}
+      - .:/mnt/ddev_config:ro
+      - ./xhprof:/usr/local/bin/xhprof:ro
+        {{- if .MutagenEnabled }}
+          {{- range $uploadDirMap := .UploadDirsMap}}
+      - {{ $uploadDirMap }}:rw
+          {{- end}} {{- /* end range .UploadDirsMap */}}
+          {{- if .GitDirMount }}
       - ../.git:/var/www/html/.git:rw
-          {{ end }} {{/* end if .GitDirMount */}}
-        {{ end }} {{/* end if .MutagenEnabled */}}
-      {{ end }} {{/* end else of if .NoBindMounts */}}
-      - "ddev-global-cache:/mnt/ddev-global-cache"
-      {{ if not .OmitSSHAgent }}
-      - "ddev-ssh-agent_socket_dir:/home/.ssh-agent"
-      {{ end }}
+          {{- end }} {{- /* end if .GitDirMount */}}
+        {{- end }} {{- /* end if .MutagenEnabled */}}
+      {{- end }} {{- /* end else of if .NoBindMounts */}}
+      - ddev-global-cache:/mnt/ddev-global-cache
+      {{- if not .OmitSSHAgent }}
+      - ddev-ssh-agent_socket_dir:/home/.ssh-agent
+      {{- end }}
 
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     user: '$DDEV_UID:$DDEV_GID'
@@ -182,6 +182,7 @@ services:
     - DDEV_SITENAME
     - DDEV_TLD
     - DDEV_FILES_DIR
+    - DDEV_FILES_DIRS
     - DDEV_WEB_ENTRYPOINT=/mnt/ddev_config/web-entrypoint.d
     - DDEV_WEBSERVER_TYPE
     - DDEV_XDEBUG_ENABLED

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -172,7 +172,7 @@ func init() {
 
 		nodeps.AppTypeMagento2: {
 			settingsCreator:      createMagento2SettingsFile,
-			uploadDirs:           getMagentoUploadDirs,
+			uploadDirs:           getMagento2UploadDirs,
 			appTypeSettingsPaths: setMagento2SiteSettingsPaths,
 			appTypeDetect:        isMagento2App,
 			configOverrideAction: magento2ConfigOverrideAction,

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -46,7 +46,7 @@ type postConfigAction func(app *DdevApp) error
 type postStartAction func(app *DdevApp) error
 
 // importFilesAction
-type importFilesAction func(app *DdevApp, uploadDir, importPath, extPath string) error
+type importFilesAction func(app *DdevApp, uploadDir, importPath, extractPath string) error
 
 // defaultWorkingDirMap returns the app type's default working directory map
 type defaultWorkingDirMap func(app *DdevApp, defaults map[string]string) map[string]string
@@ -357,13 +357,13 @@ func (app *DdevApp) PostStartAction() error {
 }
 
 // dispatchImportFilesAction executes the relevant import files workflow for each app type.
-func (app *DdevApp) dispatchImportFilesAction(uploadDir, importPath, extPath string) error {
+func (app *DdevApp) dispatchImportFilesAction(uploadDir, importPath, extractPath string) error {
 	if strings.TrimSpace(uploadDir) == "" {
 		return errors.Errorf("upload_dirs is not set for this project (%s)", app.Type)
 	}
 
 	if appFuncs, ok := appTypeMatrix[app.Type]; ok && appFuncs.importFilesAction != nil {
-		return appFuncs.importFilesAction(app, uploadDir, importPath, extPath)
+		return appFuncs.importFilesAction(app, uploadDir, importPath, extractPath)
 	}
 
 	return fmt.Errorf("this project type (%s) does not support import-files", app.Type)

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -2,15 +2,15 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/dockerutil"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"os"
 	"path"
 	"path/filepath"
 	"text/template"
 
 	"github.com/ddev/ddev/pkg/archive"
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 )
@@ -128,13 +128,9 @@ func writeBackdropSettingsDdevPHP(settings *BackdropSettings, filePath string, _
 	return err
 }
 
-// getBackdropUploadDir will return a custom upload dir if defined, returning a default path if not.
-func getBackdropUploadDir(app *DdevApp) string {
-	if app.UploadDir == "" {
-		return "files"
-	}
-
-	return app.UploadDir
+// getBackdropUploadDirs will return the default paths.
+func getBackdropUploadDirs(_ *DdevApp) UploadDirs {
+	return UploadDirs{"files"}
 }
 
 // getBackdropHooks for appending as byte array.
@@ -170,8 +166,8 @@ func backdropPostImportDBAction(_ *DdevApp) error {
 
 // backdropImportFilesAction defines the Backdrop workflow for importing project files.
 // The Backdrop workflow is currently identical to the Drupal import-files workflow.
-func backdropImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetHostUploadDirFullPath()
+func backdropImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
+	destPath := app.calculateHostUploadDirFullPath(uploadDir)
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -1,15 +1,16 @@
 package ddevapp_test
 
 import (
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"strings"
-	"testing"
 )
 
 // TestComposer does trivial tests of the ddev composer command
@@ -57,6 +58,7 @@ func TestComposer(t *testing.T) {
 	})
 
 	err = app.Start()
+	os.Exit(1)
 	require.NoError(t, err)
 
 	// Make sure to remove the var-dump-server to start; composer install should replace it.

--- a/pkg/ddevapp/composer_test.go
+++ b/pkg/ddevapp/composer_test.go
@@ -1,16 +1,15 @@
 package ddevapp_test
 
 import (
-	"os"
-	"strings"
-	"testing"
-
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"os"
+	"strings"
+	"testing"
 )
 
 // TestComposer does trivial tests of the ddev composer command
@@ -58,7 +57,6 @@ func TestComposer(t *testing.T) {
 	})
 
 	err = app.Start()
-	os.Exit(1)
 	require.NoError(t, err)
 
 	// Make sure to remove the var-dump-server to start; composer install should replace it.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -111,7 +111,7 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	if _, err := os.Stat(app.ConfigPath); !os.IsNotExist(err) {
 		_, err = app.ReadConfig(includeOverrides)
 		if err != nil {
-			return app, fmt.Errorf("%v exists but cannot be read. It may be invalid due to a syntax error.: %v", app.ConfigPath, err)
+			return app, fmt.Errorf("%v exists but cannot be read. It may be invalid due to a syntax error: %v", app.ConfigPath, err)
 		}
 	}
 
@@ -127,8 +127,15 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	if app.Database.Type == "" {
 		app.Database = DatabaseDefault
 	}
+
 	if app.DefaultContainerTimeout == "" {
 		app.DefaultContainerTimeout = nodeps.DefaultDefaultContainerTimeout
+	}
+
+	// Migrate UploadDir to UploadDirs
+	if app.UploadDirDeprecated != "" {
+		app.addUploadDir(app.UploadDirDeprecated)
+		app.UploadDirDeprecated = ""
 	}
 
 	app.SetApptypeSettingsPaths()
@@ -338,6 +345,13 @@ func (app *DdevApp) LoadConfigYamlFile(filePath string) error {
 	if err != nil {
 		return err
 	}
+
+	// Handle UploadDirs value which can take multiple types.
+	err = app.validateUploadDirs()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -684,8 +698,7 @@ type composeYAMLVars struct {
 	WebEnvironment                  []string
 	NoBindMounts                    bool
 	Docroot                         string
-	ContainerUploadDir              string
-	HostUploadDir                   string
+	UploadDirsMap                   []string
 	GitDirMount                     bool
 	IsGitpod                        bool
 	IsCodespaces                    bool
@@ -773,8 +786,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		NFSMountVolumeName:    app.GetNFSMountVolumeName(),
 		NoBindMounts:          globalconfig.DdevGlobalConfig.NoBindMounts,
 		Docroot:               app.GetDocroot(),
-		HostUploadDir:         app.GetHostUploadDirFullPath(),
-		ContainerUploadDir:    app.GetContainerUploadDirFullPath(),
+		UploadDirsMap:         app.getUploadDirsHostContainerMapping(),
 		GitDirMount:           false,
 		IsGitpod:              nodeps.IsGitpod(),
 		IsCodespaces:          nodeps.IsCodespaces(),
@@ -792,13 +804,6 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	envFile := app.GetConfigPath(".env")
 	if fileutil.FileExists(envFile) {
 		templateVars.EnvFile = envFile
-	}
-
-	// And we don't want to bind-mount upload dir if it doesn't exist.
-	// templateVars.UploadDir is relative path rooted in approot.
-	if app.GetHostUploadDirFullPath() == "" || !fileutil.FileExists(app.GetHostUploadDirFullPath()) {
-		templateVars.HostUploadDir = ""
-		templateVars.ContainerUploadDir = ""
 	}
 
 	webimageExtraHTTPPorts := []string{}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -134,8 +134,9 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 
 	// Migrate UploadDir to UploadDirs
 	if app.UploadDirDeprecated != "" {
-		app.addUploadDir(app.UploadDirDeprecated)
+		uploadDirDeprecated := app.UploadDirDeprecated
 		app.UploadDirDeprecated = ""
+		app.addUploadDir(uploadDirDeprecated)
 	}
 
 	app.SetApptypeSettingsPaths()

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -2,13 +2,13 @@ package ddevapp
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/ddev/ddev/pkg/archive"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/pkg/errors"
-	"os"
-	"path/filepath"
 )
 
 // isCraftCmsApp returns true if the app is of type craftcms
@@ -17,11 +17,8 @@ func isCraftCmsApp(app *DdevApp) bool {
 }
 
 // craftCmsImportFilesAction defines the workflow for importing project files.
-func craftCmsImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	if app.UploadDir == "" {
-		return errors.Errorf("No upload_dir is set for this (craftcms) project")
-	}
-	destPath := app.GetHostUploadDirFullPath()
+func craftCmsImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
+	destPath := app.calculateHostUploadDirFullPath(uploadDir)
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -849,7 +849,7 @@ func (app *DdevApp) getCommonStatus(statuses map[string]string) (bool, string) {
 }
 
 // ImportFiles takes a source directory or archive and copies to the uploaded files directory of a given app.
-func (app *DdevApp) ImportFiles(uploadDir, importPath, extPath string) error {
+func (app *DdevApp) ImportFiles(uploadDir, importPath, extractPath string) error {
 	app.DockerEnv()
 
 	if err := app.ProcessHooks("pre-import-files"); err != nil {
@@ -860,7 +860,7 @@ func (app *DdevApp) ImportFiles(uploadDir, importPath, extPath string) error {
 		uploadDir = app.GetUploadDir()
 	}
 
-	if err := app.dispatchImportFilesAction(uploadDir, importPath, extPath); err != nil {
+	if err := app.dispatchImportFilesAction(uploadDir, importPath, extractPath); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/dotddev_assets/providers/README.txt
+++ b/pkg/ddevapp/dotddev_assets/providers/README.txt
@@ -23,7 +23,7 @@ Each provider recipe is a file named `<provider>.yaml` and consists of several m
 * `db_pull_command`: A script that determines how ddev should pull a database. It's job is to create a gzipped database dump in /var/www/html/.ddev/.downloads/db.sql.gz.
 * `files_pull_command`: A script that determines how ddev can get user-generated files from upstream. Its job is to copy the files from upstream to  /var/www/html/.ddev/.downloads/files.
 * `db_push_command`: A script that determines how ddev should push a database. It's job is to take a  gzipped database dump from /var/www/html/.ddev/.downloads/db.sql.gz and load it on the hosting provider.
-* `files_pull_command`: A script that determines how ddev push user-generated files to upstream. Its job is to copy the files from the project's user-files directory ($DDEV_FILES_DIR) to the correct place on the upstream provider.
+* `files_pull_command`: A script that determines how ddev push user-generated files to upstream. Its job is to copy the files from the project's user-files directories ($DDEV_FILES_DIRS) to the correct places on the upstream provider.
 
 The environment variables provided to custom commands (see https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/#environment-variables-provided) are also available for use in these recipes.
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"fmt"
+
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
@@ -249,13 +250,9 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
 	return nil
 }
 
-// getDrupalUploadDir will return a custom upload dir if defined, returning a default path if not.
-func getDrupalUploadDir(app *DdevApp) string {
-	if app.UploadDir == "" {
-		return "sites/default/files"
-	}
-
-	return app.UploadDir
+// getDrupalUploadDirs will return the default paths.
+func getDrupalUploadDirs(_ *DdevApp) UploadDirs {
+	return UploadDirs{"sites/default/files"}
 }
 
 // Drupal8Hooks adds a d8-specific hooks example for post-import-db
@@ -552,8 +549,8 @@ func appendIncludeToDrupalSettingsFile(siteSettingsPath string, appType string) 
 }
 
 // drupalImportFilesAction defines the Drupal workflow for importing project files.
-func drupalImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetHostUploadDirFullPath()
+func drupalImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
+	destPath := app.calculateHostUploadDirFullPath(uploadDir)
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -251,14 +251,8 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
 }
 
 // getDrupalUploadDirs will return the default paths.
-func getDrupalUploadDirs(app *DdevApp) UploadDirs {
+func getDrupalUploadDirs(_ *DdevApp) UploadDirs {
 	uploadDirs := UploadDirs{"sites/default/files"}
-
-	/* TODO needs some additional config in Drupal settings to work.
-	if app.Docroot != "" {
-		uploadDirs = append(uploadDirs, "../private")
-	}
-	*/
 
 	return uploadDirs
 }

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -251,8 +251,14 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
 }
 
 // getDrupalUploadDirs will return the default paths.
-func getDrupalUploadDirs(_ *DdevApp) UploadDirs {
-	return UploadDirs{"sites/default/files", "../private123"}
+func getDrupalUploadDirs(app *DdevApp) UploadDirs {
+	uploadDirs := UploadDirs{"sites/default/files"}
+
+	if app.Docroot != "" {
+		uploadDirs = append(uploadDirs, "../private")
+	}
+
+	return uploadDirs
 }
 
 // Drupal8Hooks adds a d8-specific hooks example for post-import-db

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -252,7 +252,7 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
 
 // getDrupalUploadDirs will return the default paths.
 func getDrupalUploadDirs(_ *DdevApp) UploadDirs {
-	return UploadDirs{"sites/default/files"}
+	return UploadDirs{"sites/default/files", "../private"}
 }
 
 // Drupal8Hooks adds a d8-specific hooks example for post-import-db

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -254,9 +254,11 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
 func getDrupalUploadDirs(app *DdevApp) UploadDirs {
 	uploadDirs := UploadDirs{"sites/default/files"}
 
+	/* TODO needs some additional config in Drupal settings to work.
 	if app.Docroot != "" {
 		uploadDirs = append(uploadDirs, "../private")
 	}
+	*/
 
 	return uploadDirs
 }

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -252,7 +252,7 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
 
 // getDrupalUploadDirs will return the default paths.
 func getDrupalUploadDirs(_ *DdevApp) UploadDirs {
-	return UploadDirs{"sites/default/files", "../private"}
+	return UploadDirs{"sites/default/files", "../private123"}
 }
 
 // Drupal8Hooks adds a d8-specific hooks example for post-import-db

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -117,6 +117,11 @@ func getMagentoUploadDirs(_ *DdevApp) UploadDirs {
 	return UploadDirs{"media"}
 }
 
+// getMagento2UploadDirs will return the default paths.
+func getMagento2UploadDirs(_ *DdevApp) UploadDirs {
+	return UploadDirs{"pub/media"}
+}
+
 // createMagento2SettingsFile manages creation and modification of app/etc/env.php.
 func createMagento2SettingsFile(app *DdevApp) (string, error) {
 

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -2,13 +2,14 @@ package ddevapp
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/ddev/ddev/pkg/archive"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
-	"os"
-	"path/filepath"
 )
 
 // isMagentoApp returns true if the app is of type magento
@@ -67,8 +68,8 @@ func setMagentoSiteSettingsPaths(app *DdevApp) {
 }
 
 // magentoImportFilesAction defines the magento workflow for importing project files.
-func magentoImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetHostUploadDirFullPath()
+func magentoImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
+	destPath := app.calculateHostUploadDirFullPath(uploadDir)
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {
@@ -111,22 +112,9 @@ func magentoImportFilesAction(app *DdevApp, importPath, extPath string) error {
 	return nil
 }
 
-// getMagentoUploadDir will return a custom upload dir if defined, returning a default path if not.
-func getMagentoUploadDir(app *DdevApp) string {
-	if app.UploadDir == "" {
-		return "media"
-	}
-
-	return app.UploadDir
-}
-
-// getMagento2UploadDir will return a custom upload dir if defined, returning a default path if not.
-func getMagento2UploadDir(app *DdevApp) string {
-	if app.UploadDir == "" {
-		return "media"
-	}
-
-	return app.UploadDir
+// getMagentoUploadDirs will return the default paths.
+func getMagentoUploadDirs(_ *DdevApp) UploadDirs {
+	return UploadDirs{"media"}
 }
 
 // createMagento2SettingsFile manages creation and modification of app/etc/env.php.

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -642,18 +642,14 @@ func (app *DdevApp) GenerateMutagenYml() error {
 		return err
 	}
 
-	uploadDir := ""
-	if app.GetUploadDir() != "" {
-		uploadDir = path.Join(app.Docroot, app.GetUploadDir())
-	}
-
 	templateMap := map[string]interface{}{
 		"SymlinkMode": symlinkMode,
-		"UploadDir":   uploadDir,
+		"UploadDirs":  app.getUploadDirsRelative(),
 	}
+
 	// If no bind mounts, then we can't ignore UploadDir, must sync it
 	if globalconfig.DdevGlobalConfig.NoBindMounts {
-		templateMap["UploadDir"] = ""
+		templateMap["UploadDirs"] = []string{}
 	}
 
 	err = fileutil.TemplateStringToFile(content, templateMap, mutagenYmlPath)
@@ -802,10 +798,11 @@ func GetDefaultMutagenVolumeSignature(_ *DdevApp) string {
 	return fmt.Sprintf("%s-%v", dockerutil.GetDockerHostID(), time.Now().Unix())
 }
 
-// CheckMutagenUploadDir just tells people if they are using mutagen without upload_dir
-func CheckMutagenUploadDir(app *DdevApp) {
-	if app.IsMutagenEnabled() && app.GetUploadDir() == "" {
-		util.Warning("You have mutagen enabled and your '%s' project type doesn't have an upload_dir set.", app.Type)
-		util.Warning("For faster startup and less disk usage,\nset upload_dir to where your user-generated files are stored.")
+// checkMutagenUploadDirs just tells people if they are using mutagen without upload_dir
+func (app *DdevApp) checkMutagenUploadDirs() {
+	if app.IsMutagenEnabled() && !app.IsUploadDirsDisabled() && len(app.GetUploadDirs()) == 0 {
+		util.Warning("You have mutagen enabled and your '%s' project type doesn't have an upload_dirs set.", app.Type)
+		util.Warning("For faster startup and less disk usage, set upload_dirs to where your user-generated files are stored.")
+		util.Warning("If this is intended you can disable this warning by running `ddev config --upload-dirs`.")
 	}
 }

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -801,8 +801,8 @@ func GetDefaultMutagenVolumeSignature(_ *DdevApp) string {
 // checkMutagenUploadDirs just tells people if they are using mutagen without upload_dir
 func (app *DdevApp) checkMutagenUploadDirs() {
 	if app.IsMutagenEnabled() && !app.IsUploadDirsDisabled() && len(app.GetUploadDirs()) == 0 {
-		util.Warning("You have mutagen enabled and your '%s' project type doesn't have an upload_dirs set.", app.Type)
+		util.Warning("You have Mutagen enabled and your '%s' project type doesn't have `upload_dirs` set.", app.Type)
 		util.Warning("For faster startup and less disk usage, set upload_dirs to where your user-generated files are stored.")
-		util.Warning("If this is intended you can disable this warning by running `ddev config --upload-dirs`.")
+		util.Warning("If this is intended you can disable this warning by running `ddev config --upload-dirs=false`.")
 	}
 }

--- a/pkg/ddevapp/mutagen_config_assets/mutagen.yml
+++ b/pkg/ddevapp/mutagen_config_assets/mutagen.yml
@@ -13,26 +13,24 @@ sync:
     stageMode: "neighboring"
     ignore:
       paths:
-      # The top-level .git directory is ignored because where possible it's mounted
-      # into the container with a traditional docker bind-mount
-      - "/.git"
+        # The top-level .git directory is ignored because where possible it's
+        # mounted into the container with a traditional docker bind-mount
+        - "/.git"
+        - "/.tarballs"
+        - "/.ddev/db_snapshots"
+        - "/.ddev/.importdb*"
+        - ".DS_Store"
+        - ".idea"
+        {{- range $uploadDir := .UploadDirs}}
+        - "/{{ $uploadDir }}"
+        {{- end}} {{- /* end range .UploadDirsMap */}}
 
-      - "/.tarballs"
-      - "/.ddev/db_snapshots"
-      - "/.ddev/.importdb*"
-      - ".DS_Store"
-      - ".idea"
-      {{ if .UploadDir }}
-      - "/{{ .UploadDir }}"
-      {{ end }}
-
-      # You can also exclude other directories from mutagen-syncing
-      # For example /var/www/html/var does not need to sync in TYPO3
-      # so you can add:
-      # - "/var"
-      # vcs like .git can be ignored for safety, but then some
-      # composer operations may fail if they use dev versions/git.
-      # vcs: true
+        # You can also exclude other directories from mutagen-syncing
+        # For example /var/www/html/var does not need to sync in TYPO3
+        # so you can add:
+        # - "/var"
+        # vcs like .git can be ignored for safety, but then some
+        # composer operations may fail if they use dev versions/git.
+        # vcs: true
     symlink:
       mode: "{{ .SymlinkMode }}"
-

--- a/pkg/ddevapp/php.go
+++ b/pkg/ddevapp/php.go
@@ -2,11 +2,11 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/archive"
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
+
+	"github.com/ddev/ddev/pkg/archive"
+	"github.com/ddev/ddev/pkg/fileutil"
 )
 
 func phpPostStartAction(app *DdevApp) error {
@@ -18,17 +18,9 @@ func phpPostStartAction(app *DdevApp) error {
 	return nil
 }
 
-// getPHPUploadDir will return a custom upload dir if defined
-func getPHPUploadDir(app *DdevApp) string {
-	return app.UploadDir
-}
-
 // phpImportFilesAction defines the workflow for importing project files.
-func phpImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	if app.UploadDir == "" {
-		return errors.Errorf("No upload_dir is set for this (php-generic) project")
-	}
-	destPath := app.GetHostUploadDirFullPath()
+func phpImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
+	destPath := app.calculateHostUploadDirFullPath(uploadDir)
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -2,15 +2,14 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/output"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
-
 	"gopkg.in/yaml.v3"
 )
 
@@ -394,7 +393,7 @@ func (p *Provider) importDatabaseBackup(fileLocation []string, importPath []stri
 func (p *Provider) doFilesImport(fileLocation string, importPath string) error {
 	var err error
 	if p.FilesImportCommand.Command == "" {
-		err = p.app.ImportFiles(fileLocation, importPath)
+		err = p.app.ImportFiles("", fileLocation, importPath)
 	} else {
 		s := p.FilesImportCommand.Service
 		if s == "" {

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -2,10 +2,11 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/archive"
-	"github.com/ddev/ddev/pkg/fileutil"
 	"os"
 	"path/filepath"
+
+	"github.com/ddev/ddev/pkg/archive"
+	"github.com/ddev/ddev/pkg/fileutil"
 )
 
 // isShopware6App returns true if the app is of type shopware6
@@ -23,8 +24,8 @@ func setShopware6SiteSettingsPaths(app *DdevApp) {
 }
 
 // shopware6ImportFilesAction defines the shopware6 workflow for importing user-generated files.
-func shopware6ImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetHostUploadDirFullPath()
+func shopware6ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
+	destPath := app.calculateHostUploadDirFullPath(uploadDir)
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {
@@ -67,14 +68,9 @@ func shopware6ImportFilesAction(app *DdevApp, importPath, extPath string) error 
 	return nil
 }
 
-// getShopwareUploadDir will return a custom upload dir if defined,
-// returning a default path if not; this is relative to the docroot
-func getShopwareUploadDir(app *DdevApp) string {
-	if app.UploadDir == "" {
-		return "media"
-	}
-
-	return app.UploadDir
+// getShopwareUploadDirs will return the default paths.
+func getShopwareUploadDirs(_ *DdevApp) UploadDirs {
+	return UploadDirs{"media"}
 }
 
 // shopware6PostStartAction checks to see if the .env file is set up

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -79,10 +79,17 @@ const ConfigInstructions = `
 # would provide http and https URLs for "example.com" and "sub1.example.com"
 # Please take care with this because it can cause great confusion.
 
-# upload_dir: custom/upload/dir
-# would set the destination path for ddev import-files to <docroot>/custom/upload/dir
+# upload_dirs: "custom/upload/dir"
+#    
+# upload_dirs:
+#   - custom/upload/dir1
+#   - custom/upload/dir2
+#
+# upload_dirs: false
+#
+# would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
 # When mutagen is enabled this path is bind-mounted so that all the files
-# in the upload_dir don't have to be synced into mutagen
+# in the upload_dirs don't have to be synced into mutagen.
 
 # working_dir:
 #   web: /var/www/html

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -82,8 +82,8 @@ const ConfigInstructions = `
 # upload_dirs: "custom/upload/dir"
 #    
 # upload_dirs:
-#   - custom/upload/dir1
-#   - custom/upload/dir2
+#   - custom/upload/dir
+#   - ../private
 #
 # upload_dirs: false
 #

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -107,13 +107,9 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 	return nil
 }
 
-// getTypo3UploadDir will return a custom upload dir if defined, returning a default path if not.
-func getTypo3UploadDir(app *DdevApp) string {
-	if app.UploadDir == "" {
-		return "fileadmin"
-	}
-
-	return app.UploadDir
+// getTypo3UploadDirs will return the default paths.
+func getTypo3UploadDirs(_ *DdevApp) UploadDirs {
+	return UploadDirs{"fileadmin"}
 }
 
 // Typo3Hooks adds a TYPO3-specific hooks example for post-import-db
@@ -170,8 +166,8 @@ func isTypo3App(app *DdevApp) bool {
 
 // typo3ImportFilesAction defines the TYPO3 workflow for importing project files.
 // The TYPO3 import-files workflow is currently identical to the Drupal workflow.
-func typo3ImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetHostUploadDirFullPath()
+func typo3ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
+	destPath := app.calculateHostUploadDirFullPath(uploadDir)
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -14,7 +14,17 @@ type UploadDirs []string
 
 // addUploadDir adds a new upload dir if it does not already exist in the list.
 func (app *DdevApp) addUploadDir(uploadDir string) {
-	for _, existingUploadDir := range app.GetUploadDirs() {
+	err := app.validateUploadDirs()
+	if err != nil {
+		// Should never happen
+		panic(err)
+	}
+
+	if app.UploadDirs == false {
+		app.UploadDirs = UploadDirs{}
+	}
+
+	for _, existingUploadDir := range app.UploadDirs.(UploadDirs) {
 		if uploadDir == existingUploadDir {
 			return
 		}
@@ -51,7 +61,7 @@ func (app *DdevApp) GetUploadDirs() UploadDirs {
 		return UploadDirs{}
 	}
 
-	if app.UploadDirs != false && app.UploadDirs != nil && len(app.UploadDirs.(UploadDirs)) > 0 {
+	if len(app.UploadDirs.(UploadDirs)) > 0 {
 		return app.UploadDirs.(UploadDirs)
 	}
 

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -42,8 +42,13 @@ func (app *DdevApp) GetUploadDirs() UploadDirs {
 	}
 
 	if app.UploadDirDeprecated != "" {
-		app.addUploadDir(app.UploadDirDeprecated)
+		uploadDirDeprecated := app.UploadDirDeprecated
 		app.UploadDirDeprecated = ""
+		app.addUploadDir(uploadDirDeprecated)
+	}
+
+	if app.UploadDirs == false {
+		return UploadDirs{}
 	}
 
 	if app.UploadDirs != false && app.UploadDirs != nil && len(app.UploadDirs.(UploadDirs)) > 0 {

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -1,0 +1,214 @@
+package ddevapp
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"reflect"
+
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/util"
+)
+
+type UploadDirs []string
+
+// addUploadDir adds a new upload dir if it does not already exist in the list.
+func (app *DdevApp) addUploadDir(uploadDir string) {
+	for _, existingUploadDir := range app.GetUploadDirs() {
+		if uploadDir == existingUploadDir {
+			return
+		}
+	}
+
+	app.UploadDirs = append(app.UploadDirs.(UploadDirs), uploadDir)
+}
+
+// GetUploadDir returns the first upload (public files) directory.
+func (app *DdevApp) GetUploadDir() string {
+	uploadDirs := app.GetUploadDirs()
+	if len(uploadDirs) > 0 {
+		return uploadDirs[0]
+	}
+
+	return ""
+}
+
+// GetUploadDirs returns the upload (public files) directories.
+func (app *DdevApp) GetUploadDirs() UploadDirs {
+	err := app.validateUploadDirs()
+	if err != nil {
+		// Should never happen
+		panic(err)
+	}
+
+	if app.UploadDirDeprecated != "" {
+		app.addUploadDir(app.UploadDirDeprecated)
+		app.UploadDirDeprecated = ""
+	}
+
+	if app.UploadDirs != false && app.UploadDirs != nil && len(app.UploadDirs.(UploadDirs)) > 0 {
+		return app.UploadDirs.(UploadDirs)
+	}
+
+	appFuncs, ok := appTypeMatrix[app.GetType()]
+	if ok && appFuncs.uploadDirs != nil {
+		return appFuncs.uploadDirs(app)
+	}
+
+	return UploadDirs{}
+}
+
+// IsUploadDirsDisabled returns true if UploadDirs is disabled by the user.
+func (app *DdevApp) IsUploadDirsDisabled() bool {
+	return app.UploadDirs == false
+}
+
+// calculateHostUploadDirFullPath returns the full path to the upload directory
+// on the host or "" if there is none.
+func (app *DdevApp) calculateHostUploadDirFullPath(uploadDir string) string {
+	if uploadDir != "" {
+		return path.Join(app.AppRoot, app.Docroot, uploadDir)
+	}
+
+	return ""
+}
+
+// GetHostUploadDirFullPath returns the full path to the first upload directory on the
+// host or "" if there is none.
+func (app *DdevApp) GetHostUploadDirFullPath() string {
+	uploadDirs := app.GetUploadDirs()
+	if len(uploadDirs) > 0 {
+		return app.calculateHostUploadDirFullPath(uploadDirs[0])
+	}
+
+	return ""
+}
+
+// calculateContainerUploadDirFullPath returns the full path to the upload
+// directory in container or "" if there is none.
+func (app *DdevApp) calculateContainerUploadDirFullPath(uploadDir string) string {
+	if uploadDir != "" {
+		return path.Join("/var/www/html", app.Docroot, uploadDir)
+	}
+
+	return ""
+}
+
+// getContainerUploadDir returns the full path to the first upload
+// directory in container or "" if there is none.
+func (app *DdevApp) getContainerUploadDir() string {
+	uploadDirs := app.GetUploadDirs()
+	if len(uploadDirs) > 0 {
+		return app.calculateContainerUploadDirFullPath(uploadDirs[0])
+	}
+
+	return ""
+}
+
+// getContainerUploadDirs returns a slice of the full path to the upload
+// directories in container.
+func (app *DdevApp) getContainerUploadDirs() []string {
+	uploadDirs := app.GetUploadDirs()
+	containerUploadDirs := make([]string, 0, len(uploadDirs))
+
+	for _, uploadDir := range uploadDirs {
+		containerUploadDirs = append(containerUploadDirs, app.calculateContainerUploadDirFullPath(uploadDir))
+	}
+
+	return containerUploadDirs
+}
+
+// getUploadDirsHostContainerMapping returns a slice containing host / container
+// mapping separated by ":" to be used within docker-compose config.
+func (app *DdevApp) getUploadDirsHostContainerMapping() []string {
+	uploadDirs := app.GetUploadDirs()
+	uploadDirsMapping := make([]string, 0, len(uploadDirs))
+
+	for _, uploadDir := range uploadDirs {
+		hostUploadDir := app.calculateHostUploadDirFullPath(uploadDir)
+
+		// Exclude non existing dirs
+		if !fileutil.FileExists(hostUploadDir) {
+			continue
+		}
+
+		uploadDirsMapping = append(uploadDirsMapping, fmt.Sprintf(
+			"%s:%s",
+			hostUploadDir,
+			app.calculateContainerUploadDirFullPath(uploadDir),
+		))
+	}
+
+	return uploadDirsMapping
+}
+
+// getUploadDirsRelative returns a slice containing upload dirs to be used with
+// Mutagen config.
+func (app *DdevApp) getUploadDirsRelative() []string {
+	uploadDirs := app.GetUploadDirs()
+	uploadDirsMap := make([]string, 0 /*, len(uploadDirs)*/)
+
+	for _, uploadDir := range uploadDirs {
+		hostUploadDir := app.calculateHostUploadDirFullPath(uploadDir)
+
+		// Exclude non existing dirs
+		if !fileutil.FileExists(hostUploadDir) {
+			continue
+		}
+
+		uploadDirsMap = append(uploadDirsMap, path.Join(app.Docroot, uploadDir))
+	}
+
+	return uploadDirsMap
+}
+
+// createUploadDirsIfNecessary creates the upload dirs if it doesn't exist, so we can properly
+// set up bind-mounts when doing mutagen.
+// There is no need to do it if mutagen is not enabled, and
+// we'll just respect a symlink if it exists, and the user has to figure out the right
+// thing to do with mutagen.
+func (app *DdevApp) createUploadDirsIfNecessary() {
+	for _, target := range app.GetUploadDirs() {
+		if hostDir := app.calculateHostUploadDirFullPath(target); hostDir != "" && app.IsMutagenEnabled() && !fileutil.FileExists(hostDir) {
+			err := os.MkdirAll(hostDir, 0755)
+			if err != nil {
+				util.Warning("unable to create upload directory %s: %v", hostDir, err)
+			}
+		}
+	}
+}
+
+// validateUploadDirs validates and converts UploadDirs to a app.UploadDirs
+// interface or if disabled to bool false and returns nil if succeeded or an
+// error if not.
+func (app *DdevApp) validateUploadDirs() error {
+	if _, ok := app.UploadDirs.(UploadDirs); ok {
+		// Conversion was already done, nothing to do.
+		return nil
+	}
+
+	typeOfUploadDirs := reflect.TypeOf(app.UploadDirs)
+	switch {
+	case typeOfUploadDirs == nil:
+		// Config option is not set.
+		app.UploadDirs = UploadDirs{}
+	case typeOfUploadDirs.Kind() == reflect.Bool && app.UploadDirs == false:
+		// bool false is fine too, means users has disabled it.
+	case typeOfUploadDirs.Kind() == reflect.String:
+		// User provided a string, convert it to UploadDirs.
+		app.UploadDirs = UploadDirs{app.UploadDirs.(string)}
+	case typeOfUploadDirs.Kind() == reflect.Slice:
+		// User provided a list of strings, convert it to UploadDirs.
+		uploadDirsRaw := app.UploadDirs.([]any)
+		uploadDirs := make(UploadDirs, 0, len(uploadDirsRaw))
+		for _, v := range uploadDirsRaw {
+			uploadDirs = append(uploadDirs, v.(string))
+		}
+		app.UploadDirs = uploadDirs
+	default:
+		// Provided value is not valid, user has to fix it.
+		return fmt.Errorf("`upload_dirs` must be a string, a list of strings, or false but `%v` given", app.UploadDirs)
+	}
+
+	return nil
+}

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -2,23 +2,22 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/output"
-	docker "github.com/fsouza/go-dockerclient"
-	"github.com/jedib0t/go-pretty/v6/table"
+	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"os"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/jedib0t/go-pretty/v6/table"
 )
 
 // GetActiveProjects returns an array of ddev projects
@@ -263,7 +262,7 @@ func CreateGitIgnore(targetDir string, ignores ...string) error {
 
 // isTar determines whether the object at the filepath is a .tar archive.
 func isTar(filepath string) bool {
-	tarSuffixes := []string{"tar", "tar.gz", "tar.bz2", "tar.xz", "tgz", "tar.xz", "tar.bz2"}
+	tarSuffixes := []string{".tar", ".tar.gz", ".tar.bz2", ".tar.xz", ".tgz"}
 	for _, suffix := range tarSuffixes {
 		if strings.HasSuffix(filepath, suffix) {
 			return true
@@ -275,11 +274,7 @@ func isTar(filepath string) bool {
 
 // isZip determines if the object at hte filepath is a .zip.
 func isZip(filepath string) bool {
-	if strings.HasSuffix(filepath, ".zip") {
-		return true
-	}
-
-	return false
+	return strings.HasSuffix(filepath, ".zip")
 }
 
 // GetErrLogsFromApp is used to do app.Logs on an app after an error has

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -2,14 +2,15 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/archive"
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/util"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/ddev/ddev/pkg/archive"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/util"
 )
 
 // WordpressConfig encapsulates all the configurations for a WordPress site.
@@ -78,13 +79,9 @@ func getWordpressHooks() []byte {
 	return []byte(wordPressHooks)
 }
 
-// getWordpressUploadDir will return a custom upload dir if defined, returning a default path if not.
-func getWordpressUploadDir(app *DdevApp) string {
-	if app.UploadDir == "" {
-		return "wp-content/uploads"
-	}
-
-	return app.UploadDir
+// getWordpressUploadDirs will return the default paths.
+func getWordpressUploadDirs(_ *DdevApp) UploadDirs {
+	return UploadDirs{"wp-content/uploads"}
 }
 
 const wordpressConfigInstructions = `
@@ -264,8 +261,8 @@ func isWordpressApp(app *DdevApp) bool {
 
 // wordpressImportFilesAction defines the Wordpress workflow for importing project files.
 // The Wordpress workflow is currently identical to the Drupal import-files workflow.
-func wordpressImportFilesAction(app *DdevApp, importPath, extPath string) error {
-	destPath := app.GetHostUploadDirFullPath()
+func wordpressImportFilesAction(app *DdevApp, target, importPath, extPath string) error {
+	destPath := app.calculateHostUploadDirFullPath(target)
 
 	// parent of destination dir should exist
 	if !fileutil.FileExists(filepath.Dir(destPath)) {

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -2,32 +2,29 @@ package testcommon
 
 import (
 	"crypto/tls"
-	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/output"
-	"github.com/docker/docker/pkg/homedir"
-	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"time"
-
-	log "github.com/sirupsen/logrus"
-
-	"path"
-
 	"fmt"
-
-	"github.com/ddev/ddev/pkg/archive"
-	"github.com/ddev/ddev/pkg/dockerutil"
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/util"
-	"github.com/pkg/errors"
-	asrt "github.com/stretchr/testify/assert"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
+
+	"github.com/ddev/ddev/pkg/archive"
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/docker/docker/pkg/homedir"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	asrt "github.com/stretchr/testify/assert"
 )
 
 // URIWithExpect pairs a URI like "/readme.html" with some substring content "should be found in URI"
@@ -71,8 +68,8 @@ type TestSite struct {
 	Safe200URIWithExpectation URIWithExpect
 	// DynamicURI provides a dynamic (after db load) URI with contents we can expect.
 	DynamicURI URIWithExpect
-	// UploadDir overrides the dir used for upload_dir
-	UploadDir string
+	// UploadDirs overrides the dirs used for upload_dirs
+	UploadDirs ddevapp.UploadDirs
 	// FilesImageURI is URI to a file loaded by import-files that is a jpg.
 	FilesImageURI string
 	// FullSiteArchiveExtPath is the path that should be extracted from inside an archive when
@@ -122,7 +119,7 @@ func (site *TestSite) Prepare() error {
 	// ignore app name defined in config file if present.
 	app.Name = site.Name
 	app.Docroot = site.Docroot
-	app.UploadDir = site.UploadDir
+	app.UploadDirs = site.UploadDirs
 	app.Type = app.DetectAppType()
 	if app.Type != site.Type {
 		return errors.Errorf("Detected apptype (%s) does not match provided apptype (%s)", app.Type, site.Type)


### PR DESCRIPTION
## The Issue

- #4190
- #4796
- #5047 

## How This PR Solves The Issue

A new config property `upload_dirs` is introduced to hold more than one upload dir. Existing config `upload_dir` is migrated to the new config and removed from the projects afterwards. For project types which do not predefine a default upload dir like `php` the warning about the missing upload dir can be disabled by setting `upload_dirs: false` which is also mentioned in the warning message.

## Manual Testing Instructions

- [x] `upload_dir` is migrated to `upload_dirs`
- [x] multiple dirs can be set
- [x] `import-files` works correctly when importing in a upload dir using the `--target` flag
- [x] configuration with `ddev config` works properly, using `--upload-dirs` and `--uplod-dir` flags

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- #5047

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5005"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

