### PR TITLE
fix: pass domain/project name to `ddev sequelace`, fixes #5394

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
@@ -10,7 +10,7 @@
 
 DATABASE="${1:-db}"
 
-query="mysql://root:root@${DDEV_HOSTNAME}:${DDEV_HOST_DB_PORT}/${DATABASE}"
+query="mysql://root:root@$${DDEV_PROJECT}.${DDEV_TLD}:${DDEV_HOST_DB_PORT}/${DATABASE}"
 
 set -x
 open "$query" -a "/Applications/Sequel Ace.app/Contents/MacOS/Sequel Ace"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
@@ -10,7 +10,7 @@
 
 DATABASE="${1:-db}"
 
-query="mysql://root:root@$${DDEV_PROJECT}.${DDEV_TLD}:${DDEV_HOST_DB_PORT}/${DATABASE}"
+query="mysql://root:root@${DDEV_PROJECT}.${DDEV_TLD}:${DDEV_HOST_DB_PORT}/${DATABASE}"
 
 set -x
 open "$query" -a "/Applications/Sequel Ace.app/Contents/MacOS/Sequel Ace"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
@@ -10,7 +10,7 @@
 
 DATABASE="${1:-db}"
 
-query="mysql://root:root@127.0.0.1:${DDEV_HOST_DB_PORT}/${DATABASE}"
+query="mysql://root:root@${DDEV_HOSTNAME}:${DDEV_HOST_DB_PORT}/${DATABASE}"
 
 set -x
 open "$query" -a "/Applications/Sequel Ace.app/Contents/MacOS/Sequel Ace"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

Fixes #5394. The domain name is sent to SequelAce instead of 127.0.0.1, which means that it shows in the SequelAce window title.

See #5397 however -- this was the only env var I could see which was suitable, but the docs for it are suspicious. An array here would clearly be wrong.

## Manual Testing Instructions

Do `ddev sequelace`. The new SequelAce window should show the domain, allowing the project to be identified.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

