### PR TITLE
test: stop testing TestDdevFullSiteSetup on Windows/Colima [skip ci]

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1999,6 +1999,9 @@ func readLastLine(fileName string) (string, error) {
 // TestDdevFullSiteSetup tests a full import-db and import-files and then looks to see if
 // we have a spot-test success hit on a URL
 func TestDdevFullSiteSetup(t *testing.T) {
+	if runtime.GOOS == "windows" || dockerutil.IsColima() {
+		t.Skip("Skipping on Windows and Colima as this is tested adequately elsewhere")
+	}
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
 


### PR DESCRIPTION
## The Issue

Traditional Windows and Colima testing are very slow and TestDdevFullSiteSetup is particularly problematic with both.

## How This PR Solves The Issue

We don't need TestDdevFullSiteSetup on Windows/Colima. Stop testing it

Future:

For ddevapp package, we could easily change the TestMain to skip certain tests automatically based on some general criteria instead of doing one-off changes like this.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5041"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

