### PR TITLE
docs: implement search priority setting using mkdocs-material

### DIFF
--- a/docs/content/developers/brand-guide.md
+++ b/docs/content/developers/brand-guide.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: .5
+---
 # Brand Guide
 
 ## Logos

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: .5
+---
 # Building, Testing, and Contributing
 
 ## Testing Latest Commits on HEAD

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: .2
+---
 # Buildkite Test Agent Setup
 
 We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testing. The build machines and `buildkite-agent` must be set up before use.

--- a/docs/content/developers/github-selfhosted-setup.md
+++ b/docs/content/developers/github-selfhosted-setup.md
@@ -1,8 +1,9 @@
 ---
 hide:
   - toc
+search:
+  boost: .2
 ---
-
 # GitHub Self-Hosted Agent Setup
 
 We are using GitHub Self-Hosted Agents for Windows and macOS testing. The build machines and agents must be set up before use.

--- a/docs/content/developers/index.md
+++ b/docs/content/developers/index.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: .5
+---
 # Developing and Improving DDEV
 
 This section is for folks making contributions to DDEV. It covers how to build and release Docker images, and contribute documentation.

--- a/docs/content/developers/project-types.md
+++ b/docs/content/developers/project-types.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: .5
+---
 # Adding New Project Types
 
 Adding and maintaining project types (like `typo3`, `magento2`, etc.) is not too hard. Please update and add to this doc when you find things that have been missed.

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: .5
+---
 # Release Management & Docker Images
 
 ## Release process and tools

--- a/docs/content/developers/remote-config.md
+++ b/docs/content/developers/remote-config.md
@@ -1,9 +1,13 @@
+---
+search:
+  boost: .5
+---
 # Remote Config
 
 DDEV supports downloading a [`remote config`](https://github.com/ddev/remote-config/blob/main/remote-config.jsonc)
 from the [`ddev/remote-config`](https://github.com/ddev/remote-config)
-GitHub repository with messages that will be shown to the user. This feature
-could be enhanced later with more information and configuration.
+GitHub repository with messages that will be shown to the user as a "Tip of the Day". This feature
+may be enhanced later with more information and filtering.
 
 ## Messages
 

--- a/docs/content/developers/testing-docs.md
+++ b/docs/content/developers/testing-docs.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: .5
+---
 # Working on the Docs
 
 This page is about working with the DDEV documentation. See the [Writing Style Guide](writing-style-guide.md) for stylistic guidance.

--- a/docs/content/developers/writing-style-guide.md
+++ b/docs/content/developers/writing-style-guide.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: .5
+---
 # Writing Style Guide
 
 This page formalizes the writing conventions we aspire to use in the documentation.  

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # Config Options
 
 DDEV configuration is stored in YAML files that come in two flavors:

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Additional Service Configurations & Add-ons
 
 DDEV projects can be extended to provide additional add-ons, including services. You can define these add-ons using docker-compose files in the project’s `.ddev` directory.

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Extending and Customizing Environments
 
 DDEV provides several ways to customize and extend project environments.

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2 
+---
 # Database Management
 
 DDEV provides lots of flexibility for managing your databases between your local, staging and production environments. You may commonly use the [`ddev import-db`](../usage/commands.md#import-db) and [`ddev export-db`](../usage/commands.md#export-db) commands, but there are plenty of other adaptable ways to work with your databases.

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # Built-in Developer Tools
 
 Run [`ddev describe`](../usage/commands.md#describe) to see the project information and services available for your project and how to access them.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,9 @@ theme:
 #  - toc.follow
 #  - toc.integrate
   - navigation.footer
+  - search.suggest
+  - search.highlight
+  - search.share
   favicon: favicon.png
   # readthedocs doesn't seem to do logo css right
 #  logo: /logo.svg

--- a/version-history.md
+++ b/version-history.md
@@ -1,3 +1,7 @@
+---
+search:
+  exclude: true
+---
 # DDEV Version History
 
 This version history has been driven by what we hear from our wonderful community of users. Please share your comments or ideas in the [issue queue](https://github.com/ddev/ddev/issues). We listen. Or talk to us in any of the [support locations](https://ddev.readthedocs.io/en/stable/#support).


### PR DESCRIPTION
## The Issue

In ddev.readthedocs.io docs search, sometimes the links we want people to find first aren't the ones they find

## How This PR Solves The Issue

Based on https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/?h=search+boost#search-boosting we are supposed to be able to affect this. This is a first attempt.

## Manual Testing Instructions

Visit the docs built for this PR and see if the search boosting implemented here works at all.
https://ddev--5500.org.readthedocs.build/en/5500/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

