### PR TITLE
docs: fix URL in error message, remove warning in NFS docs

### DIFF
--- a/cmd/ddev/cmd/debug-nfsmount.go
+++ b/cmd/ddev/cmd/debug-nfsmount.go
@@ -64,7 +64,7 @@ var DebugNFSMountCmd = &cobra.Command{
 
 		_, out, err := dockerutil.RunSimpleContainer(docker.GetWebImage(), containerName, []string{"sh", "-c", "findmnt -T /nfsmount && ls -d /nfsmount/.ddev"}, []string{}, []string{}, []string{"testnfsmount" + ":/nfsmount"}, uidStr, true, false, map[string]string{"com.ddev.site-name": ""}, nil)
 		if err != nil {
-			util.Warning("NFS does not seem to be set up yet, see debugging instructions at https://ddev.readthedocs.io/en/stable/users/install/performance/#debugging-ddev-start-failures-with-nfs_mount_enabled-true")
+			util.Warning("NFS does not seem to be set up yet, see debugging instructions at https://ddev.readthedocs.io/en/stable/users/install/performance/#nfs")
 			util.Failed("Details: error=%v\noutput=%v", err, out)
 		}
 		output.UserOut.Printf(strings.TrimSpace(out))

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -194,13 +194,8 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
 
     !!!warning "NFS is deprecated"
 
-        NFS is now deprecated and should no longer be used. This feature may be
-        removed in an upcoming release.
-
-
-    !!!warning "macOS Ventura may not work with NFS"
-
-        A bug in macOS Ventura means that NFS mounting doesn't work for many projects, so Mutagen is recommended instead. Follow [issue](https://github.com/ddev/ddev/issues/4122) for details.
+        NFS is deprecated and no longer recommended. This feature may be
+        removed in a future release.
 
 
     ### Using NFS to Mount the Project into the Web Container


### PR DESCRIPTION
## The Issue

* URL in error message is incorrect
* Warning about NFS on Ventura is incorrect

## How This PR Solves The Issue

Update them



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5284"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

