### PR TITLE
fix: traefik dashboard should not bind all interfaces by default

### DIFF
--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -24,7 +24,7 @@ services:
     {{ if eq .Router "traefik" }}
     # Traefik router; configured in static config as entrypoint
     # TODO: Make this configurable? Put it somewhere else?
-    - 9999:9999
+    - "{{ if not .router_bind_all_interfaces }}{{ $dockerIP }}:{{ end }}9999:9999"
     {{ end }}
     volumes:
       {{ if ne .Router "traefik" }}


### PR DESCRIPTION
## The Issue

There is no difference in `router_bind_all_interfaces` for Traefik:

```
ddev config global --router-bind-all-interfaces=true
ddev start
cat ~/.ddev/.router-compose.yaml | grep 9999
    - 9999:9999

ddev config global --router-bind-all-interfaces=false
ddev start
cat ~/.ddev/.router-compose.yaml | grep 9999
    - 9999:9999
```

## How This PR Solves The Issue

Traefik must consider the `router_bind_all_interfaces` config.

## Manual Testing Instructions

```
ddev config global --router-bind-all-interfaces=false
ddev start
cat ~/.ddev/.router-compose.yaml | grep 9999
    - "127.0.0.1:9999:9999"

ddev config global --router-bind-all-interfaces=true
ddev start
cat ~/.ddev/.router-compose.yaml | grep 9999
    - "9999:9999"
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5185"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

