### PR TITLE
build: use gsudo.exe directly from gerardog/gsudo, for #4701

### DIFF
--- a/.ci-scripts/nsis_setup.sh
+++ b/.ci-scripts/nsis_setup.sh
@@ -24,5 +24,5 @@ curl -sfL -o /tmp/ExecDos.zip https://nsis.sourceforge.io/mediawiki/images/0/0f/
 curl -sfL -o /tmp/ZipDLL.zip https://nsis.sourceforge.io/mediawiki/images/d/d9/ZipDLL.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/ZipDLL.zip && rm /tmp/ZipDLL.zip
 curl -sfL -o /tmp/NsUnzip.zip https://nsis.sourceforge.io/mediawiki/images/8/88/NsUnzip.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/NsUnzip.zip && rm /tmp/NsUnzip.zip
 curl -sfL -o /tmp/NSISunzU.zip https://nsis.sourceforge.io/mediawiki/images/5/5a/NSISunzU.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/NSISunzU.zip && rm /tmp/NSISunzU.zip
-cp "$NSIS_HOME/Plugins/x86-unicode/NSISunzU/Plugin unicode/nsisunz.dll" $NSIS_HOME/Plugins/x86-unicode
+sudo cp "$NSIS_HOME/Plugins/x86-unicode/NSISunzU/Plugin unicode/nsisunz.dll" $NSIS_HOME/Plugins/x86-unicode
 

--- a/.ci-scripts/nsis_setup.sh
+++ b/.ci-scripts/nsis_setup.sh
@@ -10,7 +10,7 @@ if [ $1 = "" ]; then
   echo "first arg must be the NSIS_HOME"
   echo "For example nsis_setup.sh /usr/share/nsis"
   echo "For example nsis_setup.sh /usr/local/share/nsis"
-  echo "For example, nsis_setup.sh /opt/homebrew/Cellar/makensis/3.08/share/nsis"
+  echo "For example, nsis_setup.sh /opt/homebrew/share/nsis"
   echo "For example, nsis_setup.sh /home/linuxbrew/.linuxbrew/Cellar/makensis/3.08/share/nsis"
   echo "For example, nsis_setup.sh /c/Program Files (x86)/NSIS"
   echo "For example, nsis_setup.sh /c/ProgramData/Chocolatey/lib/nsis"

--- a/.ci-scripts/nsis_setup.sh
+++ b/.ci-scripts/nsis_setup.sh
@@ -21,7 +21,6 @@ curl -sfL -o /tmp/nsis.zip https://sourceforge.net/projects/nsis/files/NSIS%203/
 curl -sfL -o /tmp/EnVar-Plugin.zip https://github.com/GsNSIS/EnVar/releases/latest/download/EnVar-Plugin.zip && sudo unzip -o -d $"${NSIS_HOME}" /tmp/EnVar-Plugin.zip && rm /tmp/EnVar-Plugin.zip
 curl -sfL -o /tmp/INetC.zip https://github.com/DigitalMediaServer/NSIS-INetC-plugin/releases/latest/download/INetC.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins" /tmp/INetC.zip && rm /tmp/INetC.zip
 curl -sfL -o /tmp/ExecDos.zip https://nsis.sourceforge.io/mediawiki/images/0/0f/ExecDos.zip && sudo unzip -o -d "${NSIS_HOME}" /tmp/ExecDos.zip && rm /tmp/ExecDos.zip
-curl -sfL -o /tmp/ZipDLL.zip https://nsis.sourceforge.io/mediawiki/images/d/d9/ZipDLL.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/ZipDLL.zip && rm /tmp/ZipDLL.zip
 curl -sfL -o /tmp/NsUnzip.zip https://nsis.sourceforge.io/mediawiki/images/8/88/NsUnzip.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/NsUnzip.zip && rm /tmp/NsUnzip.zip
 curl -sfL -o /tmp/NSISunzU.zip https://nsis.sourceforge.io/mediawiki/images/5/5a/NSISunzU.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/NSISunzU.zip && rm /tmp/NSISunzU.zip
 sudo cp "$NSIS_HOME/Plugins/x86-unicode/NSISunzU/Plugin unicode/nsisunz.dll" $NSIS_HOME/Plugins/x86-unicode

--- a/.ci-scripts/nsis_setup.sh
+++ b/.ci-scripts/nsis_setup.sh
@@ -13,9 +13,16 @@ if [ $1 = "" ]; then
   echo "For example, nsis_setup.sh /opt/homebrew/Cellar/makensis/3.08/share/nsis"
   echo "For example, nsis_setup.sh /home/linuxbrew/.linuxbrew/Cellar/makensis/3.08/share/nsis"
   echo "For example, nsis_setup.sh /c/Program Files (x86)/NSIS"
+  echo "For example, nsis_setup.sh /c/ProgramData/Chocolatey/lib/nsis"
   exit 1
 fi
 NSIS_HOME=$1
 curl -sfL -o /tmp/nsis.zip https://sourceforge.net/projects/nsis/files/NSIS%203/${NSIS_VERSION}/nsis-${NSIS_VERSION}.zip/download && unzip -o -d /tmp/nsistemp /tmp/nsis.zip && sudo mv /tmp/nsistemp/*/* "${NSIS_HOME}" && rm -rf /tmp/nsistemp /tmp/nsis.zip
 curl -sfL -o /tmp/EnVar-Plugin.zip https://github.com/GsNSIS/EnVar/releases/latest/download/EnVar-Plugin.zip && sudo unzip -o -d $"${NSIS_HOME}" /tmp/EnVar-Plugin.zip && rm /tmp/EnVar-Plugin.zip
 curl -sfL -o /tmp/INetC.zip https://github.com/DigitalMediaServer/NSIS-INetC-plugin/releases/latest/download/INetC.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins" /tmp/INetC.zip && rm /tmp/INetC.zip
+curl -sfL -o /tmp/ExecDos.zip https://nsis.sourceforge.io/mediawiki/images/0/0f/ExecDos.zip && sudo unzip -o -d "${NSIS_HOME}" /tmp/ExecDos.zip && rm /tmp/ExecDos.zip
+curl -sfL -o /tmp/ZipDLL.zip https://nsis.sourceforge.io/mediawiki/images/d/d9/ZipDLL.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/ZipDLL.zip && rm /tmp/ZipDLL.zip
+curl -sfL -o /tmp/NsUnzip.zip https://nsis.sourceforge.io/mediawiki/images/8/88/NsUnzip.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/NsUnzip.zip && rm /tmp/NsUnzip.zip
+curl -sfL -o /tmp/NSISunzU.zip https://nsis.sourceforge.io/mediawiki/images/5/5a/NSISunzU.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/NSISunzU.zip && rm /tmp/NSISunzU.zip
+cp "$NSIS_HOME/Plugins/x86-unicode/NSISunzU/Plugin unicode/nsisunz.dll" $NSIS_HOME/Plugins/x86-unicode
+

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -29,7 +29,7 @@ echo "capath=/etc/ssl/certs/" >>~/.curlrc
 
 source ~/.bashrc
 
-for item in ddev/ddev/ddev docker-compose golangci-lint mkcert; do
+for item in certutil ddev/ddev/ddev docker-compose golangci-lint mkcert; do
     brew install $item >/dev/null || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item >/dev/null
 done
 

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -29,7 +29,7 @@ echo "capath=/etc/ssl/certs/" >>~/.curlrc
 
 source ~/.bashrc
 
-for item in certutil ddev/ddev/ddev docker-compose golangci-lint mkcert; do
+for item in ddev/ddev/ddev docker-compose golangci-lint mkcert; do
     brew install $item >/dev/null || /home/linuxbrew/.linuxbrew/bin/brew upgrade $item >/dev/null
 done
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -12,6 +12,7 @@ on:
       - "pkg/**"
       - "third_party/**"
       - "vendor/**"
+      - "winpkg/**"
       - "go.*"
       - "Makefile"
 

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -425,26 +425,45 @@ Section "${GSUDO_NAME}" SecSudo
   SetOutPath "$INSTDIR"
   SetOverwrite try
 
-  ; Copy files
-  File "..\.gotmp\bin\windows_amd64\sudo_license.txt"
-
   ; Set URL and temporary file name
-  !define GSUDO_DEST "$INSTDIR\${GSUDO_SETUP}"
+  !define GSUDO_ZIP_DEST "$INSTDIR\gsudo.portable.zip"
+  !define GSUDO_EXE_DEST "$INSTDIR\${GSUDO_SETUP}"
+  !define GSUDO_LICENSE_URL "https://github.com/gerardog/gsudo/blob/master/LICENSE.txt"
+  !define GSUDO_LICENSE_DEST "$INSTDIR\gsudo_license.txt"
 
-  ; Download installer
-  INetC::get /CANCELTEXT "Skip download" /QUESTION "" "${GSUDO_URL}" "${GSUDO_DEST}" /END
+  ; Download license file
+  INetC::get /CANCELTEXT "Skip download" /QUESTION "" "${GSUDO_LICENSE_URL}" "${GSUDO_LICENSE_DEST}" /END
   Pop $R0 ; return value = exit code, "OK" if OK
 
   ; Check download result
   ${If} $R0 != "OK"
     ; Download failed, show message and continue
     SetDetailsView show
-    DetailPrint "Download of `${GSUDO_NAME}` failed:"
+    DetailPrint "Download of `${GSUDO_NAME}` license file failed:"
     DetailPrint " $R0"
-    MessageBox MB_ICONEXCLAMATION|MB_OK "Download of `${GSUDO_NAME}` has failed, please download it to the DDEV installation folder `$INSTDIR` once this installation has finished. Continue with the rest of the installation."
+    MessageBox MB_ICONEXCLAMATION|MB_OK "Download of `${GSUDO_NAME}` license file has failed, please download it to the DDEV installation folder `$INSTDIR` once this installation has finished. Continue with the rest of the installation."
   ${EndIf}
 
-  !undef GSUDO_DEST
+  ; Download zip file
+  INetC::get /CANCELTEXT "Skip download" /QUESTION "" "https://github.com/gerardog/gsudo/releases/download/v2.4.0/gsudo.portable.zip" "${GSUDO_ZIP_DEST}" /END
+  Pop $R0 ; return value = exit code, "OK" if OK
+
+  ; Check download result
+  ${If} $R0 != "OK"
+    ; Download failed, show message and continue
+    SetDetailsView show
+    DetailPrint "Download of `${GSUDO_NAME}` zip file failed:"
+    DetailPrint " $R0"
+    MessageBox MB_ICONEXCLAMATION|MB_OK "Download of `${GSUDO_NAME}` zip file has failed, please download it to the DDEV installation folder `$INSTDIR` once this installation has finished. Continue with the rest of the installation."
+  ${Else}
+    ; Extract gsudo.exe from the zip file
+    Exec 'unzip "${GSUDO_ZIP_DEST}" x64/gsudo.exe -d "${GSUDO_EXE_DEST}"'
+  ${EndIf}
+
+  !undef GSUDO_ZIP_DEST
+  !undef GSUDO_EXE_DEST
+  !undef GSUDO_LICENSE_URL
+  !undef GSUDO_LICENSE_DEST
 SectionEnd
 
 /**

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -419,6 +419,7 @@ SectionGroupEnd
 /**
  * gsudo application install
  */
+
 Section "${GSUDO_NAME}" SecSudo
   ; Force installation
   SectionIn 1 2 3 RO
@@ -498,6 +499,10 @@ Section "${GSUDO_NAME}" SecSudo
           ; Read expected hash from file
           FileRead $2 $R2
           FileClose $2
+
+          ; Convert both hashes to lowercase for case-insensitive comparison
+          StrCpy $R1 $R1 L
+          StrCpy $R2 $R2 L
 
           ; Compare calculated hash with expected hash
           ${If} $R1 != $R2


### PR DESCRIPTION
## The Issue

* #4701

We want to use gsudo.exe directly from the upstream gerardog/gsudo repository, instead of using our forked one with an implanted old release

## How This PR Solves The Issue

Use the upstream zipball and extract it.

## Manual Testing Instructions

* Remove any sudo.exe from the installer directory C:\Program Files\DDEV
Download the installer from this PR (https://github.com/ddev/ddev/pull/5314#issuecomment-1701925943) and run the installer. 
* Verify that sudo.exe has been installed and can be used



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5314"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

