### PR TITLE
fix: make traefik monitoring port configurable, not just 9999, fixes #5196

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -237,6 +237,12 @@ func handleGlobalConfig(cmd *cobra.Command, _ []string) {
 		globalconfig.DdevGlobalConfig.RouterHTTPSPort = val
 		dirty = true
 	}
+	if cmd.Flag("traefik-monitor-port").Changed {
+		val, _ := cmd.Flags().GetString("traefik-monitor-port")
+		globalconfig.DdevGlobalConfig.TraefikMonitorPort = val
+		dirty = true
+	}
+
 	if dirty {
 		err = globalconfig.ValidateGlobalConfig()
 		if err != nil {
@@ -272,6 +278,7 @@ func handleGlobalConfig(cmd *cobra.Command, _ []string) {
 	output.UserOut.Printf("wsl2-no-windows-hosts-mgt=%v", globalconfig.DdevGlobalConfig.WSL2NoWindowsHostsMgt)
 	output.UserOut.Printf("router-http-port=%v", globalconfig.DdevGlobalConfig.RouterHTTPPort)
 	output.UserOut.Printf("router-https-port=%v", globalconfig.DdevGlobalConfig.RouterHTTPSPort)
+	output.UserOut.Printf("traefik-monitor-port=%v", globalconfig.DdevGlobalConfig.TraefikMonitorPort)
 }
 
 func init() {
@@ -306,7 +313,8 @@ func init() {
 	_ = configGlobalCommand.Flags().MarkDeprecated("use-traefik", "please use --router instead")
 	configGlobalCommand.Flags().String("router", globalconfigTypes.RouterTypeTraefik, fmt.Sprintf("Valid router types are %s, default is %s", strings.Join(globalconfigTypes.GetValidRouterTypes(), ", "), globalconfigTypes.RouterTypeDefault))
 	configGlobalCommand.Flags().Bool("wsl2-no-windows-hosts-mgt", true, "WSL2 only; make DDEV ignore Windows-side hosts file")
-	configGlobalCommand.Flags().String("router-http-port", "", "The router HTTP port for this project")
-	configGlobalCommand.Flags().String("router-https-port", "", "The router HTTPS port for this project")
+	configGlobalCommand.Flags().String("router-http-port", "", "The default router HTTP port for all projects")
+	configGlobalCommand.Flags().String("router-https-port", "", "The default router HTTPS port for all projects")
+	configGlobalCommand.Flags().String("traefik-monitor-port", "", "The Traefik monitor port; can be changed in case of port conflicts")
 	ConfigCommand.AddCommand(configGlobalCommand)
 }

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -32,7 +32,7 @@ func TestCmdGlobalConfig(t *testing.T) {
 	// nolint: errcheck
 	t.Cleanup(func() {
 		// Even though the global config is going to be deleted, make sure it's sane before leaving
-		args := []string{"config", "global", "--omit-containers", "", "--disable-http2=false", "--performance-mode-reset", "--simple-formatting=false", "--table-style=default", `--required-docker-compose-version=""`, `--use-docker-compose-from-path=false`, `--xdebug-ide-location`, "", `--router=traefik`}
+		args := []string{"config", "global", "--omit-containers", "", "--disable-http2=false", "--performance-mode-reset", "--simple-formatting=false", "--table-style=default", `--required-docker-compose-version=""`, `--use-docker-compose-from-path=false`, `--xdebug-ide-location`, "", `--router=traefik`, `--traefik-monitor-port=10999`}
 		globalconfig.DdevGlobalConfig.OmitContainersGlobal = nil
 		out, err := exec.RunHostCommand(DdevBin, args...)
 		assert.NoError(err, "error running ddev config global; output=%s", out)
@@ -69,11 +69,12 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.Contains(out, "router=traefik")
 	assert.Contains(out, "wsl2-no-windows-hosts-mgt=false")
 	assert.Contains(out, "router-http-port=80\nrouter-https-port=443")
+	assert.Contains(out, "traefik-monitor-port=10999")
 
 	// Update a config
 	// Don't include no-bind-mounts because global testing
 	// will turn it on and break this
-	args = []string{"config", "global", "--project-tld=ddev.test", "--instrumentation-opt-in=false", "--omit-containers=ddev-ssh-agent", "--performance-mode=mutagen", "--router-bind-all-interfaces=true", "--internet-detection-timeout-ms=850", "--table-style=bright", "--simple-formatting=true", "--auto-restart-containers=true", "--use-hardened-images=true", "--fail-on-hook-fail=true", `--web-environment="SOMEENV=some+val"`, `--xdebug-ide-location=container`, `--router=nginx-proxy`, `--router-http-port=8081`, `--router-https-port=8882`}
+	args = []string{"config", "global", "--project-tld=ddev.test", "--instrumentation-opt-in=false", "--omit-containers=ddev-ssh-agent", "--performance-mode=mutagen", "--router-bind-all-interfaces=true", "--internet-detection-timeout-ms=850", "--table-style=bright", "--simple-formatting=true", "--auto-restart-containers=true", "--use-hardened-images=true", "--fail-on-hook-fail=true", `--web-environment="SOMEENV=some+val"`, `--xdebug-ide-location=container`, `--router=nginx-proxy`, `--router-http-port=8081`, `--router-https-port=8882`, `--traefik-monitor-port=11999`}
 	out, err = exec.RunCommand(DdevBin, args)
 	require.NoError(t, err)
 	assert.NoError(err, "error running ddev config global; output=%s", out)
@@ -97,6 +98,7 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.Contains(out, "wsl2-no-windows-hosts-mgt=false")
 	assert.Contains(out, "router-http-port=8081\nrouter-https-port=8882")
 	assert.Contains(out, "router=nginx-proxy")
+	assert.Contains(out, "traefik-monitor-port=11999")
 
 	globalconfig.EnsureGlobalConfig()
 	assert.False(globalconfig.DdevGlobalConfig.InstrumentationOptIn)

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -474,6 +474,14 @@ Timezone for container and PHP configuration.
 | -- | -- | --
 | :octicons-file-directory-16: project | `UTC` | Can be any [valid timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), like `Europe/Dublin` or `MST7MDT`.
 
+## `traefik-monitor-port`
+
+Specify an alternate port for the Traefik (ddev-router) monitor port. This defaults to 10999 and rarely needs to be changed, but can be changed in cases of port conflicts.
+
+| Type | Default | Usage
+| -- |---------| --
+| :octicons-globe-16: global | `10999` | Can be any unused port below 65535.
+
 ## `type`
 
 The DDEV-specific project type.

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -474,7 +474,7 @@ Timezone for container and PHP configuration.
 | -- | -- | --
 | :octicons-file-directory-16: project | `UTC` | Can be any [valid timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), like `Europe/Dublin` or `MST7MDT`.
 
-## `traefik-monitor-port`
+## `traefik_monitor_port`
 
 Specify an alternate port for the Traefik (ddev-router) monitor port. This defaults to 10999 and rarely needs to be changed, but can be changed in cases of port conflicts.
 

--- a/docs/content/users/extend/traefik-router.md
+++ b/docs/content/users/extend/traefik-router.md
@@ -32,5 +32,5 @@ Project configuration is automatically generated in the project’s `.ddev/traef
 
 ## Debugging Traefik Routing
 
-Traefik provides a dynamic description of its configuration you can visit at `http://localhost:9999`.
+Traefik provides a dynamic description of its configuration you can visit at `http://localhost:10999`.
 When things seem to be going wrong, run [`ddev poweroff`](../usage/commands.md#poweroff) and then start your project again by running [`ddev start`](../usage/commands.md#start). Examine the router’s logs to see what the Traefik daemon is doing (or failing at) by running `docker logs ddev-router` or `docker logs -f ddev-router`.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -240,6 +240,7 @@ ddev config global --omit-containers=ddev-ssh-agent
 * `--performance-mode-reset`: Reset performance optimization mode to operating system default (`none` for Linux and WSL2, `mutagen` for macOS and traditional Windows).
 * `--simple-formatting`: If `true`, use simple formatting and no color for tables.
 * `--table-style`: Table style for list and describe, see `~/.ddev/global_config.yaml` for values.
+* `--traefik-monitor-port`: Can be used to change the traefik monitor port in case of port conflicts, for example `ddev config global --traefik-monitor-port=11999`.
 * `--use-hardened-images`: If `true`, use more secure 'hardened' images for an actual internet deployment.
 * `--use-letsencrypt`: Enables experimental Let’s Encrypt integration; `ddev global --use-letsencrypt` or `ddev global --use-letsencrypt=false`.
 * `--web-environment`: Set the environment variables in the web container: `--web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"`

--- a/pkg/ddevapp/healthcheck/router/traefik/traefik_healthcheck.sh
+++ b/pkg/ddevapp/healthcheck/router/traefik/traefik_healthcheck.sh
@@ -25,7 +25,7 @@ fi
 # If we can now access the traefik ping endpoint, then we're healthy
 # We should be able to use `traefik healthcheck --ping` but it doesn't work if
 # using nonstandard port (always tries port 8080 even if traefik port is something else)
-if curl -s -f http://127.0.0.1:{{.traefik_monitor_port}}/ping ; then
+if curl -s -f http://127.0.0.1:{{.TraefikMonitorPort}}/ping ; then
     printf "healthy"
     touch /tmp/healthy
     exit 0

--- a/pkg/ddevapp/healthcheck/router/traefik/traefik_healthcheck.sh
+++ b/pkg/ddevapp/healthcheck/router/traefik/traefik_healthcheck.sh
@@ -24,8 +24,8 @@ fi
 
 # If we can now access the traefik ping endpoint, then we're healthy
 # We should be able to use `traefik healthcheck --ping` but it doesn't work if
-# using nonstandard port (always tries port 8080 even if traefik port is 9999)
-if curl -s -f http://127.0.0.1:9999/ping ; then
+# using nonstandard port (always tries port 8080 even if traefik port is something else)
+if curl -s -f http://127.0.0.1:{{.traefik_monitor_port}}/ping ; then
     printf "healthy"
     touch /tmp/healthy
     exit 0

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -23,7 +23,6 @@ services:
     - "{{ $port }}:{{ $port }}"{{ end }}{{ end }}
     {{ if eq .Router "traefik" }}
     # Traefik router; configured in static config as entrypoint
-    # TODO: Make this configurable? Put it somewhere else?
     - "{{ if not .router_bind_all_interfaces }}{{ $dockerIP }}:{{ end }}{{.TraefikMonitorPort}}:{{.TraefikMonitorPort}}"
     {{ end }}
     volumes:

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -24,7 +24,7 @@ services:
     {{ if eq .Router "traefik" }}
     # Traefik router; configured in static config as entrypoint
     # TODO: Make this configurable? Put it somewhere else?
-    - "{{ if not .router_bind_all_interfaces }}{{ $dockerIP }}:{{ end }}{{.traefik_monitor_port}}:{{.traefik_monitor_port}}"
+    - "{{ if not .router_bind_all_interfaces }}{{ $dockerIP }}:{{ end }}{{.TraefikMonitorPort}}:{{.TraefikMonitorPort}}"
     {{ end }}
     volumes:
       {{ if ne .Router "traefik" }}

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -24,7 +24,7 @@ services:
     {{ if eq .Router "traefik" }}
     # Traefik router; configured in static config as entrypoint
     # TODO: Make this configurable? Put it somewhere else?
-    - "{{ if not .router_bind_all_interfaces }}{{ $dockerIP }}:{{ end }}9999:9999"
+    - "{{ if not .router_bind_all_interfaces }}{{ $dockerIP }}:{{ end }}{{.traefik_monitor_port}}:{{.traefik_monitor_port}}"
     {{ end }}
     volumes:
       {{ if ne .Router "traefik" }}

--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -150,19 +150,21 @@ func pushGlobalTraefikConfig() error {
 	}
 
 	type traefikData struct {
-		App              *DdevApp
-		Hostnames        []string
-		PrimaryHostname  string
-		TargetCertsPath  string
-		RouterPorts      []string
-		UseLetsEncrypt   bool
-		LetsEncryptEmail string
+		App                *DdevApp
+		Hostnames          []string
+		PrimaryHostname    string
+		TargetCertsPath    string
+		RouterPorts        []string
+		UseLetsEncrypt     bool
+		LetsEncryptEmail   string
+		TraefikMonitorPort string
 	}
 	templateData := traefikData{
-		TargetCertsPath:  targetCertsPath,
-		RouterPorts:      determineRouterPorts(),
-		UseLetsEncrypt:   globalconfig.DdevGlobalConfig.UseLetsEncrypt,
-		LetsEncryptEmail: globalconfig.DdevGlobalConfig.LetsEncryptEmail,
+		TargetCertsPath:    targetCertsPath,
+		RouterPorts:        determineRouterPorts(),
+		UseLetsEncrypt:     globalconfig.DdevGlobalConfig.UseLetsEncrypt,
+		LetsEncryptEmail:   globalconfig.DdevGlobalConfig.LetsEncryptEmail,
+		TraefikMonitorPort: globalconfig.DdevGlobalConfig.TraefikMonitorPort,
 	}
 
 	traefikYamlFile := filepath.Join(sourceConfigDir, "default_config.yaml")

--- a/pkg/ddevapp/traefik_static_config_template.yaml
+++ b/pkg/ddevapp/traefik_static_config_template.yaml
@@ -31,7 +31,7 @@ ping:
 
 entryPoints:
   traefik:
-    address: ":{{.traefik_monitor_port}}"
+    address: ":{{.TraefikMonitorPort}}"
   {{ range $port := .RouterPorts}}
   http-{{$port}}:
     address: ":{{$port}}"

--- a/pkg/ddevapp/traefik_static_config_template.yaml
+++ b/pkg/ddevapp/traefik_static_config_template.yaml
@@ -31,7 +31,7 @@ ping:
 
 entryPoints:
   traefik:
-    address: ":9999"
+    address: ":{{.traefik_monitor_port}}"
   {{ range $port := .RouterPorts}}
   http-{{$port}}:
     address: ":{{$port}}"

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -721,7 +721,7 @@ func GetRouterURL() string {
 	routerURL := ""
 	// Until we figure out how to configure this, use static value
 	if DdevGlobalConfig.IsTraefikRouter() {
-		routerURL = "http://localhost:9999"
+		routerURL = "http://localhost:" + TraefikMonitorPort
 	}
 	return routerURL
 }

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -62,6 +62,7 @@ type GlobalConfig struct {
 	XdebugIDELocation                string                      `yaml:"xdebug_ide_location"`
 	NoBindMounts                     bool                        `yaml:"no_bind_mounts"`
 	Router                           string                      `yaml:"router"`
+	TraefikMonitorPort               string                      `yaml:"traefik_monitor_port,omitempty"`
 	WSL2NoWindowsHostsMgt            bool                        `yaml:"wsl2_no_windows_hosts_mgt"`
 	RouterHTTPPort                   string                      `yaml:"router_http_port"`
 	RouterHTTPSPort                  string                      `yaml:"router_https_port"`
@@ -84,6 +85,7 @@ func New() GlobalConfig {
 		Router:                       types.RouterTypeDefault,
 		MkcertCARoot:                 readCAROOT(),
 		ProjectList:                  make(map[string]*ProjectInfo),
+		TraefikMonitorPort:           nodeps.TraefikMonitorPortDefault,
 	}
 
 	return cfg
@@ -385,6 +387,10 @@ func WriteGlobalConfig(config GlobalConfig) error {
 
 # fail_on_hook_fail: false
 # Decide whether 'ddev start' should be interrupted by a failing hook
+
+# traefik_monitor_port: 10999
+# Change this only if you're having conflicts with some 
+# service that needs port 10999
 
 # wsl2_no_windows_hosts_mgt: false
 # On WSL2 by default the Windows-side hosts file (normally C:\Windows\system32\drivers\etc\hosts)
@@ -721,7 +727,7 @@ func GetRouterURL() string {
 	routerURL := ""
 	// Until we figure out how to configure this, use static value
 	if DdevGlobalConfig.IsTraefikRouter() {
-		routerURL = "http://localhost:" + TraefikMonitorPort
+		routerURL = "http://localhost:" + DdevGlobalConfig.TraefikMonitorPort
 	}
 	return routerURL
 }

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -727,7 +727,7 @@ func GetRouterURL() string {
 	routerURL := ""
 	// Until we figure out how to configure this, use static value
 	if DdevGlobalConfig.IsTraefikRouter() {
-		routerURL = "http://localhost:" + DdevGlobalConfig.TraefikMonitorPort
+		routerURL = "http://127.0.0.1:" + DdevGlobalConfig.TraefikMonitorPort
 	}
 	return routerURL
 }

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -229,13 +229,16 @@ func ReadGlobalConfig() error {
 		DdevGlobalConfig.InternetDetectionTimeout = nodeps.InternetDetectionTimeoutDefault
 	}
 
-	// It's possible to have had pre-existing `router_http_port: ""`, if
+	// It's possible to have had pre-existing `router_http_port: ""` or `traefik_monitor_port`, if
 	// so we have to override that.
 	if DdevGlobalConfig.RouterHTTPPort == "" {
 		DdevGlobalConfig.RouterHTTPPort = nodeps.DdevDefaultRouterHTTPPort
 	}
 	if DdevGlobalConfig.RouterHTTPSPort == "" {
 		DdevGlobalConfig.RouterHTTPSPort = nodeps.DdevDefaultRouterHTTPSPort
+	}
+	if DdevGlobalConfig.TraefikMonitorPort == "" {
+		DdevGlobalConfig.TraefikMonitorPort = nodeps.TraefikMonitorPortDefault
 	}
 
 	// Remove dba

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -112,6 +112,7 @@ const (
 	DdevDefaultTLD                  = "ddev.site"
 	DefaultDefaultContainerTimeout  = "120"
 	InternetDetectionTimeoutDefault = 3000
+	TraefikMonitorPortDefault       = "10999"
 	MinimumDockerSpaceWarning       = 5000000 // 5GB in KB (to compare against df reporting in KB)
 )
 


### PR DESCRIPTION
## The Issue

* #5196

In DDEV v1.22.0, the traefik monitoring port was fixed at 9999. This conflicted with lots of existing usage, and also conflicted with many suggested configurations in the docs.

## How This PR Solves The Issue

* Change the default port to 10999
* Make it configurable with global config: `traefik_monitor_port`

## Manual Testing Instructions

* `ddev describe` should show it running now on port 10999 by default
* Change it using `traefik_monitor_port` in the global_config.yaml

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5216"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

