### PR TITLE
feat: add new disable-upload-dirs-warning configuration

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -296,6 +296,7 @@ func init() {
 	ConfigCommand.Flags().String("database", "", fmt.Sprintf(`Specify the database type:version to use. Defaults to mariadb:%s`, nodeps.MariaDBDefaultVersion))
 	ConfigCommand.Flags().String("nodejs-version", "", fmt.Sprintf(`Specify the nodejs version to use if you don't want the default NodeJS %s`, nodeps.NodeJSDefault))
 	ConfigCommand.Flags().Int("default-container-timeout", 120, `default time in seconds that ddev waits for all containers to become ready on start`)
+	ConfigCommand.Flags().Bool("disable-upload-dirs-warning", true, `Disable warnings about upload-dirs not being set when using performance-mode=mutagen.`)
 
 	RootCmd.AddCommand(ConfigCommand)
 
@@ -644,6 +645,10 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 
 	if cmd.Flag("upload-dirs").Changed {
 		app.UploadDirs, _ = cmd.Flags().GetStringSlice("upload-dirs")
+	}
+
+	if cmd.Flag("disable-upload-dirs-warning").Changed {
+		app.DisableUploadDirsWarning, _ = cmd.Flags().GetBool("disable-upload-dirs-warning")
 	}
 
 	if webserverTypeArg != "" {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -229,6 +229,7 @@ func TestConfigSetValues(t *testing.T) {
 		"--default-container-timeout", strconv.FormatInt(int64(defaultContainerTimeout), 10),
 		fmt.Sprintf("--use-dns-when-possible=%t", useDNSWhenPossible),
 		"--timezone", timezone,
+		"--disable-upload-dirs-warning",
 	}
 
 	out, err := exec.RunHostCommand(DdevBin, args...)
@@ -274,6 +275,7 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Equal(webEnv, app.WebEnvironment[0])
 	assert.Equal(nodejsVersion, app.NodeJSVersion)
 	assert.Equal(strconv.Itoa(defaultContainerTimeout), app.DefaultContainerTimeout)
+	assert.Equal(true, app.DisableUploadDirsWarning)
 
 	// Test that container images, working dirs and composer root dir can be unset with default flags
 	args = []string{

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -139,7 +139,7 @@ Whether to disable the standard warning issued when a project is using `performa
 | -- | -- | --
 | :octicons-file-directory-16: project | `false` | Can be `true` or `false`.
 
-When `true`, DDEV will not issue the normal warning on `ddev start`: "You have Mutagen enabled and your 'php' project type doesn't have `upload_dirs` set".
+When `true`, DDEV will not issue the normal warning on `ddev start`: "You have Mutagen enabled and your 'php' project type doesn't have `upload_dirs` set". See [Mutagen and User-Generated Uploads](../install/performance.md#mutagen-and-user-generated-uploads) for context on why DDEV avoids doing the Mutagen sync on `upload_dirs`.
 
 ## `docroot`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -139,7 +139,7 @@ Whether to disable the standard warning issued when a project is using `performa
 | -- | -- | --
 | :octicons-file-directory-16: project | `false` | Can be `true` or `false`.
 
-When `true`, DDEV will not issue the normal warning on `ddev start`, "You have Mutagen enabled and your 'php' project type doesn't have `upload_dirs` set".
+When `true`, DDEV will not issue the normal warning on `ddev start`: "You have Mutagen enabled and your 'php' project type doesn't have `upload_dirs` set".
 
 ## `docroot`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -131,6 +131,16 @@ Whether to disable CMS-specific settings file management.
 
 When `true`, DDEV will not create or update CMS-specific settings files.
 
+## `disable_upload_dirs_warning`
+
+Whether to disable the standard warning issued when a project is using `performance_mode: mutagen` but `upload_dirs` is not configured.
+
+| Type | Default | Usage
+| -- | -- | --
+| :octicons-file-directory-16: project | `false` | Can be `true` or `false`.
+
+When `true`, DDEV will not issue the normal warning on `ddev start`, "You have Mutagen enabled and your 'php' project type doesn't have `upload_dirs` set".
+
 ## `docroot`
 
 Relative path to the document root containing `index.php` or `index.html`.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -180,7 +180,7 @@ Flags:
 * `--dbimage-extra-packages`: A comma-delimited list of Debian packages that should be added to db container when the project is started.
 * `--default-container-timeout`: Default time in seconds that DDEV waits for all containers to become ready on start. (default `120`)
 * `--disable-settings-management`: Prevent DDEV from creating or updating CMS settings files.
-* `--disable-upload-dirs-warning`: Don't issue a warning when a project does not have `upload_dirs` set but is using `performance_mode: mutagen`.
+* `--disable-upload-dirs-warning`: Suppresses warning when a project is using `performance_mode: mutagen` but does not have `upload_dirs` set.
 * `--docroot`: Provide the relative docroot of the project, like `docroot` or `htdocs` or `web`. (defaults to empty, the current directory)
 * `--fail-on-hook-fail`: Decide whether `ddev start` should be interrupted by a failing hook.
 * `--host-db-port`: The db container’s localhost-bound port.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -180,6 +180,7 @@ Flags:
 * `--dbimage-extra-packages`: A comma-delimited list of Debian packages that should be added to db container when the project is started.
 * `--default-container-timeout`: Default time in seconds that DDEV waits for all containers to become ready on start. (default `120`)
 * `--disable-settings-management`: Prevent DDEV from creating or updating CMS settings files.
+* `--disable-upload-dirs-warning`: Don't issue a warning when a project does not have `upload_dirs` set but is using `performance_mode: mutagen`.
 * `--docroot`: Provide the relative docroot of the project, like `docroot` or `htdocs` or `web`. (defaults to empty, the current directory)
 * `--fail-on-hook-fail`: Decide whether `ddev start` should be interrupted by a failing hook.
 * `--host-db-port`: The db container’s localhost-bound port.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -131,6 +131,7 @@ type DdevApp struct {
 	WebExtraExposedPorts      []WebExposedPort       `yaml:"web_extra_exposed_ports,omitempty"`
 	WebExtraDaemons           []WebExtraDaemon       `yaml:"web_extra_daemons,omitempty"`
 	OverrideConfig            bool                   `yaml:"override_config,omitempty"`
+	DisableUploadDirsWarning  bool                   `yaml:"disable_upload_dirs_warning,omitempty"`
 	ComposeYaml               map[string]interface{} `yaml:"-"`
 }
 
@@ -1314,7 +1315,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	// At this point we should have all files synced inside the container
 	// Verify that we have composer.json inside container if we have it in project root
 	// This is possibly a temporary need for debugging https://github.com/ddev/ddev/issues/5089
-	// TODO: Consider removing this check when #5089 is resolved
+	// TODO: Consider removing this check when #5089 is resolved, or at least by 2024-01-01
 	if !app.NoProjectMount && fileutil.FileExists(filepath.Join(app.GetComposerRoot(false, false), "composer.json")) {
 		util.Debug("Checking for composer.json in container")
 		stdout, stderr, err := app.Exec(&ExecOpts{

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -823,7 +823,6 @@ func (app *DdevApp) checkMutagenUploadDirs() {
 	if app.IsMutagenEnabled() && !app.IsUploadDirsWarningDisabled() && len(app.GetUploadDirs()) == 0 {
 		util.Warning("You have Mutagen enabled and your '%s' project type doesn't have `upload_dirs` set.", app.Type)
 		util.Warning("For faster startup and less disk usage, set upload_dirs to where your user-generated files are stored.")
-		// TODO: Implement --no-upload-dirs-warning in new PR
-		util.Warning("If this is intended you can disable this warning with `ddev config --no-upload-dirs-warning`.")
+		util.Warning("If this is intended you can disable this warning with `ddev config --disable-upload-dirs-warning`.")
 	}
 }

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -89,6 +89,10 @@ const ConfigInstructions = `
 # When mutagen is enabled this path is bind-mounted so that all the files
 # in the upload_dirs don't have to be synced into mutagen.
 
+# disable_upload_dirs_warning: false
+# If true, turns off the normal warning that says
+# "You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set"
+
 # working_dir:
 #   web: /var/www/html
 #   db: /home

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -70,8 +70,7 @@ func (app *DdevApp) GetUploadDirs() []string {
 
 // IsUploadDirsWarningDisabled returns true if UploadDirs is disabled by the user.
 func (app *DdevApp) IsUploadDirsWarningDisabled() bool {
-	// TODO: New PR to allow a command to disable upload_dirs warning
-	return false
+	return app.DisableUploadDirsWarning
 }
 
 // calculateHostUploadDirFullPath returns the full path to the upload directory


### PR DESCRIPTION
## The Issue

Earlier we had the option of `upload_dirs: false` to turn off the pester about `upload_dirs` not being set and mutagen being enabled. This ended up being a very complex bit of code and was rolled back.

Now we need another way to do it.

## How This PR Solves The Issue

Add `disable_upload_dirs_warning`

## Manual Testing Instructions

On a `php` project without `upload_dirs`, `ddev start` should show the warning.
After `ddev config --disable-upload-dirs-warning` it should not show the warning.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5139"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

