### PR TITLE
fix: resolve inappropriate creation of .ddev/addon-metadata, fixes #5419

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -101,7 +101,6 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 		}
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		// TODO: Remove once it's activated directly in ddevapp
 		if instrumentationApp == nil {
 			app, err := ddevapp.GetActiveApp("")
 			if err == nil {
@@ -147,14 +146,8 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 
 		if globalconfig.DdevGlobalConfig.InstrumentationOptIn && versionconstants.SegmentKey != "" && globalconfig.IsInternetActive() && len(fullCommand) > 1 {
 			defer util.TimeTrackC("Instrumentation")()
-			// Try to get default instrumentationApp from current directory if not already set
-			if instrumentationApp == nil {
-				app, err := ddevapp.GetActiveApp("")
-				if err == nil {
-					instrumentationApp = app
-				}
-			}
-			// If it has been set, provide the tags, otherwise no app tags
+
+			// If instrumentationApp has been set, provide the tags, otherwise no app tags
 			if instrumentationApp != nil {
 				instrumentationApp.SetInstrumentationAppTags()
 			}

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -103,7 +103,7 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		// TODO: Remove once it's activated directly in ddevapp
 		if instrumentationApp == nil {
-			app, err := ddevapp.NewApp("", false)
+			app, err := ddevapp.GetActiveApp("")
 			if err == nil {
 				instrumentationApp = app
 			}
@@ -149,7 +149,7 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 			defer util.TimeTrackC("Instrumentation")()
 			// Try to get default instrumentationApp from current directory if not already set
 			if instrumentationApp == nil {
-				app, err := ddevapp.NewApp("", false)
+				app, err := ddevapp.GetActiveApp("")
 				if err == nil {
 					instrumentationApp = app
 				}


### PR DESCRIPTION

## The Issue

* #5419 

The PersistentPostRun function for the root command handles instrumentation. It was using NewApp(), which will create a new ddevapp right there in the current dir. I'm pretty sure it should be using GetActiveApp() and that will solve this.

The actual problem can also be solved by turning off instrumentation, because that's where the app is being created.

## Manual Testing Instructions

Use the techniques from
* #5419 

Also try it with and without instrumentation.

## Automated Testing Overview

It may deserve a test. I'm not sure a test is easy.

