### PR TITLE
feat: update Bash and PowerShell autocomplete, fixes #2961, fixes #3085

### DIFF
--- a/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
+++ b/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
@@ -14,7 +14,7 @@ func main() {
 		err = os.MkdirAll(targetDir, 0755)
 		util.CheckErr(err)
 	}
-	err := cmd.RootCmd.GenBashCompletionFile(filepath.Join(targetDir, "ddev_bash_completion.sh"))
+	err := cmd.RootCmd.GenBashCompletionFileV2(filepath.Join(targetDir, "ddev_bash_completion.sh"), false)
 	if err != nil {
 		util.Failed("could not generate ddev_bash_completion.sh: %v", err)
 	}

--- a/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
+++ b/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
@@ -26,7 +26,7 @@ func main() {
 	if err != nil {
 		util.Failed("could not generate ddev_fish_completion.sh: %v", err)
 	}
-	err = cmd.RootCmd.GenPowerShellCompletionFile(filepath.Join(targetDir, "ddev_powershell_completion.ps1"))
+	err = cmd.RootCmd.GenPowerShellCompletionFileWithDesc(filepath.Join(targetDir, "ddev_powershell_completion.ps1"))
 	if err != nil {
 		util.Failed("could not generate ddev_powershell_completion.ps1: %v", err)
 	}

--- a/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
+++ b/cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go
@@ -14,7 +14,7 @@ func main() {
 		err = os.MkdirAll(targetDir, 0755)
 		util.CheckErr(err)
 	}
-	err := cmd.RootCmd.GenBashCompletionFileV2(filepath.Join(targetDir, "ddev_bash_completion.sh"), false)
+	err := cmd.RootCmd.GenBashCompletionFileV2(filepath.Join(targetDir, "ddev_bash_completion.sh"), true)
 	if err != nil {
 		util.Failed("could not generate ddev_bash_completion.sh: %v", err)
 	}


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #2961
- #3085

## How This PR Solves The Issue

I updated bash autocomplete and now it works OOTB (even with custom user-defined commands).

Before:

In `$HOME` and in a project autocomplete is the same:

```
$ echo $SHELL
/bin/bash
$ ddev <TAB><TAB>
auth          delete        hostname      mutagen       snapshot
clean         describe      import-db     poweroff      ssh
composer      exec          import-files  restart       start
config        export-db     list          service       stop
debug         get           logs          share         version
```

After:

In `$HOME`:

```
$ echo $SHELL
/bin/bash
$ ddev <TAB><TAB>
auth          delete        hostname      poweroff      start
clean         describe      import-db     restart       stop
completion    exec          import-files  service       version
composer      export-db     list          share         
config        get           logs          snapshot      
debug         help          mutagen       ssh
```

In a project (custom commands also have autocompletion):

```
$ echo $SHELL
/bin/bash
$ touch ~/.ddev/commands/host/my-custom-command
$ ddev start
$ ddev <TAB><TAB>
auth               exec               my-custom-command  share
blackfire          export-db          mysql              snapshot
clean              get                npm                ssh
completion         help               nvm                start
composer           hostname           php                stop
config             import-db          poweroff           version
craft              import-files       pull               xdebug
dbeaver            launch             push               xhprof
debug              list               restart            yarn
delete             logs               self-upgrade       
describe           mutagen            service
```

Edit: and with descriptions:

```
$ echo $SHELL
/bin/bash
$ ddev <TAB><TAB>
auth          (A collection of authentication commands)
clean         (Removes items DDEV has created)
completion    (Generate the autocompletion script for the specified shell)
composer      (Executes a Composer command within the web container)
```

## Manual Testing Instructions

1. `make completions`
2. replace the current bash completion file (e.g. `/usr/share/bash-completion/completions/ddev` on Linux) with `.gotmp/bin/completions/ddev_bash_completion.sh`
3. try `ddev <TAB><TAB>`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

