### PR TITLE
feat: add a comment to the top of global_config.yaml to warn that comments are not preserved

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -292,6 +292,13 @@ func WriteGlobalConfig(config GlobalConfig) error {
 		return err
 	}
 
+	// Prepend a warning that comments in the file are not preserved.
+	warning := `
+# WARNING: This file gets automatically re-generated. Any custom comments will
+# NOT be preserved.
+`
+	cfgbytes = append(warning, cfgbytes)
+
 	// Append current image information
 	instructions := `
 # You can turn off usage of the


### PR DESCRIPTION
## The Issue

global_config.yaml gets regenerated automatically, and any comments the user added are lost.

Because this is a config files that docs say users can edit manually, users will assume they can put in comments, and may lose valuable information.

## How This PR Solves The Issue

Adds a warning to the top of the file to say comments won't be preserved.

(NB I have no idea what I am doing with Go, this is total frankencoding!)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

