### PR TITLE
build: update images to get get php8.3.0 and related new packages

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -109,8 +109,8 @@ ENV php81_amd64=$php80_amd64
 ENV php81_arm64=$php81_amd64
 ENV php82_amd64=$php81_amd64
 ENV php82_arm64=$php82_amd64
-# php8.3 is still missing memcached xdebug
-ENV php83_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring mysql opcache pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
+# php8.3 is still missing memcached redis xdebug
+ENV php83_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
 ENV php83_arm64=$php83_amd64
 
 RUN for v in $PHP_VERSIONS; do \

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -109,8 +109,8 @@ ENV php81_amd64=$php80_amd64
 ENV php81_arm64=$php81_amd64
 ENV php82_amd64=$php81_amd64
 ENV php82_arm64=$php82_amd64
-# php8.3 is still missing apcu, imagick, memcached, redis, uploadprogress, xdebug, xhprof, xmlrpc
-ENV php83_amd64="bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip"
+# php8.3 is still missing memcached xdebug
+ENV php83_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring mysql opcache pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
 ENV php83_arm64=$php83_amd64
 
 RUN for v in $PHP_VERSIONS; do \

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local usage)
-FROM ddev/ddev-php-base:v1.22.5_1 as ddev-webserver-base
+FROM ddev/ddev-php-base:v1.22.5 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -2,8 +2,8 @@
 ### ---------------------------ddev-webserver-base--------------------------------------
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
-### and ddev-webserver-* (For DDEV-Local)
-FROM ddev/ddev-php-base:20231126_php8.3_fix as ddev-webserver-base
+### and ddev-webserver-* (For DDEV local usage)
+FROM ddev/ddev-php-base:v1.22.5_1 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1090,8 +1090,7 @@ func TestDdevXhprofEnabled(t *testing.T) {
 	// Does not work with php5.6 anyway (SEGV), for resource conservation
 	// skip older unsupported versions
 	phpKeys := []string{}
-	// TODO: Re-enable 8.3 when it's available
-	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.3"}
+	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0"}
 	for k := range nodeps.ValidPHPVersions {
 		if !nodeps.ArrayContainsString(exclusions, k) {
 			phpKeys = append(phpKeys, k)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20231126_php8.3_fix" // Note that this can be overridden by make
+var WebTag = "v1.22.5-rc2" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

deb.sury.org has built latest packages and now we can do php 8.3.0. In addition, now only 3 packages are missing from php8.3, memcached, redis, and xdebug

## How This PR Solves The Issue

* Pushes ddev-php-base, ddev-webserver with new packages
* Updates TestDdevXhprof to test on 8.3

## Manual Testing Instructions

Use it, make sure php8.3 is 8.3.0

## Automated Testing Overview

Previously TestDdevXhprofEnabled was disabled for 8.3, it should work now.

## Related Issue Link(s)

* https://github.com/oerdnj/deb.sury.org/issues/2034

## Release/Deployment Notes

* Announce 8.3.0 and related extensions
