### PR TITLE
fix: always include pre-releases on version constraint checking, fixes feedback on #4630

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -434,6 +434,8 @@ func (app *DdevApp) ValidateConfig() error {
 	if app.DdevVersionConstraint != "" {
 		constraint := app.DdevVersionConstraint
 		if !strings.Contains(constraint, "-") {
+			// Allow preleases to be included in the constraint validation
+			// @see https://github.com/Masterminds/semver#working-with-prerelease-versions
 			constraint += "-0"
 		}
 		c, err := semver.NewConstraint(constraint)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -447,7 +447,8 @@ func (app *DdevApp) ValidateConfig() error {
 		v, err := semver.NewVersion(versionconstants.DdevVersion)
 		if err == nil {
 			if !c.Check(v) {
-				return fmt.Errorf("ddev version %v is not supported by this project (%v), use a supported version or update your project config.yaml's `ddev_version_constraint`", versionconstants.DdevVersion, app.DdevVersionConstraint)
+				return fmt.Errorf("This project has a DDEV version constraint of '%s' and the version of DDEV you are using ('%s') does not meet the constraint. Please update the `ddev_version_constraint` in your .ddev/config.yaml or use a version of DDEV that meets the constraint.", app.DdevVersionConstraint, 
+ versionconstants.DdevVersion)
 			}
 		}
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -447,7 +447,7 @@ func (app *DdevApp) ValidateConfig() error {
 		v, err := semver.NewVersion(versionconstants.DdevVersion)
 		if err == nil {
 			if !c.Check(v) {
-				return fmt.Errorf("This project has a DDEV version constraint of '%s' and the version of DDEV you are using ('%s') does not meet the constraint. Please update the `ddev_version_constraint` in your .ddev/config.yaml or use a version of DDEV that meets the constraint.", app.DdevVersionConstraint,
+				return fmt.Errorf("this project has a DDEV version constraint of '%s' and the version of DDEV you are using ('%s') does not meet the constraint. Please update the `ddev_version_constraint` in your .ddev/config.yaml or use a version of DDEV that meets the constraint", app.DdevVersionConstraint,
 					versionconstants.DdevVersion)
 			}
 		}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -447,8 +447,8 @@ func (app *DdevApp) ValidateConfig() error {
 		v, err := semver.NewVersion(versionconstants.DdevVersion)
 		if err == nil {
 			if !c.Check(v) {
-				return fmt.Errorf("This project has a DDEV version constraint of '%s' and the version of DDEV you are using ('%s') does not meet the constraint. Please update the `ddev_version_constraint` in your .ddev/config.yaml or use a version of DDEV that meets the constraint.", app.DdevVersionConstraint, 
- versionconstants.DdevVersion)
+				return fmt.Errorf("This project has a DDEV version constraint of '%s' and the version of DDEV you are using ('%s') does not meet the constraint. Please update the `ddev_version_constraint` in your .ddev/config.yaml or use a version of DDEV that meets the constraint.", app.DdevVersionConstraint,
+					versionconstants.DdevVersion)
 			}
 		}
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -432,8 +432,11 @@ func (app *DdevApp) ValidateConfig() error {
 
 	// Validate ddev version constraint, if any
 	if app.DdevVersionConstraint != "" {
-
-		c, err := semver.NewConstraint(app.DdevVersionConstraint)
+		constraint := app.DdevVersionConstraint
+		if !strings.Contains(constraint, "-") {
+			constraint += "-0"
+		}
+		c, err := semver.NewConstraint(constraint)
 		if err != nil {
 			return fmt.Errorf("%s is not a valid constraint. See https://github.com/Masterminds/semver#checking-version-constraints for valid constraints format", app.DdevVersionConstraint).(invalidConstraint)
 		}
@@ -442,7 +445,7 @@ func (app *DdevApp) ValidateConfig() error {
 		v, err := semver.NewVersion(versionconstants.DdevVersion)
 		if err == nil {
 			if !c.Check(v) {
-				return fmt.Errorf("ddev version %v is not supported by this project (%v), use a supported version or update your project config.yaml's `ddev_version_constraint`", versionconstants.DdevVersion, c)
+				return fmt.Errorf("ddev version %v is not supported by this project (%v), use a supported version or update your project config.yaml's `ddev_version_constraint`", versionconstants.DdevVersion, app.DdevVersionConstraint)
 			}
 		}
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -434,7 +434,7 @@ func (app *DdevApp) ValidateConfig() error {
 	if app.DdevVersionConstraint != "" {
 		constraint := app.DdevVersionConstraint
 		if !strings.Contains(constraint, "-") {
-			// Allow preleases to be included in the constraint validation
+			// Allow prereleases to be included in the constraint validation
 			// @see https://github.com/Masterminds/semver#working-with-prerelease-versions
 			constraint += "-0"
 		}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -625,7 +625,7 @@ func TestConfigValidate(t *testing.T) {
 	app.DdevVersionConstraint = ">= 1.23"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "ddev version v1.22.0 is not supported by this project")
+	assert.Contains(err.Error(), "this project has a DDEV version constraint of '>= 1.23' and the version of DDEV you are using ('v1.22.0') does not meet the constraint")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
@@ -643,12 +643,12 @@ func TestConfigValidate(t *testing.T) {
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
-	// prereleases with a constraint that does not include them
+	// Testing out pre-releases and built PRs versions
 	versionconstants.DdevVersion = "v1.22.3-11-g8baef014e"
 	app.DdevVersionConstraint = ">= 1.23"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "ddev version v1.22.3-11-g8baef014e is not supported by this project")
+	assert.Contains(err.Error(), "this project has a DDEV version constraint of '>= 1.23' and the version of DDEV you are using ('v1.22.3-11-g8baef014e') does not meet the constraint")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
@@ -659,25 +659,22 @@ func TestConfigValidate(t *testing.T) {
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
-	// prereleases with a constraint that does include them
 	versionconstants.DdevVersion = "v1.22.3-11-g8baef014e"
 	app.DdevVersionConstraint = ">= 1.23.0-0"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "ddev version v1.22.3-11-g8baef014e is not supported by this project")
+	assert.Contains(err.Error(), "this project has a DDEV version constraint of '>= 1.23.0-0' and the version of DDEV you are using ('v1.22.3-11-g8baef014e') does not meet the constraint")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
-	// prereleases with a constraint that does include a valid pre-release
 	versionconstants.DdevVersion = "v1.22.3-alpha2"
 	app.DdevVersionConstraint = ">= v1.22.3-alpha3"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "ddev version v1.22.3-alpha2 is not supported by this project")
+	assert.Contains(err.Error(), "this project has a DDEV version constraint of '>= v1.22.3-alpha3' and the version of DDEV you are using ('v1.22.3-alpha2') does not meet the constraint")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
-	// prereleases with a constraint that does include a valid pre-release
 	versionconstants.DdevVersion = "v1.22.3-beta1"
 	app.DdevVersionConstraint = ">= v1.22.3-alpha3"
 	err = app.ValidateConfig()

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -653,10 +653,9 @@ func TestConfigValidate(t *testing.T) {
 	versionconstants.DdevVersion = ddevVersion
 
 	versionconstants.DdevVersion = "v1.22.3-11-g8baef014e"
-	app.DdevVersionConstraint = ">= 1.22.0"
+	app.DdevVersionConstraint = ">= 1.22"
 	err = app.ValidateConfig()
-	assert.Error(err)
-	assert.Contains(err.Error(), "ddev version v1.22.3-11-g8baef014e is not supported by this project")
+	assert.NoError(err)
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
@@ -666,6 +665,23 @@ func TestConfigValidate(t *testing.T) {
 	err = app.ValidateConfig()
 	assert.Error(err)
 	assert.Contains(err.Error(), "ddev version v1.22.3-11-g8baef014e is not supported by this project")
+	app.DdevVersionConstraint = ""
+	versionconstants.DdevVersion = ddevVersion
+
+	// prereleases with a constraint that does include a valid pre-release
+	versionconstants.DdevVersion = "v1.22.3-alpha2"
+	app.DdevVersionConstraint = ">= v1.22.3-alpha3"
+	err = app.ValidateConfig()
+	assert.Error(err)
+	assert.Contains(err.Error(), "ddev version v1.22.3-alpha2 is not supported by this project")
+	app.DdevVersionConstraint = ""
+	versionconstants.DdevVersion = ddevVersion
+
+	// prereleases with a constraint that does include a valid pre-release
+	versionconstants.DdevVersion = "v1.22.3-beta1"
+	app.DdevVersionConstraint = ">= v1.22.3-alpha3"
+	err = app.ValidateConfig()
+	assert.NoError(err)
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 


### PR DESCRIPTION
## The Issue

With the new version constraint #5379, it was reported on both the PR as well as on https://github.com/ddev/ddev/issues/4630#issuecomment-1761998687 that it's not clear or is confusing why a built version like `v1.22.3-24-g3d90d5eeb` is not accepted with a constraint of `>= v1.22`. This is because of https://github.com/Masterminds/semver#checking-version-constraints.

## How This PR Solves The Issue

This assumes that pre-releases are always included. While this invalidates any means of "excluding" pre-releases with the constraint, for general usage this will lead to less support issues and matches other less strict constraints comparisons.

## Manual Testing Instructions

`ddev config --ddev-version-constraint=">= 1.22"` should work.
