### PR TITLE
fix: global project_tld should default to 'ddev.site', not empty, fixes #4290

### DIFF
--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -65,7 +65,7 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.Contains(out, "use-hardened-images=false\n")
 	assert.Contains(out, "fail-on-hook-fail=false")
 	assert.Contains(out, fmt.Sprintf("required-docker-compose-version=%s\nuse-docker-compose-from-path=false", globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion))
-	assert.Contains(out, "project-tld=\nxdebug-ide-location=")
+	assert.Contains(out, "project-tld="+globalconfig.DdevGlobalConfig.ProjectTldGlobal+"\nxdebug-ide-location=")
 	assert.Contains(out, "router=traefik")
 	assert.Contains(out, "wsl2-no-windows-hosts-mgt=false")
 	assert.Contains(out, "router-http-port=80\nrouter-https-port=443")

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -195,7 +195,7 @@ func (app *DdevApp) WriteConfig() error {
 	if appcopy.MailpitHTTPSPort == nodeps.DdevDefaultMailpitHTTPSPort {
 		appcopy.MailpitHTTPSPort = ""
 	}
-	if appcopy.ProjectTLD == nodeps.DdevDefaultTLD || appcopy.ProjectTLD == globalconfig.DdevGlobalConfig.ProjectTldGlobal {
+	if appcopy.ProjectTLD == globalconfig.DdevGlobalConfig.ProjectTldGlobal {
 		appcopy.ProjectTLD = ""
 	}
 	if appcopy.DefaultContainerTimeout == nodeps.DefaultDefaultContainerTimeout {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -473,7 +473,7 @@ func (app *DdevApp) ValidateConfig() error {
 	for _, hn := range app.GetHostnames() {
 		// If they have provided "*.<hostname>" then ignore the *. part.
 		hn = strings.TrimPrefix(hn, "*.")
-		if hn == "ddev.site" {
+		if hn == nodeps.DdevDefaultTLD {
 			return fmt.Errorf("wildcarding the full hostname or using 'ddev.site' as FQDN for the project %s is not allowed because other projects would not work in that case", app.Name)
 		}
 		if !hostRegex.MatchString(hn) {

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -257,6 +257,10 @@ func ReadGlobalConfig() error {
 		DdevGlobalConfig.OmitContainersGlobal = nodeps.RemoveItemFromSlice(DdevGlobalConfig.OmitContainersGlobal, "dba")
 	}
 
+	if DdevGlobalConfig.ProjectTldGlobal == "" {
+		DdevGlobalConfig.ProjectTldGlobal = nodeps.DdevDefaultTLD
+	}
+
 	err = ValidateGlobalConfig()
 	if err != nil {
 		return err

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -89,6 +89,7 @@ func New() GlobalConfig {
 		MkcertCARoot:                 readCAROOT(),
 		ProjectList:                  make(map[string]*ProjectInfo),
 		TraefikMonitorPort:           nodeps.TraefikMonitorPortDefault,
+		ProjectTldGlobal:             nodeps.DdevDefaultTLD,
 	}
 
 	return cfg


### PR DESCRIPTION

## The Issue

* #4290

@rpkoller pointed out that the global_config.yaml would be more useful if it just *specified* ddev.site as the project_tld.

## How This PR Solves The Issue

Make it explicit in the config.

## Manual Testing Instructions

- [ ] Test to make sure changing global project_tld still works fine
- [ ] Test to make sure default config with ddev.site works fine. Automated tests ought to do this just fine.

