### PR TITLE
docs: adds a dark theme compatible svgs, fixes #5492 #5501

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ See “How can I contribute to DDEV?” in the [FAQ](https://ddev.readthedocs.io
 ## Wonderful Sponsors
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://ddev.com/resources/featured-sponsors-darkmode.svg#gh-dark-mode-only">
-  <img alt="DDEV Sponsor logos with light and dark mode variants" src="https://ddev.com/resources/featured-sponsors.svg#gh-light-mode-only">
+  <source media="(prefers-color-scheme: dark)" srcset="https://ddev.com/resources/featured-sponsors-darkmode.svg">
+  <img alt="DDEV Sponsor logos with light and dark mode variants" src="https://ddev.com/resources/featured-sponsors.svg">
 </picture>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-![DDEV Logo](https://ddev.com/logos/ddev.svg#gh-light-mode-only)
-![DDEV Logo](https://ddev.com/logos/dark-ddev.svg#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://ddev.com/logos/dark-ddev.svg">
+  <img alt="DDEV logo with light and dark mode variants" src="https://ddev.com/logos/ddev.svg">
+</picture>
 ---
 
 [![CircleCI](https://circleci.com/gh/ddev/ddev.svg?style=shield)](https://circleci.com/gh/ddev/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
@@ -41,5 +43,7 @@ See “How can I contribute to DDEV?” in the [FAQ](https://ddev.readthedocs.io
 
 ## Wonderful Sponsors
 
-![DDEV featured sponsor logos](https://ddev.com/resources/featured-sponsors.svg#gh-light-mode-only)
-![DDEV featured sponsor logos](https://ddev.com/resources/featured-sponsors-darkmode.svg#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://ddev.com/resources/featured-sponsors-darkmode.svg#gh-dark-mode-only">
+  <img alt="DDEV Sponsor logos with light and dark mode variants" src="https://ddev.com/resources/featured-sponsors.svg#gh-light-mode-only">
+</picture>


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
relates to #5501 #5492
The #gh-dark-mode-only and #gh-light-mode-only tags don't seem to be working so we are switching to the picture tag which is better since it would read correctly outside of github.

## How This PR Solves The Issue

It switches from GitHub specific markdown language to the picture tag.