### PR TITLE
fix: ddev describe shouldn't show router when disabled, fixes #5291

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -95,6 +95,10 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 	}
 
 	router := globalconfig.DdevGlobalConfig.Router
+	if nodeps.ArrayContainsString(app.GetOmittedContainers(), `ddev-router`) {
+		router = "disabled"
+	}
+
 	t.SetTitle(fmt.Sprintf("Project: %s %s %s\nDocker platform: %s\nRouter: %s", app.Name, desc["shortroot"].(string), app.GetPrimaryURL(), dockerPlatform, router))
 	t.AppendHeader(table.Row{"Service", "Stat", "URL/Port", "Info"})
 


### PR DESCRIPTION
## The Issue

* #5291 

`ddev describe` shows the router as traefik even if `omit_containers[ddev-router]`

## How This PR Solves The Issue

Change it

## Manual Testing Instructions

Test with router disabled

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

