### PR TITLE
docs: mention the PR title rules with a link to them

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+<!-- 
+  PR titles have very precise rules, please read 
+  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
+-->
+
 ## The Issue
 
 ## How This PR Solves The Issue


### PR DESCRIPTION
I learned about the PR title rules by the github action check failing, I know always have to look for the docs, I think it's probably handy to mention it on the PR template with the proper URL.