### PR TITLE
feat: add detail about restore command to snapshot command output, fixes #5621

### DIFF
--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -89,7 +89,8 @@ func createAppSnapshot(app *ddevapp.DdevApp) {
 		errorMsg := util.ColorizeText("Failed to snapshot %s: %v", "red")
 		util.Warning(errorMsg, app.GetName(), err)
 	} else {
-		util.Success("Created database snapshot %s. Use the 'snapshot restore' command to restore this.", snapshotNameOutput)
+		util.Success("Created database snapshot %s", snapshotNameOutput)
+		util.Success("Restore this snapshot with 'ddev snapshot restore %s'", snapshotNameOutput)
 	}
 	// Return the app to its previous state, stopped or paused.
 	if appStatus == ddevapp.SiteStopped {

--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -89,7 +89,7 @@ func createAppSnapshot(app *ddevapp.DdevApp) {
 		errorMsg := util.ColorizeText("Failed to snapshot %s: %v", "red")
 		util.Warning(errorMsg, app.GetName(), err)
 	} else {
-		util.Success("Created database snapshot %s", snapshotNameOutput)
+		util.Success("Created database snapshot %s. Use the 'snapshot restore' command to restore this.", snapshotNameOutput)
 	}
 	// Return the app to its previous state, stopped or paused.
 	if appStatus == ddevapp.SiteStopped {


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

When you run `ddev snapshot`, it doesn't tell you how to restore the DB. It's easy to assume you use import-db command, which leads to #5621.

## How This PR Solves The Issue

Add to the message output after a snapshot is created to tell the user how to restore snapshots.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

