### PR TITLE
fix: make yamlToDict give useful information instead of error in invalid config, fixes #5385

### DIFF
--- a/pkg/util/yamltools.go
+++ b/pkg/util/yamltools.go
@@ -38,7 +38,8 @@ func YamlToDict(topm interface{}) (map[string]interface{}, error) {
 			case interface{}:
 				res[yk] = v
 			default:
-				return nil, fmt.Errorf("yamlToDict: type %T not handled (%v)", yk, yk)
+				Warning("Configuration has invalid type '%T' for '%s'", v, yk)
+				continue
 			}
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## The Issue

* #5385

Invalid config, especially in .ddev/config.yaml (but could happen in global_config.yaml, and might happen in customer-provided yaml) was resulting in an incomprehensible message "Unable to YamlToDict: yamlToDict: type string not handled (post-start)"

## How This PR Solves The Issue

Be more generous and just ignore and warn about the invalid yaml

## Manual Testing Instructions

There are examples of config that causes the problem in https://github.com/ddev/ddev/issues/5385

```
hooks:
post-start:
    - host-exec: ddev auth ssh
```

and 
```
hooks:
  post-start:
```

Use these in .ddev/config.yaml and see the results.

Also we can expect that a well-formed config.yaml doesn't cause trouble.

## Automated Testing Overview

No changes

