### PR TITLE
refactor: add -t flag to mailhog call for symfony/mailer native transport compat, fixes #4363

### DIFF
--- a/containers/ddev-php-base/ddev-php-files/etc/php/5.6/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/5.6/apache2/php.ini
@@ -81,7 +81,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/5.6/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/5.6/cli/php.ini
@@ -82,7 +82,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/5.6/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/5.6/fpm/php.ini
@@ -81,7 +81,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.0/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.0/apache2/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.0/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.0/cli/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.0/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.0/fpm/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.1/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.1/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.1/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.1/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.1/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.1/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.2/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.2/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.2/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.2/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.2/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.2/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.3/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.3/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.3/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.3/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.3/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.3/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.4/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.4/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.4/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.4/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.4/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.4/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.0/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.0/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.0/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.0/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.0/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.0/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.1/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.1/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.1/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.1/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.1/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.1/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/5.6/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/5.6/cli/php.ini
@@ -82,7 +82,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/5.6/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/5.6/fpm/php.ini
@@ -81,7 +81,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.0/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.0/cli/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.0/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.0/fpm/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.1/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.1/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.1/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.1/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.1/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.1/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.1/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.1/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.2/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.2/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.2/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.2/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailhog sendmail test@example.org --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailhog sendmail -t test@example.org --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off


### PR DESCRIPTION
## The Issue

* https://github.com/ddev/ddev/issues/4363

## How This PR Solves The Issue

Add a harmless -t to the mailhog call

## Manual Testing Instructions

## Automated Testing Overview

Mailhog integration is not tested AFAIK and soon will be replaced by mailpit








<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5138"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

