### PR TITLE
Use `--file` for import-db and rework import-db and export-db, fixes #4593

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /VERSION.txt
 .docker_image
 /dictionary.dic
-/.idea
 /site
 /authors.json
 /docs/cache
@@ -15,3 +14,10 @@ nbproject/
 .idea
 *.orig
 *.rej
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+cover.html

--- a/cmd/ddev/cmd/export-db.go
+++ b/cmd/ddev/cmd/export-db.go
@@ -21,9 +21,8 @@ func NewExportDBCmd() *cobra.Command {
 			$ ddev export-db --gzip=false --file /tmp/db.sql
 			$ ddev export-db > /tmp/db.sql.gz
 			$ ddev export-db --gzip=false > /tmp/db.sql
-			$ ddev export-db --database=other_db --file=.tarballs/other_db.sql.gz
+			$ ddev export-db --database=additional_db --file=.tarballs/additional_db.sql.gz
 			$ ddev export-db my-project --gzip=false --file=/tmp/my_project.sql
-			$ ddev export-db some-project --gzip=false --file=/tmp/some_project.sql
 		`),
 		Args: cobra.RangeArgs(0, 1),
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/ddev/cmd/export-db.go
+++ b/cmd/ddev/cmd/export-db.go
@@ -1,73 +1,122 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
-	"github.com/ddev/ddev/pkg/util"
+	"github.com/ddev/ddev/pkg/heredoc"
 	"github.com/spf13/cobra"
 )
 
-var outFileName string
-var doGzip bool
-var doBzip2 bool
-var doXz bool
-var exportTargetDB string
-
-// ExportDBCmd is the `ddev export-db` command.
-var ExportDBCmd = &cobra.Command{
-	Use:   "export-db [project]",
-	Short: "Dump a database to a file or to stdout",
-	Long:  `Dump a database to a file or to stdout`,
-	Example: `ddev export-db --file=/tmp/db.sql.gz
-ddev export-db -f /tmp/db.sql.gz
-ddev export-db --gzip=false --file /tmp/db.sql
-ddev export-db > /tmp/db.sql.gz
-ddev export-db --gzip=false > /tmp/db.sql
-ddev export-db myproject --gzip=false --file=/tmp/myproject.sql
-ddev export-db someproject --gzip=false --file=/tmp/someproject.sql `,
-	Args: cobra.RangeArgs(0, 1),
-	PreRun: func(cmd *cobra.Command, args []string) {
-		dockerutil.EnsureDdevNetwork()
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		projects, err := getRequestedProjects(args, false)
-		if err != nil {
-			util.Failed("Unable to get project(s): %v", err)
-		}
-
-		app := projects[0]
-		status, _ := app.SiteStatus()
-		if status != ddevapp.SiteRunning {
-			err = app.Start()
+// NewExportDBCmd initializes and returns the `ddev export-db` command.
+func NewExportDBCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export-db [project]",
+		Short: "Dump a database to a file or to stdout",
+		Long:  `Dump a database to a file or to stdout.`,
+		Example: heredoc.DocI2S(`
+			$ ddev export-db --file=/tmp/db.sql.gz
+			$ ddev export-db -f /tmp/db.sql.gz
+			$ ddev export-db --gzip=false --file /tmp/db.sql
+			$ ddev export-db > /tmp/db.sql.gz
+			$ ddev export-db --gzip=false > /tmp/db.sql
+			$ ddev export-db --database=other_db --file=.tarballs/other_db.sql.gz
+			$ ddev export-db my-project --gzip=false --file=/tmp/my_project.sql
+			$ ddev export-db some-project --gzip=false --file=/tmp/some_project.sql
+		`),
+		Args: cobra.RangeArgs(0, 1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			dockerutil.EnsureDdevNetwork()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projects, err := getRequestedProjects(args, false)
 			if err != nil {
-				util.Failed("Failed to start app %s to import-db: %v", app.Name, err)
+				return fmt.Errorf("unable to get project: %v", err)
 			}
-		}
 
-		compressionType := ""
-		if doGzip {
-			compressionType = "gzip"
-		}
-		if doBzip2 {
-			compressionType = "bzip2"
-		}
-		// xz wins over bzip2/gzip
-		if doXz {
-			compressionType = "xz"
-		}
+			app := projects[0]
 
-		err = app.ExportDB(outFileName, compressionType, exportTargetDB)
-		if err != nil {
-			util.Failed("Failed to export database for %s: %v", app.GetName(), err)
-		}
-	},
+			dumpFile, err := cmd.Flags().GetString("file")
+			if err != nil {
+				return err
+			}
+
+			database, err := cmd.Flags().GetString("database")
+			if err != nil {
+				return err
+			}
+
+			if !cmd.Flags().Lookup("database").Changed && cmd.Flags().Lookup("target-db").Changed {
+				database, err = cmd.Flags().GetString("target-db")
+				if err != nil {
+					return err
+				}
+			}
+
+			compXz, err := cmd.Flags().GetBool("xz")
+			if err != nil {
+				return err
+			}
+
+			compBzip2, err := cmd.Flags().GetBool("bzip2")
+			if err != nil {
+				return err
+			}
+
+			compGzip, err := cmd.Flags().GetBool("gzip")
+			if err != nil {
+				return err
+			}
+
+			compressionType := ""
+
+			switch {
+			case compXz:
+				compressionType = "xz"
+			case compBzip2:
+				compressionType = "bzip2"
+			case compGzip:
+				compressionType = "gzip"
+			}
+
+			return exportDBRun(app, dumpFile, database, compressionType)
+		},
+	}
+
+	cmd.Flags().StringP("file", "f", "", "Path to a SQL dump file to export to")
+	cmd.Flags().StringP("database", "d", "db", "Target database to export from")
+	cmd.Flags().BoolP("gzip", "z", true, "Use gzip compression")
+	cmd.Flags().Bool("xz", false, "Use xz compression")
+	cmd.Flags().Bool("bzip2", false, "Use bzip2 compression")
+
+	// Backward compatibility
+	cmd.Flags().String("target-db", "db", "Path to a SQL dump file to export to")
+	_ = cmd.Flags().MarkDeprecated("target-db", "please use --database instead")
+
+	_ = cmd.Flags().MarkShorthandDeprecated("z", "please use --gzip instead")
+
+	return cmd
 }
 
 func init() {
-	ExportDBCmd.Flags().StringVarP(&outFileName, "file", "f", "", "Provide the path to output the dump")
-	ExportDBCmd.Flags().BoolVarP(&doGzip, "gzip", "z", true, "Use gzip compression")
-	ExportDBCmd.Flags().BoolVarP(&doXz, "xz", "", false, "Use xz compression")
-	ExportDBCmd.Flags().BoolVarP(&doBzip2, "bzip2", "", false, "Use bzip2 compression")
-	ExportDBCmd.Flags().StringVarP(&exportTargetDB, "target-db", "d", "db", "If provided, target-db is alternate database to export")
-	RootCmd.AddCommand(ExportDBCmd)
+	// TODO move to RootCmd
+	RootCmd.AddCommand(NewExportDBCmd())
+}
+
+func exportDBRun(app *ddevapp.DdevApp, dumpFile, database, compressionType string) error {
+	status, _ := app.SiteStatus()
+	if status != ddevapp.SiteRunning {
+		err := app.Start()
+		if err != nil {
+			return fmt.Errorf("failed to start app %s to import-db: %v", app.Name, err)
+		}
+	}
+
+	err := app.ExportDB(dumpFile, compressionType, database)
+	if err != nil {
+		return fmt.Errorf("failed to export database for %s: %v", app.GetName(), err)
+	}
+
+	return nil
 }

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -1,76 +1,155 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/heredoc"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
 
-var dbSource string
-var dbExtPath string
-var targetDB string
-var noDrop bool
-var progressOption bool
+// NewImportDBCmd initializes and returns the `ddev import-db` command.
+func NewImportDBCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import-db [project]",
+		Args:  cobra.RangeArgs(0, 1),
+		Short: "Import a SQL dump file into the project",
+		Long: heredoc.Doc(`
+			Import a SQL dump file into the project.
+			
+			The database dump file can be provided as a SQL dump in a .sql, .sql.gz,
+			sql.bz2, sql.xz, .mysql, .mysql.gz, .zip, .tgz, or .tar.gz format.
+			
+			For the zip and tar formats, the path to a .sql file within the archive
+			can be provided if it is not located at the top level of the archive.
+			
+			An optional target database can also be provided; the default is the
+			default database named "db".
 
-// ImportDBCmd represents the `ddev import-db` command.
-var ImportDBCmd = &cobra.Command{
-	Use:   "import-db [project]",
-	Args:  cobra.RangeArgs(0, 1),
-	Short: "Import a sql file into the project.",
-	Long: `Import a sql file into the project.
-The database dump file can be provided as a SQL dump in a .sql, .sql.gz, sql.bz2, sql.xz, .mysql, .mysql.gz, .zip, .tgz, or .tar.gz
-format. For the zip and tar formats, the path to a .sql file within the archive
-can be provided if it is not located at the top level of the archive. An optional target database
-can also be provided; the default is the default database named "db".
-Also note the related "ddev mysql" command`,
-	Example: `ddev import-db
-ddev import-db --src=.tarballs/junk.sql
-ddev import-db --src=.tarballs/junk.sql.gz
-ddev import-db --target-db=newdb --src=.tarballs/db.sql.gz
-ddev import-db --src=.tarballs/db.sql.bz2
-ddev import-db --src=.tarballs/db.sql.xz
-ddev import-db <db.sql
-ddev import-db someproject <db.sql
-gzip -dc db.sql.gz | ddev import-db`,
-
-	PreRun: func(cmd *cobra.Command, args []string) {
-		dockerutil.EnsureDdevNetwork()
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		projects, err := getRequestedProjects(args, false)
-		if err != nil {
-			util.Failed("Unable to get project(s): %v", err)
-		}
-
-		app := projects[0]
-		status, _ := app.SiteStatus()
-
-		if status != ddevapp.SiteRunning {
-			err = app.Start()
+			Also note the related "ddev mysql" command.
+		`),
+		Example: heredoc.DocI2S(`
+			$ ddev import-db
+			$ ddev import-db --file=.tarballs/junk.sql
+			$ ddev import-db --file=.tarballs/junk.sql.gz
+			$ ddev import-db --database=other_db --file=.tarballs/db.sql.gz
+			$ ddev import-db --file=.tarballs/db.sql.bz2
+			$ ddev import-db --file=.tarballs/db.sql.xz
+			$ ddev import-db < db.sql
+			$ ddev import-db some-project < db.sql
+			$ gzip -dc db.sql.gz | ddev import-db
+		`),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			dockerutil.EnsureDdevNetwork()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projects, err := getRequestedProjects(args, false)
 			if err != nil {
-				util.Failed("Failed to start app %s to import-db: %v", app.Name, err)
+				return fmt.Errorf("unable to get project: %v", err)
 			}
-		}
 
-		err = app.ImportDB(dbSource, dbExtPath, progressOption, noDrop, targetDB)
-		if err != nil {
-			util.Failed("Failed to import database %s for %s: %v", targetDB, app.GetName(), err)
-		}
-		util.Success("Successfully imported database '%s' for %v", targetDB, app.GetName())
-		if noDrop {
-			util.Success("Existing database '%s' was NOT dropped before importing", targetDB)
-		} else {
-			util.Success("Existing database '%s' was dropped before importing", targetDB)
-		}
-	},
+			app := projects[0]
+
+			dumpFile, err := cmd.Flags().GetString("file")
+			if err != nil {
+				return err
+			}
+
+			if !cmd.Flags().Lookup("file").Changed && cmd.Flags().Lookup("src").Changed {
+				dumpFile, err = cmd.Flags().GetString("src")
+				if err != nil {
+					return err
+				}
+			}
+
+			extractPath, err := cmd.Flags().GetString("extract-path")
+			if err != nil {
+				return err
+			}
+
+			database, err := cmd.Flags().GetString("database")
+			if err != nil {
+				return err
+			}
+
+			if !cmd.Flags().Lookup("database").Changed && cmd.Flags().Lookup("target-db").Changed {
+				database, err = cmd.Flags().GetString("target-db")
+				if err != nil {
+					return err
+				}
+			}
+
+			noDrop, err := cmd.Flags().GetBool("no-drop")
+			if err != nil {
+				return err
+			}
+
+			noProgress, err := cmd.Flags().GetBool("no-progress")
+			if err != nil {
+				return err
+			}
+
+			if !cmd.Flags().Lookup("no-progress").Changed && cmd.Flags().Lookup("progress").Changed {
+				progress, err := cmd.Flags().GetBool("progress")
+				if err != nil {
+					return err
+				}
+
+				noProgress = !progress
+			}
+
+			return importDBRun(app, dumpFile, extractPath, database, noDrop, noProgress)
+		},
+	}
+
+	cmd.Flags().StringP("file", "f", "", "Path to a SQL dump file, plain text or compressed (tar/tar.gz/tgz/zip)")
+	cmd.Flags().String("extract-path", "", "Path to extract within the archive")
+	cmd.Flags().StringP("database", "d", "db", "Target database to import into")
+	cmd.Flags().Bool("no-drop", false, "Do not drop the database before importing")
+	cmd.Flags().Bool("no-progress", false, "Do not output progress")
+
+	// Backward compatibility
+	cmd.Flags().String("src", "", "Path to a SQL dump file, plain text or compressed (tar/tar.gz/tgz/zip)")
+	_ = cmd.Flags().MarkDeprecated("src", "please use --file instead")
+
+	cmd.Flags().String("target-db", "db", "Target database to import into")
+	_ = cmd.Flags().MarkDeprecated("target-db", "please use --database instead")
+
+	cmd.Flags().BoolP("progress", "p", true, "Display a progress bar during import")
+	_ = cmd.Flags().MarkDeprecated("progress", "please use --no-progress instead")
+	_ = cmd.Flags().MarkShorthandDeprecated("p", "please use --no-progress instead")
+
+	return cmd
 }
 
 func init() {
-	ImportDBCmd.Flags().StringVarP(&dbSource, "src", "f", "", "Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format")
-	ImportDBCmd.Flags().StringVarP(&dbExtPath, "extract-path", "", "", "If provided asset is an archive, provide the path to extract within the archive.")
-	ImportDBCmd.Flags().StringVarP(&targetDB, "target-db", "d", "db", "If provided, target-db is alternate database to import into")
-	ImportDBCmd.Flags().BoolVarP(&noDrop, "no-drop", "", false, "Set if you do NOT want to drop the db before importing")
-	ImportDBCmd.Flags().BoolVarP(&progressOption, "progress", "p", true, "Display a progress bar during import")
-	RootCmd.AddCommand(ImportDBCmd)
+	// TODO move to RootCmd
+	RootCmd.AddCommand(NewImportDBCmd())
+}
+
+func importDBRun(app *ddevapp.DdevApp, dumpFile, extractPath, database string, noDrop, noProgress bool) error {
+	status, _ := app.SiteStatus()
+
+	if status != ddevapp.SiteRunning {
+		err := app.Start()
+		if err != nil {
+			return fmt.Errorf("failed to start app %s to import-db: %v", app.Name, err)
+		}
+	}
+
+	err := app.ImportDB(dumpFile, extractPath, !noProgress, noDrop, database)
+	if err != nil {
+		return fmt.Errorf("failed to import database '%s' for %s: %v", database, app.GetName(), err)
+	}
+
+	noDropInfo := ""
+	if noDrop {
+		noDropInfo = ", existing database was NOT dropped before importing"
+	}
+
+	util.Success("Successfully imported database '%s' for %s%s", database, app.GetName(), noDropInfo)
+
+	return nil
 }

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -38,7 +38,7 @@ func NewImportDBCmd() *cobra.Command {
 			$ ddev import-db --file=.tarballs/db.sql.bz2
 			$ ddev import-db --file=.tarballs/db.sql.xz
 			$ ddev import-db < db.sql
-			$ ddev import-db some-project < db.sql
+			$ ddev import-db my-project < db.sql
 			$ gzip -dc db.sql.gz | ddev import-db
 		`),
 		PreRun: func(cmd *cobra.Command, args []string) {
@@ -104,14 +104,14 @@ func NewImportDBCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("file", "f", "", "Path to a SQL dump file, plain text or compressed (tar/tar.gz/tgz/zip)")
+	cmd.Flags().StringP("file", "f", "", "Path to a SQL dump in `.sql`, `.tar`, `.tar.gz`, `.tgz`, `.bz2`, `.xx`, or `.zip` format")
 	cmd.Flags().String("extract-path", "", "Path to extract within the archive")
 	cmd.Flags().StringP("database", "d", "db", "Target database to import into")
 	cmd.Flags().Bool("no-drop", false, "Do not drop the database before importing")
 	cmd.Flags().Bool("no-progress", false, "Do not output progress")
 
 	// Backward compatibility
-	cmd.Flags().String("src", "", "Path to a SQL dump file, plain text or compressed (tar/tar.gz/tgz/zip)")
+	cmd.Flags().String("src", "", "Path to a SQL dump in `.sql`, `.tar`, `.tar.gz`, `.tgz`, `.bz2`, `.xx`, or `.zip` format")
 	_ = cmd.Flags().MarkDeprecated("src", "please use --file instead")
 
 	cmd.Flags().String("target-db", "db", "Target database to import into")

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -539,9 +539,9 @@ Dump a database to a file or to stdout.
 Flags:
 
 * `--bzip2`: Use bzip2 compression.
-* `--database`, `-d`: Target database to export from (default "db")
+* `--database`, `-d`: Target database to export from (default `"db"`)
 * `--file`, `-f`: Path to a SQL dump file to export to
-* `--gzip`: Use gzip compression (default true)
+* `--gzip`: Use gzip compression (default `true`)
 * `--xz`: Use xz compression.
 
 Example:
@@ -667,9 +667,9 @@ ddev hostname somesite.ddev.local 127.0.0.1
 
 Flags:
 
-* `--database`, `-d`: Target database to import into (default "db")
+* `--database`, `-d`: Target database to import into (default `"db"`)
 * `--extract-path`: Path to extract within the archive
-* `--file`, `-f`: Path to a SQL dump file, plain text or compressed (tar/tar.gz/tgz/zip)
+* `--file`, `-f`: Path to a SQL dump in `.sql`, `.tar`, `.tar.gz`, `.tgz`, `.bz2`, `.xx`, or `.zip` format
 * `--no-drop`: Do not drop the database before importing
 * `--no-progress`: Do not output progress
 
@@ -686,13 +686,13 @@ ddev import-db --file=.tarballs/db.sql
 ddev import-db --file=.tarballs/db.sql.gz
 
 # Import the compressed `.tarballs/db.sql.gz` dump to a `other_db` database
-ddev import-db --database=other_db --file=.tarballs/db.sql.gz
+ddev import-db --database=additional_db --file=.tarballs/db.sql.gz
 
 # Import the `db.sql` dump to the project database
 ddev import-db < db.sql
 
 # Import the `db.sql` dump to a `some-project` project
-ddev import-db some-project < db.sql
+ddev import-db my-project < db.sql
 
 # Uncompress `db.sql.gz` and pipe the result to the `import-db` command
 gzip -dc db.sql.gz | ddev import-db

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -691,7 +691,7 @@ ddev import-db --database=additional_db --file=.tarballs/db.sql.gz
 # Import the `db.sql` dump to the project database
 ddev import-db < db.sql
 
-# Import the `db.sql` dump to a `some-project` project
+# Import the `db.sql` dump to the `my-project` default database
 ddev import-db my-project < db.sql
 
 # Uncompress `db.sql.gz` and pipe the result to the `import-db` command

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -539,9 +539,9 @@ Dump a database to a file or to stdout.
 Flags:
 
 * `--bzip2`: Use bzip2 compression.
-* `--file`, `-f`: Provide the path to output the dump.
-* `--gzip`, `-z`: Use gzip compression. (default `true`)
-* `--target-db`, `-d`: If provided, target-db is alternate database to export. (default `"db"`)
+* `--database`, `-d`: Target database to export from (default "db")
+* `--file`, `-f`: Path to a SQL dump file to export to
+* `--gzip`: Use gzip compression (default true)
 * `--xz`: Use xz compression.
 
 Example:
@@ -554,7 +554,7 @@ ddev export-db --file=/tmp/db.sql.gz
 ddev export-db --gzip=false --file /tmp/db.sql
 
 # Dump and compress the current project’s `foo` database instead of `db`
-ddev export-db --target-db=foo --file=/tmp/db.sql.gz
+ddev export-db --database=foo --file=/tmp/db.sql.gz
 
 # Output the current project’s database and use `>` to write to `/tmp/db.sql.gz`
 ddev export-db > /tmp/db.sql.gz
@@ -667,11 +667,11 @@ ddev hostname somesite.ddev.local 127.0.0.1
 
 Flags:
 
-* `--extract-path`: If provided asset is an archive, provide the path to extract within the archive.
-* `--no-drop`: Set if you do NOT want to drop the db before importing.
-* `--progress`, `-p`: Display a progress bar during import. (default `true`)
-* `--src`, `-f`: Provide the path to a SQL dump in `.sql`, `.tar`, `.tar.gz`, `.tgz`, `.bz2`, `.xx`, or `.zip` format.
-* `--target-db`, `-d`: If provided, target-db is alternate database to import into. (default `"db"`)
+* `--database`, `-d`: Target database to import into (default "db")
+* `--extract-path`: Path to extract within the archive
+* `--file`, `-f`: Path to a SQL dump file, plain text or compressed (tar/tar.gz/tgz/zip)
+* `--no-drop`: Do not drop the database before importing
+* `--no-progress`: Do not output progress
 
 Example:
 
@@ -680,19 +680,19 @@ Example:
 ddev import-db
 
 # Import the `.tarballs/db.sql` dump to the project database
-ddev import-db --src=.tarballs/db.sql
+ddev import-db --file=.tarballs/db.sql
 
 # Import the compressed `.tarballs/db.sql.gz` dump to the project database
-ddev import-db --src=.tarballs/db.sql.gz
+ddev import-db --file=.tarballs/db.sql.gz
 
-# Import the compressed `.tarballs/db.sql.gz` dump to a `newdb` database
-ddev import-db --target-db=newdb --src=.tarballs/db.sql.gz
+# Import the compressed `.tarballs/db.sql.gz` dump to a `other_db` database
+ddev import-db --database=other_db --file=.tarballs/db.sql.gz
 
 # Import the `db.sql` dump to the project database
-ddev import-db <db.sql
+ddev import-db < db.sql
 
-# Import the `db.sql` dump to a `newdb` database
-ddev import-db newdb <db.sql
+# Import the `db.sql` dump to a `some-project` project
+ddev import-db some-project < db.sql
 
 # Uncompress `db.sql.gz` and pipe the result to the `import-db` command
 gzip -dc db.sql.gz | ddev import-db

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
+	github.com/MakeNowJust/heredoc/v2 v2.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZYIR/J6A=
+github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
@@ -87,6 +89,7 @@ github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
 github.com/cheggaaa/pb v1.0.25 h1:tFpebHTkI7QZx1q1rWGOKhbunhZ3fMaxTvHDWn1bH/4=
 github.com/cheggaaa/pb v1.0.25/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
@@ -111,6 +114,7 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/containerd/containerd v1.7.0 h1:G/ZQr3gMZs6ZT0qPUZ15znx5QSdQdASW11nXTLTM2Pg=
 github.com/containerd/containerd v1.7.0/go.mod h1:QfR7Efgb/6X2BDpTPJRvPTYDE9rsF0FsXX9J8sIs/sc=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=
@@ -119,6 +123,7 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/corpix/uarand v0.1.1 h1:RMr1TWc9F4n5jiPDzFHtmaUXLKLNUFK0SgCLo4BhX/U=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -372,6 +377,7 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -423,11 +429,13 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 h1:ZuhckGJ10ulaKkdvJtiAqsLTiPrLaXSdnVgXJKJkTxE=
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
@@ -449,6 +457,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -460,6 +469,7 @@ github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -468,7 +468,7 @@ func (app *DdevApp) GetRouterHTTPSPort() string {
 }
 
 // ImportDB takes a source sql dump and imports it to an active site's database container.
-func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDrop bool, targetDB string) error {
+func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool, noDrop bool, targetDB string) error {
 	app.DockerEnv()
 	dockerutil.CheckAvailableSpace()
 
@@ -496,28 +496,28 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 
 	// If they don't provide an import path and we're not on a tty (piped in stuff)
 	// then prompt for path to db
-	if imPath == "" && isatty.IsTerminal(os.Stdin.Fd()) {
+	if dumpFile == "" && isatty.IsTerminal(os.Stdin.Fd()) {
 		// ensure we prompt for extraction path if an archive is provided, while still allowing
 		// non-interactive use of --src flag without providing a --extract-path flag.
-		if extPath == "" {
+		if extractPath == "" {
 			extPathPrompt = true
 		}
 		output.UserOut.Println("Provide the path to the database you want to import.")
 		fmt.Print("Path to file: ")
 
-		imPath = util.GetInput("")
+		dumpFile = util.GetInput("")
 	}
 
-	if imPath != "" {
-		importPath, isArchive, err := appimport.ValidateAsset(imPath, "db")
+	if dumpFile != "" {
+		importPath, isArchive, err := appimport.ValidateAsset(dumpFile, "db")
 		if err != nil {
 			if isArchive && extPathPrompt {
 				output.UserOut.Println("You provided an archive. Do you want to extract from a specific path in your archive? You may leave this blank if you wish to use the full archive contents")
 				fmt.Print("Archive extraction path:")
 
-				extPath = util.GetInput("")
+				extractPath = util.GetInput("")
 			} else {
-				return fmt.Errorf("Unable to validate import asset %s: %s", imPath, err)
+				return fmt.Errorf("Unable to validate import asset %s: %s", dumpFile, err)
 			}
 		}
 
@@ -541,7 +541,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 			}
 
 		case strings.HasSuffix(importPath, "zip"):
-			err = archive.Unzip(importPath, dbPath, extPath)
+			err = archive.Unzip(importPath, dbPath, extractPath)
 			if err != nil {
 				return fmt.Errorf("failed to extract provided archive: %v", err)
 			}
@@ -555,7 +555,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 		case strings.HasSuffix(importPath, "tar.xz"):
 			fallthrough
 		case strings.HasSuffix(importPath, "tgz"):
-			err := archive.Untar(importPath, dbPath, extPath)
+			err := archive.Untar(importPath, dbPath, extractPath)
 			if err != nil {
 				return fmt.Errorf("failed to extract provided archive: %v", err)
 			}
@@ -628,7 +628,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 		inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && mysql -uroot -proot -e "%s" && pv %s/*.*sql |  perl -p -e 's/^(CREATE DATABASE \/\*|USE %s)[^;]*;//' | mysql %s`, preImportSQL, insideContainerImportPath, "`", targetDB)}
 
 		// Alternate case where we are reading from stdin
-		if imPath == "" && extPath == "" {
+		if dumpFile == "" && extractPath == "" {
 			inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && mysql -uroot -proot -e "%s" && perl -p -e 's/^(CREATE DATABASE \/\*|USE %s)[^;]*;//' | mysql %s`, preImportSQL, "`", targetDB)}
 		}
 
@@ -648,7 +648,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 			GRANT ALL PRIVILEGES ON DATABASE %s TO db;`, targetDB)
 
 		// If there is no import path, we're getting it from stdin
-		if imPath == "" && extPath == "" {
+		if dumpFile == "" && extractPath == "" {
 			inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && (echo '%s' | psql -d postgres) && psql -v ON_ERROR_STOP=1 -d %s`, preImportSQL, targetDB)}
 		} else { // otherwise getting it from mounted file
 			inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && (echo "%s" | psql -q -d postgres -v ON_ERROR_STOP=1) && pv %s/*.*sql | psql -q -v ON_ERROR_STOP=1 %s >/dev/null`, preImportSQL, insideContainerImportPath, targetDB)}
@@ -717,7 +717,7 @@ func (app *DdevApp) ImportDB(imPath string, extPath string, progress bool, noDro
 
 // ExportDB exports the db, with optional output to a file, default gzip
 // targetDB is the db name if not default "db"
-func (app *DdevApp) ExportDB(outFile string, compressionType string, targetDB string) error {
+func (app *DdevApp) ExportDB(dumpFile string, compressionType string, targetDB string) error {
 	app.DockerEnv()
 	exportCmd := []string{"mysqldump"}
 	if app.Database.Type == "postgres" {
@@ -737,10 +737,10 @@ func (app *DdevApp) ExportDB(outFile string, compressionType string, targetDB st
 		RawCmd:    exportCmd,
 		NoCapture: true,
 	}
-	if outFile != "" {
-		f, err := os.OpenFile(outFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if dumpFile != "" {
+		f, err := os.OpenFile(dumpFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
-			return fmt.Errorf("failed to open %s: %v", outFile, err)
+			return fmt.Errorf("failed to open %s: %v", dumpFile, err)
 		}
 		opts.Stdout = f
 		defer func() {
@@ -754,8 +754,8 @@ func (app *DdevApp) ExportDB(outFile string, compressionType string, targetDB st
 	}
 
 	confMsg := "Wrote database dump from project '" + app.Name + "' database '" + targetDB + "'"
-	if outFile != "" {
-		confMsg = confMsg + " to file " + outFile
+	if dumpFile != "" {
+		confMsg = confMsg + " to file " + dumpFile
 	} else {
 		confMsg = confMsg + " to stdout"
 	}

--- a/pkg/heredoc/heredoc.go
+++ b/pkg/heredoc/heredoc.go
@@ -1,0 +1,41 @@
+package heredoc
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+)
+
+var indentRE = regexp.MustCompile(`(?m)^`)
+
+// Indent returns a copy of the string s with indent prefixed to it, will apply
+// indent to each line of the string except the last line if empty.
+func Indent(s, indent string) string {
+	if len(strings.TrimSpace(s)) == 0 {
+		return s
+	}
+
+	return strings.TrimSuffix(indentRE.ReplaceAllLiteralString(s, indent), indent)
+}
+
+// Doc returns un-indented string as here-document.
+func Doc(raw string) string {
+	return heredoc.Doc(raw)
+}
+
+// DocIndent returns string as here-document indented by indent.
+func DocIndent(raw, indent string) string {
+	return Indent(
+		heredoc.Doc(raw),
+		indent,
+	)
+}
+
+// DocI2S returns string as here-document indented by two spaces.
+func DocI2S(raw string) string {
+	return Indent(
+		heredoc.Doc(raw),
+		"  ",
+	)
+}

--- a/pkg/heredoc/heredoc_test.go
+++ b/pkg/heredoc/heredoc_test.go
@@ -1,0 +1,144 @@
+package heredoc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndent(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		want   string
+		indent string
+	}{
+		{
+			name:   "spaces only",
+			input:  "  \t  \t   \n  ",
+			want:   "  \t  \t   \n  ",
+			indent: "  ",
+		},
+		{
+			name:   "nothing to add or remove",
+			input:  "one\ntwo\nthree\n",
+			want:   "one\ntwo\nthree\n",
+			indent: "",
+		},
+		{
+			name:   "two spaces indent",
+			input:  "one\n\ttwo\n\tthree\nfour\n\t",
+			want:   "  one\n  \ttwo\n  \tthree\n  four\n  \t",
+			indent: "  ",
+		},
+		{
+			name:   "tab indent",
+			input:  "one\n  two\n  three\nfour\n  ",
+			want:   "\tone\n\t  two\n\t  three\n\tfour\n\t  ",
+			indent: "\t",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Indent(tt.input, tt.indent)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDoc(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "nothing to add or remove",
+			input: "one\ntwo\nthree\n",
+			want:  "one\ntwo\nthree\n",
+		},
+		{
+			name:  "tabs to two spaces indent",
+			input: "\n\t\tone\n\t\t\ttwo\n\t\t\tthree\n\t\tfour\n\t",
+			want:  "one\n\ttwo\n\tthree\nfour\n",
+		},
+		{
+			name:  "spaces to two spaces indent",
+			input: "\n    one\n      two\n      three\n    four\n  ",
+			want:  "one\n  two\n  three\nfour\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Doc(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+func TestDocIndent(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		want   string
+		indent string
+	}{
+		{
+			name:   "nothing to add or remove",
+			input:  "one\ntwo\nthree\n",
+			want:   "one\ntwo\nthree\n",
+			indent: "",
+		},
+		{
+			name:   "two spaces indent",
+			input:  "\n\t\tone\n\t\t\ttwo\n\t\t\tthree\n\t\tfour\n\t",
+			want:   "  one\n  \ttwo\n  \tthree\n  four\n",
+			indent: "  ",
+		},
+		{
+			name:   "tab indent",
+			input:  "\n    one\n      two\n      three\n    four\n  ",
+			want:   "\tone\n\t  two\n\t  three\n\tfour\n",
+			indent: "\t",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DocIndent(tt.input, tt.indent)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDocI2S(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "two spaces indent",
+			input: "one\ntwo\nthree\n",
+			want:  "  one\n  two\n  three\n",
+		},
+		{
+			name:  "tabs to two spaces indent",
+			input: "\n\t\tone\n\t\t\ttwo\n\t\t\tthree\n\t\tfour\n\t",
+			want:  "  one\n  \ttwo\n  \tthree\n  four\n",
+		},
+		{
+			name:  "spaces to two spaces indent",
+			input: "\n    one\n      two\n      three\n    four\n  ",
+			want:  "  one\n    two\n    three\n  four\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DocI2S(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/vendor/github.com/MakeNowJust/heredoc/v2/LICENSE
+++ b/vendor/github.com/MakeNowJust/heredoc/v2/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 TSUYUSATO Kitsune
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/MakeNowJust/heredoc/v2/README.md
+++ b/vendor/github.com/MakeNowJust/heredoc/v2/README.md
@@ -1,0 +1,48 @@
+# heredoc
+
+[![Version](https://img.shields.io/github/v/release/MakeNowJust/heredoc)](https://github.com/MakeNowJust/heredoc/releases)
+[![Build Status](https://circleci.com/gh/MakeNowJust/heredoc.svg?style=svg)](https://circleci.com/gh/MakeNowJust/heredoc)
+[![GoDoc](https://godoc.org/github.com/MakeNowJusti/heredoc?status.svg)](https://godoc.org/github.com/MakeNowJust/heredoc)
+
+## About
+
+Package heredoc provides the here-document with keeping indent.
+
+## Import
+
+```go
+import "github.com/MakeNowJust/heredoc/v2"
+```
+
+## Example
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc/v2"
+)
+
+func main() {
+	fmt.Println(heredoc.Doc(`
+		Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+		sed do eiusmod tempor incididunt ut labore et dolore magna
+		aliqua. Ut enim ad minim veniam, ...
+	`))
+	// Output:
+	// Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+	// sed do eiusmod tempor incididunt ut labore et dolore magna
+	// aliqua. Ut enim ad minim veniam, ...
+	//
+}
+```
+
+## API Document
+
+ - [heredoc - GoDoc](https://godoc.org/github.com/MakeNowJust/heredoc)
+
+## License
+
+This software is released under the MIT License, see LICENSE.

--- a/vendor/github.com/MakeNowJust/heredoc/v2/heredoc.go
+++ b/vendor/github.com/MakeNowJust/heredoc/v2/heredoc.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2014-2019 TSUYUSATO Kitsune
+// This software is released under the MIT License.
+// http://opensource.org/licenses/mit-license.php
+
+// Package heredoc provides creation of here-documents from raw strings.
+//
+// Golang supports raw-string syntax.
+//
+//     doc := `
+//     	Foo
+//     	Bar
+//     `
+//
+// But raw-string cannot recognize indentation. Thus such content is an indented string, equivalent to
+//
+//     "\n\tFoo\n\tBar\n"
+//
+// I dont't want this!
+//
+// However this problem is solved by package heredoc.
+//
+//     doc := heredoc.Doc(`
+//     	Foo
+//     	Bar
+//     `)
+//
+// Is equivalent to
+//
+//     "Foo\nBar\n"
+package heredoc
+
+import (
+	"fmt"
+	"strings"
+)
+
+const maxInt = int(^uint(0) >> 1)
+
+// Doc returns un-indented string as here-document.
+func Doc(raw string) string {
+	skipFirstLine := false
+	if len(raw) > 0 && raw[0] == '\n' {
+		raw = raw[1:]
+	} else {
+		skipFirstLine = true
+	}
+
+	lines := strings.Split(raw, "\n")
+
+	minIndentSize := getMinIndent(lines, skipFirstLine)
+	lines = removeIndentation(lines, minIndentSize, skipFirstLine)
+
+	return strings.Join(lines, "\n")
+}
+
+// isSpace checks whether the rune represents space or not.
+// Only white spcaes (U+0020) and horizontal tabs are treated as space character.
+// It is the same as Go.
+//
+// See https://github.com/MakeNowJust/heredoc/issues/6#issuecomment-524231625.
+func isSpace(r rune) bool {
+	switch r {
+	case ' ', '\t':
+		return true
+	default:
+		return false
+	}
+}
+
+// getMinIndent calculates the minimum indentation in lines, excluding empty lines.
+func getMinIndent(lines []string, skipFirstLine bool) int {
+	minIndentSize := maxInt
+
+	for i, line := range lines {
+		if i == 0 && skipFirstLine {
+			continue
+		}
+
+		indentSize := 0
+		for _, r := range line {
+			if isSpace(r) {
+				indentSize++
+			} else {
+				break
+			}
+		}
+
+		if len(line) == indentSize {
+			if i == len(lines)-1 && indentSize < minIndentSize {
+				lines[i] = ""
+			}
+		} else if indentSize < minIndentSize {
+			minIndentSize = indentSize
+		}
+	}
+	return minIndentSize
+}
+
+// removeIndentation removes n characters from the front of each line in lines.
+// Skips first line if skipFirstLine is true, skips empty lines.
+func removeIndentation(lines []string, n int, skipFirstLine bool) []string {
+	for i, line := range lines {
+		if i == 0 && skipFirstLine {
+			continue
+		}
+
+		if len(lines[i]) >= n {
+			lines[i] = line[n:]
+		}
+	}
+	return lines
+}
+
+// Docf returns unindented and formatted string as here-document.
+// Formatting is done as for fmt.Printf().
+func Docf(raw string, args ...interface{}) string {
+	return fmt.Sprintf(Doc(raw), args...)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,6 +2,9 @@
 ## explicit; go 1.16
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
+# github.com/MakeNowJust/heredoc/v2 v2.0.1
+## explicit; go 1.12
+github.com/MakeNowJust/heredoc/v2
 # github.com/Masterminds/goutils v1.1.1
 ## explicit
 github.com/Masterminds/goutils


### PR DESCRIPTION
## The Issue

- #4593

## How This PR Solves The Issue

This PR streamlines the flags and descriptions of the import-db and export-db commands. It introduces a new package which makes it possible to write cleaner command definitions regarding indentation. Commands are created with a factory function.

Old flags are still here and marked as deprecated to avoid BC issues.

Thanks to @miromichalicka for the initial work done in #4647.

## Manual Testing Instructions

The impact is minimal and everything should be covered by automated testing.

- import-db command works including deprecated flags
- export-db command works including deprecated flags

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

Closes:
* #4593

Replaces:
* #4647

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5013"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

