### PR TITLE
test: close xdebug listening port after opening to avoid "listen tcp :9003: bind: address already in use" errors

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1053,11 +1053,12 @@ func TestDdevXdebugEnabled(t *testing.T) {
 
 		select {
 		case <-acceptListenDone:
+			listener.Close()
 			fmt.Printf("Read from acceptListenDone at %v\n", time.Now())
 		case <-time.After(time.Second * 11):
+			listener.Close()
 			t.Fatalf("Timed out waiting for accept/listen at %v, PHP version %v\n", time.Now(), v)
 		}
-		listener.Close()
 	}
 	runTime()
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1057,6 +1057,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 		case <-time.After(time.Second * 11):
 			t.Fatalf("Timed out waiting for accept/listen at %v, PHP version %v\n", time.Now(), v)
 		}
+		listener.Close()
 	}
 	runTime()
 }


### PR DESCRIPTION
In working on #5340 `TestDdevXdebugEnabled` was failing were not passing with random (but frequent) failure of `TestDdevXdebugEnabled` with

```
    ddevapp_test.go:989: 
        	Error Trace:	/home/runner/work/ddev/ddev/pkg/ddevapp/ddevapp_test.go:989
        	Error:      	Received unexpected error:
        	            	listen tcp :9003: bind: address already in use
        	Test:       	TestDdevXdebugEnabled
```

i.e. https://github.com/ddev/ddev/actions/runs/6273418171/job/17036856628#step:17:3502

These commits were previously on that issue and since then this test hasn't failed again.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5372"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

