### PR TITLE
fix: allow editing for platform.yaml

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -1,6 +1,6 @@
 #ddev-generated
 # Platform.sh provider configuration. This works out of the box, but can be edited to add
-# your own preferences. If you edit it, remove the `#ddev-generated` line from the top so
+# your own preferences. If you edit it, remove the `ddev-generated` line from the top so
 # that it won't be overwritten.
 
 # Consider using `ddev get ddev/ddev-platformsh` (https://github.com/ddev/ddev-platformsh) for more
@@ -74,7 +74,7 @@ db_pull_command:
 
 files_import_command:
   command: |
-    #set -x   # You can enable bash debugging output by uncommenting
+    # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     export PLATFORMSH_CLI_NO_INTERACTION=1
     # Use $PLATFORM_MOUNTS if it exists to get list of mounts to download, otherwise just web/sites/default/files (drupal)
@@ -104,4 +104,3 @@ files_push_command:
     export PLATFORMSH_CLI_NO_INTERACTION=1
     ls "${DDEV_FILES_DIR}" >/dev/null # This just refreshes stale NFS if possible
     platform mount:upload --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files
-


### PR DESCRIPTION
## The Issue

When testing Upsun, I copied the `platform.yaml` and checked its settings.
When I wanted to customize it, I removed the `#ddev-generated` line and ran `ddev restart`, but the file was reset.
That's because there is a second `#ddev-generated` in this file.

## How This PR Solves The Issue

Removes `#` from the extra `#ddev-generated`.
Removes an extra line at the end of the file.
Adds a space between `#set -x` - to make it look like others `# set -x` in this file.

## Manual Testing Instructions

1. Use a regular DDEV binary (no need to generate a new binary for this PR)
2. Run `ddev start`
3. Edit `.ddev/providers/platform.yaml` - remove the `#ddev-generated` from the top.
4. Run `ddev stop` - see that file is reset.
5. Edit `.ddev/providers/platform.yaml` - remove the `#ddev-generated` from the top and edit the second entry of `#ddev-generated` on the third line to `ddev-generated`
6. Run `ddev start` - see that file is not reset.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

