### PR TITLE
fix: remove CRAFT_WEB_URL, fixes #5665

### DIFF
--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -134,11 +134,10 @@ func craftCmsPostStartAction(app *DdevApp) error {
 			"CRAFT_DB_DATABASE":     "db",
 			"CRAFT_DB_USER":         "db",
 			"CRAFT_DB_PASSWORD":     "db",
-			"CRAFT_WEB_URL":         app.GetPrimaryURL(),
 			"CRAFT_WEB_ROOT":        app.GetAbsDocroot(true),
 			"MAILPIT_SMTP_HOSTNAME": "127.0.0.1",
 			"MAILPIT_SMTP_PORT":     "1025",
-			"PRIMARY_SITE_URL":      app.GetPrimaryURL(), // for backward compatibility only
+			"PRIMARY_SITE_URL":      app.GetPrimaryURL(),
 		}
 	}
 


### PR DESCRIPTION
## The Issue
The `CRAFT_WEB_URL` env variable is not necessary for a Craft project, and prevents multi-site features from working.

## How This PR Solves The Issue
Does not manage `CRAFT_WEB_URL`.

It also removes the comment about backward compatibility, as it isn't quite true. While `PRIMARY_SITE_URL` isn't an "official" var that Craft uses, it is a de-facto standard, as [Craft's installer script](https://github.com/craftcms/cms/blob/c905cc975a57ee3e41a317adf8cd7e303353a35b/src/console/controllers/InstallController.php#L189) will attempt to set it, and it is helpful to have the primary site set to reference in your config.

## Manual Testing Instructions

Start a craftcms ddev project:

```
ddev config --project-type=craftcms --docroot=web --create-docroot
touch .env
ddev start
```

Ensure `CRAFT_WEB_URL` was not written to `.env` (command should have no output):

```
cat .env | grep "CRAFT_WEB_URL="
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

Fixes https://github.com/ddev/ddev/issues/5665

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

