### PR TITLE
fix: drupal9+ shouldn't try to configure db if db container omitted

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -378,7 +378,7 @@ func drupal8PostStartAction(app *DdevApp) error {
 }
 
 func drupalPostStartAction(app *DdevApp) error {
-	if isDrupal9App(app) || isDrupal10App(app) {
+	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") && (isDrupal9App(app) || isDrupal10App(app)) {
 		err := app.Wait([]string{nodeps.DBContainer})
 		if err != nil {
 			return err


### PR DESCRIPTION

## The Issue

@weitzman pointed out in https://discord.com/channels/664580571770388500/1156252315750256721/1156252315750256721 that `omit_containers: [db]` doesn't work with drupal9+ 

## How This PR Solves The Issue

Don't try to configure the Mariadb/Mysql/Postgres things that are required for Drupal9+ if the db container is omitted.

## Manual Testing Instructions

Use `omit_containers: [db]` and try a `ddev start`. Your project won't work, but it should come up successfully.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

