### PR TITLE
fix: revert "fix: make sure Platform.sh environment is not paused before pull/push"

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -38,12 +38,10 @@
 
 auth_command:
   command: |
-    export PLATFORMSH_CLI_NO_INTERACTION=1
     set -eu -o pipefail
     if [ -z "${PLATFORMSH_CLI_TOKEN:-}" ]; then echo "Please make sure you have set PLATFORMSH_CLI_TOKEN." && exit 1; fi
     if [ -z "${PLATFORM_PROJECT:-}" ]; then echo "Please make sure you have set PLATFORM_PROJECT." && exit 1; fi
     if [ -z "${PLATFORM_ENVIRONMENT:-}" ]; then echo "Please make sure you have set PLATFORM_ENVIRONMENT." && exit 1; fi
-    platform environment:resume --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" --yes 2>/dev/null || true
 
 db_pull_command:
   command: |


### PR DESCRIPTION
Reverts ddev/ddev#5390

* #5390 did not accomplish the objective, so it doesn't make sense to leave it in there. The request has been made to just stop pausing the target environments.