### PR TITLE
fix: correct global router_mailpit_http_port, fixes #5404

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -185,7 +185,7 @@ func (app *DdevApp) WriteConfig() error {
 	if appcopy.WebImage == docker.GetWebImage() {
 		appcopy.WebImage = ""
 	}
-	if appcopy.MailpitHTTPPort == nodeps.DdevDefaultMailpitPort {
+	if appcopy.MailpitHTTPPort == nodeps.DdevDefaultMailpitHTTPPort {
 		appcopy.MailpitHTTPPort = ""
 	}
 	if appcopy.MailpitHTTPSPort == nodeps.DdevDefaultMailpitHTTPSPort {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -488,7 +488,7 @@ func (app *DdevApp) GetRouterHTTPSPort() string {
 func (app *DdevApp) GetMailpitHTTPPort() string {
 	port := globalconfig.DdevGlobalConfig.RouterMailpitHTTPPort
 	if port == "" {
-		port = nodeps.DdevDefaultMailpitPort
+		port = nodeps.DdevDefaultMailpitHTTPPort
 	}
 	if app.MailpitHTTPPort != "" {
 		port = app.MailpitHTTPPort

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -66,7 +66,7 @@ type GlobalConfig struct {
 	WSL2NoWindowsHostsMgt            bool                        `yaml:"wsl2_no_windows_hosts_mgt"`
 	RouterHTTPPort                   string                      `yaml:"router_http_port"`
 	RouterHTTPSPort                  string                      `yaml:"router_https_port"`
-	RouterMailpitHTTPPort            string                      `yaml:"mailpit_port,omitempty"`
+	RouterMailpitHTTPPort            string                      `yaml:"mailpit_http_port,omitempty"`
 	RouterMailpitHTTPSPort           string                      `yaml:"mailpit_https_port,omitempty"`
 	Messages                         MessagesConfig              `yaml:"messages,omitempty"`
 	RemoteConfig                     RemoteConfig                `yaml:"remote_config,omitempty"`
@@ -82,7 +82,7 @@ func New() GlobalConfig {
 		TableStyle:                   "default",
 		RouterHTTPPort:               nodeps.DdevDefaultRouterHTTPPort,
 		RouterHTTPSPort:              nodeps.DdevDefaultRouterHTTPSPort,
-		RouterMailpitHTTPPort:        nodeps.DdevDefaultMailpitPort,
+		RouterMailpitHTTPPort:        nodeps.DdevDefaultMailpitHTTPPort,
 		RouterMailpitHTTPSPort:       nodeps.DdevDefaultMailpitHTTPSPort,
 		LastStartedVersion:           "v0.0",
 		NoBindMounts:                 nodeps.NoBindMountsDefault,
@@ -242,7 +242,7 @@ func ReadGlobalConfig() error {
 		DdevGlobalConfig.RouterHTTPSPort = nodeps.DdevDefaultRouterHTTPSPort
 	}
 	if DdevGlobalConfig.RouterMailpitHTTPPort == "" {
-		DdevGlobalConfig.RouterMailpitHTTPPort = nodeps.DdevDefaultMailpitPort
+		DdevGlobalConfig.RouterMailpitHTTPPort = nodeps.DdevDefaultMailpitHTTPPort
 	}
 	if DdevGlobalConfig.RouterMailpitHTTPSPort == "" {
 		DdevGlobalConfig.RouterMailpitHTTPSPort = nodeps.DdevDefaultMailpitHTTPSPort

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -106,8 +106,8 @@ const (
 
 	// DdevDefaultRouterHTTPSPort is the default router HTTPS port
 	DdevDefaultRouterHTTPSPort = "443"
-	// DdevDefaultMailpitPort is the default router port for Mailpit
-	DdevDefaultMailpitPort      = "8025"
+	// DdevDefaultMailpitHTTPPort is the default router port for Mailpit
+	DdevDefaultMailpitHTTPPort  = "8025"
 	DdevDefaultMailpitHTTPSPort = "8026"
 	// DdevDefaultTLD is the top-level-domain used by default, can be overridden
 	DdevDefaultTLD                  = "ddev.site"


### PR DESCRIPTION

## The Issue

* #5404 

The global global config was supposed to be router_mailpit_http_port, not router_mailpit_port

## How This PR Solves The Issue

Change it.

## Manual Testing Instructions

Make sure it gets set correctly with the `ddev config global` and that the old version (`router_mailpit_port`) doesn't cause trouble (will be ignored)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

