### PR TITLE
Implement DdevGlobalConfig initialization in one place

### DIFF
--- a/cmd/ddev/cmd/a.go
+++ b/cmd/ddev/cmd/a.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/util"
 	"os"
 )
 
@@ -12,11 +11,7 @@ import (
 // uninitialized data
 
 func init() {
-	err := globalconfig.ReadGlobalConfig()
-	if err != nil {
-		util.Failed("unable to read global config: %v", err)
-	}
-	globalconfig.GetCAROOT()
+	globalconfig.EnsureGlobalConfig()
 	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
 	// GetDockerClient should be called early to get DOCKER_HOST set
 	_ = dockerutil.GetDockerClient()

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
@@ -52,19 +53,19 @@ func TestCmdGlobalConfig(t *testing.T) {
 	// Look at initial config
 	args := []string{"config", "global"}
 	out, err := exec.RunCommand(DdevBin, args)
-	assert.NoError(err)
-	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[]\nweb-environment=[]\nmutagen-enabled=false\nnfs-mount-enabled=false\nrouter-bind-all-interfaces=false\ninternet-detection-timeout-ms=3000\ndisable-http2=false\nuse-letsencrypt=false\nletsencrypt-email=\ntable-style=default\nsimple-formatting=false\nauto-restart-containers=false\nuse-hardened-images=false\nfail-on-hook-fail=false\nrequired-docker-compose-version=\nuse-docker-compose-from-path=false\nproject-tld=\nxdebug-ide-location=")
-	assert.Contains(string(out), "wsl2-no-windows-hosts-mgt=false\nrouter-http-port=80\nrouter-https-port=443")
+	require.NoError(t, err)
+	require.Contains(t, string(out), fmt.Sprintf("Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[]\nweb-environment=[]\nmutagen-enabled=false\nnfs-mount-enabled=false\nrouter-bind-all-interfaces=false\ninternet-detection-timeout-ms=3000\ndisable-http2=false\nuse-letsencrypt=false\nletsencrypt-email=\ntable-style=default\nsimple-formatting=false\nauto-restart-containers=false\nuse-hardened-images=false\nfail-on-hook-fail=false\nrequired-docker-compose-version=%s\nuse-docker-compose-from-path=false\nproject-tld=\nxdebug-ide-location=", globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion))
+	require.Contains(t, string(out), "wsl2-no-windows-hosts-mgt=false\nrouter-http-port=80\nrouter-https-port=443")
 
 	// Update a config
 	// Don't include no-bind-mounts because global testing
 	// will turn it on and break this
 	args = []string{"config", "global", "--project-tld=ddev.test", "--instrumentation-opt-in=false", "--omit-containers=dba,ddev-ssh-agent", "--mutagen-enabled=true", "--nfs-mount-enabled=true", "--router-bind-all-interfaces=true", "--internet-detection-timeout-ms=850", "--use-letsencrypt", "--letsencrypt-email=nobody@example.com", "--table-style=bright", "--simple-formatting=true", "--auto-restart-containers=true", "--use-hardened-images=true", "--fail-on-hook-fail=true", `--web-environment="SOMEENV=some+val"`, `--xdebug-ide-location=container`, `--router-http-port=8081`, `--router-https-port=8882`}
 	out, err = exec.RunCommand(DdevBin, args)
-	assert.NoError(err)
-	assert.Contains(string(out), "Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[dba,ddev-ssh-agent]\nweb-environment=[\"SOMEENV=some+val\"]\nmutagen-enabled=true\nnfs-mount-enabled=true\nrouter-bind-all-interfaces=true\ninternet-detection-timeout-ms=850\ndisable-http2=false\nuse-letsencrypt=true\nletsencrypt-email=nobody@example.com\ntable-style=bright\nsimple-formatting=true\nauto-restart-containers=true\nuse-hardened-images=true\nfail-on-hook-fail=true\nrequired-docker-compose-version=\nuse-docker-compose-from-path=false")
-	assert.Contains(string(out), "xdebug-ide-location=container")
-	assert.Contains(string(out), "router-http-port=8081\nrouter-https-port=8882")
+	require.NoError(t, err)
+	assert.Contains(string(out), fmt.Sprintf("Global configuration:\ninstrumentation-opt-in=false\nomit-containers=[dba,ddev-ssh-agent]\nweb-environment=[\"SOMEENV=some+val\"]\nmutagen-enabled=true\nnfs-mount-enabled=true\nrouter-bind-all-interfaces=true\ninternet-detection-timeout-ms=850\ndisable-http2=false\nuse-letsencrypt=true\nletsencrypt-email=nobody@example.com\ntable-style=bright\nsimple-formatting=true\nauto-restart-containers=true\nuse-hardened-images=true\nfail-on-hook-fail=true\nrequired-docker-compose-version=%s\nuse-docker-compose-from-path=false", globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion))
+	require.Contains(t, string(out), "xdebug-ide-location=container")
+	require.Contains(t, string(out), "router-http-port=8081\nrouter-https-port=8882")
 
 	err = globalconfig.ReadGlobalConfig()
 	assert.NoError(err)

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/stretchr/testify/require"
 	"runtime"
 	"strings"
@@ -55,6 +56,12 @@ func TestDescribeBadArgs(t *testing.T) {
 func TestCmdDescribe(t *testing.T) {
 	assert := asrt.New(t)
 
+	out, err := exec.RunHostCommand(DdevBin, "config", "global", "--simple-formatting=false", "--table-style=default")
+	require.NoError(t, err, "ddev config global failed with output: '%s'", out)
+	t.Logf("ddev config global output: '%s'", out)
+	globalconfig.EnsureGlobalConfig()
+
+	require.NoError(t, err, "ddev config global failed with output: '%s'", out)
 	for _, v := range TestSites {
 		app, err := ddevapp.NewApp(v.Dir, false)
 		require.NoError(t, err)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -25,6 +25,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	globalconfig.EnsureGlobalConfig()
+}
+
 var (
 	// DdevBin is the full path to the ddev binary
 	DdevBin   = "ddev"

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -89,8 +89,6 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	}
 	app.FailOnHookFail = nodeps.FailOnHookFailDefault
 	app.FailOnHookFailGlobal = globalconfig.DdevGlobalConfig.FailOnHookFailGlobal
-	app.RouterHTTPPortGlobal = globalconfig.DdevGlobalConfig.RouterHTTPPort
-	app.RouterHTTPSPortGlobal = globalconfig.DdevGlobalConfig.RouterHTTPSPort
 	app.PHPMyAdminPort = nodeps.DdevDefaultPHPMyAdminPort
 	app.PHPMyAdminHTTPSPort = nodeps.DdevDefaultPHPMyAdminHTTPSPort
 	app.MailhogPort = nodeps.DdevDefaultMailhogPort

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -83,9 +83,7 @@ type DdevApp struct {
 	DBImage               string                `yaml:"dbimage,omitempty"`
 	DBAImage              string                `yaml:"dbaimage,omitempty"`
 	RouterHTTPPort        string                `yaml:"router_http_port,omitempty"`
-	RouterHTTPPortGlobal  string                `yaml:"-"`
 	RouterHTTPSPort       string                `yaml:"router_https_port,omitempty"`
-	RouterHTTPSPortGlobal string                `yaml:"-"`
 	XdebugEnabled         bool                  `yaml:"xdebug_enabled"`
 	NoProjectMount        bool                  `yaml:"no_project_mount,omitempty"`
 	AdditionalHostnames   []string              `yaml:"additional_hostnames"`
@@ -450,13 +448,9 @@ func (app *DdevApp) GetWebserverType() string {
 }
 
 // GetRouterHTTPPort returns app's router http port
+// Start with global config and then override with project config
 func (app *DdevApp) GetRouterHTTPPort() string {
-	port := app.RouterHTTPPortGlobal
-	// TODO: This default setting should be done in creation of the
-	// globalconfig.DdevGlobalCOnfig
-	if port == "" {
-		port = nodeps.DdevDefaultRouterHTTPPort
-	}
+	port := globalconfig.DdevGlobalConfig.RouterHTTPPort
 	if app.RouterHTTPPort != "" {
 		port = app.RouterHTTPPort
 	}
@@ -464,13 +458,9 @@ func (app *DdevApp) GetRouterHTTPPort() string {
 }
 
 // GetRouterHTTPSPort returns app's router https port
+// Start with global config and then override with project config
 func (app *DdevApp) GetRouterHTTPSPort() string {
-	port := app.RouterHTTPSPortGlobal
-	// TODO: This default setting should be done in creation of the
-	// globalconfig.DdevGlobalCOnfig
-	if port == "" {
-		port = nodeps.DdevDefaultRouterHTTPSPort
-	}
+	port := globalconfig.DdevGlobalConfig.RouterHTTPSPort
 	if app.RouterHTTPSPort != "" {
 		port = app.RouterHTTPSPort
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -326,6 +326,7 @@ func init() {
 	if os.Getenv("DDEV_BINARY_FULLPATH") != "" {
 		DdevBin = os.Getenv("DDEV_BINARY_FULLPATH")
 	}
+	globalconfig.EnsureGlobalConfig()
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -29,7 +29,7 @@ func TestDockerComposeDownload(t *testing.T) {
 	tmpHome := testcommon.CreateTmpDir(t.Name() + "tempHome")
 	// Unusual case where we need to alter the RequiredDockerComposeVersion
 	// just so we can make sure the one in PATH is different.
-	origRequiredComposeVersion := globalconfig.RequiredDockerComposeVersion
+	origRequiredComposeVersion := globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion
 
 	// Change the homedir temporarily
 	t.Setenv("HOME", tmpHome)
@@ -43,7 +43,7 @@ func TestDockerComposeDownload(t *testing.T) {
 
 		err = os.RemoveAll(tmpHome)
 		assert.NoError(err)
-		globalconfig.RequiredDockerComposeVersion = origRequiredComposeVersion
+		globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = origRequiredComposeVersion
 		// Reset the cached DockerComposeVersion so it doesn't come into play again
 		globalconfig.DockerComposeVersion = ""
 		globalconfig.DdevGlobalConfig.UseDockerComposeFromPath = false
@@ -53,8 +53,8 @@ func TestDockerComposeDownload(t *testing.T) {
 	globalconfig.DockerComposeVersion = ""
 
 	downloaded, err := dockerutil.DownloadDockerComposeIfNeeded()
-	assert.NoError(err)
-	assert.True(downloaded)
+	require.NoError(t, err)
+	require.True(t, downloaded)
 	v, err := dockerutil.GetLiveDockerComposeVersion()
 	assert.NoError(err)
 	assert.Equal(globalconfig.GetRequiredDockerComposeVersion(), v)
@@ -64,7 +64,7 @@ func TestDockerComposeDownload(t *testing.T) {
 	assert.NoError(err)
 	assert.False(downloaded)
 
-	for _, v := range []string{"v2.5.1", "v2.8.0"} {
+	for _, v := range []string{"v2.18.0"} {
 		globalconfig.DockerComposeVersion = ""
 		globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = v
 		downloaded, err = dockerutil.DownloadDockerComposeIfNeeded()
@@ -81,7 +81,7 @@ func TestDockerComposeDownload(t *testing.T) {
 	// Test using docker-compose from path.
 	// Make sure our Required/Expected DockerComposeVersion is not something we'd find on the machine
 	globalconfig.DockerComposeVersion = ""
-	globalconfig.RequiredDockerComposeVersion = "v2.5.1"
+	globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = "v2.5.1"
 	globalconfig.DdevGlobalConfig.UseDockerComposeFromPath = true
 	activeVersion, err := dockerutil.GetLiveDockerComposeVersion()
 	assert.NoError(err)

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -27,12 +27,15 @@ import (
 
 var testContainerName = "TestDockerUtils"
 
+func init() {
+	globalconfig.EnsureGlobalConfig()
+	EnsureDdevNetwork()
+}
+
 func TestMain(m *testing.M) { os.Exit(testMain(m)) }
 
 func testMain(m *testing.M) int {
 	output.LogSetUp()
-
-	EnsureDdevNetwork()
 
 	_ = os.Setenv("DDEV_NONINTERACTIVE", "true")
 	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
@@ -344,7 +347,7 @@ func TestCheckCompose(t *testing.T) {
 		require.NoError(t, err)
 		ddevVersion, err := exec.RunHostCommand(DdevBin, "version")
 		require.NoError(t, err)
-		assert.NoError(composeErr, "RequiredDockerComposeVersion=%s global config=%s ddevVersion=%s", globalconfig.RequiredDockerComposeVersion, out, ddevVersion)
+		assert.NoError(composeErr, "RequiredDockerComposeVersion=%s global config=%s ddevVersion=%s", globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion, out, ddevVersion)
 	}
 }
 

--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -18,6 +18,10 @@ import (
 	"time"
 )
 
+func init() {
+	globalconfig.EnsureGlobalConfig()
+}
+
 // TestGetFreePort checks GetFreePort() to make sure it respects
 // ports reserved in DdevGlobalConfig.UsedHostPorts
 // and that the port can actually be bound.

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -15,6 +15,7 @@ const (
 )
 
 const DdevGithubOrg = "ddev"
+const RequiredDockerComposeVersionDefault = "v2.18.1"
 
 // ValidOmitContainers is the valid omit's that can be done in for a project
 var ValidOmitContainers = map[string]bool{

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -17,6 +17,11 @@ import (
 )
 
 var DdevBin = "ddev"
+
+func init() {
+	globalconfig.EnsureGlobalConfig()
+}
+
 var TestSites = []TestSite{
 	{
 		SourceURL:                     "https://wordpress.org/wordpress-5.8.2.tar.gz",


### PR DESCRIPTION
## The Issue

@gilbertsoft pointed out elsewhere that globalconfig.DdevGlobalConfig initialization should be encapsulated in a New() function. 

## How This PR Solves The Issue

Do it and work it all out. 

This one ends up being a pre-requisite for some other PRs, especially 
* https://github.com/ddev/ddev/pull/4983
* https://github.com/ddev/ddev/pull/5006

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5007"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

