### PR TITLE
fix: when settings files not set, don't chmod, fixes #5675

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -253,27 +253,29 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 	// Drupal and WordPress love to change settings files to be unwriteable.
 	// Chmod them to something we can work with in the event that they already
 	// exist.
-	chmodTargets := []string{filepath.Dir(app.SiteSettingsPath), app.SiteDdevSettingsFile}
-	for _, fp := range chmodTargets {
-		fileInfo, err := os.Stat(fp)
-		if err != nil {
-			// We're not doing anything about this error other than warning,
-			// and will have to deal with the same check in settingsCreator.
-			if !os.IsNotExist(err) {
-				util.Warning("Unable to ensure write permissions: %v", err)
+	if app.SiteSettingsPath != "" {
+		chmodTargets := []string{filepath.Dir(app.SiteSettingsPath), app.SiteDdevSettingsFile}
+		for _, fp := range chmodTargets {
+			fileInfo, err := os.Stat(fp)
+			if err != nil {
+				// We're not doing anything about this error other than warning,
+				// and will have to deal with the same check in settingsCreator.
+				if !os.IsNotExist(err) {
+					util.Warning("Unable to ensure write permissions: %v", err)
+				}
+
+				continue
 			}
 
-			continue
-		}
+			perms := 0644
+			if fileInfo.IsDir() {
+				perms = 0755
+			}
 
-		perms := 0644
-		if fileInfo.IsDir() {
-			perms = 0755
-		}
-
-		err = os.Chmod(fp, os.FileMode(perms))
-		if err != nil {
-			return "", fmt.Errorf("could not change permissions on file %s to make it writeable: %v", fp, err)
+			err = os.Chmod(fp, os.FileMode(perms))
+			if err != nil {
+				return "", fmt.Errorf("could not change permissions on file %s to make it writeable: %v", fp, err)
+			}
 		}
 	}
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -197,7 +197,7 @@ func init() {
 		},
 
 		nodeps.AppTypePHP: {
-			postStartAction: phpPostStartAction,
+			postStartAction: nil,
 		},
 
 		nodeps.AppTypePython: {

--- a/pkg/ddevapp/php.go
+++ b/pkg/ddevapp/php.go
@@ -1,14 +1,1 @@
 package ddevapp
-
-import (
-	"fmt"
-)
-
-func phpPostStartAction(app *DdevApp) error {
-	if !app.DisableSettingsManagement {
-		if _, err := app.CreateSettingsFile(); err != nil {
-			return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
## The Issue

* #5675 

Projects with no settings may fail when starting outside homedir. They shouldn't even be chmodding in that case

## How This PR Solves The Issue

* Remove the chmod action if no settings files are configured (as with php project type)
* Completely remove phpPostStartAction as it contained nothing useful. PHP projects never have settings.

## Manual Testing Instructions

Run `ddev start <somephpproject>` in the root directory of a linux machine. It should work fine.
Run `ddev start <somedrupalproject>` in the root directory on linux, it should work and unwriteable settings files should be  chmodded properly.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

