### PR TITLE
fix: rancher desktop docker-platform should not report linux-docker

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -69,13 +69,13 @@ func GetDockerPlatform() (string, error) {
 		platform = "colima"
 	case platform == "OrbStack":
 		platform = "orbstack"
+	case strings.HasPrefix(platform, "Rancher Desktop") || strings.Contains(info.Name, "rancher-desktop"):
+
+		platform = "rancher-desktop"
 	case nodeps.IsWSL2() && info.OSType == "linux":
 		platform = "wsl2-docker-ce"
 	case !nodeps.IsWSL2() && info.OSType == "linux":
 		platform = "linux-docker"
-	case strings.HasPrefix(platform, "Rancher Desktop") || strings.Contains(info.Name, "rancher-desktop"):
-
-		platform = "rancher-desktop"
 	default:
 		platform = info.OperatingSystem
 	}


### PR DESCRIPTION

## The Issue

`ddev version` with Rancher Desktop was showing `linux-docker` instead of `rancher-desktop`


## Manual Testing Instructions

`ddev version` with Rancher Desktop running to see what it says for docker platform.

