### PR TITLE
fix: chmod ugo+rwx /usr/local/bin *after* dirs have been added, fixes #5191

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -34,14 +34,13 @@ RUN curl --fail -sSL https://raw.githubusercontent.com/netz98/n98-magerun/develo
 RUN curl --fail -sSL https://files.magerun.net/n98-magerun2-latest.phar -o /usr/local/bin/magerun2 && chmod 777 /usr/local/bin/magerun2
 RUN curl --fail -sSL https://raw.githubusercontent.com/netz98/n98-magerun2/develop/res/autocompletion/bash/n98-magerun2.phar.bash -o /etc/bash_completion.d/n98-magerun2.phar && chmod +x /usr/local/bin/magerun
 
-# /usr/local/bin may need to be updated by start.sh, etc
-RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer
-
 RUN apt-get -qq autoremove && apt-get -qq clean -y && rm -rf /var/lib/apt/lists/*
 
 ADD ddev-webserver-base-files /
 ADD ddev-webserver-base-scripts /
 
+# /usr/local/bin may need to be updated by start.sh, etc
+RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer
 # END ddev-webserver-base
 
 

--- a/pkg/ddevapp/hardened_test.go
+++ b/pkg/ddevapp/hardened_test.go
@@ -27,7 +27,13 @@ func TestHardenedStart(t *testing.T) {
 
 	origDir, _ := os.Getwd()
 
-	site := TestSites[0]
+	testSite := 0
+	// Prefer the drupal7 project, as it does ln -s into /usr/local/bin, possibly
+	// requiring sudo, which isn't installed
+	if len(TestSites) >= 3 {
+		testSite = 2
+	}
+	site := TestSites[testSite]
 	err := app.Init(site.Dir)
 	assert.NoError(err)
 	if app.IsMutagenEnabled() {

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.22.0" // Note that this can be overridden by make
+var WebTag = "20230726_hardened_images" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

* #5191

## How This PR Solves The Issue

* Fix the build (/usr/local/bin was being overwritten with unwriteable perms)
* Push new image
* Fix TestHardenedImages to prefer drupal7

## Manual Testing Instructions

In drupal7 project:
```
ddev config global --use-hardened-images
ddev restart
```


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5199"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

