### PR TITLE
ci: stop testing no-bind-mounts and use drupal10 by default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,8 +47,8 @@ jobs:
             webserver: "nginx-fpm"
           - name: "mutagen"
             mutagen: true
-          - name: "no-bind-mounts"
-            no-bind-mounts: "true"
+#          - name: "no-bind-mounts"
+#            no-bind-mounts: "true"
           - name: "nginx-proxy"
             router: "nginx-proxy"
           - name: "pull-push-test-platforms"
@@ -60,7 +60,7 @@ jobs:
 
     env:
       DDEV_NONINTERACTIVE: "true"
-      GOTEST_SHORT: "8" # 8 is drupal9; means in TestFullSiteSetup we only use drupal9
+      GOTEST_SHORT: "12" # 8 is drupal10; means in TestFullSiteSetup we only use drupal10
       DDEV_TEST_WEBSERVER_TYPE: ${{ matrix.webserver }}
       DDEV_TEST_USE_MUTAGEN: ${{ matrix.mutagen }}
       DDEV_TEST_NO_BIND_MOUNTS: ${{ matrix.no-bind-mounts }}


### PR DESCRIPTION

## The Issue

* We have been using significant Github workflow resources testing no-bind-mounts, but nobody uses this and it turns out not to be an important effort.
* Drupal9 is obsolete, long live Drupal10. Or at least for a year or so.

