### PR TITLE
build: remove nssm as choco dependency, fixes #5336

### DIFF
--- a/winpkg/chocolatey/ddev.nuspec
+++ b/winpkg/chocolatey/ddev.nuspec
@@ -24,7 +24,6 @@
       <dependency id="gsudo" />
       <dependency id="ngrok" />
       <dependency id="mkcert" />
-      <dependency id="nssm" />
   </dependencies>
 
   </metadata>


### PR DESCRIPTION

## The Issue

* #5336 

The Windows installer installs nssm, and it's rarely used any more. Remove the Chocolatey dependency


