### PR TITLE
fix: add config validation for --all flag, for #5452

### DIFF
--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -27,6 +27,13 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 
 	// If all projects are requested, return here
 	if all {
+		for _, project := range allProjects {
+			err = project.ValidateConfig()
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		return allProjects, nil
 	}
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- https://github.com/ddev/ddev/pull/5452#pullrequestreview-1742421480

> `ddev start -a` doesn't validate config

## How This PR Solves The Issue

Adds validation when you pass `--all` flag for a DDEV command.

## Manual Testing Instructions

1. Break some config value in the project's `.ddev/config.yaml` (e.g. `php_version: "test"`)
2. Run `ddev start -a` and immediately see the error.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

