### PR TITLE
docs: note that the CLI flag `--project-name` is what sets `name` in config.yaml

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -291,9 +291,7 @@ The URL-friendly name DDEV should use to reference the project.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | enclosing directory name | Must be unique; no two projects can have the same name. It’s best if this matches the directory name. If this option is omitted, the project will take the name of the enclosing directory.
-
-!!!note "May also be set via `ddev config --project-name=example-project`. (The flag is `project-name`, not `name`.)"
+| :octicons-file-directory-16: project | enclosing directory name | Must be unique; no two projects can have the same name. It’s best if this matches the directory name. If this option is omitted, the project will take the name of the enclosing directory. This value may also be set via `ddev config --project-name=<name>`. (The `ddev config` flag is `project-name`, not `name`, see [`ddev config` docs](../usage/commands.md#config).)"
 
 ## `ngrok_args`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -293,7 +293,7 @@ The URL-friendly name DDEV should use to reference the project.
 | -- | -- | --
 | :octicons-file-directory-16: project | enclosing directory name | Must be unique; no two projects can have the same name. It’s best if this matches the directory name. If this option is omitted, the project will take the name of the enclosing directory.
 
-!!!note "May also be set via `ddev config --project-name=example-project` (the flag is `project-name` not "name").
+!!!note "May also be set via `ddev config --project-name=example-project` (the flag is `project-name` not 'name')."
 
 ## `ngrok_args`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -293,6 +293,8 @@ The URL-friendly name DDEV should use to reference the project.
 | -- | -- | --
 | :octicons-file-directory-16: project | enclosing directory name | Must be unique; no two projects can have the same name. It’s best if this matches the directory name. If this option is omitted, the project will take the name of the enclosing directory.
 
+!!!note "May also be set via `ddev config --project-name=example-project` (the flag is `project-name` not "name").
+
 ## `ngrok_args`
 
 Extra flags for [configuring ngrok](https://ngrok.com/docs/ngrok-agent/config) when [sharing projects](../topics/sharing.md) with the [`ddev share`](../usage/commands.md#share) command.

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -293,7 +293,7 @@ The URL-friendly name DDEV should use to reference the project.
 | -- | -- | --
 | :octicons-file-directory-16: project | enclosing directory name | Must be unique; no two projects can have the same name. It’s best if this matches the directory name. If this option is omitted, the project will take the name of the enclosing directory.
 
-!!!note "May also be set via `ddev config --project-name=example-project` (the flag is `project-name` not 'name')."
+!!!note "May also be set via `ddev config --project-name=example-project`. (The flag is `project-name`, not `name`.)"
 
 ## `ngrok_args`
 


### PR DESCRIPTION
## The Issue

name in the config yaml needs to be project-name when used with `ddev config`

## How This PR Solves The Issue

Explains that.


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5315"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

