### PR TITLE
fix: disable docker CLI hints, fixes #5077

### DIFF
--- a/cmd/ddev/cmd/a.go
+++ b/cmd/ddev/cmd/a.go
@@ -12,6 +12,7 @@ import (
 
 func init() {
 	globalconfig.EnsureGlobalConfig()
+	_ = os.Setenv("DOCKER_CLI_HINTS", "false")
 	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
 	// GetDockerClient should be called early to get DOCKER_HOST set
 	_ = dockerutil.GetDockerClient()

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -927,6 +927,7 @@ func Pull(imageName string) error {
 	if exists {
 		return nil
 	}
+	_ = os.Setenv("DOCKER_CLI_HINTS", "false")
 	cmd := exec.Command("docker", "pull", imageName)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -927,7 +927,6 @@ func Pull(imageName string) error {
 	if exists {
 		return nil
 	}
-	_ = os.Setenv("DOCKER_CLI_HINTS", "false")
 	cmd := exec.Command("docker", "pull", imageName)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## The Issue

* #5077 

## How This PR Solves The Issue

Turn off cli hints with environment variable DOCKER_CLI_HINTS=false

## Manual Testing Instructions

`ddev poweroff && docker rmi -f $(docker images -q) && ddev start`



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5085"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

