### PR TITLE
docs: add instructions for testing a PR by installing a downloaded binary in the $PATH

### DIFF
--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -19,6 +19,8 @@ Each [PR build](https://github.com/ddev/ddev/actions/workflows/pr-build.yml) cre
 
 Download and unzip the appropriate binary and place it in your `$PATH`.
 
+### Homebrew with macOS
+
 If you’re using Homebrew, start by unlinking your current binary:
 
 ```
@@ -50,6 +52,33 @@ After you’re done, you can delete your downloaded binary and re-link the origi
 ```
 sudo rm /usr/local/bin/ddev
 brew link --force ddev
+```
+
+
+### Linux
+
+Start by removing your current binary, for Debian flavor systems use this:
+
+```
+sudo apt remove ddev
+```
+
+Next, unzip the binary you downloaded, make it executable, and move it to a folder in your path. Check with `echo $PATH`:
+
+```
+unzip ddev.zip
+chmod +x ddev && mv ddev ~/.local/bin/ddev
+```
+
+Verify the replacement worked by running `ddev version`. The output should be something like `DDEV version v1.22.3-39-gfbb878843`, instead of the regular `DDEV version v1.22.3`.
+
+You need to restart DDEV, to download the Docker images that it needs
+
+After you’re done, you can delete your downloaded binary and re-install the latest DDEV:
+
+```
+rm ~/.local/bin/ddev
+sudo apt install ddev
 ```
 
 ## Open in Gitpod

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -57,6 +57,7 @@ brew link --force ddev
 ### Installing a downloaded binary in the $PATH
 
 Normally, you can put any binary in your path, and it takes precedence, so you don't need to remove or disable an already installed DDEV instance, which we will use here. In this example, `~/.local/bin` is used. Since not every distro has `~/.local/bin` in `$PATH`, you can create the folder and add it to your path in `~/.bashrc` with these commands:
+
 ```
 mkdir -p ~/.local/bin
 export PATH="$HOME/.local/bin:$PATH"

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -54,7 +54,6 @@ sudo rm /usr/local/bin/ddev
 brew link --force ddev
 ```
 
-
 ### Linux
 
 Start by removing your current binary, for Debian flavor systems use this:

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -54,12 +54,12 @@ sudo rm /usr/local/bin/ddev
 brew link --force ddev
 ```
 
-### Linux
+### Installing a downloaded binary in the $PATH
 
-Start by removing your current binary, for Debian flavor systems use this:
-
+Normally, you can put any binary in your path, and it takes precedence, so you don't need to remove or disable an already installed DDEV instance, which we will use here. In this example, `~/.local/bin` is used. Since not every distro has `~/.local/bin` in `$PATH`, you can create the folder and add it to your path in `~/.bashrc` with these commands:
 ```
-sudo apt remove ddev
+mkdir -p ~/.local/bin
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Next, unzip the binary you downloaded, make it executable, and move it to a folder in your path. Check with `echo $PATH`:
@@ -69,15 +69,14 @@ unzip ddev.zip
 chmod +x ddev && mv ddev ~/.local/bin/ddev
 ```
 
-Verify the replacement worked by running `ddev version`. The output should be something like `DDEV version v1.22.3-39-gfbb878843`, instead of the regular `DDEV version v1.22.3`.
+Now, close and reopen your terminal, and verify the replacement worked by running `ddev version`. The output should be something like `DDEV version v1.22.3-39-gfbb878843`, instead of the regular `DDEV version v1.22.3`.
 
-You need to restart DDEV, to download the Docker images that it needs
+You need to run `ddev poweroff` and `ddev start` to download the Docker images that it needs.
 
-After you’re done, you can delete your downloaded binary and re-install the latest DDEV:
+After you’re done testing, you can delete your downloaded binary, restart your terminal, and again use the standard DDEV:
 
 ```
 rm ~/.local/bin/ddev
-sudo apt install ddev
 ```
 
 ## Open in Gitpod

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -19,7 +19,7 @@ Each [PR build](https://github.com/ddev/ddev/actions/workflows/pr-build.yml) cre
 
 Download and unzip the appropriate binary and place it in your `$PATH`.
 
-### Homebrew with macOS
+### Homebrew with macOS or Linux
 
 If you’re using Homebrew, start by unlinking your current binary:
 
@@ -34,7 +34,7 @@ unzip ddev.zip
 chmod +x ddev && sudo mv ddev /usr/local/bin/ddev
 ```
 
-Verify the replacement worked by running `ddev -v`. The output should be something like `ddev version v1.19.1-42-g5334d3c1`, instead of the regular `ddev version v1.19.1`.
+Verify the replacement worked by running `ddev -v`. The output should be something like `ddev version v1.22.5-alpha1-70-g0852fc2df`, instead of the regular `ddev version v1.22.5`.
 
 !!!tip "macOS and Unsigned Binaries"
     macOS doesn’t like these downloaded binaries, so you’ll need to bypass the automatic quarantine to use them:
@@ -56,28 +56,28 @@ brew link --force ddev
 
 ### Installing a Downloaded Binary in the `$PATH`
 
-Normally, you can put any binary in your path, and it takes precedence, so you don't need to remove or disable an already installed DDEV instance, which we will use here. This example uses `~/.local/bin`. `echo $PATH` and `which ddev` are valuable commands for debugging. Since not every distro has `~/.local/bin` in `$PATH`, you can create the folder and add it to your path in `~/.bashrc` with these commands:
+Normally, you can put any executable in your path, and it takes precedence, so you don't need to remove or disable an already installed DDEV instance, which we will use here. This example uses `~/bin`. `echo $PATH` and `which ddev` are valuable commands for debugging. Since not every distro has `~/bin` in `$PATH`, you can create the folder and add it to your path in `~/.bashrc` with these commands:
 
 ```
-mkdir -p ~/.local/bin
-export PATH="$HOME/.local/bin:$PATH"
+mkdir -p ~/bin
+export PATH="~/bin:$PATH"
 ```
 
-Next, unzip the binary you downloaded, make it executable, and move it to a folder in your path. Check with `echo $PATH`:
+Next, unzip the Zip file you downloaded, make it executable, and move it to a folder in your path. Check with `echo $PATH`:
 
 ```
 unzip ddev.zip
-chmod +x ddev && mv ddev ~/.local/bin/ddev
+chmod +x ddev && mv ddev ~/bin
 ```
 
 Now, close and reopen your terminal, and verify the replacement worked by running `ddev version`. The output should be something like `DDEV version v1.22.3-39-gfbb878843`, instead of the regular `DDEV version v1.22.3`.
 
 You need to run `ddev poweroff` and `ddev start` to download the Docker images that it needs.
 
-After you’re done testing, you can delete your downloaded binary, restart your terminal, and again use the standard DDEV:
+After you’re done testing, you can delete your downloaded executable, restart your terminal, and again use the standard DDEV:
 
 ```
-rm ~/.local/bin/ddev
+rm ~/bin/ddev
 ```
 
 ## Open in Gitpod

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -56,7 +56,7 @@ brew link --force ddev
 
 ### Installing a Downloaded Binary in the `$PATH`
 
-Normally, you can put any binary in your path, and it takes precedence, so you don't need to remove or disable an already installed DDEV instance, which we will use here. In this example, `~/.local/bin` is used. `echo $PATH` and `which ddev` are valuable commands for debugging. Since not every distro has `~/.local/bin` in `$PATH`, you can create the folder and add it to your path in `~/.bashrc` with these commands:
+Normally, you can put any binary in your path, and it takes precedence, so you don't need to remove or disable an already installed DDEV instance, which we will use here. This example uses `~/.local/bin`. `echo $PATH` and `which ddev` are valuable commands for debugging. Since not every distro has `~/.local/bin` in `$PATH`, you can create the folder and add it to your path in `~/.bashrc` with these commands:
 
 ```
 mkdir -p ~/.local/bin

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -56,7 +56,7 @@ brew link --force ddev
 
 ### Installing a downloaded binary in the $PATH
 
-Normally, you can put any binary in your path, and it takes precedence, so you don't need to remove or disable an already installed DDEV instance, which we will use here. In this example, `~/.local/bin` is used. Since not every distro has `~/.local/bin` in `$PATH`, you can create the folder and add it to your path in `~/.bashrc` with these commands:
+Normally, you can put any binary in your path, and it takes precedence, so you don't need to remove or disable an already installed DDEV instance, which we will use here. In this example, `~/.local/bin` is used. `echo $PATH` and `which ddev` are valuable commands for debugging. Since not every distro has `~/.local/bin` in `$PATH`, you can create the folder and add it to your path in `~/.bashrc` with these commands:
 
 ```
 mkdir -p ~/.local/bin

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -54,7 +54,7 @@ sudo rm /usr/local/bin/ddev
 brew link --force ddev
 ```
 
-### Installing a downloaded binary in the $PATH
+### Installing a Downloaded Binary in the `$PATH`
 
 Normally, you can put any binary in your path, and it takes precedence, so you don't need to remove or disable an already installed DDEV instance, which we will use here. In this example, `~/.local/bin` is used. `echo $PATH` and `which ddev` are valuable commands for debugging. Since not every distro has `~/.local/bin` in `$PATH`, you can create the folder and add it to your path in `~/.bashrc` with these commands:
 


### PR DESCRIPTION
## The Issue

It is documented how to [test a PR in macOS with Homebrew](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr), but not by installing a downloaded binary in the $PATH.

## How This PR Solves The Issue

Documents how to test a PR by installing a downloaded binary in the $PATH, to be used for example in Linux and MacOS.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

