### PR TITLE
refactor: anonymize user-defined custom commands

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -41,7 +41,15 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 		// again *after* --json flag is parsed.
 		output.LogSetUp()
 
-		amplitude.TrackCommand(cmd, args)
+		// Anonymize user defined custom commands.
+		cmdCopy := *cmd
+		argsCopy := args
+		if IsUserDefinedCustomCommand(&cmdCopy) {
+			cmdCopy.Use = "custom-command"
+			argsCopy = []string{}
+		}
+
+		amplitude.TrackCommand(&cmdCopy, argsCopy)
 
 		// Skip docker and other validation for most commands
 		if command != "start" && command != "restart" {

--- a/pkg/ddevapp/assets.go
+++ b/pkg/ddevapp/assets.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"embed"
+	"path/filepath"
 
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
@@ -52,4 +53,17 @@ func PopulateExamplesCommandsHomeadditions(appName string) error {
 	}
 
 	return nil
+}
+
+func IsBundledCustomCommand(globalCommand bool, service, command string) bool {
+	var baseDir string
+	if globalCommand {
+		baseDir = "global_dotddev_assets"
+	} else {
+		baseDir = "dotddev_assets"
+	}
+
+	_, err := bundledAssets.ReadFile(filepath.Join(baseDir, "commands", service, command))
+
+	return err == nil
 }


### PR DESCRIPTION
## The Issue

User-defined custom commands are exposed to instrumentation which is not what we want regarding data protection.

## How This PR Solves The Issue

User-defined custom commands are now anonymized with the name `custom-command`. So we still are able to record statistics about the usage of custom commands but have not longer critical data stored in Amplitude.

## Manual Testing Instructions

Run user-defined custom commands and check on Amplitude if they are properly anonymized. This is best done with the user lookup debug technique where all commands are visible.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5110"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

