### PR TITLE
docs: make sure sudo is done early in linux installation, fixes #5327

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -54,14 +54,17 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ```bash
     # Add DDEV’s GPG key to your keyring
+    sudo sh -c 'echo ""'
     sudo install -m 0755 -d /etc/apt/keyrings
     curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/ddev.gpg > /dev/null
     sudo chmod a+r /etc/apt/keyrings/ddev.gpg
 
     # Add DDEV releases to your package repository
+    sudo sh -c 'echo ""'
     echo "deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
 
     # Update package information and install DDEV
+    sudo sh -c 'echo ""'
     sudo apt update && sudo apt install -y ddev
     ```
 
@@ -78,6 +81,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ```bash
     # Add DDEV releases to your package repository
+    sudo sh -c 'echo ""'
     echo '[ddev]
     name=ddev
     baseurl=https://pkg.ddev.com/yum/
@@ -85,6 +89,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     enabled=1' | perl -p -e 's/^ +//' | sudo tee /etc/yum.repos.d/ddev.repo >/dev/null
 
     # Install DDEV
+    sudo sh -c 'echo ""'
     sudo dnf install --refresh ddev
     ```
 


### PR DESCRIPTION
## The Issue

* #5327  

The docs suggestion does `sudo` in a place where it can eat important info. Do it early and rely on the cached status.

## Manual Testing

- [ ] Go through full Debian installation using copy/paste from this