### PR TITLE
fix: make GetDockerPlatform() more accurate, fixes #5250

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -63,16 +63,16 @@ func GetDockerPlatform() (string, error) {
 
 	platform := info.OperatingSystem
 	switch {
-	case nodeps.IsWSL2() && info.OSType == "linux":
-		platform = "wsl2-docker-ce"
 	case strings.HasPrefix(platform, "Rancher Desktop"):
 		platform = "rancher-desktop"
 	case strings.HasPrefix(platform, "Docker Desktop"):
 		platform = "docker-desktop"
-	case info.Name == "colima":
+	case strings.HasPrefix(info.Name, "colima"):
 		platform = "colima"
 	case platform == "OrbStack":
 		platform = "orbstack"
+	case nodeps.IsWSL2() && info.OSType == "linux":
+		platform = "wsl2-docker-ce"
 	default:
 		platform = info.OperatingSystem
 	}


### PR DESCRIPTION
## The Issue

* #5250 

Both `docker version` and Amplitude were reporting some thing incorrectly for docker-platform.

## How This PR Solves The Issue

Reorganize the tests.

## Manual Testing Instructions

Use `ddev version` to validate the docker platform on several OSes:

- [x] Test on WSL2 docker-ce
- [x] Test on WSL2 docker-desktop
- [x] Test on macOS Colima with non-default colima profile

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5258"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

