### PR TITLE
test: fix broken Mutagen test, fixes #5053

### DIFF
--- a/cmd/ddev/cmd/mutagen-cmd_test.go
+++ b/cmd/ddev/cmd/mutagen-cmd_test.go
@@ -53,14 +53,14 @@ func TestCmdMutagen(t *testing.T) {
 		assert.NoError(err)
 
 		require.Equal(t, runtime.GOOS == "darwin" || runtime.GOOS == "windows", globalconfig.DdevGlobalConfig.IsMutagenEnabled())
-		require.Equal(t, runtime.GOOS == "darwin" || runtime.GOOS == "windows", app.IsMutagenEnabled())
+		require.Equal(t, (runtime.GOOS == "darwin" || runtime.GOOS == "windows") && nodeps.PerformanceModeDefault != types.PerformanceModeNFS, app.IsMutagenEnabled())
 
 		err = os.Chdir(origDir)
 		assert.NoError(err)
 	})
 
 	require.Equal(t, runtime.GOOS == "darwin" || runtime.GOOS == "windows", globalconfig.DdevGlobalConfig.IsMutagenEnabled())
-	require.Equal(t, runtime.GOOS == "darwin" || runtime.GOOS == "windows", app.IsMutagenEnabled())
+	require.Equal(t, (runtime.GOOS == "darwin" || runtime.GOOS == "windows") && nodeps.PerformanceModeDefault != types.PerformanceModeNFS, app.IsMutagenEnabled())
 
 	// Turn mutagen off globally
 	_, err = exec.RunHostCommand(DdevBin, "config", "global", "--performance-mode-reset")


### PR DESCRIPTION
## The Issue

- #5053

## How This PR Solves The Issue

Config overridden by env vars is now taken into account.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5054"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

