### PR TITLE
codespaces - remove docker-in-docker since it's installed via universal image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,8 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:0-1-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/universal:2",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
 			"packages": "autojump,curl,wget,xdg-utils"
 		},

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -352,16 +352,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
       "postCreateCommand": "bash -c 'ddev config global --omit-containers=ddev-router && ddev config --auto && ddev debug download-images'"
     }
     ```
-
-    The universal image used above already installs `docker-in-docker`. If you use another image which does not include it, you'll need to add it:
-
-    ```json
-    "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-        "ghcr.io/ddev/ddev/install-ddev:latest": {}
-    },
-    ```
-
+    
     !!!note "Normal Linux installation also works"
         You can also install DDEV as if it were on any normal [Linux installation](#linux).
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -327,13 +327,12 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     * Open your project’s codespace directly, edit the `.devcontainer/devcontainer.json` file, and rebuild the container with VS Code’s “Codespaces: Rebuild Container” action. (<kbd>⌘</kbd> + <kbd>SHIFT</kbd> + <kbd>P</kbd> on a Mac or <kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>P</kbd> on Windows, then search for “rebuild”.)
 
-    Your updated `devcontainer.json` file may differ depending on your project, but you should have `docker-in-docker` and `install-ddev` in the `features` section:
+    Your updated `devcontainer.json` file may differ depending on your project, but you should have `install-ddev` in the `features` section:
 
     ```json
     {
       "image": "mcr.microsoft.com/devcontainers/universal:2",
       "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/ddev/ddev/install-ddev:latest": {}
       },
       "portsAttributes": {
@@ -352,6 +351,15 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
       },
       "postCreateCommand": "bash -c 'ddev config global --omit-containers=ddev-router && ddev config --auto && ddev debug download-images'"
     }
+    ```
+
+    The universal image used above already installs `docker-in-docker`. If you use another image which does not include it, you'll need to add it:
+
+    ```json
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/ddev/ddev/install-ddev:latest": {}
+    },
     ```
 
     !!!note "Normal Linux installation also works"


### PR DESCRIPTION
## The Issue

- it was explained here, that the universal image already installs `docker-in-docker` https://github.com/devcontainers/features/issues/634#issuecomment-1681303196
- `docker-in-docker` feature had no effect and lead to irritating output, since the outputted version info in codespaces creation log had no real effect (since docker was already installed) 

- updated my demo repo https://github.com/mandrasch/ddev-craftcms-vite/blob/main/.devcontainer/devcontainer.json#L4, first tests worked

- We might discuss whether ddev itself should be tested with universal image as well?  https://github.com/ddev/ddev/blob/56afe4bee4170688435510c79135d32d63b7d824/.devcontainer/devcontainer.json#L2-L14 (don't know about ramifications, just a quick idea)

## How This PR Solves The Issue

- updating the docs, removing docker-in-docker from code snippet

## Manual Testing Instructions

- [x] [Ran mkdocs locally](https://discord.com/channels/664580571770388500/1124990159629320262/1124990159629320262)

## Automated Testing Overview

- no automated test option for codespaces available

## Related Issue Link(s)

- https://github.com/devcontainers/features/issues/634#issuecomment-1681303196
- [ ] frontend website https://ddev.com/get-started/ --> codespaces also needs an update, open ticket / PR

## Release/Deployment Notes

no


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5267"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

