### PR TITLE
ci: change technique for PR artifact comment, fixes #5386

### DIFF
--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -11,49 +11,68 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@v3
-      with:
-        # This snippet is public-domain, taken from
-        # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
-        script: |
-          const {owner, repo} = context.repo;
-          const run_id = ${{github.event.workflow_run.id}};
-          const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
-          const pull_user_id = ${{github.event.sender.id}};
-
-          const issue_number = await (async () => {
-            const pulls = await github.pulls.list({owner, repo});
-            for await (const {data} of github.paginate.iterator(pulls)) {
-              for (const pull of data) {
-                if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
-                  return pull.number;
+      - uses: actions/github-script@v6
+        with:
+          # This snippet is public-domain, combined from
+          # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
+          # https://github.com/AKSW/submission.d2r2.aksw.org/blob/main/.github/workflows/pr-comment.yml
+          script: |
+            // get a PR number
+            const {owner, repo} = context.repo;
+            const pullHeadSHA = '${{github.event.workflow_run.head_sha}}';
+            const pullUserId = ${{github.event.sender.id}};
+            const prNumber = await (async () => {
+              const pulls = await github.rest.pulls.list({owner, repo});
+              for await (const {data} of github.paginate.iterator(pulls)) {
+                for (const pull of data) {
+                  if (pull.head.sha === pullHeadSHA && pull.user.id === pullUserId) {
+                    return pull.number;
+                  }
                 }
               }
+            })();
+            if (!prNumber) {
+              return core.error("This workflow doesn't match any pull requests!");
             }
-          })();
-          if (issue_number) {
-            core.info(`Using pull request ${issue_number}`);
-          } else {
-            return core.error(`No matching pull request found`);
-          }
 
-          const {data: {artifacts}} = await github.actions.listWorkflowRunArtifacts({owner, repo, run_id});
-          if (!artifacts.length) {
-            return core.error(`No artifacts found`);
-          }
-          let body = `Download the artifacts for this pull request:\n`;
-          for (const art of artifacts) {
-            body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
-          }
+            // collect all artifacts
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            if (!(allArtifacts && allArtifacts.data && allArtifacts.data.artifacts && allArtifacts.data.artifacts.length)) {
+              return core.error(`No artifacts found`);
+            }
 
-          body += `\n\n See [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr)`;
+            let body = allArtifacts.data.artifacts.reduce((acc, item) => {
+              if (item.name === "assets") return acc;
+              acc += `\n* [${item.name}.zip](https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/artifacts/${item.id}.zip)`;
+              return acc;
+            }, 'Download the artifacts for this pull request:\n');
 
-          const {data: comments} = await github.issues.listComments({repo, owner, issue_number});
-          const existing_comment = comments.find((c) => c.user.login === 'github-actions[bot]');
-          if (existing_comment) {
-            core.info(`Updating comment ${existing_comment.id}`);
-            await github.issues.updateComment({repo, owner, comment_id: existing_comment.id, body});
-          } else {
-            core.info(`Creating a comment`);
-            await github.issues.createComment({repo, owner, issue_number, body});
-          }
+            body += `\n\n See [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr)`;
+
+            // insert or update a bot comment
+            async function upsertComment(owner, repo, issue_number, purpose, body) {
+              const {data: comments} = await github.rest.issues.listComments(
+                {owner, repo, issue_number});
+
+              const marker = `<!-- bot: ${purpose} -->`;
+              body = marker + "\n" + body;
+
+              const existing = comments.filter((c) => c.body.includes(marker));
+              if (existing.length > 0) {
+                const last = existing[existing.length - 1];
+                core.info(`Updating comment ${last.id}`);
+                await github.rest.issues.updateComment({
+                  owner, repo,
+                  body,
+                  comment_id: last.id,
+                });
+              } else {
+                core.info(`Creating a comment in issue / PR #${issue_number}`);
+                await github.rest.issues.createComment({issue_number, body, owner, repo});
+              }
+            }
+            await upsertComment(owner, repo, prNumber, "nightly-link", body);


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- https://github.com/ddev/ddev/issues/5386

## How This PR Solves The Issue

From what I can see, there are no problems with `nightly.link` itself, the failures for PR artifact comments are from GitHub Actions.

The current implementation of upstream [pr-comment.yml](https://github.com/oprypin/nightly.link/blob/5a34469cc7939d3c6a79ad5badbc62971145fa57/.github/workflows/pr-comment.yml) uses different technique to insert/update a bot comment (it looks for `<!-- bot: nightly-link -->` in the comments), but it doesn't work with forked PRs.

Also, DDEV is currently using the deprecated action `actions/github-script@v3`.

I combined two different workflows (see the changes) and used `actions/github-script@v6`.

## Manual Testing Instructions

I tested the new technique on this repo https://github.com/stasadev/ddev-pr-artifacts-comment

The change affects the current open PRs, a second bot comment like this https://github.com/stasadev/ddev-pr-artifacts-comment/pull/12 will be added (because it looks for `<!-- bot: nightly-link -->`  in the comments).

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

