### PR TITLE
build: use latest version of mailpit at image build time

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -47,7 +47,7 @@ RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer
 ### ---------------------------ddev-webserver-dev-base--------------------------------------
 ### Build ddev-webserver-dev-base from ddev-webserver-base
 FROM ddev-webserver-base as ddev-webserver-dev-base
-ENV MAILPIT_VERSION="v1.8.2"
+ENV MAILPIT_VERSION="v1.9.10"
 ENV CAROOT /mnt/ddev-global-cache/mkcert
 ENV PHP_DEFAULT_VERSION="8.1"
 

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -47,7 +47,6 @@ RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer
 ### ---------------------------ddev-webserver-dev-base--------------------------------------
 ### Build ddev-webserver-dev-base from ddev-webserver-base
 FROM ddev-webserver-base as ddev-webserver-dev-base
-ENV MAILPIT_VERSION="v1.9.10"
 ENV CAROOT /mnt/ddev-global-cache/mkcert
 ENV PHP_DEFAULT_VERSION="8.1"
 
@@ -97,7 +96,7 @@ RUN mkdir -p /home/blackfire && chown blackfire:blackfire /home/blackfire && use
 ADD ddev-webserver-dev-base-files /
 RUN phpdismod blackfire xdebug xhprof
 
-RUN set -x; curl --fail -sSL "https://github.com/axllent/mailpit/releases/download/${MAILPIT_VERSION}/mailpit-linux-${TARGETPLATFORM##linux/}.tar.gz" -o /tmp/mailpit.tar.gz && tar -zx -C /usr/local/bin -f /tmp/mailpit.tar.gz mailpit && rm /tmp/mailpit.tar.gz
+RUN set -x && set -o pipefail && tag=$(curl -L --fail --silent "https://api.github.com/repos/axllent/mailpit/releases/latest" | jq -r .tag_name) && curl --fail -sSL "https://github.com/axllent/mailpit/releases/download/${tag}/mailpit-linux-${TARGETPLATFORM##linux/}.tar.gz" -o /tmp/mailpit.tar.gz && tar -zx -C /usr/local/bin -f /tmp/mailpit.tar.gz mailpit && rm /tmp/mailpit.tar.gz
 
 RUN curl -sSL --fail --output /usr/local/bin/phive "https://phar.io/releases/phive.phar" && chmod 777 /usr/local/bin/phive
 RUN set -o pipefail && curl --fail -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl -L --fail --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod 777 /usr/local/bin/terminus

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20231102_joelpittet_revert_sendmail_t" // Note that this can be overridden by make
+var WebTag = "20231110_syssi_mailpit_latest" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

Mailpit is outdated.

## How This PR Solves The Issue

Bumps the mailpit version to the recent release.

## Manual Testing Instructions

`ddev launch -m` -> About -> v1.9.10

## Automated Testing Overview

## Related Issue Link(s)

This project (https://github.com/pushpak1300/cypress-mailpit) cannot be used at the moment because it uses recent API features which aren't available in v1.8.1.

## Release/Deployment Notes

Bumps the mailpit version to v1.9.10.


