### PR TITLE
ci: don't set default context to default - fix rancher desktop failures

### DIFF
--- a/.buildkite/macos-rancher-desktop.yml
+++ b/.buildkite/macos-rancher-desktop.yml
@@ -7,7 +7,7 @@
       - "os=macos"
       - "rancher-desktop=true"
       - "architecture=arm64"
-    branches: "master"
+#    branches: "master"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -14,6 +14,8 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
   }
   trap cleanup EXIT
 
+  echo "original docker context situation:"
+  docker context ls
   case ${DOCKER_TYPE} in
     "docker-desktop")
       orb stop &

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -31,6 +31,13 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
       killall com.docker.backend || true
       orb stop &
       ~/.rd/bin/rdctl start
+      for i in {1..120}; do
+        if docker context use rancher-desktop >/dev/null 2>&1 ; then
+          break
+        fi
+        echo "$(date): Waiting for rancher-desktop context to be available"
+        sleep 1
+      done
       docker context use rancher-desktop
       ;;
 

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -9,7 +9,8 @@ export GOTEST_SHORT=8
 # On macOS, we can have several different docker providers, allow testing all
 if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
   function cleanup {
-      docker context use default
+#      docker context use default
+    true
   }
   trap cleanup EXIT
 
@@ -18,13 +19,13 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
       orb stop &
       ~/.rd/bin/rdctl shutdown || true
       open -a Docker &
-      docker context use default
+      docker context use desktop-linux
       ;;
     "orbstack")
       ~/.rd/bin/rdctl shutdown || true
       killall com.docker.backend || true
       orb start &
-      docker context use default
+      docker context use orbstack
       ;;
     "rancher-desktop")
       killall com.docker.backend || true


### PR DESCRIPTION
## The Issue

Multiple failures of rancher-desktop tests (see https://github.com/ddev/maintainer-info/issues/1#issuecomment-1828804959) have resulted in the docker context being left as "default" but the default context isn't wired to any provider. Orbstack and Docker Desktop both claim "default", but Rancher Desktop doesn't.

## How This PR Solves The Issue

* Don't set context to default
* Leave the provider running that was running at the end of test


## Manual Testing Instructions

We'll see if this works.

**This temporarily allows rancher to run on this PR, but that should be removed before pulling**

