### PR TITLE
fix: remove cruft from DdevApp

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -82,8 +82,6 @@ type DdevApp struct {
 	PHPVersion                string                 `yaml:"php_version"`
 	WebserverType             string                 `yaml:"webserver_type"`
 	WebImage                  string                 `yaml:"webimage,omitempty"`
-	DBImage                   string                 `yaml:"dbimage,omitempty"`
-	DBAImage                  string                 `yaml:"dbaimage,omitempty"`
 	RouterHTTPPort            string                 `yaml:"router_http_port,omitempty"`
 	RouterHTTPSPort           string                 `yaml:"router_https_port,omitempty"`
 	XdebugEnabled             bool                   `yaml:"xdebug_enabled"`


### PR DESCRIPTION

## The Issue

DdevApp had unused items:

* DBImage was no longer used by anything
* DBAImage no longer exists because dba was removed



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5274"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

