### PR TITLE
fix: change codespaces forwarding domain name to app.github.dev 

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2542,7 +2542,7 @@ func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs
 	if nodeps.IsCodespaces() {
 		codespaceName := os.Getenv("CODESPACE_NAME")
 		if codespaceName != "" {
-			url := fmt.Sprintf("https://%s-%s.preview.app.github.dev", codespaceName, app.HostWebserverPort)
+			url := fmt.Sprintf("https://%s-%s.app.github.dev", codespaceName, app.HostWebserverPort)
 			httpsURLs = append(httpsURLs, url)
 		}
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2541,8 +2541,9 @@ func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs
 	}
 	if nodeps.IsCodespaces() {
 		codespaceName := os.Getenv("CODESPACE_NAME")
-		if codespaceName != "" {
-			url := fmt.Sprintf("https://%s-%s.app.github.dev", codespaceName, app.HostWebserverPort)
+		previewDomain := os.Getenv("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN")
+		if codespaceName != "" && previewDomain != "" {
+			url := fmt.Sprintf("https://%s-%s.%s", codespaceName, app.HostWebserverPort, previewDomain)
 			httpsURLs = append(httpsURLs, url)
 		}
 	}


### PR DESCRIPTION
## The Issue

Codespaces changed their port forwarding domain from `preview.app.github.dev` to `app.github.dev`

> To prepare for this change, replace any hardcoded references to preview.app.github.dev in your code with the GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN environment variable by July 31 to avoid any disruptions. The environment variable value will be updated from preview.app.github.dev to app.github.dev when the migration completes. Learn more about environments variables [here](https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace).

https://github.blog/changelog/2023-07-14-codespaces-port-forwarding-domain-name-updates/

- `ddev launch` did not work anymore

## How This PR Solves The Issue

- replacing `preview.app.github.dev` with `app.github.dev`

## Manual Testing Instructions

- test `ddev launch` in codespaces / check with `ddev describe` if correct domain is used for ddev project url

Info from @rfay: "testing might be as easy as downloading the artifacts from the PR page and running them on Codespaces."

I haven't done this yet - not quite sure how to exactly do this.
(Demo repo I used recently: https://github.com/mandrasch/ddev-craftcms-vite)

## Automated Testing Overview

- no automated tests are needed?

## Related Issue Link(s)

https://github.com/ddev/ddev/issues/5256

## Release/Deployment Notes

- none -


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5257"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

