### PR TITLE
fix: correct xdebug port detection for colima on linux, fixes #5222

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -227,8 +227,7 @@ services:
 
       {{ if .HostDockerInternalIP }}
     extra_hosts: [ "host.docker.internal:{{ .HostDockerInternalIP }}" ]
-      {{ end }}
-      {{ if .UseHostDockerInternalExtraHosts }}
+      {{ else if .UseHostDockerInternalExtraHosts }}
     extra_hosts:
       - "host.docker.internal:host-gateway"
       {{ end }}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -805,9 +805,9 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		IsCodespaces:          nodeps.IsCodespaces(),
 		// Default max time we wait for containers to be healthy
 		DefaultContainerTimeout: app.DefaultContainerTimeout,
-		// Only use the extra_hosts technique for linux and only if not WSL2
+		// Only use the extra_hosts technique for linux and only if not WSL2 and not Colima
 		// If WSL2 we have to figure out other things, see GetHostDockerInternalIP()
-		UseHostDockerInternalExtraHosts: (runtime.GOOS == "linux" && !nodeps.IsWSL2()) || (nodeps.IsWSL2() && globalconfig.DdevGlobalConfig.XdebugIDELocation == globalconfig.XdebugIDELocationWSL2),
+		UseHostDockerInternalExtraHosts: (runtime.GOOS == "linux" && !nodeps.IsWSL2() && !dockerutil.IsColima()) || (nodeps.IsWSL2() && globalconfig.DdevGlobalConfig.XdebugIDELocation == globalconfig.XdebugIDELocationWSL2),
 	}
 	// We don't want to bind-mount git dir if it doesn't exist
 	if fileutil.IsDirectory(filepath.Join(app.AppRoot, ".git")) {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1107,6 +1107,10 @@ func GetHostDockerInternalIP() (string, error) {
 		// In docker 20.10+, host.docker.internal is already taken care of by extra_hosts in docker-compose
 		util.Debug("host.docker.internal='%s' runtime.GOOS==linux and docker 20.10+", hostDockerInternal)
 		break
+
+	default:
+		util.Debug("host.docker.internal='%s' because no other case was discovered", hostDockerInternal)
+		break
 	}
 
 	return hostDockerInternal, nil


### PR DESCRIPTION
## The Issue

* #5222

There are two code problems;
* In the app_compose_template.yaml there are two "if" statements but it needs an else if instead to avoid duplicating in case of odd situations like this
* In config.go, UseHostDockerInternalExtraHosts should not be set if we're using Colima, when we use a static host.docker.internal.

## How This PR Solves The Issue

Fix the two problems above.

## Manual Testing Instructions

- [x] Test it on Linux amd64 colima.
- [x] Test on macOS colima
- [x] Make sure Xdebug works both places

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5223"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

