### PR TITLE
docs: docker desktop for mac may need extra setting

### DIFF
--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -46,8 +46,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     ### Docker Desktop for Mac
 
     Docker Desktop for Mac can be installed via Homebrew (`brew install homebrew/cask/docker`) or can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has long been supported by DDEV and has extensive automated testing.
-
-    We do not recommend the `VirtioFS` option with Docker Desktop for Mac. While it’s performant, it can cause mysterious problems that are not present with [Mutagen](performance.md#mutagen)—which offers comparable performance when enabled.
+    If you get messages like `Ports are not available... exposing port failed... is vmnetd running?` it means you need to check the "Allow privileged port mapping (requires password)" checkbox in the "Advanced" section of the Docker Desktop configuration.
 
 === "Linux"
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -47,7 +47,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     Docker Desktop for Mac can be installed via Homebrew (`brew install homebrew/cask/docker`) or can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has long been supported by DDEV and has extensive automated testing.
     
-    !!!Warning
+    !!!warning "Ports unavailable?"
         If you get messages like `Ports are not available... exposing port failed... is vmnetd running?` it means you need to check the "Allow privileged port mapping (requires password)" checkbox in the "Advanced" section of the Docker Desktop configuration. You may have to stop and restart Docker Desktop.
 
 === "Linux"

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -46,7 +46,9 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     ### Docker Desktop for Mac
 
     Docker Desktop for Mac can be installed via Homebrew (`brew install homebrew/cask/docker`) or can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has long been supported by DDEV and has extensive automated testing.
-    If you get messages like `Ports are not available... exposing port failed... is vmnetd running?` it means you need to check the "Allow privileged port mapping (requires password)" checkbox in the "Advanced" section of the Docker Desktop configuration.
+    
+    !!!Warning
+        If you get messages like `Ports are not available... exposing port failed... is vmnetd running?` it means you need to check the "Allow privileged port mapping (requires password)" checkbox in the "Advanced" section of the Docker Desktop configuration. You may have to stop and restart Docker Desktop.
 
 === "Linux"
 


### PR DESCRIPTION
## The Issue

docs: Some users of Docker Desktop for mac have gotten errors indicating that ports 80 and 443 (privileged ports) are not accessible, and implicating vmnetd.

This usually means checking the "allow privileged ports" checkbox in Docker Desktop.





<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5388"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

