### PR TITLE
docs: change code refs of Mac M1 to Apple Silicon

### DIFF
--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -1,16 +1,17 @@
 package cmd_test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/ddev/ddev/cmd/ddev/cmd"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
 
 	"github.com/ddev/ddev/pkg/exec"
 	asrt "github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ import (
 
 // TestCmdAuthSSH runs `ddev auth ssh` and checks that it actually worked out.
 func TestCmdAuthSSH(t *testing.T) {
-	if nodeps.IsMacM1() {
+	if nodeps.IsAppleSilicon() {
 		t.Skip("Skipping TestCmdAuthSSH on Mac M1 because of useless Docker Desktop failures to connect")
 	}
 

--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
-	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/testcommon"
@@ -29,7 +30,7 @@ func TestLogsNoConfig(t *testing.T) {
 
 // TestCmdLogs tests that the ddev logs functionality is working.
 func TestCmdLogs(t *testing.T) {
-	//if nodeps.IsMacM1() {
+	//if nodeps.IsAppleSilicon() {
 	//	t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
 	//}
 	assert := asrt.New(t)

--- a/cmd/ddev/cmd/ssh_test.go
+++ b/cmd/ddev/cmd/ssh_test.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -10,13 +13,11 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"testing"
 )
 
 // TestCmdSSH runs `ddev ssh` on basic apps, including with a dot and a dash in them
 func TestCmdSSH(t *testing.T) {
-	if nodeps.IsMacM1() {
+	if nodeps.IsAppleSilicon() {
 		t.Skip("Skipping TestCmdSSH on Mac M1 because of useless Docker Desktop failures to connect")
 	}
 	assert := asrt.New(t)

--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
+	"os"
+	"testing"
+
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/stretchr/testify/require"
-	"os"
-	"testing"
 
 	"github.com/ddev/ddev/pkg/exec"
 	asrt "github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ import (
 
 // TestCmdXdebug tests the `ddev xdebug` command
 func TestCmdXdebug(t *testing.T) {
-	if nodeps.IsMacM1() && dockerutil.IsDockerDesktop() {
+	if nodeps.IsAppleSilicon() && dockerutil.IsDockerDesktop() {
 		// 2022-03-16: On Docker Desktop 4.6.0, Mac M1, the `ddev xdebug status` fails to return after
 		// turning `ddev xdebug on`. Seems to be new problem with docker desktop 4.6.0, seems to be only
 		// on mac M1. Unable to recreate locally.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -587,7 +587,7 @@ func TestReadConfigCRLF(t *testing.T) {
 
 // TestConfigValidate tests validation of configuration values.
 func TestConfigValidate(t *testing.T) {
-	if nodeps.IsMacM1() {
+	if nodeps.IsAppleSilicon() {
 		t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
 	}
 
@@ -806,7 +806,7 @@ func TestConfigOverrideDetection(t *testing.T) {
 
 // TestPHPOverrides tests to make sure that PHP overrides work in all webservers.
 func TestPHPOverrides(t *testing.T) {
-	if nodeps.IsMacM1() {
+	if nodeps.IsAppleSilicon() {
 		t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
 	}
 
@@ -1064,7 +1064,7 @@ func TestTimezoneConfig(t *testing.T) {
 
 // TestComposerVersionConfig tests to make sure setting composer version takes effect in the container.
 func TestComposerVersionConfig(t *testing.T) {
-	if nodeps.IsMacM1() || dockerutil.IsColima() {
+	if nodeps.IsAppleSilicon() || dockerutil.IsColima() {
 		t.Skip("Skipping on Mac M1 and Colima, just lots of failed network connections")
 	}
 	assert := asrt.New(t)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -652,7 +652,7 @@ func TestDdevStartCustomEntrypoint(t *testing.T) {
 
 // TestDdevStartMultipleHostnames tests start with multiple hostnames
 func TestDdevStartMultipleHostnames(t *testing.T) {
-	//if nodeps.IsMacM1() {
+	//if nodeps.IsAppleSilicon() {
 	//	t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
 	//}
 
@@ -1054,7 +1054,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 
 // TestDdevXhprofEnabled tests running with xhprof_enabled = true, etc.
 func TestDdevXhprofEnabled(t *testing.T) {
-	if nodeps.IsMacM1() || dockerutil.IsColima() {
+	if nodeps.IsAppleSilicon() || dockerutil.IsColima() {
 		t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
 	}
 
@@ -3117,7 +3117,7 @@ func TestAppdirAlreadyInUse(t *testing.T) {
 // TestHttpsRedirection tests to make sure that webserver and php redirect to correct
 // scheme (http or https).
 func TestHttpsRedirection(t *testing.T) {
-	if nodeps.IsMacM1() {
+	if nodeps.IsAppleSilicon() {
 		t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
 	}
 	if globalconfig.GetCAROOT() == "" {
@@ -3425,7 +3425,7 @@ func TestPHPWebserverType(t *testing.T) {
 // TestInternalAndExternalAccessToURL checks we can access content
 // from host and from inside container by URL (with port)
 func TestInternalAndExternalAccessToURL(t *testing.T) {
-	if nodeps.IsMacM1() || dockerutil.IsColima() {
+	if nodeps.IsAppleSilicon() || dockerutil.IsColima() {
 		t.Skip("Skipping on mac M1/Colima to ignore problems with 'connection reset by peer'")
 	}
 

--- a/pkg/ddevapp/hardened_test.go
+++ b/pkg/ddevapp/hardened_test.go
@@ -18,7 +18,7 @@ import (
 
 // TestHardenedStart makes sure we can do a start and basic use with hardened images
 func TestHardenedStart(t *testing.T) {
-	if nodeps.IsMacM1() {
+	if nodeps.IsAppleSilicon() {
 		t.Skip("Skipping TestHardenedStart on Mac M1 because of useless Docker Desktop failures to connect")
 	}
 

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -218,7 +218,7 @@ func TestRouterConfigOverride(t *testing.T) {
 
 // TestDisableHTTP2 tests we can enable or disable http2
 func TestDisableHTTP2(t *testing.T) {
-	if nodeps.IsMacM1() {
+	if nodeps.IsAppleSilicon() {
 		t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
 	}
 	if globalconfig.GetCAROOT() == "" {

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -1,7 +1,6 @@
 package nodeps
 
 import (
-	"golang.org/x/term"
 	"math/rand"
 	"net"
 	"os"
@@ -10,6 +9,8 @@ import (
 	"strconv"
 	"time"
 	"unicode"
+
+	"golang.org/x/term"
 )
 
 // ArrayContainsString returns true if slice contains element
@@ -62,8 +63,8 @@ func RandomString(length int) string {
 	return string(b)
 }
 
-// IsMacM1 returns true if running on mac M1
-func IsMacM1() bool {
+// IsAppleSilicon returns true if running on mac M1
+func IsAppleSilicon() bool {
 	return runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
 }
 


### PR DESCRIPTION
## The Issue
There are references to Mac M1 in the code, but with Apple's release of M2, it is probably wise to change those references to a more general "Apple Silicon", when checking architectures.

## How This PR Solves The Issue
This simply updates the function name and all of the references to it.

## Manual Testing Instructions
Start up a DDEV project on a device using Apple Silicon, particularly one using Docker Desktop, as this code is required due to compat quirks with that.

## Automated Testing Overview

This change should included updated tests where necessary.

## Related Issue Link(s)
https://github.com/ddev/ddev/issues/5125

## Release/Deployment Notes
This should be fairly self-contained and not affect other code to a large degree.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5129"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

