### PR TITLE
ci: revert colima to 0.5.6, use macos-13

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -98,7 +98,7 @@ jobs:
           # brew install mysql-client is failing because of existing 2to3
           sudo rm -f /usr/local/bin/2to3*
           brew install --overwrite mysql-client || true
-          colima start --cpu 3 --memory 6 --mount-type=sshfs --vm-type=qemu --dns=1.1.1.1
+          colima start --cpu 3 --memory 6 --mount-type=virtiofs --vm-type=vz --dns=1.1.1.1
           colima version
 
       - name: Build ddev

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -93,6 +93,7 @@ jobs:
         run: |
           set -x
           sudo chmod ugo+w /usr/local/bin
+          brew install --overwrite python@3.11
           brew install colima docker docker-compose
           # brew install mysql-client is failing because of existing 2to3
           sudo rm -f /usr/local/bin/2to3*

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -93,9 +93,9 @@ jobs:
         run: |
           set -x
           sudo chmod ugo+w /usr/local/bin
+          sudo rm -f /usr/local/bin/2to3
           brew install colima docker docker-compose
           # brew install mysql-client is failing because of existing 2to3
-          sudo rm -f /usr/local/bin/2to3
           brew install --overwrite mysql-client || true
           colima start --cpu 3 --memory 6 --mount-type=sshfs --vm-type=qemu --dns=1.1.1.1
           colima version

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -x
           sudo chmod ugo+w /usr/local/bin
-          brew install -q colima docker docker-compose jq >/dev/null
+          brew install colima docker docker-compose jq >/dev/null
           # brew install mysql-client is failing because of existing 2to3
           sudo rm -f /usr/local/bin/2to3
           brew install --overwrite mysql-client || true

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -x
           sudo chmod ugo+w /usr/local/bin
-          brew install colima docker docker-compose jq >/dev/null
+          brew install colima docker docker-compose
           # brew install mysql-client is failing because of existing 2to3
           sudo rm -f /usr/local/bin/2to3
           brew install --overwrite mysql-client || true

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -105,7 +105,7 @@ jobs:
           sudo mkdir -p /usr/local/bin && sudo curl -L -o /usr/local/bin/colima https://github.com/abiosoft/colima/releases/download/v0.5.6/colima-Darwin-x86_64 && sudo chmod +x /usr/local/bin/colima
           hash -r
           colima version
-          colima start --cpu 3 --memory 6 --mount-type=virtiofs --vm-type=vz
+          colima start --cpu 3 --memory 6 --disk 100 --vm-type=qemu --mount-type=sshfs --dns=1.1.1.1
 
       - name: Build ddev
         run: | 

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -x
           sudo chmod ugo+w /usr/local/bin
-          sudo rm -f /usr/local/bin/2to3
+          sudo rm -f /usr/local/bin/2to3*
           brew install colima docker docker-compose
           # brew install mysql-client is failing because of existing 2to3
           brew install --overwrite mysql-client || true

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -93,9 +93,9 @@ jobs:
         run: |
           set -x
           sudo chmod ugo+w /usr/local/bin
-          sudo rm -f /usr/local/bin/2to3*
           brew install colima docker docker-compose
           # brew install mysql-client is failing because of existing 2to3
+          sudo rm -f /usr/local/bin/2to3*
           brew install --overwrite mysql-client || true
           colima start --cpu 3 --memory 6 --mount-type=sshfs --vm-type=qemu --dns=1.1.1.1
           colima version

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         webserver: [nginx-fpm]
         tests: [ test ]
-        os: [ macos-latest ]
+        os: [ macos-13 ]
         no-bind-mounts: ['false']
       fail-fast: true
 
@@ -81,7 +81,6 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-
       - run: echo "/usr/local/opt/mysql-client/bin" >> $GITHUB_PATH
 
       - name: Setup tmate session
@@ -98,9 +97,7 @@ jobs:
           # brew install mysql-client is failing because of existing 2to3
           sudo rm -f /usr/local/bin/2to3
           brew install --overwrite mysql-client || true
-          # hopefully qemu reinstall will be temporary. 2023-08-30 after weeks of trouble.
-          brew reinstall --force qemu
-          colima start --cpu 3 --memory 6 --mount-type=sshfs --dns=1.1.1.1
+          colima start --cpu 3 --memory 6 --mount-type=sshfs --vm-type=qemu --dns=1.1.1.1
           colima version
 
       - name: Build ddev
@@ -124,7 +121,7 @@ jobs:
           done >/dev/null
 
       - name: "show versions"
-        run: "set -x && ddev version && docker version && go version"
+        run: "set -x && ddev version && docker version && go version && colima version"
 
       - name: time make "${{ matrix.tests }}"
         run: |

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -x
           sudo chmod ugo+w /usr/local/bin
-          brew install -q docker docker-compose jq >/dev/null
+          brew install -q colima docker docker-compose jq >/dev/null
           # brew install mysql-client is failing because of existing 2to3
           sudo rm -f /usr/local/bin/2to3
           brew install --overwrite mysql-client || true

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -89,17 +89,23 @@ jobs:
           limit-access-to-actor: true
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
-      - name: Install homebrew dependencies (macOS)
+      - name: Install homebrew dependencies
         run: |
           set -x
           sudo chmod ugo+w /usr/local/bin
           brew install --overwrite python@3.11
-          brew install colima docker docker-compose
+          brew install docker docker-compose
           # brew install mysql-client is failing because of existing 2to3
           sudo rm -f /usr/local/bin/2to3*
           brew install --overwrite mysql-client || true
-          colima start --cpu 3 --memory 6 --mount-type=virtiofs --vm-type=vz --dns=1.1.1.1
+
+      - name: Install and start Colima
+        run: |
+          # Temporarily use colima 0.5.6 as 0.6.* can't pass tests
+          sudo mkdir -p /usr/local/bin && sudo curl -L -o /usr/local/bin/colima https://github.com/abiosoft/colima/releases/download/v0.5.6/colima-Darwin-x86_64 && sudo chmod +x /usr/local/bin/colima
+          hash -r
           colima version
+          colima start --cpu 3 --memory 6 --mount-type=virtiofs --vm-type=vz
 
       - name: Build ddev
         run: | 

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -94,7 +94,7 @@ jobs:
           set -x
           sudo chmod ugo+w /usr/local/bin
           brew install --overwrite python@3.11
-          brew install docker docker-compose
+          brew install docker docker-compose lima
           # brew install mysql-client is failing because of existing 2to3
           sudo rm -f /usr/local/bin/2to3*
           brew install --overwrite mysql-client || true


### PR DESCRIPTION
## The Issue

Colima tests have been failing even with 0.6.2, apparently due to 
* https://github.com/abiosoft/colima/issues/856

* Update to run on macos-13 instead of 12 (which was "latest")
* Remove the previous fix to reinstall qemu
* Revert colima to 0.5.6
* Test with vz/virtiofs

