### PR TITLE
Move init of remote-config to start, fixes #5022

### DIFF
--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"os"
+	"path"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/config/remoteconfig"
+	"github.com/ddev/ddev/pkg/config/state/storage/yaml"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
@@ -33,6 +35,32 @@ ddev start --all`,
 		dockerutil.EnsureDdevNetwork()
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		// Create a global state to be injected later.
+		state := yaml.NewState(path.Join(globalconfig.GetGlobalDdevDir(), ".state.yaml"))
+
+		// TODO for the time being this triggers the download from Github but
+		// should be realized with a clean bootstrap as soon as it exists. The
+		// download does not hurt here as it's done in a asynchronous call but it's
+		// important to start it as early as possible to have an up to date
+		// remote config at the end of the command execution.
+		remoteconfig.InitGlobal(
+			remoteconfig.Config{
+				Local: remoteconfig.Local{
+					Path: globalconfig.GetGlobalDdevDir(),
+				},
+				Remote: remoteconfig.Remote{
+					Owner:    globalconfig.DdevGlobalConfig.RemoteConfig.Remote.Owner,
+					Repo:     globalconfig.DdevGlobalConfig.RemoteConfig.Remote.Repo,
+					Ref:      globalconfig.DdevGlobalConfig.RemoteConfig.Remote.Ref,
+					Filepath: globalconfig.DdevGlobalConfig.RemoteConfig.Remote.Filepath,
+				},
+				UpdateInterval: globalconfig.DdevGlobalConfig.RemoteConfig.UpdateInterval,
+				TickerInterval: globalconfig.DdevGlobalConfig.Messages.TickerInterval,
+			},
+			state,
+			globalconfig.IsInternetActive,
+		)
+
 		remoteconfig.GetGlobal().ShowTicker()
 		remoteconfig.GetGlobal().ShowNotifications()
 

--- a/cmd/ddev/main.go
+++ b/cmd/ddev/main.go
@@ -2,13 +2,9 @@ package main
 
 import (
 	"os"
-	"path"
 
 	"github.com/ddev/ddev/cmd/ddev/cmd"
 	"github.com/ddev/ddev/pkg/amplitude"
-	"github.com/ddev/ddev/pkg/config/remoteconfig"
-	"github.com/ddev/ddev/pkg/config/state/storage/yaml"
-	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/util"
 )
 
@@ -28,32 +24,6 @@ func main() {
 	if os.Geteuid() == 0 && len(os.Args) > 1 && os.Args[1] != "hostname" {
 		util.Failed("ddev is not designed to be run with root privileges, please run as normal user and without sudo")
 	}
-
-	// Create a global state to be injected later.
-	state := yaml.NewState(path.Join(globalconfig.GetGlobalDdevDir(), ".state.yaml"))
-
-	// TODO for the time being this triggers the download from Github but
-	// should be realized with a clean bootstrap as soon as it exists. The
-	// download does not hurt here as it's done in a asynchronous call but it's
-	// important to start it as early as possible to have an up to date
-	// remote config at the end of the command execution.
-	remoteconfig.InitGlobal(
-		remoteconfig.Config{
-			Local: remoteconfig.Local{
-				Path: globalconfig.GetGlobalDdevDir(),
-			},
-			Remote: remoteconfig.Remote{
-				Owner:    globalconfig.DdevGlobalConfig.RemoteConfig.Remote.Owner,
-				Repo:     globalconfig.DdevGlobalConfig.RemoteConfig.Remote.Repo,
-				Ref:      globalconfig.DdevGlobalConfig.RemoteConfig.Remote.Ref,
-				Filepath: globalconfig.DdevGlobalConfig.RemoteConfig.Remote.Filepath,
-			},
-			UpdateInterval: globalconfig.DdevGlobalConfig.RemoteConfig.UpdateInterval,
-			TickerInterval: globalconfig.DdevGlobalConfig.Messages.TickerInterval,
-		},
-		state,
-		globalconfig.IsInternetActive,
-	)
 
 	cmd.Execute()
 }


### PR DESCRIPTION
## The Issue

#5022

## How This PR Solves The Issue

Initialization of remote-config is moved to start command.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5024"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

