### PR TITLE
fix: default_container_timeout should actually work, fixes #5133

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -80,7 +80,7 @@ services:
       interval: 1s
       retries: 120
       start_period: 120s
-      timeout: 120s
+      timeout: "{{ .DefaultContainerTimeout }}s"
   {{ end }} {{/* end if not .OmitDB */}}
 
   web:
@@ -242,7 +242,7 @@ services:
       interval: 1s
       retries: 120
       start_period: 120s
-      timeout: 120s
+      timeout: "{{ .DefaultContainerTimeout }}s"
 
 networks:
   ddev_default:


### PR DESCRIPTION
## The Issue

* #5133

## How This PR Solves The Issue

Actually use the timeout in the docker-compose setup

## Manual Testing Instructions

```
ddev config --default-container-timeout=600
ddev start
ddev snapshot restore huge
```

Assuming `huge` snapshot can be imported in 10m, it shouldn't time out or give the timeout message



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5154"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

