### PR TITLE
build: update .gitpod.yml for v1.22.0 release [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,16 +1,14 @@
-image: ddev/ddev-gitpod-base:20230512
+image: ddev/ddev-gitpod-base:20230724
 tasks:
   - name: build-run
     init: |
       # Compile ddev
       make
-      cd /tmp && ddev config --auto
       ddev debug download-images
-      ddev delete -Oy tmp
       mkcert -install
     command: |
       export DDEV_NONINTERACTIVE=true
-      DDEV_REPO=${DDEV_REPO:-https://github.com/ddev/d9simple}
+      DDEV_REPO=${DDEV_REPO:-https://github.com/ddev/d10simple}
       DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
       git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
       reponame=${DDEV_REPO##*/}


### PR DESCRIPTION
## The Issue

DDEV v1.22.0 is out.

* Push new gitpod image
* `ddev debug download-images` no longer needs a project in which to run, so remove cruft
* Use `d10simple` instead of d9simple

