### PR TITLE
fix: add PHP 8.3 to list of versions in config template

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -11,7 +11,7 @@ const ConfigInstructions = `
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "8.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2"
+# php_version: "8.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"
 
 # You can explicitly specify the webimage but this
 # is not recommended, as the images are often closely tied to DDEV's' behavior,


### PR DESCRIPTION
## The Issue

PHP 8.3 is missing in the list of available PHP versions in the template for the configuration file.

## How This PR Solves The Issue

This PR adds PHP 8.3 to the list.

## Manual Testing Instructions

After `ddev config` you should be able to see PHP 8.3 at the end of the list of available PHP versions in `config.yaml`.

