### PR TITLE
fix: php8.3-xdebug and redis, memcached now available

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -109,8 +109,7 @@ ENV php81_amd64=$php80_amd64
 ENV php81_arm64=$php81_amd64
 ENV php82_amd64=$php81_amd64
 ENV php82_arm64=$php82_amd64
-# php8.3 is still missing memcached redis xdebug
-ENV php83_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
+ENV php83_amd64=$php82_amd64
 ENV php83_arm64=$php83_amd64
 
 RUN for v in $PHP_VERSIONS; do \

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local usage)
-FROM ddev/ddev-php-base:v1.22.5 as ddev-webserver-base
+FROM ddev/ddev-php-base:20231205_xdebug as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -925,8 +925,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 
 	// Most of the time there's no reason to do all versions of PHP
 	phpKeys := []string{}
-	// TODO: Enable 8.3 when php8.3-xdebug becomes available
-	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.3"}
+	exclusions := []string{"5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0"}
 	for k := range nodeps.ValidPHPVersions {
 		if os.Getenv("GOTEST_SHORT") != "" && !nodeps.ArrayContainsString(exclusions, k) {
 			phpKeys = append(phpKeys, k)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.22.5" // Note that this can be overridden by make
+var WebTag = "20231205_xdebug" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

At release of DDEV v1.22.5, php8.3-xdebug, redis, and memcached were not yet available. Now they are

## How This PR Solves The Issue

Build them and test them.

## Manual Testing Instructions

Just try using xdebug with php 8.3

