### PR TITLE
ci: try Colima latest to fix serious docker failures

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -101,8 +101,7 @@ jobs:
 
       - name: Install and start Colima
         run: |
-          brew unlink colima || true
-          brew install --HEAD --fetch-head colima
+          brew install colima
           colima version
           colima start --cpu 3 --memory 6 --disk 100 --vm-type=qemu --mount-type=sshfs --dns=1.1.1.1
 

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -101,9 +101,8 @@ jobs:
 
       - name: Install and start Colima
         run: |
-          # Temporarily use colima 0.5.6 as 0.6.* can't pass tests
-          sudo mkdir -p /usr/local/bin && sudo curl -L -o /usr/local/bin/colima https://github.com/abiosoft/colima/releases/download/v0.5.6/colima-Darwin-x86_64 && sudo chmod +x /usr/local/bin/colima
-          hash -r
+          brew unlink colima || true
+          brew install --HEAD --fetch-head colima
           colima version
           colima start --cpu 3 --memory 6 --disk 100 --vm-type=qemu --mount-type=sshfs --dns=1.1.1.1
 


### PR DESCRIPTION
With 
* https://github.com/abiosoft/colima/pull/884

the problem with Colima v0.6.* may be solved:
* https://github.com/abiosoft/colima/issues/856

This changes the Colima test to use latest release, which may be working.