### PR TITLE
fix: do not fail on `apt-get update` for extra packages, for #5620

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1085,7 +1085,6 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 	if extraPackages != nil {
 		contents = contents + `
 ### DDEV-injected from webimage_extra_packages or dbimage_extra_packages
-RUN echo "Disk usage problems: " && df -h / && ls -l /var/lib/apt/lists
 RUN (apt-get -qq update || true) && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1085,8 +1085,8 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 	if extraPackages != nil {
 		contents = contents + `
 ### DDEV-injected from webimage_extra_packages or dbimage_extra_packages
-RUN echo "Disk usage problems: " && df -h /tmp && ls -l /var/lib/apt/lists
-RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
+RUN echo "Disk usage problems: " && df -h / && ls -l /var/lib/apt/lists
+RUN (apt-get -qq update || true) && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
 	}
 
 	// For webimage, update to latest Composer.


### PR DESCRIPTION
## The Issue

- #5620

We must not allow `apt-get update` to fail if some repository is down, because it can stop the webserver from starting.

## How This PR Solves The Issue

Allows `apt-get install` to continue after a fail for `apt-get update`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

