### PR TITLE
docs: add feedback to the analytics section in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,7 +89,7 @@ extra:
           name: Search results and/or this page could be improved
           data: 0
           note: >-
-            Thanks for your feedback! Help us improve this page and the search experience in general by creating an issue <a href="https://github.com/ddev/ddev/issues/new/?title=[Feedback]+{title}+-+{url}&labels=feedback&template=mkdocs_feedback.yml" target="_blank" rel="noopener">on Github</a>.
+            Thanks for your feedback! Help us improve this page and the search experience in general by creating an issue <a href="https://github.com/ddev/ddev/issues/new/?title=[Feedback]+{title}+-+{url}&labels=feedback&template=bug_report.yml&labels=documenation" target="_blank" rel="noopener">on Github</a>.
 
 # Extensions
 markdown_extensions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,19 @@ extra:
   generator: false
   analytics:
     provider: plausible
+    feedback:
+      title: Did this page help you solve your problem?
+      ratings:
+        - icon: material/thumb-up-outline
+          name: This page was helpful
+          data: 1
+          note: >-
+            Thank you for your feedback! Happy
+        - icon: material/thumb-down-outline
+          name: Search results and/or this page could be improved
+          data: 0
+          note: >-
+            Thanks for your feedback! Help us improve this page and the search experience in general by creating an issue <a href="https://github.com/ddev/ddev/issues/new/?title=[Feedback]+{title}+-+{url}&labels=feedback&template=mkdocs_feedback.yml" target="_blank" rel="noopener">on Github</a>.
 
 # Extensions
 markdown_extensions:


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
@rfay is currently trying to add search priorities for the search field on ddev.readthedocs.com to prioritize search results (https://github.com/ddev/ddev/pull/5500). The problem is there is currently no direct way for a visitor to provide some sort of in context feedback about the search results and the docs page the person was pointed to in particular. Therefore there is no direct way to get an idea about potential problems and ambiguities users face in the docs experience. 
 
## How This PR Solves The Issue
There is the option to add a `Was this page helpful?`widget to each docs page in mkdocs (see https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#was-this-page-helpful). It is basically adding two icons (thumbs up and thumbs down) at the bottom of the page. on thumbs up everything was all right and it is forwarding the value 1 to the analytics software (per default google analytics - not sure how well it will work with plausible). on thumbs down the value 0 is forwarded to analytics and there is the option to leave a comment what actually went wrong. out of the box the mkdocs outline two options. squidfunk itself uses google forms. on the upside that doesnt require any account but on the downside it has gdpr implications therefore i would would vote against it. in addition there is also no way to get a reply to your feedback. so if you have a question you as the person providing a feedback depend on the maintainers to act on your feedback and solve your issue or provide some sort of reaction proactively. the other option is to instead of pointing a google form link to simply point to a github issue. the downside is a person reporting needs to have a github account but on the upside the maintainers have a direct way to provide some actual feedback on the feedback. i consider that a way better experience and a win win for both sides. 

i've created an initial PR #5503 where the github feedback link points to 

`https://github.com/ddev/ddev/issues/new/?title=[Feedback]+{title}+-+{url}&labels= documentation&template=bug_report.yml` 

creating a bug_report with a label of documentation. until a dedicated repo for mkdocs feedback is set up. otherwise the ddev queue might be "spammed". and i wanted to put the PR up to get some feedback on the microcopy for the ratings and the widget in general. as soon as the other repo is created the link could be changed to something like this: 

`https://github.com/ddev/mkdocs-feedback/issues/new/?title=[Feedback]+{title}+-+{url}&labels=feedback&template=mkdocs_feedback.yml`

any thoughts and or feedback? 

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

