### PR TITLE
feat: add mailpit command (alias of launch -m), fixes #5627

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -10,8 +13,6 @@ import (
 	"github.com/ddev/ddev/pkg/styles"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/version"
-	"sort"
-	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
@@ -180,7 +181,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 			if _, ok := desc["mailpit_https_url"]; ok {
 				mailpitURL = desc["mailpit_https_url"].(string)
 			}
-			t.AppendRow(table.Row{"Mailpit", "", fmt.Sprintf("Mailpit: %s\n`ddev launch -m`", mailpitURL)})
+			t.AppendRow(table.Row{"Mailpit", "", fmt.Sprintf("Mailpit: %s\n`ddev mailpit`", mailpitURL)})
 
 			//WebExtraExposedPorts stanza
 			for _, extraPort := range app.WebExtraExposedPorts {

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -823,6 +823,17 @@ ddev logs -s db
 ddev logs -s db my-project
 ```
 
+## `mailpit`
+
+Launch a browser with mailpit for the current project (global shell host container command).
+
+Example:
+
+```shell
+# Open Mailpit in the default browser
+ddev mailpit
+```
+
 ## `magento`
 
 Run the `magento` command; available only in projects of type `magento2`, and only works if `bin/magento` is in the project.

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -71,7 +71,7 @@ Use [`ddev composer`](../usage/commands.md#composer) (Composer inside the contai
 
 [Mailpit](https://github.com/axllent/mailpit) is a mail catcher that’s configured to capture and display emails sent by PHP in the development environment.
 
-After your project is started, access the Mailpit web interface at `https://mysite.ddev.site:8026`, or run [`ddev launch -m`](../usage/commands.md#launch) to launch it in your default browser.
+After your project is started, access the Mailpit web interface at `https://mysite.ddev.site:8026`, or run [`ddev mailpit`](../usage/commands.md#mailpit) to launch it in your default browser.
 
 Mailpit will **not** intercept emails if your application is configured to use SMTP or a third-party ESP integration.
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/mailpit
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/mailpit
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## #ddev-generated: If you want to edit and own this file, remove this line.
+## Description: Launch a browser with Mailpit (an email & SMTP testing tool)
+## Usage: mailpit
+## Example: "ddev mailpit"
+
+ddev launch -m


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- https://github.com/ddev/ddev/issues/5627

## How This PR Solves The Issue

Adds a new `ddev mailpit` host command.

A lot of the code is copied directly from `launch`, which is the same way [adminer](https://github.com/ddev/ddev-adminer/blob/main/commands/host/adminer) and [phpmyadmin](https://github.com/ddev/ddev-phpmyadmin/blob/main/commands/host/phpmyadmin) work.

## Manual Testing Instructions

Run `ddev mailpit` - it should perform the same as `ddev launch -m`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
Added a new test right next to the `TestLaunchCommand` test, with a lot of the same code since it's effectively testing the same thing.

## Related Issue Link(s)

https://github.com/ddev/ddev/issues/5627

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
No deployment ramifications that I'm aware of.

## Other notes

Once https://github.com/ddev/ddev/pull/5525 is merged, this command (and the adminer/phpmyadmin commands) can be vastly simplified.