### PR TITLE
refactor: revert `upload_dirs=false`, fixes #5131

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 // Define flags for the config command
@@ -641,28 +640,11 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 
 	if cmd.Flag("upload-dir").Changed {
 		uploadDirRaw, _ := cmd.Flags().GetString("upload-dir")
-		app.UploadDirs = ddevapp.UploadDirs{uploadDirRaw}
+		app.UploadDirs = []string{uploadDirRaw}
 	}
 
 	if cmd.Flag("upload-dirs").Changed {
-		uploadDirsRaw := cmd.Flag("upload-dirs").Value.(pflag.SliceValue).GetSlice()
-
-		var uploadDirs any
-		uploadDirs = uploadDirsRaw
-
-		if len(uploadDirsRaw) == 1 {
-			uploadDirsBool, err := strconv.ParseBool(uploadDirsRaw[0])
-
-			if err == nil {
-				if uploadDirsBool {
-					util.Failed("Incorrect value for --upload-dirs: %v", uploadDirsBool)
-				}
-
-				uploadDirs = uploadDirsBool
-			}
-		}
-
-		app.UploadDirs = uploadDirs
+		app.UploadDirs, _ = cmd.Flags().GetStringSlice("upload-dirs")
 	}
 
 	if webserverTypeArg != "" {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -226,7 +226,6 @@ func init() {
 	ConfigCommand.Flags().BoolVar(&createDocroot, "create-docroot", false, "Prompts ddev to create the docroot if it doesn't exist")
 	ConfigCommand.Flags().BoolVar(&showConfigLocation, "show-config-location", false, "Output the location of the config.yaml file if it exists, or error that it doesn't exist.")
 	ConfigCommand.Flags().StringSlice("upload-dirs", []string{}, "Sets the project's upload directories, the destination directories of the import-files command.")
-	ConfigCommand.Flags().Lookup("upload-dirs").NoOptDefVal = "false"
 	ConfigCommand.Flags().String("upload-dir", "", "Sets the project's upload directories, the destination directories of the import-files command.")
 	_ = ConfigCommand.Flags().MarkDeprecated("upload-dir", "please use --upload-dirs instead")
 	ConfigCommand.Flags().StringVar(&webserverTypeArg, "webserver-type", "", "Sets the project's desired webserver type: nginx-fpm/apache-fpm/nginx-gunicorn")

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -184,7 +184,7 @@ func TestConfigSetValues(t *testing.T) {
 	dbimageExtraPackagesSlice := []string{"netcat", "ncdu"}
 	dbimageExtraPackages := strings.Join(dbimageExtraPackagesSlice, ",")
 
-	uploadDir := filepath.Join("custom", "config", "path")
+	uploadDirsSlice := []string{"custom", "config", "path"}
 	webserverType := nodeps.WebserverApacheFPM
 	webImage := "custom-web-image"
 	webWorkingDir := "/custom/web/dir"
@@ -211,7 +211,7 @@ func TestConfigSetValues(t *testing.T) {
 		fmt.Sprintf("--no-project-mount=%t", noProjectMount),
 		"--additional-hostnames", additionalHostnames,
 		"--additional-fqdns", additionalFQDNs,
-		fmt.Sprintf("--upload-dirs=\"%s\"", uploadDir),
+		"--upload-dirs=" + strings.Join(uploadDirsSlice, ","),
 		"--webserver-type", webserverType,
 		"--web-image", webImage,
 		"--web-working-dir", webWorkingDir,
@@ -259,7 +259,7 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Equal(noProjectMount, app.NoProjectMount)
 	assert.Equal(additionalHostnamesSlice, app.AdditionalHostnames)
 	assert.Equal(additionalFQDNsSlice, app.AdditionalFQDNs)
-	assert.Equal(uploadDir, app.GetUploadDir())
+	assert.Equal(uploadDirsSlice, app.GetUploadDirs())
 	assert.Equal(webserverType, app.WebserverType)
 	assert.Equal(webImage, app.WebImage)
 	assert.Equal(webWorkingDir, app.WorkingDir["web"])

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -454,7 +454,7 @@ The `php` and `python` types don’t attempt [CMS configuration](../../users/qui
 
 ## `upload_dirs`
 
-Paths from the project’s docroot to the user-generated files directory targeted by `ddev import-files`. Can be outside the docroot but must be within the project directory e.g. `../private`. Some CMSs and frameworks have default `upload_dirs`, like Drupal's `sites/default/files`; `upload_dirs` will override the defaults, so if you want Drupal to use both `sites/default/files` and `../private` you would list both, `upload_dirs: ["sites/default/files", "../private"]`. `upload_dirs` is used for targeting `ddev import-files` and also, when Mutagen is enabled, to bind-mount those directories so their contents does not need to be synced into Mutagen.
+Paths from the project’s docroot to the user-generated files directory targeted by `ddev import-files`. Can be outside the docroot but must be within the project directory e.g. `../private`. Some CMSes and frameworks have default `upload_dirs`, like Drupal's `sites/default/files`; `upload_dirs` will override the defaults, so if you want Drupal to use both `sites/default/files` and `../private` you would list both, `upload_dirs: ["sites/default/files", "../private"]`. `upload_dirs` is used for targeting `ddev import-files` and also, when Mutagen is enabled, to bind-mount those directories so their contents does not need to be synced into Mutagen.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -454,11 +454,11 @@ The `php` and `python` types don’t attempt [CMS configuration](../../users/qui
 
 ## `upload_dirs`
 
-Paths from the project’s docroot to the user-generated files directory targeted by `ddev import-files`. Can be be outside the docroot but must be within the project directory e.g. `../private`.
+Paths from the project’s docroot to the user-generated files directory targeted by `ddev import-files`. Can be outside the docroot but must be within the project directory e.g. `../private`. Some CMSs and frameworks have default `upload_dirs`, like Drupal's `sites/default/files`; `upload_dirs` will override the defaults, so if you want Drupal to use both `sites/default/files` and `../private` you would list both, `upload_dirs: ["sites/default/files", "../private"]`. `upload_dirs` is used for targeting `ddev import-files` and also, when Mutagen is enabled, to bind-mount those directories so their contents does not need to be synced into Mutagen.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | | A list of directories or `false` to disable warnings for project types without any default e.g. `php`.
+| :octicons-file-directory-16: project | | A list of directories.
 
 ## `use_dns_when_possible`
 

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -84,7 +84,7 @@ If you want to use `import-files` without answering prompts, use the `--source` 
 
 `ddev import-files --source=/tmp/files.tgz`
 
-With multiple `upload_dirs` defined if you want to import to another upload dir than the first one, use the `--target` or `-t` flag to provide the path to the desired upload dir.
+When multiple `upload_dirs` are defined and you want to import to another upload dir than the first one, use the `--target` or `-t` flag to provide the path to the desired upload dir:
 
 `ddev import-files --target=../private --source=/tmp/files.tgz`
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -19,7 +19,7 @@ import (
 type settingsCreator func(*DdevApp) (string, error)
 
 // uploadDirs
-type uploadDirs func(*DdevApp) UploadDirs
+type uploadDirs func(*DdevApp) []string
 
 // hookDefaultComments should probably change its arg from string to app when
 // config refactor is done.

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -129,8 +129,8 @@ func writeBackdropSettingsDdevPHP(settings *BackdropSettings, filePath string, _
 }
 
 // getBackdropUploadDirs will return the default paths.
-func getBackdropUploadDirs(_ *DdevApp) UploadDirs {
-	return UploadDirs{"files"}
+func getBackdropUploadDirs(_ *DdevApp) []string {
+	return []string{"files"}
 }
 
 // getBackdropHooks for appending as byte array.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -105,7 +105,7 @@ type DdevApp struct {
 	ProviderInstance          *Provider              `yaml:"-"`
 	Hooks                     map[string][]YAMLTask  `yaml:"hooks,omitempty"`
 	UploadDirDeprecated       string                 `yaml:"upload_dir,omitempty"`
-	UploadDirs                interface{}            `yaml:"upload_dirs,omitempty"`
+	UploadDirs                []string               `yaml:"upload_dirs,omitempty"`
 	WorkingDir                map[string]string      `yaml:"working_dir,omitempty"`
 	OmitContainers            []string               `yaml:"omit_containers,omitempty,flow"`
 	OmitContainersGlobal      []string               `yaml:"-"`

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -256,7 +256,7 @@ var (
 			Type:                          nodeps.AppTypeCraftCms,
 			Docroot:                       "web",
 			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/test.html", Expect: "Thanks for testing Craft CMS"},
-			UploadDirs:                    ddevapp.UploadDirs{"files"},
+			UploadDirs:                    []string{"files"},
 			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "Thanks for installing Craft CMS"},
 			FilesImageURI:                 "/files/happy-brad.jpg",
 		},
@@ -2029,7 +2029,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		// TestPkgPHP uses mostly stuff from Drupal6, but we'll set the type to php
 		if site.Name == "TestPkgPHP" {
 			app.Type = nodeps.AppTypePHP
-			app.UploadDirs = ddevapp.UploadDirs{"files"}
+			app.UploadDirs = []string{"files"}
 			err = os.MkdirAll(app.GetHostUploadDirFullPath(), 0755)
 			assert.NoError(err)
 		}
@@ -2123,7 +2123,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 
 		// Project type 'php' should fail ImportFiles if no upload_dirs is provided
 		if app.Type == nodeps.AppTypePHP {
-			app.UploadDirs = ddevapp.UploadDirs{}
+			app.UploadDirs = []string{}
 			err = app.WriteConfig()
 			assert.NoError(err)
 			_, tarballPath, err := testcommon.GetCachedArchive(site.Name, "local-tarballs-files", "", site.FilesTarballURL)
@@ -2462,7 +2462,7 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 			// Second, try with a single custom upload_dirs
 			targetFilesPath := "single/custom/target/dir"
 			// This is automatically relative to docroot
-			app.UploadDirs = ddevapp.UploadDirs{targetFilesPath}
+			app.UploadDirs = []string{targetFilesPath}
 			fullTargetFilesPath = app.GetHostUploadDirFullPath()
 			err = os.MkdirAll(fullTargetFilesPath, 0755)
 			require.NoError(t, err)
@@ -2480,7 +2480,7 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 			// Now try explicit import to targeted import_dir
 			secondTargetDir := "second/targeted/dir"
 			secondTargetedFulPath := filepath.Join(app.AppRoot, app.Docroot, secondTargetDir)
-			app.UploadDirs = ddevapp.UploadDirs{"sites/default/files", secondTargetDir}
+			app.UploadDirs = []string{"sites/default/files", secondTargetDir}
 			err = os.MkdirAll(secondTargetedFulPath, 0755)
 			require.NoError(t, err)
 			err = fileutil.PurgeDirectory(secondTargetedFulPath)
@@ -2497,7 +2497,7 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 			if app.Docroot != "" {
 				targetFilesPath = "../private"
 				// This is automatically relative to docroot
-				app.UploadDirs = ddevapp.UploadDirs{targetFilesPath}
+				app.UploadDirs = []string{targetFilesPath}
 				fullTargetFilesPath = app.GetHostUploadDirFullPath()
 				err = os.MkdirAll(fullTargetFilesPath, 0755)
 				require.NoError(t, err)
@@ -2513,7 +2513,7 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 				assert.NotEmpty(dirEntrySlice)
 
 				// Try with upload_dir that is outside project
-				app.UploadDirs = "../../nowhere"
+				app.UploadDirs = []string{"../../nowhere"}
 				_, tarballPath, err := testcommon.GetCachedArchive(site.Name, "local-tarballs-files", "", site.FilesTarballURL)
 				require.NoError(t, err)
 				err = app.ImportFiles("", tarballPath, "")
@@ -2544,12 +2544,6 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 			assert.NoError(err)
 			assert.NotEmpty(dirEntrySlice)
 		}
-
-		// We should not be able to import with upload_dirs=false
-		app.UploadDirs = false
-		err = app.ImportFiles("", "/tmp", "")
-		assert.Error(err)
-		require.Contains(t, err.Error(), "cannot import files")
 
 		switchDir()
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2397,26 +2397,27 @@ func TestDdevImportFiles(t *testing.T) {
 			}
 		}
 
-		// Import trivial archive with various types of archive/compression and verify that files arrive
-		extensions := []string{"tgz", "zip", "tar.xz", "tar.bz2", "tar.gz"}
-		for _, ext := range extensions {
-			tarballPath := filepath.Join(origDir, "testdata", t.Name(), "files."+ext)
-			_ = os.RemoveAll(filepath.Join(app.GetHostUploadDirFullPath(), "files."+ext+".txt"))
-			err = app.ImportFiles("", tarballPath, "")
-			if err != nil {
-				assert.NoError(err)
-				continue
+		if app.GetUploadDir() != "" {
+			// Import trivial archive with various types of archive/compression and verify that files arrive
+			extensions := []string{"tgz", "zip", "tar.xz", "tar.bz2", "tar.gz"}
+			for _, ext := range extensions {
+				tarballPath := filepath.Join(origDir, "testdata", t.Name(), "files."+ext)
+				_ = os.RemoveAll(filepath.Join(app.GetHostUploadDirFullPath(), "files."+ext+".txt"))
+
+				err = app.ImportFiles("", tarballPath, "")
+				if err != nil {
+					assert.NoError(err)
+					continue
+				}
+				assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), ext+".txt"))
 			}
-			assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), ext+".txt"))
+			assert.FileExists("hello-pre-import-files-" + app.Name)
+			assert.FileExists("hello-post-import-files-" + app.Name)
+			err = os.Remove("hello-pre-import-files-" + app.Name)
+			assert.NoError(err)
+			err = os.Remove("hello-post-import-files-" + app.Name)
+			assert.NoError(err)
 		}
-
-		assert.FileExists("hello-pre-import-files-" + app.Name)
-		assert.FileExists("hello-post-import-files-" + app.Name)
-		err = os.Remove("hello-pre-import-files-" + app.Name)
-		assert.NoError(err)
-		err = os.Remove("hello-post-import-files-" + app.Name)
-		assert.NoError(err)
-
 		runTime()
 	}
 }

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -251,8 +251,8 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
 }
 
 // getDrupalUploadDirs will return the default paths.
-func getDrupalUploadDirs(_ *DdevApp) UploadDirs {
-	uploadDirs := UploadDirs{"sites/default/files"}
+func getDrupalUploadDirs(_ *DdevApp) []string {
+	uploadDirs := []string{"sites/default/files"}
 
 	return uploadDirs
 }

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -113,13 +113,13 @@ func magentoImportFilesAction(app *DdevApp, uploadDir, importPath, extPath strin
 }
 
 // getMagentoUploadDirs will return the default paths.
-func getMagentoUploadDirs(_ *DdevApp) UploadDirs {
-	return UploadDirs{"media"}
+func getMagentoUploadDirs(_ *DdevApp) []string {
+	return []string{"media"}
 }
 
 // getMagento2UploadDirs will return the default paths.
-func getMagento2UploadDirs(_ *DdevApp) UploadDirs {
-	return UploadDirs{"pub/media"}
+func getMagento2UploadDirs(_ *DdevApp) []string {
+	return []string{"pub/media"}
 }
 
 // createMagento2SettingsFile manages creation and modification of app/etc/env.php.

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -823,6 +823,7 @@ func (app *DdevApp) checkMutagenUploadDirs() {
 	if app.IsMutagenEnabled() && !app.IsUploadDirsWarningDisabled() && len(app.GetUploadDirs()) == 0 {
 		util.Warning("You have Mutagen enabled and your '%s' project type doesn't have `upload_dirs` set.", app.Type)
 		util.Warning("For faster startup and less disk usage, set upload_dirs to where your user-generated files are stored.")
-		util.Warning("If this is intended you can disable this warning by running `ddev config --upload-dirs=false`.")
+		// TODO: Implement --no-upload-dirs-warning in new PR
+		util.Warning("If this is intended you can disable this warning with `ddev config --no-upload-dirs-warning`.")
 	}
 }

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -820,7 +820,7 @@ func GetDefaultMutagenVolumeSignature(_ *DdevApp) string {
 
 // checkMutagenUploadDirs just tells people if they are using mutagen without upload_dir
 func (app *DdevApp) checkMutagenUploadDirs() {
-	if app.IsMutagenEnabled() && !app.IsUploadDirsDisabled() && len(app.GetUploadDirs()) == 0 {
+	if app.IsMutagenEnabled() && !app.IsUploadDirsWarningDisabled() && len(app.GetUploadDirs()) == 0 {
 		util.Warning("You have Mutagen enabled and your '%s' project type doesn't have `upload_dirs` set.", app.Type)
 		util.Warning("For faster startup and less disk usage, set upload_dirs to where your user-generated files are stored.")
 		util.Warning("If this is intended you can disable this warning by running `ddev config --upload-dirs=false`.")

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -69,8 +69,8 @@ func shopware6ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath str
 }
 
 // getShopwareUploadDirs will return the default paths.
-func getShopwareUploadDirs(_ *DdevApp) UploadDirs {
-	return UploadDirs{"media"}
+func getShopwareUploadDirs(_ *DdevApp) []string {
+	return []string{"media"}
 }
 
 // shopware6PostStartAction checks to see if the .env file is set up

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -85,8 +85,6 @@ const ConfigInstructions = `
 #   - custom/upload/dir
 #   - ../private
 #
-# upload_dirs: false
-#
 # would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
 # When mutagen is enabled this path is bind-mounted so that all the files
 # in the upload_dirs don't have to be synced into mutagen.

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -108,8 +108,8 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 }
 
 // getTypo3UploadDirs will return the default paths.
-func getTypo3UploadDirs(_ *DdevApp) UploadDirs {
-	return UploadDirs{"fileadmin"}
+func getTypo3UploadDirs(_ *DdevApp) []string {
+	return []string{"fileadmin"}
 }
 
 // Typo3Hooks adds a TYPO3-specific hooks example for post-import-db

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -43,7 +43,7 @@ func (app *DdevApp) GetUploadDir() string {
 func (app *DdevApp) GetUploadDirs() []string {
 	err := app.validateUploadDirs()
 	if err != nil {
-		util.Failed("Invalid upload_dirs value: %v", err)
+		util.Warning("Ignoring invalid upload_dirs value: %v", err)
 		return []string{}
 	}
 
@@ -53,6 +53,13 @@ func (app *DdevApp) GetUploadDirs() []string {
 		app.addUploadDir(uploadDirDeprecated)
 	}
 
+	// If an UploadDirs has been specified for the app, it overrides
+	// anything that the project type would give us.
+	if len(app.UploadDirs) > 0 {
+		return app.UploadDirs
+	}
+
+	// Otherwise continue to get the UploadDirs from the project type
 	appFuncs, ok := appTypeMatrix[app.GetType()]
 	if ok && appFuncs.uploadDirs != nil {
 		return appFuncs.uploadDirs(app)

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -4,34 +4,26 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"reflect"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/util"
 )
 
-type UploadDirs []string
-
 // addUploadDir adds a new upload dir if it does not already exist in the list.
 func (app *DdevApp) addUploadDir(uploadDir string) {
 	err := app.validateUploadDirs()
 	if err != nil {
-		// Should never happen
-		panic(err)
+		util.Failed("Failed to validate upload_dirs: %v", err)
 	}
 
-	if app.UploadDirs == false {
-		app.UploadDirs = UploadDirs{}
-	}
-
-	for _, existingUploadDir := range app.UploadDirs.(UploadDirs) {
+	for _, existingUploadDir := range app.UploadDirs {
 		if uploadDir == existingUploadDir {
 			return
 		}
 	}
 
-	app.UploadDirs = append(app.UploadDirs.(UploadDirs), uploadDir)
+	app.UploadDirs = append(app.UploadDirs, uploadDir)
 }
 
 // GetUploadDir returns the first upload (public files) directory.
@@ -48,11 +40,11 @@ func (app *DdevApp) GetUploadDir() string {
 // GetUploadDirs returns the upload (public files) directories.
 // These are gathered from the per-CMS configurations and the
 // value of upload_dirs. upload_dirs overrides the per-CMS configuration
-func (app *DdevApp) GetUploadDirs() UploadDirs {
+func (app *DdevApp) GetUploadDirs() []string {
 	err := app.validateUploadDirs()
 	if err != nil {
-		util.Warning("Ignoring invalid upload_dirs value: %v", err)
-		return UploadDirs{}
+		util.Failed("Invalid upload_dirs value: %v", err)
+		return []string{}
 	}
 
 	if app.UploadDirDeprecated != "" {
@@ -61,44 +53,18 @@ func (app *DdevApp) GetUploadDirs() UploadDirs {
 		app.addUploadDir(uploadDirDeprecated)
 	}
 
-	switch app.UploadDirs.(type) {
-	case UploadDirs:
-		if len(app.UploadDirs.(UploadDirs)) > 0 {
-			return app.UploadDirs.(UploadDirs)
-		}
-		// Otherwise we go get the CMS-defined values
-	case []any:
-		if len(app.UploadDirs.([]any)) > 0 {
-			// User provided a list of strings, convert it to UploadDirs.
-			uploadDirsRaw := app.UploadDirs.([]any)
-			uploadDirs := make(UploadDirs, 0, len(uploadDirsRaw))
-			for _, v := range uploadDirsRaw {
-				uploadDirs = append(uploadDirs, v.(string))
-			}
-			app.UploadDirs = uploadDirs
-			return uploadDirs
-		}
-		// Otherwise we go get the CMS-defined values
-	case bool:
-		if app.UploadDirs.(bool) == false {
-			return UploadDirs{}
-		}
-	default:
-		util.Warning("app.UploadDirs is of invalid type %T", app.UploadDirs)
-		return UploadDirs{}
-	}
-
 	appFuncs, ok := appTypeMatrix[app.GetType()]
 	if ok && appFuncs.uploadDirs != nil {
 		return appFuncs.uploadDirs(app)
 	}
 
-	return UploadDirs{}
+	return []string{}
 }
 
-// IsUploadDirsDisabled returns true if UploadDirs is disabled by the user.
-func (app *DdevApp) IsUploadDirsDisabled() bool {
-	return app.UploadDirs == false
+// IsUploadDirsWarningDisabled returns true if UploadDirs is disabled by the user.
+func (app *DdevApp) IsUploadDirsWarningDisabled() bool {
+	// TODO: New PR to allow a command to disable upload_dirs warning
+	return false
 }
 
 // calculateHostUploadDirFullPath returns the full path to the upload directory
@@ -223,34 +189,11 @@ func (app *DdevApp) createUploadDirsIfNecessary() {
 // - slice of string (possibly empty)
 // - boolean false
 func (app *DdevApp) validateUploadDirs() error {
-	if raw, ok := app.UploadDirs.(UploadDirs); ok {
-		// User provided a list of strings, convert it to UploadDirs.
-		app.UploadDirs = raw
-	}
 
-	typeOfUploadDirs := reflect.TypeOf(app.UploadDirs)
-	switch {
-	case typeOfUploadDirs == nil:
-		// Config option is not set.
-		app.UploadDirs = UploadDirs{}
-	case typeOfUploadDirs.Kind() == reflect.Bool && app.UploadDirs == false:
-		// bool false is fine too, means users has disabled it.
-	case typeOfUploadDirs.Kind() == reflect.String:
-		// User provided a string, convert it to UploadDirs.
-		app.UploadDirs = UploadDirs{app.UploadDirs.(string)}
-	case typeOfUploadDirs.Kind() == reflect.Slice:
-		break
-	default:
-		// Provided value is not valid, user has to fix it.
-		return fmt.Errorf("`upload_dirs` must be a string, a list of strings, or false but `%v` given", app.UploadDirs)
-	}
-
-	if dirs, ok := app.UploadDirs.(UploadDirs); ok {
-		// Check upload dirs are in the project root.
-		for _, uploadDir := range dirs {
-			if !strings.HasPrefix(app.calculateHostUploadDirFullPath(uploadDir), app.AppRoot) {
-				return fmt.Errorf("invalid upload dir `%s` outside of project root `%s` found", uploadDir, app.AppRoot)
-			}
+	// Check that upload dirs aren't outside the project root.
+	for _, uploadDir := range app.UploadDirs {
+		if !strings.HasPrefix(app.calculateHostUploadDirFullPath(uploadDir), app.AppRoot) {
+			return fmt.Errorf("invalid upload dir `%s` outside of project root `%s` found", uploadDir, app.AppRoot)
 		}
 	}
 

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -80,8 +80,8 @@ func getWordpressHooks() []byte {
 }
 
 // getWordpressUploadDirs will return the default paths.
-func getWordpressUploadDirs(_ *DdevApp) UploadDirs {
-	return UploadDirs{"wp-content/uploads"}
+func getWordpressUploadDirs(_ *DdevApp) []string {
+	return []string{"wp-content/uploads"}
 }
 
 const wordpressConfigInstructions = `

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -70,7 +70,7 @@ type TestSite struct {
 	// DynamicURI provides a dynamic (after db load) URI with contents we can expect.
 	DynamicURI URIWithExpect
 	// UploadDirs overrides the dirs used for upload_dirs
-	UploadDirs ddevapp.UploadDirs
+	UploadDirs []string
 	// FilesImageURI is URI to a file loaded by import-files that is a jpg.
 	FilesImageURI string
 	// FullSiteArchiveExtPath is the path that should be extracted from inside an archive when


### PR DESCRIPTION
## The Issue

We tried to support a multi-type upload_dirs but it added a lot of complexity to the code. 

Unfortunately, I've decided to revert that and go back to a simpler approach.

An additional PR will be required to add a new config that turns off warnings about upload_dirs

Also accidentally fixes
* #5131 

by going back to a simple array for the declaration.

## How This PR Solves The Issue

## Manual Testing Instructions

Many things have to be re-tested:

* #5131 - empty `config.*.yaml` was resulting in upload_dirs being emptied
* #5031 (after #5132 goes in) - Specific upload_dirs with Craft CMS
* #5127 - import-files needs to work on Laravel and Craft if import-dirs specified
* #5126 - panic with upload-dirs
* #4796 - Of course we need a way to do that.

## Automated Testing Overview

I think the tests cover the things that matter

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5134"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

