### PR TITLE
fix: add comment required by wordpress for `wp config set` to work, fixes #3940

### DIFF
--- a/pkg/ddevapp/wordpress/wp-config.php
+++ b/pkg/ddevapp/wordpress/wp-config.php
@@ -23,6 +23,12 @@ define( 'SECURE_AUTH_SALT', '{{ $config.SecureAuthSalt }}' );
 define( 'LOGGED_IN_SALT', '{{ $config.LoggedInSalt }}' );
 define( 'NONCE_SALT', '{{ $config.NonceSalt }}' );
 
+/* Add any custom values between this line and the "stop editing" line. */
+
+
+
+/* That's all, stop editing! Happy publishing. */
+
 /** Absolute path to the WordPress directory. */
 defined( 'ABSPATH' ) || define( 'ABSPATH', dirname( __FILE__ ) . '/{{ $config.AbsPath }}' );
 


### PR DESCRIPTION

## The Issue

* #3940 

In a Wordpress install using ddev, WP-CLI `wp config set` and `ddev wp config set` commands fail with
```
Error: Could not process the 'wp-config.php' transformation.
Reason: Unable to locate placement anchor.
```

## How This PR Solves The Issue

As discussed in https://github.com/ddev/ddev/issues/3940, wordpress cli seems to look for `/* That's all, stop editing! Happy publishing. */` in order to find a "placement anchor" for config changes added via `wp config set`.

In a standard Wordpress install, `wp-config.php` includes that comment and one preceding it, like this:

```
/* Add any custom values between this line and the "stop editing" line. */



/* That's all, stop editing! Happy publishing. */
```

The addition of the second comment is the only required fix, but this PR adds the standard pair of comments to better match the standard Wordpress install.

With this addition, `ddev wp config set` and `wp config set` commands execute successfully.

## Manual Testing Instructions

Install Wordpress using the ddev [Quick Install](https://ddev.readthedocs.io/en/latest/users/quickstart/#wordpress) instructions.

In the command line, while in the `wordpress` root directory, try setting a config such as `ddev wp config WP_MEMORY_LIMIT 256M` or `wp config WP_MEMORY_LIMIT 256M`

Without the changes in this PR, the result is:
```
Error: Could not process the 'wp-config.php' transformation.
Reason: Unable to locate placement anchor.
```

With the changes, the result is:

```
Success: Added the constant 'WP_MEMORY_LIMIT' to the 'wp-config.php' file with the value '256M'.
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

Manual testing should suffice?

## Related Issue Link(s)

#3940

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

