### PR TITLE
fix: Add correct mime types for Javascript

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/mods-available/mime.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/apache2/mods-available/mime.conf
@@ -27,6 +27,7 @@
 	AddType application/x-compress .Z
 	AddType application/x-gzip .gz .tgz
 	AddType application/x-bzip2 .bz2
+	AddType text/javascript .js .cjs .mjs
 
 	#
 	# DefaultLanguage and AddLanguage allows you to specify the language of 

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/nginx.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/nginx.conf
@@ -37,10 +37,8 @@ http {
   # Specify MIME types for files.
   include       mime.types;
   types {
-    application/xslt+xml xsl xslt;
-  }
-  types {
     application/javascript js cjs mjs;
+    application/xslt+xml xsl xslt;
   }
 
   default_type  application/octet-stream;

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/nginx.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/nginx.conf
@@ -37,7 +37,7 @@ http {
   # Specify MIME types for files.
   include       mime.types;
   types {
-    application/javascript js cjs mjs;
+    text/javascript js cjs mjs;
     application/xslt+xml xsl xslt;
   }
 

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/nginx.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/nginx.conf
@@ -39,6 +39,9 @@ http {
   types {
     application/xslt+xml xsl xslt;
   }
+  types {
+    application/javascript js cjs mjs;
+  }
 
   default_type  application/octet-stream;
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.22.6" // Note that this can be overridden by make
+var WebTag = "20231227_jonnitto_nginx_js_mimetypes" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20231227_jonnitto_nginx_js_mimetypes" // Note that this can be overridden by make
+var WebTag = "20240123_jonnitto_js_mimetypes" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
This add the correct MIME type for the Javascript file extension for Modules `.mjs` and for CommonJS `.cjs`

CJS, MJS, and .JS are file extensions used to denote different types of JavaScript files. Here's the difference between them:

### JS (JavaScript):

The `.js` extension is the most common file extension for JavaScript files. It is used to indicate that a file contains JavaScript code. `.js` files can be executed in different JavaScript environments, such as web browsers, servers, and other JavaScript runtime environments.

### CJS (CommonJS):

CommonJS is a module system for JavaScript used in server-side environments like Node.js. The CJS module format allows you to define modules using the `require` and `module.exports` syntax. In CommonJS, each file is treated as a separate module, and you can import/export functionality between modules using `require` and `module.exports`.

### MJS (ECMAScript Modules):

MJS is an extension used for JavaScript files that adhere to the ECMAScript Modules (ESM) specification. ECMAScript modules are part of the JavaScript language standard and provide a more modern and standardized way to define modules.  ECMAScript modules use the `import` and `export` keywords to define dependencies and expose functionality between modules.


## The Issue

If I try to include a Javascript Module with the extension `.mjs`, I'll get the error 

```
Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "application/octet-stream". Strict MIME type checking is enforced for module scripts per HTML spec.
```

## How This PR Solves The Issue

It adds the correct type for all kind of Javascript files

## Manual Testing Instructions

```
mkdir pr5661 && cd pr5661 && touch test.{js,mjs,cjs} && ddev config --auto --omit-containers db

# see text/javascript for all three types in nginx
ddev start && ddev exec curl -I https://pr5661.ddev.site/test.{js,mjs,cjs}

# see text/javascript for all three types in Apache2
ddev config --webserver-type apache-fpm && ddev restart && ddev exec curl -I https://pr5661.ddev.site/test.{js,mjs,cjs}
```

## Automated Testing Overview

If there is way to test this, please tell me

## Release/Deployment Notes

This does not affect the behavior of other parts of ddev itself.

If a user's application relies on a non-standards-compliant content-type mimetype for `.mjs` / `.cjs` files, their application may fail, as we are now serving the files as javascript
