### PR TITLE
fix: allow testcmd to run as make tarket on `pull-push-test-platforms`, follow up to #5516

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Override environment variables for push-pull-test-platforms
         run: |
-          echo "MAKE_TARGET=testpkg" >> $GITHUB_ENV
+          echo "MAKE_TARGET=test" >> $GITHUB_ENV
           echo "TESTARGS=-failfast -run '(TestDdevFullSite.*|TestDdevImportFiles|TestDdevAllDatabases|TestComposerCreateCmd|Test.*(Push|Pull))'" >> $GITHUB_ENV
           echo "GOTEST_SHORT=" >> $GITHUB_ENV
           echo "DDEV_PLATFORM_API_TOKEN=${{ secrets.DDEV_PLATFORM_API_TOKEN }}" >> $GITHUB_ENV


### PR DESCRIPTION
On #5516 we added the test, but it didn't run because testcmd was not part of the make target.