### PR TITLE
fix: update global schema

### DIFF
--- a/pkg/globalconfig/schema.json
+++ b/pkg/globalconfig/schema.json
@@ -224,7 +224,7 @@
       "type": "boolean"
     },
     "use_letsencrypt": {
-      "description": "hether to enable Let’s Encrypt integration. (Works in conjunction with letsencrypt_email.) (Not currently compatible with Traefik router.)",
+      "description": "Whether to enable Let’s Encrypt integration. (Works in conjunction with letsencrypt_email.) (Not currently compatible with Traefik router.)",
       "type": "boolean"
     },
     "web_environment": {

--- a/pkg/globalconfig/schema.json
+++ b/pkg/globalconfig/schema.json
@@ -135,6 +135,14 @@
       "description": "Email associated with Let’s Encrypt feature. (Works in conjunction with use_letsencrypt.) (Not currently compatible with Traefik router.)",
       "type": "string"
     },
+    "mailpit_http_port": {
+      "description": "Port for project’s Mailpit HTTP URL.",
+      "type": "string"
+    },
+    "mailpit_https_port": {
+      "description": "Port for project’s Mailpit HTTPS URL.",
+      "type": "string"
+    },
     "messages": {
       "description": "Configure messages like the Tip of the Day.",
       "type": "object",
@@ -157,6 +165,14 @@
       "type": "array",
       "items": {
         "type": "string"
+      },
+      "uniqueItems": true
+    },
+    "project_info": {
+      "description": "List of all projects DDEV currently knows about. DDEV manages this list when using `config` and `delete` commands.",
+      "type": "array",
+      "items": {
+        "type": "array"
       },
       "uniqueItems": true
     },

--- a/pkg/globalconfig/schema.json
+++ b/pkg/globalconfig/schema.json
@@ -132,15 +132,15 @@
       "type": "integer"
     },
     "letsencrypt_email": {
-      "description": "Email associated with Let’s Encrypt feature. (Works in conjunction with use_letsencrypt.) (Not currently compatible with Traefik router.)",
+      "description": "Email associated with Let's Encrypt feature. (Works in conjunction with use_letsencrypt.) (Not currently compatible with Traefik router.)",
       "type": "string"
     },
     "mailpit_http_port": {
-      "description": "Port for project’s Mailpit HTTP URL.",
+      "description": "Port for project's Mailpit HTTP URL.",
       "type": "string"
     },
     "mailpit_https_port": {
-      "description": "Port for project’s Mailpit HTTPS URL.",
+      "description": "Port for project's Mailpit HTTPS URL.",
       "type": "string"
     },
     "messages": {
@@ -203,7 +203,7 @@
       ]
     },
     "router_bind_all_interfaces": {
-      "description": "Whether to bind ddev-router’s ports on all network interfaces.",
+      "description": "Whether to bind ddev-router's ports on all network interfaces.",
       "type": "boolean"
     },
     "router_http_port": {
@@ -240,7 +240,7 @@
       "type": "boolean"
     },
     "use_letsencrypt": {
-      "description": "Whether to enable Let’s Encrypt integration. (Works in conjunction with letsencrypt_email.) (Not currently compatible with Traefik router.)",
+      "description": "Whether to enable Let's Encrypt integration. (Works in conjunction with letsencrypt_email.) (Not currently compatible with Traefik router.)",
       "type": "boolean"
     },
     "web_environment": {


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
While editing the global config file, VScode reported 3 invalid keys.

Strangely, after a couple of minutes, the warning disappeared. However, the same 3 keys reported invalid again after a system restart.

The apostrophes also displayed a warning in VSCode:
"The character U+2019 "’" could be confused with the ASCII character U+0060 "`", which is more common in source code."

## How This PR Solves The Issue
This PR 
- fixes a single typo.
- adds the missing keys to the the global schema file.
- replaces apostrophes with single quote

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

I understand apostrophes vs. single quotes is a personal preference. 
My intention is to remove warnings displayed when using the following setting: 
`"editor.unicodeHighlight.ambiguousCharacters": true,`.  We can revert that commit, as required.