### PR TITLE
build: bump ddev-webserver tag for v1.22.1

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20230803_php_serialize_precision" // Note that this can be overridden by make
+var WebTag = "v1.22.1" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

Time for DDEV v1.22.1, new ddev-webserver image



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5233"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

