### PR TITLE
build: install only binary from Upsun, for #5529

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -103,7 +103,7 @@ RUN set -o pipefail && curl --fail -sSL https://github.com/pantheon-systems/term
 RUN set -o pipefail && curl --fail -sSL https://github.com/platformsh/platformsh-cli/releases/download/$(curl -L --fail --silent "https://api.github.com/repositories/16695539/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/platform.phar --output /usr/local/bin/platform && chmod 777 /usr/local/bin/platform
 
 # Install upsun cli
-RUN set -o pipefail && curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | VENDOR=upsun bash
+RUN set -o pipefail && tag=$(curl -L --fail --silent "https://api.github.com/repos/platformsh/cli/releases/latest" | jq -r .tag_name) && curl --fail -sSL "https://github.com/platformsh/cli/releases/download/${tag}/upsun_${tag}_linux_${TARGETPLATFORM##linux/}.tar.gz" -o /tmp/upsun.tar.gz && tar -zx -C /usr/local/bin -f /tmp/upsun.tar.gz upsun && rm /tmp/upsun.tar.gz
 
 # Install lagoon cli
 RUN set -o pipefail && tag=$(curl -L --fail --silent "https://api.github.com/repos/uselagoon/lagoon-cli/releases/latest" | jq -r .tag_name) && curl --fail -sSL "https://github.com/uselagoon/lagoon-cli/releases/download/$tag/lagoon-cli-$tag-linux-${TARGETPLATFORM##linux/}" --output /usr/local/bin/lagoon && chmod 777 /usr/local/bin/lagoon

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20231102_stasadev_upsun" // Note that this can be overridden by make
+var WebTag = "20231123_stasadev_upsun" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #5529

```
ddev exec sudo apt update | grep upsun
Get:7 https://dl.cloudsmith.io/public/platformsh/upsun-cli/deb/debian bullseye InRelease [5079 B]
```

I think we don't really want the Upsun repo to be pulled up on `sudo apt update`.

1. It's not needed here, because not everyone uses it.
2. This can lead to unpredictable behavior if someone has a post-start hook for `sudo apt update && sudo apt upgrade`, a new untested version of Upsun can be installed, and then who knows how `ddev pull upsun` will behave.

## How This PR Solves The Issue

Installs only `upsun` binary, without any extras.

## Manual Testing Instructions

```
ddev exec upsun version
ddev pull upsun -y --environment UPSUN_PROJECT=xxx,UPSUN_ENVIRONMENT=yyy --skip-files
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

