### PR TITLE
docs: add privacy plugins to not use external fonts

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ theme:
 # Plugins
 plugins:
 - search
+- privacy
 - redirects:
     redirect_maps:
 - minify:
@@ -58,7 +59,6 @@ plugins:
 #- git-committers:
 #    repository: https://github.com/ddev/ddev
 #    token: !ENV GH_TOKEN
-
 
 # Customization
 extra:


### PR DESCRIPTION
## The Issue

Fixes #4982.

We should keep an eye out for possibly slowed down automated builds, after this change.

## How This PR Solves The Issue

Bundles the fonts with the generated documents, as opposed to getting them from a third-party.

## Manual Testing Instructions

- **Now:**
    Open https://ddev.readthedocs.io/ in Firefox with uBlock Origin, and see that currently fonts are requested from fonts.googleapis.com
- **After adding the privacy plugin:**
    See that fonts are included and served from https://ddev.readthedocs.io/en/stable/ 

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

