### PR TITLE
refactor: detect more dependency changes

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -45,7 +45,10 @@ labels:
     sync: true
     matcher:
       files:
-        any: ["go.*", "vendor/**"]
+        any:
+          - "pkg/versionconstants/**"
+          - "go.*"
+          - "vendor/**"
 
 checks:
   - context: "Semantic Pull Request"

--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -2,15 +2,16 @@ package cmd
 
 import (
 	"encoding/json"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/versionconstants"
-	"github.com/stretchr/testify/require"
-	"testing"
-
-	"github.com/ddev/ddev/pkg/exec"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCmdVersion(t *testing.T) {
@@ -29,7 +30,7 @@ func TestCmdVersion(t *testing.T) {
 
 	assert.Equal(versionconstants.DdevVersion, raw["DDEV version"])
 	assert.Equal(versionconstants.WebImg+":"+versionconstants.WebTag, raw["web"])
-	assert.Equal(versionconstants.GetDBImage(nodeps.MariaDB, ""), raw["db"])
+	assert.Equal(docker.GetDBImage(nodeps.MariaDB, ""), raw["db"])
 	dockerVersion, _ := dockerutil.GetDockerVersion()
 	assert.Equal(dockerVersion, raw["docker"])
 	composeVersion, _ := dockerutil.GetDockerComposeVersion()
@@ -39,7 +40,7 @@ func TestCmdVersion(t *testing.T) {
 	assert.Contains(versionData["msg"], versionconstants.WebImg)
 	assert.Contains(versionData["msg"], versionconstants.WebTag)
 	assert.Contains(versionData["msg"], versionconstants.DBImg)
-	assert.Contains(versionData["msg"], versionconstants.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion))
+	assert.Contains(versionData["msg"], docker.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion))
 	assert.NotEmpty(dockerutil.DockerVersion)
 	assert.NotEmpty(globalconfig.DockerComposeVersion)
 	assert.Contains(versionData["msg"], dockerutil.DockerVersion)

--- a/cmd/ddev/cmd/debug-dockercheck.go
+++ b/cmd/ddev/cmd/debug-dockercheck.go
@@ -2,15 +2,16 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	exec2 "github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/version"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/spf13/cobra"
-	"os"
-	"os/exec"
-	"strings"
 )
 
 // DebugDockercheckCmd implements the ddev debug dockercheck command
@@ -72,14 +73,14 @@ var DebugDockercheckCmd = &cobra.Command{
 		}
 
 		uid, _, _ := util.GetContainerUIDGid()
-		_, _, err = dockerutil.RunSimpleContainer(versionconstants.GetWebImage(), "dockercheck-runcontainer--"+util.RandString(6), []string{"ls", "/mnt/ddev-global-cache"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-globa-cache"}, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil)
+		_, _, err = dockerutil.RunSimpleContainer(docker.GetWebImage(), "dockercheck-runcontainer--"+util.RandString(6), []string{"ls", "/mnt/ddev-global-cache"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-globa-cache"}, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil)
 		if err != nil {
 			util.Warning("Unable to run simple container: %v", err)
 		} else {
 			util.Success("Able to run simple container that mounts a volume.")
 		}
 
-		_, _, err = dockerutil.RunSimpleContainer(versionconstants.GetWebImage(), "dockercheck-curl--"+util.RandString(6), []string{"curl", "-sfLI", "https://google.com"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-globa-cache"}, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil)
+		_, _, err = dockerutil.RunSimpleContainer(docker.GetWebImage(), "dockercheck-curl--"+util.RandString(6), []string{"curl", "-sfLI", "https://google.com"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-globa-cache"}, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil)
 		if err != nil {
 			util.Warning("Unable to run use internet inside container, many things will fail: %v", err)
 		} else {

--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
+	"runtime"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/spf13/cobra"
-	"runtime"
 )
 
 // DebugDownloadImagesCmd implements the ddev debug download-images command
@@ -36,7 +37,7 @@ var DebugDownloadImagesCmd = &cobra.Command{
 		}
 
 		// Provide at least the default database image
-		dbImage := versionconstants.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion)
+		dbImage := docker.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion)
 		err = dockerutil.Pull(dbImage)
 		if err != nil {
 			util.Failed("Failed to pull dbImage: %v", err)

--- a/cmd/ddev/cmd/debug-download-images_test.go
+++ b/cmd/ddev/cmd/debug-download-images_test.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"github.com/ddev/ddev/pkg/versionconstants"
 	"os"
 	"testing"
 
+	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
@@ -38,7 +38,7 @@ func TestDebugDownloadImages(t *testing.T) {
 	t.Setenv("DDEV_DEBUG", "true")
 	out, err = exec.RunHostCommand(DdevBin, "debug", "download-images")
 	require.NoError(t, err, "Failed to run ddev debug download-images: %s", out)
-	assert.Contains(out, versionconstants.GetWebImage())
-	assert.Contains(out, versionconstants.GetRouterImage())
+	assert.Contains(out, docker.GetWebImage())
+	assert.Contains(out, docker.GetRouterImage())
 	assert.Contains(out, "Successfully downloaded ddev images")
 }

--- a/cmd/ddev/cmd/debug-nfsmount.go
+++ b/cmd/ddev/cmd/debug-nfsmount.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/spf13/cobra"
 )
 
@@ -62,7 +62,7 @@ var DebugNFSMountCmd = &cobra.Command{
 		_ = volume
 		uidStr, _, _ := util.GetContainerUIDGid()
 
-		_, out, err := dockerutil.RunSimpleContainer(versionconstants.GetWebImage(), containerName, []string{"sh", "-c", "findmnt -T /nfsmount && ls -d /nfsmount/.ddev"}, []string{}, []string{}, []string{"testnfsmount" + ":/nfsmount"}, uidStr, true, false, map[string]string{"com.ddev.site-name": ""}, nil)
+		_, out, err := dockerutil.RunSimpleContainer(docker.GetWebImage(), containerName, []string{"sh", "-c", "findmnt -T /nfsmount && ls -d /nfsmount/.ddev"}, []string{}, []string{}, []string{"testnfsmount" + ":/nfsmount"}, uidStr, true, false, map[string]string{"com.ddev.site-name": ""}, nil)
 		if err != nil {
 			util.Warning("NFS does not seem to be set up yet, see debugging instructions at https://ddev.readthedocs.io/en/stable/users/install/performance/#debugging-ddev-start-failures-with-nfs_mount_enabled-true")
 			util.Failed("Details: error=%v\noutput=%v", err, out)

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -1,16 +1,16 @@
 package cmd
 
 import (
-	"github.com/ddev/ddev/pkg/versionconstants"
 	"os"
 	"sort"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
-
+	dockerImages "github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/ddev/ddev/pkg/versionconstants"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/spf13/cobra"
 )
@@ -96,11 +96,11 @@ func deleteDdevImages(deleteAll bool) error {
 		return images[i].RepoTags[0] > images[j].RepoTags[0]
 	})
 
-	webimg := versionconstants.GetWebImage()
-	routerimage := versionconstants.GetRouterImage()
-	sshimage := versionconstants.GetSSHAuthImage()
+	webimg := dockerImages.GetWebImage()
+	routerimage := dockerImages.GetRouterImage()
+	sshimage := dockerImages.GetSSHAuthImage()
 
-	nameAry := strings.Split(versionconstants.GetDBImage(nodeps.MariaDB, ""), ":")
+	nameAry := strings.Split(dockerImages.GetDBImage(nodeps.MariaDB, ""), ":")
 	keepDBImageTag := "notagfound"
 	if len(nameAry) > 1 {
 		keepDBImageTag = nameAry[1]
@@ -129,7 +129,7 @@ func deleteDdevImages(deleteAll bool) error {
 			}
 			// TODO: Verify the functionality here. May not work since GetRouterImage() returns full image spec
 			// If a routerImage, but doesn't match our routerimage, delete it
-			if strings.HasPrefix(tag, versionconstants.GetRouterImage()) && !strings.HasPrefix(tag, routerimage) {
+			if strings.HasPrefix(tag, dockerImages.GetRouterImage()) && !strings.HasPrefix(tag, routerimage) {
 				if err = dockerutil.RemoveImage(tag); err != nil {
 					return err
 				}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -14,13 +14,13 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/ddev/ddev/pkg/config/types"
+	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	copy2 "github.com/otiai10/copy"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -104,7 +104,7 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	}
 	app.UseDNSWhenPossible = true
 
-	app.WebImage = versionconstants.GetWebImage()
+	app.WebImage = docker.GetWebImage()
 
 	// Load from file if available. This will return an error if the file doesn't exist,
 	// and it is up to the caller to determine if that's an issue.
@@ -176,7 +176,7 @@ func (app *DdevApp) WriteConfig() error {
 	appcopy := *app
 
 	// Only set the images on write if non-default values have been specified.
-	if appcopy.WebImage == versionconstants.GetWebImage() {
+	if appcopy.WebImage == docker.GetWebImage() {
 		appcopy.WebImage = ""
 	}
 	if appcopy.MailhogPort == nodeps.DdevDefaultMailhogPort {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	. "github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -20,7 +21,6 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/google/uuid"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,8 +54,8 @@ func TestNewConfig(t *testing.T) {
 	})
 
 	// Ensure the config uses specified defaults.
-	assert.Equal(app.GetDBImage(), versionconstants.GetDBImage(nodeps.MariaDB, ""))
-	assert.Equal(app.WebImage, versionconstants.GetWebImage())
+	assert.Equal(app.GetDBImage(), docker.GetDBImage(nodeps.MariaDB, ""))
+	assert.Equal(app.WebImage, docker.GetWebImage())
 	app.Name = util.RandString(32)
 	app.Type = nodeps.AppTypeDrupal8
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ddev/ddev/pkg/archive"
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
+	dockerImages "github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -476,8 +477,8 @@ func TestDdevStart(t *testing.T) {
 	})
 
 	// Make sure the -built docker image exists before stop
-	webBuilt := versionconstants.GetWebImage() + "-" + site.Name + "-built"
-	dbBuilt := versionconstants.GetWebImage() + "-" + site.Name + "-built"
+	webBuilt := dockerImages.GetWebImage() + "-" + site.Name + "-built"
+	dbBuilt := dockerImages.GetWebImage() + "-" + site.Name + "-built"
 	exists, err := dockerutil.ImageExistsLocally(webBuilt)
 	assert.NoError(err)
 	assert.True(exists)
@@ -2926,7 +2927,7 @@ func TestRouterPortsCheck(t *testing.T) {
 		},
 	}
 
-	containerID, out, err := dockerutil.RunSimpleContainer(versionconstants.GetWebImage(), t.Name()+"occupyport", nil, []string{}, []string{}, []string{"testnfsmount" + ":/nfsmount"}, "", false, true, map[string]string{"ddevtestcontainer": t.Name()}, portBinding)
+	containerID, out, err := dockerutil.RunSimpleContainer(dockerImages.GetWebImage(), t.Name()+"occupyport", nil, []string{}, []string{}, []string{"testnfsmount" + ":/nfsmount"}, "", false, true, map[string]string{"ddevtestcontainer": t.Name()}, portBinding)
 
 	if err != nil {
 		t.Fatalf("Failed to run docker command to occupy port 80/443, err=%v output=%v", err, out)

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -12,13 +12,13 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	dockerImages "github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/netutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	docker "github.com/fsouza/go-dockerclient"
 )
 
@@ -150,7 +150,7 @@ func generateRouterCompose() (string, error) {
 		"Username":                   username,
 		"UID":                        uid,
 		"GID":                        gid,
-		"router_image":               versionconstants.GetRouterImage(),
+		"router_image":               dockerImages.GetRouterImage(),
 		"ports":                      exposedPorts,
 		"router_bind_all_interfaces": globalconfig.DdevGlobalConfig.RouterBindAllInterfaces,
 		"dockerIP":                   dockerIP,

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -1,0 +1,54 @@
+package docker
+
+import (
+	"fmt"
+
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/globalconfig/types"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/versionconstants"
+)
+
+// GetWebImage returns the correctly formatted web image:tag reference
+func GetWebImage() string {
+	fullWebImg := versionconstants.WebImg
+	if globalconfig.DdevGlobalConfig.UseHardenedImages {
+		fullWebImg = fullWebImg + "-prod"
+	}
+	return fmt.Sprintf("%s:%s", fullWebImg, versionconstants.WebTag)
+}
+
+// GetDBImage returns the correctly formatted db image:tag reference
+func GetDBImage(dbType string, dbVersion string) string {
+	v := nodeps.MariaDBDefaultVersion
+	if dbVersion != "" {
+		v = dbVersion
+	}
+	if dbType == "" {
+		dbType = nodeps.MariaDB
+	}
+	switch dbType {
+	case nodeps.Postgres:
+		return fmt.Sprintf("%s:%s", dbType, v)
+	case nodeps.MySQL:
+		fallthrough
+	case nodeps.MariaDB:
+		fallthrough
+	default:
+		return fmt.Sprintf("%s-%s-%s:%s", versionconstants.DBImg, dbType, v, versionconstants.BaseDBTag)
+	}
+}
+
+// GetSSHAuthImage returns the correctly formatted sshauth image:tag reference
+func GetSSHAuthImage() string {
+	return fmt.Sprintf("%s:%s", versionconstants.SSHAuthImage, versionconstants.SSHAuthTag)
+}
+
+// GetRouterImage returns the router image:tag reference
+func GetRouterImage() string {
+	image := versionconstants.TraefikRouterImage
+	if globalconfig.DdevGlobalConfig.Router == types.RouterTypeNginxProxy {
+		image = versionconstants.TraditionalRouterImage
+	}
+	return image
+}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,19 +18,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
+	"github.com/ddev/ddev/pkg/archive"
+	dockerImages "github.com/ddev/ddev/pkg/docker"
 	ddevexec "github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/versionconstants"
-
-	"net/url"
-
-	"github.com/ddev/ddev/pkg/archive"
 	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/util"
-
-	"github.com/Masterminds/semver/v3"
 	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
 	docker "github.com/fsouza/go-dockerclient"
 )
 
@@ -1243,7 +1240,7 @@ func CopyIntoVolume(sourcePath string, volumeName string, targetSubdir string, u
 	containerName := "CopyIntoVolume_" + nodeps.RandomString(12)
 
 	track := util.TimeTrackC("CopyIntoVolume " + sourcePath + " " + volumeName)
-	containerID, _, err := RunSimpleContainer(versionconstants.GetWebImage(), containerName, []string{"sh", "-c", "mkdir -p " + targetSubdirFullPath + " && sleep infinity"}, nil, nil, []string{volumeName + ":" + volPath}, "0", false, true, map[string]string{"com.ddev.site-name": ""}, nil)
+	containerID, _, err := RunSimpleContainer(dockerImages.GetWebImage(), containerName, []string{"sh", "-c", "mkdir -p " + targetSubdirFullPath + " && sleep infinity"}, nil, nil, []string{volumeName + ":" + volPath}, "0", false, true, map[string]string{"com.ddev.site-name": ""}, nil)
 	if err != nil {
 		return err
 	}
@@ -1312,7 +1309,7 @@ func Exec(containerID string, command string, uid string) (string, string, error
 
 // CheckAvailableSpace outputs a warning if docker space is low
 func CheckAvailableSpace() {
-	_, out, _ := RunSimpleContainer(versionconstants.GetWebImage(), "check-available-space-"+util.RandString(6), []string{"sh", "-c", `df / | awk '!/Mounted/ {print $4, $5;}'`}, []string{}, []string{}, []string{}, "", true, false, map[string]string{"com.ddev.site-name": ""}, nil)
+	_, out, _ := RunSimpleContainer(dockerImages.GetWebImage(), "check-available-space-"+util.RandString(6), []string{"sh", "-c", `df / | awk '!/Mounted/ {print $4, $5;}'`}, []string{}, []string{}, []string{}, "", true, false, map[string]string{"com.ddev.site-name": ""}, nil)
 	out = strings.Trim(out, "% \r\n")
 	parts := strings.Split(out, " ")
 	if len(parts) != 2 {

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -2,7 +2,6 @@ package dockerutil_test
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/globalconfig"
 	"log"
 	"os"
 	"path"
@@ -12,17 +11,18 @@ import (
 	"testing"
 	"time"
 
+	dockerImages "github.com/ddev/ddev/pkg/docker"
+	. "github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
+	docker "github.com/fsouza/go-dockerclient"
 	logOutput "github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
-
-	. "github.com/ddev/ddev/pkg/dockerutil"
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/output"
-	"github.com/fsouza/go-dockerclient"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testContainerName = "TestDockerUtils"
@@ -45,13 +45,13 @@ func testMain(m *testing.M) int {
 	}
 
 	// prep docker container for docker util tests
-	imageExists, err := ImageExistsLocally(versionconstants.GetWebImage())
+	imageExists, err := ImageExistsLocally(dockerImages.GetWebImage())
 	if err != nil {
-		logOutput.Errorf("Failed to check for local image %s: %v", versionconstants.GetWebImage(), err)
+		logOutput.Errorf("Failed to check for local image %s: %v", dockerImages.GetWebImage(), err)
 		return 6
 	}
 	if !imageExists {
-		err := Pull(versionconstants.GetWebImage())
+		err := Pull(dockerImages.GetWebImage())
 		if err != nil {
 			logOutput.Errorf("failed to pull test image: %v", err)
 			return 7
@@ -107,7 +107,7 @@ func startTestContainer() (string, error) {
 		"8025/tcp": {
 			{HostPort: "8890"},
 		}}
-	containerID, _, err := RunSimpleContainer(versionconstants.GetWebImage(), testContainerName, nil, nil, []string{
+	containerID, _, err := RunSimpleContainer(dockerImages.GetWebImage(), testContainerName, nil, nil, []string{
 		"HOTDOG=superior-to-corndog",
 		"POTATO=future-fry",
 		"DDEV_WEBSERVER_TYPE=nginx-fpm",

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ddev/ddev/pkg/globalconfig/types"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
@@ -73,7 +74,7 @@ type GlobalConfig struct {
 func New() GlobalConfig {
 
 	cfg := GlobalConfig{
-		RequiredDockerComposeVersion: RequiredDockerComposeVersionDefault,
+		RequiredDockerComposeVersion: versionconstants.RequiredDockerComposeVersionDefault,
 		InternetDetectionTimeout:     nodeps.InternetDetectionTimeoutDefault,
 		TableStyle:                   "default",
 		RouterHTTPPort:               nodeps.DdevDefaultRouterHTTPPort,
@@ -243,7 +244,7 @@ func WriteGlobalConfig(config GlobalConfig) error {
 
 	cfgCopy := config
 	// Remove some items that are defaults
-	if cfgCopy.RequiredDockerComposeVersion == RequiredDockerComposeVersionDefault {
+	if cfgCopy.RequiredDockerComposeVersion == versionconstants.RequiredDockerComposeVersionDefault {
 		cfgCopy.RequiredDockerComposeVersion = ""
 	}
 

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -1,8 +1,9 @@
 package globalconfig
 
 import (
-	"github.com/ddev/ddev/pkg/nodeps"
 	"os"
+
+	"github.com/ddev/ddev/pkg/nodeps"
 )
 
 // Container types used with ddev (duplicated from ddevapp, avoiding cross-package cycles)
@@ -14,7 +15,6 @@ const (
 )
 
 const DdevGithubOrg = "ddev"
-const RequiredDockerComposeVersionDefault = "v2.18.1"
 
 // ValidOmitContainers is the valid omit's that can be done in for a project
 var ValidOmitContainers = map[string]bool{

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,15 +2,17 @@ package version
 
 import (
 	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/versionconstants"
-	"github.com/fsouza/go-dockerclient"
-	"os/exec"
-	"runtime"
-	"strings"
+	dockerClient "github.com/fsouza/go-dockerclient"
 )
 
 // IMPORTANT: These versions are overridden by version ldflags specifications VERSION_VARIABLES in the Makefile
@@ -21,10 +23,10 @@ func GetVersionInfo() map[string]string {
 	versionInfo := make(map[string]string)
 
 	versionInfo["DDEV version"] = versionconstants.DdevVersion
-	versionInfo["web"] = versionconstants.GetWebImage()
-	versionInfo["db"] = versionconstants.GetDBImage(nodeps.MariaDB, "")
-	versionInfo["router"] = versionconstants.GetRouterImage()
-	versionInfo["ddev-ssh-agent"] = versionconstants.GetSSHAuthImage()
+	versionInfo["web"] = docker.GetWebImage()
+	versionInfo["db"] = docker.GetDBImage(nodeps.MariaDB, "")
+	versionInfo["router"] = docker.GetRouterImage()
+	versionInfo["ddev-ssh-agent"] = docker.GetSSHAuthImage()
 	versionInfo["build info"] = versionconstants.BUILDINFO
 	versionInfo["os"] = runtime.GOOS
 	versionInfo["architecture"] = runtime.GOARCH
@@ -48,9 +50,9 @@ func GetVersionInfo() map[string]string {
 
 // GetDockerPlatform gets the platform used for docker engine
 func GetDockerPlatform() (string, error) {
-	var client *docker.Client
+	var client *dockerClient.Client
 	var err error
-	if client, err = docker.NewClientFromEnv(); err != nil {
+	if client, err = dockerClient.NewClientFromEnv(); err != nil {
 		return "", err
 	}
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -1,12 +1,5 @@
 package versionconstants
 
-import (
-	"fmt"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/globalconfig/types"
-	"github.com/ddev/ddev/pkg/nodeps"
-)
-
 // DdevVersion is the current version of ddev, by default the git committish (should be current git tag)
 var DdevVersion = "v0.0.0-overridden-by-make" // Note that this is overridden by make
 
@@ -50,46 +43,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.17.1"
 
-// GetWebImage returns the correctly formatted web image:tag reference
-func GetWebImage() string {
-	fullWebImg := WebImg
-	if globalconfig.DdevGlobalConfig.UseHardenedImages {
-		fullWebImg = fullWebImg + "-prod"
-	}
-	return fmt.Sprintf("%s:%s", fullWebImg, WebTag)
-}
-
-// GetDBImage returns the correctly formatted db image:tag reference
-func GetDBImage(dbType string, dbVersion string) string {
-	v := nodeps.MariaDBDefaultVersion
-	if dbVersion != "" {
-		v = dbVersion
-	}
-	if dbType == "" {
-		dbType = nodeps.MariaDB
-	}
-	switch dbType {
-	case nodeps.Postgres:
-		return fmt.Sprintf("%s:%s", dbType, v)
-	case nodeps.MySQL:
-		fallthrough
-	case nodeps.MariaDB:
-		fallthrough
-	default:
-		return fmt.Sprintf("%s-%s-%s:%s", DBImg, dbType, v, BaseDBTag)
-	}
-}
-
-// GetSSHAuthImage returns the correctly formatted sshauth image:tag reference
-func GetSSHAuthImage() string {
-	return fmt.Sprintf("%s:%s", SSHAuthImage, SSHAuthTag)
-}
-
-// GetRouterImage returns the router image:tag reference
-func GetRouterImage() string {
-	image := TraefikRouterImage
-	if globalconfig.DdevGlobalConfig.Router == types.RouterTypeNginxProxy {
-		image = TraditionalRouterImage
-	}
-	return image
-}
+const RequiredDockerComposeVersionDefault = "v2.18.1"


### PR DESCRIPTION
## The Issue

We like to detect dependency changes in the CI to properly label PRs changing dependencies. The required Docker Compose version is currently located in the global config and is not taken into account

## How This PR Solves The Issue

This PR moves the Docker Compose version to the version constants. To avoid import cycles the functions from version constants are moved to a new package docker/images.

Changes in the version constants are now properly label with `dependencies`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5072"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

