### PR TITLE
docs: improve docs example on building-contributing.md

### DIFF
--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -278,7 +278,7 @@ The pull request title must follow this convention which is based on the [Conven
 
 * `build: bump mutagen to 0.17.2`
 * `ci: enforce commit message convention, fixes #5037`
-* `docs: improve additional-hostnames.md`
+* `docs: change code refs of Mac M1 to Apple Silicon`
 * `feat: allow multiple upload dirs, fixes #4190, fixes #4796`
 * `fix: create upload_dir if it doesn't exist in ddev composer create, fixes #5031`
 * `refactor: add new Amplitude Property DDEV-Environment`


### PR DESCRIPTION
## The Issue

As described by Randy on 

[2023-07-18 | Maintaining and Improving the Docs](https://www.dropbox.com/scl/fi/2d5qryxzgwa5zat9xz056/20230718_contributor_traiing_docs.mp4?dl=0&rlkey=senzp6l6j8zq52vd4y74uhqfy)

This line could be better at reflecting what has been changed.
`docs: improve additional-hostnames.md` 

## How This PR Solves The Issue

It replaces `docs: improve additional-hostnames.md` for this one `docs: change code refs of Mac M1 to Apple Silicon`.

Both are merged PR's

## Manual Testing Instructions

## Automated Testing Overview


## Related Issue Link(s)

## Release/Deployment Notes


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5183"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

