### PR TITLE
docs: adds a dark theme compatible svgs, fixes #5492

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![DDEV Logo](images/ddev-logo.svg)
-
+![DDEV Logo](https://ddev.com/logos/ddev.svg#gh-light-mode-only)
+![DDEV Logo](https://ddev.com/logos/dark-ddev.svg#gh-dark-mode-only)
 ---
 
 [![CircleCI](https://circleci.com/gh/ddev/ddev.svg?style=shield)](https://circleci.com/gh/ddev/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
@@ -41,4 +41,5 @@ See “How can I contribute to DDEV?” in the [FAQ](https://ddev.readthedocs.io
 
 ## Wonderful Sponsors
 
-![DDEV featured sponsor logos](https://ddev.com/resources/featured-sponsors.svg)
+![DDEV featured sponsor logos](https://ddev.com/resources/featured-sponsors.svg#gh-light-mode-only)
+![DDEV featured sponsor logos](https://ddev.com/resources/featured-sponsors-darkmode.svg#gh-dark-mode-only)


### PR DESCRIPTION
Modifies  README.md to add the missing logos
However, it requires this PR to get merged first https://github.com/ddev/ddev.com/pull/134
Otherwise, the sponsors will break on GitHub's dark theme. Due to the asset not being there.

Fixes #5492 

## Manual Testing Instructions

Check that the README sponsors load well on a light GitHub theme and a dark theme.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

No