### PR TITLE
fix: ddev config should not stumble on invalid app type, fixes #5146

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1259,7 +1259,7 @@ func (app *DdevApp) AppTypePrompt() error {
 	typePrompt := "Project Type [%s] (%s): "
 
 	defaultAppType := app.Type
-	if app.Type == nodeps.AppTypeNone {
+	if app.Type == nodeps.AppTypeNone || !IsValidAppType(app.Type) {
 		defaultAppType = detectedAppType
 	}
 
@@ -1269,7 +1269,7 @@ func (app *DdevApp) AppTypePrompt() error {
 	for !IsValidAppType(appType) {
 		output.UserOut.Errorf("'%s' is not a valid project type. Allowed project types are: %s\n", appType, validAppTypes)
 
-		fmt.Print(typePrompt, validAppTypes, appType)
+		fmt.Printf(typePrompt, validAppTypes, appType)
 		appType = strings.ToLower(util.GetInput(appType))
 	}
 


### PR DESCRIPTION
## The Issue

* #5146

* It kept repeating on invalid type
* The second through nth times it used `print` instead of the correct `printf`, so showed an invalid message

## How This PR Solves The Issue

* Replace print with printf
* If invalid project type, use detected project type

## Manual Testing Instructions

Set an invalid type in .ddev/config.yaml and then try to do interactive config.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5148"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

