### PR TITLE
ci: use only SHA to find PR number, for #5386 [skip ci]

### DIFF
--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -20,12 +20,11 @@ jobs:
             // get a PR number
             const {owner, repo} = context.repo;
             const pullHeadSHA = '${{github.event.workflow_run.head_sha}}';
-            const pullUserId = ${{github.event.sender.id}};
             const prNumber = await (async () => {
               const pulls = await github.rest.pulls.list({owner, repo});
               for await (const {data} of github.paginate.iterator(pulls)) {
                 for (const pull of data) {
-                  if (pull.head.sha === pullHeadSHA && pull.user.id === pullUserId) {
+                  if (pull.head.sha === pullHeadSHA) {
                     return pull.number;
                   }
                 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #5386

`This workflow doesn't match any pull requests!` in [Add download link to PR](https://github.com/ddev/ddev/blob/7ab3e70b487aa70712b3e62290d3f38aabbe0fc6/.github/workflows/pr-artifacts-comment.yml)

## How This PR Solves The Issue

After changing to a new technique for making PR artifact comments (#5396) everything looked fine until a force-pushed commit was made and no bot comment was updated.

After some debugging, I discovered that the workflow cannot find the PR after doing the force push if the PR author is another user. At first I thought it might be something with a different SHA, but it turned out to be a different user ID.

I believe the user ID check was added usptream just to make it extra unique, but I think only SHA can be used for comparison.

## Manual Testing Instructions

I run tests on my [repo](https://github.com/stasadev/ddev-pr-artifacts-comment/pull/15).

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

