### PR TITLE
[tests only] Fix TestDdevFullSiteSetup flask test

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -264,8 +264,8 @@ var (
 		// https://github.com/greyli/sayhello - no database download required
 		{
 			Name:                          "TestPkgPython",
-			SourceURL:                     "https://github.com/ddev/test-flask-sayhello/archive/refs/tags/v1.0.0.tar.gz",
-			ArchiveInternalExtractionPath: "test-flask-sayhello-1.0.0/",
+			SourceURL:                     "https://github.com/ddev/test-flask-sayhello/archive/refs/tags/v1.0.1.tar.gz",
+			ArchiveInternalExtractionPath: "test-flask-sayhello-1.0.1/",
 			DBTarURL:                      "",
 			FullSiteTarballURL:            "",
 			PretestCmd:                    "ddev exec flask forge",


### PR DESCRIPTION
## The Issue

@gilbertsoft debugged the routine failures in TestDdevFullSiteSetup and found 
* https://github.com/ddev/test-flask-sayhello/pull/1

* This moves to https://github.com/ddev/test-flask-sayhello/releases/tag/v1.0.1, which includes that change.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5008"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

