### PR TITLE
fix: make sure Platform.sh environment is not paused before pull/push

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -38,10 +38,12 @@
 
 auth_command:
   command: |
+    export PLATFORMSH_CLI_NO_INTERACTION=1
     set -eu -o pipefail
     if [ -z "${PLATFORMSH_CLI_TOKEN:-}" ]; then echo "Please make sure you have set PLATFORMSH_CLI_TOKEN." && exit 1; fi
     if [ -z "${PLATFORM_PROJECT:-}" ]; then echo "Please make sure you have set PLATFORM_PROJECT." && exit 1; fi
     if [ -z "${PLATFORM_ENVIRONMENT:-}" ]; then echo "Please make sure you have set PLATFORM_ENVIRONMENT." && exit 1; fi
+    platform environment:resume --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" --yes 2>/dev/null || true
 
 db_pull_command:
   command: |


### PR DESCRIPTION

## The Issue

Platform.sh now pauses environments if they're not "production". This breaks TestPlatformPull periodically, etc. 
This actually fixes it for regular users.

## How This PR Solves The Issue

Do a `platform environment:resume` before doing anything else.

## Manual Testing Instructions

`ddev pull platform` on a paused project and on a running project.



<a href="https://gitpod.io/#https://github.com/ddev/ddev/pull/5390"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

