### PR TITLE
fix: don't report json-formatted commands to Amplitude

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -49,7 +49,12 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 			argsCopy = []string{}
 		}
 
-		amplitude.TrackCommand(&cmdCopy, argsCopy)
+		// We don't want to send to amplitude if using --json-output
+		// That captures an enormous number of PhpStorm running the
+		// ddev describe -j over and over again.
+		if !output.JSONOutput {
+			amplitude.TrackCommand(&cmdCopy, argsCopy)
+		}
 
 		// Skip docker and other validation for most commands
 		if command != "start" && command != "restart" {
@@ -104,7 +109,9 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 			}
 		}
 
-		if instrumentationApp != nil {
+		// We don't need to track when used with --json-output
+		// picks up enormous number of automated ddev describe
+		if instrumentationApp != nil && !output.JSONOutput {
 			instrumentationApp.TrackProject()
 		}
 


### PR DESCRIPTION
## The Issue

People who use the PhpStorm extension for DDEV have `ddev describe -j` happening every minute or so in the background. This causes loads of useless traffic.

## How This PR Solves The Issue

Don't report commands when using `--json-ouput`

## Manual Testing Instructions

`for ((i=0; i<100; i++)); do ddev describe -j; done >/tmp/out 2>&1 && ddev debug instrumentation flush` should *not* result in new data in amplitude

`for ((i=0; i<100; i++)); do ddev describe; done >/tmp/out 2>&1 && ddev debug instrumentation flush` SHOULD result in new data in amplitude

https://app.amplitude.com/analytics/ddev/chart/vqe8wcsj can be used to study this; the filtering will have to be adjusted for your use.

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5169"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

