### PR TITLE
docs: document bind_all_interfaces project config, fixes #5280

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -63,7 +63,7 @@ The wildcard (`*`) setting only works if you’re using DNS to resolve hostnames
 
 ## `bind_all_interfaces`
 
-When the network interfaces of a project should be exposed to the local network, you can specify `bind_all_interfaces: true` to do that. This is sometimes used to share projects on a local network, see [Sharing Your Project](../topics/sharing.md#exposing-a-host-port-and-providing-a-direct-url). This is an unusual application.
+When the network interfaces of a project should be exposed to the local network, you can specify `bind_all_interfaces: true` to do that. This is an unusual application, sometimes used to [share projects on a local network](../topics/sharing.md#exposing-a-host-port-and-providing-a-direct-url).
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -61,6 +61,14 @@ Example: `additional_hostnames: ["somename", "someothername", "*.thirdname"]` wo
 
 The wildcard (`*`) setting only works if you’re using DNS to resolve hostnames (default) and connected to the internet.
 
+## `bind_all_interfaces`
+
+When the network interfaces of a project should be exposed to the local network, you can specify `bind_all_interfaces: true` to do that. This is sometimes used to share projects on a local network, see [Sharing Your Project](../topics/sharing.md#exposing-a-host-port-and-providing-a-direct-url). This is an unusual application.
+
+| Type | Default | Usage
+| -- | -- | --
+| :octicons-globe-16: global | `false` | Can be `true` or `false`.
+
 ## `composer_root`
 
 The relative path, from the project root, to the directory containing `composer.json`. (This is where all Composer-related commands are executed.)


### PR DESCRIPTION
## The Issue

* #5280

the `bind_all_interfaces` option is not shown in config.md

Review at https://ddev--5334.org.readthedocs.build/en/5334/users/configuration/config/#bind_all_interfaces


<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5334"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

