### PR TITLE
ci: rancher desktop test only on master [skip ci]

### DIFF
--- a/.buildkite/macos-rancher-desktop.yml
+++ b/.buildkite/macos-rancher-desktop.yml
@@ -7,7 +7,7 @@
       - "os=macos"
       - "rancher-desktop=true"
       - "architecture=arm64"
-#    branches: "master"
+    branches: "master"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds


### PR DESCRIPTION

## The Issue

We forgot to disable rancher-desktop except on master again after getting it stabilized.

