### PR TITLE
build: bump images to v1.22.3 for release

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM ddev/ddev-php-base:v1.22.2 as ddev-webserver-base
+FROM ddev/ddev-php-base:v1.22.3 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,22 +15,22 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.22.2" // Note that this can be overridden by make
+var WebTag = "v1.22.3" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.22.2"
+var BaseDBTag = "v1.22.3"
 
-const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.22.2"
-const TraefikRouterImage = "ddev/ddev-traefik-router:v1.22.2"
+const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.22.3"
+const TraefikRouterImage = "ddev/ddev-traefik-router:v1.22.3"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.22.2"
+var SSHAuthTag = "v1.22.3"
 
 // Busybox is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION
## The Issue

Bump images to v1.22.3 for release.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5357"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

