### PR TITLE
build: always use the latest go and golangci-lint for gitpod [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ddev/ddev-gitpod-base:20231026
+image: ddev/ddev-gitpod-base:20231030
 tasks:
   - name: build-run
     init: |

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -14,9 +14,9 @@ RUN apt-get update >/dev/null && sudo apt-get install -y aspell autojump ddev fi
 
 RUN pip3 install mkdocs pyspelling pymdown-extensions
 RUN npm install -g markdownlint-cli
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.50.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin
 
-RUN rm -rf /usr/local/go && curl -sL -o /tmp/go.tar.gz https://go.dev/dl/go1.20.linux-amd64.tar.gz && tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz && ln -s /usr/local/go/bin/go /usr/local/bin/go
+RUN rm -rf /usr/local/go && curl -sL -o /tmp/go.tar.gz https://go.dev/dl/$(curl -fsSL "https://go.dev/dl/?mode=json" | jq -r ".[0].version").linux-amd64.tar.gz && tar -C /usr/local -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz && ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 USER gitpod
 


### PR DESCRIPTION
## The Issue

It is easy to forget to update some packages in [Dockerfile](https://github.com/ddev/ddev/blob/34d7fd76bb9068ac1d8d304c1f928624ff0ded22/.gitpod/images/Dockerfile#L17-L19) for Gitpod after release.

## How This PR Solves The Issue

Try to use the latest version all the time.

Found the solution for `go` [here](https://stackoverflow.com/a/77085404).
And it was super easy for `golangci-lint` - I just removed the hard-coded version.

## Manual Testing Instructions

```
$ docker buildx build -t ddev/ddev-gitpod-base --platform=linux/amd64 .gitpod/images

$ docker run --rm -it ddev/ddev-gitpod-base go version
go version go1.21.3 linux/amd64

$ docker run --rm -it ddev/ddev-gitpod-base golangci-lint version
golangci-lint has version 1.55.1 built with go1.21.3 from 9b20d49d on 2023-10-25T10:03:43Z
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

