### PR TITLE
Add --create-docroot flag to Drupal 9/10 quickstarters

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -109,7 +109,7 @@ ddev launch
     ```bash
     mkdir my-drupal10-site
     cd my-drupal10-site
-    ddev config --project-type=drupal10 --docroot=web
+    ddev config --project-type=drupal10 --docroot=web --create-docroot
     ddev start
     ddev composer create drupal/recommended-project
     ddev composer require drush/drush
@@ -123,7 +123,7 @@ ddev launch
     ```bash
     mkdir my-drupal9-site
     cd my-drupal9-site
-    ddev config --project-type=drupal9 --docroot=web
+    ddev config --project-type=drupal9 --docroot=web --create-docroot
     ddev start
     ddev composer create "drupal/recommended-project:^9"
     ddev composer require drush/drush


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

DDEV version v1.22.4, following the quickstart commands for Drupal 10, after `mkdir` and `cd` running `ddev config --project-type=drupal10 --docroot=web` like in the quickstart without the `--create-docroot` flag returns the following error and after that you can't run the subsequent commands because the config.yml didn't got created.

> The provided docroot web does not exist. Allow DDEV to create it with the --create-docroot flag.

Next you do `ddev start` and then you get:

> Failed to get project(s): could not find a project in /Users/leymannx/Sites/my-drupal10-site. Have you run 'ddev config'? Please specify a project name or change directories: no .ddev/config.yaml file was found in this directory or any parent

## How This PR Solves The Issue

Add `--create-docroot` flag to Drupal 9/10 quickstart guide to prevent the above issue.

## Manual Testing Instructions

Follow the Drupal 9/10 quickstart guide again.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

