### PR TITLE
feat: add contao project type

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -18,6 +18,7 @@ CMD
 CMS
 CMSes
 Colima
+Contao
 CPUs
 CTRL
 CentOS

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -262,6 +262,17 @@ func TestCustomCommands(t *testing.T) {
 		assert.NoError(err, "expected to find command %s for app.Type=%s", c, app.Type)
 	}
 
+	// Contao commands should only be available for type contao
+	app.Type = nodeps.AppTypeContao
+	_ = app.WriteConfig()
+	_, _ = exec.RunHostCommand(DdevBin)
+	err = app.MutagenSyncFlush()
+	assert.NoError(err)
+	for _, c := range []string{"contao"} {
+		_, err = exec.RunHostCommand(DdevBin, "help", c)
+		assert.NoError(err)
+	}
+
 	// Craft CMS commands should only be available for type craftcms
 	app.Type = nodeps.AppTypeCraftCms
 	_ = app.WriteConfig()

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -90,7 +90,7 @@ for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3; do
     done
 done
 
-for project_type in backdrop craftcms drupal drupal6 drupal7 drupal8 drupal9 drupal10 laravel magento magento2 typo3 wordpress default; do
+for project_type in backdrop contao craftcms drupal drupal6 drupal7 drupal8 drupal9 drupal10 laravel magento magento2 typo3 wordpress default; do
 	export PHP_VERSION="8.0"
     export project_type
 	if [ "$project_type" == "drupal6" ]; then

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -546,7 +546,7 @@ The DDEV-specific project type.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | `php` | Can be `backdrop`, `craftcms`, `django4`, `drupal6`, `drupal7`, `drupal`,  `laravel`, `magento`, `magento2`, `php`, `python`, `shopware6`, `silverstripe`, `typo3`, or `wordpress`.
+| :octicons-file-directory-16: project | `php` | Can be `backdrop`, `contao`, `craftcms`, `django4`, `drupal6`, `drupal7`, `drupal`,  `laravel`, `magento`, `magento2`, `php`, `python`, `shopware6`, `silverstripe`, `typo3`, or `wordpress`.
 
 The `php` and `python` types don’t attempt [CMS configuration](../../users/quickstart.md) or settings file management and can work with any project.
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -71,6 +71,62 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
     ddev launch
     ```
 
+## Contao
+
+=== "Managed Edition"
+
+New Contao projects can be created from the official [Contao Managed Edition](https://github.com/contao/managed-edition) using DDEV’s [`composer create` command](../users/usage/commands.md#composer):
+
+    ```shell
+    # Create a project directory and move into it:
+    mkdir my-contao-project && cd my-contao-project
+
+    # Set up the DDEV environment:
+    ddev config --project-type=contao --docroot=public
+
+    # Start the project:
+    ddev start
+
+    # Install the managed edition:
+    ddev composer create contao/managed-edition
+
+    # Install database content:
+    ddev contao contao:migrate --no-interaction
+
+    # Create admin user:
+    ddev contao contao:user:create
+
+    # Open admin panel:
+    ddev launch contao
+    ```
+
+=== "Demo"
+
+A Contao demo project can be created from the official [Contao Demo](https://github.com/contao/contao-demo) using DDEV’s [`composer create` command](../users/usage/commands.md#composer):
+
+    ```shell
+    # Create a project directory and move into it:
+    mkdir my-contao-demo && cd my-contao-project
+
+    # Set up the DDEV environment:
+    ddev config --project-type=contao --docroot=public
+
+    # Start the project:
+    ddev start
+
+    # Install the demo edition:
+    ddev composer create contao/contao-demo
+
+    # Import the database backup:
+    ddev contao contao:backup:restore
+
+    # Finalize the database:
+    ddev contao contao:migrate --no-interaction
+
+    # Open the demo site:
+    ddev launch
+    ```
+
 ## Craft CMS
 
 Start a new [Craft CMS](https://craftcms.com) project or retrofit an existing one.

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -28,6 +28,7 @@ Type `ddev` or `ddev -h` in a terminal window to see the available DDEV [command
 * `ddev drush` (Drupal and Backdrop only) gives direct access to the `drush` CLI.
 * `ddev artisan` (Laravel only) gives direct access to the Laravel `artisan` CLI.
 * `ddev magento` (Magento2 only) gives access to the `magento` CLI.
+* [`ddev contao`](../usage/commands.md#contao) (Contao only) gives access to the `contao` CLI.
 * [`ddev craft`](../usage/commands.md#craft) (Craft CMS only) gives access to the `craft` CLI.
 * [`ddev yarn`](../usage/commands.md#yarn) and [`ddev npm`](../usage/commands.md#npm) give direct access to the `yarn` and `npm` CLIs.
 * `ddev cake` (CakePHP only) gives direct access to the CakePHP `cake` CLI.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -224,7 +224,7 @@ Flags:
 * `--php-version`: PHP version that will be enabled in the web container.
 * `--project-name`: Provide the project name of project to configure. (normally the same as the last part of directory name)
 * `--project-tld`: Set the top-level domain to be used for projects. (default `"ddev.site"`)
-* `--project-type`: Provide the project type: `backdrop`, `drupal`, `drupal6`, `drupal7`, `laravel`, `magento`, `magento2`, `php`, `shopware6`, `silverstripe`, `typo3`, `wordpress`. This is autodetected and this flag is necessary only to override the detection.
+* `--project-type`: Provide the project type: `backdrop`, `contao`, `drupal`, `drupal6`, `drupal7`, `laravel`, `magento`, `magento2`, `php`, `shopware6`, `silverstripe`, `typo3`, `wordpress`. This is autodetected and this flag is necessary only to override the detection.
 * `--show-config-location`: Output the location of the `config.yaml` file if it exists, or error that it doesn’t exist.
 * `--timezone`: Specify timezone for containers and PHP, like `Europe/London` or `America/Denver` or `GMT` or `UTC`.
 * `--update`: Automatically detect and update settings by inspecting the code.
@@ -274,6 +274,17 @@ ddev config global --omit-containers=ddev-ssh-agent
 * `--use-letsencrypt`: Enables experimental Let’s Encrypt integration; `ddev global --use-letsencrypt` or `ddev global --use-letsencrypt=false`.
 * `--web-environment`: Set the environment variables in the web container: `--web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"`
 * `--web-environment-add`: Append environment variables to the web container: `--web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"`
+
+## `contao`
+
+Run a [Contao command](https://docs.contao.org/manual/en/cli/) inside the web container (global shell web container command).
+
+Example:
+
+```shell
+# Get a list of all available commands
+ddev contao list
+```
 
 ## `craft`
 

--- a/docs/content/users/usage/managing-projects.md
+++ b/docs/content/users/usage/managing-projects.md
@@ -2,6 +2,8 @@
 
 The [`ddev config`](../usage/commands.md#config) and `ddev start` commands attempt to create a CMS-specific settings file pre-populated with DDEV credentials. If you don't want DDEV to do this, set the [`disable_settings_management`](../configuration/config.md#disable_settings_management) config option to `true`.
 
+For **Contao** DDEV settings are added to the `.env.local` file.
+
 For **Craft CMS** DDEV settings are added to the `.env` file.
 
 For **Django 4** DDEV settings are placed in `.ddev/settings/settings.django4.py` and a stanza is added to your `settings.py` that is only invoked in DDEV context.

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -97,6 +97,13 @@ func init() {
 			postStartAction:      cakephpPostStartAction,
 		},
 
+		nodeps.AppTypeContao: {
+			appTypeDetect:        isContaoApp,
+			appTypeSettingsPaths: setContaoSiteSettingsPaths,
+			configOverrideAction: contaoConfigOverrideAction,
+			postStartAction:      contaoPostStartAction,
+		},
+
 		nodeps.AppTypeCraftCms: {
 			importFilesAction:    craftCmsImportFilesAction,
 			appTypeDetect:        isCraftCmsApp,

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -62,6 +62,7 @@ func TestConfigOverrideAction(t *testing.T) {
 	appTypes := map[string]string{
 		nodeps.AppTypeBackdrop:     nodeps.PHPDefault,
 		nodeps.AppTypeCakePHP:      nodeps.PHP83,
+		nodeps.AppTypeContao:       nodeps.PHPDefault,
 		nodeps.AppTypeCraftCms:     nodeps.PHPDefault,
 		nodeps.AppTypeDrupal6:      nodeps.PHP56,
 		nodeps.AppTypeDrupal7:      nodeps.PHP82,

--- a/pkg/ddevapp/contao.go
+++ b/pkg/ddevapp/contao.go
@@ -1,0 +1,61 @@
+package ddevapp
+
+import (
+	"errors"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/util"
+	"os"
+	"path/filepath"
+)
+
+// isContaoApp returns true if the app is of type contao
+func isContaoApp(app *DdevApp) bool {
+	isContao, err := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, app.ComposerRoot, "vendor/composer/installed.json"), `"name": "contao/core-bundle"`)
+	if err == nil && isContao {
+		return true
+	}
+	return false
+}
+
+// setContaoSiteSettingsPaths sets the paths to .env.local file.
+func setContaoSiteSettingsPaths(app *DdevApp) {
+	app.SiteSettingsPath = filepath.Join(app.AppRoot, ".env.local")
+}
+
+// contaoConfigOverrideAction sets up the default webserverType
+func contaoConfigOverrideAction(app *DdevApp) error {
+	if app.WebserverType == nodeps.WebserverDefault {
+		app.WebserverType = nodeps.WebserverApacheFPM
+	}
+	return nil
+}
+
+// contaoPostStartAction sets up the .env.local file
+func contaoPostStartAction(app *DdevApp) error {
+	if app.DisableSettingsManagement {
+		return nil
+	}
+
+	envFilePath := filepath.Join(app.AppRoot, ".env.local")
+	_, envText, err := ReadProjectEnvFile(envFilePath)
+	var envMap = map[string]string{
+		"DATABASE_URL": `mysql://db:db@db/db`,
+		"MAILER_DSN":   `smtp://127.0.0.1:1025`,
+	}
+
+	switch {
+	case err == nil:
+		util.Warning("Updating %s with %v", envFilePath, envMap)
+		fallthrough
+	case errors.Is(err, os.ErrNotExist):
+		err := WriteProjectEnvFile(envFilePath, envMap, envText)
+		if err != nil {
+			return err
+		}
+	default:
+		util.Warning("error opening %s: %v", envFilePath, err)
+	}
+
+	return nil
+}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -364,6 +364,16 @@ var (
 			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "Super easy vegetarian pasta bake TEST PROJECT"},
 			FilesImageURI:                 "/sites/default/files/Logo.png",
 		},
+		// 20: Contao
+		{
+			Name:                          "TestPkgContao",
+			SourceURL:                     "https://github.com/Morgy93/ddev-test-contao/archive/refs/tags/5.3.tar.gz",
+			ArchiveInternalExtractionPath: "ddev-test-contao-5.3/",
+			DBTarURL:                      "https://github.com/Morgy93/ddev-test-contao/releases/download/5.3/contao_db.sql.tar.gz",
+			Type:                          nodeps.AppTypeContao,
+			Docroot:                       "public",
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "A powerful CMS"},
+		},
 	}
 
 	FullTestSites = TestSites
@@ -2141,7 +2151,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		settingsLocation, err := app.DetermineSettingsPathLocation()
 		assert.NoError(err)
 
-		if app.Type != nodeps.AppTypeShopware6 {
+		if app.Type != nodeps.AppTypeShopware6 && app.Type != nodeps.AppTypeContao {
 			assert.Equal(filepath.Dir(settingsLocation), filepath.Dir(app.SiteSettingsPath))
 		}
 		if nodeps.ArrayContainsString([]string{"drupal6", "drupal7"}, app.Type) {

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/contao
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/contao
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#ddev-generated
+## Description: Run Contao command inside the web container
+## Usage: contao [flags] [args]
+## Example: "ddev contao contao:user:create" or "ddev contao contao:backup:create" (seehttps://docs.contao.org/manual/en/cli/)
+## ProjectTypes: contao,php
+## ExecRaw: true
+
+if [[ ${DDEV_PROJECT_TYPE} != "contao" ]]; then
+        echo "The contao command is only available in the contao project type. You can update this in your project's config file, followed by restarting the DDEV project."
+        exit 1
+fi
+
+CONTAO_BIN="vendor/bin/contao-console"
+
+if [[ ! -f ${CONTAO_BIN} ]]; then
+        echo "${CONTAO_BIN} does not exist in your project root directory."
+        echo "Please verify that you installed contao in your project directory."
+        exit 1
+fi
+
+php vendor/bin/contao-console "$@"

--- a/pkg/ddevapp/schema.json
+++ b/pkg/ddevapp/schema.json
@@ -298,6 +298,7 @@
       "type": "string",
       "enum": [
         "backdrop",
+        "contao",
         "craftcms",
         "django4",
         "drupal",

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -7,7 +7,7 @@ const ConfigInstructions = `
 # name: <projectname> # Name of the project, automatically provides
 #   http://projectname.ddev.site and https://projectname.ddev.site
 
-# type: <projecttype>  # backdrop, craftcms, django4, drupal, drupal6, drupal7, laravel, magento, magento2, php, python, shopware6, silverstripe, typo3, wordpress
+# type: <projecttype>  # backdrop, contao, craftcms, django4, drupal, drupal6, drupal7, laravel, magento, magento2, php, python, shopware6, silverstripe, typo3, wordpress
 # See https://ddev.readthedocs.io/en/stable/users/quickstart/ for more
 # information on the different project types
 # "drupal" covers recent Drupal 8+

--- a/pkg/ddevapp/testdata/TestApptypeDetection/contao/vendor/composer/installed.json
+++ b/pkg/ddevapp/testdata/TestApptypeDetection/contao/vendor/composer/installed.json
@@ -1,0 +1,35 @@
+{
+    "packages": [
+        {
+            "name": "contao/core-bundle",
+            "version": "5.2.8",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Leo Feyer",
+                    "homepage": "https://github.com/leofeyer"
+                },
+                {
+                    "name": "Contao Community",
+                    "homepage": "https://contao.org/contributors"
+                }
+            ],
+            "description": "Contao Open Source CMS",
+            "homepage": "https://contao.org",
+            "support": {
+                "docs": "https://docs.contao.org",
+                "forum": "https://community.contao.org",
+                "issues": "https://github.com/contao/contao/issues",
+                "source": "https://github.com/contao/core-bundle"
+            },
+            "funding": [
+                {
+                    "url": "https://to.contao.org/donate",
+                    "type": "other"
+                }
+            ]
+        }
+    ]
+}

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -85,6 +85,7 @@ const (
 	AppTypeNone         = ""
 	AppTypeBackdrop     = "backdrop"
 	AppTypeCakePHP      = "cakephp"
+	AppTypeContao       = "contao"
 	AppTypeCraftCms     = "craftcms"
 	AppTypeDjango4      = "django4"
 	AppTypeDrupal6      = "drupal6"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

https://contao.org/en/ is not supported officially.

## How This PR Solves The Issue

It adds a new project type called `contao` that adds native support.

## Manual Testing Instructions

Follow new CMS Quickstart section for `contao`.

https://github.com/ddev/ddev/pull/5672/files#diff-cdacb5ab99042792ddb67ee7d62ac1d36c4699992949005880517b4955e10f7e

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

It extends the `TestDdevFullSiteSetup` to test Contao.

https://github.com/Morgy93/ddev-test-contao is used for the test environment which should probably be moved to the DDEV namespace.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

Add a new project typed called `contao` for using the CMS https://contao.org/en/.

