### PR TITLE
docs: improve “Additional Project Hostnames” intro and add YAML syntax highlighting

### DIFF
--- a/docs/content/users/extend/additional-hostnames.md
+++ b/docs/content/users/extend/additional-hostnames.md
@@ -1,8 +1,10 @@
 # Additional Project Hostnames
 
-Add additional hostnames to a project in its `.ddev/config.yaml`:
+You can add hostnames to a project by editing its [config file](../configuration/config.md#additional_hostnames) or using the [`ddev config`](../usage/commands.md#config) command.
 
-```
+Use the `additional_hostnames` array in `.ddev/config.yaml`:
+
+```yaml
 name: mysite
 
 additional_hostnames:
@@ -27,7 +29,7 @@ In addition, the wildcard `*.lotsofnames` will result in anything `*.lotsofnames
 
 **If you use a FQDN which is resolvable on the internet, you must use `use_dns_when_possible: false` or configure that with `ddev config --use-dns-when-possible=false`.**
 
-```
+```yaml
 name: somename
 
 additional_fqdns:


### PR DESCRIPTION
## The Issue

I made some suggestions for #5045 I couldn’t get into fenced text blocks, so they’re back here with a vengeance:

1. Have the intro summarize the page from the start, linking away to the relevant config and command docs to reiterate the core concepts.
2. Apply syntax highlighting to the YAML examples, because syntax highlighting is good for your health.

## How This PR Solves The Issue

It makes the suggestions much easier to follow.

## Manual Testing Instructions

[Preview changes locally](https://ddev.readthedocs.io/en/stable/developers/testing-docs/#preview-changes) or inspect the [automatic build](https://ddev--5120.org.readthedocs.build/en/5120/users/extend/additional-hostnames/).

## Automated Testing Overview

n/a

## Related Issue Link(s)

- #5045

## Release/Deployment Notes

n/a


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5120"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

