### PR TITLE
docs: fix a tab in "CMS Quickstarts"

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -340,7 +340,7 @@ Use a new or existing Composer project, or clone a Git repository.
     ddev sake dev/build flush=all
     ```
 
- === "Git Clone"
+=== "Git Clone"
 
     ```bash
     git clone <your-silverstripe-repo>


### PR DESCRIPTION
## The Issue

Fix Silverstripe “Git Clone” tab

An indent error was making it seen as raw text instead of tab title.

## How This PR Solves The Issue

Buggy space is removed

## Manual Testing Instructions

On https://ddev.readthedocs.io/en/latest/users/quickstart/#silverstripe "Composer" tab is lonely and followed by a raw `=== “Git Clone”`

With this PR, there should now be two tabs, side by side, titled "Composer" and "Git Clone".

## Automated Testing Overview

N/A
It seems that there is no automated test to check tab syntax in Markdown.
<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

N/A

## Release/Deployment Notes

N/A. Affect nothing else.
<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5302"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

