### PR TITLE
build: bump mysql to 8.0.33 and 5.7.42, fixes #5114

### DIFF
--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -10,7 +10,7 @@ CURRENT_ARCH=$(shell ../get_arch.sh)
 # So has to explicitly declare anything it might need from there (like SHELL)
 SHELL = /bin/bash
 
-BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_both mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mariadb_10.7_both mariadb_10.8_both mariadb_10.11_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.31
+BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_both mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mariadb_10.7_both mariadb_10.8_both mariadb_10.11_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.33
 TEST_TARGETS=$(shell if [ "$(CURRENT_ARCH)" = "amd64" ] ; then \
 	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mariadb_10.11_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
 	else \
@@ -38,13 +38,13 @@ mysql_5.7: mysql_5.7_both
 
 # Mysql 8.0 often must be pinned because xtrabackup is not ready for latest 8.0
 # So check whether xtrabackup is available for latest 8.0 before changing pin
-mysql_8.0: mysql_8.0_both_8.0.31
+mysql_8.0: mysql_8.0_both_8.0.33
 
 
 # Examples:
 # make <dbtype>_<dbmajor>_[both|amd64]_<pin>  # pin is optional, often needed for mysql 8.0
 # make mariadb_10.3_both VERSION=someversion PUSH=true
-# make mysql_8.0_amd64_8.0.31 VERSION=someversion
+# make mysql_8.0_amd64_8.0.33 VERSION=someversion
 $(BUILD_TARGETS):
 	@echo "building $@";
 	export DB_TYPE=$(word 1, $(subst _, ,$@)) && \

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -21,7 +21,7 @@ var WebTag = "20230707_fix_process_group_kill" // Note that this can be overridd
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.22.0-beta1"
+var BaseDBTag = "v1.22.0-beta4"
 
 const TraditionalRouterImage = "ddev/ddev-router:v1.22.0-beta1"
 const TraefikRouterImage = "traefik:v2.10"


### PR DESCRIPTION
## The Issue

mysql 8.0.33 and 5.7.42 are out

## How This PR Solves The Issue

* #5114 

upgrade to them

## Manual Testing Instructions

Start a mysql 8 project and check version, `mysql --version`

See also 
* https://github.com/ddev/mysql-arm64-images/pull/6
* https://github.com/ddev/xtrabackup-build/releases/tag/8.0.33-27 (actually worked this time)

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5140"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

