### PR TITLE
docs: remove information about obsolete omit-containers=dba config, fixes #5246

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -141,7 +141,6 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 
 	// Remove dba
 	if nodeps.ArrayContainsString(app.OmitContainers, "dba") || nodeps.ArrayContainsString(app.OmitContainersGlobal, "dba") {
-		util.Warning("PhpMyAdmin (`dba`) is no longer part of DDEV core, please edit your `omit_containers` configuration to remove it")
 		app.OmitContainers = nodeps.RemoveItemFromSlice(app.OmitContainers, "dba")
 		app.OmitContainersGlobal = nodeps.RemoveItemFromSlice(app.OmitContainersGlobal, "dba")
 	}


### PR DESCRIPTION
## The Issue

* #5246

Described in [issue #5646](https://github.com/ddev/ddev/issues/5246): Removes unneeded notice about removed "dba" container

## How This PR Solves The Issue

Removes the string output; keeps configuration strip code in place.

## Manual Testing Instructions

1. Use this patched version
2. Choose any project
3. Edit that project's `.ddev/config.yam` file and add `omit_containers: [dba]` at the end
4. Run the project via `ddev start`
5. You should NOT GET this warning output now: "PhpMyAdmin (`dba`) is no longer part of DDEV core, please edit your `omit_containers` configuration to remove it"
6. Rest of functionality untouched, so the 'dba' container will not try to be referenced.


## Automated Testing Overview

N/A

## Related Issue Link(s)

https://github.com/ddev/ddev/issues/5246

## Release/Deployment Notes

- [x] Remove the explanation about how to resolve these from the "info" sections, https://github.com/ddev/remote-config/blob/e4f777a9d205849c63264b2803e564509dae4042/remote-config.jsonc#L12

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5247"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

