### PR TITLE
feat: initial JSON schemas for global config and project/app config, fixes #4511

### DIFF
--- a/pkg/ddevapp/schema.json
+++ b/pkg/ddevapp/schema.json
@@ -1,0 +1,401 @@
+{
+  "$id": "https://json.schemastore.org/base.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DDEV project config",
+  "description": "Schema for DDEV project config for version 1.22",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "DdevTask": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "exec": {
+            "type": "string"
+          },
+          "exec-host": {
+            "type": "string"
+          },
+          "composer": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "additional_fqdns": {
+      "description": "A comma-delimited list of FQDNs for the project",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "additional_hostnames": {
+      "description": "A comma-delimited list of hostnames for the project",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "bind_all_interfaces": {
+      "description": "Bind host ports on all interfaces, not just on localhost network interface",
+      "type": "boolean"
+    },
+    "composer_root": {
+      "description": "The relative path, from the project root, to the directory containing composer.json. (This is where all Composer-related commands are executed.)",
+      "type": "string"
+    },
+    "composer_version": {
+      "description": "Composer version for the web container and the ddev composer command.",
+      "type": "string"
+    },
+    "database": {
+      "description": "Specify the database type and version to use. Defaults to mariadb:10.3",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Specify the database type to use",
+          "type": "string"
+        },
+        "version": {
+          "description": "Specify the database version to use",
+          "type": "string"
+        }
+      }
+    },
+    "dbimage_extra_packages": {
+      "description": "A list of Debian packages that should be added to db container when the project is started",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "default_container_timeout": {
+      "description": "Seconds DDEV will wait for all containers to become ready.",
+      "type": "integer"
+    },
+    "disable_settings_management": {
+      "description": "Prevent ddev from creating or updating CMS settings files",
+      "type": "boolean"
+    },
+    "disable_upload_dirs_warning": {
+      "description": "Whether to disable the standard warning issued when a project is using performance_mode: mutagen but upload_dirs is not configured.",
+      "type": "boolean"
+    },
+    "docroot": {
+      "description": "Provide the relative docroot of the project, like 'docroot' or 'htdocs' or 'web', defaults to empty, the current directory",
+      "type": "string"
+    },
+    "fail_on_hook_fail": {
+      "description": "Decide whether 'ddev start' should be interrupted by a failing hook",
+      "type": "boolean"
+    },
+    "hooks": {
+      "description": "Run tasks before or after main DDEV commands are executed",
+      "type": "object",
+      "properties": {
+        "pre-start": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-start": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-import-db": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-import-db": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-import-files": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-import-files": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-composer": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-composer": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-stop": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-config": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-config": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-exec": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-exec": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-pause": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-pause": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-pull": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-pull": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-push": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-push": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-snapshot": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-snapshot": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-restore-snapshot": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-restore-snapshot": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-stop": {
+          "$ref": "#/definitions/DdevTask"
+        }
+      }
+    },
+    "host_db_port": {
+      "description": "The db container's localhost-bound port",
+      "type": "string"
+    },
+    "host_dba_port": {
+      "description": "The dba (PHPMyAdmin) container's localhost-bound port, if exposed via bind-all-interfaces",
+      "type": "string"
+    },
+    "host_https_port": {
+      "description": "The web container's localhost-bound https port",
+      "type": "string"
+    },
+    "host_webserver_port": {
+      "description": "The web container's localhost-bound port",
+      "type": "string"
+    },
+    "mailhog_https_port": {
+      "description": "Router port to be used for mailhog access (https)",
+      "type": "string"
+    },
+    "mailhog_port": {
+      "description": "Router port to be used for mailhog access",
+      "type": "string"
+    },
+    "name": {
+      "description": "Provide the name of the project to configure (normally the same as the last part of directory name)",
+      "type": "string"
+    },
+    "nfs_mount_enabled": {
+      "description": "enable NFS mounting of project in container",
+      "type": "boolean"
+    },
+    "ngrok_args": {
+      "description": "Provide extra args to ngrok in ddev share",
+      "type": "string"
+    },
+    "no_project_mount": {
+      "description": "Whether to skip mounting project into web container.",
+      "type": "boolean"
+    },
+    "nodejs_version": {
+      "description": "Node.js version for the web container’s “system” version.",
+      "type": "string",
+      "enum": [
+        "14",
+        "16",
+        "18",
+        "20"
+      ]
+    },
+    "omit_containers": {
+      "description": "A list of container types that should not be started when the project is started",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "override_config": {
+      "description": "Whether to override config values instead of merging.",
+      "type": "boolean"
+    },
+    "performance_mode": {
+      "description": "Defines the performance optimization mode to be used. Currently Mutagen asynchronous caching and NFS are supported. Mutagen is enabled by default on Mac and Windows.",
+      "type": "string",
+      "enum": [
+        "global",
+        "none",
+        "mutagen",
+        "nfs"
+      ]
+    },
+    "php_version": {
+      "description": "The PHP version the project should use.",
+      "type": "string",
+      "enum": [
+        "5.6",
+        "7.0",
+        "7.1",
+        "7.2",
+        "7.3",
+        "7.4",
+        "8.0",
+        "8.1",
+        "8.2",
+        "8.3"
+      ]
+    },
+    "project_tld": {
+      "description": "Set the top-level domain to be used for projects, defaults to ddev.site (default \"ddev.site\")",
+      "type": "string"
+    },
+    "router_http_port": {
+      "description": "The router HTTP port for this project",
+      "type": "string"
+    },
+    "router_https_port": {
+      "description": "The router HTTPS port for this project",
+      "type": "string"
+    },
+    "timezone": {
+      "description": "Specify timezone for containers and php",
+      "type": "string"
+    },
+    "type": {
+      "description": "Provide the project type",
+      "type": "string",
+      "enum": [
+        "backdrop",
+        "craftcms",
+        "django4",
+        "drupal6",
+        "drupal7",
+        "drupal8",
+        "drupal9",
+        "drupal10",
+        "laravel",
+        "magento",
+        "magento2",
+        "php",
+        "python",
+        "shopware6",
+        "silverstripe",
+        "typo3",
+        "wordpress"
+      ]
+    },
+    "upload_dirs": {
+      "description": "Sets multiple project upload directories, the first is taken as the destination directory of the import-files command",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "use_dns_when_possible": {
+      "description": "Use DNS for hostname resolution instead of /etc/hosts when possible",
+      "type": "boolean"
+    },
+    "web_environment": {
+      "description": "Add environment variables to web container",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "web_extra_daemons": {
+      "description": "Additional daemons that should automatically be started in the web container.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "directory": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "web_extra_exposed_ports": {
+      "description": "Additional named sets of ports to expose via ddev-router.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "container_port": {
+            "type": "integer"
+          },
+          "http_port": {
+            "type": "integer"
+          },
+          "https_port": {
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "webimage": {
+      "description": "Sets the web container image",
+      "type": "string"
+    },
+    "webimage_extra_packages": {
+      "description": "A list of Debian packages that should be added to web container when the project is started",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "webserver_type": {
+      "description": "Sets the project's desired webserver type",
+      "type": "string",
+      "enum": [
+        "nginx-fpm",
+        "apache-fpm",
+        "nginx-gunicorn"
+      ]
+    },
+    "working_dir": {
+      "description": "Override default project working directories for db and web service",
+      "type": "object",
+      "properties": {
+        "web": {
+          "description": "Overrides the default working directory for the web service",
+          "type": "string"
+        },
+        "db": {
+          "description": "Overrides the default working directory for the db service",
+          "type": "string"
+        }
+      }
+    },
+    "xdebug_enabled": {
+      "description": "Whether or not XDebug is enabled in the web container",
+      "type": "boolean"
+    }
+  }
+}

--- a/pkg/globalconfig/schema.json
+++ b/pkg/globalconfig/schema.json
@@ -1,0 +1,250 @@
+{
+  "$id": "https://json.schemastore.org/base.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DDEV global config",
+  "description": "Schema for DDEV global config for version 1.22",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "DdevTask": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "exec": {
+            "type": "string"
+          },
+          "exec-host": {
+            "type": "string"
+          },
+          "composer": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "auto_restart_containers": {
+      "description": "If true, automatically restart containers after a reboot or docker restart",
+      "type": "boolean"
+    },
+    "developer_mode": {
+      "description": "Not currently used.",
+      "type": "boolean"
+    },
+    "disable_http2": {
+      "description": "Whether to disable HTTP/2 listen in ddev-router.",
+      "type": "boolean"
+    },
+    "fail_on_hook_fail": {
+      "description": "Whether ddev start should be interrupted by a failing hook, on a single project or for all projects if used globally.",
+      "type": "boolean"
+    },
+    "hooks": {
+      "description": "Run tasks before or after main DDEV commands are executed",
+      "type": "object",
+      "properties": {
+        "pre-start": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-start": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-import-db": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-import-db": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-import-files": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-import-files": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-composer": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-composer": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-stop": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-config": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-config": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-exec": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-exec": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-pause": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-pause": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-pull": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-pull": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-push": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-push": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-snapshot": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-snapshot": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "pre-restore-snapshot": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-restore-snapshot": {
+          "$ref": "#/definitions/DdevTask"
+        },
+        "post-stop": {
+          "$ref": "#/definitions/DdevTask"
+        }
+      }
+    },
+    "instrumentation_opt_in": {
+      "description": "Whether to allow instrumentation reporting.",
+      "type": "boolean"
+    },
+    "instrumentation_queue_size": {
+      "description": "Maximum number of locally collected events for instrumentation reporting.",
+      "type": "integer"
+    },
+    "instrumentation_reporting_interval": {
+      "description": "Reporting interval in hours for instrumentation reporting.",
+      "type": "integer"
+    },
+    "internet_detection_timeout_ms": {
+      "description": "Internet detection timeout in milliseconds.",
+      "type": "integer"
+    },
+    "letsencrypt_email": {
+      "description": "Email associated with Let’s Encrypt feature. (Works in conjunction with use_letsencrypt.) (Not currently compatible with Traefik router.)",
+      "type": "string"
+    },
+    "messages": {
+      "description": "Configure messages like the Tip of the Day.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ticker_interval": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "ticker_interval"
+      ]
+    },
+    "no_bind_mounts": {
+      "description": "Whether to not use Docker bind mounts.",
+      "type": "boolean"
+    },
+    "omit_containers": {
+      "description": "A list of container types that should not be started when the project is started",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "performance_mode": {
+      "description": "Defines the performance optimization mode to be used. Currently Mutagen asynchronous caching and NFS are supported. Mutagen is enabled by default on Mac and Windows.",
+      "type": "string",
+      "enum": [
+        "global",
+        "none",
+        "mutagen",
+        "nfs"
+      ]
+    },
+    "project_tld": {
+      "description": "Set the top-level domain to be used for projects, defaults to ddev.site (default \"ddev.site\")",
+      "type": "string"
+    },
+    "required_docker_compose_version": {
+      "description": "Specific docker-compose version for download.",
+      "type": "string"
+    },
+    "router": {
+      "description": "The PHP version the project should use.",
+      "type": "string",
+      "enum": [
+        "traefik",
+        "nginx-proxy"
+      ]
+    },
+    "router_bind_all_interfaces": {
+      "description": "Whether to bind ddev-router’s ports on all network interfaces.",
+      "type": "boolean"
+    },
+    "router_http_port": {
+      "description": "The router HTTP port for this project",
+      "type": "string"
+    },
+    "router_https_port": {
+      "description": "The router HTTPS port for this project",
+      "type": "string"
+    },
+    "simple_formatting": {
+      "description": "Whether to disable most ddev list and ddev describe table formatting.",
+      "type": "boolean"
+    },
+    "table_style": {
+      "description": "Style for ddev list and ddev describe.",
+      "type": "string",
+      "enum": [
+        "default",
+        "bold",
+        "bright"
+      ]
+    },
+    "traefik_monitor_port": {
+      "description": "Specify an alternate port for the Traefik (ddev-router) monitor port. This defaults to 10999 and rarely needs to be changed, but can be changed in cases of port conflicts.",
+      "type": "string"
+    },
+    "use_docker_compose_from_path": {
+      "description": "Whether to use the system-installed docker-compose. You can otherwise use required_docker_compose_version to specify a version for download.",
+      "type": "boolean"
+    },
+    "use_hardened_images": {
+      "description": "Whether to use hardened images for internet deployment.",
+      "type": "boolean"
+    },
+    "use_letsencrypt": {
+      "description": "hether to enable Let’s Encrypt integration. (Works in conjunction with letsencrypt_email.) (Not currently compatible with Traefik router.)",
+      "type": "boolean"
+    },
+    "web_environment": {
+      "description": "Add environment variables to web container",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "wsl2_no_windows_hosts_mgt": {
+      "description": "(WSL2 only) Whether to disable the management and checking of the Windows hosts file. By default, when using WSL2, DDEV manages the system-wide hosts file on the Windows side (normally C:\\Windows\\system32\\drivers\\etc\\hosts) by using ddev.exe installed on the Windows side. This normally works better for all applications, including browsers and IDEs. However, this behavior can be disabled by setting wsl_no_windows_hosts_mgt: true.",
+      "type": "boolean"
+    },
+    "xdebug_ide_location": {
+      "description": "Adjust Xdebug listen location for WSL2 or in-container.",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
## The Issue

Having IDEs automatically validate the global_config.yaml or config.yaml is useful to help guide valid changes within a specification. This also allows DDEV plugins to leverage a schema file that is maintained in the project, allowing for updates across versions.

This scenario was born from the fact the JetBrains Intellij plugin for DDEV written by @nico-loeber was implementing it's own JSON Schema but it was based on 1.19 and had become outdated. By doing this, we allow other plugins to use a single source of truth to prevent issues with out date options or missing options e.g. project types. Any changes required can be directly submitted to the ddev repository, maintaining a single source of truth,

## How This PR Solves The Issue

This PR provides two JSON schema files which have been validated against test files for the global_config.yml and config.yaml respectively. This is part one of having the schemas included in the main DDEV repository, to then get the schema linked in the schemastore once we have a URL reference.

While the schemas pass validation from the test cases, this is the initial version and there may be other improvements possible, I welcome anyone else with experience with JSON Schemas, given this is my first adventure into them!

Due to DDEV configuration options/features changing, hosting this within DDEV itself is likely the best solution to allow for rapid updates and changes when needed.

## Automated Testing Overview

The two schemas have been tested against a sample global_config.yaml and config.yaml and validates to the strict type validation.

## Related Issue Link(s)

#4511

## Release/Deployment Notes

This would not have any impact of the DDEV software itself, other than shipping two JSON schema files for use by other software.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5281"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

