### PR TITLE
docs: re-introduce Rancher Desktop docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DDEV is an open source tool for running local web development environments for P
 ## Get Started
 
 1. **Check [System Requirements](https://ddev.readthedocs.io/):** macOS (Intel and Apple Silicon), Windows 10/11, WSL2, Linux, [Gitpod](https://www.gitpod.io), and [GitHub Codespaces](https://github.com/codespaces).
-2. **Install [Docker/Colima and DDEV](https://ddev.readthedocs.io/en/latest/users/install/)**.
+2. **Install [Docker/Colima/Rancher Desktop and DDEV](https://ddev.readthedocs.io/en/latest/users/install/)**.
 3. **Try a [CMS Quick Start Guide](https://ddev.readthedocs.io/en/latest/users/quickstart/)**.
 
 If you need help, our friendly community provides [great support](https://ddev.readthedocs.io/en/latest/users/support).

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -20,7 +20,7 @@ These environments can be extended, version controlled, and shared, so you can t
     * macOS Big Sur (11) or higher, [mostly](./users/usage/faq.md#can-i-run-ddev-on-an-older-mac)
     * RAM: 8GB
     * Storage: 256GB
-    * [Colima](https://github.com/abiosoft/colima) or [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+    * [Colima](https://github.com/abiosoft/colima), [Rancher Desktop](https://rancherdesktop.io/), or [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
 === "Windows WSL2"
 


### PR DESCRIPTION
Added Rancher Desktop as a container system that Ddev works on

## The Issue
I happily use Rancher Desktop on Mac as my container-supporting environment for Ddev, but it's not currently shown in the docs
## How This PR Solves The Issue
Added Rancher Desktop to the list along with Colima and Docker Desktop
## Manual Testing Instructions
N/A
## Automated Testing Overview
N/A - Doc only
<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)
N/A
## Release/Deployment Notes
N/A - Doc only
<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5014"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

