### PR TITLE
fix: don't let people run ddev under rosetta, report no-bind-mounts behavior, fixes #5590

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1069,6 +1069,9 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	app.CreateUploadDirsIfNecessary()
 
 	if app.IsMutagenEnabled() {
+		if globalconfig.DdevGlobalConfig.NoBindMounts {
+			util.Warning("Mutagen is enabled because `no_bind_mounts: true` is set.\n`ddev config global --no-bind-mounts=false` if you do not intend that.")
+		}
 		err = app.GenerateMutagenYml()
 		if err != nil {
 			return err

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/ddev/ddev/pkg/appimport"
@@ -1039,6 +1040,15 @@ Please use the built-in docker-compose.
 Fix with 'ddev config global --required-docker-compose-version="" --use-docker-compose-from-path=false': %v`, err)
 	}
 
+	if runtime.GOOS == "darwin" {
+		r, err := syscall.Sysctl("sysctl.proc_translated")
+		if err == nil {
+			// from https://www.yellowduck.be/posts/detecting-apple-silicon-via-go
+			if r == "\x01\x00\x00" {
+				util.Failed("You seem to be running under Rosetta, please install the ARM64 version of DDEV. If you're using homebrew, you need to reinstall it properly, see https://brew.sh")
+			}
+		}
+	}
 	err = app.ProcessHooks("pre-start")
 	if err != nil {
 		return err

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -10,7 +10,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/ddev/ddev/pkg/appimport"
@@ -1041,13 +1040,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	if runtime.GOOS == "darwin" {
-		r, err := syscall.Sysctl("sysctl.proc_translated")
-		if err == nil {
-			// from https://www.yellowduck.be/posts/detecting-apple-silicon-via-go
-			if r == "\x01\x00\x00" {
-				util.Failed("You seem to be running under Rosetta, please install the ARM64 version of DDEV. If you're using homebrew, you need to reinstall it properly, see https://brew.sh")
-			}
-		}
+		failOnRosetta()
 	}
 	err = app.ProcessHooks("pre-start")
 	if err != nil {

--- a/pkg/ddevapp/os_warnings.go
+++ b/pkg/ddevapp/os_warnings.go
@@ -1,0 +1,9 @@
+//go:build linux || windows
+// +build linux windows
+
+package ddevapp
+
+// failOnRosetta is a no-op on linux and windows
+func failOnRosetta() {
+
+}

--- a/pkg/ddevapp/os_warnings_darwin.go
+++ b/pkg/ddevapp/os_warnings_darwin.go
@@ -1,0 +1,17 @@
+package ddevapp
+
+import (
+	"github.com/ddev/ddev/pkg/util"
+	"syscall"
+)
+
+// failOnRosetta checks to see if we're running under Rosetta and fails if we are.
+func failOnRosetta() {
+	r, err := syscall.Sysctl("sysctl.proc_translated")
+	if err == nil {
+		// from https://www.yellowduck.be/posts/detecting-apple-silicon-via-go
+		if r == "\x01\x00\x00" {
+			util.Failed("You seem to be running under Rosetta, please install the ARM64 version of DDEV. If you're using homebrew, you need to reinstall it properly, see https://brew.sh")
+		}
+	}
+}

--- a/pkg/globalconfig/performance_mode.go
+++ b/pkg/globalconfig/performance_mode.go
@@ -7,8 +7,10 @@ import (
 // GetPerformanceMode returns the performance mode config respecting
 // defaults.
 func (c *GlobalConfig) GetPerformanceMode() types.PerformanceMode {
-	switch c.PerformanceMode {
-	case types.PerformanceModeEmpty:
+	switch {
+	case c.NoBindMounts:
+		return types.PerformanceModeMutagen
+	case c.PerformanceMode == types.PerformanceModeEmpty:
 		return types.GetPerformanceModeDefault()
 	default:
 		return c.PerformanceMode


### PR DESCRIPTION

## The Issue

* https://github.com/ddev/ddev/issues/5590

* If `--no-bind-mounts` is set it forces mutagen behavior. Normally people don't want it, it's a mistake to set it.
* Running DDEV under rosetta by accident causes lots of pain. Prevent it.

## How This PR Solves The Issue

* Detect rosetta and error out
* Warn if --no-bind-mounts. 

<img width="889" alt="image" src="https://github.com/ddev/ddev/assets/112444/d2299cdc-44ea-4a5d-9b7e-5f86e1f501dd">


<img width="898" alt="image" src="https://github.com/ddev/ddev/assets/112444/acdaeefc-1f43-4f21-a2fb-0f1c23489769">


## Manual Testing Instructions

* Try doing `ddev start` on macOS arm64 with the amd64 version in this PR
* Try start on your normal architecture with `ddev config global --no-bind-mounts`
* Verify that `ddev describe` shows actual performance-mode.

