### PR TITLE
fix: avoid `type: php` to detected project type but instead show a warning, fixes #4403, fixes #1919

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -160,9 +160,6 @@ func handleConfigRun(cmd *cobra.Command, args []string) {
 	err = app.ProcessHooks("pre-config")
 	if err != nil {
 		util.Failed(err.Error())
-	}
-
-	if err != nil {
 		util.Failed("Failed to process hook 'pre-config'")
 	}
 

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -417,22 +417,26 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	}
 
 	switch {
-	case (app.Type == "" || app.Type == nodeps.AppTypePHP) && (projectTypeArg == "" || projectTypeArg == detectedApptype): // Found an app, matches passed-in or no apptype passed
-		projectTypeArg = detectedApptype
+	case projectTypeArg != "" && detectedApptype == nodeps.AppTypePHP: // apptype was passed, but we found no app at all
 		app.Type = projectTypeArg
-		if app.Type == nodeps.AppTypePHP {
-			util.Success("Configuring unrecognized codebase as project type 'php' at %s", fullPath)
-		} else {
-			util.Success("Configuring a %s codebase with docroot '%s' at %s", detectedApptype, app.Docroot, fullPath)
-		}
-	case projectTypeArg != "": // apptype was passed, but we found no app at all
-		app.Type = projectTypeArg
-		util.Warning("You have specified a project type of %s but no project of that type is found in %s", projectTypeArg, fullPath)
+		util.Warning("You have specified a project type of '%s' but no project of that type is found in %s", projectTypeArg, fullPath)
 	case projectTypeArg != "" && detectedApptype != projectTypeArg: // apptype was passed, app was found, but not the same type
 		app.Type = projectTypeArg
-		util.Warning("You have specified a project type of %s but a project of type %s was discovered in %s", projectTypeArg, detectedApptype, fullPath)
-	case app.Type != "" && detectedApptype != app.Type: // apptype was not passed, but we found an app of a different type
-		util.Warning("A project of type %s was found in %s, but the project is configured with type=%s", detectedApptype, fullPath, app.Type)
+		util.Warning("You have specified a project type of '%s' but a project of type '%s' was discovered in %s", projectTypeArg, detectedApptype, fullPath)
+	case app.Type != nodeps.AppTypeNone && projectTypeArg == "" && detectedApptype != app.Type: // apptype was not passed, but we found an app of a different type
+		util.Warning("A project of type '%s' was found in %s, but the project is configured with type '%s'", detectedApptype, fullPath, app.Type)
+	default:
+		if projectTypeArg == "" {
+			projectTypeArg = detectedApptype
+		}
+
+		app.Type = projectTypeArg
+
+		if detectedApptype == nodeps.AppTypePHP {
+			util.Success("Configuring unrecognized codebase as project of type '%s' at %s", app.Type, fullPath)
+		} else {
+			util.Success("Configuring a '%s' codebase with docroot '%s' at %s", detectedApptype, app.Docroot, fullPath)
+		}
 	}
 
 	// App overrides are done after app type is detected, but

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -73,7 +73,7 @@ func TestConfigDescribeLocation(t *testing.T) {
 	})
 	out, err := exec.RunHostCommand(DdevBin, "config", "--docroot=.", "--project-name="+t.Name())
 	assert.NoError(err)
-	assert.Contains(string(out), "Configuring unrecognized codebase as project type 'php'")
+	assert.Contains(string(out), "Configuring unrecognized codebase as project of type 'php'")
 
 	// Now see if we can detect it
 	out, err = exec.RunHostCommand(DdevBin, "config", "--show-config-location")
@@ -127,7 +127,7 @@ func TestConfigWithSitenameFlagDetectsDocroot(t *testing.T) {
 	defer func() {
 		_, _ = exec.RunCommand(DdevBin, []string{"delete", "-Oy", "config-with-sitename"})
 	}()
-	assert.Contains(string(out), "Configuring a drupal6 codebase with docroot", nodeps.AppTypeDrupal6)
+	assert.Contains(string(out), "Configuring a 'drupal6' codebase with docroot", nodeps.AppTypeDrupal6)
 }
 
 // TestConfigSetValues sets all available configuration values using command flags, then confirms that the

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -6,11 +6,9 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/pkg/errors"
 )
 
 // appTypeFuncs prototypes
@@ -312,6 +310,7 @@ func (app *DdevApp) DetectAppType() string {
 			return appName
 		}
 	}
+
 	return nodeps.AppTypePHP
 }
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -2,10 +2,12 @@ package ddevapp
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1245,16 +1245,19 @@ func (app *DdevApp) AppTypePrompt() error {
 	// First, see if we can auto detect what kind of site it is so we can set a sane default.
 	detectedAppType := app.DetectAppType()
 
-	// If the detected detectedAppType is php, we'll ask them to confirm,
-	// otherwise go with it.
 	// If we found an application type just set it and inform the user.
 	util.Success("Found a %s codebase at %s.", detectedAppType, filepath.Join(app.AppRoot, app.Docroot))
 
 	validAppTypes := strings.Join(GetValidAppTypes(), ", ")
 	typePrompt := "Project Type [%s] (%s): "
 
-	fmt.Printf(typePrompt, validAppTypes, detectedAppType)
-	appType := strings.ToLower(util.GetInput(detectedAppType))
+	defaultAppType := app.Type
+	if app.Type == nodeps.AppTypeNone {
+		defaultAppType = detectedAppType
+	}
+
+	fmt.Printf(typePrompt, validAppTypes, defaultAppType)
+	appType := strings.ToLower(util.GetInput(defaultAppType))
 
 	for !IsValidAppType(appType) {
 		output.UserOut.Errorf("'%s' is not a valid project type. Allowed project types are: %s\n", appType, validAppTypes)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -887,6 +887,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 	projDir := testcommon.CreateTmpDir(t.Name())
 	app, err := ddevapp.NewApp(projDir, false)
 	require.NoError(t, err)
+	app.Type = nodeps.AppTypePHP
 	err = app.WriteConfig()
 	require.NoError(t, err)
 
@@ -1063,6 +1064,7 @@ func TestDdevXhprofEnabled(t *testing.T) {
 	projDir := testcommon.CreateTmpDir(t.Name())
 	app, err := ddevapp.NewApp(projDir, false)
 	require.NoError(t, err)
+	app.Type = nodeps.AppTypePHP
 	err = app.WriteConfig()
 	require.NoError(t, err)
 

--- a/pkg/ddevapp/network_test.go
+++ b/pkg/ddevapp/network_test.go
@@ -1,15 +1,17 @@
 package ddevapp_test
 
 import (
-	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/testcommon"
-	asrt "github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/testcommon"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestNetworkAmbiguity tests the behavior and setup of docker networking.
@@ -51,6 +53,7 @@ func TestNetworkAmbiguity(t *testing.T) {
 		// Create new app
 		app, err = ddevapp.NewApp(projDir, false)
 		assert.NoError(err)
+		app.Type = nodeps.AppTypePHP
 		app.Name = projName
 		err = app.WriteConfig()
 		assert.NoError(err)

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -79,6 +79,7 @@ var ValidNodeJSVersions = []string{"14", "16", "18", "20"}
 
 // App types
 const (
+	AppTypeNone      = ""
 	AppTypeBackdrop  = "backdrop"
 	AppTypeCraftCms  = "craftcms"
 	AppTypeDjango4   = "django4"


### PR DESCRIPTION
## The Issue

* #4403
* https://github.com/ddev/ddev/issues/1919

## How This PR Solves The Issue

If an app type was set already before running `ddev config` it won't longer be overwritten by the detected app type but a warning is shown to let the user know about. The only way to change the type config is to provide a new value using `--projecttype` flag.

Not implemented so far but could be an option to allow the type `auto` to enforce the value from the detection. But to me this currently looks superfluous.

## Manual Testing Instructions

Use `ddev config --projecttype=...` with an other type than already specified in the project. This should set the new value and not using the auto detected type.

## Automated Testing Overview

No new tests are introduced.

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5011"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

