### PR TITLE
fix: make host_webserver_port and host_https_port config work again, fixes #5341

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -159,7 +159,7 @@ services:
     hostname: {{ .Name }}-web
 
     ports:
-      - "{{ .DockerIP }}:$DDEV_HOST_WEBSERVER_PORT:80"
+      - "{{ .DockerIP }}:$DDEV_HOST_HTTP_PORT:80"
       - "{{ .DockerIP }}:$DDEV_HOST_HTTPS_PORT:443"
     {{ if .HostMailpitPort }}
       - "{{ .DockerIP }}:{{ .HostMailpitPort }}:8025"

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2016,11 +2016,15 @@ func (app *DdevApp) DockerEnv() {
 		dbPortStr = app.HostDBPort
 	}
 
-	// Figure out what the host-webserver port is
+	// Figure out what the host-webserver (host-http) port is
+	// First we try to see if there's an existing webserver container and use that
 	hostHTTPPort, err := app.GetPublishedPort("web")
 	hostHTTPPortStr := ""
+	// Otherwise we'll use the configured value from app.HostWebserverPort
 	if hostHTTPPort > 0 || err == nil {
 		hostHTTPPortStr = strconv.Itoa(hostHTTPPort)
+	} else {
+		hostHTTPPortStr = app.HostWebserverPort
 	}
 
 	// Figure out what the host-webserver https port is
@@ -2030,6 +2034,9 @@ func (app *DdevApp) DockerEnv() {
 	hostHTTPSPortStr := ""
 	if hostHTTPSPort > 0 || err == nil {
 		hostHTTPSPortStr = strconv.Itoa(hostHTTPSPort)
+	} else {
+		hostHTTPSPortStr = app.HostHTTPSPort
+
 	}
 
 	// DDEV_DATABASE_FAMILY can be use for connection URLs
@@ -2059,6 +2066,7 @@ func (app *DdevApp) DockerEnv() {
 
 		"DDEV_HOST_DB_PORT":        dbPortStr,
 		"DDEV_HOST_MAILPIT_PORT":   app.HostMailpitPort,
+		"DDEV_HOST_HTTP_PORT":      hostHTTPPortStr,
 		"DDEV_HOST_HTTPS_PORT":     hostHTTPSPortStr,
 		"DDEV_HOST_WEBSERVER_PORT": hostHTTPPortStr,
 		"DDEV_MAILPIT_PORT":        app.GetMailpitPort(),


### PR DESCRIPTION
## The Issue

* #5341 
* There didn't seem to be any test coverage for this regression

## How This PR Solves The Issue

* Make it work on `ddev restart`
* Add a test

## Manual Testing Instructions

- [x] `ddev config --host-webserver-port=9998 --host-https-port=9999 && ddev restart`
- [x] If you use the https (or http) port provided by `ddev start` you it should be on port 9999 and should function. So test `https://localhost:9999`
- [x] Test and make sure it works correctly on gitpod (especially `ddev launch`)

## Automated Testing Overview

Added TestConfigFunctionality



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5353"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

