### PR TITLE
docs: fix typo in sharing.md

### DIFF
--- a/docs/content/users/topics/sharing.md
+++ b/docs/content/users/topics/sharing.md
@@ -35,7 +35,7 @@ WordPress only has the one base URL, but the `wp` command is built into DDEV’s
 This set of steps assumes an ngrok domain of `wp23.ngrok-free.app` and a starting URL of `https://wordpress.ddev.site`.
 
 * Configure `.ddev/config.yaml` to use a custom domain: `ngrok_args: --domain wp23.ngrok-free.app`.
-* Make a backup of your database with [`ddev export-db`](../usage/commands.md#export-db) or [`ddev shapshot`](../usage/commands.md#snapshot).
+* Make a backup of your database with [`ddev export-db`](../usage/commands.md#export-db) or [`ddev snapshot`](../usage/commands.md#snapshot).
 * Edit `wp-config-ddev.php` (or whatever your config is) to change `WP_HOME`, for example, `define('WP_HOME', 'https://wp23.ngrok-free.app');`
 * `ddev wp search-replace https://wordpress.ddev.site https://wp23.ngrok-free.app`, assuming your project is configured for `https://wordpress.ddev.site` and your `ngrok_args` are configured for the `wp23.ngrok-free.app` domain.
 * Now run [`ddev share`](../usage/commands.md#share).


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
The following section contains a typo [Sharing - WordPress: Change the URL](https://ddev.readthedocs.io/en/stable/users/topics/sharing/#wordpress-change-the-url-with-wp-search-replace) the `snapshot` command in the second bullet point has a typo.

## How This PR Solves The Issue
Changed `shapshot` to `snapshot`

## Manual Testing Instructions
Review the file change

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

