### PR TITLE
fix: make project network external, fixes #5193

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -249,11 +249,13 @@ networks:
   ddev_default:
     name: ddev_default
     external: true
-  {{if .IsGitpod}}{{/* see https://github.com/ddev/ddev/issues/3766 */}}
   default:
+    name: ${COMPOSE_PROJECT_NAME}_default
+    external: true
+    {{ if .IsGitpod }}{{/* see https://github.com/ddev/ddev/issues/3766 */}}
     driver_opts:
       com.docker.network.driver.mtu: 1440
-  {{end}}
+    {{ end }}
 
 volumes:
   {{if and (not .OmitDB) (ne .DBType "postgres") }}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2558,6 +2558,10 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	}
 
 	// Remove current project network
+	// Working around duplicate network creation problem apparently caused by
+	// https://github.com/docker/compose/issues/6532#issuecomment-769263484
+	// see https://github.com/ddev/ddev/issues/5193 and
+	// https://github.com/ddev/ddev/pull/5305
 	dockerutil.RemoveNetworkWithWarningOnError(os.Getenv("COMPOSE_PROJECT_NAME") + "_default")
 
 	return nil

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2557,6 +2557,9 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 		}
 	}
 
+	// Remove current project network
+	dockerutil.RemoveNetworkWithWarningOnError(os.Getenv("COMPOSE_PROJECT_NAME") + "_default")
+
 	return nil
 }
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -617,7 +617,7 @@ func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
 	// Container (or Volume) ... Creating or Created or Stopping or Starting or Removing
 	// Container Stopped or Created
 	// No resource found to remove (when doing a stop and no project exists)
-	ignoreRegex := "(^ *(Network|Container|Volume) .* (Creat|Start|Stopp|Remov)ing$|^Container .*(Stopp|Creat)(ed|ing)$|Warning: No resource found to remove$|Pulling fs layer|Waiting|Downloading|Extracting|Verifying Checksum|Download complete|Pull complete)"
+	ignoreRegex := "(^ *(Network|Container|Volume) .* (Creat|Start|Stopp|Remov)ing$|^Container .*(Stopp|Creat)(ed|ing)$|Warning: No resource found to remove|Pulling fs layer|Waiting|Downloading|Extracting|Verifying Checksum|Download complete|Pull complete)"
 	downRE, err := regexp.Compile(ignoreRegex)
 	if err != nil {
 		util.Warning("Failed to compile regex %v: %v", ignoreRegex, err)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -59,14 +59,24 @@ func EnsureNetwork(client *docker.Client, name string) error {
 	return nil
 }
 
+// EnsureNetworkWithFatal creates or ensures the provided network exists or
+// exits with fatal.
+func EnsureNetworkWithFatal(name string) {
+	client := GetDockerClient()
+	err := EnsureNetwork(client, name)
+	if err != nil {
+		log.Fatalf("Failed to ensure Docker network %s: %v", name, err)
+	}
+}
+
 // EnsureDdevNetwork creates or ensures the DDEV network exists or
 // exits with fatal.
 func EnsureDdevNetwork() {
 	// Ensure we have the fallback global DDEV network
-	client := GetDockerClient()
-	err := EnsureNetwork(client, NetName)
-	if err != nil {
-		log.Fatalf("Failed to ensure Docker network %s: %v", NetName, err)
+	EnsureNetworkWithFatal(NetName)
+	// Ensure we have the current project network
+	if os.Getenv("COMPOSE_PROJECT_NAME") != "" {
+		EnsureNetworkWithFatal(os.Getenv("COMPOSE_PROJECT_NAME") + "_default")
 	}
 }
 


### PR DESCRIPTION
## The Issue

* #5193 

Sometimes when you start a project, multiple project networks are created (e.g. `ddev-npg_default`) which prevents the project from starting.

```
Error response from daemon: network ddev-npg_default is ambiguous (16 matches found on name)
```

It doesn't happen all the time, but it's really annoying.

## How This PR Solves The Issue

The idea is that if the project's docker network is created before doing the usual stuff, it can prevent the problem from occurring.

Let's make the project's docker network external (just like the `ddev_default` global network).

## Manual Testing Instructions

This PR must *not* break existing features to be considered something valuable to merge.

There is no reliable way to test this, because the issue is related to `docker-compose` (not DDEV itself), and it occurs randomly.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- https://github.com/ddev/ddev/issues/5193

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5305"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

