### PR TITLE
fix: import-files should work with any project type

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -98,7 +98,6 @@ func init() {
 			configOverrideAction: django4ConfigOverrideAction,
 			postConfigAction:     django4PostConfigAction,
 			postStartAction:      django4PostStartAction,
-			importFilesAction:    genericImportFilesAction,
 		},
 
 		nodeps.AppTypeDrupal6: {
@@ -160,14 +159,12 @@ func init() {
 			appTypeDetect:        isLaravelApp,
 			postStartAction:      laravelPostStartAction,
 			configOverrideAction: laravelConfigOverrideAction,
-			importFilesAction:    genericImportFilesAction,
 		},
 
 		nodeps.AppTypeSilverstripe: {
 			appTypeDetect:        isSilverstripeApp,
 			postStartAction:      silverstripePostStartAction,
 			configOverrideAction: silverstripeConfigOverrideAction,
-			importFilesAction:    genericImportFilesAction,
 		},
 
 		nodeps.AppTypeMagento: {
@@ -190,14 +187,12 @@ func init() {
 
 		nodeps.AppTypePHP: {
 			postStartAction:   phpPostStartAction,
-			importFilesAction: genericImportFilesAction,
 		},
 
 		nodeps.AppTypePython: {
 			appTypeDetect:        isPythonApp,
 			configOverrideAction: pythonConfigOverrideAction,
 			postConfigAction:     pythonPostConfigAction,
-			importFilesAction:    genericImportFilesAction,
 		},
 
 		nodeps.AppTypeShopware6: {
@@ -377,7 +372,11 @@ func (app *DdevApp) dispatchImportFilesAction(uploadDir, importPath, extractPath
 		return errors.Errorf("upload_dirs is not set for this project (%s)", app.Type)
 	}
 
-	if appFuncs, ok := appTypeMatrix[app.Type]; ok && appFuncs.importFilesAction != nil {
+	if appFuncs, ok := appTypeMatrix[app.Type]; ok {
+		// if a specific action is not defined, use a generic action
+		if appFuncs.importFilesAction == nil {
+			appFuncs.importFilesAction = genericImportFilesAction
+		}
 		return appFuncs.importFilesAction(app, uploadDir, importPath, extractPath)
 	}
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -186,7 +186,7 @@ func init() {
 		},
 
 		nodeps.AppTypePHP: {
-			postStartAction:   phpPostStartAction,
+			postStartAction: phpPostStartAction,
 		},
 
 		nodeps.AppTypePython: {

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -2,7 +2,6 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"path"
 	"path/filepath"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/pkg/errors"
 )
 
 // appTypeFuncs prototypes
@@ -167,6 +167,7 @@ func init() {
 			appTypeDetect:        isSilverstripeApp,
 			postStartAction:      silverstripePostStartAction,
 			configOverrideAction: silverstripeConfigOverrideAction,
+			importFilesAction:    genericImportFilesAction,
 		},
 
 		nodeps.AppTypeMagento: {


### PR DESCRIPTION
## The Issue

`ddev import-files` should work for all project types, including `silverstripe`.

## How This PR Solves The Issue

`importFilesAction` can be easily forgotten for newly created project types.

Let's use `genericImportFilesAction` if no specific `importFilesAction` is defined.

## Manual Testing Instructions

```
mkdir silverstripe && cd silverstripe && mkdir source && touch source/file
ddev config --project-type=silverstripe
```

Before:

```
ddev import-files --source=source --target=target 
Error: failed to import files for silverstripe: this project type (silverstripe) does not support import-files
```

After:

```
ddev import-files --source=source --target=target 
Successfully imported files for silverstripe
```

## Related Issue Link(s)

- https://github.com/ddev/ddev/pull/5119



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5234"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

