### PR TITLE
docs: expand docs on PHP extension installation, including pecl

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -27,7 +27,7 @@ If a PHP extension is supported by the upstream package management from `deb.sur
 !!!tip "Few people need pecl extensions"
     Most people don't need to install PHP extensions that aren't supported by `deb.sury.org`, so you only need to go down this path if you have very particular needs.
 
-If a PHP extension is not supported by the upstream package management from `deb.sury.org`, you'll  install it via pecl using a `.ddev/web-build/Dockerfile`.  You can search for the extension on [pecl.php.net](https://pecl.php.net/) to find the package name. (This technique can also be used to get newer versions of PHP extensions than are available in the `deb.sury.org` distribution.)
+If a PHP extension is not supported by the upstream package management from `deb.sury.org`, you'll install it via pecl using a `.ddev/web-build/Dockerfile`. You can search for the extension on [pecl.php.net](https://pecl.php.net/) to find the package name. (This technique can also be used to get newer versions of PHP extensions than are available in the `deb.sury.org` distribution.)
 
 For example, a `.ddev/web-build/Dockerfile.mcrypt` might look like this:
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -43,7 +43,7 @@ RUN echo "extension=${extension}.so" > /etc/php/${DDEV_PHP_VERSION}/mods-availab
 RUN phpenmod ${extension}
 ```
 
-A Dockerfile.xlswriter to add `xlswriter` might be:
+A `.ddev/web-build/Dockerfile.xlswriter` to add `xlswriter` might be:
 
 ```dockerfile
 ENV extension=xlswriter

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -58,7 +58,7 @@ RUN phpenmod ${extension}
 
 ```
 
-A `.ddev/web-build/Dockerfile.xdebug` (overriding the deb.sury.org version) might look like this:
+A `.ddev/web-build/Dockerfile.xdebug` (overriding the `deb.sury.org` version) might look like this:
 
 ```dockerfile
 # This example installs xdebug from pecl instead of the standard deb.sury.org package


### PR DESCRIPTION
## The Issue

Several recent discussions in Discord have shown people floundering with adding extra PHP extensions. This adds more detail about how to add both deb.sury.org-supported extensions and pecl extensions.

* https://discordapp.com/channels/664580571770388500/1195343397238616124
* https://discordapp.com/channels/664580571770388500/1197477136215330827

Review new content at https://ddev--5715.org.readthedocs.build/en/5715/users/extend/customizing-images/#adding-php-extensions (and a bit above there)