### PR TITLE
docs: remove search suggestions and share

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,8 +43,6 @@ theme:
 #  - toc.integrate
   - navigation.footer
   - search.suggest
-  - search.highlight
-  - search.share
   favicon: favicon.png
   # readthedocs doesn't seem to do logo css right
 #  logo: /logo.svg


### PR DESCRIPTION
## The Issue

The mkdocs-material "search.highlight" and "search.share" features weren't very useful, and the "search.highlight" just messed up URLs when you were trying to share with somebody.

## Manual Testing Instructions

Use the docs at https://ddev--5588.org.readthedocs.build/en/5588/ and do searches. It should work fine without the highlighting.

