### PR TITLE
fix: provide consistent hash per drupal/backdrop project name, fixes #5255

### DIFF
--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -43,7 +43,7 @@ func NewBackdropSettings(app *DdevApp) *BackdropSettings {
 		DatabaseHost:     "ddev-" + app.Name + "-db",
 		DatabaseDriver:   "mysql",
 		DatabasePort:     GetExposedPort(app, "db"),
-		HashSalt:         util.RandString(64),
+		HashSalt:         util.HashSalt(app.Name),
 		Signature:        nodeps.DdevFileSignature,
 		SiteSettings:     "settings.php",
 		SiteSettingsDdev: "settings.ddev.php",

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -2,7 +2,6 @@ package ddevapp
 
 import (
 	"fmt"
-
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
@@ -50,7 +49,7 @@ func NewDrupalSettings(app *DdevApp) *DrupalSettings {
 		DatabaseHost:     "db",
 		DatabaseDriver:   "mysql",
 		DatabasePort:     GetExposedPort(app, "db"),
-		HashSalt:         util.RandString(64),
+		HashSalt:         util.HashSalt(app.Name),
 		Signature:        nodeps.DdevFileSignature,
 		SitePath:         path.Join("sites", "default"),
 		SiteSettings:     "settings.php",

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"math"
 	"math/rand"
@@ -107,6 +108,14 @@ func RandString(n int) string {
 		b[i] = letterBytes[rand.Intn(len(letterBytes))]
 	}
 	return string(b)
+}
+
+// HashSalt returns a hash of the projectName to be used as a salt.
+// This is appropriate onlly for development work, but means
+// that the HashSalt will be predictable for users on a team
+func HashSalt(projectName string) string {
+	hash := sha256.Sum256([]byte(projectName))
+	return fmt.Sprintf("%x", hash)
 }
 
 // AskForConfirmation requests a y/n from user.


### PR DESCRIPTION
## The Issue

* #5255

Creating a new hash on restart can cause a number of Drupal/Backdrop functions to misbehave

## How This PR Solves The Issue

The hash is now calculated based on the project name. This is inappropriate for production, but should work great for developer situations. It also means that the hash will be the same for all developers on a team.

## Manual Testing Instructions

`ddev start` multiple times and review the `settings.ddev.php` for the project. It should not change, but should be different for different projects.

## Automated Testing Overview


Added TestDrupalBackdropConsistentHash

