### PR TITLE
feat: add toggle arg to xdebug command, fixes #3593

### DIFF
--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -78,6 +78,22 @@ func TestCmdXdebug(t *testing.T) {
 		assert.NoError(err)
 		assert.Contains(string(out), "xdebug disabled")
 
+		out, err = exec.RunHostCommand(DdevBin, "xdebug", "toggle")
+		assert.NoError(err)
+		assert.Contains(string(out), "Enabled xdebug")
+
+		out, err = exec.RunHostCommand(DdevBin, "xdebug", "status")
+		assert.NoError(err)
+		assert.Contains(string(out), "xdebug enabled")
+
+		out, err = exec.RunHostCommand(DdevBin, "xdebug", "toggle")
+		assert.NoError(err)
+		assert.Contains(string(out), "Disabled xdebug")
+
+		out, err = exec.RunHostCommand(DdevBin, "xdebug", "status")
+		assert.NoError(err)
+		assert.Contains(string(out), "xdebug disabled")
+
 		_, err = exec.RunHostCommand(DdevBin, "stop")
 		assert.NoError(err, "Failed ddev stop with php=%v: %v", phpVersion, err)
 	}

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -662,7 +662,7 @@ Whether Xdebug should be enabled for [step debugging](../debugging-profiling/ste
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | `false` | Please leave this `false` in most cases. Most people use [`ddev xdebug`](../usage/commands.md#xdebug) and `ddev xdebug off` commands.
+| :octicons-file-directory-16: project | `false` | Please leave this `false` in most cases. Most people use [`ddev xdebug`](../usage/commands.md#xdebug) and `ddev xdebug off` (or `ddev xdebug toggle`) commands.
 
 ## `xdebug_ide_location`
 

--- a/docs/content/users/debugging-profiling/step-debugging.md
+++ b/docs/content/users/debugging-profiling/step-debugging.md
@@ -14,6 +14,7 @@ All IDEs basically work the same, listening on a port and reacting when they’r
 * Enable Xdebug by running [`ddev xdebug`](../usage/commands.md#xdebug) or `ddev xdebug on` from your project directory.  
 It will remain enabled until you start or restart the project.
 * Disable Xdebug for better performance when not debugging with `ddev xdebug off`.
+* Toggle Xdebug on and off easily with `ddev xdebug toggle`.
 * `ddev xdebug status` will show Xdebug’s current status.
 * You may need to open port 9003 in your firewall to allow Xdebug access. (See [Troubleshooting Xdebug](#troubleshooting-xdebug) below.)
 * The IDE’s debug server port must be set to Xdebug’s default 9003, which is already the case in popular IDEs. If the unusual case that you have a port conflict, see [Using Xdebug on a Port Other than the Default 9003](#using-xdebug-on-a-port-other-than-the-default-9003) below.
@@ -122,6 +123,7 @@ Here are basic steps to take to sort out any difficulty:
 * Temporarily disable any *firewall* or *VPN* if you’re having trouble. Xdebug is a network protocol, and the PHP process inside the web container must be able to establish a TCP connection to the listening IDE (PhpStorm, for example).
 * Confirm that DDEV’s [`xdebug_ide_location`](../configuration/config.md#xdebugidelocation) config setting is set properly, which in most cases should be set to an empty string. Check both your project's `.ddev/config.yaml` and DDEV’s global `~/.ddev/global_config.yaml`.
 * Use `ddev xdebug on` to enable Xdebug when you want it, and `ddev xdebug off` when you’re done with it.
+* You can also use `ddev xdebug toggle` to easily toggle Xdebug on and off.
 * Set a breakpoint at the first executable line of your `index.php`.
 * Tell your IDE to start listening. (PhpStorm: click the telephone button, VS Code: run the debugger.)
 * Use `curl` or a browser to create a web request. For example, `curl https://d10.ddev.site` or run `ddev exec curl localhost`.

--- a/docs/content/users/debugging-profiling/xdebug-profiling.md
+++ b/docs/content/users/debugging-profiling/xdebug-profiling.md
@@ -18,6 +18,7 @@ Although DDEV has more sophisticated profiling capabilities with [xhprof](xhprof
 * Make an HTTP request to the DDEV project and the profile will be located in `.ddev/xdebug` directory.
 * Analyze it with any call graph viewer, for example [kcachegrind](https://kcachegrind.github.io/html/Home.html).
 * When you’re done, execute `ddev xdebug off` to avoid generating unneeded profile files.
+* You can also toggle Xdebug on and off using `ddev xdebug toggle`.
 
 ## Information Links
 

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -23,7 +23,7 @@ Type `ddev` or `ddev -h` in a terminal window to see the available DDEV [command
 * [`ddev composer`](../usage/commands.md#composer) runs Composer inside the container. For example, `ddev composer install` will do a full composer install for you without even needing Composer on your computer. See [developer tools](developer-tools.md#ddev-and-composer).
 * [`ddev snapshot`](../usage/commands.md#snapshot) makes a very fast snapshot of your database that can be easily and quickly restored with [`ddev snapshot restore`](../usage/commands.md#snapshot-restore).
 * [`ddev share`](../usage/commands.md#share) requires ngrok and at least a free account on [ngrok.com](https://ngrok.com) so you can let someone in the next office or on the other side of the planet see your project and what you’re working on. `ddev share -h` gives more info about how to set up ngrok.
-* [`ddev xdebug`](../usage/commands.md#xdebug) enables Xdebug, `ddev xdebug off` disables it, and `ddev xdebug status` shows status.
+* [`ddev xdebug`](../usage/commands.md#xdebug) enables Xdebug, `ddev xdebug off` disables it, and `ddev xdebug status` shows status. You can toggle Xdebug on and off easily using `ddev xdebug toggle`.
 * [`ddev xhprof`](../usage/commands.md#xhprof) enables xhprof, `ddev xhprof off` disables it, and `ddev xhprof status` shows status.
 * `ddev drush` (Drupal and Backdrop only) gives direct access to the `drush` CLI.
 * `ddev artisan` (Laravel only) gives direct access to the Laravel `artisan` CLI.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1402,6 +1402,9 @@ ddev xdebug on
 
 # Turn Xdebug off
 ddev xdebug off
+
+# Toggle Xdebug on and off
+ddev xdebug toggle
 ```
 
 ## `xhprof`

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
@@ -15,12 +15,12 @@ fi
 xdebug_version=$(php --version | awk '/Xdebug v/ {print $3}')
 
 case $1 in
-    on|true|enable)
-	enable_xdebug
-	;;
-	off|false|disable)
-	disable_xdebug
-	;;
+  on|true|enable)
+    enable_xdebug
+    ;;
+  off|false|disable)
+    disable_xdebug
+    ;;
   toggle)
     case ${xdebug_version} in
     v3*)
@@ -44,32 +44,32 @@ case $1 in
       ;;
     esac
     ;;
-	status)
-  case ${xdebug_version} in
-  v3*)
-    status=$(php -r 'echo ini_get("xdebug.mode");' 2>/dev/null)
-    if [[ "${status}" =~ .*"debug".* ]]; then
-      result="xdebug enabled"
-    else
+  status)
+    case ${xdebug_version} in
+    v3*)
+      status=$(php -r 'echo ini_get("xdebug.mode");' 2>/dev/null)
+      if [[ "${status}" =~ .*"debug".* ]]; then
+        result="xdebug enabled"
+      else
+        result="xdebug disabled"
+      fi
+      ;;
+    v2*)
+      status=$(php -r 'echo ini_get("xdebug.remote_enable");')
+      if [ "${status}" = "1" ]; then
+        result="xdebug enabled"
+      else
+        result="xdebug disabled"
+      fi
+      ;;
+    *)
       result="xdebug disabled"
-    fi
-    ;;
-  v2*)
-    status=$(php -r 'echo ini_get("xdebug.remote_enable");')
-    if [ "${status}" = "1" ]; then
-      result="xdebug enabled"
-    else
-      result="xdebug disabled"
-    fi
+      ;;
+    esac
+
+    echo $result
     ;;
   *)
-    result="xdebug disabled"
-    ;;
-  esac
-
-	echo $result
-	;;
-    *)
     echo "Invalid argument: $1"
     ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
@@ -2,8 +2,8 @@
 
 ## #ddev-generated
 ## Description: Enable or disable xdebug
-## Usage: xdebug on|off|enable|disable|true|false|status
-## Example: "ddev xdebug" (default is "on"), "ddev xdebug off", "ddev xdebug on", "ddev xdebug status"
+## Usage: xdebug on|off|enable|disable|true|false|toggle|status
+## Example: "ddev xdebug" (default is "on"), "ddev xdebug off", "ddev xdebug on", "ddev xdebug toggle", "ddev xdebug status"
 ## Execraw: false
 ## Flags: []
 
@@ -21,6 +21,29 @@ case $1 in
 	off|false|disable)
 	disable_xdebug
 	;;
+  toggle)
+    case ${xdebug_version} in
+    v3*)
+      status=$(php -r 'echo ini_get("xdebug.mode");' 2>/dev/null)
+      if [[ "${status}" =~ .*"debug".* ]]; then
+        disable_xdebug
+      else
+        enable_xdebug
+      fi
+      ;;
+    v2*)
+      status=$(php -r 'echo ini_get("xdebug.remote_enable");')
+      if [ "${status}" = "1" ]; then
+        disable_xdebug
+      else
+        enable_xdebug
+      fi
+      ;;
+    *)
+      enable_xdebug
+      ;;
+    esac
+    ;;
 	status)
   case ${xdebug_version} in
   v3*)


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #3593 

## How This PR Solves The Issue

Adds new "toggle" argument to the `xdebug` command

## Manual Testing Instructions

1. Run `ddev xdebug toggle` - see it enable xdebug
1. Run `ddev xdebug toggle` - see it disable xdebug

Optionally run `ddev xdebug status` inbetween to see that the status has _actually_ changed.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

Added tests to validate that `ddev xdebug toggle` outputs the correct text to indicate the new status, and that running `ddev xdebug status` afterwards reports that the status was in fact toggled.

I'm not sure how to run tests locally so just wrote them blind and hoping they pass - but they're based on existing tests and it seems pretty straight forward so should be fine.

## Related Issue Link(s)

#3593 

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

I don't think this has any other ramifications.

## Other notes

I wanted to also change the default for `ddev xdebug` to be a shortcut for `ddev xdebug toggle` (it's currently a shortcut for `ddev xdebug on`) - but I figure that's probably a breaking change so if that does get done it should probably be done in a separate PR.

