### PR TITLE
feat: Platform.sh specific app pull, fixes #5727

### DIFF
--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -42,23 +42,23 @@ web_environment:
 4. Run `ddev pull platform`. After you agree to the prompt, the current upstream databases and files will be downloaded.
 5. Optionally use `ddev push platform` to push local files and database to Platform.sh. The [`ddev push`](../usage/commands.md#push) command can potentially damage your production site, so we don’t recommend using it.
 
-### Multiple apps
+### Managing Multiple Apps
 
 If your environment contains more than one app, add `PLATFORM_APP` variable to your project:
 
-    * Either in `.ddev/config.yaml` or a `.ddev/config.*.yaml` file:
+* Either in `.ddev/config.yaml` or a `.ddev/config.*.yaml` file:
 
-        ```yaml
-        web_environment:
-        - ...
-        - PLATFORM_APP=app
-        ```
+    ```yaml
+    web_environment:
+    - ...
+    - PLATFORM_APP=app
+    ```
 
-    * Or with a command from your terminal:
+* Or with a command from your terminal:
 
-        ```bash
-        ddev config --web-environment-add="PLATFORM_APP=app"
-        ```
+    ```bash
+    ddev config --web-environment-add="PLATFORM_APP=app"
+    ```
 
 ### Managing Multiple Databases
 

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -22,7 +22,7 @@ web_environment:
 ## Platform.sh Per-Project Configuration
 
 1. Check out the site from Platform.sh and configure it with [`ddev config`](../usage/commands.md#config). You’ll want to use [`ddev start`](../usage/commands.md#start) and make sure the basic functionality is working.
-2. Add `PLATFORM_PROJECT` and `PLATFORM_ENVIRONMENT` variables to your project.
+2. Add `PLATFORM_PROJECT` and `PLATFORM_ENVIRONMENT` and  `PLATFORM_APP` (optional) variables to your project.
 
     * Either in `.ddev/config.yaml` or a `.ddev/config.*.yaml` file:
 
@@ -30,6 +30,7 @@ web_environment:
         web_environment:
         - PLATFORM_PROJECT=nf4amudfn23biyourproject
         - PLATFORM_ENVIRONMENT=main
+        - PLATFORM_APP=app (optional)
         ```
 
     * Or with a command from your terminal:
@@ -41,6 +42,9 @@ web_environment:
 3. Run [`ddev restart`](../usage/commands.md#restart).
 4. Run `ddev pull platform`. After you agree to the prompt, the current upstream databases and files will be downloaded.
 5. Optionally use `ddev push platform` to push local files and database to Platform.sh. The [`ddev push`](../usage/commands.md#push) command can potentially damage your production site, so we don’t recommend using it.
+
+### Multiple apps
+It is necessary to specify PLATFORM_APP variable under web_environment if your environment contains more than one app
 
 ### Managing Multiple Databases
 

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -22,7 +22,7 @@ web_environment:
 ## Platform.sh Per-Project Configuration
 
 1. Check out the site from Platform.sh and configure it with [`ddev config`](../usage/commands.md#config). You’ll want to use [`ddev start`](../usage/commands.md#start) and make sure the basic functionality is working.
-2. Add `PLATFORM_PROJECT` and `PLATFORM_ENVIRONMENT` and  `PLATFORM_APP` (optional) variables to your project.
+2. Add `PLATFORM_PROJECT` and `PLATFORM_ENVIRONMENT` variables to your project.
 
     * Either in `.ddev/config.yaml` or a `.ddev/config.*.yaml` file:
 
@@ -30,7 +30,6 @@ web_environment:
         web_environment:
         - PLATFORM_PROJECT=nf4amudfn23biyourproject
         - PLATFORM_ENVIRONMENT=main
-        - PLATFORM_APP=app (optional)
         ```
 
     * Or with a command from your terminal:
@@ -44,7 +43,22 @@ web_environment:
 5. Optionally use `ddev push platform` to push local files and database to Platform.sh. The [`ddev push`](../usage/commands.md#push) command can potentially damage your production site, so we don’t recommend using it.
 
 ### Multiple apps
-It is necessary to specify PLATFORM_APP variable under web_environment if your environment contains more than one app
+
+If your environment contains more than one app, add `PLATFORM_APP` variable to your project:
+
+    * Either in `.ddev/config.yaml` or a `.ddev/config.*.yaml` file:
+
+        ```yaml
+        web_environment:
+        - ...
+        - PLATFORM_APP=app
+        ```
+
+    * Or with a command from your terminal:
+
+        ```bash
+        ddev config --web-environment-add="PLATFORM_APP=app"
+        ```
 
 ### Managing Multiple Databases
 

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -16,7 +16,7 @@
 #    web_environment:
 #    - PLATFORMSH_CLI_TOKEN=abcdeyourtoken
 #    ```
-# 3. Add PLATFORM_PROJECT and PLATFORM_ENVIRONMENT and PLATFORM_APP(optional) variables to your project `.ddev/config.yaml` or a `.ddev/config.platform.yaml`
+# 3. Add PLATFORM_PROJECT and PLATFORM_ENVIRONMENT and PLATFORM_APP (optional) variables to your project `.ddev/config.yaml` or a `.ddev/config.platform.yaml`
 #    ```yaml
 #    web_environment:
 #    - PLATFORM_PROJECT=nf4amudfn23biyourproject
@@ -52,7 +52,7 @@ db_pull_command:
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     # /tmp/db_relationships.yaml is the full yaml output of the database relationships
     db_relationships_file=/tmp/db_relationships.yaml
-    PLATFORM_RELATIONSHIPS="" platform relationships -y  -e "${PLATFORM_ENVIRONMENT}" $( [ -n "${PLATFORM_APP}" ] && echo "--app=${PLATFORM_APP}" ) | yq 'with_entries(select(.[][].type == "mariadb:*" or .[][].type == "*mysql:*" or .[][].type == "postgresql:*")) ' >${db_relationships_file}
+    PLATFORM_RELATIONSHIPS="" platform relationships -y  -e "${PLATFORM_ENVIRONMENT}" ${PLATFORM_APP:+"--app=${PLATFORM_APP}"} | yq 'with_entries(select(.[][].type == "mariadb:*" or .[][].type == "*mysql:*" or .[][].type == "postgresql:*")) ' >${db_relationships_file}
     db_relationships=($(yq ' keys | .[] ' ${db_relationships_file}))
     db_names=($(yq '.[][].path' ${db_relationships_file}))
     db_count=${#db_relationships[@]}
@@ -69,7 +69,7 @@ db_pull_command:
         db_name="db"
       fi
 
-      platform db:dump --yes $( [ -n "${PLATFORM_APP}" ] && echo "--app=${PLATFORM_APP}" ) --relationship=${rel} --gzip --file=/var/www/html/.ddev/.downloads/${db_name}.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
+      platform db:dump --yes ${PLATFORM_APP:+"--app=${PLATFORM_APP}"} --relationship=${rel} --gzip --file=/var/www/html/.ddev/.downloads/${db_name}.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
     done
     echo "Downloaded db dumps for databases '${db_names[@]}'"
 
@@ -80,7 +80,7 @@ files_import_command:
     export PLATFORMSH_CLI_NO_INTERACTION=1
     # Use $PLATFORM_MOUNTS if it exists to get list of mounts to download, otherwise just web/sites/default/files (drupal)
     declare -a mounts=(${PLATFORM_MOUNTS:-/web/sites/default/files})
-    platform mount:download --all --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" $( [ -n "${PLATFORM_APP}" ] && echo "--app=${PLATFORM_APP}" ) --target=/var/www/html
+    platform mount:download --all --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" ${PLATFORM_APP:+"--app=${PLATFORM_APP}"} --target=/var/www/html
 
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
@@ -94,7 +94,7 @@ db_push_command:
     if [ "${PLATFORM_PRIMARY_RELATIONSHIP:-}" != "" ] ; then
       rel="--relationship ${PLATFORM_PRIMARY_RELATIONSHIP}"
     fi
-    gzip -dc db.sql.gz | platform db:sql --project="${PLATFORM_PROJECT}" ${rel:-} --environment="${PLATFORM_ENVIRONMENT} $( [ -n "${PLATFORM_APP}" ] && echo "--app=${PLATFORM_APP}" )"
+    gzip -dc db.sql.gz | platform db:sql --project="${PLATFORM_PROJECT}" ${rel:-} --environment="${PLATFORM_ENVIRONMENT}" ${PLATFORM_APP:+"--app=${PLATFORM_APP}"}
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 # TODO: This is a naive, Drupal-centric push, which needs adjustment for the mount to be pushed.
@@ -104,4 +104,4 @@ files_push_command:
     set -eu -o pipefail
     export PLATFORMSH_CLI_NO_INTERACTION=1
     ls "${DDEV_FILES_DIR}" >/dev/null # This just refreshes stale NFS if possible
-    platform mount:upload --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" $( [ -n "${PLATFORM_APP}" ] && echo "--app=${PLATFORM_APP}" ) --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files
+    platform mount:upload --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" ${PLATFORM_APP:+"--app=${PLATFORM_APP}"} --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -16,7 +16,7 @@
 #    web_environment:
 #    - PLATFORMSH_CLI_TOKEN=abcdeyourtoken
 #    ```
-# 3. Add PLATFORM_PROJECT and PLATFORM_ENVIRONMENT and PLATFORM_APP (optional) variables to your project `.ddev/config.yaml` or a `.ddev/config.platform.yaml`
+# 3. Add PLATFORM_PROJECT and PLATFORM_ENVIRONMENT and optional PLATFORM_APP (only if your environment contains more than one app) variables to your project `.ddev/config.yaml` or a `.ddev/config.platform.yaml`
 #    ```yaml
 #    web_environment:
 #    - PLATFORM_PROJECT=nf4amudfn23biyourproject

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -16,11 +16,12 @@
 #    web_environment:
 #    - PLATFORMSH_CLI_TOKEN=abcdeyourtoken
 #    ```
-# 3. Add PLATFORM_PROJECT and PLATFORM_ENVIRONMENT variables to your project `.ddev/config.yaml` or a `.ddev/config.platform.yaml`
+# 3. Add PLATFORM_PROJECT and PLATFORM_ENVIRONMENT and PLATFORM_APP(optional) variables to your project `.ddev/config.yaml` or a `.ddev/config.platform.yaml`
 #    ```yaml
 #    web_environment:
 #    - PLATFORM_PROJECT=nf4amudfn23biyourproject
 #    - PLATFORM_ENVIRONMENT=main
+#    - PLATFORM_APP=app
 # 4. `ddev restart`
 # 5. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
 # 6. Optionally use `ddev push platform` to push local files and database to platform.sh. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
@@ -51,7 +52,7 @@ db_pull_command:
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     # /tmp/db_relationships.yaml is the full yaml output of the database relationships
     db_relationships_file=/tmp/db_relationships.yaml
-    PLATFORM_RELATIONSHIPS="" platform relationships -y  -e "${PLATFORM_ENVIRONMENT}" | yq 'with_entries(select(.[][].type == "mariadb:*" or .[][].type == "*mysql:*" or .[][].type == "postgresql:*")) ' >${db_relationships_file}
+    PLATFORM_RELATIONSHIPS="" platform relationships -y  -e "${PLATFORM_ENVIRONMENT}" $( [ -n "${PLATFORM_APP}" ] && echo "--app=${PLATFORM_APP}" ) | yq 'with_entries(select(.[][].type == "mariadb:*" or .[][].type == "*mysql:*" or .[][].type == "postgresql:*")) ' >${db_relationships_file}
     db_relationships=($(yq ' keys | .[] ' ${db_relationships_file}))
     db_names=($(yq '.[][].path' ${db_relationships_file}))
     db_count=${#db_relationships[@]}
@@ -68,18 +69,18 @@ db_pull_command:
         db_name="db"
       fi
 
-      platform db:dump --yes --relationship=${rel} --gzip --file=/var/www/html/.ddev/.downloads/${db_name}.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
+      platform db:dump --yes $( [ -n "${PLATFORM_APP}" ] && echo "--app=${PLATFORM_APP}" ) --relationship=${rel} --gzip --file=/var/www/html/.ddev/.downloads/${db_name}.sql.gz --project="${PLATFORM_PROJECT:-setme}" --environment="${PLATFORM_ENVIRONMENT:-setme}"
     done
     echo "Downloaded db dumps for databases '${db_names[@]}'"
 
 files_import_command:
   command: |
-    # set -x   # You can enable bash debugging output by uncommenting
+    #set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     export PLATFORMSH_CLI_NO_INTERACTION=1
     # Use $PLATFORM_MOUNTS if it exists to get list of mounts to download, otherwise just web/sites/default/files (drupal)
     declare -a mounts=(${PLATFORM_MOUNTS:-/web/sites/default/files})
-    platform mount:download --all --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}"  --target=/var/www/html
+    platform mount:download --all --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" $( [ -n "${PLATFORM_APP}" ] && echo "--app=${PLATFORM_APP}" ) --target=/var/www/html
 
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
@@ -93,7 +94,7 @@ db_push_command:
     if [ "${PLATFORM_PRIMARY_RELATIONSHIP:-}" != "" ] ; then
       rel="--relationship ${PLATFORM_PRIMARY_RELATIONSHIP}"
     fi
-    gzip -dc db.sql.gz | platform db:sql --project="${PLATFORM_PROJECT}" ${rel:-} --environment="${PLATFORM_ENVIRONMENT}"
+    gzip -dc db.sql.gz | platform db:sql --project="${PLATFORM_PROJECT}" ${rel:-} --environment="${PLATFORM_ENVIRONMENT} $( [ -n "${PLATFORM_APP}" ] && echo "--app=${PLATFORM_APP}" )"
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 # TODO: This is a naive, Drupal-centric push, which needs adjustment for the mount to be pushed.
@@ -103,4 +104,4 @@ files_push_command:
     set -eu -o pipefail
     export PLATFORMSH_CLI_NO_INTERACTION=1
     ls "${DDEV_FILES_DIR}" >/dev/null # This just refreshes stale NFS if possible
-    platform mount:upload --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files
+    platform mount:upload --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" $( [ -n "${PLATFORM_APP}" ] && echo "--app=${PLATFORM_APP}" ) --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files


### PR DESCRIPTION
…an one app under your env.

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
Today there is no option to choose an app when pulling data from platform.sh using ddev pull platform

## How This PR Solves The Issue
Adding new env variable support PLATFORM_APP, when this variable exists we are adding --app flag 

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)
https://github.com/ddev/ddev/issues/5727

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

