### PR TITLE
build: update .gitpod.yml for v1.22.5 release [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ddev/ddev-gitpod-base:20231030
+image: ddev/ddev-gitpod-base:20231127
 tasks:
   - name: build-run
     init: |


### PR DESCRIPTION
## The Issue

DDEV v1.22.5 is out.

## How This PR Solves The Issue

Push new gitpod image.