### PR TITLE
ci: don't install libpq on macOS any more, postgresql is installed

### DIFF
--- a/.github/workflows/macos-colima-setup.sh
+++ b/.github/workflows/macos-colima-setup.sh
@@ -15,9 +15,9 @@ brew uninstall php || true
 brew untap homebrew/cask || true
 brew untap homebrew/core || true
 echo "====== Running brew install ======"
-brew install -q docker docker-compose jq libpq mkcert mysql-client
+brew install -q docker docker-compose jq mkcert mysql-client
 echo "====== Running brew link ======"
-brew link --force libpq mysql-client
+brew link --force mysql-client
 echo "====== Completed brew link ======"
 
 


### PR DESCRIPTION
## The Issue

Colima tests are all failing. I'm pretty sure we don't need libpq any more.

```
====== Running brew link ======
+ brew link --force libpq mysql-client
Linking /usr/local/Cellar/libpq/15.4... 
Error: Could not symlink bin/clusterdb
Target /usr/local/bin/clusterdb
is a symlink belonging to postgresql@14. You can unlink it:
  brew unlink postgresql@14

To force the link and overwrite all conflicting files:
  brew link --overwrite libpq

To list all files that would be deleted:
  brew link --overwrite --dry-run libpq
```

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5264"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

