### PR TITLE
fix: supervisord should not bring down the whole web container when non-essential service fails, fixes #5358

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
@@ -27,10 +27,6 @@ def check_supervisord():
         return False
     
     supervisordPid = int(open('/var/run/supervisord.pid','r').readline())
-    if(check_pid(supervisordPid)):
-        write_stdout("supervisord alive\n")
-    else:
-        write_stdout("supervisord dead\n")
     return check_pid(supervisordPid)
 
 def check_apache():
@@ -38,10 +34,6 @@ def check_apache():
         return False
     
     apachePid = int(open('/var/run/apache2/apache2.pid','r').readline())
-    if(check_pid(apachePid)):
-        write_stdout("apache alive\n")
-    else:
-        write_stdout("apache dead\n")
     return check_pid(apachePid)
 
 def check_nginx():
@@ -49,10 +41,6 @@ def check_nginx():
         return False
     
     nginxPid = int(open('/var/run/nginx.pid','r').readline())
-    if(check_pid(nginxPid)):
-        write_stdout("nginx alive\n")
-    else:
-        write_stdout("nginx dead\n")
     return check_pid(nginxPid)
     
         

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
@@ -2,7 +2,6 @@
 import sys
 import os
 import signal
-import pdb
 
 # From https://blog.zhaw.ch/icclab/process-management-in-docker-containers/
 
@@ -68,7 +67,6 @@ def main():
             isNginxAlive = check_nginx()
 
             if (not isApacheAlive and not isNginxAlive and isSupervisordAlive):
-                pdb.set_trace()
                 supervisordPid = int(open('/var/run/supervisord.pid','r').readline())
                 os.kill(supervisordPid, signal.SIGQUIT)
         except Exception as e:

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
@@ -22,40 +22,26 @@ def check_pid(pid):
     else:
         return True
 
-def check_supervisord():
-    if(not os.path.isfile('/var/run/supervisord.pid')):
+def check_by_pid_file(pidFile):
+    if(not os.path.isfile(pidFile)):
         return False
     
-    supervisordPid = int(open('/var/run/supervisord.pid','r').readline())
-    return check_pid(supervisordPid)
-
-def check_apache():
-    if(not os.path.isfile('/var/run/apache2/apache2.pid')):
-        return False
+    pid = int(open(pidFile,'r').readline())
+    return check_pid(pid)
     
-    apachePid = int(open('/var/run/apache2/apache2.pid','r').readline())
-    return check_pid(apachePid)
-
-def check_nginx():
-    if(not os.path.isfile('/var/run/nginx.pid')):
-        return False
-    
-    nginxPid = int(open('/var/run/nginx.pid','r').readline())
-    return check_pid(nginxPid)
-    
-        
 def main():
     while 1:
         write_stdout('READY\n')
         line = sys.stdin.readline()
         write_stdout('This line kills supervisor: ' + line)
         try:
-            isSupervisordAlive = check_supervisord()
-            isApacheAlive = check_apache()
-            isNginxAlive = check_nginx()
+            supervisorPidFile = '/var/run/supervisord.pid'
+            isSupervisordAlive = check_by_pid_file(supervisorPidFile)
+            isApacheAlive = check_by_pid_file('/var/run/apache2/apache2.pid')
+            isNginxAlive = check_by_pid_file('/var/run/nginx.pid')
 
             if (not isApacheAlive and not isNginxAlive and isSupervisordAlive):
-                supervisordPid = int(open('/var/run/supervisord.pid','r').readline())
+                supervisordPid = int(open(supervisorPidFile,'r').readline())
                 os.kill(supervisordPid, signal.SIGQUIT)
         except Exception as e:
                 write_stdout('Could not kill supervisor: ' + e.strerror + '\n')

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
@@ -76,4 +76,3 @@ def main():
         write_stdout('RESULT 2\nOK')
 if __name__ == '__main__':
     main()
-   import sys

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
@@ -35,13 +35,12 @@ def main():
         line = sys.stdin.readline()
         write_stdout('This line kills supervisor: ' + line)
         try:
-            supervisorPidFile = '/var/run/supervisord.pid'
-            isSupervisordAlive = check_by_pid_file(supervisorPidFile)
+            isSupervisordAlive = check_by_pid_file('/var/run/supervisord.pid')
             isApacheAlive = check_by_pid_file('/var/run/apache2/apache2.pid')
             isNginxAlive = check_by_pid_file('/var/run/nginx.pid')
 
             if (not isApacheAlive and not isNginxAlive and isSupervisordAlive):
-                supervisordPid = int(open(supervisorPidFile,'r').readline())
+                supervisordPid = int(open('/var/run/supervisord.pid','r').readline())
                 os.kill(supervisordPid, signal.SIGQUIT)
         except Exception as e:
                 write_stdout('Could not kill supervisor: ' + e.strerror + '\n')

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
@@ -2,27 +2,78 @@
 import sys
 import os
 import signal
+import pdb
 
 # From https://blog.zhaw.ch/icclab/process-management-in-docker-containers/
 
 def write_stdout(s):
    sys.stdout.write(s)
    sys.stdout.flush()
+
 def write_stderr(s):
    sys.stderr.write(s)
    sys.stderr.flush()
+
+def check_pid(pid):        
+    """ Check For the existence of a unix pid. """
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    else:
+        return True
+
+def check_supervisord():
+    if(not os.path.isfile('/var/run/supervisord.pid')):
+        return False
+    
+    supervisordPid = int(open('/var/run/supervisord.pid','r').readline())
+    if(check_pid(supervisordPid)):
+        write_stdout("supervisord alive\n")
+    else:
+        write_stdout("supervisord dead\n")
+    return check_pid(supervisordPid)
+
+def check_apache():
+    if(not os.path.isfile('/var/run/apache2/apache2.pid')):
+        return False
+    
+    apachePid = int(open('/var/run/apache2/apache2.pid','r').readline())
+    if(check_pid(apachePid)):
+        write_stdout("apache alive\n")
+    else:
+        write_stdout("apache dead\n")
+    return check_pid(apachePid)
+
+def check_nginx():
+    if(not os.path.isfile('/var/run/nginx.pid')):
+        return False
+    
+    nginxPid = int(open('/var/run/nginx.pid','r').readline())
+    if(check_pid(nginxPid)):
+        write_stdout("nginx alive\n")
+    else:
+        write_stdout("nginx dead\n")
+    return check_pid(nginxPid)
+    
+        
 def main():
-   while 1:
-       write_stdout('READY\n')
-       line = sys.stdin.readline()
-       write_stdout('This line kills supervisor: ' + line)
-       try:
-               pidfile = open('/var/run/supervisord.pid','r')
-               pid = int(pidfile.readline())
-               os.kill(pid, signal.SIGQUIT)
-       except Exception as e:
-               write_stdout('Could not kill supervisor: ' + e.strerror + '\n')
-       write_stdout('RESULT 2\nOK')
+    while 1:
+        write_stdout('READY\n')
+        line = sys.stdin.readline()
+        write_stdout('This line kills supervisor: ' + line)
+        try:
+            isSupervisordAlive = check_supervisord()
+            isApacheAlive = check_apache()
+            isNginxAlive = check_nginx()
+
+            if (not isApacheAlive and not isNginxAlive and isSupervisordAlive):
+                pdb.set_trace()
+                supervisordPid = int(open('/var/run/supervisord.pid','r').readline())
+                os.kill(supervisordPid, signal.SIGQUIT)
+        except Exception as e:
+                write_stdout('Could not kill supervisor: ' + e.strerror + '\n')
+        write_stdout('RESULT 2\nOK')
 if __name__ == '__main__':
-   main()
+    main()
    import sys


### PR DESCRIPTION
## The Issue
When a command that runs by the Supervisor gets an error or crash, it automatically turns off the web container. Making the supervisor auto restart feature useless.

## How This PR Solves The Issue
This PR check when there's an error happen in supervisord whether nginx or apache is working properly or not. if one of them is down, kill supervisord

## Manual Testing Instructions
I cannot test this on real use case because I need the file to run when supervisord start. please guide me how to test this in my env.

## Automated Testing Overview
I cannot test this because of the same reason above.

## Related Issue Link(s)
https://github.com/ddev/ddev/issues/5358

## Release/Deployment Notes
this shouldn't affect anything else. 

