### PR TITLE
fix: replace outdated nfs_mount_enabled comments with use_dns_when_possible

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -157,12 +157,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 			// Get extra info for web container
 			if k == "web" {
 				extraInfo = append(extraInfo, fmt.Sprintf("%s PHP%s\n%s\ndocroot:'%s'", desc["type"], desc["php_version"], desc["webserver_type"], desc["docroot"]))
-				if desc["nfs_mount_enabled"].(bool) {
-					extraInfo = append(extraInfo, fmt.Sprintf("NFS Enabled"))
-				}
-				if desc["mutagen_enabled"].(bool) {
-					extraInfo = append(extraInfo, fmt.Sprintf("Mutagen enabled (%s)", ddevapp.FormatSiteStatus(desc["mutagen_status"].(string))))
-				}
+				extraInfo = append(extraInfo, fmt.Sprintf("Perf mode: %s", desc["performance_mode"].(string)))
 				if v, ok := desc["nodejs_version"].(string); ok {
 					extraInfo = append(extraInfo, fmt.Sprintf("NodeJS:%s", v))
 				}

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -385,7 +385,7 @@ Whether to override config values instead of merging.
 | -- | -- | --
 | :octicons-file-directory-16: project | `false` | Can be `true` or `false`.
 
-When `true`, the `config.*.yaml` file with the option will have its settings *override* rather than *merge with* others. Allows statements like `performance_mode: none` or `additional_hostnames: []` to work.
+When `true`, the `config.*.yaml` file with the option will have its settings *override* rather than *merge with* others. Allows statements like `use_dns_when_possible: false` or `additional_hostnames: []` to work.
 
 See [Extending `config.yaml` with Custom `config.*.yaml` Files](../extend/customization-extendibility.md#extending-configyaml-with-custom-configyaml-files).
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -385,7 +385,7 @@ Whether to override config values instead of merging.
 | -- | -- | --
 | :octicons-file-directory-16: project | `false` | Can be `true` or `false`.
 
-When `true`, the `config.*.yaml` file with the option will have its settings *override* rather than *merge with* others. Allows statements like `nfs_mount_enabled: false` or `additional_hostnames: []` to work.
+When `true`, the `config.*.yaml` file with the option will have its settings *override* rather than *merge with* others. Allows statements like `performance_mode: none` or `additional_hostnames: []` to work.
 
 See [Extending `config.yaml` with Custom `config.*.yaml` Files](../extend/customization-extendibility.md#extending-configyaml-with-custom-configyaml-files).
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -281,7 +281,7 @@ Team members may choose to use `config.local.yaml` for local non-committed confi
 3. The list of environment variables in [`web_environment`](../configuration/config.md#web_environment) are “smart merged”: if you add the same environment variable with a different value, the value in the override file will replace the value from `config.yaml`.
 4. Hook specifications in the [`hooks`](../configuration/config.md#hooks) variable are merged.
 
-If you need to _override_ existing values, set [`override_config: true`](../configuration/config.md#override_config) in the `config.*.yaml` where the override behavior should take place. Since `config.*.yaml` files are normally _merged_ into the configuration, some things can’t be overridden normally. For example, if you have [`performance_mode: none`](../configuration/config.md#performance_mode) you can’t override it with a merge and you can’t erase existing hooks or all environment variables. However, with `override_config: true` in a particular `config.*.yaml` file,
+If you need to _override_ existing values, set [`override_config: true`](../configuration/config.md#override_config) in the `config.*.yaml` where the override behavior should take place. Since `config.*.yaml` files are normally _merged_ into the configuration, some things can’t be overridden normally. For example, if you have [`use_dns_when_possible: false`](../configuration/config.md#use_dns_when_possible) you can’t override it with a merge and you can’t erase existing hooks or all environment variables. However, with `override_config: true` in a particular `config.*.yaml` file,
 
 ```yaml
 override_config: true

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -281,11 +281,11 @@ Team members may choose to use `config.local.yaml` for local non-committed confi
 3. The list of environment variables in [`web_environment`](../configuration/config.md#web_environment) are “smart merged”: if you add the same environment variable with a different value, the value in the override file will replace the value from `config.yaml`.
 4. Hook specifications in the [`hooks`](../configuration/config.md#hooks) variable are merged.
 
-If you need to _override_ existing values, set [`override_config: true`](../configuration/config.md#override_config) in the `config.*.yaml` where the override behavior should take place. Since `config.*.yaml` files are normally _merged_ into the configuration, some things can’t be overridden normally. For example, if you have [`nfs_mount_enabled: true`](../configuration/config.md#nfs_mount_enabled) you can’t override it with a merge and you can’t erase existing hooks or all environment variables. However, with `override_config: true` in a particular `config.*.yaml` file,
+If you need to _override_ existing values, set [`override_config: true`](../configuration/config.md#override_config) in the `config.*.yaml` where the override behavior should take place. Since `config.*.yaml` files are normally _merged_ into the configuration, some things can’t be overridden normally. For example, if you have [`performance_mode: none`](../configuration/config.md#performance_mode) you can’t override it with a merge and you can’t erase existing hooks or all environment variables. However, with `override_config: true` in a particular `config.*.yaml` file,
 
 ```yaml
 override_config: true
-nfs_mount_enabled: false
+performance_mode: none
 ```
 
 can override the existing values, and

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -285,7 +285,7 @@ If you need to _override_ existing values, set [`override_config: true`](../conf
 
 ```yaml
 override_config: true
-performance_mode: none
+use_dns_when_possible: false
 ```
 
 can override the existing values, and

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -230,7 +230,7 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 	}
 	appDesc["hostname"] = app.GetHostname()
 	appDesc["hostnames"] = app.GetHostnames()
-	appDesc["nfs_mount_enabled"] = app.IsNFSMountEnabled()
+	appDesc["performance_mode"] = app.GetPerformanceMode()
 	appDesc["fail_on_hook_fail"] = app.FailOnHookFail || app.FailOnHookFailGlobal
 	httpURLs, httpsURLs, allURLs := app.GetAllURLs()
 	appDesc["httpURLs"] = httpURLs

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3626,9 +3626,9 @@ func TestCaptureLogs(t *testing.T) {
 	assert.NoError(err)
 }
 
-// TestNFSMount tests ddev start functionality with nfs_mount_enabled: true
+// TestNFSMount tests ddev start functionality with performance_mode: nfs
 // This requires that the test machine must have NFS shares working
-// Tests using both app-specific nfs_mount_enabled and global nfs_mount_enabled
+// Tests using both app-specific performance_mode: nfs and etc
 func TestNFSMount(t *testing.T) {
 	if nodeps.IsWSL2() || dockerutil.IsColima() {
 		t.Skip("Skipping on WSL2/Colima")

--- a/pkg/ddevapp/instrumentation_test.go
+++ b/pkg/ddevapp/instrumentation_test.go
@@ -41,7 +41,7 @@ func TestSetInstrumentationAppTags(t *testing.T) {
 	}
 
 	// Make sure that expected attributes come through
-	for _, wanted := range []string{"database_type", "nfs_mount_enabled", "ProjectID", "php_version", "router_http_port", "router_https_port", "router_status", "ssh_agent_status", "status", "type", "webimg", "webserver_type"} {
+	for _, wanted := range []string{"database_type", "ProjectID", "performance_mode", "php_version", "router_http_port", "router_https_port", "router_status", "ssh_agent_status", "status", "type", "webimg", "webserver_type"} {
 		assert.NotEmpty(nodeps.InstrumentationTags[wanted], "tag '%s' was not found and it should have been", wanted)
 	}
 	runTime()

--- a/pkg/ddevapp/schema.json
+++ b/pkg/ddevapp/schema.json
@@ -209,10 +209,6 @@
       "description": "Provide the name of the project to configure (normally the same as the last part of directory name)",
       "type": "string"
     },
-    "nfs_mount_enabled": {
-      "description": "enable NFS mounting of project in container",
-      "type": "boolean"
-    },
     "ngrok_args": {
       "description": "Provide extra args to ngrok in ddev share",
       "type": "string"

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -238,10 +238,10 @@ const ConfigInstructions = `
 # override_config: false
 # By default, config.*.yaml files are *merged* into the configuration
 # But this means that some things can't be overridden
-# For example, if you have 'nfs_mount_enabled: true'' you can't override it with a merge
+# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
 # and you can't erase existing hooks or all environment variables.
 # However, with "override_config: true" in a particular config.*.yaml file,
-# 'nfs_mount_enabled: false' can override the existing values, and
+# 'use_dns_when_possible: false' can override the existing values, and
 # hooks:
 #   post-start: []
 # or

--- a/pkg/ddevapp/testdata/TestConfigMerge/fulloverridetest/components/.ddev/config.override.yaml
+++ b/pkg/ddevapp/testdata/TestConfigMerge/fulloverridetest/components/.ddev/config.override.yaml
@@ -1,3 +1,3 @@
 override_config: true
-nfs_mount_enabled: false
+use_dns_when_possible: false
 additional_hostnames: [overrideone, overridetwo]

--- a/pkg/ddevapp/testdata/TestConfigMerge/fulloverridetest/components/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestConfigMerge/fulloverridetest/components/.ddev/config.yaml
@@ -3,5 +3,5 @@ database:
   version: 10.5
 php_version: 5.6
 webserver_type: apache-fpm
-nfs_mount_enabled: true
+use_dns_when_possible: true
 additional_hostnames: [baseone, basetwo, basethree]

--- a/pkg/ddevapp/testdata/TestConfigMerge/fulloverridetest/expected/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestConfigMerge/fulloverridetest/expected/.ddev/config.yaml
@@ -3,5 +3,5 @@ database:
   version: 10.5
 php_version: 5.6
 webserver_type: apache-fpm
-nfs_mount_enabled: false
+use_dns_when_possible: false
 additional_hostnames: [overrideone, overridetwo, z-one]

--- a/pkg/ddevapp/testdata/TestConfigMerge/overridetest/components/.ddev/config.last.yaml
+++ b/pkg/ddevapp/testdata/TestConfigMerge/overridetest/components/.ddev/config.last.yaml
@@ -1,2 +1,2 @@
 webimage_extra_packages: [php7.4-tidy]
-nfs_mount_enabled: true
+use_dns_when_possible: true

--- a/pkg/ddevapp/testdata/TestConfigMerge/overridetest/components/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestConfigMerge/overridetest/components/.ddev/config.yaml
@@ -5,4 +5,4 @@ database:
   version: 10.5
 php_version: 5.6
 webserver_type: apache-fpm
-nfs_mount_enabled: false
+use_dns_when_possible: false

--- a/pkg/ddevapp/testdata/TestConfigMerge/overridetest/expected/.ddev/config.yaml
+++ b/pkg/ddevapp/testdata/TestConfigMerge/overridetest/expected/.ddev/config.yaml
@@ -5,4 +5,4 @@ database:
 php_version: 5.6
 webserver_type: apache-fpm
 webimage_extra_packages: [php7.4-tidy]
-nfs_mount_enabled: true
+use_dns_when_possible: true


### PR DESCRIPTION
## The Issue
During a BOF you mentioned this was a bit outdated, so I updated it with what you said it needed to be 😄 

## How This PR Solves The Issue

* Updated the docs!
* Updated other usages in tests which shouldn't have been relying on that. 

## Manual Testing Instructions

I don't think we have to do anything.

## Automated Testing Overview

I think the minor modifications to tests are OK.

