### PR TITLE
fix: properly support DDEV_HOST_WEBSERVER_PORT, fixes #1812

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -4100,6 +4100,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.NoError(err)
 	})
 
+	app.DockerEnv()
 	for k, v := range webContainerExpectations {
 		envVal, _, err := app.Exec(&ddevapp.ExecOpts{
 			Cmd: fmt.Sprintf("echo ${%s}", k),
@@ -4118,14 +4119,19 @@ func TestEnvironmentVariables(t *testing.T) {
 		dbPortStr = app.HostDBPort
 	}
 
+	httpPort, err := app.GetPublishedPort("web")
+	require.NoError(t, err)
+	httpsPort, err := app.GetPublishedPortForPrivatePort("web", 443)
+	require.NoError(t, err)
+
 	// This set of hostExpectations should be maintained in parallel with documentation
 	hostExpectations := map[string]string{
 		"DDEV_APPROOT":             app.AppRoot,
 		"DDEV_DOCROOT":             app.GetDocroot(),
 		"DDEV_HOST_DB_PORT":        dbPortStr,
-		"DDEV_HOST_HTTPS_PORT":     app.HostHTTPSPort,
+		"DDEV_HOST_HTTPS_PORT":     strconv.Itoa(httpsPort),
+		"DDEV_HOST_WEBSERVER_PORT": strconv.Itoa(httpPort),
 		"DDEV_HOST_MAILHOG_PORT":   app.HostMailhogPort,
-		"DDEV_HOST_WEBSERVER_PORT": app.HostWebserverPort,
 		"DDEV_HOSTNAME":            app.GetHostname(),
 		"DDEV_PHP_VERSION":         app.PHPVersion,
 		"DDEV_PRIMARY_URL":         app.GetPrimaryURL(),


### PR DESCRIPTION
## The Issue

* #1812 

## How This PR Solves The Issue

Actually figure out what the port is for DDEV_HOST_WEBSERVER_PORT and DDEV_HOST_HTTPS_PORT and provide it.

## Manual Testing Instructions

- [x] Start a project and try to use $DDEV_HOST_WEBSERVER_PORT in a custom command. This should work whether or not the `host_webserver_port` is set in config.yaml

## Automated Testing Overview

Corrected the coverage in TestEnvironmentVariables

## Related Issue Link(s)

* https://github.com/ddev/ddev/pull/5173

## Release/Deployment Notes

After this is done custom commands can implement things like localhost.run, etc.

* https://github.com/ddev/ddev/pull/5173


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5263"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

