### PR TITLE
fix: make mkdocs-serve should work with no mkdocs installed [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ mkdocs-serve:
 	if command -v mkdocs >/dev/null ; then \
   		mkdocs serve; \
 	else \
-		docker run -it -p 8000:8000 -v "${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs; \
+		docker run -it -p 8000:8000 -v "${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs:1.2.3; \
 	fi
 
 # Install markdown-link-check locally with "npm install -g markdown-link-check"


### PR DESCRIPTION
## The Issue

@mandrasch reported in https://discord.com/channels/664580571770388500/1124990159629320262/1124990159629320262 that he couldn't use the local `make mkdocs-serve`

## How This PR Solves The Issue

Revert to explicit older docker version for mkdocs.

## Manual Testing Instructions

Run `make mkdocs-serve` without mkdocs installed locally.

