### PR TITLE
feat: add `ddev debug testcleanup`, fixes #5210

### DIFF
--- a/cmd/ddev/cmd/debug-testcleanup.go
+++ b/cmd/ddev/cmd/debug-testcleanup.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// DebugTestCleanupCmd implements the ddev debug testcleanup command
+var DebugTestCleanupCmd = &cobra.Command{
+	Use:     "testcleanup",
+	Short:   "Cleanup diagnostic projects named with the tryddevproject prefix",
+	Example: "ddev debug testcleanup",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 0 {
+			util.Failed("This command takes no additional arguments")
+		}
+		allProjects, err := ddevapp.GetProjects(false)
+		if err != nil {
+			util.Failed("failed getting GetProjects: %v", err)
+		}
+		if len(allProjects) < 1 {
+			output.UserOut.Println("No ddev projects were found.")
+			return
+		}
+		for _, project := range allProjects {
+			name := project.GetName()
+			if !strings.HasPrefix(project.GetName(), "tryddevproject") {
+				continue
+			}
+			output.UserOut.Printf("Running ddev delete -Oy %v", name)
+			err = DeleteCmd.Flags().Set("omit-snapshot", "true")
+			if err != nil {
+				util.Failed("failed setting a flag --omit-snapshot for ddev delete: %v", err)
+			}
+			err = DeleteCmd.Flags().Set("yes", "true")
+			if err != nil {
+				util.Failed("failed setting a flag --yes for ddev delete: %v", err)
+			}
+			DeleteCmd.Run(cmd, []string{name})
+		}
+		util.Success("Finished cleaning ddev diagnostics projects")
+	},
+}
+
+func init() {
+	DebugCmd.AddCommand(DebugTestCleanupCmd)
+}

--- a/cmd/ddev/cmd/debug-testcleanup.go
+++ b/cmd/ddev/cmd/debug-testcleanup.go
@@ -12,7 +12,7 @@ import (
 // DebugTestCleanupCmd implements the ddev debug testcleanup command
 var DebugTestCleanupCmd = &cobra.Command{
 	Use:     "testcleanup",
-	Short:   "Cleanup diagnostic projects named with the tryddevproject prefix",
+	Short:   "Removes diagnostic projects prefixed with 'tryddevproject-'",
 	Example: "ddev debug testcleanup",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 0 {
@@ -28,7 +28,7 @@ var DebugTestCleanupCmd = &cobra.Command{
 		}
 		for _, project := range allProjects {
 			name := project.GetName()
-			if !strings.HasPrefix(name, "tryddevproject") {
+			if !strings.HasPrefix(name, "tryddevproject-") {
 				continue
 			}
 			output.UserOut.Printf("Running ddev delete -Oy %v", name)
@@ -42,7 +42,7 @@ var DebugTestCleanupCmd = &cobra.Command{
 			}
 			DeleteCmd.Run(cmd, []string{name})
 		}
-		util.Success("Finished cleaning ddev diagnostics projects")
+		util.Success("Finished cleaning ddev diagnostic projects")
 	},
 }
 

--- a/cmd/ddev/cmd/debug-testcleanup.go
+++ b/cmd/ddev/cmd/debug-testcleanup.go
@@ -28,7 +28,7 @@ var DebugTestCleanupCmd = &cobra.Command{
 		}
 		for _, project := range allProjects {
 			name := project.GetName()
-			if !strings.HasPrefix(project.GetName(), "tryddevproject") {
+			if !strings.HasPrefix(name, "tryddevproject") {
 				continue
 			}
 			output.UserOut.Printf("Running ddev delete -Oy %v", name)

--- a/cmd/ddev/cmd/debug-testcleanup_test.go
+++ b/cmd/ddev/cmd/debug-testcleanup_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/testcommon"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDebugTestCleanupCmd ensures the debug testcleanup only removes diagnostic projects prefixed with 'tryddevproject-'
+func TestDebugTestCleanupCmd(t *testing.T) {
+	assert := asrt.New(t)
+
+	origDir, _ := os.Getwd()
+
+	debugAppName := "tryddevproject-" + t.Name()
+	nonDebugAppName := TestSites[0].Name
+
+	testDir := testcommon.CreateTmpDir(debugAppName)
+	err := os.Chdir(testDir)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		err = os.RemoveAll(testDir)
+		assert.NoError(err)
+	})
+
+	out, err := exec.RunHostCommand(DdevBin, "config", "--project-name", debugAppName)
+	require.NoError(t, err, "Failed to run ddev config: %s", out)
+
+	out, err = exec.RunHostCommand(DdevBin, "debug", "testcleanup")
+	require.NoError(t, err, "Failed to run ddev debug testcleanup: %s", out)
+
+	assert.NotContains(out, fmt.Sprintf("Project %s was deleted", nonDebugAppName))
+	assert.Contains(out, fmt.Sprintf("Project %s was deleted", debugAppName))
+	assert.Contains(out, "Finished cleaning ddev diagnostic projects")
+
+	out, err = exec.RunCommand(DdevBin, []string{"describe", debugAppName})
+	assert.Error(err, "Expected an error when describing a deleted project")
+	assert.Contains(out, "could not find requested project")
+}

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -12,7 +12,7 @@
 PROJECT_NAME=tryddevproject-${RANDOM}
 
 function cleanup {
-  printf "\nPlease delete this project after debugging with 'ddev delete -Oy ${PROJECT_NAME}'\n"
+  printf "\nPlease run cleanup after debugging with 'ddev debug testcleanup'\n"
 }
 
 function docker_desktop_version {
@@ -135,7 +135,3 @@ echo "Thanks for running the diagnostic. It was successful."
 echo "Please provide the output of this script in a new gist at gist.github.com"
 echo "Running ddev launch in 5 seconds" && sleep 5
 ddev launch
-
-echo "If you're brave and you have jq you can delete all tryddevproject instances with this one-liner:"
-echo "    ddev list -j | jq -r '.raw[].name' | grep tryddevproject | xargs -L 1 -r ddev delete -Oy"
-echo "In the future ddev debug test will also provide this option."

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -137,5 +137,5 @@ echo "Running ddev launch in 5 seconds" && sleep 5
 ddev launch
 
 echo "If you're brave and you have jq you can delete all tryddevproject instances with this one-liner:"
-echo '    ddev delete -Oy $(ddev list -j |jq -r .raw[].name | grep tryddevproject)'
+echo "    ddev list -j | jq -r '.raw[].name' | grep tryddevproject | xargs -L 1 -r ddev delete -Oy"
 echo "In the future ddev debug test will also provide this option."

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -425,6 +425,17 @@ Example:
 ddev debug test
 ```
 
+### `debug testcleanup`
+
+Removes all diagnostic projects created with `ddev debug test`.
+
+Example:
+
+```shell
+# Remove all DDEV’s diagnostic projects
+ddev debug testcleanup
+```
+
 ## `delete`
 
 Remove all information, including the database, for an existing project.


### PR DESCRIPTION
## The Issue

The output for `ddev debug test` contains:

```
If you're brave and you have jq you can delete all tryddevproject instances with this one-liner:
    ddev delete -Oy $(ddev list -j |jq -r .raw[].name | grep tryddevproject)
In the future ddev debug test will also provide this option.
```

It is dangerous to run this one-liner twice in a row, because the second run will be the same as `ddev delete -Oy` without any arguments, and it will delete the DDEV project with its volumes.

## How This PR Solves The Issue

Add `ddev debug testcleanup` command that will clean up all projects with `tryddevproject` prefix. No `jq` required.

## Manual Testing Instructions

Run `ddev debug test` several times, then `ddev debug testcleanup`

## Related Issue Link(s)

- https://github.com/ddev/ddev/issues/5210

## Alternative:

Use `xargs`:

```
ddev list -j | jq -r '.raw[].name' | grep tryddevproject | xargs -L 1 -r ddev delete -Oy
```

* `-L 1` - process one line at a time
* `-r` - do not run `xargs` if the result of previous command is empty

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5212"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

