### PR TITLE
feat: bashrc to support very early bashrc additions that can work for edge cases like sshd

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.nointeractive.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.nointeractive.bashrc
@@ -3,6 +3,10 @@ for f in /etc/bashrc/*.bashrc; do
   source $f;
 done
 
+for i in $(\ls $HOME/.bashrc.pre.d/* 2>/dev/null); do
+    source $i;
+done
+
 for i in $(\ls $HOME/.bashrc.d/* 2>/dev/null); do
     source $i;
 done

--- a/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
@@ -2,6 +2,8 @@
 # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
 # for examples
 
+for i in $(\ls $HOME/.bashrc.pre.d/* 2>/dev/null); do source $i; done
+
 # If not running interactively, don't do anything
 case $- in
     *i*) ;;


### PR DESCRIPTION
## The Issue

Having worked on https://github.com/hanoii/ddev-sshd I was looking for a way to force the landing directory of ssh to be `/var/www/html`. The logical place to do this is on `.bash_profile` or `.bashrc`. I [did it](https://github.com/hanoii/ddev-sshd/blob/94cb0c50ae2c5f5599c529b0185d25b9143bebc6/homeadditions/.bashrc.d/sshd) by adding a file to `.ddev/homeadditions/.bashrc.d` that does exactly that.

This works when I ssh to the host, but not if I run it with a command:

`ssh ddev-pr-5227.ddev.site ls` list the home directory.
`ddev exec ls` lists the `/var/www/html` directory.

I wanted both to behave the same.

I did some research into the different bash execution scripts and the reason for this happening is:

https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Bash-Startup-Files

> **Invoked by remote shell daemon**
>
> Bash attempts to determine when it is being run with its standard input connected to a network connection, as when executed by the historical remote shell daemon, usually rshd, or the secure shell daemon sshd. If Bash determines it is being run non-interactively in this fashion, it reads and executes commands from ~/.bashrc, if that file exists and is readable. It will not do this if invoked as sh. The --norc option may be used to inhibit this behavior, and the --rcfile option may be used to force another file to be read, but neither rshd nor sshd generally invoke the shell with those options or allow them to be specified.

The default skeleton file (on ddev which is very close to debian's one) [has a very early check](https://github.com/ddev/ddev/blob/ce8f23b3a83b627a08bb30938c1cbfd70470366b/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc#L5-L9) that looks to see if the shell is interactive, and if so, continue or halt bashrc executing.

I created a test sandbox repo for this at https://github.com/hanoii/ddev-pr-5227. Besides the add on, it [adds](https://github.com/hanoii/ddev-pr-5227/blob/main/.ddev/web-build/Dockerfile) some `echo`s  to the bash start up file:

- `ddev ssh`
```
!! /etc/bash.nointeractive.bashrc
!! /etc/bash.bashrc - all
!! /etc/bash.bashrc - interactive
!! bash_profile
```

- `ddev exec ls`
```
!! /etc/bash.nointeractive.bashrc
```

- `ssh ddev-pr-5227.ddev.site`
```
!! /etc/bash.bashrc - all
!! /etc/bash.bashrc - interactive
!! bash_profile
```

- `ssh ddev-pr-5227.ddev.site ls`
```
!! /etc/bash.bashrc - all
!! home .bashrc-all
```

Where:
- `bash.bashrc - all`: is in the beginning of the bashrc 
- `bash.bashrc - interactive` is after the interactive check.

## How This PR Solves The Issue

It allows addons to add bashrc additions that are both run in interactive and remote shells.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5227"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

