### PR TITLE
ci: apply new rules from golangci-lint v1.55.0

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
-	. "github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
@@ -42,7 +42,7 @@ func TestNewConfig(t *testing.T) {
 	origDir, _ := os.Getwd()
 
 	// Load a new Config
-	app, err := NewApp(testDir, true)
+	app, err := ddevapp.NewApp(testDir, true)
 	assert.NoError(err)
 
 	t.Cleanup(func() {
@@ -66,7 +66,7 @@ func TestNewConfig(t *testing.T) {
 	_, err = os.Stat(app.ConfigPath)
 	assert.NoError(err)
 
-	loadedConfig, err := NewApp(testDir, true)
+	loadedConfig, err := ddevapp.NewApp(testDir, true)
 	assert.NoError(err)
 	assert.Equal(app.Name, loadedConfig.Name)
 	assert.Equal(app.Type, loadedConfig.Type)
@@ -80,7 +80,7 @@ func TestDisasterConfig(t *testing.T) {
 
 	// Make sure we're not allowed to config in home directory.
 	tmpDir, _ := os.UserHomeDir()
-	_, err := NewApp(tmpDir, false)
+	_, err := ddevapp.NewApp(tmpDir, false)
 	assert.Error(err)
 	assert.Contains(err.Error(), "ddev config is not useful")
 	_ = os.Chdir(origDir)
@@ -89,7 +89,7 @@ func TestDisasterConfig(t *testing.T) {
 	tmpDir = testcommon.CreateTmpDir(t.Name())
 
 	// Load a new Config
-	app, err := NewApp(tmpDir, false)
+	app, err := ddevapp.NewApp(tmpDir, false)
 	assert.NoError(err)
 
 	t.Cleanup(func() {
@@ -111,7 +111,7 @@ func TestDisasterConfig(t *testing.T) {
 	assert.NoError(err)
 	err = os.Chdir(subdir)
 	assert.NoError(err)
-	subdirApp, err := NewApp(subdir, false)
+	subdirApp, err := ddevapp.NewApp(subdir, false)
 	assert.NoError(err)
 	_ = subdirApp
 
@@ -120,13 +120,13 @@ func TestDisasterConfig(t *testing.T) {
 // TestAllowedAppType tests the IsAllowedAppType function.
 func TestAllowedAppTypes(t *testing.T) {
 	assert := asrt.New(t)
-	for _, v := range GetValidAppTypes() {
-		assert.True(IsValidAppType(v))
+	for _, v := range ddevapp.GetValidAppTypes() {
+		assert.True(ddevapp.IsValidAppType(v))
 	}
 
 	for i := 1; i <= 50; i++ {
 		randomType := util.RandString(32)
-		assert.False(IsValidAppType(randomType))
+		assert.False(ddevapp.IsValidAppType(randomType))
 	}
 }
 
@@ -145,11 +145,11 @@ func TestPrepDirectory(t *testing.T) {
 		err = os.RemoveAll(testDir)
 		assert.NoError(err)
 	})
-	app, err := NewApp(testDir, true)
+	app, err := ddevapp.NewApp(testDir, true)
 	assert.NoError(err)
 
 	// Prep the directory.
-	err = PrepDdevDirectory(app)
+	err = ddevapp.PrepDdevDirectory(app)
 	assert.NoError(err)
 
 	// Read directory info an ensure it exists.
@@ -164,7 +164,7 @@ func TestHostName(t *testing.T) {
 	testDir := testcommon.CreateTmpDir("TestHostName")
 	err := os.Chdir(testDir)
 	require.NoError(t, err)
-	app, err := NewApp(testDir, true)
+	app, err := ddevapp.NewApp(testDir, true)
 	assert.NoError(err)
 	t.Cleanup(func() {
 		err = os.Chdir(origDir)
@@ -186,7 +186,7 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	origDir, _ := os.Getwd()
 	testDir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(testDir, true)
+	app, err := ddevapp.NewApp(testDir, true)
 	assert.NoError(err)
 
 	t.Cleanup(func() {
@@ -198,7 +198,7 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	})
 
 	app.Name = util.RandString(32)
-	app.Type = GetValidAppTypes()[0]
+	app.Type = ddevapp.GetValidAppTypes()[0]
 
 	// WriteConfig a config to create/prep necessary directories.
 	err = app.WriteConfig()
@@ -247,7 +247,7 @@ func TestConfigCommand(t *testing.T) {
 
 		// Create the ddevapp we'll use for testing.
 		// This will not return an error, since there is no existing configuration.
-		app, err := NewApp(testDir, true)
+		app, err := ddevapp.NewApp(testDir, true)
 		assert.NoError(err)
 
 		t.Cleanup(func() {
@@ -297,7 +297,7 @@ func TestConfigCommand(t *testing.T) {
 		assert.Equal(testValues[apptypePos], app.Type)
 		assert.Equal("docroot", app.Docroot)
 		assert.EqualValues(testValues[phpVersionPos], app.PHPVersion, "PHP value incorrect for apptype %v (expected %s got %s) (%v)", app.Type, testValues[phpVersionPos], app.PHPVersion, app)
-		err = PrepDdevDirectory(app)
+		err = ddevapp.PrepDdevDirectory(app)
 		assert.NoError(err)
 	}
 }
@@ -326,7 +326,7 @@ func TestConfigCommandInteractiveCreateDocrootDenied(t *testing.T) {
 
 		// Create the ddevapp we'll use for testing.
 		// This will not return an error, since there is no existing configuration.
-		app, err := NewApp(testDir, true)
+		app, err := ddevapp.NewApp(testDir, true)
 		require.NoError(t, err)
 
 		t.Cleanup(func() {
@@ -354,7 +354,7 @@ func TestConfigCommandInteractiveCreateDocrootDenied(t *testing.T) {
 		// Ensure we have expected vales in output.
 		assert.Contains(err.Error(), "docroot must exist to continue configuration")
 
-		err = PrepDdevDirectory(app)
+		err = ddevapp.PrepDdevDirectory(app)
 		assert.NoError(err)
 		util.Success("Finished %s", t.Name())
 	}
@@ -382,7 +382,7 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 
 		// Create the ddevapp we'll use for testing.
 		// This will not return an error, since there is no existing configuration.
-		app, err := NewApp(tmpDir, true)
+		app, err := ddevapp.NewApp(tmpDir, true)
 		assert.NoError(err)
 
 		t.Cleanup(func() {
@@ -419,7 +419,7 @@ func TestConfigCommandCreateDocrootAllowed(t *testing.T) {
 		assert.Equal(nonexistentDocroot, app.Docroot)
 		assert.Equal(testValues[phpVersionPos], app.PHPVersion, "expected php%v for apptype %s", testValues[phpVersionPos], app.Type)
 
-		err = PrepDdevDirectory(app)
+		err = ddevapp.PrepDdevDirectory(app)
 		assert.NoError(err)
 	}
 	util.Success("Finished %s", t.Name())
@@ -431,7 +431,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
 
-	testMatrix := AvailablePHPDocrootLocations()
+	testMatrix := ddevapp.AvailablePHPDocrootLocations()
 	for index, testDocrootName := range testMatrix {
 		tmpDir := testcommon.CreateTmpDir(fmt.Sprintf("TestConfigCommand_%v", index))
 
@@ -445,7 +445,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 
 		// Create the ddevapp we'll use for testing.
 		// This will not return an error, since there is no existing configuration.
-		app, err := NewApp(tmpDir, true)
+		app, err := ddevapp.NewApp(tmpDir, true)
 		assert.NoError(err)
 
 		t.Cleanup(func() {
@@ -475,7 +475,7 @@ func TestConfigCommandDocrootDetection(t *testing.T) {
 		assert.Equal(name, app.Name)
 		assert.Equal(nodeps.AppTypeDrupal8, app.Type)
 		assert.Equal(testDocrootName, app.Docroot)
-		err = PrepDdevDirectory(app)
+		err = ddevapp.PrepDdevDirectory(app)
 		assert.NoError(err)
 	}
 }
@@ -504,7 +504,7 @@ func TestConfigCommandDocrootDetectionIndexVerification(t *testing.T) {
 
 	// Create the ddevapp we'll use for testing.
 	// This will not return an error, since there is no existing configuration.
-	app, err := NewApp(testDir, true)
+	app, err := ddevapp.NewApp(testDir, true)
 	assert.NoError(err)
 
 	t.Cleanup(func() {
@@ -534,7 +534,7 @@ func TestConfigCommandDocrootDetectionIndexVerification(t *testing.T) {
 	assert.Equal(name, app.Name)
 	assert.Equal(nodeps.AppTypeDrupal8, app.Type)
 	assert.Equal("docroot", app.Docroot)
-	err = PrepDdevDirectory(app)
+	err = ddevapp.PrepDdevDirectory(app)
 	assert.NoError(err)
 }
 
@@ -543,7 +543,7 @@ func TestReadConfig(t *testing.T) {
 	assert := asrt.New(t)
 
 	// This closely resembles the values one would have from NewApp()
-	app := &DdevApp{
+	app := &ddevapp.DdevApp{
 		ConfigPath: filepath.Join("testdata", "config.yaml"),
 		AppRoot:    "testdata",
 		Name:       "TestRead",
@@ -568,7 +568,7 @@ func TestReadConfigCRLF(t *testing.T) {
 	assert := asrt.New(t)
 
 	// This closely resembles the values one would have from NewApp()
-	app := &DdevApp{
+	app := &ddevapp.DdevApp{
 		ConfigPath: filepath.Join("testdata", t.Name(), ".ddev", "config.yaml"),
 		AppRoot:    filepath.Join("testdata", t.Name()),
 		Name:       t.Name(),
@@ -594,7 +594,7 @@ func TestConfigValidate(t *testing.T) {
 
 	assert := asrt.New(t)
 	site := TestSites[0]
-	app, err := NewApp(site.Dir, false)
+	app, err := ddevapp.NewApp(site.Dir, false)
 	assert.NoError(err)
 	savedApp := *app
 
@@ -779,7 +779,7 @@ func TestWriteConfig(t *testing.T) {
 	err = fileutil.CopyDir("./testdata/TestWriteConfig/.ddev", filepath.Join(projDir, ".ddev"))
 	require.NoError(t, err)
 
-	app, err := NewApp(projDir, true)
+	app, err := ddevapp.NewApp(projDir, true)
 	assert.NoError(err)
 	err = os.Chdir(projDir)
 	assert.NoError(err)
@@ -798,7 +798,7 @@ func TestWriteConfig(t *testing.T) {
 	assert.Equal("drupal9", app.Type)
 
 	// However, if we ReadConfig() without includeOverrides, we should get "php" as the type
-	app, err = NewApp(projDir, false)
+	app, err = ddevapp.NewApp(projDir, false)
 	assert.NoError(err)
 	assert.Equal("php", app.Type)
 
@@ -820,7 +820,7 @@ func TestConfigOverrideDetection(t *testing.T) {
 	testDataDdevDir := filepath.Join("testdata", t.Name(), ".ddev")
 
 	assert := asrt.New(t)
-	app := &DdevApp{}
+	app := &ddevapp.DdevApp{}
 	testDir, _ := os.Getwd()
 
 	site := TestSites[0]
@@ -858,7 +858,7 @@ func TestConfigOverrideDetection(t *testing.T) {
 
 	var logs, health string
 	if startErr != nil {
-		logs, health, _ = GetErrLogsFromApp(app, startErr)
+		logs, health, _ = ddevapp.GetErrLogsFromApp(app, startErr)
 	}
 
 	require.NoError(t, startErr, "app.StartAndWait() did not succeed: output:\n=====\n%s\n===== health:\n========= health =======\n%s\n========\n===== logs:\n========= logs =======\n%s\n========\n", stdout, health, logs)
@@ -888,7 +888,7 @@ func TestPHPOverrides(t *testing.T) {
 
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
-	app := &DdevApp{}
+	app := &ddevapp.DdevApp{}
 
 	site := TestSites[0]
 
@@ -935,7 +935,7 @@ func TestPHPOverrides(t *testing.T) {
 	startErr := app.StartAndWait(5)
 	assert.NoError(startErr)
 	if startErr != nil {
-		logs, health, _ := GetErrLogsFromApp(app, startErr)
+		logs, health, _ := ddevapp.GetErrLogsFromApp(app, startErr)
 		t.Fatalf("============== health from app.StartAndWait() ==============\n%s\n============== logs from app.StartAndWait() ==============\n%s\n", health, logs)
 	}
 
@@ -950,7 +950,7 @@ func TestPHPConfig(t *testing.T) {
 
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
-	app := &DdevApp{}
+	app := &ddevapp.DdevApp{}
 	site := TestSites[0]
 	err := os.Chdir(site.Dir)
 	require.NoError(t, err)
@@ -979,14 +979,14 @@ func TestPHPConfig(t *testing.T) {
 		err = app.Start()
 		require.NoError(t, err)
 
-		out, _, err := app.Exec(&ExecOpts{
+		out, _, err := app.Exec(&ddevapp.ExecOpts{
 			Cmd: "php --version",
 		})
 		require.NoError(t, err)
 		t.Logf("============= PHP version=%s ================", out)
 
 		// Look for problems with serialize_precision,https://github.com/ddev/ddev/issues/5092
-		out, _, err = app.Exec(&ExecOpts{
+		out, _, err = app.Exec(&ddevapp.ExecOpts{
 			Cmd: `php -r "var_dump(0.6);"`,
 		})
 		require.NoError(t, err)
@@ -1006,10 +1006,10 @@ func TestPostgresConfigOverride(t *testing.T) {
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
-	app, err := NewApp(tmpDir, false)
+	app, err := ddevapp.NewApp(tmpDir, false)
 	require.NoError(t, err)
 	app.Name = t.Name()
-	app.Database = DatabaseDesc{Type: nodeps.Postgres, Version: nodeps.PostgresDefaultVersion}
+	app.Database = ddevapp.DatabaseDesc{Type: nodeps.Postgres, Version: nodeps.PostgresDefaultVersion}
 	err = app.WriteConfig()
 	require.NoError(t, err)
 
@@ -1024,7 +1024,7 @@ func TestPostgresConfigOverride(t *testing.T) {
 	err = app.Start()
 	require.NoError(t, err)
 
-	out, stderr, err := app.Exec(&ExecOpts{
+	out, stderr, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "db",
 		Cmd:     `psql -t -c "SELECT setting FROM pg_settings WHERE name='max_connections'"`,
 	})
@@ -1039,7 +1039,7 @@ func TestPostgresConfigOverride(t *testing.T) {
 	require.NoError(t, err)
 	err = app.Restart()
 	require.NoError(t, err)
-	out, stderr, err = app.Exec(&ExecOpts{
+	out, stderr, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "db",
 		Cmd:     `psql -t -c "SELECT setting FROM pg_settings WHERE name='max_connections'"`,
 	})
@@ -1051,7 +1051,7 @@ func TestPostgresConfigOverride(t *testing.T) {
 // work (and are overridden by *-build/Dockerfile).
 func TestExtraPackages(t *testing.T) {
 	assert := asrt.New(t)
-	app := &DdevApp{}
+	app := &ddevapp.DdevApp{}
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
@@ -1086,7 +1086,7 @@ func TestExtraPackages(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test db container to make sure no ncdu in there at beginning
-	_, _, err = app.Exec(&ExecOpts{
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "db",
 		Cmd:     "command -v ncdu 2>/dev/null",
 	})
@@ -1096,7 +1096,7 @@ func TestExtraPackages(t *testing.T) {
 	addedPackage := "tidy"
 	addedPackageTitle := "Tidy"
 
-	_, _, err = app.Exec(&ExecOpts{
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Cmd:     fmt.Sprintf("dpkg -s php%s-%s >/dev/null 2>&1", app.PHPVersion, addedPackage),
 	})
@@ -1109,19 +1109,19 @@ func TestExtraPackages(t *testing.T) {
 	err = app.Restart()
 	require.NoError(t, err)
 
-	stdout, stderr, err := app.Exec(&ExecOpts{
+	stdout, stderr, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Cmd:     "dpkg -s php" + app.PHPVersion + "-" + addedPackage,
 	})
 	assert.NoError(err, "dpkg -s php%s-%s failed", app.PHPVersion, addedPackage, stdout, stderr)
 
-	stdout, stderr, err = app.Exec(&ExecOpts{
+	stdout, stderr, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Cmd:     fmt.Sprintf("php -i | grep  '%s support =. enabled'", addedPackageTitle),
 	})
 	assert.NoError(err, "failed to grep for %s support, stdout=%s, stderr=%s", addedPackage, stdout, stderr)
 
-	stdout, _, err = app.Exec(&ExecOpts{
+	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "db",
 		Cmd:     "command -v ncdu",
 	})
@@ -1132,7 +1132,7 @@ func TestExtraPackages(t *testing.T) {
 // TestTimezoneConfig tests to make sure setting timezone config takes effect in the container.
 func TestTimezoneConfig(t *testing.T) {
 	assert := asrt.New(t)
-	app := &DdevApp{}
+	app := &ddevapp.DdevApp{}
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
@@ -1154,7 +1154,7 @@ func TestTimezoneConfig(t *testing.T) {
 	assert.NoError(err)
 
 	// Without timezone set, we should find Etc/UTC
-	stdout, _, err := app.Exec(&ExecOpts{
+	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Cmd:     "printf \"timezone=$(date +%Z)\n\" && php -r 'print \"phptz=\" . date_default_timezone_get();'",
 	})
@@ -1162,7 +1162,7 @@ func TestTimezoneConfig(t *testing.T) {
 	assert.Equal("timezone=UTC\nphptz=UTC", stdout)
 
 	// Make sure db container is also working
-	stdout, _, err = app.Exec(&ExecOpts{
+	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "db",
 		Cmd:     "echo -n timezone=$(date +%Z)",
 	})
@@ -1173,7 +1173,7 @@ func TestTimezoneConfig(t *testing.T) {
 	app.Timezone = "Europe/Paris"
 	err = app.Start()
 	require.NoError(t, err)
-	stdout, _, err = app.Exec(&ExecOpts{
+	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
 		Cmd:     "printf \"timezone=$(date +%Z)\n\" && php -r 'print \"phptz=\" . date_default_timezone_get();'",
 	})
@@ -1181,7 +1181,7 @@ func TestTimezoneConfig(t *testing.T) {
 	assert.Regexp(regexp.MustCompile("timezone=CES?T\nphptz=Europe/Paris"), stdout)
 
 	// Make sure db container is also working with CET
-	stdout, _, err = app.Exec(&ExecOpts{
+	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "db",
 		Cmd:     "echo -n timezone=$(date +%Z)",
 	})
@@ -1197,7 +1197,7 @@ func TestComposerVersionConfig(t *testing.T) {
 		t.Skip("Skipping on Mac M1 and Colima, lots of network connections failed")
 	}
 	assert := asrt.New(t)
-	app := &DdevApp{}
+	app := &ddevapp.DdevApp{}
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
@@ -1223,7 +1223,7 @@ func TestComposerVersionConfig(t *testing.T) {
 		err = app.Start()
 		assert.NoError(err)
 
-		stdout, _, err := app.Exec(&ExecOpts{
+		stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
 			Cmd:     "composer --version 2>/dev/null | awk '/Composer version/ {print $3;}'",
 		})
@@ -1247,7 +1247,7 @@ func TestComposerVersionConfig(t *testing.T) {
 // Dockerfiles work properly
 func TestCustomBuildDockerfiles(t *testing.T) {
 	assert := asrt.New(t)
-	app := &DdevApp{}
+	app := &ddevapp.DdevApp{}
 
 	site := TestSites[0]
 	switchDir := site.Chdir()
@@ -1274,37 +1274,37 @@ func TestCustomBuildDockerfiles(t *testing.T) {
 	for _, item := range []string{"web", "db"} {
 		err = fileutil.TemplateStringToFile("junkfile", nil, app.GetConfigPath(fmt.Sprintf("%s-build/junkfile", item)))
 		assert.NoError(err)
-		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile"), []byte(`
+		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile"), []byte(`
 RUN touch /var/tmp/`+"added-by-"+item+".txt"))
 		assert.NoError(err)
 		// Add also Dockerfile.* alternatives
 		// Last one includes previously recommended ARG/FROM that needs to be removed
-		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test1"), []byte(`
+		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test1"), []byte(`
 ADD junkfile /
 RUN touch /var/tmp/`+"added-by-"+item+"-test1.txt"))
 		assert.NoError(err)
 
-		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test2"), []byte(`
+		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test2"), []byte(`
 RUN touch /var/tmp/`+"added-by-"+item+"-test2.txt"))
 		assert.NoError(err)
 
 		// Testing pre.Dockerfile.*
-		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/pre.Dockerfile.test3"), []byte(`
+		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/pre.Dockerfile.test3"), []byte(`
 RUN touch /var/tmp/`+"added-by-"+item+"-test3.txt"))
 		assert.NoError(err)
 
 		// Testing that pre comes before post, we create a file on pre and remove
 		// it on post
-		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/pre.Dockerfile.test4"), []byte(`
+		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/pre.Dockerfile.test4"), []byte(`
 RUN touch /var/tmp/`+"added-by-"+item+"-test4.txt"))
 		assert.NoError(err)
-		err = WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test4"), []byte(`
+		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test4"), []byte(`
 RUN rm /var/tmp/`+"added-by-"+item+"-test4.txt"))
 		assert.NoError(err)
 	}
 
 	// Make sure that DDEV_PHP_VERSION gets into the build
-	err = WriteImageDockerfile(app.GetConfigPath("web-build/Dockerfile.ddev-php-version"), []byte(`
+	err = ddevapp.WriteImageDockerfile(app.GetConfigPath("web-build/Dockerfile.ddev-php-version"), []byte(`
 ARG DDEV_PHP_VERSION
 RUN touch /var/tmp/running-php-${DDEV_PHP_VERSION}
 `))
@@ -1316,39 +1316,39 @@ RUN touch /var/tmp/running-php-${DDEV_PHP_VERSION}
 
 	// Make sure that the expected in-container file has been created
 	for _, item := range []string{"web", "db"} {
-		_, _, err = app.Exec(&ExecOpts{
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: item,
 			Cmd:     "ls /junkfile",
 		})
 		assert.NoError(err)
-		_, _, err = app.Exec(&ExecOpts{
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: item,
 			Cmd:     "ls /var/tmp/added-by-" + item + ".txt >/dev/null",
 		})
 		assert.NoError(err)
-		_, _, err = app.Exec(&ExecOpts{
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: item,
 			Cmd:     "ls /var/tmp/added-by-" + item + "-test1.txt >/dev/null",
 		})
 		assert.NoError(err)
-		_, _, err = app.Exec(&ExecOpts{
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: item,
 			Cmd:     "ls /var/tmp/added-by-" + item + "-test2.txt >/dev/null",
 		})
 		assert.NoError(err)
-		_, _, err = app.Exec(&ExecOpts{
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: item,
 			Cmd:     "ls /var/tmp/added-by-" + item + "-test3.txt >/dev/null",
 		})
 		assert.NoError(err)
-		_, _, err = app.Exec(&ExecOpts{
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: item,
 			Cmd:     "ls /var/tmp/added-by-" + item + "-test4.txt 2>/dev/null",
 		})
 		assert.Error(err)
 	}
 
-	_, _, err = app.Exec(&ExecOpts{
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Cmd: fmt.Sprintf("ls /var/tmp/running-php-%s >/dev/null", app.PHPVersion),
 	})
 	assert.NoError(err)
@@ -1366,7 +1366,7 @@ func TestConfigLoadingOrder(t *testing.T) {
 	err = fileutil.CopyDir("./testdata/TestConfigLoadingOrder/.ddev", filepath.Join(projDir, ".ddev"))
 	require.NoError(t, err)
 
-	app, err := NewApp(projDir, true)
+	app, err := ddevapp.NewApp(projDir, true)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1392,7 +1392,7 @@ func TestConfigLoadingOrder(t *testing.T) {
 		assert.NoError(err)
 		err = os.Symlink(item, linkedMatch)
 		assert.NoError(err)
-		app, err = NewApp(app.AppRoot, true)
+		app, err = ddevapp.NewApp(app.AppRoot, true)
 		assert.NoError(err)
 		assert.Equal(filepath.Base(item), app.WebImage)
 		err = os.Remove(linkedMatch)
@@ -1409,13 +1409,13 @@ func TestConfigLoadingOrder(t *testing.T) {
 		assert.NoError(err)
 		err = os.Symlink(item, linkedMatch)
 		assert.NoError(err)
-		app, err = NewApp(app.AppRoot, true)
+		app, err = ddevapp.NewApp(app.AppRoot, true)
 		assert.Equal(filepath.Base(item), app.WebImage)
 	}
 
 	// Now we still have all those linked overrides, but do a NewApp() without allowing them
 	// and verify that they don't get loaded
-	app, err = NewApp(app.AppRoot, false)
+	app, err = ddevapp.NewApp(app.AppRoot, false)
 	assert.NoError(err)
 	assert.Equal("config.yaml", app.WebImage)
 }
@@ -1435,7 +1435,7 @@ func TestPkgConfigDatabaseDBVersion(t *testing.T) {
 	err = globalconfig.ReadGlobalConfig()
 	require.NoError(t, err)
 
-	app, err := NewApp(tmpDir, false)
+	app, err := ddevapp.NewApp(tmpDir, false)
 	require.NoError(t, err)
 	app.Name = t.Name()
 	err = app.WriteConfig()
@@ -1479,7 +1479,7 @@ func TestDatabaseConfigUpgrade(t *testing.T) {
 	err = globalconfig.ReadGlobalConfig()
 	require.NoError(t, err)
 
-	app, err := NewApp(tmpDir, false)
+	app, err := ddevapp.NewApp(tmpDir, false)
 	require.NoError(t, err)
 	app.Name = t.Name()
 	err = app.WriteConfig()
@@ -1499,7 +1499,7 @@ func TestDatabaseConfigUpgrade(t *testing.T) {
 		err = os.RemoveAll(configFile)
 		assert.NoError(err)
 		err = fileutil.AppendStringToFile(configFile, fmt.Sprintf("name: %s\n%s_version: %s\n", t.Name(), parts[0], parts[1]))
-		app, err := NewApp(tmpDir, false)
+		app, err := ddevapp.NewApp(tmpDir, false)
 		require.NoError(t, err)
 		assert.Equal(parts[0], app.Database.Type)
 		assert.Equal(parts[1], app.Database.Version)
@@ -1517,7 +1517,7 @@ func TestConfigFunctionality(t *testing.T) {
 
 	site := TestSites[0]
 
-	app, err := NewApp(site.Dir, false)
+	app, err := ddevapp.NewApp(site.Dir, false)
 	assert.NoError(err)
 	err = os.Chdir(site.Dir)
 	assert.NoError(err)

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -2,16 +2,17 @@ package ddevapp_test
 
 import (
 	"fmt"
-	. "github.com/ddev/ddev/pkg/ddevapp"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 // TestExtraPortExpose tests exposing additional ports with web_extra_exposed_ports.
@@ -22,7 +23,7 @@ func TestExtraPortExpose(t *testing.T) {
 	site := TestSites[0]
 
 	testcommon.ClearDockerEnv()
-	app := new(DdevApp)
+	app := new(ddevapp.DdevApp)
 	err := app.Init(site.Dir)
 	assert.NoError(err)
 
@@ -40,11 +41,11 @@ func TestExtraPortExpose(t *testing.T) {
 	err = os.WriteFile(filepath.Join(app.AppRoot, "sub", "testfile.html"), []byte(`this is test2 in root/sub`), 0755)
 	require.NoError(t, err)
 
-	app.WebExtraExposedPorts = []WebExposedPort{
+	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
 		{Name: "first", WebContainerPort: 3000, HTTPPort: 2999, HTTPSPort: 3000},
 		{Name: "second", WebContainerPort: 4000, HTTPPort: 3999, HTTPSPort: 4000},
 	}
-	app.WebExtraDaemons = []WebExtraDaemon{
+	app.WebExtraDaemons = []ddevapp.WebExtraDaemon{
 		{Name: "FirstDaemon", Command: "php -S 0.0.0.0:3000", Directory: "/var/www/html"},
 		{Name: "SecondDaemon", Command: "php -S 0.0.0.0:4000", Directory: "/var/www/html/sub"},
 	}
@@ -56,7 +57,7 @@ func TestExtraPortExpose(t *testing.T) {
 
 	// Careful with portsToTest because https ports won't work on GitHub Actions Colima tests (although they work fine on normal Mac)
 	portsToTest := []string{"3000", "4000"}
-	if !nodeps.IsGitpod() && !nodeps.IsCodespaces() && (globalconfig.GetCAROOT() == "" || IsRouterDisabled(app)) {
+	if !nodeps.IsGitpod() && !nodeps.IsCodespaces() && (globalconfig.GetCAROOT() == "" || ddevapp.IsRouterDisabled(app)) {
 		portsToTest = []string{"2999", "3999"}
 	}
 

--- a/pkg/ddevapp/providerGit_test.go
+++ b/pkg/ddevapp/providerGit_test.go
@@ -1,17 +1,17 @@
 package ddevapp_test
 
 import (
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/mitchellh/go-homedir"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	. "github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/mitchellh/go-homedir"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestGitPull ensures we can pull backups from a Git repository
@@ -25,7 +25,7 @@ func TestGitPull(t *testing.T) {
 
 	err = os.Chdir(siteDir)
 	assert.NoError(err)
-	app, err := NewApp(siteDir, true)
+	app, err := ddevapp.NewApp(siteDir, true)
 	assert.NoError(err)
 	app.Name = t.Name()
 	app.Type = nodeps.AppTypeDrupal9
@@ -47,7 +47,7 @@ func TestGitPull(t *testing.T) {
 		_ = os.RemoveAll(filepath.Join(home, "tmp", "ddev-pull-git-test-repo"))
 	})
 
-	err = PopulateExamplesCommandsHomeadditions(app.Name)
+	err = ddevapp.PopulateExamplesCommandsHomeadditions(app.Name)
 	require.NoError(t, err)
 
 	// Build our git.yaml from the example file
@@ -67,7 +67,7 @@ func TestGitPull(t *testing.T) {
 	assert.NoError(err)
 
 	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "tmp/veggie-pasta-bake-hero-umami.jpg"))
-	out, _, err := app.Exec(&ExecOpts{
+	out, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd:     "echo 'select COUNT(*) from users_field_data where mail=\"margaret.hopper@example.com\";' | mysql -N",
 		Service: "db",
 	})

--- a/pkg/ddevapp/providerLagoon_test.go
+++ b/pkg/ddevapp/providerLagoon_test.go
@@ -2,19 +2,19 @@ package ddevapp_test
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/exec"
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	. "github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 /**
@@ -60,7 +60,7 @@ func TestLagoonPull(t *testing.T) {
 
 	err = os.Chdir(siteDir)
 	assert.NoError(err)
-	app, err := NewApp(siteDir, true)
+	app, err := ddevapp.NewApp(siteDir, true)
 	assert.NoError(err)
 	app.Name = t.Name()
 	app.Type = nodeps.AppTypeDrupal9
@@ -81,7 +81,7 @@ func TestLagoonPull(t *testing.T) {
 		assert.NoError(err)
 	})
 
-	err = PopulateExamplesCommandsHomeadditions(app.Name)
+	err = ddevapp.PopulateExamplesCommandsHomeadditions(app.Name)
 	require.NoError(t, err)
 
 	app.Docroot = "web"
@@ -125,7 +125,7 @@ func TestLagoonPush(t *testing.T) {
 	err = globalconfig.RemoveProjectInfo(t.Name())
 	require.NoError(t, err)
 
-	app, err := NewApp(siteDir, true)
+	app, err := ddevapp.NewApp(siteDir, true)
 	assert.NoError(err)
 
 	t.Cleanup(func() {
@@ -149,7 +149,7 @@ func TestLagoonPush(t *testing.T) {
 
 	testcommon.ClearDockerEnv()
 
-	err = PopulateExamplesCommandsHomeadditions(app.Name)
+	err = ddevapp.PopulateExamplesCommandsHomeadditions(app.Name)
 	require.NoError(t, err)
 
 	provider, err := app.GetProvider("lagoon")
@@ -169,7 +169,7 @@ func TestLagoonPush(t *testing.T) {
 
 	// Create database and files entries that we can verify after push
 	tval := nodeps.RandomString(10)
-	_, _, err = app.Exec(&ExecOpts{
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Cmd: fmt.Sprintf(`mysql -e 'CREATE TABLE IF NOT EXISTS %s ( title VARCHAR(255) NOT NULL ); INSERT INTO %s VALUES("%s");'`, t.Name(), t.Name(), tval),
 	})
 	require.NoError(t, err)
@@ -184,14 +184,14 @@ func TestLagoonPush(t *testing.T) {
 	// Test that the database row was added
 	c := fmt.Sprintf(`echo 'SELECT title FROM %s WHERE title="%s";' | lagoon ssh -p %s -e %s -C 'mysql --host=$MARIADB_HOST --user=$MARIADB_USERNAME --password=$MARIADB_PASSWORD --database=$MARIADB_DATABASE'`, t.Name(), tval, lagoonProjectName, lagoonPushTestSiteEnvironment)
 	//t.Logf("attempting command '%s'", c)
-	out, _, err := app.Exec(&ExecOpts{
+	out, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd: c,
 	})
 	assert.NoError(err)
 	assert.Contains(out, tval)
 
 	// Test that the file arrived there
-	out, _, err = app.Exec(&ExecOpts{
+	out, _, err = app.Exec(&ddevapp.ExecOpts{
 		Cmd: fmt.Sprintf(`lagoon ssh -p %s -e %s -C 'ls -l /app/web/sites/default/files/%s'`, lagoonProjectName, lagoonPushTestSiteEnvironment, fName),
 	})
 	assert.NoError(err)

--- a/pkg/ddevapp/providerLocalfile_test.go
+++ b/pkg/ddevapp/providerLocalfile_test.go
@@ -1,19 +1,19 @@
 package ddevapp_test
 
 import (
-	"github.com/ddev/ddev/pkg/dockerutil"
-	"github.com/ddev/ddev/pkg/exec"
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	. "github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestLocalfilePull ensures we can pull backups from a flat file for a configured environment.
@@ -28,7 +28,7 @@ func TestLocalfilePull(t *testing.T) {
 	err = os.Chdir(tmpDir)
 	require.NoError(t, err)
 
-	app, err := NewApp(tmpDir, true)
+	app, err := ddevapp.NewApp(tmpDir, true)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err = app.Stop(true, false)
@@ -55,7 +55,7 @@ func TestLocalfilePull(t *testing.T) {
 
 	testcommon.ClearDockerEnv()
 
-	err = PopulateExamplesCommandsHomeadditions(app.Name)
+	err = ddevapp.PopulateExamplesCommandsHomeadditions(app.Name)
 	require.NoError(t, err)
 
 	// Build our localfile.yaml from the example file
@@ -78,7 +78,7 @@ func TestLocalfilePull(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "docs/developers/building-contributing.md"))
-	out, _, err = app.Exec(&ExecOpts{
+	out, _, err = app.Exec(&ddevapp.ExecOpts{
 		Cmd:     "echo 'select COUNT(*) from users_field_data where mail=\"margaret.hopper@example.com\";' | mysql -N",
 		Service: "db",
 	})

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -2,18 +2,18 @@ package ddevapp_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
 
-	. "github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type settingsLocations struct {
@@ -45,7 +45,7 @@ func TestWriteSettings(t *testing.T) {
 	}
 	testDir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(testDir, true)
+	app, err := ddevapp.NewApp(testDir, true)
 	assert.NoError(err)
 
 	t.Cleanup(func() {
@@ -91,7 +91,7 @@ func TestWriteSettings(t *testing.T) {
 // TestWriteDrushConfig test the Drush config we write
 func TestWriteDrushConfig(t *testing.T) {
 	assert := asrt.New(t)
-	app := &DdevApp{}
+	app := &ddevapp.DdevApp{}
 	origDir, _ := os.Getwd()
 
 	for _, site := range TestSites {
@@ -121,7 +121,7 @@ func TestWriteDrushConfig(t *testing.T) {
 		//nolint: errcheck
 		defer app.Stop(true, false)
 		if startErr != nil {
-			logs, health, _ := GetErrLogsFromApp(app, startErr)
+			logs, health, _ := ddevapp.GetErrLogsFromApp(app, startErr)
 			t.Fatalf("app.Start failed, startErr=%v, healthcheck:\n%s\n\nlogs=\n========\n%s\n===========\n", startErr, health, logs)
 		}
 
@@ -155,7 +155,7 @@ func TestDrupalBackdropIncludeSettingsDdevInNewSettingsFile(t *testing.T) {
 
 	dir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(dir, true)
+	app, err := ddevapp.NewApp(dir, true)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
@@ -200,7 +200,7 @@ func TestDrupalBackdropIncludeSettingsDdevInExistingSettingsFile(t *testing.T) {
 
 	dir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(dir, true)
+	app, err := ddevapp.NewApp(dir, true)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
@@ -255,7 +255,7 @@ func TestDrupalBackdropCreateGitIgnoreIfNoneExists(t *testing.T) {
 
 	dir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(dir, true)
+	app, err := ddevapp.NewApp(dir, true)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
@@ -298,12 +298,12 @@ func TestDrupalBackdropConsistentHash(t *testing.T) {
 	for _, projectType := range projectTypes {
 		// Make a spare directory for the first project
 		firstProjectDir := testcommon.CreateTmpDir(t.Name() + "-firstproject")
-		app, err := NewApp(firstProjectDir, true)
+		app, err := ddevapp.NewApp(firstProjectDir, true)
 		app.Type = projectType
 		require.NoError(t, err)
 
 		secondProjectDir := testcommon.CreateTmpDir(t.Name() + "-secondproject")
-		secondApp, err := NewApp(secondProjectDir, true)
+		secondApp, err := ddevapp.NewApp(secondProjectDir, true)
 		secondApp.Type = projectType
 		require.NoError(t, err)
 
@@ -341,7 +341,7 @@ func TestDrupalBackdropConsistentHash(t *testing.T) {
 	}
 }
 
-func extractSettingsHashSalt(app *DdevApp) (string, error) {
+func extractSettingsHashSalt(app *ddevapp.DdevApp) (string, error) {
 	// Read the file content
 	content, err := os.ReadFile(app.SiteDdevSettingsFile)
 	if err != nil {
@@ -367,7 +367,7 @@ func TestDrupalBackdropGitIgnoreAlreadyExists(t *testing.T) {
 
 	dir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(dir, true)
+	app, err := ddevapp.NewApp(dir, true)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
@@ -410,7 +410,7 @@ func TestDrupalBackdropOverwriteDdevSettings(t *testing.T) {
 
 	dir := testcommon.CreateTmpDir(t.Name())
 
-	app, err := NewApp(dir, true)
+	app, err := ddevapp.NewApp(dir, true)
 	assert.NoError(err)
 
 	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -129,10 +129,9 @@ func AskForConfirmation() bool {
 		return true
 	} else if nodeps.ArrayContainsString(nokayResponses, responseLower) {
 		return false
-	} else {
-		output.UserOut.Println("Please type yes or no and then press enter:")
-		return AskForConfirmation()
 	}
+	output.UserOut.Println("Please type yes or no and then press enter:")
+	return AskForConfirmation()
 }
 
 // MapKeysToArray takes the keys of the map and turns them into a string array


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

```
$ make golangci-lint
golangci-lint: 
pkg/ddevapp/providerLocalfile_test.go:14:2: dot-imports: should not use dot imports (revive)
        . "github.com/ddev/ddev/pkg/ddevapp"
        ^
pkg/ddevapp/providerGit_test.go:12:2: dot-imports: should not use dot imports (revive)
        . "github.com/ddev/ddev/pkg/ddevapp"
        ^
pkg/ddevapp/providerPlatform_test.go:15:2: dot-imports: should not use dot imports (revive)
        . "github.com/ddev/ddev/pkg/ddevapp"
        ^
pkg/util/utils.go:132:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
        } else {
                output.UserOut.Println("Please type yes or no and then press enter:")
                return AskForConfirmation()
        }
make: *** [Makefile:265: golangci-lint] Error 1
```

## How This PR Solves The Issue

Removes dot-imports and fixes indent-error-flow.

## Manual Testing Instructions

## Automated Testing Overview

Tests should pass as before.

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

