### PR TITLE
ci: don't check error in test because windows can't clean up

### DIFF
--- a/cmd/ddev/cmd/debug-refresh_test.go
+++ b/cmd/ddev/cmd/debug-refresh_test.go
@@ -32,8 +32,8 @@ func TestDebugRefreshCmd(t *testing.T) {
 		_ = os.Chdir(origDir)
 		err = app.Stop(true, false)
 		assert.NoError(err)
-		err := os.RemoveAll(tmpdir)
-		assert.NoError(err)
+		// On Windows the tmpdir may not be removable for unknown reasons, don't check result
+		_ = os.RemoveAll(tmpdir)
 	})
 
 	err = fileutil.AppendStringToFile(app.GetConfigPath("web-build/Dockerfile"), `


### PR DESCRIPTION
## The Issue

On Windows [TestDebugRefreshCmd](https://buildkite.com/ddev/ddev-windows-mutagen/builds/4247#018ae11f-41f6-4caa-9624-64a8eaa1fa23) may fail due to some file being held open:

`
Received unexpected error:
--
  | remove C:\Users\testbot\tmp\ddevtest\TestDebugRefreshCmd1061869345\.ddev\traefik\config\TestDebugRefreshCmd1061869345.yaml: The process cannot access the file because it is being used by another process.`

## How This PR Solves The Issue

Just don't check the error, don't fail. It doesn't matter. 

