### PR TITLE
docs: textlint is complaining about Zip usage - use ZIP

### DIFF
--- a/.ci-scripts/nsis_setup.sh
+++ b/.ci-scripts/nsis_setup.sh
@@ -14,6 +14,7 @@ if [ $1 = "" ]; then
   echo "For example, nsis_setup.sh /home/linuxbrew/.linuxbrew/Cellar/makensis/3.08/share/nsis"
   echo "For example, nsis_setup.sh /c/Program Files (x86)/NSIS"
   echo "For example, nsis_setup.sh /c/ProgramData/Chocolatey/lib/nsis"
+  echo 'For example, nsis_setup.sh "/c/Program Files (x86)/NSIS"'
   exit 1
 fi
 NSIS_HOME=$1
@@ -23,5 +24,5 @@ curl -sfL -o /tmp/INetC.zip https://github.com/DigitalMediaServer/NSIS-INetC-plu
 curl -sfL -o /tmp/ExecDos.zip https://nsis.sourceforge.io/mediawiki/images/0/0f/ExecDos.zip && sudo unzip -o -d "${NSIS_HOME}" /tmp/ExecDos.zip && rm /tmp/ExecDos.zip
 curl -sfL -o /tmp/NsUnzip.zip https://nsis.sourceforge.io/mediawiki/images/8/88/NsUnzip.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/NsUnzip.zip && rm /tmp/NsUnzip.zip
 curl -sfL -o /tmp/NSISunzU.zip https://nsis.sourceforge.io/mediawiki/images/5/5a/NSISunzU.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/NSISunzU.zip && rm /tmp/NSISunzU.zip
-sudo cp "$NSIS_HOME/Plugins/x86-unicode/NSISunzU/Plugin unicode/nsisunz.dll" $NSIS_HOME/Plugins/x86-unicode
+sudo cp "$NSIS_HOME/Plugins/x86-unicode/NSISunzU/Plugin unicode/nsisunz.dll" "$NSIS_HOME/Plugins/x86-unicode"
 

--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    name: Docs check (spellcheck, markdownlint)
+    name: Docs check (spellcheck, markdownlint, textlint)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/content/users/usage/managing-projects.md
+++ b/docs/content/users/usage/managing-projects.md
@@ -146,10 +146,10 @@ Database imports can be any of the following file types:
 - Gzipped SQL Dump (`.sql.gz`)
 - Xz’d SQL Dump (`.sql.xz`)
 - (Gzipped) Tarball Archive (`.tar`, `.tar.gz`, `.tgz`)
-- Zip Archive (`.zip`)
+- ZIP Archive (`.zip`)
 - stdin
 
-If a Tarball Archive or Zip Archive is provided for the import, you’ll be prompted to specify a path within the archive to use for the import asset. The specified path should provide a raw SQL dump (`.sql`). In the following example, the database we want to import is named `data.sql` and resides at the top level of the archive:
+If a Tarball Archive or ZIP Archive is provided for the import, you’ll be prompted to specify a path within the archive to use for the import asset. The specified path should provide a raw SQL dump (`.sql`). In the following example, the database we want to import is named `data.sql` and resides at the top level of the archive:
 
 ```bash
 ddev import-db


### PR DESCRIPTION
## The Issue

* Minor fixups to pacify linter, which only seemed to complain on master.
* nsis_setup.sh failed on win11-06 because of missing double quote. 



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5323"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

