### PR TITLE
docs: point to new location of DDEV GitHub Action

### DIFF
--- a/docs/content/users/topics/remote-docker.md
+++ b/docs/content/users/topics/remote-docker.md
@@ -19,7 +19,7 @@ You can use remote Docker instances, whether on the internet, inside your networ
 
 A number of people have found it easy to test their projects using DDEV on a CI system like [GitHub Actions](https://github.com/features/actions), [Travis CI](https://www.travis-ci.com), or [CircleCI](https://circleci.com). Instead of setting up a hosting environment for testing, they start the project using DDEV and run their tests.
 
-Examples of this approach are demonstrated in [Codeception Tests in Travis CI with DDEV and Selenium](https://dev.to/tomasnorre/codeception-tests-in-travis-ci-with-ddev-and-selenium-1607) and a [DDEV Setup GitHub Action](https://github.com/jonaseberle/github-action-setup-ddev).
+Examples of this approach are demonstrated in [Codeception Tests in Travis CI with DDEV and Selenium](https://dev.to/tomasnorre/codeception-tests-in-travis-ci-with-ddev-and-selenium-1607) and [Setup DDEV in Github Workflows](https://github.com/marketplace/actions/setup-ddev-in-github-workflows).
 
 ## Integration of DDEV Docker Images Into Other Projects
 

--- a/docs/content/users/topics/remote-docker.md
+++ b/docs/content/users/topics/remote-docker.md
@@ -19,7 +19,7 @@ You can use remote Docker instances, whether on the internet, inside your networ
 
 A number of people have found it easy to test their projects using DDEV on a CI system like [GitHub Actions](https://github.com/features/actions), [Travis CI](https://www.travis-ci.com), or [CircleCI](https://circleci.com). Instead of setting up a hosting environment for testing, they start the project using DDEV and run their tests.
 
-Examples of this approach are demonstrated in [Codeception Tests in Travis CI with DDEV and Selenium](https://dev.to/tomasnorre/codeception-tests-in-travis-ci-with-ddev-and-selenium-1607) and [Setup DDEV in Github Workflows](https://github.com/marketplace/actions/setup-ddev-in-github-workflows).
+Examples of this approach are demonstrated in [Codeception Tests in Travis CI with DDEV and Selenium](https://dev.to/tomasnorre/codeception-tests-in-travis-ci-with-ddev-and-selenium-1607) and [Setup DDEV in GitHub Workflows](https://github.com/marketplace/actions/setup-ddev-in-github-workflows).
 
 ## Integration of DDEV Docker Images Into Other Projects
 


### PR DESCRIPTION
## The Issue

https://github.com/jonaseberle/github-action-setup-ddev has been migrated to https://github.com/ddev/github-action-setup-ddev.

I suggest to use the Github marketplace URL as a landing page in the docs.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5105"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

