### PR TITLE
feat: support Env writing without overwriting existing values

### DIFF
--- a/pkg/ddevapp/envfile.go
+++ b/pkg/ddevapp/envfile.go
@@ -42,7 +42,7 @@ func WriteProjectEnvFile(envFilePath string, envMap map[string]string, envText s
 
 // WriteProjectEnvFileNoOverwrite writes the passed envText into the project-root .env file
 // with all items in envMap added that do not already exist
-func WriteProjectEnvFileNoOverwrite(envFilePath string, envMap map[string]string, envText string, overwrite) error {
+func WriteProjectEnvFileNoOverwrite(envFilePath string, envMap map[string]string, envText string) error {
 	// envFilePath := filepath.Join(app.AppRoot, ".env")
 	for k, v := range envMap {
 		// If the item is already in envText (checking via regex)

--- a/pkg/ddevapp/envfile.go
+++ b/pkg/ddevapp/envfile.go
@@ -39,3 +39,23 @@ func WriteProjectEnvFile(envFilePath string, envMap map[string]string, envText s
 	}
 	return nil
 }
+
+// WriteProjectEnvFileNoOverwrite writes the passed envText into the project-root .env file
+// with all items in envMap added that do not already exist
+func WriteProjectEnvFileNoOverwrite(envFilePath string, envMap map[string]string, envText string, overwrite) error {
+	// envFilePath := filepath.Join(app.AppRoot, ".env")
+	for k, v := range envMap {
+		// If the item is already in envText (checking via regex)
+		// do nothing, otherwise append it to the envText.
+		exp := regexp.MustCompile(fmt.Sprintf(`((^|[\r\n]+)%s)=(.*)`, k))
+		if !exp.MatchString(envText) {
+			envText = strings.TrimSuffix(envText, "\n")
+			envText = fmt.Sprintf("%s\n%s=%s\n", envText, k, v)
+		}
+	}
+	err := fileutil.TemplateStringToFile(envText, nil, envFilePath)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/ddevapp/silverstripe.go
+++ b/pkg/ddevapp/silverstripe.go
@@ -56,7 +56,7 @@ func silverstripePostStartAction(app *DdevApp) error {
 		"SS_DEFAULT_ADMIN_USERNAME": "admin",
 		"SS_DEFAULT_ADMIN_PASSWORD": "password",
 	}
-	err = WriteProjectEnvFile(envFilePath, envMap, envText)
+	err = WriteProjectEnvFileNoOverwrite(envFilePath, envMap, envText)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
(Surprised this hasn't been brought up before. 🤔 )

Currently in the `pkg/ddevapp/silverstripe.go` file it has logic to ensure you have some basic required `.env` details present.

The implementation actually overwrites some of these details locally.

Arguably `.env` values are specific and shouldn't necessarily be overwritten.

There should be a way to **create if it does not exist**, I couldn't see this in the `envfile.go` file.

### Current work around
Adding details you wish to persist to `.ddev/config.yaml` `web_environment: []`
This isn't a satisfactory solution as you shouldn't have to maintain two "env" files.


## How This PR Solves The Issue

This PR solves this by adding a new function that allows writing to `.env` only when the value **does not** already exist.
It also includes a valid usage of it for Silverstripe sites.

Summary of Changes:
1. Added the function `WriteProjectEnvFileNoOverwrite` to `pkg/ddevapp/envfile.go`
2. Implementation in `silverstripe.go`


## Manual Testing Instructions
### Step 1
Get Silverstripe running via composer
```bash
mkdir my-silverstripe-app
cd my-silverstripe-app
ddev config --project-type=silverstripe --docroot=public --create-docroot
ddev composer create --prefer-dist --no-scripts silverstripe/installer -y
ddev start
ddev sake dev/build flush=all
```

This ensures a silverstripe site is created and running.

### Step 2
Edit the .env file eg
```env
SS_DATABASE_SERVER="foo"
SS_DATABASE_USERNAME="bar"
SS_DATABASE_PASSWORD="fizz"
SS_DATABASE_NAME="bang"
```

```bash
ddev start
```

Your `.env` values above should stay how it was above ⬆️ ✅ 

Without this PR they'd be changing to. i.e. ⬇️ ❌
```env
SS_DATABASE_SERVER="db"
SS_DATABASE_USERNAME="db"
SS_DATABASE_PASSWORD="db"
SS_DATABASE_NAME="db"
```


## Automated Testing Overview
I've never written Go before
Any help on whats needed here would be appreciated.


I would hazard that a new function means new tests
<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes
New function might be useful for other project types, worth mentioning in documentation?
<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

