### PR TITLE
docs: add info about mutagen sync slow due to node_modules

### DIFF
--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -61,7 +61,8 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
 
     * **It may not be the right choice for every project.**<br>
     Filesystem consistency has been excellent with Mutagen, but performance is its specialty. If consistency is your highest priority, then there are reasons to be cautious. Two-way sync is a very difficult computational problem, and problems *may* surface.
-    * **Sync time should not be enormous**: For most projects the initial first-time Mutagen sync of a project is no more than 30 seconds, and subsequent starts take 10 seconds or less. If your project is taking a long time to sync, especially after the initial sync, see [Advanced Configuration](#advanced-mutagen-configuration-options) below to figure out what's taking time and how to bind-mount it.
+    * **The initial sync takes longer.**<br>
+      For most projects, the first-time Mutagen sync of a project takes no more than 30 seconds, and subsequent starts take 10 seconds or less. If your project is taking a long time to sync, especially after the initial sync, see [Advanced Configuration](#advanced-mutagen-configuration-options) below to figure out what's taking time and how to bind-mount it.
     * **Reset if you change `mutagen.yml`.**<br>
     If you take control of the `mutagen.yml` file and make changes to it, run `ddev mutagen reset` after making changes.
     * **Avoid file changes when DDEV is stopped.**<br>

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -67,7 +67,7 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
     * **Avoid file changes when DDEV is stopped.**<br>
     If you change files—checking out a different branch, removing a file—while DDEV is stopped, Mutagen has no way to know about it. When you start again, it will get the files that are stored and bring them back to the host. If you *do* change files while DDEV is stopped, run `ddev mutagen reset` before restarting the project so Mutagen only starts with awareness of the host’s file contents.
     * **It modestly increases disk usage.**<br>
-    Mutagen integration increases the size of your project code’s disk usage, because the code exists both on your computer *and* inside a Docker volume. Your user-uploaded files directories (`upload_dirs`) are normally excluded from mutagen so they're not a problem for most project types or generic configurations where `upload_dirs` is specified. Take care that you have enough overall disk space, and that on macOS you’ve allocated enough file space in Docker Desktop. If you have other large directories you can [exclude specific directories from getting synced](#advanced-mutagen-configuration-options) and use a regular Docker mount for them instead.
+    Mutagen integration increases the size of your project code’s disk usage, because the code exists both on your computer *and* inside a Docker volume. Your user-uploaded files directories (`upload_dirs`) are normally excluded from Mutagen so they're not a problem for most project types or generic configurations where `upload_dirs` is specified. Take care that you have enough overall disk space, and that on macOS you’ve allocated enough file space in Docker Desktop. If you have other large directories you can [exclude specific directories from getting synced](#advanced-mutagen-configuration-options) and use a regular Docker mount for them instead.
     * **Beware simultaneous changes to the same file in both filesystems.**<br>
     As we pointed out above, any project likely to change the same file on the host *and* inside the container may encounter conflicts.
     * **Massive changes can cause problems.**<br>
@@ -171,7 +171,7 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
 
     #### Advanced Mutagen Troubleshooting
 
-    Most people get all the information they need about mutagen by watching `ddev mutagen monitor` in another terminal window to see the results. However, Mutagen has full logging. You can run it with `ddev mutagen logs`.
+    You can observe what Mutagen is doing by watching `ddev mutagen monitor` in another terminal window to see the results. However, Mutagen has full logging. You can run it with `ddev mutagen logs`.
 
     ### Mutagen Strategies and Design Considerations
 

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -59,8 +59,9 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
 
     Mutagen has generally been great for those using it, but it’s good to be aware of its trade-offs:
 
-    * **It’s not the right choice for every project.**<br>
+    * **It may not be the right choice for every project.**<br>
     Filesystem consistency has been excellent with Mutagen, but performance is its specialty. If consistency is your highest priority, then there are reasons to be cautious. Two-way sync is a very difficult computational problem, and problems *may* surface.
+    * For most projects the initial first-time Mutagen sync of a project is no more than 30 seconds, and subsequent starts take 10 seconds or less. If your project is taking a long time to sync, especially after the initial sync, see [Advanced Configuration](#advanced-mutagen-configuration-options) below to figure out what's taking time and how to bind-mount it.
     * **Reset if you change `mutagen.yml`.**<br>
     If you take control of the `mutagen.yml` file and make changes to it, run `ddev mutagen reset` after making changes.
     * **Avoid file changes when DDEV is stopped.**<br>
@@ -139,6 +140,8 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
         volumes:
         - "../web/core/node_modules:/var/www/html/web/core/node_modules"
     ```
+
+    * `ddev mutagen reset` and `ddev start` to get the new configuration.
 
     ### Troubleshooting Mutagen Sync Issues
 

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -85,6 +85,8 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
     On macOS and Linux (including WSL2) the default `.ddev/mutagen/mutagen.yml` chooses the `posix-raw` type of symlink handling. (See [mutagen docs](https://mutagen.io/documentation/synchronization/symbolic-links)). This basically means any symlink created will try to sync, regardless of whether it’s valid in the other environment. Mutagen, however, does not support `posix-raw` on traditional Windows, so DDEV uses the `portable` symlink mode. The result is that on Windows, using Mutagen, symlinks must be strictly limited to relative links that are inside the Mutagen section of the project.
     * **It’s a filesystem feature. Make backups!**<br>
     If we’ve learned anything from computer file-storage adventures, it’s that backups are always a good idea!
+    * **`node_modules` on non-NodeJS projects can cause problems**<br>
+    When using npm, yarn, etc to compile front-end themes on a system that only uses the rendered output from these tools, e.g. Drupal themes, including the `node_modules` directory to be included can cause major performance problems. The recommendation is to exclude the `node_modules` directory by adding it to the sync:defaults:ignore:paths list in mutagen.yml; see below for details.
 
     ### Syncing After `git checkout`
 

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -85,8 +85,8 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
     On macOS and Linux (including WSL2) the default `.ddev/mutagen/mutagen.yml` chooses the `posix-raw` type of symlink handling. (See [mutagen docs](https://mutagen.io/documentation/synchronization/symbolic-links)). This basically means any symlink created will try to sync, regardless of whether it’s valid in the other environment. Mutagen, however, does not support `posix-raw` on traditional Windows, so DDEV uses the `portable` symlink mode. The result is that on Windows, using Mutagen, symlinks must be strictly limited to relative links that are inside the Mutagen section of the project.
     * **It’s a filesystem feature. Make backups!**<br>
     If we’ve learned anything from computer file-storage adventures, it’s that backups are always a good idea!
-    * **`node_modules` on non-NodeJS projects can cause problems**<br>
-    When using npm, yarn, etc to compile front-end themes on a system that only uses the rendered output from these tools, e.g. Drupal themes, including the `node_modules` directory to be included can cause major performance problems. The recommendation is to exclude the `node_modules` directory by adding it to the sync:defaults:ignore:paths list in mutagen.yml; see below for details.
+    * **`node_modules` on non-Node.js projects can cause problems**<br>
+    When you’re compiling static, front-end assets with tools like `npm` and `yarn`, e.g. Drupal themes, including the `node_modules` directory can cause major performance problems. We recommend excluding `node_modules` by adding it to the `sync:defaults:ignore:paths` list in `mutagen.yml`; see below for details.
 
     ### Syncing After `git checkout`
 

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -61,7 +61,7 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
 
     * **It may not be the right choice for every project.**<br>
     Filesystem consistency has been excellent with Mutagen, but performance is its specialty. If consistency is your highest priority, then there are reasons to be cautious. Two-way sync is a very difficult computational problem, and problems *may* surface.
-    * For most projects the initial first-time Mutagen sync of a project is no more than 30 seconds, and subsequent starts take 10 seconds or less. If your project is taking a long time to sync, especially after the initial sync, see [Advanced Configuration](#advanced-mutagen-configuration-options) below to figure out what's taking time and how to bind-mount it.
+    * **Sync time should not be enormous**: For most projects the initial first-time Mutagen sync of a project is no more than 30 seconds, and subsequent starts take 10 seconds or less. If your project is taking a long time to sync, especially after the initial sync, see [Advanced Configuration](#advanced-mutagen-configuration-options) below to figure out what's taking time and how to bind-mount it.
     * **Reset if you change `mutagen.yml`.**<br>
     If you take control of the `mutagen.yml` file and make changes to it, run `ddev mutagen reset` after making changes.
     * **Avoid file changes when DDEV is stopped.**<br>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,3 +193,4 @@ nav:
       - developers/brand-guide.md
       - developers/testing-docs.md
       - developers/writing-style-guide.md
+      - developers/remote-config.md


### PR DESCRIPTION
## The Issue

* #5299

When using npm / 

## How This PR Solves The Issue
This adds a note to the Mutagen section of the performance page about node_modules and the recommendation to exclude it on website projects that doesn't need it at runtime.

## Manual Testing Instructions

Review at https://ddev--5303.org.readthedocs.build/en/5303/users/install/performance/#mutagen

## Automated Testing Overview
*shrug*

## Related Issue Link(s)

* #5299

## Release/Deployment Notes
N/a

<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5303"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

