### PR TITLE
build: clean up Windows installer, fixes #1945

### DIFF
--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -507,14 +507,14 @@ SectionGroupEnd
 /**
  * WinNFSd group
  */
-SectionGroup /e "WinNFSd"
+SectionGroup /e "WinNFSd (deprecated)"
   /**
    * WinNFSd application install
    */
-  Section "${WINNFSD_NAME}" SecWinNFSd
+  Section /o "${WINNFSD_NAME}" SecWinNFSd
     SectionIn 1
     SetOutPath "$INSTDIR"
-    SetOverwrite try
+    SetOverwrite off
 
     ; Copy files
     File "licenses\winnfsd_license.txt"
@@ -542,7 +542,7 @@ SectionGroup /e "WinNFSd"
   /**
    * NSSM application install
    */
-  Section "${NSSM_NAME}" SecNSSM
+  Section /o "${NSSM_NAME}" SecNSSM
     ; Install in non choco mode only
     ${IfNot} ${Chocolatey}
       SectionIn 1

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -616,11 +616,11 @@ SectionEnd
  */
 LangString DESC_SecDDEV ${LANG_ENGLISH} "Install ${PRODUCT_NAME_FULL} (required)"
 LangString DESC_SecAddToPath ${LANG_ENGLISH} "Add the ${PRODUCT_NAME} (and sudo) directory to the global PATH"
-LangString DESC_SecSudo ${LANG_ENGLISH} "Sudo for Windows (github.com/ddev/gsudo) allows for elevated privileges which are used to add hostnames to the Windows hosts file (required)"
+LangString DESC_SecSudo ${LANG_ENGLISH} "Sudo for Windows (github.com/gerardog/gsudo) allows for elevated privileges which are used to add hostnames to the Windows hosts file (required)"
 LangString DESC_SecMkcert ${LANG_ENGLISH} "mkcert (github.com/FiloSottile/mkcert) is a simple tool for making locally-trusted development certificates. It requires no configuration"
 LangString DESC_SecMkcertSetup ${LANG_ENGLISH} "Run `mkcert -install` to setup a local CA"
-LangString DESC_SecWinNFSd ${LANG_ENGLISH} "WinNFSd (github.com/winnfsd/winnfsd) is an optional NFS server that can be used with ${PRODUCT_NAME_FULL}"
-LangString DESC_SecNSSM ${LANG_ENGLISH} "NSSM (nssm.cc) is used to install services, specifically WinNFSd for NFS"
+LangString DESC_SecWinNFSd ${LANG_ENGLISH} "WinNFSd (github.com/winnfsd/winnfsd) is an optional NFS server that can be used with ${PRODUCT_NAME_FULL} (deprecated)"
+LangString DESC_SecNSSM ${LANG_ENGLISH} "NSSM (nssm.cc) is used to install services, specifically WinNFSd for NFS (deprecated)"
 
 
 

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -616,10 +616,10 @@ SectionEnd
  */
 LangString DESC_SecDDEV ${LANG_ENGLISH} "Install ${PRODUCT_NAME_FULL} (required)"
 LangString DESC_SecAddToPath ${LANG_ENGLISH} "Add the ${PRODUCT_NAME} (and sudo) directory to the global PATH"
-LangString DESC_SecSudo ${LANG_ENGLISH} "Sudo for Windows (github.com/mattn/sudo) allows for elevated privileges which are used to add hostnames to the Windows hosts file (required)"
+LangString DESC_SecSudo ${LANG_ENGLISH} "Sudo for Windows (github.com/ddev/gsudo) allows for elevated privileges which are used to add hostnames to the Windows hosts file (required)"
 LangString DESC_SecMkcert ${LANG_ENGLISH} "mkcert (github.com/FiloSottile/mkcert) is a simple tool for making locally-trusted development certificates. It requires no configuration"
 LangString DESC_SecMkcertSetup ${LANG_ENGLISH} "Run `mkcert -install` to setup a local CA"
-LangString DESC_SecWinNFSd ${LANG_ENGLISH} "WinNFSd (github.com/ winnfsd/winnfsd) is an optional NFS server that can be used with ${PRODUCT_NAME_FULL}"
+LangString DESC_SecWinNFSd ${LANG_ENGLISH} "WinNFSd (github.com/winnfsd/winnfsd) is an optional NFS server that can be used with ${PRODUCT_NAME_FULL}"
 LangString DESC_SecNSSM ${LANG_ENGLISH} "NSSM (nssm.cc) is used to install services, specifically WinNFSd for NFS"
 
 


### PR DESCRIPTION
## The Issue

The language strings were accidentially removed with https://github.com/ddev/ddev/pull/4553 and some other parts were not properly removed.

Also fixes 
* #1945 

## How This PR Solves The Issue

The missing language strings are added again and left overs are removed properly.

## Manual Testing Instructions

Check build if there are no warnings. When running the installer, on the component page the descriptions should be shown properly for all components now.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5098"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

