### PR TITLE
Add healthcheck to router so we wait for it to be started

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/router-build/traefik_healthcheck.sh
+++ b/pkg/ddevapp/global_dotddev_assets/router-build/traefik_healthcheck.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+#ddev-generated
+
+## traefik health check
+set -eu -o pipefail
+sleeptime=59
+
+# Since docker doesn't provide a lazy period for startup,
+# we track health. If the last check showed healthy
+# as determined by existence of /tmp/healthy, then
+# sleep at startup. This requires the timeout to be set
+# higher than the sleeptime used here.
+if [ -f /tmp/healthy ]; then
+    printf "container was previously healthy, so sleeping ${sleeptime} seconds before continuing healthcheck...  "
+    sleep ${sleeptime}
+fi
+
+# If /tmp/initializing, it means we're loading the default starter database
+if [ -f /tmp/initializing ]; then
+  printf "initializing"
+  exit 1
+fi
+
+# If we can now access the traefik ping endpoint, then we're healthy
+# We should be able to use `traefik healthcheck --ping` but it doesn't work if
+# using nonstandard port (always tries port 8080 even if traefik port is 9999)
+if curl -s -f http://127.0.0.1:9999/ping ; then
+    printf "healthy"
+    touch /tmp/healthy
+    exit 0
+fi
+
+rm -f /tmp/healthy
+exit 1
+

--- a/pkg/ddevapp/router_Dockerfile_template
+++ b/pkg/ddevapp/router_Dockerfile_template
@@ -6,4 +6,5 @@ FROM $BASE_IMAGE
 {{ if eq .Router "traefik" }}
 RUN apk add bash curl htop vim
 WORKDIR /mnt/ddev-global-cache/traefik
+COPY /traefik_healthcheck.sh /healthcheck.sh
 {{ end }}

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: router-build
       args:
-        BASE_IMAGE: {{ .router_image }}
+        BASE_IMAGE: '{{ .router_image }}'
         username: '{{ .Username }}'
         uid: '{{ .UID }}'
         gid: '{{ .GID }}'
@@ -43,7 +43,7 @@ services:
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     healthcheck:
       {{ if eq .Router "traefik" }}
-      test: ["CMD-SHELL", "curl -I -s -f http://127.0.0.1:9999/dashboard || exit 1"]
+      test: "/healthcheck.sh"
       {{ end }}
       interval: 1s
       retries: 120

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -42,6 +42,9 @@ services:
         {{ end }}{{/* end if .letsencrypt */}}
     restart: "{{ if .AutoRestartContainers }}always{{ else }}no{{ end }}"
     healthcheck:
+      {{ if eq .Router "traefik" }}
+      test: ["CMD-SHELL", "curl -I -s -f http://127.0.0.1:9999/dashboard || exit 1"]
+      {{ end }}
       interval: 1s
       retries: 120
       start_period: 120s

--- a/pkg/ddevapp/traefik_static_config_template.yaml
+++ b/pkg/ddevapp/traefik_static_config_template.yaml
@@ -26,6 +26,9 @@ providers:
 global:
   sendanonymoususage: false
 
+ping:
+  entryPoint: "traefik"
+
 entryPoints:
   traefik:
     address: ":9999"


### PR DESCRIPTION
## The Issue

We saw some test failures, TestDdevFullSiteSetup is failing on both [linux](https://github.com/ddev/ddev/actions/runs/5384364660/jobs/9772197856?pr=5028) and [colima](https://github.com/ddev/ddev/actions/runs/5392269854/jobs/9790378473?pr=4904). seems to fail on checking port 8025. Fails on WordPress in each case.  But it may be because that’s the first test? (Traefik has no healthcheck)

## TODO:

- [x] For ddev-webserver and I think dbserver we have a special healthcheck that doesn't keep active all the time, and this is important for battery and CPU usage.

## How This PR Solves The Issue

Add healthcheck to ddev-router when Traefik

## Manual Testing Instructions

Ordinary testing. See how our tests go.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5034"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

