### PR TITLE
docs: add messages configuration to config.md

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -263,6 +263,28 @@ Port for project’s MailHog HTTP URL.
 | -- | -- | --
 | :octicons-file-directory-16: project | `8025` | Can be changed to avoid a port conflict.
 
+## `messages`
+
+Configure messages like the Tip of the Day.
+
+| Type | Default            | Usage
+| -- |--------------------| --
+| :octicons-globe-16: global | `ticker_interval:` | hours between ticker messages.
+
+Example: Disable the "Tip of the Day" ticker in `~/.ddev/global_config.yaml`
+
+```yaml
+messages:
+  ticker_interval: -1
+```
+
+Example: Show the "Tip of the Day" ticket every two hours:
+
+```yaml`
+messages:
+  ticker_interval: 2
+``
+
 ## `name`
 
 The URL-friendly name DDEV should use to reference the project.

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -406,7 +406,7 @@ func WriteGlobalConfig(config GlobalConfig) error {
 #   ticker_interval: 20 // Interval in hours to show ticker messages, -1 disables the ticker
 # Controls the display of the ticker messages.
 
-# remote_config:
+# remote_config: # Intended for debugging only, should not be changed.
 #   update_interval: 10 // Interval in hours to download the remote config
 #   remote:
 #     owner: ddev


### PR DESCRIPTION
## The Issue

`messages` configuration was omitted from the config docs



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5156"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

