### PR TITLE
ci: update devcontainer package since we have new devcontainer stuff

### DIFF
--- a/.github/devcontainers/src/install-ddev/devcontainer-feature.json
+++ b/.github/devcontainers/src/install-ddev/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "name": "Install DDEV for Codespaces",
     "id": "install-ddev",
-    "version": "v1.22.0-beta1",
+    "version": "v1.22.2",
     "description": "DDEV feature for Codespaces/devcontainers"
 }

--- a/.github/workflows/macos-colima-setup.sh
+++ b/.github/workflows/macos-colima-setup.sh
@@ -18,6 +18,8 @@ echo "====== Running brew install ======"
 brew install -q docker docker-compose jq mkcert mysql-client
 echo "====== Running brew upgrade ======"
 brew upgrade colima lima
+# see https://github.com/lima-vm/lima/issues/1742
+brew reinstall -f --force-bottle qemu
 echo "====== Running brew link ======"
 brew link --force mysql-client
 echo "====== Completed brew link ======"

--- a/.github/workflows/macos-colima-setup.sh
+++ b/.github/workflows/macos-colima-setup.sh
@@ -6,16 +6,18 @@ sudo chown -R ${USER} /usr/local/*
 
 # colima has golang as dependency, so is going to install go anyway.
 # So we have to get rid of it somehow.
-brew uninstall go@1.15 || true
-brew unlink go || true
-brew uninstall go@1.17 || true
-brew uninstall postgresql || true
-brew uninstall composer || true
-brew uninstall php || true
-brew untap homebrew/cask || true
-brew untap homebrew/core || true
+brew uninstall go@1.15 2>/dev/null || true
+brew unlink go 2>/dev/null || true
+brew uninstall go@1.17 2>/dev/null || true
+brew uninstall postgresql 2>/dev/null || true
+brew uninstall composer 2>/dev/null || true
+brew uninstall php 2>/dev/null || true
+brew untap homebrew/cask 2>/dev/null || true
+brew untap homebrew/core 2>/dev/null || true
 echo "====== Running brew install ======"
 brew install -q docker docker-compose jq mkcert mysql-client
+echo "====== Running brew upgrade ======"
+brew upgrade colima lima
 echo "====== Running brew link ======"
 brew link --force mysql-client
 echo "====== Completed brew link ======"


### PR DESCRIPTION
## The Issue

* A few devcontainer-related changes went in and we want to pick them up
* Colima tests have been failing due to broken macOS running in Github. Update lima to get current



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5289"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

