### PR TITLE
feat: add output for removed network, for #5305

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -92,6 +92,8 @@ func RemoveNetworkWithWarningOnError(netName string) {
 	// If it's a "no such network" there's no reason to report error
 	if err != nil && !isNoSuchNetwork {
 		util.Warning("Unable to remove network %s: %v", netName, err)
+	} else if err == nil {
+		output.UserOut.Println("Network", netName, "removed")
 	}
 }
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

When you start a project, you always see `Network ddev_default created`.

But when you run `ddev poweroff`, there is no indication at all that `ddev_default` is removed.

With docker-compose you can see the output for the project's network when it was removed, but when #5305 comes in, there's no output for that sort of thing at all.

## How This PR Solves The Issue

Outputs the message `Network ddev_default removed` (and for any other removed external DDEV created network).

## Manual Testing Instructions

1. `ddev start`
2. `ddev poweroff` - see `Network ddev_default removed`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- https://github.com/ddev/ddev/pull/5305

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

