### PR TITLE
fix: warn about obsolete nodejs_version instead of failing

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -350,6 +350,8 @@ Node.js version for the web container’s “system” version.
 | -- | -- | --
 | :octicons-file-directory-16: project | current LTS version | Can be `16`, `18`, or `20`.
 
+There is no need to configure the `nodejs_version` unless you want to use a major version that is not the default.
+
 `nvm` is also available inside the container and via [`ddev nvm`](../usage/commands.md#nvm), and can be set to any valid version including much older ones.
 
 ## `omit_containers`

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -196,6 +196,10 @@ func (app *DdevApp) WriteConfig() error {
 		appcopy.DefaultContainerTimeout = ""
 	}
 
+	if appcopy.NodeJSVersion == nodeps.NodeJSDefault {
+		appcopy.NodeJSVersion = ""
+	}
+
 	// Ensure valid type
 	if appcopy.Type == nodeps.AppTypeNone {
 		appcopy.Type = nodeps.AppTypePHP
@@ -457,7 +461,9 @@ func (app *DdevApp) ValidateConfig() error {
 	}
 
 	if !nodeps.IsValidNodeVersion(app.NodeJSVersion) {
-		return fmt.Errorf("unsupported system Node.js version: '%s'; for the system Node.js version DDEV only supports %s. However, you can use 'ddev nvm install' at runtime to use any supported version", app.NodeJSVersion, nodeps.GetValidNodeVersions())
+		util.Warning("Node.js version '%s' is not currently supported by DDEV, ignoring and using default version '%v'.", app.NodeJSVersion, nodeps.NodeJSDefault)
+		util.Warning("Use `ddev config --auto` to fix, or use `ddev nvm` to support an arbitrary Node.js version.")
+		app.NodeJSVersion = nodeps.NodeJSDefault
 	}
 
 	if !nodeps.IsValidOmitContainers(app.OmitContainers) {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -124,7 +124,7 @@ type DdevApp struct {
 	ComposerVersion           string                 `yaml:"composer_version"`
 	DisableSettingsManagement bool                   `yaml:"disable_settings_management,omitempty"`
 	WebEnvironment            []string               `yaml:"web_environment"`
-	NodeJSVersion             string                 `yaml:"nodejs_version"`
+	NodeJSVersion             string                 `yaml:"nodejs_version,omitempty"`
 	DefaultContainerTimeout   string                 `yaml:"default_container_timeout,omitempty"`
 	WebExtraExposedPorts      []WebExposedPort       `yaml:"web_extra_exposed_ports,omitempty"`
 	WebExtraDaemons           []WebExtraDaemon       `yaml:"web_extra_daemons,omitempty"`

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -66,6 +66,8 @@ const ConfigInstructions = `
 # change from the default system Node.js version to another supported version, like 16, 18, 20.
 # Note that you can use 'ddev nvm' or nvm inside the web container to provide nearly any
 # Node.js version, including v6, etc.
+# You only need to configure this if you are not using nvm and you want to use a major
+# version that is not the default.
 
 # additional_hostnames:
 #  - somename


### PR DESCRIPTION

## The Issue

In
* https://github.com/ddev/ddev/pull/5405 and 
* https://github.com/ddev/ddev/pull/5400

we invalidated `nodejs_version: 14` because the upstream package manager does not support it any more.

However, we don't want to break people who happen to have that in their config. 

## How This PR Solves The Issue

* Allow incorrect config but warn about it
* Empty `nodejs_version` if it's the default, to try to prevent this in the future. This means people will only configure it if they want something other than DDEV's default. This is slightly intrusive, but not too much.

Here's what happens. It's not as pretty as it should be but it gets the job done:

<img width="1290" alt="image" src="https://github.com/ddev/ddev/assets/112444/62c4e4b9-89a6-4460-aa35-c6e27980deb7">


## Manual Testing Instructions

Set `nodejs_version: 14` and `ddev start`. Use `ddev config --auto` to fix.

## Automated Testing Overview

No new tests - the other 2 PRs handled everything.

## Related Issue Link(s)

## Release/Deployment Notes

* Release requires announcement of the v14 removal
