### PR TITLE
docs: replace elasticsearch with opensearch for magento 2 quickstart

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -248,13 +248,12 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ```bash
     mkdir ddev-magento2 && cd ddev-magento2
     ddev config --project-type=magento2 --php-version=8.1 --docroot=pub --create-docroot --disable-settings-management
-    ddev get ddev/ddev-elasticsearch
+    ddev get netz98/ddev-opensearch
     ddev start
     ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition -y
-    rm -f app/etc/env.php
 
     # Change the base-url below to your project's URL
-    ddev magento setup:install --base-url='https://ddev-magento2.ddev.site/' --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db --elasticsearch-host=elasticsearch --search-engine=elasticsearch7 --elasticsearch-port=9200 --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=Password123 --language=en_US
+    ddev magento setup:install --base-url='https://ddev-magento2.ddev.site/' --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db --opensearch-host=opensearch --search-engine=opensearch --opensearch-port=9200 --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com --admin-user=admin --admin-password=Password123 --language=en_US
 
     ddev magento deploy:mode:set developer
     ddev magento module:disable Magento_TwoFactorAuth Magento_AdminAdobeImsTwoFactorAuth


### PR DESCRIPTION
## The Issue
Regarding https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/system-requirements.html only opensearch is supported going forward. The current quickstart for Magento 2 still uses elasticsearch.

## How This PR Solves The Issue
- Elasticsearch has been replaced by opensearch.
- The `rm -f app/etc/env.php` is not needed because of `--disable-settings-management`.

## Manual Testing Instructions
Simply follow the new quickstart instructions.

## Automated Testing Overview

I could not find anything related to documentation testing, so I think it's not needed.

## Release/Deployment Notes

Only related to the documentation. (markdown)

