### PR TITLE
fix: add label for ddev-router, fixes #5542

### DIFF
--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -9,15 +9,18 @@ services:
     {{ end }}
 
     networks:
-        - ddev_default
+      - ddev_default
     container_name: ddev-router
-    ports:{{ $dockerIP := .dockerIP }}{{ if not .router_bind_all_interfaces }}{{ range $port := .ports }}
-    - "{{ $dockerIP }}:{{ $port }}:{{ $port }}"{{ end }}{{ else }}{{ range $port := .ports }}
-    - "{{ $port }}:{{ $port }}"{{ end }}{{ end }}
-    {{ if eq .Router "traefik" }}
-    # Traefik router; configured in static config as entrypoint
-    - "{{ if not .router_bind_all_interfaces }}{{ $dockerIP }}:{{ end }}{{.TraefikMonitorPort}}:{{.TraefikMonitorPort}}"
-    {{ end }}
+    ports: {{ $dockerIP := .dockerIP }}{{ if not .router_bind_all_interfaces }}{{ range $port := .ports }}
+      - "{{ $dockerIP }}:{{ $port }}:{{ $port }}"{{ end }}{{ else }}{{ range $port := .ports }}
+      - "{{ $port }}:{{ $port }}"{{ end }}{{ end }}
+      {{ if eq .Router "traefik" }}
+      # Traefik router; configured in static config as entrypoint
+      - "{{ if not .router_bind_all_interfaces }}{{ $dockerIP }}:{{ end }}{{.TraefikMonitorPort}}:{{.TraefikMonitorPort}}"
+      {{ end }}
+    labels:
+      # For cleanup on ddev poweroff
+      com.ddev.site-name: ""
     volumes:
       {{ if ne .Router "traefik" }}
       - /var/run/docker.sock:/tmp/docker.sock:ro


### PR DESCRIPTION
## The Issue

- #5542

## How This PR Solves The Issue

Adds a label, does a little reformatting of the router template.

## Manual Testing Instructions

1. `ddev start`
2. `docker inspect $(docker ps -f name=router -q) | jq '.[0].Config.Labels'` check for `com.ddev.site-name`
3. `ddev poweroff`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

