### PR TITLE
docs: add Ibexa DXP to "CMS Quickstarts"

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -39,6 +39,7 @@ Docs
 Does
 DrupalEasy
 Dump
+DXP
 Enable
 EndeavourOS
 ExecRaw
@@ -62,6 +63,7 @@ Gzipped
 HOWTO
 HeidiSQL
 Homebrew
+Ibexa
 IDE
 IDE's
 IDEs

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -192,6 +192,20 @@ ddev launch
 
     When the installation wizard prompts for database settings, enter `db` for the _DB Server Address_, _DB Name_, _DB Username_, and _DB Password_.
 
+## Ibexa DXP
+
+```bash
+mkdir my-ibexa-project
+cd my-ibexa-project
+ddev config --project-type=php --php-version 8.1 --docroot=public --create-docroot
+ddev config --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
+ddev start
+ddev composer create ibexa/oss-skeleton
+ddev php bin/console ibexa:install
+ddev php bin/console ibexa:graphql:generate-schema
+ddev launch
+```
+
 ## Laravel
 
 Use a new or existing Composer project, or clone a Git repository.

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -194,7 +194,7 @@ ddev launch
 
 ## Ibexa DXP
 
-Install Ibexa DXP OSS Edition. Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/install_with_ddev/) for more cases.
+Install Ibexa DXP OSS Edition.
 
 ```bash
 mkdir my-ibexa-project && cd my-ibexa-project
@@ -206,6 +206,8 @@ ddev php bin/console ibexa:install
 ddev php bin/console ibexa:graphql:generate-schema
 ddev launch
 ```
+
+Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/install_with_ddev/) for more cases.
 
 ## Laravel
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -194,7 +194,7 @@ ddev launch
 
 ## Ibexa DXP
 
-Install Ibexa DXP OSS Edition.
+Install [Ibexa DXP](https://www.ibexa.co) OSS Edition.
 
 ```bash
 mkdir my-ibexa-project && cd my-ibexa-project

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -194,9 +194,10 @@ ddev launch
 
 ## Ibexa DXP
 
+Install Ibexa DXP OSS Edition. Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/install_with_ddev/) for more cases.
+
 ```bash
-mkdir my-ibexa-project
-cd my-ibexa-project
+mkdir my-ibexa-project && cd my-ibexa-project
 ddev config --project-type=php --php-version 8.1 --docroot=public --create-docroot
 ddev config --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
 ddev start


### PR DESCRIPTION
How to quickly install Ibexa DXP OSS

## The Issue

N/A

## How This PR Solves The Issue

N/A

## Manual Testing Instructions

Run the proposed command lines.
It could need the addition of `ddev config --http-port=8080 --https-port=8443` on some platform where ports 443 and/or 80 are already reserved.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
"CMS Quickstarts" scripts do'nt seem to have automated tests. Did I miss something?

## Related Issue Link(s)

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
No side effect.

## Release/Deployment Notes

N/A


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5301"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

