### PR TITLE
fix: add PATH_INFO CGI parameter to all nginx configs, fixes #3854, fixes #4001

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/sites-enabled/nginx-site-default.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/sites-enabled/nginx-site-default.conf
@@ -39,6 +39,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/containers/ddev-webserver/tests/ddev-webserver/testdata/nginx-site.conf
+++ b/containers/ddev-webserver/tests/ddev-webserver/testdata/nginx-site.conf
@@ -47,6 +47,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
@@ -48,6 +48,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
@@ -53,6 +53,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
@@ -47,6 +47,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
@@ -58,6 +58,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
@@ -51,6 +51,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
@@ -46,6 +46,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
@@ -47,6 +47,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
@@ -42,6 +42,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
@@ -49,6 +49,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors on;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
@@ -40,6 +40,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors on;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
@@ -43,6 +43,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
@@ -58,6 +58,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -76,6 +76,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
@@ -69,6 +69,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/ddevapp/webserver_config_assets/nginx_second_docroot_example-site-php.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx_second_docroot_example-site-php.conf
@@ -46,6 +46,7 @@ server {
         fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_intercept_errors off;

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240123_jonnitto_js_mimetypes" // Note that this can be overridden by make
+var WebTag = "20231030_longwave_nginx_path_info" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

When using SimpleSAMLphp inside a ddev project with nginx, it crashes because it cannot find the $_SERVER['PATH_INFO'] variable, which is expected to be set. This is documented at https://simplesamlphp.org/docs/stable/simplesamlphp-install#configuring-nginx

## How This PR Solves The Issue

`PATH_INFO` is added to all nginx config files. This is only needed to handle special URLs that have a `.php` script file in the _middle_ of the URL, e.g. `/some/path/index.php/extra/arguments` where `/some/path/index.php` is executed and the `extra/arguments` are picked up by the script.

## Manual Testing Instructions

Start a new project with SimpleSAMLphp:
```
mkdir samltest
cd samltest
composer require simplesamlphp/simplesamlphp:^1

mkdir config
cp vendor/simplesamlphp/simplesamlphp/config-templates/config.php config/config.php
ln -s vendor/simplesamlphp/simplesamlphp/www simplesaml

ddev config --project-type drupal10 --web-environment SIMPLESAMLPHP_CONFIG_DIR=/var/www/html/config
ddev start
```

Then visit https://samltest.ddev.site/simplesaml/module.php/core/frontpage_welcome.php 

Without the changes in this PR, you get an error page because SimpleSAMLphp cannot parse the path.
With the changes in this PR, you get the SimpleSAMLphp welcome page.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

* #3854
* #4001

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

