### PR TITLE
feat: `pre-cmd` and `post-cmd` hooks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+<!-- 
+  PR titles have very precise rules, please read 
+  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
+-->
+
 ## The Issue
 
 ## How This PR Solves The Issue


### PR DESCRIPTION
I am looking for ways to do more automations within ddev rather than on the host, and I wanted a hook that I can hook that it's run on every ddev command. I thought of different ways and came up with ` pre-cmd` and `post-cmd` command.

For now this is an idea, it works and does what I need, not fully tested but didn't want to lose what I did without sharing.

More context on https://discord.com/channels/664580571770388500/1144344589549973636/1166023601540051004 