### PR TITLE
fix: composer create project must restart to fix broken bind mounts, fixes #5031

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -95,6 +95,17 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 			}
 		}
 
+		// Upload dirs have to be there for bind-mounts to work when mutagen enabled
+		app.CreateUploadDirsIfNecessary()
+		// We may have just removed host-side directories, invalidating
+		// the docker bind-mounts are using, so restart to pick up the new ones.
+		if app.IsMutagenEnabled() {
+			err = app.Restart()
+			if err != nil {
+				util.Failed("Failed to restart project after removal of project files: %v", err)
+			}
+		}
+
 		err = app.MutagenSyncFlush()
 		if err != nil {
 			util.Failed("Failed to sync mutagen contents: %v", err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -992,7 +992,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 	}
 
-	app.createUploadDirsIfNecessary()
+	app.CreateUploadDirsIfNecessary()
 
 	if app.IsMutagenEnabled() {
 		err = app.GenerateMutagenYml()

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -178,12 +178,12 @@ func (app *DdevApp) getUploadDirsRelative() []string {
 	return uploadDirsMap
 }
 
-// createUploadDirsIfNecessary creates the upload dirs if it doesn't exist, so we can properly
+// CreateUploadDirsIfNecessary creates the upload dirs if it doesn't exist, so we can properly
 // set up bind-mounts when doing mutagen.
 // There is no need to do it if mutagen is not enabled, and
 // we'll just respect a symlink if it exists, and the user has to figure out the right
 // thing to do with mutagen.
-func (app *DdevApp) createUploadDirsIfNecessary() {
+func (app *DdevApp) CreateUploadDirsIfNecessary() {
 	for _, target := range app.GetUploadDirs() {
 		if hostDir := app.calculateHostUploadDirFullPath(target); hostDir != "" && app.IsMutagenEnabled() && !fileutil.FileExists(hostDir) {
 			err := os.MkdirAll(hostDir, 0755)


### PR DESCRIPTION

## The Issue

* #5031

Because we delete most things in the project directory, we're removing the host-side directories that bind-mounts depend on, invalidating them. When using mutagen, there are (by default) bind-mounts to the upload_dirs, and so those get invalidated.

## How This PR Solves The Issue

The way to fix this is to recreate the bind mount directories (upload_dirs) after we've deleted them unknowingly, and then Restart()

## Manual Testing Instructions

Use the recipe in #5031 

## Automated Testing Overview

Existing tests should be adequate

## Related Issue Link(s)

Previous attempts:
* #5042 (Two separate attempts there)

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5132"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

