### PR TITLE
fix: make the primary URL https if the custom cert exists

### DIFF
--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"strings"
 
-	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/globalconfig"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/output"
@@ -56,7 +54,7 @@ ddev restart --all`,
 
 			util.Success("Restarted %s", app.GetName())
 			httpURLs, urlList, _ := app.GetAllURLs()
-			if globalconfig.GetCAROOT() == "" || ddevapp.IsRouterDisabled(app) {
+			if app.CanUseHTTPOnly() {
 				urlList = httpURLs
 			}
 			util.Success("Your project can be reached at %s", strings.Join(urlList, " "))

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"strings"
 
+	"github.com/ddev/ddev/pkg/ddevapp"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/output"

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -139,7 +139,7 @@ ddev start --all`,
 
 			util.Success("Successfully started %s", project.GetName())
 			httpURLs, httpsURLs, _ := project.GetAllURLs()
-			if !nodeps.IsGitpod() && !nodeps.IsCodespaces() && (globalconfig.GetCAROOT() == "" || ddevapp.IsRouterDisabled(project)) {
+			if !nodeps.IsGitpod() && !nodeps.IsCodespaces() && (globalconfig.GetCAROOT() == "" || ddevapp.IsRouterDisabled(project)) && !project.IsCustomCert() {
 				httpsURLs = httpURLs
 			}
 			util.Success("Project can be reached at %s", strings.Join(httpsURLs, " "))

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/manifoldco/promptui"
@@ -139,7 +138,7 @@ ddev start --all`,
 
 			util.Success("Successfully started %s", project.GetName())
 			httpURLs, httpsURLs, _ := project.GetAllURLs()
-			if !nodeps.IsGitpod() && !nodeps.IsCodespaces() && (globalconfig.GetCAROOT() == "" || ddevapp.IsRouterDisabled(project)) && !project.IsCustomCert() {
+			if project.CanUseHTTPOnly() {
 				httpsURLs = httpURLs
 			}
 			util.Success("Project can be reached at %s", strings.Join(httpsURLs, " "))

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2675,7 +2675,7 @@ func (app *DdevApp) GetPrimaryURL() string {
 	httpURLs, httpsURLs, _ := app.GetAllURLs()
 	urlList := httpsURLs
 	// If no mkcert trusted https, use the httpURLs instead
-	if !nodeps.IsGitpod() && !nodeps.IsCodespaces() && (globalconfig.GetCAROOT() == "" || IsRouterDisabled(app)) {
+	if !nodeps.IsGitpod() && !nodeps.IsCodespaces() && (globalconfig.GetCAROOT() == "" || IsRouterDisabled(app)) && !app.IsCustomCert() {
 		urlList = httpURLs
 	}
 	if len(urlList) > 0 {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2675,7 +2675,7 @@ func (app *DdevApp) GetPrimaryURL() string {
 	httpURLs, httpsURLs, _ := app.GetAllURLs()
 	urlList := httpsURLs
 	// If no mkcert trusted https, use the httpURLs instead
-	if !nodeps.IsGitpod() && !nodeps.IsCodespaces() && (globalconfig.GetCAROOT() == "" || IsRouterDisabled(app)) && !app.IsCustomCert() {
+	if app.CanUseHTTPOnly() {
 		urlList = httpURLs
 	}
 	if len(urlList) > 0 {

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,7 +54,7 @@ func TestExtraPortExpose(t *testing.T) {
 
 	// Careful with portsToTest because https ports won't work on GitHub Actions Colima tests (although they work fine on normal Mac)
 	portsToTest := []string{"3000", "4000"}
-	if !nodeps.IsGitpod() && !nodeps.IsCodespaces() && (globalconfig.GetCAROOT() == "" || ddevapp.IsRouterDisabled(app)) {
+	if app.CanUseHTTPOnly() {
 		portsToTest = []string{"2999", "3999"}
 	}
 

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -484,7 +484,16 @@ func (app *DdevApp) GetRelativeWorkingDirectory() string {
 	return app.GetRelativeDirectory(pwd)
 }
 
-func (app *DdevApp) IsCustomCert() bool {
+// HasCustomCert returns true if the project uses a custom certificate
+func (app *DdevApp) HasCustomCert() bool {
 	customCertsPath := app.GetConfigPath("custom_certs")
 	return fileutil.FileExists(filepath.Join(customCertsPath, fmt.Sprintf("%s.crt", app.Name)))
+}
+
+// CanUseHTTPOnly returns true if the project can be accessed via http only
+func (app *DdevApp) CanUseHTTPOnly() bool {
+	return !nodeps.IsGitpod() &&
+		!nodeps.IsCodespaces() &&
+		(globalconfig.GetCAROOT() == "" || IsRouterDisabled(app)) &&
+		!app.HasCustomCert()
 }

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -483,3 +483,8 @@ func (app *DdevApp) GetRelativeWorkingDirectory() string {
 	pwd, _ := os.Getwd()
 	return app.GetRelativeDirectory(pwd)
 }
+
+func (app *DdevApp) IsCustomCert() bool {
+	customCertsPath := app.GetConfigPath("custom_certs")
+	return fileutil.FileExists(filepath.Join(customCertsPath, fmt.Sprintf("%s.crt", app.Name)))
+}


### PR DESCRIPTION
## The Issue
When the command determines a primary URL, it creates a `http` URL even if you're using custom certs.

## How This PR Solves The Issue
The URL will now have a `https` schema if you have custom certs.

## Manual Testing Instructions
Use a custom cert in the config. You can test using my [public wildcard cert](https://github.com/tbmatuka/php-apache-nodejs-development/tree/master/dev/.docker-config/ssl) and `project_tld: loc-dev.com`

## Automated Testing Overview
The function is used in a lot of places, so if I broke something, tests should fail.

## Release/Deployment Notes
None?
