### PR TITLE
fix: avoid instrumentation of project if none is loaded, fixes #5065

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -95,7 +95,10 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 				instrumentationApp = app
 			}
 		}
-		instrumentationApp.TrackProject()
+
+		if instrumentationApp != nil {
+			instrumentationApp.TrackProject()
+		}
 
 		// TODO remove once Amplitude has verified with an alpha release.
 		// Do not report these commands


### PR DESCRIPTION
## The Issue

- #5065

## How This PR Solves The Issue

Avoids instrumentation of the project if none is available.

## Manual Testing Instructions

Run `ddev --version` in a folder without DDEV config.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5066"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

