### PR TITLE
fix: return MTU 1440 for Gitpod, fixes #5611

### DIFF
--- a/cmd/ddev/cmd/networks_test.go
+++ b/cmd/ddev/cmd/networks_test.go
@@ -60,7 +60,7 @@ func TestNetworkDuplicates(t *testing.T) {
 	}
 
 	// The duplicate network is removed here
-	err = dockerutil.EnsureNetwork(client, networkName, labels)
+	err = dockerutil.EnsureNetwork(client, networkName, netOptions)
 	assert.NoError(err)
 
 	// This check would fail if there is a network duplicate

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -249,12 +249,15 @@ networks:
   ddev_default:
     name: ddev_default
     external: true
+  {{/* the default project network is created programmatically, see EnsureProjectNetwork() */}}
   default:
     name: ${COMPOSE_PROJECT_NAME}_default
     {{ if .IsGitpod }}{{/* see https://github.com/ddev/ddev/issues/3766 */}}
     driver_opts:
       com.docker.network.driver.mtu: 1440
     {{ end }}
+    labels:
+      com.ddev.platform: ddev
 
 volumes:
   {{if and (not .OmitDB) (ne .DBType "postgres") }}


### PR DESCRIPTION
## The Issue

- #5611

This is a regression.

## How This PR Solves The Issue

The project's network is created programmatically and the MTU value is not set, since it is declared only in the `docker-compose.yaml` file and there is no way to modify the network after it is created.

This PR returns the MTU value with a small refactoring.

## Manual Testing Instructions

I don't know if this PR can be checked directly in Gitpod, so my way to check is:

1. Checkout this PR locally
2. Modify the source code to reverse the check for Gitpod, look at this change:
```go
if nodeps.IsGitpod() {
    netOptions.Options = map[string]any{
        "com.docker.network.driver.mtu": "1440",
    }
}
```

Add `!` to `nodeps.IsGitpod()`:
```go
if !nodeps.IsGitpod() {
    netOptions.Options = map[string]any{
        "com.docker.network.driver.mtu": "1440",
    }
}
```
3. `make build`
4. `ddev start`
5. `docker inspect ddev-project-name_default` should contain this:
```json
"Options": {
    "com.docker.network.driver.mtu": "1440"
},
```
## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

Probably release a new Gitpod image after this PR goes to master (since this bug breaks Gitpod).
