### PR TITLE
fix: default upload_dirs incorrect for magento2, fixes #5197

### DIFF
--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -119,7 +119,7 @@ func getMagentoUploadDirs(_ *DdevApp) []string {
 
 // getMagento2UploadDirs will return the default paths.
 func getMagento2UploadDirs(_ *DdevApp) []string {
-	return []string{"pub/media"}
+	return []string{"media"}
 }
 
 // createMagento2SettingsFile manages creation and modification of app/etc/env.php.


### PR DESCRIPTION
## The Issue

* #5197 

The default upload_dirs is incorrect for magento2 in v1.22.0

## How This PR Solves The Issue

Use the correct value

## Manual Testing Instructions

Create magento2 project using the quickstart
`ddev start && ddev exec 'echo $DDEV_UPLOAD_DIRS'` - it should show pub/media, not pub/pub/media

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

