### PR TITLE
ci: minor improvement to TestDdevNoProjectMount [skip ci]

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -820,9 +820,6 @@ func TestDdevStartUnmanagedSettings(t *testing.T) {
 
 // TestDdevNoProjectMount tests running without the app file mount.
 func TestDdevNoProjectMount(t *testing.T) {
-	if nodeps.PerformanceModeDefault == types.PerformanceModeMutagen || nodeps.NoBindMountsDefault {
-		t.Skip("Skipping because this doesn't make sense with mutagen or NoBindMounts")
-	}
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
 
@@ -840,6 +837,9 @@ func TestDdevNoProjectMount(t *testing.T) {
 	err := app.Init(site.Dir)
 	assert.NoError(err)
 
+	if app.IsMutagenEnabled() || nodeps.NoBindMountsDefault {
+		t.Skip("Skipping because this doesn't make sense with mutagen or NoBindMounts")
+	}
 	app.NoProjectMount = true
 	err = app.WriteConfig()
 	assert.NoError(err)


### PR DESCRIPTION
## The Issue

When running locally TestDdevNoProjectMount would fail just because it was set up wrong.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5149"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

