### PR TITLE
build: update .gitpod.yml for v1.22.4 release [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ddev/ddev-gitpod-base:20230919
+image: ddev/ddev-gitpod-base:20231026
 tasks:
   - name: build-run
     init: |


### PR DESCRIPTION
## The Issue

DDEV v1.22.4 is out.

* Push new gitpod image
* `ddev debug download-images` no longer downloads `ddev-traefik-router`
