### PR TITLE
fix: revert accidental change of upload-dir type, fixes #5076

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -228,7 +228,7 @@ func init() {
 	ConfigCommand.Flags().BoolVar(&showConfigLocation, "show-config-location", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
 	ConfigCommand.Flags().StringSlice("upload-dirs", []string{}, "Sets the project's upload directories, the destination directories of the import-files command.")
 	ConfigCommand.Flags().Lookup("upload-dirs").NoOptDefVal = "false"
-	ConfigCommand.Flags().StringSlice("upload-dir", []string{}, "Sets the project's upload directories, the destination directories of the import-files command.")
+	ConfigCommand.Flags().String("upload-dir", "", "Sets the project's upload directories, the destination directories of the import-files command.")
 	_ = ConfigCommand.Flags().MarkDeprecated("upload-dir", "please use --upload-dirs instead")
 	ConfigCommand.Flags().StringVar(&webserverTypeArg, "webserver-type", "", "Sets the project's desired webserver type: nginx-fpm/apache-fpm/nginx-gunicorn")
 	ConfigCommand.Flags().StringVar(&webImageArg, "web-image", "", "Sets the web container image")


### PR DESCRIPTION
## The Issue

The type of the `upload-dir` flag was accidentially changed to string slice.

## How This PR Solves The Issue

This PR reverts the accidental change back to type string which will make `--upload-dir` working again like expected.

## Manual Testing Instructions

`ddev config --project-type=craftcms --docroot=web --create-docroot --upload-dir=cpresources` should properly add the `cpresources` to the `upload_dirs` config.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5087"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

