### PR TITLE
feat: add `pre-command` and `post-command` hooks, fixes #5557 

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -51,7 +51,7 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 
 		app, err := ddevapp.GetActiveApp("")
 		if err == nil {
-			err = app.ProcessHooks("pre-command")
+			err = app.ProcessHooks("pre-command", command)
 			if err != nil {
 				util.Failed("failed to process pre-command hooks: %v", err)
 			}
@@ -109,9 +109,10 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 		}
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		command := os.Args[1]
 		app, err := ddevapp.GetActiveApp("")
 		if err == nil {
-			err = app.ProcessHooks("post-command")
+			err = app.ProcessHooks("post-command", command)
 			if err != nil {
 				util.Failed("failed to process post-command hooks: %v", err)
 			}

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -51,9 +51,9 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 
 		app, err := ddevapp.GetActiveApp("")
 		if err == nil {
-			err = app.ProcessHooks("pre-cmd")
+			err = app.ProcessHooks("pre-command")
 			if err != nil {
-				util.Failed("failed to process pre-cmd hooks: %v", err)
+				util.Failed("failed to process pre-command hooks: %v", err)
 			}
 		}
 
@@ -111,9 +111,9 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		app, err := ddevapp.GetActiveApp("")
 		if err == nil {
-			err = app.ProcessHooks("post-cmd")
+			err = app.ProcessHooks("post-command")
 			if err != nil {
-				util.Failed("failed to process post-cmd hooks: %v", err)
+				util.Failed("failed to process post-command hooks: %v", err)
 			}
 		}
 		if instrumentationApp == nil {

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -110,16 +110,14 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		command := os.Args[1]
+
 		app, err := ddevapp.GetActiveApp("")
 		if err == nil {
 			err = app.ProcessHooks("post-command", command)
 			if err != nil {
 				util.Failed("failed to process post-command hooks: %v", err)
 			}
-		}
-		if instrumentationApp == nil {
-			app, err := ddevapp.GetActiveApp("")
-			if err == nil {
+			if instrumentationApp == nil {
 				instrumentationApp = app
 			}
 		}

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -50,12 +50,11 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 		}
 
 		app, err := ddevapp.GetActiveApp("")
-		if err != nil {
-			util.Failed("Can't find active project: %v", err)
-		}
-		err = app.ProcessHooks("pre-cmd")
-		if err != nil {
-			util.Failed("failed to process pre-cmd hooks: %v", err)
+		if err == nil {
+			err = app.ProcessHooks("pre-cmd")
+			if err != nil {
+				util.Failed("failed to process pre-cmd hooks: %v", err)
+			}
 		}
 
 		// We don't want to send to amplitude if using --json-output
@@ -111,12 +110,11 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		app, err := ddevapp.GetActiveApp("")
-		if err != nil {
-			util.Failed("Can't find active project: %v", err)
-		}
-		err = app.ProcessHooks("post-cmd")
-		if err != nil {
-			util.Failed("failed to process post-cmd hooks: %v", err)
+		if err == nil {
+			err = app.ProcessHooks("post-cmd")
+			if err != nil {
+				util.Failed("failed to process post-cmd hooks: %v", err)
+			}
 		}
 		if instrumentationApp == nil {
 			app, err := ddevapp.GetActiveApp("")

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -53,7 +53,7 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 		if err == nil {
 			err = app.ProcessHooks("pre-command", command)
 			if err != nil {
-				util.Failed("failed to process pre-command hooks: %v", err)
+				output.UserOut.Errorf("failed to process pre-command hooks: %v", err)
 			}
 		}
 
@@ -115,7 +115,7 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 		if err == nil {
 			err = app.ProcessHooks("post-command", command)
 			if err != nil {
-				util.Failed("failed to process post-command hooks: %v", err)
+				output.UserOut.Errorf("failed to process post-command hooks: %v", err)
 			}
 			if instrumentationApp == nil {
 				instrumentationApp = app

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -49,6 +49,15 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 			argsCopy = []string{}
 		}
 
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed("Can't find active project: %v", err)
+		}
+		err = app.ProcessHooks("pre-cmd")
+		if err != nil {
+			util.Failed("failed to process pre-cmd hooks: %v", err)
+		}
+
 		// We don't want to send to amplitude if using --json-output
 		// That captures an enormous number of PhpStorm running the
 		// ddev describe -j over and over again.
@@ -61,7 +70,7 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 			return
 		}
 
-		err := dockerutil.CheckDockerVersion(dockerutil.DockerVersionConstraint)
+		err = dockerutil.CheckDockerVersion(dockerutil.DockerVersionConstraint)
 		if err != nil {
 			if err.Error() == "no docker" {
 				if os.Args[1] != "version" {
@@ -101,6 +110,14 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 		}
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed("Can't find active project: %v", err)
+		}
+		err = app.ProcessHooks("post-cmd")
+		if err != nil {
+			util.Failed("failed to process post-cmd hooks: %v", err)
+		}
 		if instrumentationApp == nil {
 			app, err := ddevapp.GetActiveApp("")
 			if err == nil {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1356,8 +1356,8 @@ func PrepDdevDirectory(app *DdevApp) error {
 // validateHookYAML validates command hooks and tasks defined in hooks for config.yaml
 func validateHookYAML(source []byte) error {
 	validHooks := []string{
-		"pre-cmd",
-		"post-cmd",
+		"pre-command",
+		"post-command",
 		"pre-start",
 		"post-start",
 		"pre-import-db",

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1356,6 +1356,8 @@ func PrepDdevDirectory(app *DdevApp) error {
 // validateHookYAML validates command hooks and tasks defined in hooks for config.yaml
 func validateHookYAML(source []byte) error {
 	validHooks := []string{
+		"pre-cmd",
+		"post-cmd",
 		"pre-start",
 		"post-start",
 		"pre-import-db",

--- a/pkg/ddevapp/task.go
+++ b/pkg/ddevapp/task.go
@@ -28,6 +28,7 @@ type ExecTask struct {
 	execRaw []string // Use execRaw if configured instead of exec
 	exec    string   // Actual command to be executed.
 	app     *DdevApp
+	args    []string // Task internal arguments
 }
 
 // ExecHostTask is the struct that defines "exec-host" tasks for hooks,
@@ -35,6 +36,7 @@ type ExecTask struct {
 type ExecHostTask struct {
 	exec string
 	app  *DdevApp
+	args []string // Task internal arguments
 }
 
 // ComposerTask is the struct that defines "composer" tasks for hooks, commands
@@ -116,10 +118,10 @@ func (c ComposerTask) GetDescription() string {
 // NewTask is the factory method to create whatever kind of task
 // we need using the yaml description of the task.
 // Returns a task (of various types) or nil
-func NewTask(app *DdevApp, ytask YAMLTask) Task {
+func NewTask(app *DdevApp, ytask YAMLTask, args ...string) Task {
 	if e, ok := ytask["exec-host"]; ok {
 		if v, ok := e.(string); ok {
-			t := ExecHostTask{app: app, exec: v}
+			t := ExecHostTask{app: app, exec: v, args: args}
 			return t
 		}
 		util.Warning("Invalid exec-host value, not executing it: %v", e)
@@ -144,7 +146,7 @@ func NewTask(app *DdevApp, ytask YAMLTask) Task {
 		util.Warning("Invalid Composer value, not executing it: %v", e)
 	} else if e, ok = ytask["exec"]; ok {
 		if v, ok := e.(string); ok {
-			t := ExecTask{app: app, exec: v}
+			t := ExecTask{app: app, exec: v, args: args}
 			if t.service, ok = ytask["service"].(string); !ok {
 				t.service = nodeps.WebContainer
 			}
@@ -158,7 +160,7 @@ func NewTask(app *DdevApp, ytask YAMLTask) Task {
 				return nil
 			}
 
-			t := ExecTask{app: app, execRaw: raw}
+			t := ExecTask{app: app, execRaw: raw, args: args}
 			if t.service, ok = ytask["service"].(string); !ok {
 				t.service = nodeps.WebContainer
 			}
@@ -168,7 +170,7 @@ func NewTask(app *DdevApp, ytask YAMLTask) Task {
 
 	} else if e, ok = ytask["exec"]; ok {
 		if v, ok := e.(string); ok {
-			t := ExecTask{app: app, exec: v}
+			t := ExecTask{app: app, exec: v, args: args}
 			if t.service, ok = ytask["service"].(string); !ok {
 				t.service = nodeps.WebContainer
 			}


### PR DESCRIPTION
I am looking for ways to do more automations within ddev rather than on the host, and I wanted a hook that I can hook that it's run on every ddev command. I thought of different ways and came up with  pre-cmd and post-cmd command.

This PR adds the following hooks:
- `pre-command`
- `post-command`

That would run for any `ddev COMMAND`.

i.e.
```yaml
hooks:
  pre-command:
    - exec: echo pre-command exec
    - exec-host: echo pre-command exec-host
  post-command:
    - exec: echo post-command exec
    - exec-host: echo post-command exec-host
```

Any hook is supported, *however*, those that cannot be run when the site is not `started` will show a warning and the hook will be ignored (i.e. running an `exec` hook on `pre-command` when running `ddev start`).

More context on https://discord.com/channels/664580571770388500/1144344589549973636/1166023601540051004

Fixes #5557 