### PR TITLE
build: bump images to v1.22.2, fixes #5310

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM ddev/ddev-php-base:20230831_replace_mailhog_with_mailpit as ddev-webserver-base
+FROM ddev/ddev-php-base:v1.22.2 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,22 +15,22 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20230831_replace_mailhog_with_mailpit" // Note that this can be overridden by make
+var WebTag = "v1.22.2" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20230911_fix_dbserver"
+var BaseDBTag = "v1.22.2"
 
-const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:20230816_traefik_image"
-const TraefikRouterImage = "ddev/ddev-traefik-router:20230816_traefik_image"
+const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.22.2"
+const TraefikRouterImage = "ddev/ddev-traefik-router:v1.22.2"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.22.0"
+var SSHAuthTag = "v1.22.2"
 
 // Busybox is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION
## The Issue

* #5310

Time to bump images. This brings us to v1.22.2



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5333"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

