### PR TITLE
feat: allow global host commands to be run from anywhere, for #4416

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -544,6 +544,7 @@ rfay
 rmi
 rsync
 running
+CanRunGlobally
 runtime
 rw
 s

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/mattn/go-isatty"
@@ -35,8 +36,30 @@ func IsUserDefinedCustomCommand(cmd *cobra.Command) bool {
 // .ddev/commands/<servicename> and .ddev/commands/host
 // and if it finds them adds them to Cobra's commands.
 func addCustomCommands(rootCmd *cobra.Command) error {
+	// Custom commands are shell scripts - so we can't use them on windows without bash.
+	if runtime.GOOS == "windows" {
+		windowsBashPath := util.FindBashPath()
+		if windowsBashPath == "" {
+			fmt.Println("Unable to find bash.exe in PATH, not loading custom commands")
+			return nil
+		}
+	}
+
+	// Keep a map so we don't add multiple commands with the same name.
+	commandsAdded := map[string]int{}
+
 	app, err := ddevapp.GetActiveApp("")
+	// If we're not running ddev inside a project directory, we should still add any host commands that can run without one.
 	if err != nil {
+		globalHostCommandPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands", "host")
+		commandFiles, err := fileutil.ListFilesInDir(globalHostCommandPath)
+		if err != nil {
+			return err
+		}
+		err = addCustomCommandsFromDir(rootCmd, nil, globalHostCommandPath, commandFiles, true, commandsAdded)
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -47,15 +70,13 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	commandsAdded := map[string]int{}
+
 	for _, commandSet := range []string{projectCommandPath, copiedGlobalCommandPath} {
 		commandDirs, err := fileutil.ListFilesInDirFullPath(commandSet)
 		if err != nil {
 			return err
 		}
 		for _, serviceDirOnHost := range commandDirs {
-			service := filepath.Base(serviceDirOnHost)
-
 			// If the item isn't a directory, skip it.
 			if !fileutil.IsDirectory(serviceDirOnHost) {
 				continue
@@ -64,197 +85,208 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 			if err != nil {
 				return err
 			}
-			if runtime.GOOS == "windows" {
-				windowsBashPath := util.FindBashPath()
-				if windowsBashPath == "" {
-					fmt.Println("Unable to find bash.exe in PATH, not loading custom commands")
-					return nil
-				}
-			}
-
-			for _, commandName := range commandFiles {
-				// Use path.Join() for the inContainerFullPath because it'serviceDirOnHost about the path in the container, not on the
-				// host; a Windows path is not useful here.
-				inContainerFullPath := path.Join("/mnt/ddev_config", filepath.Base(commandSet), service, commandName)
-				onHostFullPath := filepath.Join(commandSet, service, commandName)
-
-				if strings.HasSuffix(commandName, ".example") || strings.HasPrefix(commandName, "README") || strings.HasPrefix(commandName, ".") || fileutil.IsDirectory(onHostFullPath) {
-					continue
-				}
-
-				// If command has already been added, we won't work with it again.
-				if _, ok := commandsAdded[commandName]; ok {
-					continue
-				}
-
-				// Any command we find will want to be executable on Linux
-				_ = os.Chmod(onHostFullPath, 0755)
-				if hasCR, _ := fileutil.FgrepStringInFile(onHostFullPath, "\r\n"); hasCR {
-					util.Warning("Command '%s' contains CRLF, please convert to Linux-style linefeeds with dos2unix or another tool, skipping %s", commandName, onHostFullPath)
-					continue
-				}
-
-				directives := findDirectivesInScriptCommand(onHostFullPath)
-				var description, usage, example, projectTypes, osTypes, hostBinaryExists, dbTypes string
-
-				description = commandName
-				if val, ok := directives["Description"]; ok {
-					description = val
-				}
-
-				usage = commandName + " [flags] [args]"
-				if val, ok := directives["Usage"]; ok {
-					usage = val
-				}
-
-				if val, ok := directives["Example"]; ok {
-					example = "  " + strings.ReplaceAll(val, `\n`, "\n  ")
-				}
-
-				// Init and import flags
-				var flags Flags
-				flags.Init(commandName, onHostFullPath)
-
-				disableFlags := true
-				if val, ok := directives["Flags"]; ok {
-					disableFlags = false
-					if err = flags.LoadFromJSON(val); err != nil {
-						util.Warning("Error '%s', command '%s' contains an invalid flags definition '%s', skipping add flags of %s", err, commandName, val, onHostFullPath)
-					}
-				}
-
-				// Import and handle ProjectTypes
-				if val, ok := directives["ProjectTypes"]; ok {
-					projectTypes = val
-				}
-
-				// Default is to exec with Bash interpretation (not raw)
-				execRaw := false
-				if val, ok := directives["ExecRaw"]; ok {
-					if val == "true" {
-						execRaw = true
-					}
-				}
-
-				// If ProjectTypes is specified and we aren't of that type, skip
-				if projectTypes != "" && !strings.Contains(projectTypes, app.Type) {
-					continue
-				}
-
-				// Import and handle OSTypes
-				if val, ok := directives["OSTypes"]; ok {
-					osTypes = val
-				}
-
-				// If OSTypes is specified and we aren't on one of the specified OSes, skip
-				if osTypes != "" {
-					if !strings.Contains(osTypes, runtime.GOOS) && !(strings.Contains(osTypes, "wsl2") && nodeps.IsWSL2()) {
-						continue
-					}
-				}
-
-				// Import and handle HostBinaryExists
-				if val, ok := directives["HostBinaryExists"]; ok {
-					hostBinaryExists = val
-				}
-
-				// If hostBinaryExists is specified it doesn't exist here, skip
-				if hostBinaryExists != "" {
-					binExists := false
-					bins := strings.Split(hostBinaryExists, ",")
-					for _, bin := range bins {
-						if fileutil.FileExists(bin) {
-							binExists = true
-							break
-						}
-					}
-					if !binExists {
-						continue
-					}
-				}
-
-				// Import and handle DBTypes
-				if val, ok := directives["DBTypes"]; ok {
-					dbTypes = val
-				}
-
-				// If DBTypes is specified and we aren't using that DBTypes
-				if dbTypes != "" {
-					if !strings.Contains(dbTypes, app.Database.Type) {
-						continue
-					}
-				}
-
-				// Create proper description suffix
-				descSuffix := " (shell " + service + " container command)"
-				if commandSet == copiedGlobalCommandPath {
-					descSuffix = " (global shell " + service + " container command)"
-				}
-
-				// Initialize the new command
-				commandToAdd := &cobra.Command{
-					Use:                usage,
-					Short:              description + descSuffix,
-					Example:            example,
-					DisableFlagParsing: disableFlags,
-					FParseErrWhitelist: cobra.FParseErrWhitelist{
-						UnknownFlags: true,
-					},
-				}
-
-				// Add flags to command
-				if err = flags.AssignToCommand(commandToAdd); err != nil {
-					util.Warning("Error '%s' in the flags definition for command '%s', skipping %s", err, commandName, onHostFullPath)
-					continue
-				}
-
-				// Execute the command matching the host working directory relative
-				// to the app root.
-				relative := false
-				if val, ok := directives["HostWorkingDir"]; ok {
-					if val == "true" {
-						relative = true
-					}
-				}
-
-				if service == "host" {
-					commandToAdd.Run = makeHostCmd(app, onHostFullPath, commandName)
-				} else {
-					commandToAdd.Run = makeContainerCmd(app, inContainerFullPath, commandName, service, execRaw, relative)
-				}
-
-				if disableFlags {
-					// Hide -h because we are disabling flags
-					// Also hide --json-output for the same reason
-					// @see https://github.com/spf13/cobra/issues/1328
-					commandToAdd.InitDefaultHelpFlag()
-					err = commandToAdd.Flags().MarkHidden("help")
-					originalHelpFunc := commandToAdd.HelpFunc()
-					if err == nil {
-						commandToAdd.SetHelpFunc(func(command *cobra.Command, strings []string) {
-							_ = command.Flags().MarkHidden("json-output")
-							originalHelpFunc(command, strings)
-						})
-					}
-				}
-
-				// Mark custom command
-				if commandToAdd.Annotations == nil {
-					commandToAdd.Annotations = map[string]string{}
-				}
-
-				commandToAdd.Annotations[CustomCommand] = "true"
-				if ddevapp.IsBundledCustomCommand(commandSet == copiedGlobalCommandPath, service, commandName) {
-					commandToAdd.Annotations[BundledCustomCommand] = "true"
-				}
-
-				// Add the command and mark as added
-				rootCmd.AddCommand(commandToAdd)
-				commandsAdded[commandName] = 1
+			err = addCustomCommandsFromDir(rootCmd, app, serviceDirOnHost, commandFiles, commandSet == copiedGlobalCommandPath, commandsAdded)
+			if err != nil {
+				return err
 			}
 		}
 	}
 
+	return nil
+}
+
+// addCustomCommandsFromDir adds the custom commands from inside a given directory
+func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serviceDirOnHost string, commandFiles []string, isGlobalSet bool, commandsAdded map[string]int) error {
+	service := filepath.Base(serviceDirOnHost)
+	var err error
+
+	for _, commandName := range commandFiles {
+		// Use path.Join() for the inContainerFullPath because it's about the path in the container, not on the
+		// host; a Windows path is not useful here.
+		inContainerFullPath := path.Join("/mnt/ddev_config", filepath.Base(filepath.Dir(serviceDirOnHost)), service, commandName)
+		onHostFullPath := filepath.Join(serviceDirOnHost, commandName)
+
+		if strings.HasSuffix(commandName, ".example") || strings.HasPrefix(commandName, "README") || strings.HasPrefix(commandName, ".") || fileutil.IsDirectory(onHostFullPath) {
+			continue
+		}
+
+		// If command has already been added, we won't work with it again.
+		if _, ok := commandsAdded[commandName]; ok {
+			continue
+		}
+
+		// Any command we find will want to be executable on Linux
+		_ = os.Chmod(onHostFullPath, 0755)
+		if hasCR, _ := fileutil.FgrepStringInFile(onHostFullPath, "\r\n"); hasCR {
+			util.Warning("Command '%s' contains CRLF, please convert to Linux-style linefeeds with dos2unix or another tool, skipping %s", commandName, onHostFullPath)
+			continue
+		}
+
+		directives := findDirectivesInScriptCommand(onHostFullPath)
+		var description, usage, example, projectTypes, osTypes, hostBinaryExists, dbTypes string
+
+		// Skip host commands that need a project if we aren't in a project directory.
+		if service == "host" && app == nil {
+			if val, ok := directives["CanRunGlobally"]; !ok || val != "true" {
+				continue
+			}
+		}
+
+		description = commandName
+		if val, ok := directives["Description"]; ok {
+			description = val
+		}
+
+		usage = commandName + " [flags] [args]"
+		if val, ok := directives["Usage"]; ok {
+			usage = val
+		}
+
+		if val, ok := directives["Example"]; ok {
+			example = "  " + strings.ReplaceAll(val, `\n`, "\n  ")
+		}
+
+		// Init and import flags
+		var flags Flags
+		flags.Init(commandName, onHostFullPath)
+
+		disableFlags := true
+		if val, ok := directives["Flags"]; ok {
+			disableFlags = false
+			if err = flags.LoadFromJSON(val); err != nil {
+				util.Warning("Error '%s', command '%s' contains an invalid flags definition '%s', skipping add flags of %s", err, commandName, val, onHostFullPath)
+			}
+		}
+
+		// Import and handle ProjectTypes
+		if val, ok := directives["ProjectTypes"]; ok {
+			projectTypes = val
+		}
+
+		// Default is to exec with Bash interpretation (not raw)
+		execRaw := false
+		if val, ok := directives["ExecRaw"]; ok {
+			if val == "true" {
+				execRaw = true
+			}
+		}
+
+		// If ProjectTypes is specified and we aren't of that type, skip
+		if projectTypes != "" && (app == nil || !strings.Contains(projectTypes, app.Type)) {
+			continue
+		}
+
+		// Import and handle OSTypes
+		if val, ok := directives["OSTypes"]; ok {
+			osTypes = val
+		}
+
+		// If OSTypes is specified and we aren't on one of the specified OSes, skip
+		if osTypes != "" {
+			if !strings.Contains(osTypes, runtime.GOOS) && !(strings.Contains(osTypes, "wsl2") && nodeps.IsWSL2()) {
+				continue
+			}
+		}
+
+		// Import and handle HostBinaryExists
+		if val, ok := directives["HostBinaryExists"]; ok {
+			hostBinaryExists = val
+		}
+
+		// If hostBinaryExists is specified it doesn't exist here, skip
+		if hostBinaryExists != "" {
+			binExists := false
+			bins := strings.Split(hostBinaryExists, ",")
+			for _, bin := range bins {
+				if fileutil.FileExists(bin) {
+					binExists = true
+					break
+				}
+			}
+			if !binExists {
+				continue
+			}
+		}
+
+		// Import and handle DBTypes
+		if val, ok := directives["DBTypes"]; ok {
+			dbTypes = val
+		}
+
+		// If DBTypes is specified and we aren't using that DBTypes
+		if dbTypes != "" && app != nil {
+			if !strings.Contains(dbTypes, app.Database.Type) {
+				continue
+			}
+		}
+
+		// Create proper description suffix
+		descSuffix := " (shell " + service + " container command)"
+		if isGlobalSet {
+			descSuffix = " (global shell " + service + " container command)"
+		}
+
+		// Initialize the new command
+		commandToAdd := &cobra.Command{
+			Use:                usage,
+			Short:              description + descSuffix,
+			Example:            example,
+			DisableFlagParsing: disableFlags,
+			FParseErrWhitelist: cobra.FParseErrWhitelist{
+				UnknownFlags: true,
+			},
+		}
+
+		// Add flags to command
+		if err = flags.AssignToCommand(commandToAdd); err != nil {
+			util.Warning("Error '%s' in the flags definition for command '%s', skipping %s", err, commandName, onHostFullPath)
+			continue
+		}
+
+		// Execute the command matching the host working directory relative
+		// to the app root.
+		relative := false
+		if val, ok := directives["HostWorkingDir"]; ok {
+			if val == "true" {
+				relative = true
+			}
+		}
+
+		if service == "host" {
+			commandToAdd.Run = makeHostCmd(app, onHostFullPath, commandName)
+		} else {
+			commandToAdd.Run = makeContainerCmd(app, inContainerFullPath, commandName, service, execRaw, relative)
+		}
+
+		if disableFlags {
+			// Hide -h because we are disabling flags
+			// Also hide --json-output for the same reason
+			// @see https://github.com/spf13/cobra/issues/1328
+			commandToAdd.InitDefaultHelpFlag()
+			err = commandToAdd.Flags().MarkHidden("help")
+			originalHelpFunc := commandToAdd.HelpFunc()
+			if err == nil {
+				commandToAdd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+					_ = command.Flags().MarkHidden("json-output")
+					originalHelpFunc(command, strings)
+				})
+			}
+		}
+
+		// Mark custom command
+		if commandToAdd.Annotations == nil {
+			commandToAdd.Annotations = map[string]string{}
+		}
+
+		commandToAdd.Annotations[CustomCommand] = "true"
+		if ddevapp.IsBundledCustomCommand(isGlobalSet, service, commandName) {
+			commandToAdd.Annotations[BundledCustomCommand] = "true"
+		}
+
+		// Add the command and mark as added
+		rootCmd.AddCommand(commandToAdd)
+		commandsAdded[commandName] = 1
+	}
 	return nil
 }
 
@@ -266,18 +298,23 @@ func makeHostCmd(app *ddevapp.DdevApp, fullPath, name string) func(*cobra.Comman
 	}
 
 	return func(cmd *cobra.Command, cobraArgs []string) {
-		status, _ := app.SiteStatus()
+		if app != nil {
+			status, _ := app.SiteStatus()
+			app.DockerEnv()
+			_ = os.Setenv("DDEV_PROJECT_STATUS", status)
+		} else {
+			_ = os.Setenv("DDEV_PROJECT_STATUS", "")
+		}
 
-		app.DockerEnv()
-
-		_ = os.Setenv("DDEV_PROJECT_STATUS", status)
 		osArgs := []string{}
 		if len(os.Args) > 2 {
 			osArgs = os.Args[2:]
 		}
 		var err error
 		// Load environment variables that may be useful for script.
-		app.DockerEnv()
+		if app != nil {
+			app.DockerEnv()
+		}
 		if runtime.GOOS == "windows" {
 			// Sadly, not sure how to have a Bash interpreter without this.
 			args := []string{fullPath}

--- a/cmd/ddev/cmd/testdata/TestCustomCommands/global_commands/host/testhostglobal-noproject
+++ b/cmd/ddev/cmd/testdata/TestCustomCommands/global_commands/host/testhostglobal-noproject
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: testhostglobal-noproject global
+## Usage: testhostglobal-noproject
+## Example: "ddev testhostglobal-noproject"
+## CanRunGlobally: true
+
+echo "testhostglobal-noproject was executed with args=$@ on host $(hostname)"

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -186,6 +186,21 @@ The following fields can be used for a flag definition:
 * `NoOptDefVal`: default value, if the flag is on the command line without any options
 * `Annotations`: used by cobra.Command Bash autocomplete code (see <https://github.com/spf13/cobra/blob/main/site/content/completions/bash.md>)
 
+### "CanRunGlobally" Annotation
+
+This annotation is only available for global host commands.
+
+Use `CanRunGlobally: true` if your global host command can be safely run even if the current working directory isn't inside a DDEV project.
+
+This will make your command available to run regardless of what your current working directory is when you run it.
+
+This annotation will have no effect if you are also using one of the following annotations:
+
+* `ProjectTypes`
+* `DBTypes`
+
+Example: `## CanRunGlobally: true`
+
 ### “ProjectTypes” Annotation
 
 If your command should only be visible for a specific project type, `ProjectTypes` will allow you to define the supported types. This is especially useful for global custom commands. See [Quickstart for many CMSes](../../users/quickstart.md) for more information about the supported project types. Multiple types are separated by a comma.

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -5,6 +5,7 @@
 ## Description: Explain how to upgrade DDEV
 ## Usage: self-upgrade
 ## Example: "ddev self-upgrade"
+## CanRunGlobally: true
 
 mypath=$(which ddev)
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

Custom global host commands currently only be run inside a project directory - even if they don't need a project in order to do their stuff.

A great example of this is `ddev self-upgrade` which should be able to run from anywhere - but currently it has to be run from inside a project directory.

## How This PR Solves The Issue

This PR adds a new `CanRunGlobally` annotation. If custom global host commands set this annotation to `true`, they will be added to the cobra command set, and can be run from anywhere, even outside project directories.

## Manual Testing Instructions

1. Run `ddev help` - you should see the `self-upgrade` command there.
1. Run `ddev self-upgrade` - it should work from anywhere, even outside a project directory.
1. Add `## CanRunGlobally: true` to a custom global host command, then perform the first two steps again, but with your custom command rather than `self-upgrade`.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

I've added checks for the following the following:
- Check a global host command with `CanRunGlobally: true` shows and can be run from arbitrary working directories
- Check a global host command with `CanRunGlobally: true` still shows and can be run from inside a project directory
- Check commands without `CanRunGlobally: true` do not show from arbitrary working directories

This is my first time really looking at how to add tests and I've gone in with a fairly light touch - if you want more test coverage I'll be happy to add it.

## Related Issue Link(s)

- https://github.com/ddev/ddev/issues/4416

**NOTE:** This PR will be one of several iterative features that together will fulfil the requirements set forth in that issue. The issue should not be closed until all of its requirements are fulfilled.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
Anyone who maintains a DDEV extension or who has some custom commands in projects they manage should review their custom global host commands, and add the new `CanRunGlobally` annotation to any commands that should be allowed to run even outside of project directories.

