### PR TITLE
fix: Add linux-docker platform for non-wsl2 docker-ce

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -71,6 +71,8 @@ func GetDockerPlatform() (string, error) {
 		platform = "orbstack"
 	case nodeps.IsWSL2() && info.OSType == "linux":
 		platform = "wsl2-docker-ce"
+	case !nodeps.IsWSL2() && info.OSType == "linux":
+		platform = "linux-docker"
 	case strings.HasPrefix(platform, "Rancher Desktop") || strings.Contains(info.Name, "rancher-desktop"):
 
 		platform = "rancher-desktop"


### PR DESCRIPTION

## The Issue

In `ddev version` and related things (including Amplitude) the docker platform is shown as the hostname, which isn't very useful

## How This PR Solves The Issue

Make it report `linux-docker`

## Manual Testing Instructions

On linux, `ddev version`

