### PR TITLE
fix: the web container startup time should be more generous, fixes #5343

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -79,8 +79,9 @@ services:
       {{ end }}
       interval: 1s
       retries: 120
-      start_period: 120s
-      timeout: "{{ .DefaultContainerTimeout }}s"
+      start_period: "{{ .DefaultContainerTimeout }}s"
+      start_interval: 1s
+      timeout: 70s
   {{ end }} {{/* end if not .OmitDB */}}
 
   web:

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -240,8 +240,9 @@ services:
     healthcheck:
       interval: 1s
       retries: 120
-      start_period: 120s
-      timeout: "{{ .DefaultContainerTimeout }}s"
+      start_period: "{{ .DefaultContainerTimeout }}s"
+      start_interval: 1s
+      timeout: 70s
 
 networks:
   ddev_default:

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -130,6 +130,10 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 
 	if app.DefaultContainerTimeout == "" {
 		app.DefaultContainerTimeout = nodeps.DefaultDefaultContainerTimeout
+		// On Windows the default timeout may be too short for mutagen to succeed.
+		if runtime.GOOS == "windows" {
+			app.DefaultContainerTimeout = "240"
+		}
 	}
 
 	// Migrate UploadDir to UploadDirs

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -222,6 +222,9 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	_ = os.Setenv("DDEV_DB_CONTAINER_COMMAND", restoreCmd)
 	// nolint: errcheck
 	defer os.Unsetenv("DDEV_DB_CONTAINER_COMMAND")
+	// Allow extra time by default for the snapshot restore. This is arbitrary but may help.
+	origTimeout := app.DefaultContainerTimeout
+	app.DefaultContainerTimeout = "600"
 	err = app.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start project for RestoreSnapshot: %v", err)
@@ -251,6 +254,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 			fmt.Print(".")
 		}
 	}
+	app.DefaultContainerTimeout = origTimeout
 	util.Success("\nDatabase snapshot %s was restored in %vs", snapshotName, int(time.Since(start).Seconds()))
 	err = app.ProcessHooks("post-restore-snapshot")
 	if err != nil {


### PR DESCRIPTION

## The Issue

* #5343 
* I have been confused over and over again by the docker healthcheck configurations, and they were incorrect still. 
* #5133 
* #5154 (where this wasn't done right still)

## How This PR Solves The Issue

* The `start_period` is the actual time that we want to wait for things to more-or-less be ready
* The `timeout` is actually how long we'll put up with the healthcheck taking (which is normally just over a minute, based on the web container healthcheck.sh)
* On Windows we'd just rather bump this up anyway, because the mutagen sync can take some time
* When doing a snapshot restore of a large snapshot, also bump it up quite a bit

## Manual Testing Instructions

- [x] Test on Windows with a largish project, maybe even a magento2 project
- [x] Test `ddev snapshot restore` with hugedb
- [x] Use `docker inspect` to see the resulting behavior

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

