### PR TITLE
ci: enforce commit message convention, fixes #5037 [skip ci]

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,61 @@
+version: v1
+
+labels:
+  - label: 'maintenance'
+    sync: true
+    matcher:
+      title: '^build(|!): .+'
+
+  - label: 'maintenance'
+    sync: true
+    matcher:
+      title: '^ci(|!): .+'
+
+  - label: 'documentation'
+    sync: true
+    matcher:
+      title: '^docs(|!): .+'
+
+  - label: 'enhancement'
+    sync: true
+    matcher:
+      title: '^feat(|!): .+'
+
+  - label: 'bugfix'
+    sync: true
+    matcher:
+      title: '^fix(|!): .+'
+
+  - label: 'maintenance'
+    sync: true
+    matcher:
+      title: '^refactor(|!): .+'
+
+  - label: 'maintenance'
+    sync: true
+    matcher:
+      title: '^test(|!): .+'
+
+  - label: 'breaking'
+    sync: true
+    matcher:
+      title: '^[a-z]+!: .+'
+
+  - label: 'dependencies'
+    sync: true
+    matcher:
+      files:
+        any: ["go.*", "vendor/**"]
+
+checks:
+  - context: "Semantic Pull Request"
+    url: "https://ddev.readthedocs.io/en/latest/developers/building-contributing/#pull-request-title-guidelines"
+    description:
+      success: Ready for review.
+      failure: Missing semantic label.
+    labels:
+      any:
+        - bugfix
+        - documentation
+        - enhancement
+        - maintenance

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,34 @@
+name: PR Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review, review_requested]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: write
+  checks: write
+      
+jobs:
+  check_pr_title:
+    name: Check PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Type
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^(build|ci|docs|feat|fix|refactor|test)(|!): [a-z].+?((, fixes #\d+)*)($|\n|\r|\n\r)'
+          flags: ''
+          error: 'Title does not follow our conventions see https://ddev.readthedocs.io/en/latest/developers/building-contributing/#pull-request-title-guidelines.'
+
+  assign_labels:
+    name: Assign Labels
+    needs: check_pr_title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign and check labels
+        uses: fuxingloh/multi-labeler@v2
+        with:
+          config-path: .github/pr-labeler.yml

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -266,6 +266,62 @@ Once you’ve opened a pull request, a discussion will start around your propose
 
 If your pull request is merged, great! If not, no sweat; it may not be what the project maintainer had in mind, or they were already working on it. This happens, so our recommendation is to take any feedback you’ve received and go forth and pull request again. Or create your own open source project.
 
+### Pull Request Title Guidelines
+
+We have very precise rules over how our PR titles (and thus master-branch commits) are to be formatted. This leads to **more readable messages** that are easy to follow when looking through the **project history**. But also, we use the master-branch Git commit messages to **generate the changelog** for the releases.
+
+The pull request title must follow this convention which is based on the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification:
+
+`<type>[optional !]: <description>[, fixes #<issue>]`
+
+#### Examples
+
+* `build: bump mutagen to 0.17.2`
+* `ci: enforce commit message convention, fixes #5037`
+* `docs: improve additional-hostnames.md`
+* `feat: allow multiple upload dirs, fixes #4190, fixes #4796`
+* `fix: create upload_dir if it doesn't exist in ddev composer create, fixes #5031`
+* `refactor: add new Amplitude Property DDEV-Environment`
+* `test: optimize caching of downloaded assets`
+
+#### Type
+
+Must be one of the following:
+
+* **build**: Changes that affect the build or external dependencies
+* **ci**: Changes to our CI configuration files and scripts
+* **docs**: Documentation only changes
+* **feat**: A new feature
+* **fix**: A bugfix
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **test**: Adding missing tests or correcting existing tests
+
+Regarding SemVer, all types above except `feat` increase the patch version, `feat` increases the minor version.
+
+#### Scope
+
+No scope must be used.
+
+#### Breaking Changes
+
+Breaking changes must have a `!` appended after type/scope.
+
+Regarding SemVer, breaking changes increase the major version.
+
+#### Subject / Description
+
+The subject contains a succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize the first letter
+* no dot (.) at the end
+
+If an issue exists for the change, `, fixes #<issue number>` must be appended to the subject.
+
+#### Revert
+
+If the commit reverts a previous commit, it should begin with `revert:`, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.
+
 ## Coding Style
 
 Unless explicitly stated, we follow all coding guidelines from the Go community. While some of these standards may seem arbitrary, they somehow seem to result in a solid, consistent codebase.


### PR DESCRIPTION
* #5037 

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5038"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

