### PR TITLE
docs: add next steps to improve guiding new users, enable footer links

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -22,6 +22,14 @@ These environments can be extended, version controlled, and shared, so you can t
     * Storage: 256GB
     * [Colima](https://github.com/abiosoft/colima) or [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
+    **Next steps:**
+
+    *You’ll need a Docker provider on your system before you can install DDEV.*
+    
+    1. Install Colima (or Docker Desktop) with [recommended settings](users/install/docker-installation.md#macos).
+    1. Install [DDEV for macOS](users/install/ddev-installation.md#macos)
+    1. Launch your [first project](users/project) and start developing 🚀
+
 === "Windows WSL2"
 
     ### Windows WSL2
@@ -30,6 +38,14 @@ These environments can be extended, version controlled, and shared, so you can t
     * Storage: 256GB
     * [Docker Desktop](https://www.docker.com/products/docker-desktop/) on the Windows side or [Docker CE](https://docs.docker.com/engine/install/ubuntu/) inside WSL2
     * Ubuntu or an Ubuntu-derived distro is recommended, though others may work fine
+
+    **Next steps:**
+
+    You’ll need a Docker provider on your system before you can install DDEV.
+    
+    1. Install Docker with [recommended settings](users/install/docker-installation.md#windows).
+    1. Install [DDEV for Windows](users/install/ddev-installation.md#windows)
+    1. Launch your [first project](users/project) and start developing 🚀
 
 === "Traditional Windows"
 
@@ -40,6 +56,14 @@ These environments can be extended, version controlled, and shared, so you can t
     * Storage: 256GB
     * [Docker Desktop](https://www.docker.com/products/docker-desktop/) using the WSL2 backend
 
+    **Next steps:**
+
+    *You’ll need a Docker provider on your system before you can install DDEV.*
+    
+    1. Install Docker with [recommended settings](users/install/docker-installation.md#windows).
+    1. Install [DDEV for Windows](users/install/ddev-installation.md#windows)
+    1. Launch your [first project](users/project) and start developing 🚀
+
 === "Linux"
 
     ### Linux
@@ -49,8 +73,21 @@ These environments can be extended, version controlled, and shared, so you can t
     * RAM: 8GB
     * Storage: 256GB
 
+    **Next steps:**
+
+    *You’ll need a Docker provider on your system before you can install DDEV.*
+    
+    1. Install Docker with [recommended settings](users/install/docker-installation.md#linux).
+    1. Install [DDEV for Linux](users/install/ddev-installation.md#linux)
+    1. Launch your [first project](users/project) and start developing 🚀
+
 === "Gitpod & Codespaces"
 
     ### Gitpod and GitHub Codespaces
 
-    With [Gitpod](https://www.gitpod.io) and [GitHub Codespaces](https://github.com/features/codespaces) you don’t install anything; you only need a browser and an internet connection.
+    With [Gitpod](https://www.gitpod.io) and [GitHub Codespaces](https://github.com/features/codespaces) you don’t install anything on your local computer; You only need a browser and an internet connection.
+
+    **Next steps:**
+
+    1. Install DDEV within [Gitpod](users/install/ddev-installation.md#gitpod) or [GitHub Codespaces](users/install/ddev-installation.md#github-codespaces).
+    1. Launch your [first project](users/project) and start developing 🚀

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -26,9 +26,9 @@ These environments can be extended, version controlled, and shared, so you can t
 
     *You’ll need a Docker provider on your system before you can install DDEV.*
     
-    1. Install Colima (or Docker Desktop) with [recommended settings](users/install/docker-installation.md#macos).
-    1. Install [DDEV for macOS](users/install/ddev-installation.md#macos)
-    1. Launch your [first project](users/project) and start developing 🚀
+    1. Install Colima or Docker Desktop with [recommended settings](users/install/docker-installation.md#macos).
+    2. Install [DDEV for macOS](users/install/ddev-installation.md#macos).
+    3. Launch your [first project](users/project) and start developing. 🚀
 
 === "Windows WSL2"
 
@@ -41,11 +41,11 @@ These environments can be extended, version controlled, and shared, so you can t
 
     **Next steps:**
 
-    You’ll need a Docker provider on your system before you can install DDEV.
+    *You’ll need a Docker provider on your system before you can install DDEV.*
     
     1. Install Docker with [recommended settings](users/install/docker-installation.md#windows).
-    1. Install [DDEV for Windows](users/install/ddev-installation.md#windows)
-    1. Launch your [first project](users/project) and start developing 🚀
+    2. Install [DDEV for Windows](users/install/ddev-installation.md#windows).
+    3. Launch your [first project](users/project) and start developing. 🚀
 
 === "Traditional Windows"
 
@@ -61,8 +61,8 @@ These environments can be extended, version controlled, and shared, so you can t
     *You’ll need a Docker provider on your system before you can install DDEV.*
     
     1. Install Docker with [recommended settings](users/install/docker-installation.md#windows).
-    1. Install [DDEV for Windows](users/install/ddev-installation.md#windows)
-    1. Launch your [first project](users/project) and start developing 🚀
+    2. Install [DDEV for Windows](users/install/ddev-installation.md#windows).
+    3. Launch your [first project](users/project) and start developing. 🚀
 
 === "Linux"
 
@@ -78,8 +78,8 @@ These environments can be extended, version controlled, and shared, so you can t
     *You’ll need a Docker provider on your system before you can install DDEV.*
     
     1. Install Docker with [recommended settings](users/install/docker-installation.md#linux).
-    1. Install [DDEV for Linux](users/install/ddev-installation.md#linux)
-    1. Launch your [first project](users/project) and start developing 🚀
+    2. Install [DDEV for Linux](users/install/ddev-installation.md#linux).
+    3. Launch your [first project](users/project) and start developing. 🚀
 
 === "Gitpod & Codespaces"
 
@@ -90,4 +90,4 @@ These environments can be extended, version controlled, and shared, so you can t
     **Next steps:**
 
     1. Install DDEV within [Gitpod](users/install/ddev-installation.md#gitpod) or [GitHub Codespaces](users/install/ddev-installation.md#github-codespaces).
-    1. Launch your [first project](users/project) and start developing 🚀
+    2. Launch your [first project](users/project) and start developing. 🚀

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -85,7 +85,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
     ### Gitpod and GitHub Codespaces
 
-    With [Gitpod](https://www.gitpod.io) and [GitHub Codespaces](https://github.com/features/codespaces) you don’t install anything on your local computer; You only need a browser and an internet connection.
+    With [Gitpod](https://www.gitpod.io) and [GitHub Codespaces](https://github.com/features/codespaces) you don’t install anything; you only need a browser and an internet connection.
 
     **Next steps:**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,7 @@ theme:
   - navigation.tracking
 #  - toc.follow
 #  - toc.integrate
-
+  - navigation.footer
   favicon: favicon.png
   # readthedocs doesn't seem to do logo css right
 #  logo: /logo.svg


### PR DESCRIPTION
## The Issue

Thought about some UX improvements for the docs start page:

1. new users will often begin their "user journey" on https://ddev.readthedocs.io/en/latest/
1. "System Requirements" section contain external links to Docker Desktop, Colima, etc <br> --> users might exit the process of following next steps ("bounce rate")
1. no call to actions at the end of the start page <br> --> users might exit the process of following next steps ("bounce rate")

Especially the gitpod & codespaces section provides no further link, I completely missed the sub-section https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/#github-codespaces when I explored codespaces.

<img width="743" alt="image" src="https://github.com/ddev/ddev/assets/777278/e61127f5-22c6-4ac1-a88e-b80f8134cbee">

<img width="736" alt="image" src="https://github.com/ddev/ddev/assets/777278/648ad587-55ff-400d-955a-ccfdfdcf297c">

## How This PR Solves The Issue

First I thought about a "next / prev" nav (screenshot example of [vitepress](https://my-ddev-lab.mandrasch.eu/):

<img width="736" alt="image" src="https://github.com/ddev/ddev/assets/777278/01241eaa-d289-4b85-a32c-a2769dcddefe">

But Windows and Linux users would need to re-select the Linux Tab on all upcoming page navigations, therefore not the best solution from UX standpoint.

**Therefore I would like to propose a "next steps" section:**

<img width="758" alt="image" src="https://github.com/ddev/ddev/assets/777278/c25563b8-6794-483f-9664-0b8dbdb2cfc2">

The rocket emoji is of course a matter of personal taste.

Please feel free to change this in any way it fits to DDEV style (if relevant). 🤗

General side notes: 

- The entry page https://ddev.readthedocs.io/en/latest/ could also get more prominent links to Discord, Newsletter, Social Profiles - all the important things to integrate new people into the DDEV community. Don't know how many users start their journey there, but guess its a good portion (next to ddev.com and github repository page)?
- Partners or contributors could be shown there as well to promote trust in DDEV (depends on the goals), see e.g. https://docs.astro.build/en/getting-started/ , https://kit.svelte.dev/docs/introduction, https://nextjs.org/docs for inspiration

## Manual Testing Instructions

- test if links really work
- [x] tested links locally with workaround command `docker run -it -p 8000:8000 -v "${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs:1.2.3`

## Automated Testing Overview

- just docs

## Related Issue Link(s)

## Release/Deployment Notes


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5279"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

