### PR TITLE
refactor: order host, port, driver the same both places in Drupal 10 settings file

### DIFF
--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -15,8 +15,8 @@ $databases['default']['default']['database'] = "{{ $config.DatabaseName }}";
 $databases['default']['default']['username'] = "{{ $config.DatabaseUsername }}";
 $databases['default']['default']['password'] = "{{ $config.DatabasePassword }}";
 $databases['default']['default']['host'] = $host;
-$databases['default']['default']['driver'] = $driver;
 $databases['default']['default']['port'] = $port;
+$databases['default']['default']['driver'] = $driver;
 
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 

--- a/pkg/ddevapp/drupal/drupal8/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal8/settings.ddev.php
@@ -22,8 +22,8 @@ $databases['default']['default']['database'] = "{{ $config.DatabaseName }}";
 $databases['default']['default']['username'] = "{{ $config.DatabaseUsername }}";
 $databases['default']['default']['password'] = "{{ $config.DatabasePassword }}";
 $databases['default']['default']['host'] = $host;
-$databases['default']['default']['driver'] = $driver;
 $databases['default']['default']['port'] = $port;
+$databases['default']['default']['driver'] = $driver;
 
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -15,8 +15,8 @@ $databases['default']['default']['database'] = "{{ $config.DatabaseName }}";
 $databases['default']['default']['username'] = "{{ $config.DatabaseUsername }}";
 $databases['default']['default']['password'] = "{{ $config.DatabasePassword }}";
 $databases['default']['default']['host'] = $host;
-$databases['default']['default']['driver'] = $driver;
 $databases['default']['default']['port'] = $port;
+$databases['default']['default']['driver'] = $driver;
 
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 


### PR DESCRIPTION
## The Issue

It is not a big problem, but the order of host, port, driver is switched, causing a slight "hmm" when you scan the values.

```
$host = "db";
$port = 3306;
$driver = "mysql";

$databases['default']['default']['database'] = "db";
$databases['default']['default']['username'] = "db";
$databases['default']['default']['password'] = "db";
$databases['default']['default']['host'] = $host;
$databases['default']['default']['driver'] = $driver;
$databases['default']['default']['port'] = $port;
```

## How This PR Solves The Issue

Makes the order identical to the one in the default settings.php file:

```
 * $databases['default']['default'] = [
 *   'database' => 'databasename',
 *   'username' => 'sqlusername',
 *   'password' => 'sqlpassword',
 *   'host' => 'localhost',
 *   'port' => '3306',
 *   'driver' => 'mysql',
[...]
```
https://github.com/drupal/drupal/blob/10.1.x/sites/default/default.settings.php#L80-L85

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

