### PR TITLE
ci: prevent job from failing if cleanup fails

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -188,6 +188,7 @@ jobs:
           colima stop
 
       - name: Clean up Homebrew
+        continue-on-error: true
         run: |
           brew update
           brew autoremove

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,6 +161,7 @@ jobs:
         run: make TESTARGS="${TESTARGS}" ${MAKE_TARGET}
 
       - name: Clean up Homebrew
+        continue-on-error: true
         run: |
           brew update
           brew autoremove


### PR DESCRIPTION
## The Issue

Cleanup may fail on upstream problems see https://github.com/ddev/ddev/actions/runs/5482145525/jobs/9987195573?pr=5094

## How This PR Solves The Issue

Make clean up optional and don't fail anymore.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5097"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

