### PR TITLE
fix: disable Content-Type auto-detection for Traefik 2, fixes #5346

### DIFF
--- a/pkg/ddevapp/traefik_config_template.yaml
+++ b/pkg/ddevapp/traefik_config_template.yaml
@@ -10,6 +10,8 @@ http:
       {{else}}
       rule: Host({{ range $i, $h := $s.ExternalHostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
       {{end}}
+      middlewares:
+        - autodetect
       service: "{{$appname}}-{{$s.InternalServiceName}}-{{$s.InternalServicePort}}-http"
       tls: false
       entrypoints:
@@ -22,6 +24,8 @@ http:
       {{else}}
       rule: Host({{ range $i, $h := $s.ExternalHostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
       {{end}}
+      middlewares:
+        - autodetect
       service: "{{$appname}}-{{$s.InternalServiceName}}-{{$s.InternalServicePort}}-https"
       {{ if not $.UseLetsEncrypt }}
       tls: true
@@ -33,6 +37,12 @@ http:
         - http-{{$s.ExternalPort}}
     {{ end }}
     {{ end }}
+
+  # autodetect won't be needed in Traefik 3 https://github.com/traefik/traefik/pull/9546
+  middlewares:
+    autodetect:
+      contentType:
+        autoDetect: false
 
   services:
     {{$appname := .App.Name}}{{ range $s := .RoutingTable }}{{ if $s.HTTPS }}


### PR DESCRIPTION
## The Issue

- #5346

## How This PR Solves The Issue

Disables autodetect for Content-Type in Traefik project yaml config.
Note that this fix needs to be reverted when Traefik 3 is out.

## Manual Testing Instructions

From https://github.com/ddev/ddev/issues/5346#issuecomment-1860409926
I could reproduce it when just created a fresh TYPO3 Install (Apache Webserver) and then in the Backend (Install Tool) under "Environment" and "Environment Status" I get the messages mentioned in my first post. After the changes I mentioned there there are no more unexpected server responses listed.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

This fix is not needed in the upcoming Traefik 3:

- https://github.com/traefik/traefik/pull/9546
