### PR TITLE
refactor: start with random ticker message, fixes #5180

### DIFF
--- a/pkg/config/remoteconfig/messages.go
+++ b/pkg/config/remoteconfig/messages.go
@@ -113,7 +113,7 @@ func (c *remoteConfig) ShowNotifications() {
 func (c *remoteConfig) ShowTicker() {
 	defer util.TimeTrack()()
 
-	if !c.showTickerMessage() {
+	if !c.showTickerMessage() || len(c.remoteConfig.Messages.Ticker.Messages) == 0 {
 		return
 	}
 

--- a/pkg/config/remoteconfig/messages.go
+++ b/pkg/config/remoteconfig/messages.go
@@ -1,6 +1,7 @@
 package remoteconfig
 
 import (
+	"math/rand"
 	"strings"
 	"time"
 
@@ -118,6 +119,14 @@ func (c *remoteConfig) ShowTicker() {
 
 	messageOffset := c.state.LastTickerMessage
 	messageCount := len(c.remoteConfig.Messages.Ticker.Messages)
+
+	if messageOffset == 0 {
+		// As long as no message was shown, start with a random message. This
+		// is important for short living instances e.g. Gitpod to not always
+		// show the first message. A number from 0 to number of messages minus
+		// 1 is generated.
+		messageOffset = rand.Intn(messageCount)
+	}
 
 	for i := range c.remoteConfig.Messages.Ticker.Messages {
 		messageOffset++


### PR DESCRIPTION
## The Issue

* #5180

On short living instances e.g. Gitpod the first ticker message is always show.

## How This PR Solves The Issue

In case no message was shown so far, a random message is picked.

## Manual Testing Instructions

Remove the state file `~/.ddev/.state.yaml` and check if a random message is shown on `ddev start`.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5181"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

