### PR TITLE
fix: settings for django need to import os, fixes #5123

### DIFF
--- a/pkg/ddevapp/django.go
+++ b/pkg/ddevapp/django.go
@@ -77,6 +77,7 @@ func django4PostStartAction(app *DdevApp) error {
 	django4SettingsIncludeStanza := fmt.Sprintf(`
 
 # #ddev-generated code to import DDEV settings
+import os
 if os.environ.get('IS_DDEV_PROJECT') == 'true':
     from pathlib import Path
     import importlib.util


### PR DESCRIPTION
## The Issue

* #5123

## How This PR Solves The Issue

import os first. It's my understanding that in python you can do this without worrying about whether `os` has already been imported.

