### PR TITLE
Optimize output of debug instrumentation flush, fixes #5023

### DIFF
--- a/cmd/ddev/cmd/debug-instrumentation-flush.go
+++ b/cmd/ddev/cmd/debug-instrumentation-flush.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/ddev/ddev/pkg/amplitude"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -17,9 +18,13 @@ var DebugInstrumentationFlushCmd = &cobra.Command{
 			return
 		}
 
-		amplitude.FlushForce()
+		debugBackup := globalconfig.DdevDebug
+		globalconfig.DdevDebug = true
+		defer func() {
+			globalconfig.DdevDebug = debugBackup
+		}()
 
-		util.Success("Usage statistics submitted.")
+		amplitude.FlushForce()
 	},
 }
 

--- a/pkg/amplitude/amplitude.go
+++ b/pkg/amplitude/amplitude.go
@@ -183,7 +183,7 @@ func InitAmplitude() {
 		interval = 24 * time.Hour
 	}
 
-	logger := loggers.NewDdevLogger(globalconfig.DdevVerbose)
+	logger := loggers.NewDdevLogger(globalconfig.DdevDebug, globalconfig.DdevVerbose)
 
 	ampli.Instance.Load(ampli.LoadOptions{
 		Client: ampli.LoadClientOptions{

--- a/pkg/amplitude/loggers/ddev_logger.go
+++ b/pkg/amplitude/loggers/ddev_logger.go
@@ -9,13 +9,15 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 )
 
-func NewDdevLogger(verbose bool) types.Logger {
+func NewDdevLogger(debug, verbose bool) types.Logger {
 	return &ddevLogger{
+		debug:   debug,
 		verbose: verbose,
 	}
 }
 
 type ddevLogger struct {
+	debug   bool
 	verbose bool
 }
 
@@ -26,19 +28,19 @@ func (l *ddevLogger) Debugf(message string, args ...interface{}) {
 }
 
 func (l *ddevLogger) Infof(message string, args ...interface{}) {
-	if l.verbose {
+	if l.verbose || l.debug {
 		output.UserErr.Info(filterMessage(util.ColorizeText(message, "green"), args...))
 	}
 }
 
 func (l *ddevLogger) Warnf(message string, args ...interface{}) {
-	if l.verbose {
+	if l.verbose || l.debug {
 		output.UserErr.Warn(filterMessage(util.ColorizeText(message, "yellow"), args...))
 	}
 }
 
 func (l *ddevLogger) Errorf(message string, args ...interface{}) {
-	if l.verbose {
+	if l.verbose || l.debug {
 		output.UserErr.Error(filterMessage(util.ColorizeText(message, "red"), args...))
 	}
 }

--- a/pkg/amplitude/loggers/ddev_logger_test.go
+++ b/pkg/amplitude/loggers/ddev_logger_test.go
@@ -34,7 +34,7 @@ func (t *DdevLoggerSuite) TestLogger() {
 
 	require := t.Require()
 
-	logger := loggers.NewDdevLogger(true)
+	logger := loggers.NewDdevLogger(true, true)
 
 	require.Implements((*types.Logger)(nil), logger)
 

--- a/pkg/amplitude/storages/delayed_transmission_event_storage.go
+++ b/pkg/amplitude/storages/delayed_transmission_event_storage.go
@@ -172,10 +172,18 @@ func (s *delayedTransmissionEventStorage) readCache() error {
 		return nil
 	}
 
+	defer file.Close()
+
+	stat, err := file.Stat()
+	if err != nil || stat.Size() == 0 {
+		s.loaded = true
+		s.logger.Infof("Event cache is empty")
+
+		return nil
+	}
+
 	decoder := gob.NewDecoder(file)
 	err = decoder.Decode(&s.cache)
-
-	file.Close()
 
 	// If the file was properly read, mark the cache as loaded.
 	if err == nil {
@@ -194,10 +202,10 @@ func (s *delayedTransmissionEventStorage) writeCache() error {
 		return err
 	}
 
+	defer file.Close()
+
 	encoder := gob.NewEncoder(file)
 	err = encoder.Encode(&s.cache)
-
-	file.Close()
 
 	if err == nil {
 		s.logger.Debugf("Wrote %d events to the cache.", len(s.cache.Events))

--- a/pkg/amplitude/storages/delayed_transmission_event_storage_test.go
+++ b/pkg/amplitude/storages/delayed_transmission_event_storage_test.go
@@ -27,7 +27,7 @@ func (t *DelayedTransmissionEventStorageSuite) TestSimple() {
 
 	require := t.Require()
 
-	s := storages.NewDelayedTransmissionEventStorage(loggers.NewDdevLogger(true), 0, 0, filepath.Join(t.T().TempDir(), `TestSimple.cache`))
+	s := storages.NewDelayedTransmissionEventStorage(loggers.NewDdevLogger(true, true), 0, 0, filepath.Join(t.T().TempDir(), `TestSimple.cache`))
 	s.PushNew(event1)
 	require.Equal(1, s.Count(time.Time{}))
 	s.PushNew(event2)
@@ -70,7 +70,7 @@ func (t *DelayedTransmissionEventStorageSuite) TestReturnBack() {
 
 	require := t.Require()
 
-	s := storages.NewDelayedTransmissionEventStorage(loggers.NewDdevLogger(true), 0, 0, filepath.Join(t.T().TempDir(), `TestReturnBack.cache`))
+	s := storages.NewDelayedTransmissionEventStorage(loggers.NewDdevLogger(true, true), 0, 0, filepath.Join(t.T().TempDir(), `TestReturnBack.cache`))
 	s.PushNew(event1)
 	s.PushNew(event2)
 	s.PushNew(event3)
@@ -108,7 +108,7 @@ func (t *DelayedTransmissionEventStorageSuite) TestCache() {
 
 	require := t.Require()
 
-	s1 := storages.NewDelayedTransmissionEventStorage(loggers.NewDdevLogger(true), 0, 0, cacheFile)
+	s1 := storages.NewDelayedTransmissionEventStorage(loggers.NewDdevLogger(true, true), 0, 0, cacheFile)
 	s1.PushNew(event1)
 	s1.PushNew(event2)
 	s1.PushNew(event3)
@@ -119,7 +119,7 @@ func (t *DelayedTransmissionEventStorageSuite) TestCache() {
 	chunk := s1.Pull(2, time.Time{})
 	require.Equal([]*types.StorageEvent{event1, event2}, chunk)
 
-	s2 := storages.NewDelayedTransmissionEventStorage(loggers.NewDdevLogger(true), 0, 0, cacheFile)
+	s2 := storages.NewDelayedTransmissionEventStorage(loggers.NewDdevLogger(true, true), 0, 0, cacheFile)
 	require.Equal(3, s2.Count(time.Time{}))
 	chunk = s2.Pull(2, time.Time{})
 	require.Equal([]*types.StorageEvent{event3, event4}, chunk)


### PR DESCRIPTION
## The Issue

#5023

## How This PR Solves The Issue

Because the flush method of Amplitide has no return value we do not know if events are subitted or not. Only way around is to let the Amplitude logger print some messages.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5025"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

