### PR TITLE
docs: fix yarn commands link

### DIFF
--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1404,7 +1404,7 @@ ddev xhprof off
 
 ## `yarn`
 
-Run [`yarn` commands](https://yarnpkg.com/getting-started/migration#cli-commands) inside the web container in the root of the project (global shell host container command).
+Run [`yarn` commands](https://yarnpkg.com/cli) inside the web container in the root of the project (global shell host container command).
 
 !!!tip
     Use `--cwd` for another directory.


### PR DESCRIPTION
## The Issue

The yarn folks seem to have updated their site and the link has changed. 



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5265"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

