### PR TITLE
fix: empty global table style should revert to "default"

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -3,7 +3,6 @@ package globalconfig
 import (
 	"context"
 	"fmt"
-	"github.com/ddev/ddev/pkg/styles"
 	"net"
 	"os"
 	"os/exec"
@@ -228,10 +227,6 @@ func ReadGlobalConfig() error {
 		DdevGlobalConfig.InternetDetectionTimeout = nodeps.InternetDetectionTimeoutDefault
 	}
 
-	// DDEV v1.21.6 may have had empty TableStyle, set to our default
-	if DdevGlobalConfig.TableStyle == "" {
-		DdevGlobalConfig.TableStyle = styles.DefaultTableStyle
-	}
 	err = ValidateGlobalConfig()
 	if err != nil {
 		return err

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -3,6 +3,7 @@ package globalconfig
 import (
 	"context"
 	"fmt"
+	"github.com/ddev/ddev/pkg/styles"
 	"net"
 	"os"
 	"os/exec"
@@ -227,6 +228,10 @@ func ReadGlobalConfig() error {
 		DdevGlobalConfig.InternetDetectionTimeout = nodeps.InternetDetectionTimeoutDefault
 	}
 
+	// DDEV v1.21.6 may have had empty TableStyle, set to our default
+	if DdevGlobalConfig.TableStyle == "" {
+		DdevGlobalConfig.TableStyle = styles.DefaultTableStyle
+	}
 	err = ValidateGlobalConfig()
 	if err != nil {
 		return err

--- a/pkg/globalconfig/styles.go
+++ b/pkg/globalconfig/styles.go
@@ -73,7 +73,7 @@ var OptionsSeparateRows = table.Options{
 
 // IsValidTableStyle checks to see if the table style is valid
 func IsValidTableStyle(style string) bool {
-	if _, ok := StyleMap[style]; ok || style == "" {
+	if _, ok := StyleMap[style]; ok {
 		return true
 	}
 


### PR DESCRIPTION
## The Issue

Many v1.21.6 projects had `table_style: ""`

v1.22.0 requires `table_style: default`

## How This PR Solves The Issue

Disallow "" as value, then the global config reader substitutes "default"

## Manual Testing Instructions

Set `table_style: ""` in global_config.yaml, then `ddev start`

You should now see `table_style: default` in global_config.yaml




<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5117"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

