### PR TITLE
fix: don't run MutagenSyncFlush on non-running project during config, fixes #5168

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -281,9 +281,13 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 		}
 		return settingsPath, nil
 	}
-	err = app.MutagenSyncFlush()
-	if err != nil {
-		return "", err
+
+	// If the project is not running, it makes no sense to sync it
+	if s, _ := app.SiteStatus(); s == SiteRunning {
+		err = app.MutagenSyncFlush()
+		if err != nil {
+			return "", err
+		}
 	}
 
 	return "", nil


### PR DESCRIPTION


## The Issue

* #5168 

## How This PR Solves The Issue

This seems like the lightest touch possible here, just check to see if project is running before trying to sync it. The only reason for the sync is to get the new settings into the container right away, and since it's just one file normally, mutagen has probably already synced it without even a flush. However, if the project is stopped, it will be synced on start.

I first experimented with changing MutagenSyncFlush itself, and it can be done there, but it would have effects on all callers, and I'm risk-averse at this point in the release cycle.

## Manual Testing Instructions

Use #5168 instructions



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5175"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

