### PR TITLE
docs: fix custom cert issues - default router has changed

### DIFF
--- a/docs/content/users/extend/custom-tls-certificates.md
+++ b/docs/content/users/extend/custom-tls-certificates.md
@@ -4,6 +4,6 @@ It’s possible to use “real” TLS certificates issued by a CA rather than th
 
 1. Obtain a certificate and key from Let’s Encrypt or another source.
 2. Install the certificate and key in your project’s `.ddev/custom_certs` directory.
-   * If you’re using the default [Traefik](traefik-router.md#traefik-router) (`router: traefik`), the files should be named `<projectname>.crt` and `<projectname>.key`, for example `exampleproj.crt` and `exampleproj.key`.
+   * If you’re using the default [Traefik](traefik-router.md) (`router: traefik`), the files should be named `<projectname>.crt` and `<projectname>.key`, for example `exampleproj.crt` and `exampleproj.key`.
    * If you’re using the legacy nginx-proxy router (`router: nginx-proxy`) , each certificate must be named with the pattern `fqdn.crt` and `fqdn.key`. A project named `example.ddev.site`, for example, would need `example.ddev.site.crt` and `example.ddev.site.key` in `.ddev/custom_certs`. There must be one cert-set for each FQDN handled by the project.
 3. Run [`ddev start`](../usage/commands.md#start) and verify using a browser that you’re using the right certificate.

--- a/docs/content/users/extend/custom-tls-certificates.md
+++ b/docs/content/users/extend/custom-tls-certificates.md
@@ -4,6 +4,6 @@ It’s possible to use “real” TLS certificates issued by a CA rather than th
 
 1. Obtain a certificate and key from Let’s Encrypt or another source.
 2. Install the certificate and key in your project’s `.ddev/custom_certs` directory.
-   * If you’re using the default router, each certificate must be named with the pattern `fqdn.crt` and `fqdn.key`. A project named `example.ddev.site`, for example, would need `example.ddev.site.crt` and `example.ddev.site.key` in `.ddev/custom_certs`. There must be one cert-set for each FQDN handled by the project.
-   * If you’re [using Traefik](traefik-router.md#traefik-router), the files should be named `<projectname>.crt` and `<projectname>.key`, for example `exampleproj.crt` and `exampleproj.key`.
+   * If you’re using the default [Traefik](traefik-router.md#traefik-router) (`router: traefik`), the files should be named `<projectname>.crt` and `<projectname>.key`, for example `exampleproj.crt` and `exampleproj.key`.
+   * If you’re using the legacy nginx-proxy router (`router: nginx-proxy`) , each certificate must be named with the pattern `fqdn.crt` and `fqdn.key`. A project named `example.ddev.site`, for example, would need `example.ddev.site.crt` and `example.ddev.site.key` in `.ddev/custom_certs`. There must be one cert-set for each FQDN handled by the project.
 3. Run [`ddev start`](../usage/commands.md#start) and verify using a browser that you’re using the right certificate.


### PR DESCRIPTION

## The Issue

The default router is now the traefik router, and that makes the verbiage in custom certs section incorrect.

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5287"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

