### PR TITLE
fix: fix panic when upload_dirs=false, improve upload_dirs tests, fixes #5126, fixes #5127

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Override environment variables for push-pull-test-platforms
         run: |
           echo "MAKE_TARGET=testpkg" >> $GITHUB_ENV
-          echo "TESTARGS=-failfast -run '(TestDdevFullSite.*|Test.*(Push|Pull))'" >> $GITHUB_ENV
+          echo "TESTARGS=-failfast -run '(TestDdevFullSite.*|TestDdevImportFiles|TestDdevAllDatabases|Test.*(Push|Pull))'" >> $GITHUB_ENV
           echo "GOTEST_SHORT=" >> $GITHUB_ENV
           echo "DDEV_PLATFORM_API_TOKEN=${{ secrets.DDEV_PLATFORM_API_TOKEN }}" >> $GITHUB_ENV
           echo "DDEV_PANTHEON_API_TOKEN=${{ secrets.DDEV_PANTHEON_API_TOKEN }}" >> $GITHUB_ENV

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -98,6 +98,7 @@ func init() {
 			configOverrideAction: django4ConfigOverrideAction,
 			postConfigAction:     django4PostConfigAction,
 			postStartAction:      django4PostStartAction,
+			importFilesAction:    genericImportFilesAction,
 		},
 
 		nodeps.AppTypeDrupal6: {
@@ -159,6 +160,7 @@ func init() {
 			appTypeDetect:        isLaravelApp,
 			postStartAction:      laravelPostStartAction,
 			configOverrideAction: laravelConfigOverrideAction,
+			importFilesAction:    genericImportFilesAction,
 		},
 
 		nodeps.AppTypeMagento: {
@@ -181,13 +183,14 @@ func init() {
 
 		nodeps.AppTypePHP: {
 			postStartAction:   phpPostStartAction,
-			importFilesAction: phpImportFilesAction,
+			importFilesAction: genericImportFilesAction,
 		},
 
 		nodeps.AppTypePython: {
 			appTypeDetect:        isPythonApp,
 			configOverrideAction: pythonConfigOverrideAction,
 			postConfigAction:     pythonPostConfigAction,
+			importFilesAction:    genericImportFilesAction,
 		},
 
 		nodeps.AppTypeShopware6: {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -863,7 +863,7 @@ func (app *DdevApp) ImportFiles(uploadDir, importPath, extractPath string) error
 	if uploadDir == "" {
 		uploadDir = app.GetUploadDir()
 		if uploadDir == "" {
-			return fmt.Errorf("upload_dir is not set, cannot import files")
+			return fmt.Errorf("upload_dirs is not set, cannot import files")
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2847,3 +2847,48 @@ func FormatSiteStatus(status string) string {
 	}
 	return formattedStatus
 }
+
+// genericImportFilesAction defines the workflow for importing project files.
+func genericImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
+	destPath := app.calculateHostUploadDirFullPath(uploadDir)
+
+	// parent of destination dir should exist
+	if !fileutil.FileExists(filepath.Dir(destPath)) {
+		return fmt.Errorf("unable to import to %s: parent directory does not exist", destPath)
+	}
+
+	// parent of destination dir should be writable.
+	if err := os.Chmod(filepath.Dir(destPath), 0755); err != nil {
+		return err
+	}
+
+	// If the destination path exists, remove it as was warned
+	if fileutil.FileExists(destPath) {
+		if err := os.RemoveAll(destPath); err != nil {
+			return fmt.Errorf("failed to cleanup %s before import: %v", destPath, err)
+		}
+	}
+
+	if isTar(importPath) {
+		if err := archive.Untar(importPath, destPath, extPath); err != nil {
+			return fmt.Errorf("failed to extract provided archive: %v", err)
+		}
+
+		return nil
+	}
+
+	if isZip(importPath) {
+		if err := archive.Unzip(importPath, destPath, extPath); err != nil {
+			return fmt.Errorf("failed to extract provided archive: %v", err)
+		}
+
+		return nil
+	}
+
+	//nolint: revive
+	if err := fileutil.CopyDir(importPath, destPath); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -862,6 +862,9 @@ func (app *DdevApp) ImportFiles(uploadDir, importPath, extractPath string) error
 
 	if uploadDir == "" {
 		uploadDir = app.GetUploadDir()
+		if uploadDir == "" {
+			return fmt.Errorf("upload_dir is not set, cannot import files")
+		}
 	}
 
 	if err := app.dispatchImportFilesAction(uploadDir, importPath, extractPath); err != nil {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -165,8 +165,8 @@ var (
 		// 8: drupal9
 		{
 			Name:                          "TestPkgDrupal9",
-			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-9.4.2.tar.gz",
-			ArchiveInternalExtractionPath: "drupal-9.4.2/",
+			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-9.5.10.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-9.5.10/",
 			FilesTarballURL:               "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/d9_umami_files.tgz",
 			FilesZipballURL:               "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/d9_umami_files.zip",
 			DBTarURL:                      "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/d9_umami_sql.tar.gz",
@@ -225,8 +225,8 @@ var (
 		// 12: drupal10
 		{
 			Name:                          "TestPkgDrupal10",
-			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-10.0.0-alpha6.tar.gz",
-			ArchiveInternalExtractionPath: "drupal-10.0.0-alpha6",
+			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-10.1.1.tar.gz",
+			ArchiveInternalExtractionPath: "drupal-10.1.1/",
 			FilesTarballURL:               "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/drupal10-files.tgz",
 			DBTarURL:                      "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/drupal10-alpha6.sql.tar.gz",
 			FullSiteTarballURL:            "",

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2434,8 +2434,6 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 		err := app.Init(site.Dir)
 		require.NoError(t, err)
 
-		// Try custom upload dir
-		//app.UploadDirs = ddevapp.UploadDirs{"my/upload/dir"}
 		absUploadDir := filepath.Join(app.AppRoot, app.Docroot, app.GetUploadDir())
 		err = os.MkdirAll(absUploadDir, 0755)
 		assert.NoError(err)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2133,7 +2133,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 			}
 			err = app.ImportFiles("", tarballPath, "")
 			assert.Error(err)
-			assert.Contains(err.Error(), fmt.Sprintf("upload_dirs is not set for this project (%s)", app.Type))
+			assert.Contains(err.Error(), "upload_dirs is not set", app.Type)
 		}
 		// We don't want all the projects running at once.
 		err = app.Stop(true, false)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2444,7 +2444,7 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 		err = app.Init(site.Dir)
 		require.NoError(t, err)
 
-		if site.FilesTarballURL != "" {
+		if site.FilesTarballURL != "" && site.UploadDirs != nil {
 			// First, try import with the project-default upload_dirs
 			// Make sure we don't have files to start
 			fullTargetFilesPath := app.GetHostUploadDirFullPath()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2513,6 +2513,13 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 				dirEntrySlice, err = os.ReadDir(fullTargetFilesPath)
 				assert.NoError(err)
 				assert.NotEmpty(dirEntrySlice)
+
+				// Try with upload_dir that is outside project
+				app.UploadDirs = "../../nowhere"
+				_, tarballPath, err := testcommon.GetCachedArchive(site.Name, "local-tarballs-files", "", site.FilesTarballURL)
+				require.NoError(t, err)
+				err = app.ImportFiles("", tarballPath, "")
+				assert.Error(err)
 			}
 		}
 
@@ -2544,7 +2551,7 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 		app.UploadDirs = false
 		err = app.ImportFiles("", "/tmp", "")
 		assert.Error(err)
-		require.Contains(t, err.Error(), "is not set for this project")
+		require.Contains(t, err.Error(), "cannot import files")
 
 		switchDir()
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3235,7 +3235,7 @@ func TestHttpsRedirection(t *testing.T) {
 	types := ddevapp.GetValidAppTypes()
 	webserverTypes := []string{nodeps.WebserverNginxFPM, nodeps.WebserverApacheFPM}
 	if os.Getenv("GOTEST_SHORT") != "" {
-		types = []string{nodeps.AppTypePHP, nodeps.AppTypeDrupal8}
+		types = []string{nodeps.AppTypePHP, nodeps.AppTypeDrupal10}
 		webserverTypes = []string{nodeps.WebserverNginxFPM, nodeps.WebserverApacheFPM}
 	}
 	for _, projectType := range types {

--- a/pkg/ddevapp/php.go
+++ b/pkg/ddevapp/php.go
@@ -2,11 +2,6 @@ package ddevapp
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-
-	"github.com/ddev/ddev/pkg/archive"
-	"github.com/ddev/ddev/pkg/fileutil"
 )
 
 func phpPostStartAction(app *DdevApp) error {
@@ -15,50 +10,5 @@ func phpPostStartAction(app *DdevApp) error {
 			return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
 		}
 	}
-	return nil
-}
-
-// phpImportFilesAction defines the workflow for importing project files.
-func phpImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
-	destPath := app.calculateHostUploadDirFullPath(uploadDir)
-
-	// parent of destination dir should exist
-	if !fileutil.FileExists(filepath.Dir(destPath)) {
-		return fmt.Errorf("unable to import to %s: parent directory does not exist", destPath)
-	}
-
-	// parent of destination dir should be writable.
-	if err := os.Chmod(filepath.Dir(destPath), 0755); err != nil {
-		return err
-	}
-
-	// If the destination path exists, remove it as was warned
-	if fileutil.FileExists(destPath) {
-		if err := os.RemoveAll(destPath); err != nil {
-			return fmt.Errorf("failed to cleanup %s before import: %v", destPath, err)
-		}
-	}
-
-	if isTar(importPath) {
-		if err := archive.Untar(importPath, destPath, extPath); err != nil {
-			return fmt.Errorf("failed to extract provided archive: %v", err)
-		}
-
-		return nil
-	}
-
-	if isZip(importPath) {
-		if err := archive.Unzip(importPath, destPath, extPath); err != nil {
-			return fmt.Errorf("failed to extract provided archive: %v", err)
-		}
-
-		return nil
-	}
-
-	//nolint: revive
-	if err := fileutil.CopyDir(importPath, destPath); err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -35,6 +35,7 @@ func (app *DdevApp) addUploadDir(uploadDir string) {
 }
 
 // GetUploadDir returns the first upload (public files) directory.
+// This value is relative to the docroot
 func (app *DdevApp) GetUploadDir() string {
 	uploadDirs := app.GetUploadDirs()
 	if len(uploadDirs) > 0 {

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -194,7 +194,7 @@ func (app *DdevApp) createUploadDirsIfNecessary() {
 	}
 }
 
-// validateUploadDirs validates and converts UploadDirs to a app.UploadDirs
+// validateUploadDirs validates and converts UploadDirs to app.UploadDirs
 // interface or if disabled to bool false and returns nil if succeeded or an
 // error if not.
 func (app *DdevApp) validateUploadDirs() error {
@@ -226,10 +226,12 @@ func (app *DdevApp) validateUploadDirs() error {
 		return fmt.Errorf("`upload_dirs` must be a string, a list of strings, or false but `%v` given", app.UploadDirs)
 	}
 
-	// Check upload dirs are in the project root.
-	for _, uploadDir := range app.UploadDirs.(UploadDirs) {
-		if !strings.HasPrefix(app.calculateHostUploadDirFullPath(uploadDir), app.AppRoot) {
-			return fmt.Errorf("invalid upload dir `%s` outside of project root `%s` found", uploadDir, app.AppRoot)
+	if dirs, ok := app.UploadDirs.(UploadDirs); ok {
+		// Check upload dirs are in the project root.
+		for _, uploadDir := range dirs {
+			if !strings.HasPrefix(app.calculateHostUploadDirFullPath(uploadDir), app.AppRoot) {
+				return fmt.Errorf("invalid upload dir `%s` outside of project root `%s` found", uploadDir, app.AppRoot)
+			}
 		}
 	}
 


### PR DESCRIPTION
## The Issue

* #5126
* #5127 

## How This PR Solves The Issue

* Fix the panic
* Add test coverage for upload_dirs=false and several other situations
* Refactor the type conversion management
* Fix `ddev import-files` for Laravel

## Manual Testing Instructions

- [x] `ddev config --upload-dirs=false`
- [x] Try other upload_dirs situations
- [x] `ddev import-files` tests
- [x] `ddev import-files` with laravel where upload_dirs is set

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5128"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

