### PR TITLE
Update import-db parameter --target-db to --database

### DIFF
--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -29,9 +29,9 @@ DDEV creates a default database named `db` and default permissions for the `db` 
 
 ## Extra Databases
 
-You can easily create and populate additional databases. For example, `ddev import-db --target-db=backend --file=backend.sql.gz` will create the database named `backend` with permissions for that same `db` user and import from the `backend.sql.gz dumpfile`.
+You can easily create and populate additional databases. For example, `ddev import-db --database=backend --file=backend.sql.gz` will create the database named `backend` with permissions for that same `db` user and import from the `backend.sql.gz` dumpfile.
 
-You can export in the same way: `ddev export-db -f mysite.sql.gz` will export your default database (`db`). `ddev export-db --target-db=backend -f backend-export.sql.gz` will dump the database named `backend`.
+You can export in the same way: `ddev export-db -f mysite.sql.gz` will export your default database (`db`). `ddev export-db --database=backend -f backend-export.sql.gz` will dump the database named `backend`.
 
 ## Snapshots
 


### PR DESCRIPTION
## The Issue

The `import-db` parameter `--target-db` is used, but should be `--database` under [Database Management > Extra Databases](https://ddev.readthedocs.io/en/latest/users/usage/database-management/#extra-databases).

## How This PR Solves The Issue

Update parameter `--target-db` to `--database`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

