### PR TITLE
docs: platform.yaml shouldn't say it is an example

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -1,5 +1,7 @@
 #ddev-generated
-# Example Platform.sh provider configuration.
+# Platform.sh provider configuration. This works out of the box, but can be edited to add
+# your own preferences. If you edit it, remove the `#ddev-generated` line from the top so
+# that it won't be overwritten.
 
 # Consider using `ddev get ddev/ddev-platformsh` (https://github.com/ddev/ddev-platformsh) for more
 # complete platform integration.


### PR DESCRIPTION
## The Issue

The platform.yaml still said it was an "example", whereas you don't have to do anything to use it.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5369"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

