### PR TITLE
fix: solve mutagen failure, restart should check for new version, check composer.json in container, fixes #5089

### DIFF
--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -33,6 +33,17 @@ ddev restart --all`,
 			instrumentationApp = projects[0]
 		}
 
+		skip, err := cmd.Flags().GetBool("skip-confirmation")
+		if err != nil {
+			util.Failed(err.Error())
+		}
+
+		// Look for version change and opt-in to instrumentation if it has changed.
+		err = checkDdevVersionAndOptInInstrumentation(skip)
+		if err != nil {
+			util.Failed(err.Error())
+		}
+
 		for _, app := range projects {
 
 			output.UserOut.Printf("Restarting project %s...", app.GetName())
@@ -52,6 +63,7 @@ ddev restart --all`,
 }
 
 func init() {
+	RestartCmd.Flags().BoolP("skip-confirmation", "y", false, "Skip any confirmation steps")
 	RestartCmd.Flags().BoolVarP(&restartAll, "all", "a", false, "restart all projects")
 	RootCmd.AddCommand(RestartCmd)
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1315,7 +1315,11 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		})
 
 		if err != nil {
-			return fmt.Errorf("composer.json not found in container, stdout='%s', stderr='%s': %v; please report this situation, https://github.com/ddev/ddev/issues; probably can be fixed with ddev restart.", stdout, stderr, err)
+			status, _, _ := app.Exec(&ExecOpts{
+				Cmd: "pwd && tree -L 2",
+			})
+			util.Warning("Status: %s", status)
+			return fmt.Errorf("composer.json not found in container, stdout='%s', stderr='%s': %v; please report this situation, https://github.com/ddev/ddev/issues; probably can be fixed with ddev restart", stdout, stderr, err)
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1304,6 +1304,21 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 	}
 
+	// At this point we should have all files synced inside the container
+	// Verify that we have composer.json inside container if we have it in project root
+	// This is possibly a temporary need for debugging https://github.com/ddev/ddev/issues/5089
+	// TODO: Consider removing this check when #5089 is resolved
+	if fileutil.FileExists(filepath.Join(app.GetComposerRoot(false, false), "composer.json")) {
+		util.Debug("Checking for composer.json in container")
+		stdout, stderr, err := app.Exec(&ExecOpts{
+			Cmd: fmt.Sprintf("test -f %s", path.Join(app.GetComposerRoot(true, false), "composer.json")),
+		})
+
+		if err != nil {
+			return fmt.Errorf("composer.json not found in container, stdout='%s', stderr='%s': %v; please report this situation, https://github.com/ddev/ddev/issues; probably can be fixed with ddev restart.", stdout, stderr, err)
+		}
+	}
+
 	util.Debug("Running /start.sh in ddev-webserver")
 	stdout, stderr, err := app.Exec(&ExecOpts{
 		// Send output to /var/tmp/logpipe to get it to docker logs

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1309,7 +1309,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	// Verify that we have composer.json inside container if we have it in project root
 	// This is possibly a temporary need for debugging https://github.com/ddev/ddev/issues/5089
 	// TODO: Consider removing this check when #5089 is resolved
-	if fileutil.FileExists(filepath.Join(app.GetComposerRoot(false, false), "composer.json")) {
+	if !app.NoProjectMount && fileutil.FileExists(filepath.Join(app.GetComposerRoot(false, false), "composer.json")) {
 		util.Debug("Checking for composer.json in container")
 		stdout, stderr, err := app.Exec(&ExecOpts{
 			Cmd: fmt.Sprintf("test -f %s", path.Join(app.GetComposerRoot(true, false), "composer.json")),

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -49,7 +49,7 @@ const SiteConfigMissing = ".ddev/config.yaml missing"
 // SitePaused defines the string used to denote when a site is in the paused (docker stopped) state.
 const SitePaused = "paused"
 
-// SiteUnhealthy is the status for a project whose services are not all running
+// SiteUnhealthy is the status for a project whose services are not all reporting healthy yet
 const SiteUnhealthy = "unhealthy"
 
 // DatabaseDefault is the default database/version
@@ -1291,6 +1291,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		if err != nil {
 			return err
 		}
+		util.Debug("mutagen status after sync: %s", mStatus)
 
 		dur := util.FormatDuration(mutagenDuration())
 		if mStatus == "ok" {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -342,6 +342,7 @@ func TestMain(m *testing.M) {
 	// This is normally done by Testsite.Prepare()
 	_ = os.Setenv("DDEV_NONINTERACTIVE", "true")
 	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
+	_ = os.Setenv("DOCKER_CLI_HINTS", "false")
 
 	// If GOTEST_SHORT is an integer, then use it as index for a single usage
 	// in the array. Any value can be used, it will default to just using the

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -437,8 +437,8 @@ func (app *DdevApp) MutagenSyncFlush() error {
 		return nil
 	}
 	status, _ := app.SiteStatus()
-	if status != SiteRunning && status != SiteUnhealthy {
-		return fmt.Errorf("mutagenSyncFlush() not mutagen-syncing project %s with status %s because not 'unhealthy' or 'running'", app.Name, status)
+	if status != SiteRunning && status != SiteUnhealthy && status != SiteStarting {
+		return fmt.Errorf("mutagenSyncFlush() not mutagen-syncing project %s with status '%s' because not 'starting', 'unhealthy' or 'running'", app.Name, status)
 	}
 	syncName := MutagenSyncName(app.Name)
 	if !MutagenSyncExists(app) {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -168,7 +168,7 @@ func InspectContainer(name string) (*docker.Container, error) {
 	return x, err
 }
 
-// FindContainerByName takes a container name and returns the container ID
+// FindContainerByName takes a container name and returns the container
 // If container is not found, returns nil with no error
 func FindContainerByName(name string) (*docker.APIContainers, error) {
 	client := GetDockerClient()


### PR DESCRIPTION
## The Issue

* #5089 

## How This PR Solves The Issue

* Fix bug where if container was not yet healthy mutagen sync didn't happen.
* Add request to poweroff on `ddev restart`
* Check inside container to make sure mutagen flush is complete (look at /var/www/html/composer.json)

## Manual Testing Instructions

* `ddev restart` with version change
* `export DDEV_DEBUG=true && ddev mutagen reset && ddev start -y` on mutagen-enabled system. It should check composer.json (and succeed)..

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5106"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

