### PR TITLE
fix: stop warning about empty app type or docroot creation, fixes #5498

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Basic ddev usage
         run: | 
           mkdir -p ~/workspace/d9 && cd ~/workspace/d9
-          ddev config --project-type=drupal9 --docroot=web --create-docroot
+          ddev config --project-type=drupal9 --docroot=web
           ddev debug download-images
           ddev poweroff
           docker buildx prune -f -a || true

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -58,7 +58,7 @@ func TestComposerCreateCmd(t *testing.T) {
 
 			composerRoot := tmpDir
 			if docRoot != "" {
-				arguments = append(arguments, "--docroot", docRoot, "--create-docroot")
+				arguments = append(arguments, "--docroot", docRoot)
 				// For Drupal10 we test that the composer root is the same as the create root
 				if projectType == nodeps.AppTypeDrupal10 {
 					arguments = append(arguments, "--composer-root", docRoot)

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -69,11 +69,11 @@ func TestConfigDescribeLocation(t *testing.T) {
 		assert.NoError(err, "output=%s", out)
 		_ = os.RemoveAll(tmpDir)
 	})
-	out, err := exec.RunHostCommand(DdevBin, "config", "--docroot=.", "--project-name="+t.Name())
+	_, err = exec.RunHostCommand(DdevBin, "config", "--docroot=.", "--project-name="+t.Name())
 	assert.NoError(err)
 
 	// Now see if we can detect it
-	out, err = exec.RunHostCommand(DdevBin, "config", "--show-config-location")
+	out, err := exec.RunHostCommand(DdevBin, "config", "--show-config-location")
 	assert.NoError(err)
 	assert.Contains(string(out), tmpDir)
 

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -71,7 +71,6 @@ func TestConfigDescribeLocation(t *testing.T) {
 	})
 	out, err := exec.RunHostCommand(DdevBin, "config", "--docroot=.", "--project-name="+t.Name())
 	assert.NoError(err)
-	assert.Contains(string(out), "Configuring unrecognized codebase as project of type 'php'")
 
 	// Now see if we can detect it
 	out, err = exec.RunHostCommand(DdevBin, "config", "--show-config-location")
@@ -124,7 +123,7 @@ func TestConfigWithSitenameFlagDetectsDocroot(t *testing.T) {
 	defer func() {
 		_, _ = exec.RunCommand(DdevBin, []string{"delete", "-Oy", "config-with-sitename"})
 	}()
-	assert.Contains(string(out), "Configuring a 'drupal6' codebase with docroot", nodeps.AppTypeDrupal6)
+	assert.Contains(string(out), "Configuring a 'drupal6' project with docroot", nodeps.AppTypeDrupal6)
 }
 
 // TestConfigSetValues sets all available configuration values using command flags, then confirms that the

--- a/cmd/ddev/cmd/testdata/TestCmdGet/example-repo/tests/test.bats
+++ b/cmd/ddev/cmd/testdata/TestCmdGet/example-repo/tests/test.bats
@@ -5,7 +5,7 @@ setup() {
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} || true
   cd "${TESTDIR}"
-  ddev config --project-name=${PROJNAME} --project-type=drupal9 --docroot=web --create-docroot
+  ddev config --project-name=${PROJNAME} --project-type=drupal9 --docroot=web
   ddev start
 }
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -35,7 +35,7 @@ Environment variables will be automatically added to your `.env` file to simplif
     cd my-craft-project
 
     # Set up the DDEV environment:
-    ddev config --project-type=craftcms --docroot=web --create-docroot
+    ddev config --project-type=craftcms --docroot=web
 
     # Boot the project and install the starter project:
     ddev start
@@ -109,7 +109,7 @@ ddev launch
     ```bash
     mkdir my-drupal10-site
     cd my-drupal10-site
-    ddev config --project-type=drupal10 --docroot=web --create-docroot
+    ddev config --project-type=drupal10 --docroot=web
     ddev start
     ddev composer create drupal/recommended-project
     ddev composer require drush/drush
@@ -123,7 +123,7 @@ ddev launch
     ```bash
     mkdir my-drupal9-site
     cd my-drupal9-site
-    ddev config --project-type=drupal9 --docroot=web --create-docroot
+    ddev config --project-type=drupal9 --docroot=web
     ddev start
     ddev composer create "drupal/recommended-project:^9"
     ddev composer require drush/drush
@@ -198,7 +198,7 @@ Install [Ibexa DXP](https://www.ibexa.co) OSS Edition.
 
 ```bash
 mkdir my-ibexa-project && cd my-ibexa-project
-ddev config --project-type=php --php-version 8.1 --docroot=public --create-docroot
+ddev config --project-type=php --php-version 8.1 --docroot=public
 ddev config --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
 ddev start
 ddev composer create ibexa/oss-skeleton
@@ -220,7 +220,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ```bash
     mkdir my-laravel-app
     cd my-laravel-app
-    ddev config --project-type=laravel --docroot=public --create-docroot --php-version=8.1
+    ddev config --project-type=laravel --docroot=public --php-version=8.1
     ddev composer create --prefer-dist --no-install --no-scripts laravel/laravel -y
     ddev composer install
     ddev exec "php artisan key:generate"
@@ -232,7 +232,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ```bash
     git clone <your-laravel-repo>
     cd <your-laravel-project>
-    ddev config --project-type=laravel --docroot=public --create-docroot --php-version=8.1
+    ddev config --project-type=laravel --docroot=public --php-version=8.1
     ddev start
     ddev composer install
     ddev exec "php artisan key:generate"
@@ -247,7 +247,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
 
     ```bash
     mkdir ddev-magento2 && cd ddev-magento2
-    ddev config --project-type=magento2 --php-version=8.1 --docroot=pub --create-docroot --disable-settings-management
+    ddev config --project-type=magento2 --php-version=8.1 --docroot=pub --disable-settings-management
     ddev get ddev/ddev-elasticsearch
     ddev start
     ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition -y
@@ -288,7 +288,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
 ## Moodle
 
 ```bash
-ddev config --composer-root=public --create-docroot --docroot=public --webserver-type=apache-fpm --database=mariadb:10.6
+ddev config --composer-root=public --docroot=public --webserver-type=apache-fpm --database=mariadb:10.6
 ddev start
 ddev composer create moodle/moodle -y
 ddev exec 'php public/admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
@@ -327,7 +327,7 @@ Though you can set up a Shopware 6 environment many ways, we recommend the follo
 
 ```bash
 mkdir my-shopware6 && cd my-shopware6
-ddev config --project-type=shopware6 --docroot=public --create-docroot
+ddev config --project-type=shopware6 --docroot=public
 ddev composer create shopware/production:^v6.5
 # If it asks `Do you want to include Docker configuration from recipes?`
 # answer `x`, as we're using DDEV for this rather than its recipes.
@@ -349,7 +349,7 @@ Use a new or existing Composer project, or clone a Git repository.
     ```bash
     mkdir my-silverstripe-app
     cd my-silverstripe-app
-    ddev config --project-type=silverstripe --docroot=public --create-docroot
+    ddev config --project-type=silverstripe --docroot=public
     ddev composer create --prefer-dist --no-scripts silverstripe/installer -y
     ddev start
     ddev sake dev/build flush=all
@@ -360,7 +360,7 @@ Use a new or existing Composer project, or clone a Git repository.
     ```bash
     git clone <your-silverstripe-repo>
     cd <your-silverstripe-project>
-    ddev config --project-type=silverstripe --docroot=public --create-docroot
+    ddev config --project-type=silverstripe --docroot=public
     ddev start
     ddev composer install
     ddev sake dev/build flush=all
@@ -386,7 +386,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
     ```bash
     mkdir my-statamic-app
     cd my-statamic-app
-    ddev config --project-type=laravel --docroot=public --create-docroot
+    ddev config --project-type=laravel --docroot=public
     ddev composer create --prefer-dist --no-install --no-scripts statamic/statamic
     ddev composer install
     ddev exec "php artisan key:generate"
@@ -397,7 +397,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
     ```bash
     git clone <your-statamic-repo>
     cd <your-statamic-project>
-    ddev config --project-type=laravel --docroot=public --create-docroot
+    ddev config --project-type=laravel --docroot=public
     ddev start
     ddev composer install
     ddev exec "php artisan key:generate"
@@ -411,7 +411,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
     ```bash
     mkdir my-typo3-site
     cd my-typo3-site
-    ddev config --project-type=typo3 --docroot=public --create-docroot --php-version 8.1
+    ddev config --project-type=typo3 --docroot=public --php-version 8.1
     ddev start
     ddev composer create "typo3/cms-base-distribution"
     ddev exec touch public/FIRST_INSTALL
@@ -423,7 +423,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
     ```bash
     git clone https://github.com/example/example-site
     cd example-site
-    ddev config --project-type=typo3 --docroot=public --create-docroot --php-version 8.1
+    ddev config --project-type=typo3 --docroot=public --php-version 8.1
     ddev composer install
     ddev restart
     ddev exec touch public/FIRST_INSTALL
@@ -468,7 +468,7 @@ There are several easy ways to use DDEV with WordPress:
     ```bash
     mkdir my-wp-bedrock-site
     cd my-wp-bedrock-site
-    ddev config --project-type=wordpress --docroot=web --create-docroot
+    ddev config --project-type=wordpress --docroot=web
     ddev start
     ddev composer create roots/bedrock
     ```

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -180,7 +180,6 @@ Flags:
 * `--composer-root`: Overrides the default Composer root directory for the web service.
 * `--composer-root-default`: Unsets a web service Composer root directory override.
 * `--composer-version`: Specify override for Composer version in the web container. This may be `""`, `"1"`, `"2"`, `"2.2"`, `"stable"`, `"preview"`, `"snapshot"`, or a specific version.
-* `--create-docroot`: Create the docroot if it doesn’t exist.
 * `--database`: Specify the database type:version to use. Defaults to `mariadb:10.4`.
 * `--db-image`: Sets the db container image.
 * `--db-image-default`: Sets the default db container image for this DDEV version.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1305,7 +1305,7 @@ func (app *DdevApp) AppTypePrompt() error {
 		output.UserOut.Errorf("'%s' is not a valid project type. Allowed project types are: %s\n", appType, validAppTypes)
 
 		fmt.Printf(typePrompt, validAppTypes, appType)
-		appType = strings.ToLower(util.GetInput(appType))
+		return fmt.Errorf("invalid project type")
 	}
 
 	app.Type = appType

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1264,13 +1264,6 @@ func (app *DdevApp) docrootPrompt() error {
 	// Ensure the docroot exists. If it doesn't, prompt the user to verify they entered it correctly.
 	fullPath := filepath.Join(app.AppRoot, app.Docroot)
 	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-		util.Warning("Warning: the provided docroot at %s does not currently exist.", fullPath)
-
-		// Ask the user for permission to create the docroot
-		if !util.Confirm(fmt.Sprintf("Create docroot at %s?", fullPath)) {
-			return fmt.Errorf("docroot must exist to continue configuration")
-		}
-
 		if err = os.MkdirAll(fullPath, 0755); err != nil {
 			return fmt.Errorf("unable to create docroot: %v", err)
 		}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -266,7 +266,7 @@ func TestConfigCommand(t *testing.T) {
 
 		restoreOutput := util.CaptureUserOut()
 		err = app.PromptForConfig()
-		assert.NoError(err, t)
+		require.Error(t, err, "invalid project type error should have been caught")
 		out := restoreOutput()
 
 		// Ensure we have expected vales in output.


### PR DESCRIPTION

## The Issue

* #5498

We've been pestering people about the project type not matching (empty) codebase, and about creating the docroot for a long time, and it doesn't help anybody. They want to create the empty project, and they want us to create the docroot.

## How This PR Solves The Issue

* Don't warn about empty codebase when `ddev config --project-type=xxx`
* Warn about mismatched codebase (different base detected) but do what they say to do
* Always create docroot if it doesn't exist.
* Deprecate `--create-docroot` flag

## Manual Testing Instructions

Try a lot of things with empty projects, etc.

## Automated Testing Overview

Minor updates to existing tests

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

