### PR TITLE
fix: make sure wsl v2 is used, not wsl v1, fixes #5667 [skip ci]

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -145,7 +145,9 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### Important Considerations for WSL2 and DDEV
 
-    * WSL2 is supported on Windows 10 and 11.  
+    * You **must** use WSL2, not WSL version 1.
+      Use `wsl.exe -l -v` to see the versions of the distros you are using they should be v2.
+    * WSL2 is supported on Windows 10 and 11.
       All Windows 10/11 editions, including Windows 10 Home support WSL2.
     * WSL2 offers a faster, smoother experience.  
       It’s vastly more performant, and you’re less likely to have obscure Windows problems.
@@ -166,6 +168,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     * Installing WSL2 and installing a distro like Ubuntu.
     * Optionally installing Docker Desktop for Windows and enabling WSL2 integration with the distro (if you're using the Docker Desktop approach).
     * Installing DDEV inside your distro; this is normally done by running one of the two scripts below, but can be done manually step-by-step as well.
+    * Verify that your distro uses WSL version 2 with `wsl.exe -l -v`.
 
     ### WSL2 + Docker CE Inside Install Script
 
@@ -184,6 +187,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
         * Verify that you have an Ubuntu distro set as default by running `wsl.exe -l -v`.  
           If you have WSL2 but not an Ubuntu distro, install one by running `wsl.exe --install Ubuntu`. If this doesn’t work, see [manual installation](https://docs.microsoft.com/en-us/windows/wsl/install-manual) and [troubleshooting](https://docs.microsoft.com/en-us/windows/wsl/troubleshooting#installation-issues).
+
+        * Verify that your Ubuntu default distro is WSL v2 using `wsl -l -v`.
 
     2. In an administrative PowerShell run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_inside.ps1) by executing:
 

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -21,7 +21,7 @@ if (-not( wsl -e grep ^NAME=.Ubuntu //etc/os-release)) {
 }
 # Make sure using WSL2
 if (-not (wsl -e bash -c "env | grep WSL_INTEROP=")) {
-    throw "Your default distro is not WSL2, please delete it and start over again"
+    throw "Your default distro is not WSL version 2, please delete it and start over again"
 }
 if (-not(Compare-Object "root" (wsl -e whoami)) ) {
     throw "The default user in your distro seems to be root. Please configure an ordinary default user"

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -19,6 +19,10 @@ if (-not(wsl -l -v)) {
 if (-not( wsl -e grep ^NAME=.Ubuntu //etc/os-release)) {
     throw "Your installed WSL2 distro does not seem to be Ubuntu. You can certainly use DDEV with WSL2 in another distro, but this script is oriented to Ubuntu."
 }
+# Make sure using WSL2
+if (-not (wsl -e bash -c "env | grep WSL_INTEROP=")) {
+    throw "Your default distro is not WSL2, please delete it and start over again"
+}
 if (-not(Compare-Object "root" (wsl -e whoami)) ) {
     throw "The default user in your distro seems to be root. Please configure an ordinary default user"
 }

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -19,7 +19,7 @@ if (-not( wsl -e grep ^NAME=.Ubuntu //etc/os-release)) {
 }
 # Make sure using WSL2
 if (-not (wsl -e bash -c "env | grep WSL_INTEROP=")) {
-    throw "Your default distro is not WSL2, please delete it and start over again"
+    throw "Your default distro is not WSL version 2, please delete it and start over again"
 }
 if (-not(Compare-Object "root" (wsl -e whoami)) ) {
     throw "The default user in your distro seems to be root. Please configure an ordinary default user"

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -17,6 +17,10 @@ if (-not(wsl -l -v)) {
 if (-not( wsl -e grep ^NAME=.Ubuntu //etc/os-release)) {
     throw "Your installed WSL2 distro does not seem to be Ubuntu. You can certainly use DDEV with WSL2 in another distro, but this script is oriented to Ubuntu."
 }
+# Make sure using WSL2
+if (-not (wsl -e bash -c "env | grep WSL_INTEROP=")) {
+    throw "Your default distro is not WSL2, please delete it and start over again"
+}
 if (-not(Compare-Object "root" (wsl -e whoami)) ) {
     throw "The default user in your distro seems to be root. Please configure an ordinary default user"
 }


### PR DESCRIPTION

## The Issue

* #5667

Prevent people from accidentally using WSL v1

## How This PR Solves The Issue

* Add more to docs about WSL v2
* Make the automated scripts check for WSL_INTEROPE

## Manual Testing Instructions

This requires careful manual checking on a Windows machine, using both WSL v1 and v2.

I may be able to do that but this certainly can't go in without manual testing, so leaving it draft until tested.

