### PR TITLE
fix: correctly return notification and ticker interval, fixes #5177

### DIFF
--- a/pkg/config/remoteconfig/messages.go
+++ b/pkg/config/remoteconfig/messages.go
@@ -1,13 +1,13 @@
 package remoteconfig
 
 import (
-	"github.com/ddev/ddev/pkg/nodeps"
 	"strings"
 	"time"
 
 	"github.com/ddev/ddev/pkg/config/remoteconfig/internal"
 	"github.com/ddev/ddev/pkg/config/remoteconfig/types"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/styles"
 	"github.com/ddev/ddev/pkg/util"
@@ -166,7 +166,7 @@ func (c *remoteConfig) isNotificationsDisabled() bool {
 //   - remote config
 //   - const notificationsInterval
 func (c *remoteConfig) getNotificationsInterval() time.Duration {
-	if c.remoteConfig.Messages.Notifications.Interval > 0 {
+	if c.remoteConfig.Messages.Notifications.Interval != 0 {
 		return time.Duration(c.remoteConfig.Messages.Notifications.Interval) * time.Hour
 	}
 
@@ -194,11 +194,11 @@ func (c *remoteConfig) isTickerDisabled() bool {
 //   - remote config
 //   - const tickerInterval
 func (c *remoteConfig) getTickerInterval() time.Duration {
-	if c.tickerInterval > 0 {
+	if c.tickerInterval != 0 {
 		return time.Duration(c.tickerInterval) * time.Hour
 	}
 
-	if c.remoteConfig.Messages.Ticker.Interval > 0 {
+	if c.remoteConfig.Messages.Ticker.Interval != 0 {
 		return time.Duration(c.remoteConfig.Messages.Ticker.Interval) * time.Hour
 	}
 


### PR DESCRIPTION
## The Issue

* #5177

## How This PR Solves The Issue

The notification and ticker interval are not set if 0, so conditions are fixed to reflect this correctly and return the first set config.

## Manual Testing Instructions

Set `notification_interval` and `ticker_interval` to `-1` and check if notifications and ticker messages are not longer shown on `ddev start`.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5178"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

