### PR TITLE
fix: dont auto start host custom commands, fixes #2688

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -267,14 +267,10 @@ func makeHostCmd(app *ddevapp.DdevApp, fullPath, name string) func(*cobra.Comman
 
 	return func(cmd *cobra.Command, cobraArgs []string) {
 		status, _ := app.SiteStatus()
-		if status != ddevapp.SiteRunning {
-			err := app.Start()
-			if err != nil {
-				util.Failed("Failed to start project for custom command: %v", err)
-			}
-		}
+
 		app.DockerEnv()
 
+		_ = os.Setenv("DDEV_PROJECT_STATUS", status)
 		osArgs := []string{}
 		if len(os.Args) > 2 {
 			osArgs = os.Args[2:]

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -7,6 +7,11 @@
 ## OSTypes: darwin,linux
 ## HostBinaryExists: /Applications/DBeaver.app,/usr/bin/dbeaver,/usr/bin/dbeaver-ce,/usr/bin/dbeaver-le,/usr/bin/dbeaver-ue,/usr/bin/dbeaver-ee,/var/lib/flatpak/exports/bin/io.dbeaver.DBeaverCommunity,/snap/bin/dbeaver-ce
 
+if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+  echo "Project ${DDEV_PROJECT} is not running, starting it"
+  ddev start
+fi
+
 database="${1:-db}"
 user="${2:-root}"
 type="$(echo $DDEV_DATABASE | sed 's/:.*//')"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -7,7 +7,7 @@
 ## OSTypes: darwin,linux
 ## HostBinaryExists: /Applications/DBeaver.app,/usr/bin/dbeaver,/usr/bin/dbeaver-ce,/usr/bin/dbeaver-le,/usr/bin/dbeaver-ue,/usr/bin/dbeaver-ee,/var/lib/flatpak/exports/bin/io.dbeaver.DBeaverCommunity,/snap/bin/dbeaver-ce
 
-if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -9,6 +9,10 @@
 
 arguments="--host=\"127.0.0.1\" --port=${DDEV_HOST_DB_PORT} --user=root --password=root --description=${DDEV_SITENAME}"
 
+if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+  echo "Project ${DDEV_PROJECT} is not running, starting it"
+  ddev start
+fi
 case $OSTYPE in
   "win*"* | "msys"*)
     '/c/Program Files/HeidiSQL/heidisql.exe' $arguments &

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -9,7 +9,7 @@
 
 arguments="--host=\"127.0.0.1\" --port=${DDEV_HOST_DB_PORT} --user=root --password=root --description=${DDEV_SITENAME}"
 
-if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -6,7 +6,7 @@
 ## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php", for Mailpit "ddev launch -m"
 ## Flags: [{"Name":"mailpit","Shorthand":"m","Usage":"ddev launch -m launches the mailpit UI"}]
 
-if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -6,6 +6,10 @@
 ## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php", for Mailpit "ddev launch -m"
 ## Flags: [{"Name":"mailpit","Shorthand":"m","Usage":"ddev launch -m launches the mailpit UI"}]
 
+if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+  echo "Project ${DDEV_PROJECT} is not running, starting it"
+  ddev start
+fi
 FULLURL=${DDEV_PRIMARY_URL}
 HTTPS=""
 if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then HTTPS=true; fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/mysqlworkbench.example
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/mysqlworkbench.example
@@ -8,6 +8,10 @@
 # Note that this example uses $DDEV_HOST_DB_PORT to get the port for the connection
 # Mysql Workbench can be obtained from https://dev.mysql.com/downloads/workbench/
 
+if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+  echo "Project ${DDEV_PROJECT} is not running, starting it"
+  ddev start
+fi
 query="root:root@127.0.0.1:${DDEV_HOST_DB_PORT}"
 
 case $OSTYPE in

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/mysqlworkbench.example
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/mysqlworkbench.example
@@ -8,7 +8,7 @@
 # Note that this example uses $DDEV_HOST_DB_PORT to get the port for the connection
 # Mysql Workbench can be obtained from https://dev.mysql.com/downloads/workbench/
 
-if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/querious
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/querious
@@ -9,7 +9,7 @@
 ## HostBinaryExists: /Applications/Querious.app
 ## DBTypes: mysql,mariadb
 
-if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/querious
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/querious
@@ -9,6 +9,10 @@
 ## HostBinaryExists: /Applications/Querious.app
 ## DBTypes: mysql,mariadb
 
+if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+  echo "Project ${DDEV_PROJECT} is not running, starting it"
+  ddev start
+fi
 DATABASE="${1:-db}"
 
 open "querious://connect/new?host=127.0.0.1&user=db&password=db&use-compression=false&database=${DATABASE}&port=${DDEV_HOST_DB_PORT}"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
@@ -10,7 +10,7 @@
 
 DATABASE="${1:-db}"
 
-if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
@@ -10,6 +10,10 @@
 
 DATABASE="${1:-db}"
 
+if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+  echo "Project ${DDEV_PROJECT} is not running, starting it"
+  ddev start
+fi
 query="mysql://root:root@${DDEV_PROJECT}.${DDEV_TLD}:${DDEV_HOST_DB_PORT}/${DATABASE}"
 
 set -x

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelpro
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelpro
@@ -8,6 +8,10 @@
 ## HostBinaryExists: /Applications/Sequel Pro.app
 ## DBTypes: mysql,mariadb
 
+if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+  echo "Project ${DDEV_PROJECT} is not running, starting it"
+  ddev start
+fi
 tmpdir=$(mktemp -d -t sequelpro-XXXXXXXXXX)
 templatepath="$tmpdir/sequelpro.spf"
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelpro
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelpro
@@ -8,7 +8,7 @@
 ## HostBinaryExists: /Applications/Sequel Pro.app
 ## DBTypes: mysql,mariadb
 
-if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -9,7 +9,7 @@
 ## OSTypes: darwin
 ## HostBinaryExists: /Applications/TablePlus.app
 
-if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -9,6 +9,11 @@
 ## OSTypes: darwin
 ## HostBinaryExists: /Applications/TablePlus.app
 
+if [ ${DDEV_PROJECT_STATUS} != "running" ]; then
+  echo "Project ${DDEV_PROJECT} is not running, starting it"
+  ddev start
+fi
+
 dbtype=${DDEV_DBIMAGE%:*}
 driver=mysql
 if [[ $dbtype == "postgres" ]]; then


### PR DESCRIPTION

## The Issue

* #2688 

Host shell commands don't always need to start project

## How This PR Solves The Issue

* No auto-start for host commands
* Host commands that need project running can start it

## Manual Testing Instructions

Try out `ddev launch` and the various database launcher commands
Try out `ddev self-upgrade` and it should not auto start, or try another custom host command.

## Release/Deployment Notes

* We probably need to visit some add-ons that provide custom commands and update them if needed.
