### PR TITLE
docs: update moodle quickstart to use MariaDB 10.6

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -317,7 +317,7 @@ While the generic `php` project type is [ready to go](./project.md) with any CMS
     ## Moodle
 
     ```bash
-    ddev config --composer-root=public --create-docroot --docroot=public --webserver-type=apache-fpm
+    ddev config --composer-root=public --create-docroot --docroot=public --webserver-type=apache-fpm --database=mariadb:10.6
     ddev start
     ddev composer create moodle/moodle -y
     ddev exec 'php public/admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'


### PR DESCRIPTION
## The Issue

[Stack Overflow Question](https://stackoverflow.com/questions/76872710/ddev-moodle-docker/76880321#76880321) points out that Moodle requires MariaDB 10.6, which wasn't in our quickstart.


## Manual Testing Instructions

- [x] Test the Moodle quickstart manually.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

