### PR TITLE
fix: ensure no duplicates for docker networks, fixes #5193

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2558,10 +2558,8 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	}
 
 	// Remove current project network
-	// Working around duplicate network creation problem apparently caused by
-	// https://github.com/docker/compose/issues/6532#issuecomment-769263484
-	// see https://github.com/ddev/ddev/issues/5193 and
-	// https://github.com/ddev/ddev/pull/5305
+	// Working around duplicate network creation problem
+	// see https://github.com/ddev/ddev/pull/5508
 	dockerutil.RemoveNetworkWithWarningOnError(os.Getenv("COMPOSE_PROJECT_NAME") + "_default")
 
 	return nil

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -55,7 +55,8 @@ func PowerOff() {
 	removals, err := dockerutil.FindNetworksWithLabel("com.ddev.platform")
 	if err == nil {
 		for _, network := range removals {
-			dockerutil.RemoveNetworkWithWarningOnErrorByID(network.Name, network.ID)
+			util.Warning("Don't remove the network %s", network.Name)
+			//dockerutil.RemoveNetworkWithWarningOnErrorByID(network.Name, network.ID)
 		}
 	} else {
 		util.Warning("Unable to run dockerutil.FindNetworksWithLabel(): %v", err)

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -55,8 +55,7 @@ func PowerOff() {
 	removals, err := dockerutil.FindNetworksWithLabel("com.ddev.platform")
 	if err == nil {
 		for _, network := range removals {
-			util.Warning("Don't remove the network %s", network.Name)
-			//dockerutil.RemoveNetworkWithWarningOnErrorByID(network.Name, network.ID)
+			dockerutil.RemoveNetworkWithWarningOnErrorByID(network.Name, network.ID)
 		}
 	} else {
 		util.Warning("Unable to run dockerutil.FindNetworksWithLabel(): %v", err)

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -51,16 +51,19 @@ func PowerOff() {
 		util.Error("Failed to remove ddev-ssh-agent: %v", err)
 	}
 
-	// Remove all global networks created with DDEV
+	// Remove global DDEV default network
+	dockerutil.RemoveNetworkWithWarningOnError(dockerutil.NetName)
+
+	// Remove all external networks created with DDEV
+	// This is needed for compatibility if we decide to undo the changes
+	// made for the external project networks
+	// see https://github.com/ddev/ddev/pull/5508
 	removals, err := dockerutil.FindNetworksWithLabel("com.ddev.platform")
 	if err == nil {
 		for _, network := range removals {
-			dockerutil.RemoveNetworkWithWarningOnErrorByID(network.Name, network.ID)
+			dockerutil.RemoveNetworkWithWarningOnError(network.Name)
 		}
 	} else {
 		util.Warning("Unable to run dockerutil.FindNetworksWithLabel(): %v", err)
 	}
-
-	// Remove old network from DDEV before v1.22.4
-	dockerutil.RemoveNetworkWithWarningOnError(dockerutil.NetName)
 }

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -55,7 +55,7 @@ func PowerOff() {
 	removals, err := dockerutil.FindNetworksWithLabel("com.ddev.platform")
 	if err == nil {
 		for _, network := range removals {
-			dockerutil.RemoveNetworkWithWarningOnError(network.Name)
+			dockerutil.RemoveNetworkWithWarningOnErrorByID(network.Name, network.ID)
 		}
 	} else {
 		util.Warning("Unable to run dockerutil.FindNetworksWithLabel(): %v", err)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -42,19 +42,19 @@ type ComposeCmdOpts struct {
 
 // EnsureNetwork will ensure the Docker network for DDEV is created.
 func EnsureNetwork(client *docker.Client, name string) error {
-	if !NetExists(client, name) {
-		netOptions := docker.CreateNetworkOptions{
-			Name:     name,
-			Driver:   "bridge",
-			Internal: false,
-			Labels:   map[string]string{"com.ddev.platform": "ddev"},
-		}
-		_, err := client.CreateNetwork(netOptions)
-		if err != nil {
-			return err
-		}
-		output.UserOut.Println("Network", name, "created")
+	//if !NetExists(client, name) {
+	netOptions := docker.CreateNetworkOptions{
+		Name:     name,
+		Driver:   "bridge",
+		Internal: false,
+		Labels:   map[string]string{"com.ddev.platform": "ddev"},
 	}
+	_, err := client.CreateNetwork(netOptions)
+	if err != nil {
+		return err
+	}
+	output.UserOut.Println("Network", name, "created")
+	//}
 	return nil
 }
 
@@ -100,7 +100,8 @@ func RemoveNetworkWithWarningOnError(netName string) {
 	nets, _ := client.ListNetworks()
 	for _, n := range nets {
 		if n.Name == netName {
-			RemoveNetworkWithWarningOnErrorByID(n.Name, n.ID)
+			util.Warning("Don't remove the network %s", n.Name)
+			//RemoveNetworkWithWarningOnErrorByID(n.Name, n.ID)
 		}
 	}
 }

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -42,19 +42,19 @@ type ComposeCmdOpts struct {
 
 // EnsureNetwork will ensure the Docker network for DDEV is created.
 func EnsureNetwork(client *docker.Client, name string) error {
-	//if !NetExists(client, name) {
-	netOptions := docker.CreateNetworkOptions{
-		Name:     name,
-		Driver:   "bridge",
-		Internal: false,
-		Labels:   map[string]string{"com.ddev.platform": "ddev"},
+	if !NetExists(client, name) {
+		netOptions := docker.CreateNetworkOptions{
+			Name:     name,
+			Driver:   "bridge",
+			Internal: false,
+			Labels:   map[string]string{"com.ddev.platform": "ddev"},
+		}
+		_, err := client.CreateNetwork(netOptions)
+		if err != nil {
+			return err
+		}
+		output.UserOut.Println("Network", name, "created")
 	}
-	_, err := client.CreateNetwork(netOptions)
-	if err != nil {
-		return err
-	}
-	output.UserOut.Println("Network", name, "created")
-	//}
 	return nil
 }
 
@@ -100,8 +100,7 @@ func RemoveNetworkWithWarningOnError(netName string) {
 	nets, _ := client.ListNetworks()
 	for _, n := range nets {
 		if n.Name == netName {
-			util.Warning("Don't remove the network %s", n.Name)
-			//RemoveNetworkWithWarningOnErrorByID(n.Name, n.ID)
+			RemoveNetworkWithWarningOnErrorByID(n.Name, n.ID)
 		}
 	}
 }


### PR DESCRIPTION
## The Issue

- https://github.com/docker/compose/issues/6532#issuecomment-769263484
- #5193

## Summary:

Sometimes when you start a project, multiple project networks are created (e.g. `ddev-your-project_default`) which prevents the project from starting.

```
Error response from daemon: network ddev-your-project_default is ambiguous (16 matches found on name)
```

The project network is *internal* (created from `docker-compose.yaml`) in v1.22.4, and we cannot manipulate its state.
But we can make it *external* (created programmatically from DDEV) in v1.22.5 and control it however we want.

This set of PRs are intended to fix the need for user to do manually `docker network rm`, because the project cannot be started when there are duplicate networks.

An attempt has been made to fix this on the Docker side (but it will only be available with Docker 25):

- https://github.com/moby/moby/pull/46251

To make things easier for DDEV users, we can use external networks for DDEV projects and automatically remove duplicates.

## Code changes for this issue are made in:
- #5305
- #5422
- #5436
- #5508

## How This PR Solves The Issue

DDEV should remove Docker networks by ID, not by name. This way users won't need to worry about duplicate networks, because they will be removed automatically on `ddev start` and `ddev poweroff` - regardless of what users run.

## Manual Testing Instructions

Download the binary below, this is a special broken binary that creates duplicate networks:

* [all-ddev-executables.zip](https://nightly.link/ddev/ddev/actions/artifacts/1034925836.zip)
* [ddev-linux-amd64.zip](https://nightly.link/ddev/ddev/actions/artifacts/1034925838.zip)
* [ddev-linux-arm64.zip](https://nightly.link/ddev/ddev/actions/artifacts/1034925840.zip)
* [ddev-macos-amd64.zip](https://nightly.link/ddev/ddev/actions/artifacts/1034925842.zip)
* [ddev-macos-arm64.zip](https://nightly.link/ddev/ddev/actions/artifacts/1034925844.zip)
* [ddev-windows-amd64-installer.zip](https://nightly.link/ddev/ddev/actions/artifacts/1034925846.zip)

```
# use the binary from above for ddev start, the more you do it, the more duplicates will be created
ddev start
ddev start
ddev start

# then run poweroff (networks will not be removed)
ddev poweroff

# see a lot of duplicates for ddev_default and ddev-your-project_default
docker network ls

# switch the binary to the one in the second comment (from the bot) and run

ddev start

# you will see a lot of these:

Network ddev_default removed
Network ddev_default removed

You seem to have a new DDEV version. 
During an upgrade it's important to `ddev poweroff`.
May I do `ddev poweroff` before continuing?
This does no harm and loses no data. [Y/n] (yes): y

# Answer "yes", and all duplicates will be removed on ddev poweroff

Network ddev-your-project_default removed 
Network ddev-your-project_default removed 
Network ddev-your-project_default removed
Network ddev_default removed
Network ddev-your-project_default removed 
Network ddev-your-project_default removed

# Also you can repeat the same steps but this time answer "no" and then run ddev start, the duplicates will also be removed

May I do `ddev poweroff` before continuing?
This does no harm and loses no data. [Y/n] (yes): n

ddev start

Starting project... 
Network ddev-your-project_default removed 
Network ddev-your-project_default removed 
Network ddev-your-project_default removed
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

