### PR TITLE
fix: detect Craft CMS version and warn user on type mismatch and introduce new env vars, fixes #4650

### DIFF
--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -72,7 +72,7 @@ func craftCmsPostStartAction(app *DdevApp) error {
 	// Check version is v4 or higher or warn user about app type mismatch.
 	if !isCraftCms4orHigher(app) {
 		util.Warning("It looks like the installed Craft CMS is lower than version 4 where it's recommended to use project type `php` or disable settings management with `ddev config --disable-settings-management`")
-		if !util.Confirm("Would you like to continue anyway with the automatic configuration?") {
+		if !util.Confirm("Would you like to stop here, not do the automatic configuration and change project type?") {
 			return nil
 		}
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -389,14 +389,10 @@ func (app DdevApp) GetDocroot() string {
 	return app.Docroot
 }
 
-// GetComposerRoot will determine the absolute composer root directory where
-// all Composer related commands will be executed.
-// If inContainer set to true, the absolute path in the container will be
-// returned, else the absolute path on the host.
-// If showWarning set to true, a warning containing the composer root will be
-// shown to the user to avoid confusion.
-func (app *DdevApp) GetComposerRoot(inContainer, showWarning bool) string {
-	basePath := ""
+// GetAbsDocroot returns the absolute path to the docroot on the host or if
+// inContainer is set to true in the container.
+func (app DdevApp) GetAbsDocroot(inContainer bool) string {
+	var basePath string
 
 	if inContainer {
 		basePath = "/var/www/html"
@@ -404,7 +400,17 @@ func (app *DdevApp) GetComposerRoot(inContainer, showWarning bool) string {
 		basePath = app.AppRoot
 	}
 
-	absComposerRoot := path.Join(basePath, app.ComposerRoot)
+	return path.Join(basePath, app.GetDocroot())
+}
+
+// GetComposerRoot will determine the absolute composer root directory where
+// all Composer related commands will be executed.
+// If inContainer set to true, the absolute path in the container will be
+// returned, else the absolute path on the host.
+// If showWarning set to true, a warning containing the composer root will be
+// shown to the user to avoid confusion.
+func (app *DdevApp) GetComposerRoot(inContainer, showWarning bool) string {
+	absComposerRoot := path.Join(app.GetAbsDocroot(inContainer), app.ComposerRoot)
 
 	// If requested, let the user know we are not using the default composer
 	// root directory to avoid confusion.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -392,15 +392,21 @@ func (app DdevApp) GetDocroot() string {
 // GetAbsDocroot returns the absolute path to the docroot on the host or if
 // inContainer is set to true in the container.
 func (app DdevApp) GetAbsDocroot(inContainer bool) string {
-	var basePath string
-
 	if inContainer {
-		basePath = "/var/www/html"
-	} else {
-		basePath = app.AppRoot
+		return path.Join(app.GetAbsAppRoot(true), app.GetDocroot())
 	}
 
-	return path.Join(basePath, app.GetDocroot())
+	return filepath.Join(app.GetAbsAppRoot(false), app.GetDocroot())
+}
+
+// GetAbsAppRoot returns the absolute path to the project root on the host or if
+// inContainer is set to true in the container.
+func (app DdevApp) GetAbsAppRoot(inContainer bool) string {
+	if inContainer {
+		return "/var/www/html"
+	}
+
+	return app.AppRoot
 }
 
 // GetComposerRoot will determine the absolute composer root directory where
@@ -410,7 +416,13 @@ func (app DdevApp) GetAbsDocroot(inContainer bool) string {
 // If showWarning set to true, a warning containing the composer root will be
 // shown to the user to avoid confusion.
 func (app *DdevApp) GetComposerRoot(inContainer, showWarning bool) string {
-	absComposerRoot := path.Join(app.GetAbsDocroot(inContainer), app.ComposerRoot)
+	var absComposerRoot string
+
+	if inContainer {
+		absComposerRoot = path.Join(app.GetAbsAppRoot(true), app.ComposerRoot)
+	} else {
+		absComposerRoot = filepath.Join(app.GetAbsAppRoot(false), app.ComposerRoot)
+	}
 
 	// If requested, let the user know we are not using the default composer
 	// root directory to avoid confusion.


### PR DESCRIPTION
## The Issue

- #4650

## How This PR Solves The Issue

`CRAFT_WEB_URL` and `CRAFT_WEB_ROOT` are added to the `.env` file. `PRIMARY_SITE_URL` is still left untouched to not break existing installations at the moment. Additionally a version check is implemented and warns the user if using project type `craftcms` for version before 4.

## Manual Testing Instructions

Follow the quick start to setup a new Craft CMS site which should not work out-of-the-box without any additional configuration.

Setup a Craft CMS v3 or earlier with project type `craftcms` and check if a warning is properly shown.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5108"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

