### PR TITLE
refactor: make many mutagen debug outputs only verbose, fixes #5143

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -73,6 +73,15 @@ func Debug(format string, a ...interface{}) {
 	}
 }
 
+// Output controlled by DDEV_VERBOSE environment variable
+func Verbose(format string, a ...interface{}) {
+	if globalconfig.DdevVerbose {
+		n := time.Now()
+		s := fmt.Sprintf(format, a...)
+		output.UserOut.Debugf("%s %s", n.Format("2006-01-02T15:04:05.999"), s)
+	}
+}
+
 // FormatPlural is a simple wrapper which returns different strings based on the count value.
 func FormatPlural(count int, single string, plural string) string {
 	if count == 1 {


### PR DESCRIPTION
## The Issue

* #5143 

## How This PR Solves The Issue

Move many of these from "DDEV_DEBUG" to DDEV_VERBOSE.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5147"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

