### PR TITLE
build: bump to new images for v1.22.0-beta1

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM ddev/ddev-php-base:20230502_davereid_php_81 as ddev-webserver-base
+FROM ddev/ddev-php-base:v1.22.0-beta1 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -22,22 +22,22 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20230509_gitpod_output" // Note that this can be overridden by make
+var WebTag = "v1.22.0-beta1" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20230519_fix_mysql_snapshot_restore"
+var BaseDBTag = "v1.22.0-beta1"
 
-const TraditionalRouterImage = "ddev/ddev-router:20230415_move_docker_to_ddev"
+const TraditionalRouterImage = "ddev/ddev-router:v1.22.0-beta1"
 const TraefikRouterImage = "traefik:v2.10"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "20230415_move_docker_to_ddev"
+var SSHAuthTag = "v1.22.0-beta1"
 
 // Busybox is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION
## The Issue

To avoid surprises, rebuild all the images and start using them. We'll do this again at full release or if problems.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5057"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

