### PR TITLE
build: bump docker-compose to 2.20.3

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -43,4 +43,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.17.2"
 
-const RequiredDockerComposeVersionDefault = "v2.20.0"
+const RequiredDockerComposeVersionDefault = "v2.20.3"


### PR DESCRIPTION
## The Issue

docker-compose 2.20.3 is out. Try it out.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5276"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

