### PR TITLE
docs: gh codespaces install docs - update docker-in-docker to v2

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -331,7 +331,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     {
       "image": "mcr.microsoft.com/devcontainers/universal:2",
       "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:1": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/ddev/ddev/install-ddev:latest": {}
       },
       "portsAttributes": {


### PR DESCRIPTION
## The Issue

- according to https://containers.dev/features latest version of docker-in-docker is `2.2.0`, ddev docs still refer to v1

## How This PR Solves The Issue

- bump version to v2

## Manual Testing Instructions

- maybe changes / tests for https://github.com/ddev/ddev/blob/master/.devcontainer/devcontainer.json needed?

## Automated Testing Overview

- maybe changes / tests for https://github.com/ddev/ddev/blob/master/.devcontainer/devcontainer.json needed?

## Related Issue Link(s)

- https://github.com/ddev/ddev/issues/5033#issuecomment-1615076600

## Release/Deployment Notes

- could not find any release notes for `docker-in-docker`, therefore I assume there were no breaking changes (https://github.com/devcontainers/features)


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5060"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

