### PR TITLE
docs: specify ddev tap in upgrading instructions for macOS with brew

### DIFF
--- a/docs/content/users/install/ddev-upgrade.md
+++ b/docs/content/users/install/ddev-upgrade.md
@@ -10,7 +10,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ```bash
     # Upgrade DDEV to the latest version
-    brew upgrade ddev
+    brew upgrade ddev/ddev/ddev
     ```
 
     ### Install Script


### PR DESCRIPTION
## The Issue

The brew tap at https://ddev.readthedocs.io/en/stable/users/install/ddev-upgrade/ is not specific enough and results in an error when attempting to upgrade.

<img width="891" alt="Screenshot 2023-10-30 at 23 15 24" src="https://github.com/ddev/ddev/assets/57572400/0ba3fd48-5e84-4900-a98e-7991aa107497">

## How This PR Solves The Issue

This PR specifies the tap `ddev/ddev/ddev`, bringing it in line with the installation instructions at https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/