### PR TITLE
Try using wsl2 as an OS type for amplitude

### DIFF
--- a/pkg/amplitude/amplitude.go
+++ b/pkg/amplitude/amplitude.go
@@ -44,11 +44,15 @@ func GetDeviceID() string {
 
 // GetEventOptions returns default options to be used when tracking an event.
 func GetEventOptions() (options ampli.EventOptions) {
+	osType := runtime.GOOS
+	if dockerutil.IsWSL2() {
+		osType = "wsl2"
+	}
 	options = ampli.EventOptions{
 		DeviceID:   GetDeviceID(),
 		AppVersion: versionconstants.DdevVersion,
 		Platform:   runtime.GOARCH,
-		OSName:     runtime.GOOS,
+		OSName:     osType,
 		Language:   os.Getenv("LANG"),
 		ProductID:  "ddev cli",
 	}

--- a/pkg/amplitude/amplitude.go
+++ b/pkg/amplitude/amplitude.go
@@ -48,6 +48,7 @@ func GetEventOptions() (options ampli.EventOptions) {
 	if dockerutil.IsWSL2() {
 		osType = "wsl2"
 	}
+
 	options = ampli.EventOptions{
 		DeviceID:   GetDeviceID(),
 		AppVersion: versionconstants.DdevVersion,

--- a/pkg/amplitude/amplitude_test.go
+++ b/pkg/amplitude/amplitude_test.go
@@ -1,6 +1,7 @@
 package amplitude_test
 
 import (
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"os"
 	"runtime"
 	"testing"
@@ -33,7 +34,11 @@ func (t *AmplitudeSuite) TestGetEventOptions() {
 	require.Equal(versionconstants.DdevVersion, amplitude.GetEventOptions().AppVersion)
 	require.Equal(amplitude.GetDeviceID(), amplitude.GetEventOptions().DeviceID)
 	require.Equal(os.Getenv("LANG"), amplitude.GetEventOptions().Language)
-	require.Equal(runtime.GOOS, amplitude.GetEventOptions().OSName)
+	osType := runtime.GOOS
+	if dockerutil.IsWSL2() {
+		osType = "wsl2"
+	}
+	require.Equal(osType, amplitude.GetEventOptions().OSName)
 	require.Equal(runtime.GOARCH, amplitude.GetEventOptions().Platform)
 	require.Equal("ddev cli", amplitude.GetEventOptions().ProductID)
 	require.LessOrEqual(amplitude.GetEventOptions().Time, time.Now().UnixMilli())


### PR DESCRIPTION
## The Issue

We'd rather see WSL2 as a separate OS type, instead of seeing it as just Linux. 

## How This PR Solves The Issue

Try changing to "wsl2" if it is

## Manual Testing Instructions

Use this on WSL2 and see if it shows up in Amplitude.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5021"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

