### PR TITLE
ci: make TestMailpit and TestProjectPortOverride more forgiving of Rancher Desktop, fixes #5578

### DIFF
--- a/pkg/ddevapp/mailpit_test.go
+++ b/pkg/ddevapp/mailpit_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestMailpit does a basic test of mailpit.
@@ -103,9 +104,19 @@ func TestMailpit(t *testing.T) {
 	require.NotNil(t, desc["mailpit_url"])
 	require.NotNil(t, desc["mailpit_https_url"])
 
-	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
+	// The API may not be ready the first time we hit it, especially on Rancher Desktop
+	// So try a couple of times
+	for i := 0; i < 5; i++ {
+		resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
+		if err != nil {
+			t.Logf("Error getting mailpit_url (try %d): %v resp=%v", i, err, resp)
+			time.Sleep(1 * time.Second)
+		} else {
+			break
+		}
+	}
 	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
-	// Colima tests on github don't respect https
+	// Colima tests on GitHub don't respect https
 	if !dockerutil.IsColima() {
 		resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_https_url"].(string)+"/api/v1/messages", expectation)
 		require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
@@ -130,7 +141,17 @@ func TestMailpit(t *testing.T) {
 	require.NotNil(t, desc["mailpit_url"])
 	require.NotNil(t, desc["mailpit_https_url"])
 
-	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
+	// The API may not be ready the first time we hit it, especially on Rancher Desktop
+	// So try a couple of times
+	for i := 0; i < 5; i++ {
+		resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
+		if err != nil {
+			t.Logf("Error getting mailpit_url (try %d): %v resp=%v", i, err, resp)
+			time.Sleep(1 * time.Second)
+		} else {
+			break
+		}
+	}
 	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
 	// Colima tests on github don't respect https
 	if !dockerutil.IsColima() {

--- a/pkg/ddevapp/mailpit_test.go
+++ b/pkg/ddevapp/mailpit_test.go
@@ -105,16 +105,17 @@ func TestMailpit(t *testing.T) {
 	require.NotNil(t, desc["mailpit_https_url"])
 
 	// The API may not be ready the first time we hit it, especially on Rancher Desktop
-	// So try a couple of times
+	// So try a few times
 	for i := 0; i < 5; i++ {
-		resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
+		_, _, err = testcommon.GetLocalHTTPResponse(t, desc["mailpit_url"].(string)+"/api/v1/messages")
 		if err != nil {
-			t.Logf("Error getting mailpit_url (try %d): %v resp=%v", i, err, resp)
+			t.Logf("Error hitting mailpit_url (try %d): %v resp=%v", i, err, resp)
 			time.Sleep(1 * time.Second)
 		} else {
 			break
 		}
 	}
+	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
 	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
 	// Colima tests on GitHub don't respect https
 	if !dockerutil.IsColima() {
@@ -142,16 +143,17 @@ func TestMailpit(t *testing.T) {
 	require.NotNil(t, desc["mailpit_https_url"])
 
 	// The API may not be ready the first time we hit it, especially on Rancher Desktop
-	// So try a couple of times
+	// So try a few times
 	for i := 0; i < 5; i++ {
-		resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
+		_, _, err = testcommon.GetLocalHTTPResponse(t, desc["mailpit_url"].(string)+"/api/v1/messages")
 		if err != nil {
-			t.Logf("Error getting mailpit_url (try %d): %v resp=%v", i, err, resp)
+			t.Logf("Error hitting mailpit_url (try %d): %v resp=%v", i, err, resp)
 			time.Sleep(1 * time.Second)
 		} else {
 			break
 		}
 	}
+	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
 	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
 	// Colima tests on github don't respect https
 	if !dockerutil.IsColima() {


### PR DESCRIPTION

## The Issue

* #5578

TestMailpit fails intermittently on Rancher Desktop

This may be due to the mailpit API coming up after our healthcheck says it should be ready, because we're not polling the API.

## How This PR Solves The Issue

Wait in the test a few seconds if necessary

It's possible this could also be fixed by adding more extensive healthcheck.sh to check the mailpit API, but that seems like overkill for something that is not used a huge amount.