### PR TITLE
fix: add nginx support for webp images in hidden directory, sync nginx conf

### DIFF
--- a/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
@@ -85,7 +85,7 @@ server {
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
+    location ~* \.(jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         try_files $uri @rewrite;
         expires max;
         log_not_found off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
@@ -62,6 +62,15 @@ server {
         fastcgi_param HTTPS $fcgi_https;
     }
 
+    # Expire rules for static content
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
+        expires 1M;
+        access_log off;
+        add_header Cache-Control "public";
+    }
+
     # Prevent clients from accessing hidden files (starting with a dot)
     # This is particularly important if you store .htpasswd files in the site hierarchy
     # Access to `/.well-known/` is allowed.

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
@@ -84,7 +84,7 @@ server {
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
+    location ~* \.(jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         try_files $uri @rewrite;
         expires max;
         log_not_found off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
@@ -70,7 +70,7 @@ server {
     # Expire rules for static content
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
+    location ~* \.(jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         try_files $uri @rewrite;
         expires max;
         log_not_found off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
@@ -63,7 +63,7 @@ server {
     # Expire rules for static content
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
+    location ~* \.(jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         try_files $uri @rewrite;
         expires max;
         log_not_found off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
@@ -83,7 +83,7 @@ server {
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
+    location ~* \.(jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         try_files $uri @rewrite;
         expires max;
         log_not_found off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
@@ -84,7 +84,7 @@ server {
     }
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(png|jpg|jpeg|gif|ico|svg)$ {
+    location ~* \.(jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         try_files $uri @rewrite;
         expires max;
         log_not_found off;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
@@ -54,7 +54,7 @@ server {
     # Expire rules for static content
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         expires 1M;
         access_log off;
         add_header Cache-Control "public";

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
@@ -63,7 +63,7 @@ server {
     # Expire rules for static content
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         expires 1M;
         access_log off;
         add_header Cache-Control "public";

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
@@ -54,7 +54,7 @@ server {
     # Expire rules for static content
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc|webp)$ {
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         expires 1M;
         access_log off;
         add_header Cache-Control "public";
@@ -98,7 +98,7 @@ server {
             rewrite ^/static/(version[^/]+/)?(.*)$ /static/$2 last;
         }
 
-        location ~* \.(ico|jpg|jpeg|png|gif|svg|swf|eot|ttf|otf|woff|woff2|json|webp)$ {
+        location ~* \.(ico|jpg|jpeg|png|gif|svg|swf|eot|ttf|otf|woff|woff2|json)$ {
             add_header Cache-Control "public";
             add_header X-Frame-Options "SAMEORIGIN";
             expires +1y;
@@ -139,7 +139,7 @@ server {
             deny all;
         }
 
-        location ~* \.(ico|jpg|jpeg|png|gif|svg|swf|eot|ttf|otf|woff|woff2|webp)$ {
+        location ~* \.(ico|jpg|jpeg|png|gif|svg|swf|eot|ttf|otf|woff|woff2)$ {
             add_header Cache-Control "public";
             add_header X-Frame-Options "SAMEORIGIN";
             expires +1y;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
@@ -54,7 +54,7 @@ server {
     # Expire rules for static content
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc|webp)$ {
         expires 1M;
         access_log off;
         add_header Cache-Control "public";
@@ -98,7 +98,7 @@ server {
             rewrite ^/static/(version[^/]+/)?(.*)$ /static/$2 last;
         }
 
-        location ~* \.(ico|jpg|jpeg|png|gif|svg|swf|eot|ttf|otf|woff|woff2|json)$ {
+        location ~* \.(ico|jpg|jpeg|png|gif|svg|swf|eot|ttf|otf|woff|woff2|json|webp)$ {
             add_header Cache-Control "public";
             add_header X-Frame-Options "SAMEORIGIN";
             expires +1y;
@@ -139,7 +139,7 @@ server {
             deny all;
         }
 
-        location ~* \.(ico|jpg|jpeg|png|gif|svg|swf|eot|ttf|otf|woff|woff2)$ {
+        location ~* \.(ico|jpg|jpeg|png|gif|svg|swf|eot|ttf|otf|woff|woff2|webp)$ {
             add_header Cache-Control "public";
             add_header X-Frame-Options "SAMEORIGIN";
             expires +1y;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
@@ -52,6 +52,15 @@ server {
         fastcgi_param HTTPS $fcgi_https;
     }
 
+    # Expire rules for static content
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
+        expires 1M;
+        access_log off;
+        add_header Cache-Control "public";
+    }
+
     # Prevent clients from accessing hidden files (starting with a dot)
     # This is particularly important if you store .htpasswd files in the site hierarchy
     # Access to `/.well-known/` is allowed.

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
@@ -71,7 +71,7 @@ server {
     # Expire rules for static content
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         expires 1M;
         access_log off;
         add_header Cache-Control "public";

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -7,8 +7,8 @@
 
 # Support for WebP
 map $http_accept $webp_suffix {
-  default   "";
-  "~*webp"  ".webp";
+    default   "";
+    "~*webp"  ".webp";
 }
 
 server {
@@ -88,7 +88,7 @@ server {
     # Expire rules for static content
 
     # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         expires 1M;
         access_log off;
         add_header Cache-Control "public";

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
@@ -78,7 +78,10 @@ server {
         fastcgi_param HTTPS $fcgi_https;
     }
 
-    location ~* \.(png|jpg|jpeg|gif|ico)$ {
+    # Expire rules for static content
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         expires max;
         log_not_found off;
     }

--- a/pkg/ddevapp/webserver_config_assets/nginx_second_docroot_example-site-php.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx_second_docroot_example-site-php.conf
@@ -57,7 +57,7 @@ server {
 
     # Expire rules for static content
     # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         expires 1M;
         access_log off;
         add_header Cache-Control "public";


### PR DESCRIPTION
Added webp support for images in hidden directories.

## The Issue
Webp images are not supported for magento 2 projects if the image is in a hidden directory. A request to a webp image will result in a HTTP 403 Error.

## How This PR Solves The Issue
Changed nginx config to allow webp files as images in hidden directories.

## Manual Testing Instructions
Add an image in webp format in a hidden directory i.e. https://test.ddev.site/media/.renditions/test.webp and request that image. Before the changes there is an error "403 Forbidden". After the changes the image is shown in the browser.

## Automated Testing Overview

## Related Issue Link(s)

## Release/Deployment Notes
