### PR TITLE
fix: command `ddev get --remove` should be run in `.ddev` config folder, for #5342

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -94,6 +94,21 @@ ddev get --remove ddev-someaddonname
 			if err != nil {
 				util.Failed("Unable to find active project: %v", err)
 			}
+
+			origDir, _ := os.Getwd()
+
+			defer func() {
+				err = os.Chdir(origDir)
+				if err != nil {
+					util.Failed("Unable to chdir to %v: %v", origDir, err)
+				}
+			}()
+
+			err = os.Chdir(app.GetConfigPath(""))
+			if err != nil {
+				util.Failed("Unable to chdir to %v: %v", app.GetConfigPath(""), err)
+			}
+
 			app.DockerEnv()
 
 			err = ddevapp.RemoveAddon(app, cmd.Flag("remove").Value.String(), nil, bash, verbose)


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- https://github.com/ddev/ddev/issues/5342

## How This PR Solves The Issue

Changes the `$PWD` to `.ddev` config folder while the command is running.

## Manual Testing Instructions

See the issue.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

