### PR TITLE
feat: process pre-start hooks earlier so exec-host hooks can do more

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1035,6 +1035,11 @@ Please use the built-in docker-compose.
 Fix with 'ddev config global --required-docker-compose-version="" --use-docker-compose-from-path=false': %v`, err)
 	}
 
+	err = app.ProcessHooks("pre-start")
+	if err != nil {
+		return err
+	}
+
 	err = PullBaseContainerImages()
 	if err != nil {
 		util.Warning("Unable to pull Docker images: %v", err)
@@ -1127,11 +1132,6 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	err = DownloadMutagenIfNeededAndEnabled(app)
-	if err != nil {
-		return err
-	}
-
-	err = app.ProcessHooks("pre-start")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

## The Issue

At Drupalcon Lille, @davereid was trying to do some tricky automatic database updates, and was stopped because in app.Start() the check for db mismatch was earlier than the execution of the pre-start hooks. I don't see harm in doing the pre-start hooks earlier than the test. 

## How This PR Solves The Issue

Move pre-start to earlier

## Manual Testing Instructions

- [x] Use pre-start hooks to validate (they must be `exec-host` of course)
- [x] @davereid can use this technique:

```
hooks:
  pre-start:
    - exec-host: if ! ddev debug check-db-match; then docker run --rm -v $DDEV_PROJECT-mariadb:/var/tmp/mysql busybox:stable sh -c "echo mariadb_10.4 >/var/tmp/mysql/db_mariadb_version.txt"; fi
```

or some variant of it. It worked for me. This uses the `ddev debug check-db-match` to see if the configured database is the same as the actual database, if not, it forces. Of course, there is no warranty expressed or implied here because the hook is overwriting an internal feature of the DDEV db container.

## Automated Testing Overview

I think existing tests should work out ok.

