### PR TITLE
feat: replace ngrok flags in `ddev share` with `--ngrok-args`

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -38,6 +38,7 @@ Dockerfiles
 Docs
 Does
 DrupalEasy
+DrupalEasy's
 Dump
 DXP
 Enable
@@ -658,6 +659,7 @@ vite's
 vite's
 viteserve
 vue
+walkthrough
 web
 webenv
 webhosting

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -319,10 +319,7 @@ Extra flags for [configuring ngrok](https://ngrok.com/docs/ngrok-agent/config) w
 | -- | -- | --
 | :octicons-file-directory-16: project | `` |
 
-Example: `--basic-auth username:pass1234`.
-
-!!!warning
-    Some ngrok flags, such as `--subdomain`, require a paid ngrok account.
+Example: `--basic-auth username:pass1234 --domain foo.ngrok-free.app`.
 
 ## `no_bind_mounts`
 

--- a/docs/content/users/topics/sharing.md
+++ b/docs/content/users/topics/sharing.md
@@ -14,37 +14,44 @@ There are at least three different ways to share a running DDEV project outside 
 
 ## Using `ddev share` (Easiest)
 
-`ddev share` proxies the project via [ngrok](https://ngrok.com) for sharing your project with others on your team or around the world. It’s built into DDEV and requires a free or paid [ngrok.com](https://ngrok.com) account. Run `ddev share` and then give the resultant URL to your collaborator or use it on your mobile device. [Read the basic how-to from DrupalEasy](https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok) or run `ddev share -h` for more.
+`ddev share` proxies the project via [ngrok](https://ngrok.com) for sharing your project with others on your team or around the world. It’s built into DDEV and requires an [ngrok.com](https://ngrok.com) account. Run `ddev share` and then give the resultant URL to your collaborator or use it on your mobile device.
 
-CMSes like WordPress and Magento 2 make this a little harder by only responding to a single base URL that’s coded into the database. ngrok’s $8/month [personal plan](https://ngrok.com/pricing) allows you to use a persistent subdomain so you won’t have to frequently change the base URL.
+!!!tip "How to setup ngrok"
+    Read [Getting Started with ngrok](https://ngrok.com/docs/getting-started/) and run `ddev share -h` for more.
 
-### Setting up a Stable ngrok Subdomain
+    Also see [the basic how-to from DrupalEasy](https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok).
 
-1. Get a paid token with at least the basic plan, and configure it. It will be in `~/.ngrok2/ngrok.yml` as `authtoken`.
-2. Configure `ngrok_args` to use a stable subdomain. In `.ddev/config.yaml`, `ngrok_args: --subdomain wp23` will result in ngrok always using `wp23.ngrok.io` as the URL, so it’s not changing on you all the time.
+CMSes like WordPress and Magento 2 make this a little harder by only responding to a single base URL that’s coded into the database. ngrok allows you to use one static domain for free so you won’t have to frequently change the base URL.
+
+### Setting up a Stable ngrok Domain
+
+1. [Get a free static domain](https://ngrok.com/blog-post/free-static-domains-ngrok-users) from ngrok. Let's say we got `wp23.ngrok-free.app`.
+2. Pass the domain to the ngrok args:
+    * In `.ddev/config.yaml`, `ngrok_args: --domain wp23.ngrok-free.app` will result in ngrok always using `wp23.ngrok-free.app` as the URL, so it’s not changing on you all the time.
+    * Alternatively you can pass the domain directly to `ddev share --ngrok-args "--domain wp23.ngrok-free.app"`
 
 ### WordPress: Change the URL with `wp search-replace`
 
 WordPress only has the one base URL, but the `wp` command is built into DDEV’s web container.
 
-This set of steps assumes an ngrok subdomain of `wp23` and a starting URL of `https://wordpress.ddev.site`.
+This set of steps assumes an ngrok domain of `wp23.ngrok-free.app` and a starting URL of `https://wordpress.ddev.site`.
 
-* Configure `.ddev/config.yaml` to use a custom subdomain: `ngrok_args: --subdomain wp23`.
+* Configure `.ddev/config.yaml` to use a custom domain: `ngrok_args: --domain wp23.ngrok-free.app`.
 * Make a backup of your database with [`ddev export-db`](../usage/commands.md#export-db) or [`ddev shapshot`](../usage/commands.md#snapshot).
-* Edit `wp-config-ddev.php` (or whatever your config is) to change `WP_HOME`, for example, `define('WP_HOME', 'https://wp23.ngrok.io');`
-* `ddev wp search-replace https://wordpress.ddev.site https://wp23.ngrok.io`, assuming your project is configured for `https://wordpress.ddev.site` and your `ngrok_args` are configured for the wp23 subdomain.
+* Edit `wp-config-ddev.php` (or whatever your config is) to change `WP_HOME`, for example, `define('WP_HOME', 'https://wp23.ngrok-free.app');`
+* `ddev wp search-replace https://wordpress.ddev.site https://wp23.ngrok-free.app`, assuming your project is configured for `https://wordpress.ddev.site` and your `ngrok_args` are configured for the `wp23.ngrok-free.app` domain.
 * Now run [`ddev share`](../usage/commands.md#share).
 
 ### Magento2: Change the URL with Magento Tool
 
-This set of steps assumes an ngrok subdomain `mg2`:
+This set of steps assumes an ngrok domain `mg2.ngrok-free.app`:
 
-* Configure `.ddev/config.yaml` to use a custom subdomain with `ngrok_args: --subdomain mg2`.
+* Configure `.ddev/config.yaml` to use a custom domain with `ngrok_args: --domain mg2.ngrok-free.app`.
 * Make a backup of your database.
 * Edit your `.ddev/config.yaml`.
 * Run [`ddev ssh`](../usage/commands.md#ssh).
-* Run `bin/magento setup:store-config:set --base-url="https://mg2.ngrok.io/`.
-* Run [`ddev share`](../usage/commands.md#share) and you’ll see your project at `mg2.ngrok.io`.
+* Run `bin/magento setup:store-config:set --base-url="https://mg2.ngrok-free.app/`.
+* Run [`ddev share`](../usage/commands.md#share) and you’ll see your project at `mg2.ngrok-free.app`.
 
 ## Using nip.io or Custom Name Resolution Locally
 

--- a/docs/content/users/topics/sharing.md
+++ b/docs/content/users/topics/sharing.md
@@ -19,7 +19,6 @@ There are at least three different ways to share a running DDEV project outside 
 !!!tip "ngrok in depth"
     Run `ddev share -h` for more, and consider reading [ngrok’s getting started guide](https://ngrok.com/docs/getting-started/) and [DrupalEasy’s more detailed walkthrough of the `share` command](https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok).
 
-
 CMSes like WordPress and Magento 2 make this a little harder by only responding to a single base URL that’s coded into the database. ngrok allows you to use one static domain for free so you won’t have to frequently change the base URL.
 
 ### Setting up a Stable ngrok Domain

--- a/docs/content/users/topics/sharing.md
+++ b/docs/content/users/topics/sharing.md
@@ -16,10 +16,9 @@ There are at least three different ways to share a running DDEV project outside 
 
 `ddev share` proxies the project via [ngrok](https://ngrok.com) for sharing your project with others on your team or around the world. It’s built into DDEV and requires an [ngrok.com](https://ngrok.com) account. Run `ddev share` and then give the resultant URL to your collaborator or use it on your mobile device.
 
-!!!tip "How to setup ngrok"
-    Read [Getting Started with ngrok](https://ngrok.com/docs/getting-started/) and run `ddev share -h` for more.
+!!!tip "ngrok in depth"
+    Run `ddev share -h` for more, and consider reading [ngrok’s getting started guide](https://ngrok.com/docs/getting-started/) and [DrupalEasy’s more detailed walkthrough of the `share` command](https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok).
 
-    Also see [the basic how-to from DrupalEasy](https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok).
 
 CMSes like WordPress and Magento 2 make this a little harder by only responding to a single base URL that’s coded into the database. ngrok allows you to use one static domain for free so you won’t have to frequently change the base URL.
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1159,12 +1159,11 @@ ddev service enable solr
 [Share the current project](../topics/sharing.md) on the internet via [ngrok](https://ngrok.com).
 
 !!!tip
-    Some ngrok arguments are supported via CLI, but *any* ngrok flag can be specified in the [`ngrok_args` config setting](../configuration/config.md#ngrok_args).
+    Any ngrok flag can also be specified in the [`ngrok_args` config setting](../configuration/config.md#ngrok_args).
 
 Flags:
 
-* `--basic-auth`: Username and password, separated by a colon.
-* `--subdomain`: Subdomain to use with paid ngrok account.
+* `--ngrok-args`: Accepts any flag from `ngrok http --help`.
 
 Example:
 
@@ -1172,11 +1171,11 @@ Example:
 # Share the current project with ngrok
 ddev share
 
-# Share the current project with ngrok, using subdomain `foo.*`
-ddev share --subdomain foo
+# Share the current project with ngrok, using domain `foo.ngrok-free.app`
+ddev share --ngrok-args "--domain foo.ngrok-free.app"
 
 # Share the current project using ngrok’s basic-auth argument
-ddev share --basic-auth username:pass1234
+ddev share --ngrok-args "--basic-auth username:pass1234"
 
 # Share my-project with ngrok
 ddev share my-project


### PR DESCRIPTION
## The Issue

From [Discord](https://discord.com/channels/664580571770388500/1068592266752573440/1150669419123589211): documentation needs to be updated because ngrok introduced [static domains for all ngrok users](https://ngrok.com/blog-post/free-static-domains-ngrok-users).

Also, from [new ngrok domains now available](https://ngrok.com/blog-post/new-ngrok-domains):

> Deprecated `--subdomain` and `--hostname` flags in favor of `--domain` flag which accepts a fully qualified domain.

## How This PR Solves The Issue

1. Updates the documentation with the latest changes from ngrok.
2. Removes `--basic-auth` and `--subdomain` from `ddev share`.
3. Adds `--ngrok-args` to `ddev share`.

If I want to run something custom, I need to use `ngrok_args` from `.ddev/config.yaml`. But I never want to commit `ngrok_args`, I can use `config.local.yaml`, but editing the file is tedious. 

It is much better to have the ability to run any ngrok flag directly from `ddev share`. This change makes `ddev share` independent of some ngrok flags that were changed so many times:
* `-subdomain` > `--subdomain` > `--domain`
* `--auth` > `--basic-auth`

This way there is no need to update flags into `ddev share` so often.

## Manual Testing Instructions

1. `ddev start`
2. `ddev share --ngrok-args "--basic-auth username:pass1234"`
3. [Get a free static domain](https://ngrok.com/blog-post/free-static-domains-ngrok-users).
4. `ddev share --ngrok-args "--domain <ngrok-domain>"`

View changes in docs:
 * https://ddev--5331.org.readthedocs.build/en/5331/users/usage/commands/#share
 * https://ddev--5331.org.readthedocs.build/en/5331/users/configuration/config/#ngrok_args
 * https://ddev--5331.org.readthedocs.build/en/5331/users/topics/sharing/#using-ddev-share-easiest

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5331"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

