### PR TITLE
feat: provide more user info on ddev start

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1394,6 +1394,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
 		dependers = append(dependers, "db")
 	}
+	output.UserOut.Printf("Waiting for web/db containers to become ready: %v", dependers)
 	err = app.Wait(dependers)
 	if err != nil {
 		util.Warning("Failed waiting for web/db containers to become ready: %v", err)
@@ -1411,7 +1412,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	// WebExtraDaemons have to be started after Mutagen sync is done, because so often
 	// they depend on code being synced into the container/volume
 	if len(app.WebExtraDaemons) > 0 {
-		util.Debug("Starting web_extra_daaemons")
+		output.UserOut.Printf("Starting web_extra_daaemons...")
 		stdout, stderr, err := app.Exec(&ExecOpts{
 			Cmd: `supervisorctl start webextradaemons:*`,
 		})
@@ -1429,18 +1430,19 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	if !IsRouterDisabled(app) {
+		output.UserOut.Printf("Starting ddev-router if necessary...")
 		err = StartDdevRouter()
 		if err != nil {
 			return err
 		}
 	}
 
-	util.Debug("Waiting for all project containers to become ready")
+	output.UserOut.Printf("Waiting for additional project containers to become ready...")
 	err = app.WaitByLabels(map[string]string{"com.ddev.site-name": app.GetName()})
 	if err != nil {
 		return err
 	}
-	util.Debug("Project containers are now ready")
+	output.UserOut.Printf("All project containers are now ready.")
 
 	if _, err = app.CreateSettingsFile(); err != nil {
 		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1333,7 +1333,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		if !mounted {
 			util.Failed("Mutagen Docker volume is not mounted. Please use `ddev restart`")
 		}
-		output.UserOut.Printf("Starting Mutagen sync process... This can take some time.")
+		output.UserOut.Printf("Starting Mutagen sync process...")
 		mutagenDuration := util.ElapsedDuration(time.Now())
 
 		err = SetMutagenVolumeOwnership(app)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1412,7 +1412,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	// WebExtraDaemons have to be started after Mutagen sync is done, because so often
 	// they depend on code being synced into the container/volume
 	if len(app.WebExtraDaemons) > 0 {
-		output.UserOut.Printf("Starting web_extra_daaemons...")
+		output.UserOut.Printf("Starting web_extra_daemons...")
 		stdout, stderr, err := app.Exec(&ExecOpts{
 			Cmd: `supervisorctl start webextradaemons:*`,
 		})


### PR DESCRIPTION
## The Issue

People don't know what is going on during `ddev start` and so can't understand when it pauses for some time.

It can be waiting for containers to become ready, etc.

## How This PR Solves The Issue

Output when key sections start (and in some cases, when they end)

## TODO:

- [ ] Consider showing additional containers we're waiting for during start

## Manual Testing Instructions

Use `ddev restart`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5370"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

