### PR TITLE
docs: fix broken numeration in Pantheon

### DIFF
--- a/docs/content/users/providers/pantheon.md
+++ b/docs/content/users/providers/pantheon.md
@@ -11,7 +11,6 @@ If you have DDEV installed, and have an active Pantheon account with an active s
 1. Get your Pantheon machine token:
    a. Log in to your Pantheon Dashboard and [Generate a Machine Token](https://pantheon.io/docs/machine-tokens/) for DDEV to use.
    b. Add the API token to the `web_environment` section in your global DDEV configuration at `~/.ddev/global_config.yaml`.
-
    ```
    web_environment:
    - TERMINUS_MACHINE_TOKEN=abcdeyourtoken


### PR DESCRIPTION
## The Issue

The list should not start again from 1:
![image](https://github.com/ddev/ddev/assets/24270994/b2e839cd-8ed4-4423-986f-84e608b91335)

## How This PR Solves The Issue

Removes an extra line.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

