### PR TITLE
fix: revert "refactor: start reporting all commands to amplitude"

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -108,8 +108,9 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 			instrumentationApp.TrackProject()
 		}
 
+		// TODO remove once Amplitude has verified with an alpha release.
 		// Do not report these commands
-		ignores := map[string]bool{}
+		ignores := map[string]bool{"describe": true, "auth": true, "blackfire": false, "clean": true, "composer": true, "debug": true, "delete": true, "drush": true, "exec": true, "export-db": true, "get": true, "help": true, "hostname": true, "import-db": true, "import-files": true, "list": true, "logs": true, "mutagen": true, "mysql": true, "npm": true, "nvm": true, "php": true, "poweroff": true, "pull": true, "push": true, "service": true, "share": true, "snapshot": true, "ssh": true, "stop": true, "version": true, "xdebug": true, "xhprof": true, "yarn": true}
 
 		if _, ok := ignores[cmd.CalledAs()]; ok {
 			return

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -108,7 +108,8 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 			instrumentationApp.TrackProject()
 		}
 
-		// TODO remove once Amplitude has verified with an alpha release.
+		// TODO: remove when we decide to stop reporting to Segment.
+		// All code to "end TODO remove once Amplitude" will be removed
 		// Do not report these commands
 		ignores := map[string]bool{"describe": true, "auth": true, "blackfire": false, "clean": true, "composer": true, "debug": true, "delete": true, "drush": true, "exec": true, "export-db": true, "get": true, "help": true, "hostname": true, "import-db": true, "import-files": true, "list": true, "logs": true, "mutagen": true, "mysql": true, "npm": true, "nvm": true, "php": true, "poweroff": true, "pull": true, "push": true, "service": true, "share": true, "snapshot": true, "ssh": true, "stop": true, "version": true, "xdebug": true, "xhprof": true, "yarn": true}
 


### PR DESCRIPTION

Reverts ddev/ddev#5136

This code was actually only supposed to be removed when we end up removing the Segment reporting. Right now we're keeping the segment reporting in parallel with Amplitude.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5163"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

