### PR TITLE
fix: remove many of the perf trackers from amplitude, fixes #5338

### DIFF
--- a/pkg/amplitude/amplitude.go
+++ b/pkg/amplitude/amplitude.go
@@ -62,7 +62,7 @@ func GetEventOptions() (options ampli.EventOptions) {
 // TrackCommand collects and tracks information about the command for
 // instrumentation.
 func TrackCommand(cmd *cobra.Command, args []string) {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	// Initialization is currently done before via init() func somewhere while
 	// creating the ddevapp. This should be cleaned up.
@@ -85,7 +85,7 @@ func TrackCommand(cmd *cobra.Command, args []string) {
 
 // Flush transmits the queued events if limits are reached.
 func Flush() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	// Early exit if instrumentation is disabled or internet not active.
 	if IsDisabled() {
@@ -103,7 +103,7 @@ func Flush() {
 
 // FlushForce transmits the queued events even if limits are not reached.
 func FlushForce() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	// Early exit if instrumentation is disabled or internet not active.
 	if IsDisabled() {
@@ -156,7 +156,7 @@ func IsDisabled() bool {
 // creating the ddevapp. This should be cleaned up.
 // TODO: Make private once clean up has done.
 func InitAmplitude() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	if initialized {
 		return
@@ -214,7 +214,7 @@ func getCacheFileName() string {
 
 // identify collects information about this installation.
 func identify() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	// Early exit if instrumentation is disabled.
 	if ampli.Instance.Disabled {

--- a/pkg/config/remoteconfig/messages.go
+++ b/pkg/config/remoteconfig/messages.go
@@ -57,7 +57,7 @@ func ListConditions() (conditions map[string]string) {
 
 // ShowNotifications shows notifications provided by the remote config to the user.
 func (c *remoteConfig) ShowNotifications() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	if !c.showNotifications() {
 		return
@@ -111,7 +111,7 @@ func (c *remoteConfig) ShowNotifications() {
 
 // ShowTicker shows ticker messages provided by the remote config to the user.
 func (c *remoteConfig) ShowTicker() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	if !c.showTickerMessage() || len(c.remoteConfig.Messages.Ticker.Messages) == 0 {
 		return

--- a/pkg/config/remoteconfig/remote_config.go
+++ b/pkg/config/remoteconfig/remote_config.go
@@ -13,7 +13,7 @@ import (
 
 // New creates and returns a new RemoteConfig.
 func New(config *Config, stateManager statetypes.State, isInternetActive func() bool) types.RemoteConfig {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	// Create RemoteConfig.
 	cfg := &remoteConfig{
@@ -64,7 +64,7 @@ type remoteConfig struct {
 
 // write saves the remote config to the local storage.
 func (c *remoteConfig) write() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	err := c.fileStorage.Write(c.remoteConfig)
 
@@ -76,7 +76,7 @@ func (c *remoteConfig) write() {
 // loadFromLocalStorage loads the remote config from the local storage and
 // initiates an update from the remote asynchronously.
 func (c *remoteConfig) loadFromLocalStorage() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -92,7 +92,7 @@ func (c *remoteConfig) loadFromLocalStorage() {
 
 // updateFromGithub downloads the remote config from GitHub.
 func (c *remoteConfig) updateFromGithub() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	if !c.isInternetActive() {
 		util.Debug("No internet connection.")

--- a/pkg/ddevapp/amplitude_project.go
+++ b/pkg/ddevapp/amplitude_project.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/third_party/ampli"
 	"github.com/denisbrodbeck/machineid"
 )
@@ -21,7 +20,7 @@ func (app *DdevApp) ProtectedID() string {
 
 // TrackProject collects and tracks information about the project for instrumentation.
 func (app *DdevApp) TrackProject() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	// Initialization is currently done before via init() func somewhere while
 	// creating the ddevapp. This should be cleaned up.

--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
-	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/version"
 	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/denisbrodbeck/machineid"
@@ -39,7 +38,7 @@ func GetInstrumentationUser() string {
 
 // SetInstrumentationBaseTags sets the basic always-used tags for Segment
 func SetInstrumentationBaseTags() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	if globalconfig.DdevGlobalConfig.InstrumentationOptIn {
 		dockerVersion, _ := dockerutil.GetDockerVersion()
@@ -67,7 +66,7 @@ func SetInstrumentationBaseTags() {
 
 // SetInstrumentationAppTags creates app-specific tags for Segment
 func (app *DdevApp) SetInstrumentationAppTags() {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	ignoredProperties := []string{"approot", "hostname", "hostnames", "name", "router_status_log", "shortroot"}
 
@@ -126,7 +125,7 @@ func SegmentEvent(client analytics.Client, hashedID string, event string) error 
 
 // SendInstrumentationEvents does the actual send to segment
 func SendInstrumentationEvents(event string) {
-	defer util.TimeTrack()()
+	// defer util.TimeTrack()()
 
 	if globalconfig.DdevGlobalConfig.InstrumentationOptIn && globalconfig.IsInternetActive() {
 		client, _ := analytics.NewWithConfig(versionconstants.SegmentKey, analytics.Config{


### PR DESCRIPTION

## The Issue

* #5338 

Amplitude has so many util.TimeTrack() you can't see anything else

## How This PR Solves The Issue

Remove most

## Manual Testing Instructions

DDEV_VERBOSE=true ddev list

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

