### PR TITLE
Make sure InternetDetectiontimeout is a reasonable value

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -221,9 +221,9 @@ Reporting interval in hours for [instrumentation reporting](../usage/diagnostics
 
 Internet detection timeout in milliseconds.
 
-| Type | Default | Usage
-| -- | -- | --
-| :octicons-globe-16: global | `1000` (1 second) | Can be any integer.
+| Type | Default            | Usage
+| -- |--------------------| --
+| :octicons-globe-16: global | `3000` (3 seconds) | Can be any integer.
 
 DDEV must detect whether the internet is working to determine whether to add hostnames to `/etc/hosts`. In rare cases, you may need to increase this value if you have slow but working internet. See [FAQ](../usage/faq.md) and [GitHub issue](https://github.com/ddev/ddev/issues/2409#issuecomment-662448025).
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -279,9 +279,9 @@ func WriteGlobalConfig(config GlobalConfig) error {
 
 # In unusual cases the default value to wait to detect internet availability is too short.
 # You can adjust this value higher to make it less likely that ddev will declare internet
-# unavailable, but ddev may wait longer on some commands. This should not be set below the default 1000
+# unavailable, but ddev may wait longer on some commands. This should not be set below the default 3000
 # ddev will ignore low values, as they're not useful
-# internet_detection_timeout_ms: 1000
+# internet_detection_timeout_ms: 3000
 
 # You can enable 'ddev start' to be interrupted by a failing hook with
 # fail_on_hook_fail: true

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -210,6 +210,12 @@ func ReadGlobalConfig() error {
 		DdevGlobalConfig.MkcertCARoot = readCAROOT()
 	}
 
+	// If they set the internetdetectiontimeout below default, just reset to default
+	// and ignore the setting.
+	if DdevGlobalConfig.InternetDetectionTimeout < nodeps.InternetDetectionTimeoutDefault {
+		DdevGlobalConfig.InternetDetectionTimeout = nodeps.InternetDetectionTimeoutDefault
+	}
+
 	err = ValidateGlobalConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
## The Issue

In 
* https://github.com/ddev/ddev/pull/5007

the logic that forces a reasonable value for InternetDetectionTimeout was lost. And many of the test runners had that value set to 0, so we got lots of failures, for example TestEnvironmentVariables in https://buildkite.com/ddev/ddev-macos-amd64-mutagen/builds/4489#0188ef4b-872a-4bc7-a6b0-cbddbc269697

## How This PR Solves The Issue

* Add the logic back in there
* Fix docs in global config comments and also the docs themselves, which were inaccurate.

## Manual Testing Instructions

* Look around for global_config.yaml that has `internet_detection_timeout_ms: 0` - if that is happening somewhere we have another bug.
- [ ] Set internet_detection_timeout_ms to 0 in global_config.yaml and then do `ddev config global` - it should show 3000.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5017"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

