### PR TITLE
build: revert bump actions/upload-artifact from 3 to 4, for #5648

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -244,32 +244,32 @@ jobs:
         run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
       - name: Upload all artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: all-ddev-executables
           path: ${{ github.workspace }}/artifacts/*
       - name: Upload macos-amd64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ddev-macos-amd64
           path: .gotmp/bin/darwin_amd64/ddev
       - name: Upload macos-arm64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ddev-macos-arm64
           path: .gotmp/bin/darwin_arm64/ddev
       - name: Upload linux-arm64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ddev-linux-arm64
           path: .gotmp/bin/linux_arm64/ddev
       - name: Upload linux-amd64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ddev-linux-amd64
           path: .gotmp/bin/linux_amd64/ddev
       - name: Upload windows_amd64 installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ddev-windows-amd64-installer
           path: .gotmp/bin/windows_amd64/ddev_windows_installer*.exe

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -60,32 +60,32 @@ jobs:
         run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
       - name: Upload all artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: all-ddev-executables
           path: ${{ github.workspace }}/artifacts/*
       - name: Upload macos-amd64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ddev-macos-amd64
           path: .gotmp/bin/darwin_amd64/ddev
       - name: Upload macos-arm64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ddev-macos-arm64
           path: .gotmp/bin/darwin_arm64/ddev
       - name: Upload linux-arm64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ddev-linux-arm64
           path: .gotmp/bin/linux_arm64/ddev
       - name: Upload linux-amd64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ddev-linux-amd64
           path: .gotmp/bin/linux_amd64/ddev
       - name: Upload windows_amd64 installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ddev-windows-amd64-installer
           path: .gotmp/bin/windows_amd64/ddev_windows_installer*.exe


### PR DESCRIPTION
## The Issue

- #5648

Go to https://github.com/ddev/ddev/actions/runs/7340705862?pr=5661 and click on the artifact and see:

```
Failed to generate URL to download artifact.
```

## How This PR Solves The Issue

There is no update guide at the moment, go back to `actions/upload-artifact@v3` for now.

See 

- https://github.com/actions/upload-artifact/issues/472

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

