### PR TITLE
feat: create db query log command, fixes #5689

### DIFF
--- a/pkg/ddevapp/dotddev_assets/commands/db/dblog
+++ b/pkg/ddevapp/dotddev_assets/commands/db/dblog
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Turn on query logging for diagnostic purposes.
+## Usage: dblog on|off|tail
+## Example: "ddev dblog on" or "ddev dblog off" or "ddev dblog tail"
+## DBTypes: mysql,mariadb
+## ExecRaw: true
+
+case "$@" in
+  on)
+    state=1
+    ;;
+  off)
+    state=0
+    ;;
+  tail)
+    state=1
+    previous_state=$(mysql -u root -proot -e "SHOW VARIABLES LIKE 'general_log'\G;" | awk '/Value:/ { print $2 }')
+    trap ctrl_c INT
+    ;;
+  *)
+    echo "Tell us whether you want the query log on or off, or if you want to tail it."
+    echo "Usage: querylog on|off|tail"
+    exit 1
+    ;;
+esac
+
+function ctrl_c() {
+  if [ "$previous_state" = "OFF" ]; then
+    echo "Turning off general log..."
+    mysql -u root -proot -e "SET global general_log = 0"
+  fi
+  echo "Goodbye."
+  exit 0
+}
+
+mysql -u root -proot <<EOX
+SET global general_log = $state;
+SET global log_output = 'file';
+SET global general_log_file = '/tmp/dblog';
+EOX
+
+if [ "$@" = "tail" ]; then
+  tail -f /tmp/dblog
+fi


### PR DESCRIPTION
Create initial version of db query log command

This command should probably be expanded to be mysql or pgsql neutral (or a separate version written for pgsql parity).

Fixes: [#5869](https://github.com/ddev/ddev/issues/5689)

## The Issue
While using frameworks that use db abstraction layers, it can be difficult to see what queries are actually being executed on the database. While there are numerous ways to solve for this, this command contribution aims to make it dead simple for a developer to turn on/off query logging and tail it if needed.

## How This PR Solves The Issue
We create a command that allows a user to (for example) tail the actual db queries with a simple `ddev dblog tail`

## Manual Testing Instructions
Run `ddev dblog on` and verify that queries are being logged inside the db container at /tmp/dblog <--May want to use standard /var/log/query.log or /home/mysql/query.log

Run `ddev dblog off` and verify that queries are no longer being logged inside the db container. 

Run `ddev dblog tail` and verify that you are now successfully tailing the queries in your terminal window. Hit CTRL+C to break out of it, and observe that the dblog state is reverted to its previous state, and a goodbye message is printed.

## Related Issue Link(s)
No related issues.

## Release/Deployment Notes
Do default commands get documented somewhere? If so, this merge request should probably also include documentation. 

This merge request will not change anything for users or for current installations unless a user chooses to run the contributed command.

This was inspired by the xdebug on|off command and a short [post by Dries Buytaert](https://dri.es/effortless-inspecting-of-drupal-database-queries).

