### PR TITLE
fix: drupal10.1 now complains about trusted_hosts_patterns even with general regex

### DIFF
--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -32,7 +32,11 @@ $settings['skip_permissions_hardening'] = TRUE;
 
 // This will ensure the site can only be accessed through the intended host
 // names. Additional host patterns can be added for custom configurations.
-$settings['trusted_host_patterns'] = ['.*'];
+$settings['trusted_host_patterns'] = [
+    '.*',
+    '.*\.ddev\.site',
+    '127.0.0.1.*',
+];
 
 // Don't use Symfony's APCLoader. ddev includes APCu; Composer's APCu loader has
 // better performance.


### PR DESCRIPTION

## The Issue

Drupal 10.1 is whining about the trusted_host_patterns even though we have always had one.

## How This PR Solves The Issue

Add more to the patterns.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5237"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

