### PR TITLE
docs: update discord link [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 DDEV Community Discord
-    url: https://discord.gg/kDvSFBSZfs
+    url: https://discord.gg/5wjP76mBJD
     about: Join the DDEV Community to talk, exchange experiences or ask and answer questions.
   - name: 📒 Stack Overflow
     url: https://stackoverflow.com/questions/tagged/ddev

--- a/docs/content/developers/maintainers.md
+++ b/docs/content/developers/maintainers.md
@@ -10,7 +10,7 @@ Not all maintainers can do all these things at any given time, but these are the
 
 * **Support**: We try to give friendly, accurate, and timely responses to those who need help in:
     * [Issue queue](https://github.com/ddev/ddev/issues) (and discussions, etc). Please follow all in at least the ddev/ddev project. On the Watch/Unwatch button at the top of the repository, consider selecting "All Activity". Also consider this on other projects in the `ddev` organization or other projects that are in your interest area.
-    * Discord: Please read everything that happens in the [DDEV Discord](https://discord.gg/hCZFfAMc5k) and respond to questions that you can help with.
+    * Discord: Please read everything that happens in the [DDEV Discord](https://discord.gg/5wjP76mBJD) and respond to questions that you can help with.
     * Stack Overflow. You can subscribe to the [ddev tag on Stack Overflow](https://stackoverflow.com/questions/tagged/ddev) and answer or comment on questions there.
     * Often in [Drupal Slack](https://www.drupal.org/join-slack) #ddev channel. We have tried and tried to get people over to Discord, but it's still pretty active there.
     * Other add-on repositories or related repos where we can help.

--- a/docs/content/users/support.md
+++ b/docs/content/users/support.md
@@ -9,7 +9,7 @@ We love to hear from you and want you to be successful with DDEV!
 
 * See the included [`ddev help`](./usage/commands.md#help) command, which includes lots of examples.
 * [FAQ](./usage/faq.md)
-* [Discord](https://discord.gg/hCZFfAMc5k) interactive community support.
+* [Discord](https://discord.gg/5wjP76mBJD) interactive community support.
 * [DDEV issue queue](https://github.com/ddev/ddev/issues) for bugs and feature requests.
 * [Mastodon](https://fosstodon.org/@ddev)
 * [Twitter (deprecated) with tag #ddev](https://twitter.com/search?q=%23ddev&src=typd&f=live) will get to us. It’s not as good for interactive support, but we’ll answer anywhere.

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -243,7 +243,7 @@ If anything in `.ddev/config.yaml` is wrong, you can edit that directly or use [
 
 ### How do I get support?
 
-See the [support options](../support.md), including [Discord](https://discord.gg/kDvSFBSZfs), [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev) and the [issue queue](https://github.com/ddev/ddev/issues).
+See the [support options](../support.md), including [Discord](https://discord.gg/5wjP76mBJD), [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev) and the [issue queue](https://github.com/ddev/ddev/issues).
 
 ### How can I contribute to DDEV?
 
@@ -252,7 +252,7 @@ We love and welcome contributions of knowledge, support, docs, and code:
 * Submit an issue or pull request to the [main repository](https://github.com/ddev/ddev).
 * Add your external resource to [awesome-ddev](https://github.com/ddev/awesome-ddev).
 * Add your recipe or HOWTO to [ddev-contrib](https://github.com/ddev/ddev-contrib).
-* Help others in [Discord](https://discord.gg/kDvSFBSZfs) and on [Stack Overflow](https://stackoverflow.com/tags/ddev).
+* Help others in [Discord](https://discord.gg/5wjP76mBJD) and on [Stack Overflow](https://stackoverflow.com/tags/ddev).
 * Contribute financially via [GitHub Sponsors](https://github.com/sponsors/rfay).
 * Get involved with DDEV governance and the [Advisory Group](https://github.com/ddev/ddev/discussions/categories/ddev-advisory-group).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,7 +67,7 @@ extra:
   - icon: fontawesome/brands/github
     link: https://github.com/ddev/ddev
   - icon: fontawesome/brands/discord
-    link: https://discord.gg/hCZFfAMc5k
+    link: https://discord.gg/5wjP76mBJD
   - icon: fontawesome/brands/stack-overflow
     link: https://stackoverflow.com/tags/ddev
   - icon: fontawesome/brands/twitter

--- a/pkg/ddevapp/testdata/TestApptypeDetection/magento/README.md
+++ b/pkg/ddevapp/testdata/TestApptypeDetection/magento/README.md
@@ -131,7 +131,7 @@ for more information.
 
 ## Public Communication
 
-* [Discord](https://discord.gg/EV8aNbU) (maintained by Flyingmana)
+* [Discord](https://discord.gg/5wjP76mBJD) (maintained by Flyingmana)
 
 ## Maintainers
 


### PR DESCRIPTION

## The Issue

I happened to notice that our published discord link was landing people in an obsolete channel, quite confusing. This one has no expiration date and lands in #welcome - It's possible we should just land people in #support, but later.

