### PR TITLE
fix: we shouldn't show the amplitude warning on every ddev command

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -122,7 +122,6 @@ Support: https://ddev.readthedocs.io/en/stable/users/support`,
 		if _, ok := ignores[cmd.CalledAs()]; ok {
 			return
 		}
-		instrumentationNotSetUpWarning()
 
 		// All this nonsense is to capture the official usage we used for this command.
 		// Unfortunately cobra doesn't seem to provide this easily.

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -196,12 +196,6 @@ func init() {
 	}
 }
 
-func instrumentationNotSetUpWarning() {
-	if !output.JSONOutput && versionconstants.SegmentKey == "" && globalconfig.DdevGlobalConfig.InstrumentationOptIn {
-		util.Warning("Instrumentation is opted in, but SegmentKey is not available. This usually means you have a locally-built DDEV binary or one from a PR build. It's not an error. Please report it if you're using an official release build.")
-	}
-}
-
 // checkDdevVersionAndOptInInstrumentation() reads global config and checks to see if current version is different
 // from the last saved version. If it is, prompt to request anon DDEV usage stats
 // and update the info.

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/ddev/ddev/pkg/amplitude"
 	"os"
 	"path"
 	"strings"
@@ -141,6 +142,7 @@ ddev start --all`,
 			}
 			util.Success("Project can be reached at %s", strings.Join(httpsURLs, " "))
 		}
+		amplitude.CheckSetUp()
 	},
 }
 

--- a/cmd/ddev/main.go
+++ b/cmd/ddev/main.go
@@ -16,7 +16,6 @@ func main() {
 	amplitude.InitAmplitude()
 	defer func() {
 		amplitude.Flush()
-		amplitude.CheckSetUp()
 	}()
 
 	// Prevent running as root for most cases


### PR DESCRIPTION
## The Issue

When ddev has been compiled without AmplitudeAPIKey (as with `brew install --HEAD ddev` it shows a message warning about the situation.

However, it has been going overboard in recent versions, showing it on every command. Change it to warn only on `ddev start`. 

The message is:
> Instrumentation is opted in, but AmplitudeAPIKey is not available. This usually means you have a locally-built ddev binary or one from a PR build. It's not an error. Please report it if you're using an official release build.


## Manual Testing Instructions

```
unset AmplitudeAPIKey
make
ddev config global --instrumentation-opt-in=true
cd <someproject>
ddev start 
ddev exec ls 
```

The message should show at the end of ddev start but not on ddev exec.

## Automated Testing Overview

No changes.

