### PR TITLE
ci: fix Python conflicts in Colima tests

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -89,15 +89,16 @@ jobs:
           limit-access-to-actor: true
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
+      - name: Fix Python conflicts between macOS runner and Homebrew
+        run: |
+          # see https://github.com/actions/setup-python/issues/577
+          brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
+
       - name: Install homebrew dependencies
         run: |
           set -x
           sudo chmod ugo+w /usr/local/bin
-          brew install --overwrite python@3.11
-          brew install docker docker-compose lima
-          # brew install mysql-client is failing because of existing 2to3
-          sudo rm -f /usr/local/bin/2to3*
-          brew install --overwrite mysql-client || true
+          brew install docker docker-compose lima mysql-client
 
       - name: Install and start Colima
         run: |


### PR DESCRIPTION
## The Issue

- https://github.com/actions/setup-python/issues/577

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3-3.12
Target /usr/local/bin/2to3-3.12
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3-3.12'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.12

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.12

Possible conflicting files are:
/usr/local/bin/2to3-3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/2to3-3.12
/usr/local/bin/idle3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/idle3.12
/usr/local/bin/pydoc3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/pydoc3.12
/usr/local/bin/python3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12
/usr/local/bin/python3.12-config -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12-config
```

Colima tests fail from time to time when GitHub runner dependencies are not in sync with Homebrew.

## How This PR Solves The Issue

Relink all Python packages with Homebrew.