### PR TITLE
docs: add missing blank lines to readme.md, for #5513

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@
 DDEV is an open-source tool for running local web development environments for PHP, Python and Node.js, ready in minutes. Its powerful, flexible per-project environment configurations can be extended, version controlled, and shared. DDEV allows development teams to adopt a consistent Docker workflow without the complexities of bespoke configuration.
 
 ## Documentation
+
 To check out live examples, docs, contributor live training, guides and more visit [ddev.com](https://ddev.com) and [ddev.readthedocs.io](https://ddev.readthedocs.io/en/latest/users/support)
 
 ## Questions
-If you need help, our friendly community provides [great support](https://ddev.readthedocs.io/en/latest/users/support). 
+
+If you need help, our friendly community provides [great support](https://ddev.readthedocs.io/en/latest/users/support).
 
 ## Wonderful Sponsors
 


### PR DESCRIPTION
## The Issue

- #5513

https://github.com/ddev/ddev/actions/runs/7250457772/job/19750683700?pr=5648#step:10:9

```
README.md:13 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## Documentation"]
README.md:16 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## Questions"]
README.md:17:120 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
```

## How This PR Solves The Issue

Fixes `markdown-lint` errors.