### PR TITLE
ci: use explicit choices for image name to push [skip ci]

### DIFF
--- a/.github/workflows/push-tagged-image.yml
+++ b/.github/workflows/push-tagged-image.yml
@@ -7,11 +7,19 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: 'Image to be pushed (ddev-php-base, ddev-webserver, NOT ddev-dbserver)'
+        description: 'Image to be pushed)'
         required: true
         default: ddev-webserver
+        type: choice
+        options:
+          - ddev-php-base
+          - ddev-webserver
+          - ddev-ssh-agent
+          - ddev-traefik-router
+          - ddev-nginx-proxy-router
+          - test-ssh-server
       tag:
-        description: Tag for pushed image (v1.19.4 for example)'
+        description: Tag for pushed image (v1.22.2 for example)
         required: true
         default: ""
       debug_enabled:

--- a/.github/workflows/push-tagged-image.yml
+++ b/.github/workflows/push-tagged-image.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: 'Image to be pushed)'
+        description: 'Image to push'
         required: true
         default: ddev-webserver
         type: choice


### PR DESCRIPTION
## The Issue

The `choice` option for the push-tagged-image is a lot easier to use. 

## Manual Testing Instructions

Try building an image

<img width="325" alt="image" src="https://github.com/ddev/ddev/assets/112444/14af1320-3fe9-493b-9fcf-183b60f9e4d8">

<img width="496" alt="image" src="https://github.com/ddev/ddev/assets/112444/1d23506c-84de-4474-867b-68d069c71e20">


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5283"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

