### PR TITLE
refactor: add quotes for the hostname error for better visibility

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -477,7 +477,7 @@ func (app *DdevApp) ValidateConfig() error {
 			return fmt.Errorf("wildcarding the full hostname or using 'ddev.site' as FQDN for the project %s is not allowed because other projects would not work in that case", app.Name)
 		}
 		if !hostRegex.MatchString(hn) {
-			return fmt.Errorf("the %s project has an invalid hostname: %s. See https://en.wikipedia.org/wiki/Hostname#Syntax for valid hostname requirements", app.Name, hn).(invalidHostname)
+			return fmt.Errorf("the %s project has an invalid hostname: '%s', see https://en.wikipedia.org/wiki/Hostname#Syntax for valid hostname requirements", app.Name, hn).(invalidHostname)
 		}
 	}
 


### PR DESCRIPTION
## The Issue

```
$ ddev config --project-tld=""
failed to validate config: the test-project project has an invalid hostname: test-project.. See https://en.wikipedia.org/wiki/Hostname#Syntax for valid hostname requirements
```

It is not clear what hostname is in the error, whether it is `test-project.` or `test-project..`

## How This PR Solves The Issue

Adds quotes:

```
$ ddev config --project-tld=""
failed to validate config: the test-project project has an invalid hostname: 'test-project.', see https://en.wikipedia.org/wiki/Hostname#Syntax for valid hostname requirements
```

