### PR TITLE
docs: link to experimental CMS quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
 DDEV is an open-source tool for running local web development environments for PHP, Python and Node.js, ready in minutes. Its powerful, flexible per-project environment configurations can be extended, version controlled, and shared. DDEV allows development teams to adopt a consistent Docker workflow without the complexities of bespoke configuration.
 
 ## Documentation
+
 To check out live examples, docs, contributor live training, guides and more visit [ddev.com](https://ddev.com) and [ddev.readthedocs.io](https://ddev.readthedocs.io/en/latest/users/support)
 
 ## Questions
+
 If you need help, our friendly community provides [great support](https://ddev.readthedocs.io/en/latest/users/support). 
 
 ## Wonderful Sponsors

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To check out live examples, docs, contributor live training, guides and more vis
 
 ## Questions
 
-If you need help, our friendly community provides [great support](https://ddev.readthedocs.io/en/latest/users/support). 
+If you need help, our friendly community provides [great support](https://ddev.readthedocs.io/en/latest/users/support).
 
 ## Wonderful Sponsors
 

--- a/docs/content/users/configuration/experimental.md
+++ b/docs/content/users/configuration/experimental.md
@@ -6,4 +6,6 @@ DDEV v1.22+ supports Python-based projects, including those built with Django 4 
 
 `ddev config --project-type=django4` will by default a project to use the `nginx-gunicorn` `webserver_type` and the `postgres` database type.
 
+To get started with either one of these Python projects, checkout the [Django4 Quickstart](../quickstart/#django-4-experimental) or the [Flask Quickstart](../quickstart/#pythonflask-experimental).
+
 Community feedback is essential for Django/Python support to improve, thank you for participating!

--- a/docs/content/users/configuration/experimental.md
+++ b/docs/content/users/configuration/experimental.md
@@ -6,6 +6,6 @@ DDEV v1.22+ supports Python-based projects, including those built with Django 4 
 
 `ddev config --project-type=django4` will by default a project to use the `nginx-gunicorn` `webserver_type` and the `postgres` database type.
 
-To get started with either one of these Python projects, checkout the [Django 4 Quickstart](../quickstart/#django-4-experimental) or the [Flask Quickstart](../quickstart/#pythonflask-experimental).
+To get started with either one of these Python projects, checkout the [Django 4 Quickstart](../quickstart.md#django-4-experimental) or the [Flask Quickstart](../quickstart.md#pythonflask-experimental).
 
 Community feedback is essential for Django/Python support to improve, thank you for participating!

--- a/docs/content/users/configuration/experimental.md
+++ b/docs/content/users/configuration/experimental.md
@@ -6,6 +6,6 @@ DDEV v1.22+ supports Python-based projects, including those built with Django 4 
 
 `ddev config --project-type=django4` will by default a project to use the `nginx-gunicorn` `webserver_type` and the `postgres` database type.
 
-To get started with either one of these Python projects, checkout the [Django4 Quickstart](../quickstart/#django-4-experimental) or the [Flask Quickstart](../quickstart/#pythonflask-experimental).
+To get started with either one of these Python projects, checkout the [Django 4 Quickstart](../quickstart/#django-4-experimental) or the [Flask Quickstart](../quickstart/#pythonflask-experimental).
 
 Community feedback is essential for Django/Python support to improve, thank you for participating!


### PR DESCRIPTION
Added links to the Quickstarts from the experiment page

## The Issue
As I stated in issue
* #5171, I overlooked the quickstarts the first time, so I put helpful links

## How This PR Solves The Issue
It adds links

## Manual Testing Instructions
None

## Automated Testing Overview
No tests needed for docs

## Related Issue Link(s)
As I stated in issue#5171, I overlooked the quickstarts the first time, so I put helpful links

## Release/Deployment Notes
None
