### PR TITLE
ci: bump ddev-php-base and ddev-webserver for php8.3.0rc3

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM ddev/ddev-php-base:20231005_amayer5125_node_install as ddev-webserver-base
+FROM ddev/ddev-php-base:v1.22.4 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20231010_benwalch_bashrc_cleanup" // Note that this can be overridden by make
+var WebTag = "20231023_bump_php83" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

Upstream deb.sury.org has reached php8.3.0-rc3, so we should include that in our upcoming DDEV v1.22.4

## How This PR Solves The Issue

* Build new ddev-php-base (because upstream has changed)
* Build new ddev-webserver (because it's what we actually use and it derives from ddev-php-base

## Manual Testing Instructions

Use it, make sure that we have rc3 of php8.3

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

