### PR TITLE
fix: drupal9 and drupal10 shouldn't be used with host-side drush so remove facility

### DIFF
--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -11,13 +11,6 @@ $host = "{{ $config.DatabaseHost }}";
 $port = {{ $config.DatabasePort }};
 $driver = "{{ $config.DatabaseDriver }}";
 
-// If DDEV_PHP_VERSION is not set but IS_DDEV_PROJECT *is*, it means we're running (drush) on the host,
-// so use the host-side bind port on docker IP
-if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
-  $host = "{{ $config.DockerIP }}";
-  $port = {{ $config.DBPublishedPort }};
-}
-
 $databases['default']['default']['database'] = "{{ $config.DatabaseName }}";
 $databases['default']['default']['username'] = "{{ $config.DatabaseUsername }}";
 $databases['default']['default']['password'] = "{{ $config.DatabasePassword }}";

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -11,13 +11,6 @@ $host = "{{ $config.DatabaseHost }}";
 $port = {{ $config.DatabasePort }};
 $driver = "{{ $config.DatabaseDriver }}";
 
-// If DDEV_PHP_VERSION is not set but IS_DDEV_PROJECT *is*, it means we're running (drush) on the host,
-// so use the host-side bind port on docker IP
-if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
-  $host = "{{ $config.DockerIP }}";
-  $port = {{ $config.DBPublishedPort }};
-}
-
 $databases['default']['default']['database'] = "{{ $config.DatabaseName }}";
 $databases['default']['default']['username'] = "{{ $config.DatabaseUsername }}";
 $databases['default']['default']['password'] = "{{ $config.DatabasePassword }}";


### PR DESCRIPTION


## The Issue

In Drupal7 and maybe early Drupal 8 it was common for people to run Drupal's drush (8) on the host side and so there was capability in the settings.ddev.php to allow this. 

However, that's long since obsolete and just causes confusion now. 

## How This PR Solves The Issue

Remove the stanza from settings.ddev.php that set this up.

## Manual Testing Instructions

Use DDEV with D9/D10. You should see a settings.ddev.php that doesn't have the stanza any more.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5328"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

