### PR TITLE
refactor: remove support for nodejs version 14

### DIFF
--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -194,7 +194,7 @@ func TestConfigSetValues(t *testing.T) {
 	useDNSWhenPossible := false
 	timezone := "America/Chicago"
 	webEnv := "SOMEENV=some+val"
-	nodejsVersion := "14"
+	nodejsVersion := "16"
 	defaultContainerTimeout := 300
 
 	args := []string{

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -348,7 +348,7 @@ Node.js version for the web container’s “system” version.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | current LTS version | Can be `14`, `16`, `18`, or `20`.
+| :octicons-file-directory-16: project | current LTS version | Can be `16`, `18`, or `20`.
 
 `nvm` is also available inside the container and via [`ddev nvm`](../usage/commands.md#nvm), and can be set to any valid version including much older ones.
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -193,7 +193,7 @@ Flags:
 * `--mailpit-https-port`: Router port to be used for Mailpit HTTPS access.
 * `--ngrok-args`: Provide extra args to ngrok in `ddev share`.
 * `--no-project-mount`: Whether or not to skip mounting project code into the web container.
-* `--nodejs-version`: Specify the Node.js version to use if you don’t want the default Node.js 16.
+* `--nodejs-version`: Specify the Node.js version to use if you don’t want the default version.
 * `--omit-containers`: Comma-delimited list of container types that should not be started when the project is started.
 * `--performance-mode`: Performance optimization mode, possible values are `global`, `none`, `mutagen`, `nfs`.
 * `--performance-mode-reset`: Reset performance mode to global configuration.

--- a/pkg/ddevapp/schema.json
+++ b/pkg/ddevapp/schema.json
@@ -221,7 +221,6 @@
       "description": "Node.js version for the web container’s “system” version.",
       "type": "string",
       "enum": [
-        "14",
         "16",
         "18",
         "20"

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -63,7 +63,7 @@ const ConfigInstructions = `
 # To reinstall Composer after the image was built, run "ddev debug refresh".
 
 # nodejs_version: "18"
-# change from the default system Node.js version to another supported version, like 14, 16, 18, 20.
+# change from the default system Node.js version to another supported version, like 16, 18, 20.
 # Note that you can use 'ddev nvm' or nvm inside the web container to provide nearly any
 # Node.js version, including v6, etc.
 

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -75,7 +75,7 @@ var ValidWebserverTypes = map[string]bool{
 	WebserverNginxGunicorn: true,
 }
 
-var ValidNodeJSVersions = []string{"14", "16", "18", "20"}
+var ValidNodeJSVersions = []string{"16", "18", "20"}
 
 // App types
 const (


### PR DESCRIPTION
Node 14 went end of life in April 2023. New versions of the Node installer do not support version 14.

## The Issue

NodeJS version 14 is [end of life](https://endoflife.date/nodejs).

## How This PR Solves The Issue

This pull request removes support for version 14.

## Release/Deployment Notes

Users using Node 14 will need to upgrade.

