### PR TITLE
Increase test timeout for Windows tests [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ SHASUM=shasum -a 256
 ifeq ($(BUILD_OS),windows)
 	DDEVNAME=ddev.exe
 	SHASUM=sha256sum
+	TEST_TIMEOUT=6h
 endif
 
 DDEV_PATH=$(PWD)/$(GOTMP)/bin/$(BUILD_OS)_$(BUILD_ARCH)


### PR DESCRIPTION
## The Issue

Our Windows+Mutagen tests often take more than the standard limit of 4 hours. This test only happens on master when a PR is pulled.

## How This PR Solves The Issue

Increase the timeout on Windows



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5036"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

