### PR TITLE
ci: colima should use macos-13

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         webserver: [nginx-fpm]
         tests: [ test ]
-        os: [ macos-latest ]
+        os: [ macos-13 ]
         no-bind-mounts: ['false']
       fail-fast: true
 


### PR DESCRIPTION
## The Issue

colima tests have been using macos-latest, which is still macos 12. But github has macos-13 (beta) out there.

## How This PR Solves The Issue

Use the newer one.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5272"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

