### PR TITLE
ci: remove TestDdevPause because it's flaky and unuseful

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2835,7 +2835,6 @@ func TestDdevDescribe(t *testing.T) {
 	app := &ddevapp.DdevApp{}
 
 	site := TestSites[0]
-	switchDir := site.Chdir()
 
 	testcommon.ClearDockerEnv()
 	err := app.Init(site.Dir)
@@ -2879,8 +2878,6 @@ func TestDdevDescribe(t *testing.T) {
 	assert.NoError(err)
 	err = os.Remove("hello-post-describe-" + app.Name)
 	assert.NoError(err)
-
-	switchDir()
 }
 
 // TestDdevDescribeMissingDirectory tests that the describe command works properly on sites with missing directories or DDEV configs.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2849,7 +2849,11 @@ func TestDdevDescribe(t *testing.T) {
 		err = app.WriteConfig()
 		assert.NoError(err)
 	})
-	app.Hooks = map[string][]ddevapp.YAMLTask{"post-describe": {{"exec-host": "touch hello-post-describe-" + app.Name}}, "pre-describe": {{"exec-host": "touch hello-pre-describe-" + app.Name}}}
+	err = os.Chdir(site.Dir)
+	require.NoError(t, err)
+	app.Hooks = map[string][]ddevapp.YAMLTask{"post-describe": {{"exec-host": "touch ${DDEV_APPROOT}/hello-post-describe-" + app.Name}}, "pre-describe": {{"exec-host": "touch ${DDEV_APPROOT}/hello-pre-describe-" + app.Name}}}
+	err = app.WriteConfig()
+	require.NoError(t, err)
 
 	startErr := app.StartAndWait(0)
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -269,22 +269,18 @@ func ContainerCheck(checkName string, checkState string) (bool, error) {
 		log.Fatal(err)
 	}
 
-	containers, err := dockerutil.GetDockerContainers(true)
+	c, err := dockerutil.FindContainerByName(checkName)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	for _, container := range containers {
-		name := dockerutil.ContainerName(container)
-		if name == checkName {
-			if container.State == checkState {
-				return true, nil
-			}
-			return false, errors.New("container " + name + " returned " + container.State)
-		}
+	if c == nil {
+		return false, errors.New("unable to find container " + checkName)
 	}
 
-	return false, errors.New("unable to find container " + checkName)
+	if c.State == checkState {
+		return true, nil
+	}
+	return false, errors.New("container " + checkName + " returned " + c.State)
 }
 
 // GetCachedArchive returns a directory populated with the contents of the specified archive, either from cache or


### PR DESCRIPTION


## The Issue

TestDdevPause often fails. Apparently `docker-compose stop` is a gentle stop, and may not immediately result in the expected `exited` state for containers. 

## How This PR Solves The Issue

Remove the unuseful and flaky TestDdevPause
Minor simplification to ContainerCheck(), used only in a couple of tests.

