### PR TITLE
fix: remove --json-output flag from `logs` command, fixes #962

### DIFF
--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -43,6 +43,21 @@ func init() {
 	DdevLogsCmd.Flags().BoolVarP(&timestamp, "time", "t", false, "Add timestamps to logs")
 	DdevLogsCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Defines the service to retrieve logs from. [e.g. web, db]")
 	DdevLogsCmd.Flags().StringVarP(&tail, "tail", "", "", "How many lines to show")
-	RootCmd.AddCommand(DdevLogsCmd)
 
+	// JSON formatted output isn't supported, so we should hide the global --json-output flag
+	// We have to do that within the help function, since the global flag hasn't been added yet during init()
+	originalHelpFunc := DdevLogsCmd.HelpFunc()
+	DdevLogsCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		_ = command.Flags().MarkHidden("json-output")
+		originalHelpFunc(command, strings)
+	})
+	// We need to do the same with the flag error function in case flags can't be parsed correctly,
+	// because that output (although identical to the help function) is generated separately.
+	originalErrorFunc := DdevLogsCmd.FlagErrorFunc()
+	DdevLogsCmd.SetFlagErrorFunc(func(command *cobra.Command, err error) error {
+		_ = command.Flags().MarkHidden("json-output")
+		return originalErrorFunc(command, err)
+	})
+
+	RootCmd.AddCommand(DdevLogsCmd)
 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue


`ddev logs` doesn't support JSON formatted output, and there's no clear way to add that functionality given the way the logs are currently fetched and outputted.
This is discussed in #962 

## How This PR Solves The Issue

We don't display the flag when running `ddev help logs` or `ddev logs -h`.
This is the same way this is handled for the composer command (see [composer.go](https://github.com/ddev/ddev/blob/9b30cac3f0c7201da56611b5ed4cde6fead56de8/cmd/ddev/cmd/composer.go#L51-L56)) and custom commands (see [commands.go](https://github.com/ddev/ddev/blob/9b30cac3f0c7201da56611b5ed4cde6fead56de8/cmd/ddev/cmd/commands.go#L232-L238))

## Manual Testing Instructions
Run `ddev help logs` and `ddev logs -h` - the `--json-output` flag shouldn't be shown as an option.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
No automated tests added - I couldn't find associated tests for composer or for custom commands so it didn't seem sensible to add them for this.

## Related Issue Link(s)

https://github.com/ddev/ddev/issues/962

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
Doesn't affect deployments.

