### PR TITLE
fix: partial revert of #5383 add -t flag back to mailpit sendmail command

### DIFF
--- a/containers/ddev-php-base/ddev-php-files/etc/php/5.6/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/5.6/apache2/php.ini
@@ -81,7 +81,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/5.6/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/5.6/cli/php.ini
@@ -82,7 +82,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/5.6/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/5.6/fpm/php.ini
@@ -81,7 +81,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.0/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.0/apache2/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.0/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.0/cli/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.0/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.0/fpm/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.1/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.1/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.1/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.1/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.1/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.1/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.2/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.2/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.2/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.2/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.2/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.2/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.3/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.3/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.3/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.3/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.3/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.3/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.4/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.4/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.4/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.4/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.4/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.4/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.0/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.0/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.0/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.0/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.0/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.0/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.1/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.1/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.1/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.1/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.1/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.1/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/apache2/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.3/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.3/cli/php.ini
@@ -1102,7 +1102,7 @@ smtp_port = 25
 
 ; For Unix only.  You may supply arguments as well (default: "sendmail -t -i").
 ; https://php.net/sendmail-path
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 ; Force the addition of the specified parameters to be passed as extra parameters
 ; to the sendmail binary. These parameters will always replace the value of

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.3/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.3/fpm/php.ini
@@ -1102,7 +1102,7 @@ smtp_port = 25
 
 ; For Unix only.  You may supply arguments as well (default: "sendmail -t -i").
 ; https://php.net/sendmail-path
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 ; Force the addition of the specified parameters to be passed as extra parameters
 ; to the sendmail binary. These parameters will always replace the value of

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV-Local)
-FROM ddev/ddev-php-base:v1.22.4 as ddev-webserver-base
+FROM ddev/ddev-php-base:20231102_joelpittet_revert_sendmail_t as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/5.6/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/5.6/cli/php.ini
@@ -82,7 +82,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/5.6/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/5.6/fpm/php.ini
@@ -81,7 +81,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.0/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.0/cli/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.0/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.0/fpm/php.ini
@@ -75,7 +75,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.1/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.1/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.1/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.1/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.2/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.3/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/7.4/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.0/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.1/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.1/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.1/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.1/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.2/cli/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.2/cli/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.2/fpm/php.ini
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/php/8.2/fpm/php.ini
@@ -74,7 +74,7 @@ pdo_mysql.default_socket=
 SMTP = localhost
 smtp_port = 25
 mail.add_x_header = On
-sendmail_path="/usr/local/bin/mailpit sendmail --smtp-addr 127.0.0.1:1025"
+sendmail_path="/usr/local/bin/mailpit sendmail -t --smtp-addr 127.0.0.1:1025"
 
 [SQL]
 sql.safe_mode = Off

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20231030_apotek_xsl" // Note that this can be overridden by make
+var WebTag = "20231102_joelpittet_revert_sendmail_t" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue
* #5383

## How This PR Solves The Issue
Adds the `-t` flag back to sendmail command so that symfony mailer validation is appeased. 
## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)
* #5383

* https://www.drupal.org/project/swiftmailer/issues/3174215
* https://github.com/symfony/symfony/pull/47020

