### PR TITLE
docs: update quickstart --create-docroot flag

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -35,7 +35,7 @@ Environment variables will be automatically added to your `.env` file to simplif
     cd my-craft-project
 
     # Set up the DDEV environment:
-    ddev config --project-type=craftcms --docroot=web
+    ddev config --project-type=craftcms --docroot=web --create-docroot
 
     # Boot the project and install the starter project:
     ddev start


### PR DESCRIPTION
adding the --create-docroot flag to fix  the following error:

The provided docroot web does not exist. Allow DDEV to create it with the --create-docroot flag.

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
executing  `ddev config --project-type=drupal10 --docroot=web`
throws the following error
`The provided docroot web does not exist. Allow DDEV to create it with the --create-docroot flag.`

## How This PR Solves The Issue
--create-docroot flag will allow to create the web folder

## Manual Testing Instructions
self described 

## Automated Testing Overview

no tests are needed, just run the command

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

