### PR TITLE
build: gh codespaces - bump docker-in-docker to v2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/go:0-1-bullseye",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
 			"packages": "autojump,curl,wget,xdg-utils"
 		},

--- a/.devcontainer/setup_test_project.sh
+++ b/.devcontainer/setup_test_project.sh
@@ -7,7 +7,7 @@ set -x
 make
 sudo ln -sf /workspaces/ddev/.gotmp/bin/linux_amd64/ddev /usr/local/bin/ddev
 ddev debug download-images
-ddev delete -Oy tmp >/dev/null
+ddev delete -Oy tmp >/dev/null || true
 ddev --version
 
 export DDEV_NONINTERACTIVE=true


### PR DESCRIPTION
## The Issue

- according to https://containers.dev/features latest version of docker-in-docker is 2.2.0, ddev repo uses v1

## How This PR Solves The Issue

- bump to v2

## Manual Testing Instructions

- setup ddev in codespaces, check test project

Beware: `setup_test_project.sh` currently fails with

```bash
2023-07-02 09:41:48.611Z: + ddev delete -Oy tmp
2023-07-02 09:41:49.204Z: Failed to get project(s): could not find requested project 'tmp', you may need to use "ddev start" to add it to the project catalog
2023-07-02 09:41:49.297Z: postCreateCommand failed with exit code 1. Skipping any further user-provided commands.
```

I did full rebuilds, it failed on docker-in-docker v1 as well as v2.

## Automated Testing Overview

- no automated tests for codespaces so far iirc

## Related Issue Link(s)

- https://github.com/ddev/ddev/issues/5033#issuecomment-1615076600

## Release/Deployment Notes

- update docs, prs are add: https://github.com/ddev/ddev/pull/5060

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5061"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

