### PR TITLE
docs: add WorkingDirectory= directive to systemd ddev.service example

### DIFF
--- a/docs/content/users/topics/hosting.md
+++ b/docs/content/users/topics/hosting.md
@@ -58,8 +58,10 @@ You may have to restart DDEV with `ddev poweroff && ddev start --all` if Let’s
     # Stop DDEV when Docker shuts down
     # Start with `sudo systemctl start ddev`
     # Enable on boot with `sudo systemctl enable ddev`
-    # Make sure to edit the User= for your user and the
-    # full path to `ddev` on your system.
+    # Make sure to edit the User= for your user, the
+    # WorkingDirectory= ('~' will point it to your user's
+    # home directory) and the full path to `ddev` 
+    # on your system.
     # Optionally give a list of sites instead of --all
     [Unit]
     Description=DDEV sites
@@ -68,6 +70,7 @@ You may have to restart DDEV with `ddev poweroff && ddev start --all` if Let’s
     PartOf=docker.service
     [Service]
     User=rfay
+    WorkingDirectory=~
     Type=oneshot
     ExecStart=/usr/local/bin/ddev start --all
     RemainAfterExit=true


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

ddev.service fails at startup on Ubuntu 22.04 and > 1 ddev projects

## How This PR Solves The Issue

Add the WorkingDirectory= directive to the ddev.service example

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

