### PR TITLE
fix: repair broken received HTTP*EXPOSE that breaks ports statement

### DIFF
--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"text/template"
 
@@ -262,6 +262,9 @@ func determineRouterPorts() []string {
 	// loop through all containers with site-name label
 	for _, container := range containers {
 		if _, ok := container.Labels["com.ddev.site-name"]; ok {
+			if container.State != "running" {
+				continue
+			}
 			var exposePorts []string
 
 			httpPorts := dockerutil.GetContainerEnv("HTTP_EXPOSE", container)
@@ -284,11 +287,13 @@ func determineRouterPorts() []string {
 				exposePort := ""
 				var ports []string
 
-				// Make sure that we are fully numeric in the port pair, and not empty, or ignore
-				_, err = strconv.Atoi(strings.ReplaceAll(exposePortPair, ":", ""))
-				if err != nil {
+				// Each port pair should be of the form <number>:<number>
+				// It's possible to have received a malformed HTTP_EXPOSE or HTTPS_EXPOSE from
+				// some random container.
+				if !regexp.MustCompile(`^[0-9]+:[0-9]+$`).MatchString(exposePortPair) {
 					continue
 				}
+
 				if strings.Contains(exposePortPair, ":") {
 					ports = strings.Split(exposePortPair, ":")
 				} else {

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -287,10 +287,10 @@ func determineRouterPorts() []string {
 				exposePort := ""
 				var ports []string
 
-				// Each port pair should be of the form <number>:<number>
+				// Each port pair should be of the form <number>:<number> or <number>
 				// It's possible to have received a malformed HTTP_EXPOSE or HTTPS_EXPOSE from
-				// some random container.
-				if !regexp.MustCompile(`^[0-9]+:[0-9]+$`).MatchString(exposePortPair) {
+				// some random container, so don't break if that happens.
+				if !regexp.MustCompile(`^[0-9]+(:[0-9]+)?$`).MatchString(exposePortPair) {
 					continue
 				}
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -227,6 +227,15 @@ func ReadGlobalConfig() error {
 		DdevGlobalConfig.InternetDetectionTimeout = nodeps.InternetDetectionTimeoutDefault
 	}
 
+	// It's possible to have had pre-existing `router_http_port: ""`, if
+	// so we have to override that.
+	if DdevGlobalConfig.RouterHTTPPort == "" {
+		DdevGlobalConfig.RouterHTTPPort = nodeps.DdevDefaultRouterHTTPPort
+	}
+	if DdevGlobalConfig.RouterHTTPSPort == "" {
+		DdevGlobalConfig.RouterHTTPSPort = nodeps.DdevDefaultRouterHTTPSPort
+	}
+
 	// Remove dba
 	if nodeps.ArrayContainsString(DdevGlobalConfig.OmitContainersGlobal, "dba") {
 		DdevGlobalConfig.OmitContainersGlobal = nodeps.RemoveItemFromSlice(DdevGlobalConfig.OmitContainersGlobal, "dba")


### PR DESCRIPTION
## The Issue

1. We use DDEV_ROUTER_HTTP_EXPOSE and DDEV_ROUTER_HTTPS_EXPOSE in generating the .ddev/.ddev-docker-compose-full.yaml. 
2. Those are derived from the global or project router_http_port or similar
3. They can be wrong (mostly empty) (which this fixes)
4. But then they get used in HTTP_EXPOSE and HTTPS_EXPOSE
5. So other projects inherit them by inspecting the web container, and then they can end up with an HTTP_EXPOSE like ":80:443:443", which isn't valid (now ignored with this fix)

## How This PR Solves The Issue

This was showing up in TestProcessHooks and probably other places on Traditional Windows/Mutagen tests. AFAICT, that is a result of the Windows machines having `router_http_port: ""` in their global config. Fixing that to `router_http_port: "80"` actually fixed it. 

## Manual Testing Instructions

I think if tests work this is OK. 

## TODO:

- [x] I'm worried a little about add-ons that might have `HTTP_EXPOSE: 80` or something, without using the `internalport:externalport` syntax

## Automated Testing Overview




<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5150"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

