### PR TITLE
docs: fix name of HeidiSQL executable

### DIFF
--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -649,7 +649,7 @@ In general, you can run `ddev get` multiple times without doing any damage. Upda
 
 ## `heidisql`
 
-Open [HeidiSQL](https://www.heidisql.com/) with the current project’s database (global shell host container command). This command is only available if `TablePlus.app` is installed as `C:\Program Files\HeidiSQL\Heidisql.exe`.
+Open [HeidiSQL](https://www.heidisql.com/) with the current project’s database (global shell host container command). This command is only available if `Heidisql.exe` is installed as `C:\Program Files\HeidiSQL\Heidisql.exe`.
 
 Example:
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

Documentation references `TablePlus.app` in HeidiSQL section.

## How This PR Solves The Issue

Documentation now correctly references `Heidisql.exe` in HeidiSQL section.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

