### PR TITLE
fix: Solve the WSL connection failure issue, fixes #5634

### DIFF
--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -44,11 +44,11 @@ mkcert -install
 $env:CAROOT="$(mkcert -CAROOT)"
 setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
+wsl -u root -e bash -c "touch /etc/resolv.conf && printf 'nameserver 8.8.8.8\n' >>/etc/resolv.conf;"
 wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/ddev.gpg > /dev/null"
 wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
 wsl -u root -e bash -c "apt update && apt install -y ddev wslu"
 wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
-
 
 wsl bash -c 'echo $CAROOT'
 wsl -u root mkcert -install

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -45,6 +45,8 @@ $env:CAROOT="$(mkcert -CAROOT)"
 setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
 wsl -u root -e bash -c "touch /etc/resolv.conf && printf 'nameserver 8.8.8.8\n' >>/etc/resolv.conf;"
+wsl -u root -e bash -c "chattr +i /etc/resolv.conf>/dev/null;"
+wsl -u root -e bash -c "touch /etc/wsl.conf && if ! fgrep '[network]' /etc/wsl.conf >/dev/null; then printf '\n[network]\generateResolvConf=false\n' >>/etc/wsl.conf; fi"
 wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/ddev.gpg > /dev/null"
 wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
 wsl -u root -e bash -c "apt update && apt install -y ddev wslu"

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -40,6 +40,8 @@ $env:CAROOT="$(mkcert -CAROOT)"
 setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
 wsl -u root -e bash -c "touch /etc/resolv.conf && printf 'nameserver 8.8.8.8\n' >>/etc/resolv.conf;"
+wsl -u root -e bash -c "chattr +i /etc/resolv.conf>/dev/null;"
+wsl -u root -e bash -c "touch /etc/wsl.conf && if ! fgrep '[network]' /etc/wsl.conf >/dev/null; then printf '\n[network]\generateResolvConf=false\n' >>/etc/wsl.conf; fi"
 wsl -u root bash -c "apt-get remove -y -qq docker docker-engine docker.io containerd runc >/dev/null 2>&1"
 wsl -u root apt-get update
 wsl -u root apt-get install -y ca-certificates curl gnupg lsb-release
@@ -52,6 +54,7 @@ wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://
 wsl -u root -e bash -c "apt update && apt install -y ddev docker-ce docker-ce-cli containerd.io wslu"
 wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
 wsl bash -c 'sudo usermod -aG docker $USER'
+
 
 wsl bash -c 'echo CAROOT=$CAROOT'
 wsl -u root mkcert -install

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -55,7 +55,6 @@ wsl -u root -e bash -c "apt update && apt install -y ddev docker-ce docker-ce-cl
 wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
 wsl bash -c 'sudo usermod -aG docker $USER'
 
-
 wsl bash -c 'echo CAROOT=$CAROOT'
 wsl -u root mkcert -install
 wsl -u root service docker start

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -39,6 +39,7 @@ mkcert -install
 $env:CAROOT="$(mkcert -CAROOT)"
 setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
+wsl -u root -e bash -c "touch /etc/resolv.conf && printf 'nameserver 8.8.8.8\n' >>/etc/resolv.conf;"
 wsl -u root bash -c "apt-get remove -y -qq docker docker-engine docker.io containerd runc >/dev/null 2>&1"
 wsl -u root apt-get update
 wsl -u root apt-get install -y ca-certificates curl gnupg lsb-release


### PR DESCRIPTION
## The Issue
[5634](https://github.com/ddev/ddev/issues/5634)

## How This PR Solves The Issue
This adds the google nameservers to the `resolv.conf` file, which allows apt to find the repositories needed to run apt install.

## Manual Testing Instructions
Follow the instructions at as is: https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/#windows to see the issue.

Remove the WSL and re run the instructions, but when running one of commands in the instructions to trigger the ddev installation script, use this command instead:
```
iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/thegbomb/ddev/master/scripts/install_ddev_wsl2_docker_desktop.ps1'))
```
This command uses the forked version to install ddev, and the installation should complete as required.

## Related Issue Link(s)
Open issue for WSL: https://github.com/microsoft/WSL/issues/8365
Duplicated issue with the resolution: https://github.com/microsoft/WSL/issues/4285
