### PR TITLE
fix: use GITPOD_OWNER_ID as the identifier for Gitpod workspaces [skip ci]

### DIFF
--- a/pkg/ddevapp/instrumentation.go
+++ b/pkg/ddevapp/instrumentation.go
@@ -146,6 +146,7 @@ func SendInstrumentationEvents(event string) {
 	}
 }
 
+// Ref: https://github.com/denisbrodbeck/machineid#security-considerations
 func protect(appID, id string) string {
 	mac := hmac.New(sha256.New, []byte(id))
 	mac.Write([]byte(appID))
@@ -154,6 +155,7 @@ func protect(appID, id string) string {
 
 func init() {
 	// Special case for Gitpod
+	// Needed because /etc/machine-id is not unique to the Gitpod workspace user and it may not remain constant
 	if value, exists := os.LookupEnv("GITPOD_OWNER_ID"); exists {
 		hashedHostID = protect(appName, value)
 		return


### PR DESCRIPTION


<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

Currently [machineid](https://github.com/denisbrodbeck/machineid) reads from `/var/lib/dbus/machine-id` or `/etc/machine-id` but it is not unique to the Gitpod workspace user and it may not remain constant. Mainly because the machine-id is predefined by the docker image Gitpod uses for creating a workspace.

## How This PR Solves The Issue

This is an attempt to use `GITPOD_OWNER_ID` as a replacement for machine-id on Gitpod workspaces.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

