### PR TITLE
refactor: reintroduce removed flags and remove dba from `omit_containers`, fixes ddev#5095

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -86,6 +86,20 @@ func handleGlobalConfig(cmd *cobra.Command, _ []string) {
 		dirty = true
 	}
 
+	if cmd.Flag("nfs-mount-enabled").Changed {
+		if v, _ := cmd.Flags().GetBool("nfs-mount-enabled"); v {
+			globalconfig.DdevGlobalConfig.SetPerformanceMode(configTypes.PerformanceModeNFS)
+			dirty = true
+		}
+	}
+
+	if cmd.Flag("mutagen-enabled").Changed {
+		if v, _ := cmd.Flags().GetBool("mutagen-enabled"); v {
+			globalconfig.DdevGlobalConfig.SetPerformanceMode(configTypes.PerformanceModeMutagen)
+			dirty = true
+		}
+	}
+
 	if cmd.Flag(configTypes.FlagPerformanceModeName).Changed {
 		performanceMode, _ := cmd.Flags().GetString(configTypes.FlagPerformanceModeName)
 
@@ -196,6 +210,13 @@ func handleGlobalConfig(cmd *cobra.Command, _ []string) {
 		dirty = true
 	}
 
+	if cmd.Flag("use-traefik").Changed {
+		if v, _ := cmd.Flags().GetBool("use-traefik"); v {
+			globalconfig.DdevGlobalConfig.Router = globalconfigTypes.RouterTypeTraefik
+			dirty = true
+		}
+	}
+
 	if cmd.Flag("router").Changed {
 		val, _ := cmd.Flags().GetString("router")
 		globalconfig.DdevGlobalConfig.Router = val
@@ -257,6 +278,8 @@ func init() {
 	configGlobalCommand.Flags().StringVarP(&omitContainers, "omit-containers", "", "", "For example, --omit-containers=ddev-ssh-agent")
 	configGlobalCommand.Flags().StringVarP(&webEnvironmentGlobal, "web-environment", "", "", `Set the environment variables in the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"`)
 	configGlobalCommand.Flags().StringVarP(&webEnvironmentGlobal, "web-environment-add", "", "", `Append environment variables to the web container: --web-environment-add="TYPO3_CONTEXT=Development,SOMEENV=someval"`)
+	configGlobalCommand.Flags().Bool("nfs-mount-enabled", false, "Enable NFS mounting on all projects globally")
+	_ = configGlobalCommand.Flags().MarkDeprecated("nfs-mount-enabled", fmt.Sprintf("please use --%s instead", configTypes.FlagPerformanceModeName))
 	configGlobalCommand.Flags().BoolVarP(&instrumentationOptIn, "instrumentation-opt-in", "", false, "instrumentation-opt-in=true")
 	configGlobalCommand.Flags().Bool("router-bind-all-interfaces", false, "router-bind-all-interfaces=true")
 	configGlobalCommand.Flags().Int("internet-detection-timeout-ms", 3000, "Increase timeout when checking internet timeout, in milliseconds")
@@ -267,6 +290,8 @@ func init() {
 	configGlobalCommand.Flags().Bool("simple-formatting", false, "If true, use simple formatting and no color for tables")
 	configGlobalCommand.Flags().Bool("use-hardened-images", false, "If true, use more secure 'hardened' images for an actual internet deployment.")
 	configGlobalCommand.Flags().Bool("fail-on-hook-fail", false, "If true, 'ddev start' will fail when a hook fails.")
+	configGlobalCommand.Flags().Bool("mutagen-enabled", false, "If true, web container will use mutagen caching/asynchronous updates.")
+	_ = configGlobalCommand.Flags().MarkDeprecated("mutagen-enabled", fmt.Sprintf("please use --%s instead", configTypes.FlagPerformanceModeName))
 	configGlobalCommand.Flags().String(configTypes.FlagPerformanceModeName, configTypes.FlagPerformanceModeDefault, configTypes.FlagPerformanceModeDescription(configTypes.ConfigTypeGlobal))
 	configGlobalCommand.Flags().Bool(configTypes.FlagPerformanceModeResetName, true, configTypes.FlagPerformanceModeResetDescription(configTypes.ConfigTypeGlobal))
 	configGlobalCommand.Flags().String("table-style", "", "Table style for list and describe, see ~/.ddev/global_config.yaml for values")
@@ -277,6 +302,8 @@ func init() {
 	_ = configGlobalCommand.Flags().MarkHidden("use-docker-compose-from-path")
 	configGlobalCommand.Flags().Bool("no-bind-mounts", true, "If true, don't use bind-mounts - useful for environments like remote docker where bind-mounts are impossible")
 	configGlobalCommand.Flags().String("xdebug-ide-location", "", "For less usual IDE locations specify where the IDE is running for Xdebug to reach it")
+	configGlobalCommand.Flags().Bool("use-traefik", true, "If true, use traefik for ddev-router")
+	_ = configGlobalCommand.Flags().MarkDeprecated("use-traefik", "please use --router instead")
 	configGlobalCommand.Flags().String("router", globalconfigTypes.RouterTypeTraefik, fmt.Sprintf("Valid router types are %s, default is %s", strings.Join(globalconfigTypes.GetValidRouterTypes(), ", "), globalconfigTypes.RouterTypeDefault))
 	configGlobalCommand.Flags().Bool("wsl2-no-windows-hosts-mgt", true, "WSL2 only; make DDEV ignore Windows-side hosts file")
 	configGlobalCommand.Flags().String("router-http-port", "", "The router HTTP port for this project")

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -241,9 +241,13 @@ func init() {
 	ConfigCommand.Flags().BoolVar(&webWorkingDirDefaultArg, "web-working-dir-default", false, "Unsets a web service working directory override")
 	ConfigCommand.Flags().BoolVar(&dbWorkingDirDefaultArg, "db-working-dir-default", false, "Unsets a db service working directory override")
 	ConfigCommand.Flags().BoolVar(&workingDirDefaultsArg, "working-dir-defaults", false, "Unsets all service working directory overrides")
+	ConfigCommand.Flags().Bool("mutagen-enabled", false, "Enable mutagen asynchronous update of project in web container")
+	_ = ConfigCommand.Flags().MarkDeprecated("mutagen-enabled", fmt.Sprintf("please use --%s instead", types.FlagPerformanceModeName))
 	ConfigCommand.Flags().String(types.FlagPerformanceModeName, types.FlagPerformanceModeDefault, types.FlagPerformanceModeDescription(types.ConfigTypeProject))
 	ConfigCommand.Flags().Bool(types.FlagPerformanceModeResetName, true, types.FlagPerformanceModeResetDescription(types.ConfigTypeProject))
 
+	ConfigCommand.Flags().Bool("nfs-mount-enabled", false, "Enable NFS mounting of project in container")
+	_ = ConfigCommand.Flags().MarkDeprecated("nfs-mount-enabled", fmt.Sprintf("please use --%s instead", types.FlagPerformanceModeName))
 	ConfigCommand.Flags().BoolVar(&failOnHookFail, "fail-on-hook-fail", false, "Decide whether 'ddev start' should be interrupted by a failing hook")
 	ConfigCommand.Flags().StringVar(&hostWebserverPortArg, "host-webserver-port", "", "The web container's localhost-bound port")
 	ConfigCommand.Flags().StringVar(&hostHTTPSPortArg, "host-https-port", "", "The web container's localhost-bound https port")
@@ -464,6 +468,18 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 
 	if hostDBPortArg != "" {
 		app.HostDBPort = hostDBPortArg
+	}
+
+	if cmd.Flag("nfs-mount-enabled").Changed {
+		if v, _ := cmd.Flags().GetBool("nfs-mount-enabled"); v {
+			app.SetPerformanceMode(types.PerformanceModeNFS)
+		}
+	}
+
+	if cmd.Flag("mutagen-enabled").Changed {
+		if v, _ := cmd.Flags().GetBool("mutagen-enabled"); v {
+			app.SetPerformanceMode(types.PerformanceModeMutagen)
+		}
 	}
 
 	if cmd.Flag(types.FlagPerformanceModeName).Changed {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -141,7 +141,7 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 
 	// Remove dba
 	if nodeps.ArrayContainsString(app.OmitContainers, "dba") {
-		util.Warning("Container `dba` is no longer part of DDEV, please remove it from `omit_containers`")
+		util.Warning("PhpMyAdmin (`dba`) no longer part of DDEV core, please edit your `omit_containers` configuration to remove it")
 		nodeps.RemoveItemFromSlice(app.OmitContainers, "dba")
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -141,7 +141,7 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 
 	// Remove dba
 	if nodeps.ArrayContainsString(app.OmitContainers, "dba") || nodeps.ArrayContainsString(app.OmitContainersGlobal, "dba") {
-		util.Warning("PhpMyAdmin (`dba`) no longer part of DDEV core, please edit your `omit_containers` configuration to remove it")
+		util.Warning("PhpMyAdmin (`dba`) is no longer part of DDEV core, please edit your `omit_containers` configuration to remove it")
 		app.OmitContainers = nodeps.RemoveItemFromSlice(app.OmitContainers, "dba")
 		app.OmitContainersGlobal = nodeps.RemoveItemFromSlice(app.OmitContainersGlobal, "dba")
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -142,8 +142,8 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	// Remove dba
 	if nodeps.ArrayContainsString(app.OmitContainers, "dba") || nodeps.ArrayContainsString(app.OmitContainersGlobal, "dba") {
 		util.Warning("PhpMyAdmin (`dba`) no longer part of DDEV core, please edit your `omit_containers` configuration to remove it")
-		nodeps.RemoveItemFromSlice(app.OmitContainers, "dba")
-		nodeps.RemoveItemFromSlice(app.OmitContainersGlobal, "dba")
+		app.OmitContainers = nodeps.RemoveItemFromSlice(app.OmitContainers, "dba")
+		app.OmitContainersGlobal = nodeps.RemoveItemFromSlice(app.OmitContainersGlobal, "dba")
 	}
 
 	app.SetApptypeSettingsPaths()

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -140,9 +140,10 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	}
 
 	// Remove dba
-	if nodeps.ArrayContainsString(app.OmitContainers, "dba") {
+	if nodeps.ArrayContainsString(app.OmitContainers, "dba") || nodeps.ArrayContainsString(app.OmitContainersGlobal, "dba") {
 		util.Warning("PhpMyAdmin (`dba`) no longer part of DDEV core, please edit your `omit_containers` configuration to remove it")
 		nodeps.RemoveItemFromSlice(app.OmitContainers, "dba")
+		nodeps.RemoveItemFromSlice(app.OmitContainersGlobal, "dba")
 	}
 
 	app.SetApptypeSettingsPaths()

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -139,6 +139,12 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 		app.addUploadDir(uploadDirDeprecated)
 	}
 
+	// Remove dba
+	if nodeps.ArrayContainsString(app.OmitContainers, "dba") {
+		util.Warning("Container `dba` is no longer part of DDEV, please remove it from `omit_containers`")
+		nodeps.RemoveItemFromSlice(app.OmitContainers, "dba")
+	}
+
 	app.SetApptypeSettingsPaths()
 
 	// Rendered yaml is not there until after ddev config or ddev start

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -229,7 +229,7 @@ func ReadGlobalConfig() error {
 
 	// Remove dba
 	if nodeps.ArrayContainsString(DdevGlobalConfig.OmitContainersGlobal, "dba") {
-		nodeps.RemoveItemFromSlice(DdevGlobalConfig.OmitContainersGlobal, "dba")
+		DdevGlobalConfig.OmitContainersGlobal = nodeps.RemoveItemFromSlice(DdevGlobalConfig.OmitContainersGlobal, "dba")
 	}
 
 	err = ValidateGlobalConfig()

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -227,6 +227,11 @@ func ReadGlobalConfig() error {
 		DdevGlobalConfig.InternetDetectionTimeout = nodeps.InternetDetectionTimeoutDefault
 	}
 
+	// Remove dba
+	if nodeps.ArrayContainsString(DdevGlobalConfig.OmitContainersGlobal, "dba") {
+		nodeps.RemoveItemFromSlice(DdevGlobalConfig.OmitContainersGlobal, "dba")
+	}
+
 	err = ValidateGlobalConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
## The Issue

- #5095

## How This PR Solves The Issue

Removed flags are reintroduced and marked deprecated.

## Manual Testing Instructions

- [ ] test flags `--mutagen-enabled=true` and `--nfs-mount-enabled=true` with `ddev config` and `ddev config global`
- [ ] test flag `--use-traefik=true` with `ddev config global`
- [ ] test `dba` in `omit_containers` shows a warning only

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5109"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

