### PR TITLE
fix: use init option to prevent zombie ddev-router, for #5705

### DIFF
--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -1,10 +1,10 @@
 services:
   ddev-router:
     image: {{ .router_image }}
-    # Prevent zombie container
-    init: true
 
     {{ if eq .Router "traefik" }}
+    # Prevent zombie container
+    init: true
     command:
       - --configFile=/mnt/ddev-global-cache/traefik/static_config.yaml
     user: {{ .UID }}:{{ .GID }}

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -1,6 +1,8 @@
 services:
   ddev-router:
     image: {{ .router_image }}
+    # Prevent zombie container
+    init: true
 
     {{ if eq .Router "traefik" }}
     command:


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #5705

> API error (500): Could not kill running container d8079abded3b448b54fc3d22bc0abfe10ffbeb69cd7066027655bbf5598992d5, cannot remove - container d8079abded3b PID 1968501 is zombie and can not be killed. Use the --init option when creating containers to run an init inside the container that forwards signals and reaps processes

## How This PR Solves The Issue

The error suggests to use `init`, it doesn't harm to try it for `ddev-router`:

> Use the --init option when creating containers to run an init inside the container that forwards signals and reaps processes

## Manual Testing Instructions

I cannot reproduce this error, at least it should not break the tests. See the issue.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- https://stackoverflow.com/questions/49162358/docker-init-zombies-why-does-it-matter

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

