### PR TITLE
refactor: start reporting all commands to amplitude

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -108,9 +108,8 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 			instrumentationApp.TrackProject()
 		}
 
-		// TODO remove once Amplitude has verified with an alpha release.
 		// Do not report these commands
-		ignores := map[string]bool{"describe": true, "auth": true, "blackfire": false, "clean": true, "composer": true, "debug": true, "delete": true, "drush": true, "exec": true, "export-db": true, "get": true, "help": true, "hostname": true, "import-db": true, "import-files": true, "list": true, "logs": true, "mutagen": true, "mysql": true, "npm": true, "nvm": true, "php": true, "poweroff": true, "pull": true, "push": true, "service": true, "share": true, "snapshot": true, "ssh": true, "stop": true, "version": true, "xdebug": true, "xhprof": true, "yarn": true}
+		ignores := map[string]bool{}
 
 		if _, ok := ignores[cmd.CalledAs()]; ok {
 			return


### PR DESCRIPTION
## The Issue

Code said we were supposed to start reporting other commands to Amplitude by now

## How This PR Solves The Issue

Remove the exclusions

## Manual Testing Instructions

Look at Amplitude data coming in.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5136"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

