### PR TITLE
fix: always clean up ddev-global-cache, fixes #5135

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2389,9 +2389,11 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	}
 	// Clean up ddev-global-cache
 	if removeData {
-		_, _, err := dockerutil.RunSimpleContainer(dockerImages.GetWebImage(), "clean-ddev-global-cache-"+util.RandString(6), []string{"bash", "-c", fmt.Sprintf("rm -rf /mnt/ddev-global-cache/*/%s-{web,db} /mnt/ddev-global-cache/traefik/*/%s.{yaml,crt,key}", app.Name, app.Name)}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: app.GetName()}, nil)
+		c := fmt.Sprintf("rm -rf /mnt/ddev-global-cache/*/%s-{web,db} /mnt/ddev-global-cache/traefik/*/%s.{yaml,crt,key}", app.Name, app.Name)
+		util.Debug("Cleaning ddev-global-cache with command '%s'", c)
+		_, out, err := dockerutil.RunSimpleContainer(dockerImages.GetWebImage(), "clean-ddev-global-cache-"+util.RandString(6), []string{"bash", "-c", c}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: app.GetName()}, nil)
 		if err != nil {
-			util.Warning("Unable to clean up ddev-global-cache: %v", err)
+			util.Warning("Unable to clean up ddev-global-cache with command '%s': %v; output='%s'", c, err, out)
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2387,11 +2387,9 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 			util.Warning("Unable to clean up traefik configuration: %v", err)
 		}
 	}
-	// If project is running, clean up ddev-global-cache
-	if status == SiteRunning && removeData {
-		_, _, err = app.Exec(&ExecOpts{
-			Cmd: fmt.Sprintf("rm -rf /mnt/ddev-global-cache/*/%s* /mnt/ddev-global-cache/traefik/*/%s*", app.Name, app.Name),
-		})
+	// Clean up ddev-global-cache
+	if removeData {
+		_, _, err := dockerutil.RunSimpleContainer(dockerImages.GetWebImage(), "clean-ddev-global-cache-"+util.RandString(6), []string{"sh", "-c", fmt.Sprintf("rm -rf /mnt/ddev-global-cache/*/%s* /mnt/ddev-global-cache/traefik/*/%s*", app.Name, app.Name)}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: app.GetName()}, nil)
 		if err != nil {
 			util.Warning("Unable to clean up ddev-global-cache: %v", err)
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2389,7 +2389,7 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	}
 	// Clean up ddev-global-cache
 	if removeData {
-		_, _, err := dockerutil.RunSimpleContainer(dockerImages.GetWebImage(), "clean-ddev-global-cache-"+util.RandString(6), []string{"sh", "-c", fmt.Sprintf("rm -rf /mnt/ddev-global-cache/*/%s* /mnt/ddev-global-cache/traefik/*/%s*", app.Name, app.Name)}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: app.GetName()}, nil)
+		_, _, err := dockerutil.RunSimpleContainer(dockerImages.GetWebImage(), "clean-ddev-global-cache-"+util.RandString(6), []string{"bash", "-c", fmt.Sprintf("rm -rf /mnt/ddev-global-cache/*/%s-{web,db} /mnt/ddev-global-cache/traefik/*/%s.{yaml,crt,key}", app.Name, app.Name)}, []string{}, []string{}, []string{"ddev-global-cache:/mnt/ddev-global-cache"}, "", true, false, map[string]string{`com.ddev.site-name`: app.GetName()}, nil)
 		if err != nil {
 			util.Warning("Unable to clean up ddev-global-cache: %v", err)
 		}


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/issues/5135

## How This PR Solves The Issue

Project files in `ddev-global-cache` are now always deleted, not only when the project is running.

## Manual Testing Instructions

Start a project, confirm that there is a folder for this project (ending with `-web`) into `nvm_dir`:

```
docker run --rm -i -v=ddev-global-cache:/mnt/ddev-global-cache busybox:stable ls /mnt/ddev-global-cache/nvm_dir
```

Run `ddev delete --omit-snapshot --yes` on the started and stopped project.

Make sure the folder for this project (ending in `-web`) in `nvm_dir` is deleted:

```
docker run --rm -i -v=ddev-global-cache:/mnt/ddev-global-cache busybox:stable ls /mnt/ddev-global-cache/nvm_dir
```

To be safe, make sure that the cache for other projects is not deleted.

## Automated Testing Overview

No.

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5137"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

