### PR TITLE
fix: update list column width of type to fit 13 characters

### DIFF
--- a/pkg/ddevapp/list.go
+++ b/pkg/ddevapp/list.go
@@ -105,7 +105,7 @@ func CreateAppTable(out *bytes.Buffer, wrapTableText bool) table.Writer {
 	usableWidth := termWidth - 15
 	statusWidth := 7 // Maybe just "running"
 	nameWidth := 10
-	typeWidth := 9 // drupal7, magento2 or wordpress
+	typeWidth := 12 // drupal7, magento2, wordpress or silverstripe
 	locationWidth := 20
 	urlWidth := 20
 	if termWidth > 80 {


### PR DESCRIPTION
## The Issue

When a project type is of Silverstripe, the Type column of the `ddev list` command wraps around making an uneven view:

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ NAME                     ┃ STATUS  ┃ LOCATION                            ┃ URL                    ┃ TYPE      ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━┫
┃ proj1                    ┃ stopped ┃ ~/Projects/proj1                    ┃                        ┃ silverstr ┃
┃                          ┃         ┃                                     ┃                        ┃ ipe       ┃
┃ proj1                    ┃ stopped ┃ ~/Projects/proj2                    ┃                        ┃ php       ┃
```

## How This PR Solves The Issue

Update the width of the column-type to 13 characters to allow for the larger count of the word "silverstripe" to fit

## Manual Testing Instructions

See output of `ddev list`

## Automated Testing Overview

I believe this is already covered?

## Related Issue Link(s)

## Release/Deployment Notes
