### PR TITLE
docs: improve additional-hostnames.md

### DIFF
--- a/docs/content/users/extend/additional-hostnames.md
+++ b/docs/content/users/extend/additional-hostnames.md
@@ -13,9 +13,12 @@ additional_hostnames:
   - "*.lotsofnames"
 ```
 
-Hostnames can be added with the console command `ddev config --additional-hostnames comma,separated,hostnames`
 
 This configuration would result in working hostnames of `mysite.ddev.site`, `extraname.ddev.site`, `fr.mysite.ddev.site`, `es.mysite.ddev.site`, and `it.mysite.ddev.site`—with full HTTP and HTTPS URLs for each.
+
+You could accomplish the same thing by running the `ddev config` command:
+
+    ddev config --additional-hostnames extraname,fr.mysite,es.mysite,it.mysite,*.lotsofnames
 
 In addition, the wildcard `*.lotsofnames` will result in anything `*.lotsofnames.ddev.site` being recognized by the project. This works only if you’re connected to the internet, using `ddev.site` for your top-level-domain, and using DNS for name lookups. (These are all the defaults.)
 

--- a/docs/content/users/extend/additional-hostnames.md
+++ b/docs/content/users/extend/additional-hostnames.md
@@ -6,11 +6,11 @@ Add additional hostnames to a project in its `.ddev/config.yaml`:
 name: mysite
 
 additional_hostnames:
-- extraname
-- fr.mysite
-- es.mysite
-- it.mysite
-- *.lotsofnames
+  - "extraname"
+  - "fr.mysite"
+  - "es.mysite"
+  - "it.mysite"
+  - "*.lotsofnames"
 ```
 
 Hostnames can be added with the console command `ddev config --additional-hostnames comma,separated,hostnames`

--- a/docs/content/users/extend/additional-hostnames.md
+++ b/docs/content/users/extend/additional-hostnames.md
@@ -6,12 +6,14 @@ Add additional hostnames to a project in its `.ddev/config.yaml`:
 name: mysite
 
 additional_hostnames:
-- "extraname"
-- "fr.mysite"
-- "es.mysite"
-- "it.mysite"
-- "*.lotsofnames"
+- extraname
+- fr.mysite
+- es.mysite
+- it.mysite
+- *.lotsofnames
 ```
+
+Hostnames can be added with the console command `ddev config --additional-hostnames comma,separated,hostnames`
 
 This configuration would result in working hostnames of `mysite.ddev.site`, `extraname.ddev.site`, `fr.mysite.ddev.site`, `es.mysite.ddev.site`, and `it.mysite.ddev.site`—with full HTTP and HTTPS URLs for each.
 


### PR DESCRIPTION
Removed confusing string quotes that doesn't work in the config and example of console command that adds the hostnames for you.

## The Issue
Quotes around the hostnames didn't work for me.

## How This PR Solves The Issue
Removes the quotes from the text and suggests a console command

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5045"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

