### PR TITLE
docs: updates building-contributing.md pr title to comply with the linter

### DIFF
--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -300,13 +300,13 @@ The pull request title must follow this convention which is based on the [Conven
 
 Must be one of the following:
 
-* **build**: Changes that affect the build or external dependencies
-* **ci**: Changes to our CI configuration files and scripts
-* **docs**: Documentation only changes
-* **feat**: A new feature
-* **fix**: A bugfix
-* **refactor**: A code change that neither fixes a bug nor adds a feature
-* **test**: Adding missing tests or correcting existing tests
+* **build**: changes that affect the build or external dependencies
+* **ci**: changes to our CI configuration files and scripts
+* **docs**: documentation only changes
+* **feat**: a new feature
+* **fix**: a bugfix
+* **refactor**: a code change that neither fixes a bug nor adds a feature
+* **test**: adding missing tests or correcting existing tests
 
 Regarding SemVer, all types above except `feat` increase the patch version, `feat` increases the minor version.
 


### PR DESCRIPTION
The linter complains unless the PR titles are all lowercase or at least start with a lowercase.

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

The linter complains unless the PR titles are all lowercase or at least start with a lowercase.

## How This PR Solves The Issue

Provides an example that matches said expectation.
