### PR TITLE
fix: internal project network with duplicate check, revert for #5305

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -251,7 +251,6 @@ networks:
     external: true
   default:
     name: ${COMPOSE_PROJECT_NAME}_default
-    external: true
     {{ if .IsGitpod }}{{/* see https://github.com/ddev/ddev/issues/3766 */}}
     driver_opts:
       com.docker.network.driver.mtu: 1440

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1028,6 +1028,10 @@ func (app *DdevApp) Start() error {
 
 	app.DockerEnv()
 	dockerutil.EnsureDdevNetwork()
+	// "docker-compose up", which is called in this function later, may create
+	// duplicate project networks, we can create this network in advance
+	// see https://github.com/ddev/ddev/pull/5533
+	dockerutil.EnsureProjectNetwork()
 
 	if err = dockerutil.CheckDockerCompose(); err != nil {
 		util.Failed(`Your docker-compose version does not exist or is set to an invalid version.
@@ -2556,11 +2560,6 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 			return fmt.Errorf("failed to process post-stop hooks: %v", err)
 		}
 	}
-
-	// Remove current project network
-	// Working around duplicate network creation problem
-	// see https://github.com/ddev/ddev/pull/5508
-	dockerutil.RemoveNetworkWithWarningOnError(os.Getenv("COMPOSE_PROJECT_NAME") + "_default")
 
 	return nil
 }

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -54,10 +54,7 @@ func PowerOff() {
 	// Remove global DDEV default network
 	dockerutil.RemoveNetworkWithWarningOnError(dockerutil.NetName)
 
-	// Remove all external networks created with DDEV
-	// This is needed for compatibility if we decide to undo the changes
-	// made for the external project networks
-	// see https://github.com/ddev/ddev/pull/5508
+	// Remove all networks created with DDEV
 	removals, err := dockerutil.FindNetworksWithLabel("com.ddev.platform")
 	if err == nil {
 		for _, network := range removals {

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -262,12 +262,8 @@ func ClearDockerEnv() {
 
 // ContainerCheck determines if a given container name exists and matches a given state
 func ContainerCheck(checkName string, checkState string) (bool, error) {
-	// Ensure we have Docker network
-	client := dockerutil.GetDockerClient()
-	err := dockerutil.EnsureNetwork(client, dockerutil.NetName)
-	if err != nil {
-		log.Fatal(err)
-	}
+	// Ensure we have DDEV network
+	dockerutil.EnsureDdevNetwork()
 
 	c, err := dockerutil.FindContainerByName(checkName)
 	if err != nil {


### PR DESCRIPTION
## The Issue

- #5305
- #5508
- #5193

After switch to external project networks in #5305, there were issues with compatibility between different DDEV version, which made downgrade not smooth.

The last issue with downgrade from HEAD to v1.22.4:

```
$ ddev start
...
Building project images... 
Project images built in 3s. 
time="2023-11-07T08:29:14-07:00" level=warning msg="a network with name ddev-d10_default exists but was not created by compose.\nSet `external: true` to use an existing network" 
network ddev-d10_default was found but has incorrect label com.docker.compose.network set to "" 
Failed to start d10: composeCmd failed to run 'COMPOSE_PROJECT_NAME=ddev-d10 docker-compose -f /Users/rfay/workspace/d10/.ddev/.ddev-docker-compose-full.yaml up -d', action='[]', err='exit status 1', stdout='', stderr='time="2023-11-07T08:29:14-07:00" level=warning msg="a network with name ddev-d10_default exists but was not created by compose.\nSet `external: true` to use an existing network"
network ddev-d10_default was found but has incorrect label com.docker.compose.network set to ""'
```

## How This PR Solves The Issue

Move back to internal project networks, and create them before `docker-compose up` to ensure no duplicates.

I've refactored the code to make it clearer what's going on. In the previous PR #5305, it was unclear where and why the project network was created.

## Manual Testing Instructions

Use DDEV as usual.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

