### PR TITLE
fix: bad link was output when asking permission on instrumentation

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -208,7 +208,7 @@ func instrumentationNotSetUpWarning() {
 // and update the info.
 func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 	if !output.JSONOutput && semver.Compare(versionconstants.DdevVersion, globalconfig.DdevGlobalConfig.LastStartedVersion) > 0 && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false && !globalconfig.DdevNoInstrumentation && !skipConfirmation {
-		allowStats := util.Confirm("It looks like you have a new ddev release.\nMay we send anonymous ddev usage statistics and errors?\nTo know what we will see please take a look at\nhttps://ddev.readthedocs.io/en/stable/users/details/opting-in\nPermission to beam up?")
+		allowStats := util.Confirm("It looks like you have a new ddev release.\nMay we send anonymous ddev usage statistics and errors?\nTo know what we will see please take a look at\nhttps://ddev.readthedocs.io/en/latest/users/usage/diagnostics/#opt-in-usage-information\nPermission to beam up?")
 		if allowStats {
 			globalconfig.DdevGlobalConfig.InstrumentationOptIn = true
 			client, _ := analytics.NewWithConfig(versionconstants.SegmentKey, analytics.Config{


### PR DESCRIPTION
## The Issue

`ddev start` on first usage was outputting invalid link for info on instrumentation.

```
$ ddev start
Network ddev_default created
It looks like you have a new ddev release.
May we send anonymous ddev usage statistics and errors?
To know what we will see please take a look at
https://ddev.readthedocs.io/en/stable/users/details/opting-in
Permission to beam up? [Y/n] (yes):
```

## How This PR Solves The Issue

Fix link



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5170"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

