### PR TITLE
ci: enable all ddev-webserver tests for PHP 8.3, for #5238

### DIFF
--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -83,16 +83,7 @@
   7.[01234])
     extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring mysqli pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
     ;;
-  8.0)
-    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
-    ;;
-  8.1)
-    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
-    ;;
-  8.2)
-    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
-    ;;
-  8.3)
+  8.[0123])
     extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
     ;;
   esac

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -14,8 +14,6 @@
 }
 
 @test "enable and disable xdebug for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
-    if [ "${PHP_VERSION}" = "8.3" ]; then skip "Skipping for PHP_VERSION=8.3 because no xdebug yet"; fi
-
     CURRENT_ARCH=$(../get_arch.sh)
 
     docker exec -t $CONTAINER_NAME enable_xdebug
@@ -31,8 +29,6 @@
 }
 
 @test "enable and disable xhprof for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
-    if [ "${PHP_VERSION}" = "8.3" ]; then skip "Skipping for PHP_VERSION=8.3 because no xhprof yet"; fi
-
     CURRENT_ARCH=$(../get_arch.sh)
 
     docker exec -t $CONTAINER_NAME enable_xhprof
@@ -97,17 +93,12 @@
     extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
     ;;
   8.3)
-    # TODO: Update when more extensions are available for PHP 8.3
-    extensions="bcmath bz2 curl gd intl ldap mbstring mysqli pgsql readline soap sqlite3 xml zip"
+    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
     ;;
   esac
 
-  # TODO: Remove the if block when xdebug and xhprof are available for PHP 8.3
-  if [ "${PHP_VERSION}" != "8.3" ]; then
-    run docker exec -t $CONTAINER_NAME enable_xdebug
-    run docker exec -t $CONTAINER_NAME enable_xhprof
-  fi
-
+  run docker exec -t $CONTAINER_NAME enable_xdebug
+  run docker exec -t $CONTAINER_NAME enable_xhprof
   run docker exec -t $CONTAINER_NAME bash -c "php -r \"print_r(get_loaded_extensions());\" 2>/dev/null | tr -d '\r\n'"
   loaded="${output}"
   # echo "# loaded=${output}" >&3
@@ -116,12 +107,8 @@
     grep -q "=> $item " <<< ${loaded} || (echo "# extension ${item} not loaded" >&3 && false)
   done
 
-  # TODO: Remove the if block when xdebug and xhprof are available for PHP 8.3
-  if [ "${PHP_VERSION}" != "8.3" ]; then
-    run docker exec -t $CONTAINER_NAME disable_xdebug
-    run docker exec -t $CONTAINER_NAME disable_xhprof
-  fi
-
+  run docker exec -t $CONTAINER_NAME disable_xdebug
+  run docker exec -t $CONTAINER_NAME disable_xhprof
 }
 
 @test "verify htaccess doesn't break ${WEBSERVER_TYPE} php${PHP_VERSION}" {


### PR DESCRIPTION
## The Issue

- #5238

## How This PR Solves The Issue

Enables all ddev-webserver tests for PHP 8.3 after its release.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

