### PR TITLE
fix: add project config validation when using args, fixes #5445

### DIFF
--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -119,7 +119,7 @@ ddev start --all`,
 
 		projects, err := getRequestedProjects(args, startAll)
 		if err != nil {
-			util.Failed("Failed to get project(s): %v", err)
+			util.Failed("Failed to start project(s): %v", err)
 		}
 		if len(projects) > 0 {
 			instrumentationApp = projects[0]

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -46,7 +46,7 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 		if requestedProjectsMap[name], exists = allProjectMap[name]; !exists {
 			p := globalconfig.GetProject(name)
 			if p != nil && p.AppRoot != "" {
-				requestedProjectsMap[name] = &ddevapp.DdevApp{Name: name}
+				requestedProjectsMap[name] = &ddevapp.DdevApp{Name: name, AppRoot: p.AppRoot}
 			} else {
 				return nil, fmt.Errorf("could not find requested project '%s', you may need to use \"ddev start\" to add it to the project catalog", name)
 			}

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -55,6 +55,11 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 
 	// Convert map back to slice
 	for _, project := range requestedProjectsMap {
+		err = project.ValidateConfig()
+		if err != nil {
+			return nil, err
+		}
+
 		requestedProjects = append(requestedProjects, project)
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -461,8 +461,11 @@ func (app *DdevApp) ValidateConfig() error {
 		return err
 	}
 
-	// Stop here if no config found
+	// Skip any validation below this check if there is nothing to validate
 	if err := CheckForMissingProjectFiles(app); err != nil {
+		// Do not return an error here because not all DDEV commands should be stopped by this check
+		// It matters when you start a project, but not when you stop or delete it
+		// This check is reused elsewhere where appropriate
 		return nil
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -433,7 +433,6 @@ func ValidateProjectName(name string) error {
 
 // ValidateConfig ensures the configuration meets ddev's requirements.
 func (app *DdevApp) ValidateConfig() error {
-
 	// Validate ddev version constraint, if any
 	if app.DdevVersionConstraint != "" {
 		constraint := app.DdevVersionConstraint
@@ -460,6 +459,11 @@ func (app *DdevApp) ValidateConfig() error {
 	// Validate project name
 	if err := ValidateProjectName(app.Name); err != nil {
 		return err
+	}
+
+	// Stop here if no config found
+	if err := CheckForMissingProjectFiles(app); err != nil {
+		return nil
 	}
 
 	// Validate hostnames

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -493,7 +493,7 @@ func (app *DdevApp) ValidateConfig() error {
 
 	// Validate webserver type
 	if !nodeps.IsValidWebserverType(app.WebserverType) {
-		return fmt.Errorf("the %s project has unsupported webserver type: %s, DDEV (%s) only supports the following webserver types: %s", app.Name, app.WebserverType, runtime.GOARCH, nodeps.GetValidWebserverTypes()).(invalidWebserverType)
+		return fmt.Errorf("the %s project has an unsupported webserver type: %s, DDEV (%s) only supports the following webserver types: %s", app.Name, app.WebserverType, runtime.GOARCH, nodeps.GetValidWebserverTypes()).(invalidWebserverType)
 	}
 
 	if !nodeps.IsValidOmitContainers(app.OmitContainers) {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -618,14 +618,14 @@ func TestConfigValidate(t *testing.T) {
 	app.DdevVersionConstraint = ">= 1.twentythree"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "not a valid constraint")
+	assert.Contains(err.Error(), "constraint that is not valid")
 	app.DdevVersionConstraint = ""
 
 	versionconstants.DdevVersion = "v1.22.0"
 	app.DdevVersionConstraint = ">= 1.23"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "this project has a DDEV version constraint of '>= 1.23' and the version of DDEV you are using ('v1.22.0') does not meet the constraint")
+	assert.Contains(err.Error(), "project has a DDEV version constraint of '>= 1.23' and the version of DDEV you are using ('v1.22.0') does not meet the constraint")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
@@ -648,7 +648,7 @@ func TestConfigValidate(t *testing.T) {
 	app.DdevVersionConstraint = ">= 1.23"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "this project has a DDEV version constraint of '>= 1.23' and the version of DDEV you are using ('v1.22.3-11-g8baef014e') does not meet the constraint")
+	assert.Contains(err.Error(), "project has a DDEV version constraint of '>= 1.23' and the version of DDEV you are using ('v1.22.3-11-g8baef014e') does not meet the constraint")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
@@ -663,7 +663,7 @@ func TestConfigValidate(t *testing.T) {
 	app.DdevVersionConstraint = ">= 1.23.0-0"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "this project has a DDEV version constraint of '>= 1.23.0-0' and the version of DDEV you are using ('v1.22.3-11-g8baef014e') does not meet the constraint")
+	assert.Contains(err.Error(), "project has a DDEV version constraint of '>= 1.23.0-0' and the version of DDEV you are using ('v1.22.3-11-g8baef014e') does not meet the constraint")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
@@ -671,7 +671,7 @@ func TestConfigValidate(t *testing.T) {
 	app.DdevVersionConstraint = ">= v1.22.3-alpha3"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "this project has a DDEV version constraint of '>= v1.22.3-alpha3' and the version of DDEV you are using ('v1.22.3-alpha2') does not meet the constraint")
+	assert.Contains(err.Error(), "project has a DDEV version constraint of '>= v1.22.3-alpha3' and the version of DDEV you are using ('v1.22.3-alpha2') does not meet the constraint")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- https://github.com/ddev/ddev/issues/5445

## How This PR Solves The Issue

Runs validation check for every projects that you pass to any DDEV command that uses args, so fixes more than just `ddev start`.

## Manual Testing Instructions

See the issue.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

