### PR TITLE
Update dbeaver command to allow usage with dbeaver flatpak installs o…

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -5,7 +5,6 @@
 ## Usage: dbeaver
 ## Example: "ddev dbeaver [db] [user]"
 ## OSTypes: darwin,linux
-## HostBinaryExists: /Applications/DBeaver.app,/usr/bin/dbeaver,/usr/bin/dbeaver-ce,/usr/bin/dbeaver-le,/usr/bin/dbeaver-ue,/usr/bin/dbeaver-ee,/var/lib/flatpak/exports/bin/io.dbeaver.DBeaverCommunity,/snap/bin/dbeaver-ce
 
 database="${1:-db}"
 user="${2:-root}"
@@ -25,6 +24,7 @@ case $OSTYPE in
     BINARIES=(
       /usr/bin/dbeaver{,-ce,-le,-ue,-ee}
       /var/lib/flatpak/exports/bin/io.dbeaver.DBeaverCommunity
+      $HOME/.local/share/flatpak/app/io.dbeaver.DBeaverCommunity/current/active/export/bin/io.dbeaver.DBeaverCommunity
       /snap/bin/dbeaver-ce
     )
     for binary in "${BINARIES[@]}"; do


### PR DESCRIPTION
…n user level

In most cases you don't install flatpaks on system level but on user level unfortually its not possible to use the "$HOME" variable inside "## HostBinaryExists:" there for IMHO it have to be removed from the command

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

