### PR TITLE
refactor: use StrictHostKeyChecking=accept-new

### DIFF
--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -62,7 +62,7 @@ func TestCmdAuthSSH(t *testing.T) {
 	// identity
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh -o BatchMode=yes -o StrictHostKeyChecking=false root@" + internalIPAddr + " pwd",
+		Cmd:     "ssh -o BatchMode=yes root@" + internalIPAddr + " pwd",
 	})
 	assert.Error(err)
 
@@ -78,7 +78,7 @@ func TestCmdAuthSSH(t *testing.T) {
 	// And at this point we should be able to ssh into the test-cmd-ssh-server
 	out, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh -o BatchMode=yes -o StrictHostKeyChecking=false root@" + internalIPAddr + " pwd",
+		Cmd:     "ssh -o BatchMode=yes root@" + internalIPAddr + " pwd",
 	})
 	assert.NoError(err)
 	assert.Contains(out, "/root")

--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -49,7 +49,7 @@ func TestCmdAuthSSH(t *testing.T) {
 	assert.NoError(err)
 
 	// Run a simple SSH server to act on and get its internal IP address
-	_, err = exec.RunCommand("docker", []string{"run", "-d", "--name=test-cmd-ssh-server", "--network=ddev_default", "ddev/test-ssh-server:v1.22.0"})
+	_, err = exec.RunCommand("docker", []string{"run", "-d", "--name=test-cmd-ssh-server", "--network=ddev_default", "ddev/test-ssh-server:v1.22.2"})
 	assert.NoError(err)
 	internalIPAddr, err := exec.RunCommand("docker", []string{"inspect", "-f", "'{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'", "test-cmd-ssh-server"})
 	internalIPAddr = strings.Trim(internalIPAddr, "\r\n\"'")

--- a/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.ssh/config
+++ b/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.ssh/config
@@ -1,5 +1,9 @@
 # Share known_hosts across all users of the ssh-agent
 UserKnownHostsFile=/home/.ssh-agent/known_hosts
-# In the container host key checking can be a problem with non-interactive composer, etc.
-# Turn it off. When we upgrade to openssh 7.6 we can use the "accept-new" option instead of "no"
-StrictHostKeyChecking=no
+# This accepts new host keys automatically but rejects changed ones for 
+# known domains/IPs.
+# In case the host key actually changed the OpenSSH error message is very 
+# helpful and gives the command that removes the offending host key from 
+# known_hosts (`ssh-keygen -R <hostOrIp>`) after a verbose warning about 
+# possible IP spoofing.
+StrictHostKeyChecking=accept-new

--- a/docs/content/users/extend/in-container-configuration.md
+++ b/docs/content/users/extend/in-container-configuration.md
@@ -18,7 +18,7 @@ Usage examples:
 
     ```
     UserKnownHostsFile=/home/.ssh-agent/known_hosts
-    StrictHostKeyChecking=no
+    StrictHostKeyChecking=accept-new
     ```
 
 * If you need to add a script or other executable component into the project (or global configuration), you can put it in the project or global `.ddev/homeadditions/bin` directory and `~/bin/<script` will be created inside the container. This is useful for adding a script to one project or every project, or for overriding standard scripts, as `~/bin` is first in the `$PATH` in the `web` container.

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -78,7 +78,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try a simple ssh (with no auth set up), it should fail with "Permission denied"
 	_, stderr, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh -o BatchMode=yes root@test-ssh-server pwd",
+		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server; ssh -o BatchMode=yes root@test-ssh-server pwd",
 	})
 
 	assert.Error(err)
@@ -96,7 +96,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try SSH, should succeed
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh root@test-ssh-server pwd",
+		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server; ssh root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\r\n")
 	assert.Equal(stdout, "/root")
@@ -112,7 +112,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try SSH, should succeed
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh root@test-ssh-server pwd",
+		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server; ssh root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\r\n")
 	assert.Equal(stdout, "/root")

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -78,7 +78,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try a simple ssh (with no auth set up), it should fail with "Permission denied"
 	_, stderr, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server &> /dev/null; ssh -o BatchMode=yes root@test-ssh-server pwd",
+		Cmd:     "rm -f /home/.ssh-agent/known_hosts; ssh -o BatchMode=yes root@test-ssh-server pwd",
 	})
 
 	assert.Error(err)
@@ -96,7 +96,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try SSH, should succeed
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server &> /dev/null; ssh root@test-ssh-server pwd",
+		Cmd:     "rm -f /home/.ssh-agent/known_hosts; ssh root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\r\n")
 	assert.Equal(stdout, "/root")
@@ -112,7 +112,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try SSH, should succeed
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server &> /dev/null; ssh root@test-ssh-server pwd",
+		Cmd:     "rm -f /home/.ssh-agent/known_hosts; ssh root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\r\n")
 	assert.Equal(stdout, "/root")

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -78,7 +78,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try a simple ssh (with no auth set up), it should fail with "Permission denied"
 	_, stderr, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh -o BatchMode=yes -o StrictHostKeyChecking=false root@test-ssh-server pwd",
+		Cmd:     "ssh -o BatchMode=yes root@test-ssh-server pwd",
 	})
 
 	assert.Error(err)
@@ -96,7 +96,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try SSH, should succeed
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh -o StrictHostKeyChecking=false root@test-ssh-server pwd",
+		Cmd:     "ssh root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\r\n")
 	assert.Equal(stdout, "/root")
@@ -112,7 +112,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try SSH, should succeed
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh -o StrictHostKeyChecking=false root@test-ssh-server pwd",
+		Cmd:     "ssh root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\r\n")
 	assert.Equal(stdout, "/root")

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -78,7 +78,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try a simple ssh (with no auth set up), it should fail with "Permission denied"
 	_, stderr, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server; ssh -o BatchMode=yes root@test-ssh-server pwd",
+		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server &> /dev/null; ssh -o BatchMode=yes root@test-ssh-server pwd",
 	})
 
 	assert.Error(err)
@@ -96,7 +96,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try SSH, should succeed
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server; ssh root@test-ssh-server pwd",
+		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server &> /dev/null; ssh root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\r\n")
 	assert.Equal(stdout, "/root")
@@ -112,7 +112,7 @@ func TestSSHAuth(t *testing.T) {
 	// Try SSH, should succeed
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server; ssh root@test-ssh-server pwd",
+		Cmd:     "ssh-keygen -f /home/.ssh-agent/known_hosts -R test-ssh-server &> /dev/null; ssh root@test-ssh-server pwd",
 	})
 	stdout = strings.Trim(stdout, "\r\n")
 	assert.Equal(stdout, "/root")

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20230720_ted933_doc_installation_ubuntu_apt_vulnerability" // Note that this can be overridden by make
+var WebTag = "20230707_jonaseberle_use-ssh-StrictHostKeyChecking" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

SSH power users and security folks expect `ssh` to check host keys.

## How This PR Solves The Issue

The option `StrictHostKeyChecking=accept-new` has been introduced in OpenSSH 7.6. It provides the protection against IP-spoofing without the previously necessary user interaction (in case of `=yes/true`) to accept unknown keys on first connect.

In case a host key has actually changed, OpenSSH gives a helpful warning including the exact command that is necessary to remove the old host key from known_hosts.

## Manual Testing Instructions

Using `ssh` from within containers works as before. If a host key actually changed, the connection is rejected and OpenSSH shows an error message.

## Automated Testing Overview

Tests have been adapted to use the web container's default SSH config.

## Related Issue Link(s)

(Discussion topic) https://github.com/orgs/ddev/discussions/5029

## Release/Deployment Notes

Would be great to see this for 1.22.


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5104"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

