### PR TITLE
ci: stop caching colima and homebrew on colima

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -81,65 +81,6 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Get Homebrew Cache Directory
-        id: homebrew-cache
-        run: |
-          echo "dir=$(brew --cache)" >> $GITHUB_OUTPUT
-
-      - name: Homebrew cache
-        uses: actions/cache@v3
-        if: github.ref == 'refs/heads/master'
-        with:
-          path: ${{ steps.homebrew-cache.outputs.dir }}
-          key: ${{ runner.os }}-homebrew-cache-${{ steps.get-date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-homebrew-cache-
-
-      - name: Homebrew cache/restore
-        uses: actions/cache/restore@v3
-        if: github.ref != 'refs/heads/master'
-        with:
-          path: ${{ steps.homebrew-cache.outputs.dir }}
-          key: ${{ runner.os }}-homebrew-cache-${{ steps.get-date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-homebrew-cache-
-
-      - name: Lima home
-        uses: actions/cache@v3
-        if: github.ref == 'refs/heads/master'
-        with:
-          path: ~/.lima
-          key: ${{ runner.os }}-lima-home-${{ steps.get-date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-lima-home-
-
-      - name: Lima home/restore
-        uses: actions/cache/restore@v3
-        if: github.ref != 'refs/heads/master'
-        with:
-          path: ~/.lima
-          key: ${{ runner.os }}-lima-home-${{ steps.get-date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-lima-home-
-
-      - name: Lima cache
-        uses: actions/cache@v3
-        if: github.ref == 'refs/heads/master'
-        with:
-          path: ~/Library/Caches/lima
-          key: ${{ runner.os }}-lima-cache-${{ steps.get-date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-lima-cache-
-
-      - name: Lima cache/restore
-        uses: actions/cache/restore@v3
-        if: github.ref != 'refs/heads/master'
-        with:
-          path: ~/Library/Caches/lima
-          key: ${{ runner.os }}-lima-cache-${{ steps.get-date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-lima-cache-
-      
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         with:
@@ -193,4 +134,3 @@ jobs:
           brew update
           brew autoremove
           brew cleanup
-  

--- a/.github/workflows/macos-colima-setup.sh
+++ b/.github/workflows/macos-colima-setup.sh
@@ -3,7 +3,6 @@
 set -eu -o pipefail
 
 sudo chown -R ${USER} /usr/local/*
-brew update >/dev/null
 
 # colima has golang as dependency, so is going to install go anyway.
 # So we have to get rid of it somehow.
@@ -11,6 +10,10 @@ brew uninstall go@1.15 || true
 brew unlink go || true
 brew uninstall go@1.17 || true
 brew uninstall postgresql || true
+brew uninstall composer || true
+brew uninstall php || true
+brew untap homebrew/cask || true
+brew untap homebrew/core || true
 echo "====== Running brew install ======"
 brew install -q colima docker docker-compose jq libpq mkcert mysql-client
 echo "====== Running brew link ======"


### PR DESCRIPTION
## The Issue

Random homebrew installation failures were breaking all of colima tests
On review, the huge caches and cache restores were taking longer than it would take to start colima from scratch

## How This PR Solves The Issue

Try giving up cache.
Some homebrew cleanup

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5157"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

