### PR TITLE
fix: terminate mutagen sessions on DDEV upgrade, fixes #5040

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -224,6 +224,8 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 			if okPoweroff {
 				ddevapp.PowerOff()
 			}
+			util.Debug("Terminating all mutagen sync sessions")
+			ddevapp.TerminateAllMutagenSync()
 		}
 
 		// If they have a new version write the new version into last-started

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -787,9 +787,11 @@ func GetMutagenConfigFileHashLabel(app *DdevApp) (string, error) {
 
 // TerminateAllMutagenSync terminates all sync sessions
 func TerminateAllMutagenSync() {
-	out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "terminate", "-a")
-	if err != nil {
-		util.Warning("could not terminate all mutagen sessions (mutagen sync terminate -a), output=%s, err=%v", out, err)
+	if fileutil.FileExists(globalconfig.GetMutagenPath()) {
+		out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "terminate", "-a")
+		if err != nil {
+			util.Warning("could not terminate all mutagen sessions (mutagen sync terminate -a), output=%s, err=%v", out, err)
+		}
 	}
 }
 

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -729,11 +729,11 @@ func CheckMutagenVolumeSyncCompatibility(app *DdevApp) (ok bool, volumeExists bo
 	if mutagenSyncExists {
 		mutagenLabel, mutagenSyncLabelErr = GetMutagenSyncLabel(app)
 		if mutagenSyncLabelErr != nil {
-			util.Warning("mutagen sync %s exists but unable to get label: %v", app.Name, mutagenSyncLabelErr)
+			util.Warning("mutagen sync session '%s' exists but unable to get sync label '%s': '%v' This is normal on upgrade from v1.21.6; error=%v", app.Name, mutagenSignatureLabelName, mutagenLabel, mutagenSyncLabelErr)
 		}
 		configFileHashLabel, configFileHashLabelErr = GetMutagenConfigFileHashLabel(app)
 		if configFileHashLabelErr != nil {
-			util.Warning("mutagen sync %s exists but unable to get label: %v", app.Name, configFileHashLabel)
+			util.Warning("mutagen sync session '%s' exists but unable to get sync label '%s': '%v' This is normal on upgrade from v1.21.6; error=%v", app.Name, mutagenConfigFileHashLabelName, configFileHashLabel, configFileHashLabelErr)
 		}
 	}
 	switch {


### PR DESCRIPTION
## The Issue

* #5040

## How This PR Solves The Issue

When DDEV upgrade is detected, after poweroff, destroy mutagen sessions. These should already have been flushed when they were stopped.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5096"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

