### PR TITLE
test: refresh colima/lima/homebrew github caches, docker build cache

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -57,3 +57,10 @@ docker rmi -f $(docker images | awk '/ddev.*-built/ {print $3}' ) >/dev/null 2>&
 if docker volume ls | grep '[Tt]est.*_nfsmount'; then
   docker volume rm -f $(docker volume ls | awk '/[Tt]est.*_nfsmount/ { print $2; }') || true
 fi
+
+# Clean the docker build cache
+docker builder prune -f -a || true
+docker buildx prune -f -a || true
+# Remove any images with name '-built'
+docker rm -f $(docker ps -aq) >/dev/null || true
+docker rmi -f $(docker images | awk '/[-]built/ { print $3 }')  >/dev/null || true

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Homebrew cache/restore
         uses: actions/cache@v3
         env:
-          cache-name: cache-homebrew-cache-13
+          cache-name: cache-homebrew-cache-14
         with:
           path: ~/Library/Caches/Homebrew
           key: ${{ runner.os }}-build-${{ env.cache-name }}
@@ -86,7 +86,7 @@ jobs:
       - name: Lima cache/restore
         uses: actions/cache@v3
         env:
-          cache-name: cache-lima-13
+          cache-name: cache-lima-14
         with:
           path: ~/.lima
           key: ${{ runner.os }}-build-${{ env.cache-name }}

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -120,7 +120,7 @@ jobs:
           docker rm -f $(docker ps -aq) >/dev/null || true
           docker rmi -f $(docker images | awk '/[-]built/ { print $3 }')  >/dev/null || true
 
-  # Pre-cache these so we don't see a mess in the later pull
+          # Pre-cache these so we don't see a mess in the later pull
           for image in schickling/beanstalkd:latest memcached:1.5 solr:8; do
             docker pull $image
           done >/dev/null

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -115,7 +115,12 @@ jobs:
           ddev config --project-type=drupal9 --docroot=web --create-docroot
           ddev debug download-images
           ddev poweroff
-          # Pre-cache these so we don't see a mess in the later pull
+          docker builder prune -f -a || true
+          docker buildx prune -f -a || true
+          docker rm -f $(docker ps -aq) >/dev/null || true
+          docker rmi -f $(docker images | awk '/[-]built/ { print $3 }')  >/dev/null || true
+
+  # Pre-cache these so we don't see a mess in the later pull
           for image in schickling/beanstalkd:latest memcached:1.5 solr:8; do
             docker pull $image
           done >/dev/null

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -39,14 +39,5 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: latest
+        args: --timeout=30m --disable-all --enable=gofmt --enable=govet --enable=revive --enable=errcheck --enable=staticcheck --enable=ineffassign
 
-        # Optional: working directory, useful for monorepos
-        # working-directory: somedir
-
-        args: --disable-all --enable=gofmt --enable=govet --enable=revive --enable=errcheck --enable=staticcheck --enable=ineffassign
-
-        # Optional: show only new issues if it's a pull request. The default value is `false`.
-        # only-new-issues: true
-
-        # Optional: if set to true then the action will use pre-installed Go
-        # skip-go-install: true

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -780,12 +780,12 @@ func TestConfigOverrideDetection(t *testing.T) {
 	startErr := app.StartAndWait(2)
 	stdout := stdoutFunc()
 
-	var logs string
+	var logs, health string
 	if startErr != nil {
-		logs, _ = GetErrLogsFromApp(app, startErr)
+		logs, health, _ = GetErrLogsFromApp(app, startErr)
 	}
 
-	require.NoError(t, startErr, "app.StartAndWait() did not succeed: output:\n=====\n%s\n===== logs:\n========= logs =======\n%s\n========\n", stdout, logs)
+	require.NoError(t, startErr, "app.StartAndWait() did not succeed: output:\n=====\n%s\n===== health:\n========= health =======\n%s\n========\n===== logs:\n========= logs =======\n%s\n========\n", stdout, health, logs)
 
 	assert.Contains(stdout, "collation.cnf")
 	assert.Contains(stdout, "my-php.ini")
@@ -859,8 +859,8 @@ func TestPHPOverrides(t *testing.T) {
 	startErr := app.StartAndWait(5)
 	assert.NoError(startErr)
 	if startErr != nil {
-		logs, _ := GetErrLogsFromApp(app, startErr)
-		t.Fatalf("============== logs from app.StartAndWait() ==============\n%s\n", logs)
+		logs, health, _ := GetErrLogsFromApp(app, startErr)
+		t.Fatalf("============== health from app.StartAndWait() ==============\n%s\n============== logs from app.StartAndWait() ==============\n%s\n", health, logs)
 	}
 
 	err = app.MutagenSyncFlush()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2697,7 +2697,7 @@ func TestDdevPause(t *testing.T) {
 		assert.NoError(err)
 		check, err := testcommon.ContainerCheck(containerName, "exited")
 		assert.NoError(err)
-		assert.True(check, containerType, "container has exited")
+		assert.True(check, "Container should have shown 'exited' but instead showed something else, err=%v, containerType=%s: %s", err, containerType, "container has exited")
 	}
 	assert.FileExists("hello-pre-pause-" + app.Name)
 	assert.FileExists("hello-post-pause-" + app.Name)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2072,9 +2072,9 @@ func TestDdevFullSiteSetup(t *testing.T) {
 
 		startErr := app.StartAndWait(2)
 		if startErr != nil {
-			appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
+			appLogs, health, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 			assert.NoError(getLogsErr)
-			t.Fatalf("app.StartAndWait() failure err=%v; logs:\n=====\n%s\n=====\n", startErr, appLogs)
+			t.Fatalf("app.StartAndWait() failure err=%v; health=\n%s\n\nlogs:\n=====\n%s\n=====\n", startErr, health, appLogs)
 		}
 
 		// Test static content.
@@ -2094,9 +2094,9 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		body, resp, err := testcommon.GetLocalHTTPResponse(t, rawurl, 120)
 		assert.NoError(err, "GetLocalHTTPResponse returned err on project=%s rawurl %s, resp=%v: %v", site.Name, rawurl, resp, err)
 		if err != nil && strings.Contains(err.Error(), "container ") {
-			logs, err := ddevapp.GetErrLogsFromApp(app, err)
+			logs, health, err := ddevapp.GetErrLogsFromApp(app, err)
 			assert.NoError(err)
-			t.Fatalf("Logs after GetLocalHTTPResponse: %s", logs)
+			t.Fatalf("Health:\n%s\n\nLogs after GetLocalHTTPResponse: %s", health, logs)
 		}
 		assert.Contains(body, site.DynamicURI.Expect, "expected %s on project %s", site.DynamicURI.Expect, site.Name)
 
@@ -2504,9 +2504,9 @@ func TestDdevExec(t *testing.T) {
 
 	startErr := app.Start()
 	if startErr != nil {
-		logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
+		logs, health, err := ddevapp.GetErrLogsFromApp(app, startErr)
 		assert.NoError(err)
-		t.Fatalf("app.Start() failed err=%v, logs from broken container:\n=======\n%s\n========\n", startErr, logs)
+		t.Fatalf("app.Start() failed err=%v, health:\n%s\n\nlogs from broken container:\n=======\n%s\n========\n", startErr, health, logs)
 	}
 
 	out, _, err := app.Exec(&ddevapp.ExecOpts{
@@ -2638,9 +2638,9 @@ func TestDdevLogs(t *testing.T) {
 
 	startErr := app.StartAndWait(0)
 	if startErr != nil {
-		logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
+		logs, health, err := ddevapp.GetErrLogsFromApp(app, startErr)
 		assert.NoError(err)
-		t.Fatalf("app.Start failed, err=%v, logs=\n========\n%s\n===========\n", startErr, logs)
+		t.Fatalf("app.Start failed, err=%v, health=\n%s\n\nlogs=\n========\n%s\n===========\n", startErr, health, logs)
 	}
 
 	out, err := app.CaptureLogs("web", false, "")
@@ -2728,9 +2728,9 @@ func TestDdevStopMissingDirectory(t *testing.T) {
 	//nolint: errcheck
 	defer app.Stop(true, false)
 	if startErr != nil {
-		logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
+		logs, health, err := ddevapp.GetErrLogsFromApp(app, startErr)
 		assert.NoError(err)
-		t.Fatalf("app.StartAndWait failed err=%v logs from broken container: \n=======\n%s\n========\n", startErr, logs)
+		t.Fatalf("app.StartAndWait failed err=%v health=\n%s\n\nlogs from broken container: \n=======\n%s\n========\n", startErr, health, logs)
 	}
 
 	tempPath := testcommon.CreateTmpDir("site-copy")
@@ -2832,9 +2832,9 @@ func TestDdevDescribeMissingDirectory(t *testing.T) {
 	//nolint: errcheck
 	defer app.Stop(true, false)
 	if startErr != nil {
-		logs, err := ddevapp.GetErrLogsFromApp(app, startErr)
+		logs, health, err := ddevapp.GetErrLogsFromApp(app, startErr)
 		assert.NoError(err)
-		t.Fatalf("app.StartAndWait failed err=%v logs from broken container: \n=======\n%s\n========\n", startErr, logs)
+		t.Fatalf("app.StartAndWait failed err=%v health:\n%s\nlogs from broken container: \n=======\n%s\n========\n", startErr, health, logs)
 	}
 	// Move the site directory to a temp location to mimic a missing directory.
 	err = app.Stop(false, false)
@@ -2885,9 +2885,9 @@ func TestRouterPortsCheck(t *testing.T) {
 	//nolint: errcheck
 	defer app.Stop(true, false)
 	if startErr != nil {
-		appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
+		appLogs, health, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 		assert.NoError(getLogsErr)
-		t.Fatalf("app.StartAndWait() failure; err=%v logs:\n=====\n%s\n=====\n", startErr, appLogs)
+		t.Fatalf("app.StartAndWait() failure; err=%v health:\n%s\n\nlogs:\n=====\n%s\n=====\n", startErr, health, appLogs)
 	}
 
 	app, err = ddevapp.GetActiveApp(site.Name)
@@ -2898,9 +2898,9 @@ func TestRouterPortsCheck(t *testing.T) {
 	//nolint: errcheck
 	defer app.Stop(true, false)
 	if startErr != nil {
-		appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
+		appLogs, health, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 		assert.NoError(getLogsErr)
-		t.Fatalf("app.StartAndWait() failure err=%v logs:\n=====\n%s\n=====\n", startErr, appLogs)
+		t.Fatalf("app.StartAndWait() failure err=%v healthcheck:\n%s\n\nlogs:\n=====\n%s\n=====\n", startErr, health, appLogs)
 	}
 
 	// Stop the router using code from StopRouterIfNoContainers().
@@ -3172,9 +3172,9 @@ func TestHttpsRedirection(t *testing.T) {
 			startErr := app.StartAndWait(5)
 			assert.NoError(startErr, "app.Start() failed with projectType=%s, webserverType=%s", projectType, webserverType)
 			if startErr != nil {
-				appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
+				appLogs, health, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 				assert.NoError(getLogsErr)
-				t.Fatalf("app.StartAndWait failure; err=%v \n===== container logs ==\n%s\n", startErr, appLogs)
+				t.Fatalf("app.StartAndWait failure; err=%v \nhealthchecks:\n%s\n\n===== container logs ==\n%s\n", startErr, health, appLogs)
 			}
 			// Test for directory redirects under https and http
 			for _, parts := range expectations {
@@ -3383,9 +3383,9 @@ func TestPHPWebserverType(t *testing.T) {
 				assert.NoError(err)
 			})
 			if startErr != nil {
-				appLogs, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
+				appLogs, health, getLogsErr := ddevapp.GetErrLogsFromApp(app, startErr)
 				assert.NoError(getLogsErr)
-				t.Fatalf("app.StartAndWait failure for WebserverType=%s; site.Name=%s; err=%v, logs:\n=====\n%s\n=====\n", app.WebserverType, site.Name, startErr, appLogs)
+				t.Fatalf("app.StartAndWait failure for WebserverType=%s; site.Name=%s; err=%v, health:\n%s\n\nlogs:\n=====\n%s\n=====\n", app.WebserverType, site.Name, startErr, health, appLogs)
 			}
 			out, resp, err := testcommon.GetLocalHTTPResponse(t, app.GetWebContainerDirectHTTPURL()+"/servertype.php")
 			require.NoError(t, err)

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -214,7 +214,7 @@ func RenderRouterStatus() string {
 	var renderedStatus string
 	if !nodeps.ArrayContainsString(globalconfig.DdevGlobalConfig.OmitContainersGlobal, globalconfig.DdevRouterContainer) {
 		status, logOutput := GetRouterStatus()
-		badRouter := "The router is not healthy. Your projects may not be accessible.\nIf it doesn't become healthy try running 'ddev start' on a project to recreate it."
+		badRouter := "The router is not healthy. Your projects may not be accessible.\nIf it doesn't become healthy try running 'ddev poweroff && ddev start' on a project to recreate it."
 
 		switch status {
 		case SiteStopped:

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -118,7 +118,7 @@ func StartDdevRouter() error {
 	}
 	logOutput, err := dockerutil.ContainerWait(routerWaitTimeout, label)
 	if err != nil {
-		return fmt.Errorf("ddev-router failed to become ready; debug with 'docker logs ddev-router'; logOutput=%s, err=%v", logOutput, err)
+		return fmt.Errorf("ddev-router failed to become ready; debug with 'docker logs ddev-router' and 'docker inspect --format \"{{json .State.Health }}\" ddev-router'; logOutput=%s, err=%v", logOutput, err)
 	}
 
 	return nil

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -119,8 +119,8 @@ func TestWriteDrushConfig(t *testing.T) {
 		//nolint: errcheck
 		defer app.Stop(true, false)
 		if startErr != nil {
-			logs, _ := GetErrLogsFromApp(app, startErr)
-			t.Fatalf("app.Start failed, startErr=%v, logs=\n========\n%s\n===========\n", startErr, logs)
+			logs, health, _ := GetErrLogsFromApp(app, startErr)
+			t.Fatalf("app.Start failed, startErr=%v, healthcheck:\n%s\n\nlogs=\n========\n%s\n===========\n", startErr, health, logs)
 		}
 
 		drushFilePath := filepath.Join(filepath.Dir(app.SiteSettingsPath), "drushrc.php")

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -64,7 +64,7 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 	sshWaitTimeout := 60
 	_, err = dockerutil.ContainerWait(sshWaitTimeout, label)
 	if err != nil {
-		return fmt.Errorf("ddev-ssh-agent failed to become ready; debug with 'docker logs ddev-ssh-agent'; error: %v", err)
+		return fmt.Errorf("ddev-ssh-agent failed to become ready; debug with 'docker logs ddev-ssh-agent' and 'docker inspect --format \"{{json .State.Health }}\" ddev-ssh-agent'; error: %v", err)
 	}
 
 	util.Warning("ssh-agent container is running: If you want to add authentication to the ssh-agent container, run 'ddev auth ssh' to enable your keys.")

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -299,10 +299,10 @@ func GetErrLogsFromApp(app *DdevApp, errorReceived error) (string, string, error
 		if len(splitError) > 0 && nodeps.ArrayContainsString([]string{"web", "db", "ddev-router", "ddev-ssh-agent"}, splitError[0]) {
 			serviceName = splitError[0]
 			health := ""
-			if containerID, err := dockerutil.FindContainerByName(serviceName); err != nil {
+			if containerID, err := dockerutil.FindContainerByName(serviceName); err == nil {
 				_, health = dockerutil.GetContainerHealth(containerID)
 			}
-			logs, err := app.CaptureLogs(serviceName, false, "")
+			logs, err := app.CaptureLogs(serviceName, false, "10")
 			if err != nil {
 				return "", "", err
 			}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -463,7 +463,7 @@ func GetContainerHealth(container *docker.APIContainers) (string, string) {
 	if inspect.State.Health.Status != "" {
 		numLogs := len(inspect.State.Health.Log)
 		if numLogs > 0 {
-			logOutput = inspect.State.Health.Log[numLogs-1].Output
+			logOutput = fmt.Sprintf("%v", inspect.State.Health.Log)
 		}
 	} else {
 		// Some containers may not have a healthcheck. In that case

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -146,7 +146,7 @@ func TestGetContainerHealth(t *testing.T) {
 		assert.NotNil(container)
 
 		status, healthDetail := GetContainerHealth(container)
-		assert.Equal("/var/www/html:OK mailhog:OK phpstatus:OK ", healthDetail)
+		assert.Contains(healthDetail, "/var/www/html:OK mailhog:OK phpstatus:OK ")
 		assert.Equal("healthy", status)
 	})
 

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -161,8 +161,8 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 		startErr := app.StartAndWait(5)
 		assert.NoError(startErr, "app.StartAndWait failed for port pair %v", pair)
 		if startErr != nil {
-			logs, _ := ddevapp.GetErrLogsFromApp(app, startErr)
-			t.Fatalf("logs from broken container:\n=======\n%s\n========\n", logs)
+			logs, health, _ := ddevapp.GetErrLogsFromApp(app, startErr)
+			t.Fatalf("healthcheck:\n%s\n\nlogs from broken container:\n=======\n%s\n========\n", health, logs)
 		}
 
 		safeURL := app.GetHTTPURL() + site.Safe200URIWithExpectation.URI


### PR DESCRIPTION
## The Issue

I'm seeing [failures in colima](https://github.com/ddev/ddev/actions/runs/5405137627/jobs/9820257249?pr=5042) of the Traefik router healthcheck coming up; in other environments this has meant the build cache is messy, or that's the best I've been able to figure out.

## How This PR Solves The Issue

* New cache for homebrew and colima/lima.
* Clean docker build cache and `-built` images at start of test
* Destroy any existing containers before starting test
* Add healthcheck history to the output of many tests for debugging


## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5043"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

