### PR TITLE
fix: handle Drupal 10.1 asset aggregation URLs.

### DIFF
--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
@@ -34,8 +34,8 @@ server {
         rewrite ^ /index.php;
     }
 
-    # Handle image styles for Drupal 7+
-    location ~ ^/sites/.*/files/styles/ {
+    # Passes image style and asset generation to PHP.
+    location ~ ^/sites/.*/files/(css|js|styles)/ {
         try_files $uri @rewrite;
     }
 


### PR DESCRIPTION
## The Issue
Drupal 10.1 asset aggregation uses a similar mechanism to image derivatives/image styles. These directories don't fall through to PHP in the default ddev nginx config which leads to 404s

## How This PR Solves The Issue
Allow more directories

## Manual Testing Instructions
Install Drupal 10.1 and enable js/css aggregation

## Automated Testing Overview

Just a default config change, would need to install Drupal to really test that it fixes what it says it does.

## Related Issue Link(s)

## Release/Deployment Notes