### PR TITLE
fix: make xhprof faster, fixes #5712

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/xhprof/xhprof_prepend.php
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/xhprof/xhprof_prepend.php
@@ -11,7 +11,7 @@ if (!empty($_SERVER) && array_key_exists('REQUEST_URI', $_SERVER)) {
 // Enable xhprof profiling if we're not on an xhprof page
 if (extension_loaded('xhprof') && strpos($uri, '/xhprof') === false) {
   // If this is too much information, just use xhprof_enable(), which shows CPU only
-  xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY);
+  xhprof_enable(XHPROF_FLAGS_MEMORY);
   register_shutdown_function('xhprof_completion');
 }
 

--- a/docs/content/users/debugging-profiling/xhprof-profiling.md
+++ b/docs/content/users/debugging-profiling/xhprof-profiling.md
@@ -20,7 +20,7 @@ You can change the contents of the `xhprof_prepend` function in `.ddev/xhprof/xh
 
 For example, you may want to add a link to the profile run to the bottom of the profiled web page. The provided `xhprof_prepend.php` has comments and a sample function to do that, which works with Drupal 7. If you change it, remove the `#ddev-generated` line from the top, and check it in (`git add -f .ddev/xhprof/xhprof_prepend.php`).
 
-Another example: you could exclude memory profiling so there are fewer columns to study. Change `xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY);` to `xhprof_enable(XHPROF_FLAGS_CPU);` in `.ddev/xhprof/xhprof_prepend.php` and remove the `#ddev-generated` at the top of the file. See the docs on [xhprof_enable()](https://www.php.net/manual/en/function.xhprof-enable.php).
+Another example: you could exclude memory profiling so there are fewer columns to study. Change `xhprof_enable(XHPROF_FLAGS_MEMORY);` to `xhprof_enable();` in `.ddev/xhprof/xhprof_prepend.php` and remove the `#ddev-generated` at the top of the file. See the docs on [xhprof_enable()](https://www.php.net/manual/en/function.xhprof-enable.php).
 
 ## Information Links
 

--- a/pkg/ddevapp/dotddev_assets/xhprof/xhprof_prepend.php
+++ b/pkg/ddevapp/dotddev_assets/xhprof/xhprof_prepend.php
@@ -19,7 +19,7 @@ if (!empty($_SERVER) && array_key_exists('REQUEST_URI', $_SERVER)) {
 // Enable xhprof profiling if we're not on an xhprof page
 if (extension_loaded('xhprof') && strpos($uri, '/xhprof') === false) {
   // If this is too much information, just use xhprof_enable(), which shows CPU only
-  xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY);
+  xhprof_enable(XHPROF_FLAGS_MEMORY);
   register_shutdown_function('xhprof_completion');
 }
 


### PR DESCRIPTION
## The Issue

xhprof_prepend.php uses:

```
xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY);
```

This makes xhprof unnecessary slow. (~ 50% more overhead on function calls)

## How This PR Solves The Issue

It uses just:

```
xhprof_enable(XHPROF_FLAGS_MEMORY);
```

## Manual Testing Instructions

Ensure that xhprof output does no longer show the CPU columns and generally has less function call overhead.

## Automated Testing Overview

Tests should not be affected, because they only test the existence of a run and not the run itself.

## Related Issue Link(s)

#5712 

## Release/Deployment Notes

None