### PR TITLE
fix: ddev-webserver process kill function was incorrect

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/pre-start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/pre-start.sh
@@ -15,6 +15,6 @@ if [[ ! -p ${logpipe} ]]; then
 fi
 
 # Kill process 1 + process group if this exist or fails
-trap "trap - SIGTERM && kill -- --1" SIGINT SIGTERM EXIT SIGHUP SIGQUIT
+trap "trap - SIGTERM && kill -- -1" SIGINT SIGTERM EXIT SIGHUP SIGQUIT
 
 cat < ${logpipe}

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.22.0-beta1" // Note that this can be overridden by make
+var WebTag = "20230707_fix_process_group_kill" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

* https://github.com/ddev/ddev/issues/5089#issuecomment-1626124810

During debugging we saw:

```
2023-07-07 20:47:42,159 INFO stopped: child_exit_monitor (terminated by SIGTERM)
+ trap - SIGTERM
+ kill -- --1
/pre-start.sh: line 1: kill: --1: arguments must be process or job IDs
```

Apparently in the situation of a failing web_extra_daemon things weren't handled correctly. 

## How This PR Solves The Issue

Use the correct syntax, `kill -- -1` (`-1` rather than `--1`)

## Manual Testing Instructions

The previous error was created by making an error happen with something like this:

```yaml
  web_extra_daemons:
    - name: "failit"
      command: "./failit.sh"
      directory: /var/www/html
```

and after ddev start, `ddev logs` showed the error. 

This shouldn't happen now.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5107"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

