### PR TITLE
docs: use import-db --file instead of import-db --src

### DIFF
--- a/.devcontainer/setup_test_project.sh
+++ b/.devcontainer/setup_test_project.sh
@@ -25,6 +25,6 @@ fi
 ddev stop -a
 ddev start -y
 if [ -d "/tmp/${DDEV_ARTIFACTS##*/}" ]; then
-    ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
+    ddev import-db --file=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
     ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
 fi

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -24,7 +24,7 @@ tasks:
       ddev stop -a
       ddev start -y
       if [ -d "/tmp/${DDEV_ARTIFACTS##*/}" ]; then
-        ddev import-db --src=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
+        ddev import-db --file=/tmp/${DDEV_ARTIFACTS##*/}/db.sql.gz
         ddev import-files --src=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
       fi
       gp ports await 8080 && sleep 1 && gp preview $(gp url 8080)

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -53,7 +53,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
         ddev composer install
 
         # Import a database backup and open the site in your browser:
-        ddev import-db --src=/path/to/db.sql.gz
+        ddev import-db --file=/path/to/db.sql.gz
         ddev launch
         ```
 
@@ -308,7 +308,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
     * Download Magento [1.9.2.4 Sample Data](https://github.com/Vinai/compressed-magento-sample-data/raw/master/compressed-magento-sample-data-1.9.2.4.tgz).
     * Extract the download:
         `tar -zxf ~/Downloads/compressed-magento-sample-data-1.9.2.4.tgz --strip-components=1`
-    * Import the example database `magento_sample_data_for_1.9.2.4.sql` with `ddev import-db --src=magento_sample_data_for_1.9.2.4.sql` to database **before** running OpenMage install.
+    * Import the example database `magento_sample_data_for_1.9.2.4.sql` with `ddev import-db --file=magento_sample_data_for_1.9.2.4.sql` to database **before** running OpenMage install.
 
     OpenMage is a huge codebase, and we recommend [using Mutagen for performance](install/performance.md#using-mutagen) on macOS and traditional Windows.
 
@@ -639,7 +639,7 @@ An important aspect of local web development is the ability to have a precise lo
 
 ### Importing a Database
 
-The [`ddev import-db`](../users/usage/commands.md#import-db) command imports the database for a project. Running this command will prompt you to specify the location of your database import. By default `ddev import-db` empties the default `db` database, then loads the provided dump file. Most people use it with command flags, like `ddev import-db --src=.tarballs/db.sql.gz`, but it can also prompt for the location of the dump if you only use `ddev import-db`:
+The [`ddev import-db`](../users/usage/commands.md#import-db) command imports the database for a project. Running this command will prompt you to specify the location of your database import. By default `ddev import-db` empties the default `db` database, then loads the provided dump file. Most people use it with command flags, like `ddev import-db --file=.tarballs/db.sql.gz`, but it can also prompt for the location of the dump if you only use `ddev import-db`:
 
 ```bash
 ddev import-db
@@ -682,7 +682,7 @@ Successfully imported database for drupal8
 If you want to use the [`import-db`](../users/usage/commands.md#import-db) command without answering prompts, you can use the `--src` flag to provide the path to the import asset. If you’re importing an archive and wish to specify the path within the archive to extract, you can use the `--extract-path` flag in conjunction with the `--src` flag. Examples:
 
 ```bash
-ddev import-db --src=/tmp/mydb.sql.gz
+ddev import-db --file=/tmp/mydb.sql.gz
 gzip -dc /tmp/mydb.sql.gz | ddev import-db
 ddev import-db <mydb.sql
 ```

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -13,7 +13,7 @@ Import a database with one command, from one of the following file formats:
 Here’s an example of a database import using DDEV:
 
 ```bash
-ddev import-db --src=dumpfile.sql.gz
+ddev import-db --file=dumpfile.sql.gz
 ```
 
 You can also:

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -191,7 +191,7 @@ Delete it and migrate it to a new project with your preferred name:
 2. Delete the project: `ddev delete <project>`. (This takes a snapshot by default for safety.)
 3. Rename the project: `ddev config --project-name=<new_name>`.
 4. Start thew new project with `ddev start`.
-5. Import the database dump from step one: `ddev import-db --src=/path/to/db.sql.gz`.
+5. Import the database dump from step one: `ddev import-db --file=/path/to/db.sql.gz`.
 
 ### How can I move a project to another directory?
 

--- a/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
@@ -30,7 +30,7 @@ db_import_command:
   command: |
     set -eu -o pipefail
     # set -x
-    ddev import-db --src="${checkout_dir}/db.sql.gz"
+    ddev import-db --file="${checkout_dir}/db.sql.gz"
 
 files_import_command:
   service: host


### PR DESCRIPTION
## The Issue

When we moved from `ddev import-db --src` to `ddev import-db --files`  we didn't update a number of references to the old usage.

