### PR TITLE
ci: fix PostgreSQL client for testbot on WSL2

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -39,9 +39,10 @@ windows)
 linux)
     # homebrew is only on amd64
     if [ "$(arch)" = "x86_64" ]; then
-      for item in ddev/ddev-edge/ddev golang mkcert mkdocs postgresql-client; do
+      for item in ddev/ddev-edge/ddev golang libpq mkcert mkdocs; do
         brew upgrade $item || brew install $item || true
       done
+      brew link --force libpq
     fi
     ;;
 


### PR DESCRIPTION
## The Issue

Noticed a wrong formula in tests:
```
Error: No available formula with the name "postgresql-client". Did you mean postgrest?
```
https://buildkite.com/ddev/wsl2-docker-inside/builds/3039#018c9045-77f3-48e4-879b-01dae0cfaf66/99-116

## How This PR Solves The Issue

Uses the same formula from macOS setup.