### PR TITLE
feat: add autocomplete for project name arguments, fixes #4880

### DIFF
--- a/cmd/ddev/cmd/autocompletion_test.go
+++ b/cmd/ddev/cmd/autocompletion_test.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/exec"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAutocompletionForStopCmd checks autocompletion of project names for ddev stop
+func TestAutocompletionForStopCmd(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Skip if we don't have enough tests.
+	if len(TestSites) < 2 {
+		t.Skip("Must have at least two test sites to test autocompletion")
+	}
+
+	t.Cleanup(func() {
+		removeSites()
+	})
+
+	// Make sure we have some sites.
+	err := addSites()
+	require.NoError(t, err)
+
+	var siteNames []string
+	for _, site := range TestSites {
+		siteNames = append(siteNames, site.Name)
+	}
+
+	// ddev stop should show all running sites
+	out, err := exec.RunHostCommand(DdevBin, "__complete", "stop", "")
+	assert.NoError(err)
+	filteredOut := getTestingSitesFromOutput(out)
+	for _, name := range siteNames {
+		assert.Contains(filteredOut, name)
+	}
+
+	// Project names shouldn't be repeated
+	out, err = exec.RunHostCommand(DdevBin, "__complete", "stop", siteNames[0], "")
+	assert.NoError(err)
+	filteredOut = getTestingSitesFromOutput(out)
+	for i, name := range siteNames {
+		if i == 0 {
+			assert.NotContains(filteredOut, name)
+		} else {
+			assert.Contains(filteredOut, name)
+		}
+	}
+
+	// If we've used all the project names, there should be no further suggestions
+	allArgs := append([]string{"__complete", "stop"}, siteNames...)
+	allArgs = append(allArgs, "")
+	out, err = exec.RunHostCommand(DdevBin, allArgs...)
+	assert.NoError(err)
+	filteredOut = getTestingSitesFromOutput(out)
+	assert.Empty(filteredOut)
+
+	// If a project is stopped, it shouldn't be suggested for stop anymore
+	_, err = exec.RunHostCommand(DdevBin, "stop", siteNames[0])
+	assert.NoError(err)
+	out, err = exec.RunHostCommand(DdevBin, "__complete", "stop", "")
+	assert.NoError(err)
+	filteredOut = getTestingSitesFromOutput(out)
+	for i, name := range siteNames {
+		if i == 0 {
+			assert.NotContains(filteredOut, name)
+		} else {
+			assert.Contains(filteredOut, name)
+		}
+	}
+
+	// If all projects are stopped (or no projects exist), completion should be empty
+	allArgs = append([]string{"stop"}, siteNames...)
+	_, err = exec.RunHostCommand(DdevBin, allArgs...)
+	assert.NoError(err)
+	out, err = exec.RunHostCommand(DdevBin, "__complete", "stop", "")
+	assert.NoError(err)
+	filteredOut = getTestingSitesFromOutput(out)
+	assert.Empty(filteredOut)
+}
+
+// TestAutocompletionForStartCmd checks autocompletion of project names for ddev start
+func TestAutocompletionForStartCmd(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Skip if we don't have enough tests.
+	if len(TestSites) < 2 {
+		t.Skip("Must have at least two test sites to test autocompletion")
+	}
+
+	t.Cleanup(func() {
+		removeSites()
+	})
+
+	// Make sure we have some sites.
+	err := addSites()
+	require.NoError(t, err)
+
+	var siteNames []string
+	for _, site := range TestSites {
+		siteNames = append(siteNames, site.Name)
+	}
+
+	// If all projects are running, completion should be empty
+	out, err := exec.RunHostCommand(DdevBin, "__complete", "start", "")
+	assert.NoError(err)
+	filteredOut := getTestingSitesFromOutput(out)
+	assert.Empty(filteredOut)
+
+	// All stopped projects should display in completion
+	_, err = exec.RunHostCommand(DdevBin, "stop", siteNames[0])
+	assert.NoError(err)
+	out, err = exec.RunHostCommand(DdevBin, "__complete", "start", "")
+	assert.NoError(err)
+	filteredOut = getTestingSitesFromOutput(out)
+	for i, name := range siteNames {
+		if i == 0 {
+			assert.Contains(filteredOut, name)
+		} else {
+			assert.NotContains(filteredOut, name)
+		}
+	}
+
+	allArgs := append([]string{"stop"}, siteNames...)
+	_, err = exec.RunHostCommand(DdevBin, allArgs...)
+	assert.NoError(err)
+	out, err = exec.RunHostCommand(DdevBin, "__complete", "start", "")
+	assert.NoError(err)
+	filteredOut = getTestingSitesFromOutput(out)
+	for _, name := range siteNames {
+		assert.Contains(filteredOut, name)
+	}
+
+	// Project names shouldn't be repeated
+	out, err = exec.RunHostCommand(DdevBin, "__complete", "start", siteNames[0], "")
+	assert.NoError(err)
+	filteredOut = getTestingSitesFromOutput(out)
+	for i, name := range siteNames {
+		if i == 0 {
+			assert.NotContains(filteredOut, name)
+		} else {
+			assert.Contains(filteredOut, name)
+		}
+	}
+
+	// If we've used all the project names, there should be no further suggestions
+	allArgs = append([]string{"__complete", "start"}, siteNames...)
+	allArgs = append(allArgs, "")
+	out, err = exec.RunHostCommand(DdevBin, allArgs...)
+	assert.NoError(err)
+	filteredOut = getTestingSitesFromOutput(out)
+	assert.Empty(filteredOut)
+}
+
+// TestAutocompletionForStartCmd checks autocompletion of project names for ddev describe
+func TestAutocompletionForDescribeCmd(t *testing.T) {
+	assert := asrt.New(t)
+
+	// Skip if we don't have enough tests.
+	if len(TestSites) < 2 {
+		t.Skip("Must have at least two test sites to test autocompletion")
+	}
+
+	t.Cleanup(func() {
+		removeSites()
+	})
+
+	// Make sure we have some sites.
+	err := addSites()
+	require.NoError(t, err)
+
+	var siteNames []string
+	for _, site := range TestSites {
+		siteNames = append(siteNames, site.Name)
+	}
+
+	// If all projects are running, completion should show all project names
+	out, err := exec.RunHostCommand(DdevBin, "__complete", "describe", "")
+	assert.NoError(err)
+	filteredOut := getTestingSitesFromOutput(out)
+	for _, name := range siteNames {
+		assert.Contains(filteredOut, name)
+	}
+
+	// Even stopped projects should display in completion
+	_, err = exec.RunHostCommand(DdevBin, "stop", siteNames[0])
+	assert.NoError(err)
+	out, err = exec.RunHostCommand(DdevBin, "__complete", "describe", "")
+	assert.NoError(err)
+	filteredOut = getTestingSitesFromOutput(out)
+	for _, name := range siteNames {
+		assert.Contains(filteredOut, name)
+	}
+
+	// If there's already an argument, nothing more should be suggested
+	out, err = exec.RunHostCommand(DdevBin, "__complete", "describe", "anything", "")
+	assert.NoError(err)
+	filteredOut = getTestingSitesFromOutput(out)
+	assert.Empty(filteredOut)
+}
+
+// getTestingSitesFromOutput() finds only the ddev list items that
+// have names starting with "Test" from a space separated list of project names.
+// This is useful when running the tests locally, to filter out projects that
+// aren't test-related.
+func getTestingSitesFromOutput(output string) []interface{} {
+	testSites := make([]interface{}, 0)
+	for _, siteName := range strings.Fields(output) {
+		if strings.HasPrefix(siteName, "Test") {
+			testSites = append(testSites, siteName)
+		}
+	}
+	return testSites
+}

--- a/cmd/ddev/cmd/clean.go
+++ b/cmd/ddev/cmd/clean.go
@@ -14,8 +14,9 @@ import (
 )
 
 var CleanCmd = &cobra.Command{
-	Use:   "clean [projectname ...]",
-	Short: "Removes items DDEV has created",
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 0),
+	Use:               "clean [projectname ...]",
+	Short:             "Removes items DDEV has created",
 	Long: `Stops all running projects and then removes downloads and snapshots
 for the selected projects. Then clean will remove "ddev/ddev-*" images.
 

--- a/cmd/ddev/cmd/debug-compose-config.go
+++ b/cmd/ddev/cmd/debug-compose-config.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/ddev/ddev/pkg/fileutil"
 	"strings"
+
+	"github.com/ddev/ddev/pkg/fileutil"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/output"
@@ -12,8 +13,9 @@ import (
 
 // DebugComposeConfigCmd implements the ddev debug compose-config command
 var DebugComposeConfigCmd = &cobra.Command{
-	Use:   "compose-config [project]",
-	Short: "Prints the docker-compose configuration of the current project",
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
+	Use:               "compose-config [project]",
+	Short:             "Prints the docker-compose configuration of the current project",
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := ""
 

--- a/cmd/ddev/cmd/debug-config-yaml.go
+++ b/cmd/ddev/cmd/debug-config-yaml.go
@@ -1,19 +1,21 @@
 package cmd
 
 import (
+	"reflect"
+	"strings"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
-	"reflect"
-	"strings"
 )
 
 // DebugConfigYamlCmd implements the ddev debug configyaml command
 var DebugConfigYamlCmd = &cobra.Command{
-	Use:     "configyaml [project]",
-	Short:   "Prints the project config.*.yaml usage",
-	Example: "ddev debug configyaml, ddev debug configyaml <projectname>",
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
+	Use:               "configyaml [project]",
+	Short:             "Prints the project config.*.yaml usage",
+	Example:           "ddev debug configyaml, ddev debug configyaml <projectname>",
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := ""
 

--- a/cmd/ddev/cmd/debug-refresh.go
+++ b/cmd/ddev/cmd/debug-refresh.go
@@ -12,8 +12,9 @@ import (
 
 // DebugRefreshCmd implements the ddev debug refresh command
 var DebugRefreshCmd = &cobra.Command{
-	Use:   "refresh",
-	Short: "Refreshes Docker cache for project",
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
+	Use:               "refresh",
+	Short:             "Refreshes Docker cache for project",
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := ""
 

--- a/cmd/ddev/cmd/delete.go
+++ b/cmd/ddev/cmd/delete.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -15,9 +16,10 @@ var deleteAll bool
 
 // DeleteCmd provides the delete command
 var DeleteCmd = &cobra.Command{
-	Use:   "delete [projectname ...]",
-	Short: "Remove all project information (including database) for an existing project",
-	Long:  `Removes all DDEV project information (including database) for an existing project, but does not touch the project codebase or the codebase's .ddev folder.'.`,
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 0),
+	Use:               "delete [projectname ...]",
+	Short:             "Remove all project information (including database) for an existing project",
+	Long:              `Removes all DDEV project information (including database) for an existing project, but does not touch the project codebase or the codebase's .ddev folder.'.`,
 	Example: `ddev delete
 ddev delete proj1 proj2 proj3
 ddev delete --omit-snapshot proj1

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -21,9 +21,10 @@ import (
 
 // DescribeCommand represents the `ddev config` command
 var DescribeCommand = &cobra.Command{
-	Use:     "describe [projectname]",
-	Aliases: []string{"status", "st", "desc"},
-	Short:   "Get a detailed description of a running DDEV project.",
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
+	Use:               "describe [projectname]",
+	Aliases:           []string{"status", "st", "desc"},
+	Short:             "Get a detailed description of a running DDEV project.",
 	Long: `Get a detailed description of a running DDEV project. Describe provides basic
 information about a DDEV project, including its name, location, url, and status.
 It also provides details for MySQL connections, and connection information for

--- a/cmd/ddev/cmd/import-db.go
+++ b/cmd/ddev/cmd/import-db.go
@@ -13,9 +13,10 @@ import (
 // NewImportDBCmd initializes and returns the `ddev import-db` command.
 func NewImportDBCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "import-db [project]",
-		Args:  cobra.RangeArgs(0, 1),
-		Short: "Import a SQL dump file into the project",
+		ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
+		Use:               "import-db [project]",
+		Args:              cobra.RangeArgs(0, 1),
+		Short:             "Import a SQL dump file into the project",
 		Long: heredoc.Doc(`
 			Import a SQL dump file into the project.
 

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -13,9 +14,10 @@ var (
 
 // DdevLogsCmd contains the "ddev logs" command
 var DdevLogsCmd = &cobra.Command{
-	Use:   "logs [projectname]",
-	Short: "Get the logs from your running services.",
-	Long:  `Uses 'docker logs' to display stdout from the running services.`,
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("active", 1),
+	Use:               "logs [projectname]",
+	Short:             "Get the logs from your running services.",
+	Long:              `Uses 'docker logs' to display stdout from the running services.`,
 	Example: `ddev logs
 ddev logs -f
 ddev logs -s db

--- a/cmd/ddev/cmd/mutagen-monitor.go
+++ b/cmd/ddev/cmd/mutagen-monitor.go
@@ -8,9 +8,10 @@ import (
 
 // MutagenMonitorCmd implements the ddev mutagen monitor command
 var MutagenMonitorCmd = &cobra.Command{
-	Use:     "monitor",
-	Short:   "Monitor Mutagen status",
-	Example: `"ddev mutagen monitor", "ddev mutagen monitor <projectname>"`,
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
+	Use:               "monitor",
+	Short:             "Monitor Mutagen status",
+	Example:           `"ddev mutagen monitor", "ddev mutagen monitor <projectname>"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := ""
 		if len(args) > 1 {

--- a/cmd/ddev/cmd/mutagen-reset.go
+++ b/cmd/ddev/cmd/mutagen-reset.go
@@ -1,18 +1,20 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 // MutagenResetCmd implements the ddev mutagen reset command
 var MutagenResetCmd = &cobra.Command{
-	Use:     "reset",
-	Short:   "Reset Mutagen for project",
-	Long:    "Stops project, removes the Mutagen Docker volume",
-	Example: `"ddev mutagen reset", "ddev mutagen reset <projectname>"`,
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
+	Use:               "reset",
+	Short:             "Reset Mutagen for project",
+	Long:              "Stops project, removes the Mutagen Docker volume",
+	Example:           `"ddev mutagen reset", "ddev mutagen reset <projectname>"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := ""
 		if len(args) > 1 {

--- a/cmd/ddev/cmd/mutagen-status.go
+++ b/cmd/ddev/cmd/mutagen-status.go
@@ -11,10 +11,11 @@ import (
 
 // MutagenStatusCmd implements the ddev mutagen status command
 var MutagenStatusCmd = &cobra.Command{
-	Use:     "status",
-	Short:   "Shows Mutagen sync status",
-	Aliases: []string{"st"},
-	Example: `"ddev mutagen status", "ddev mutagen status <projectname>"`,
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
+	Use:               "status",
+	Short:             "Shows Mutagen sync status",
+	Aliases:           []string{"st"},
+	Example:           `"ddev mutagen status", "ddev mutagen status <projectname>"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := ""
 		verbose := false

--- a/cmd/ddev/cmd/mutagen-sync.go
+++ b/cmd/ddev/cmd/mutagen-sync.go
@@ -9,9 +9,10 @@ import (
 
 // MutagenSyncCmd implements the ddev mutagen sync command
 var MutagenSyncCmd = &cobra.Command{
-	Use:     "sync",
-	Short:   "Explicit sync for Mutagen",
-	Example: `"ddev mutagen sync", "ddev mutagen sync <projectname>"`,
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
+	Use:               "sync",
+	Short:             "Explicit sync for Mutagen",
+	Example:           `"ddev mutagen sync", "ddev mutagen sync <projectname>"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := ""
 		verbose := false

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/globalconfig"
-	"strings"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/output"
@@ -15,9 +16,10 @@ var restartAll bool
 
 // RestartCmd rebuilds an apps settings
 var RestartCmd = &cobra.Command{
-	Use:   "restart [projects]",
-	Short: "Restart a project or several projects.",
-	Long:  `Stops named projects and then starts them back up again.`,
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 0),
+	Use:               "restart [projects]",
+	Short:             "Restart a project or several projects.",
+	Long:              `Stops named projects and then starts them back up again.`,
 	Example: `ddev restart
 ddev restart <project1> <project2>
 ddev restart --all`,

--- a/cmd/ddev/cmd/share.go
+++ b/cmd/ddev/cmd/share.go
@@ -12,9 +12,10 @@ import (
 
 // DdevShareCommand contains the "ddev share" command
 var DdevShareCommand = &cobra.Command{
-	Use:   "share [project]",
-	Short: "Share project on the internet via ngrok.",
-	Long:  `Requires an account on ngrok.com, use the "ngrok config add-authtoken <token>" command to set up ngrok. Any ngrok flag can be added in the "ngrok_args" section of .ddev/config.yaml or via --ngrok-args.`,
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
+	Use:               "share [project]",
+	Short:             "Share project on the internet via ngrok.",
+	Long:              `Requires an account on ngrok.com, use the "ngrok config add-authtoken <token>" command to set up ngrok. Any ngrok flag can be added in the "ngrok_args" section of .ddev/config.yaml or via --ngrok-args.`,
 	Example: `ddev share
 ddev share --ngrok-args "--basic-auth username:pass1234"
 ddev share --ngrok-args "--domain foo.ngrok-free.app"

--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 var snapshotAll bool
@@ -20,9 +21,10 @@ var snapshotCleanupNoConfirm bool
 
 // DdevSnapshotCommand provides the snapshot command
 var DdevSnapshotCommand = &cobra.Command{
-	Use:   "snapshot [projectname projectname...]",
-	Short: "Create a database snapshot for one or more projects.",
-	Long:  `Uses mariabackup or xtrabackup command to create a database snapshot in the .ddev/db_snapshots folder. These are compatible with server backups using the same tools and can be restored with "ddev snapshot restore".`,
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 0),
+	Use:               "snapshot [projectname projectname...]",
+	Short:             "Create a database snapshot for one or more projects.",
+	Long:              `Uses mariabackup or xtrabackup command to create a database snapshot in the .ddev/db_snapshots folder. These are compatible with server backups using the same tools and can be restored with "ddev snapshot restore".`,
 	Example: `ddev snapshot
 ddev snapshot --name some_descriptive_name
 ddev snapshot --cleanup

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -15,9 +15,10 @@ var sshDirArg string
 
 // DdevSSHCmd represents the SSH command.
 var DdevSSHCmd = &cobra.Command{
-	Use:   "ssh [projectname]",
-	Short: "Starts a shell session in the container for a service. Uses web service by default.",
-	Long:  `Starts a shell session in the container for a service. Uses web service by default. To start a shell session for another service, run "ddev ssh --service <service>`,
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("active", 1),
+	Use:               "ssh [projectname]",
+	Short:             "Starts a shell session in the container for a service. Uses web service by default.",
+	Long:              `Starts a shell session in the container for a service. Uses web service by default. To start a shell session for another service, run "ddev ssh --service <service>`,
 	Example: `ddev ssh
 ddev ssh -s db
 ddev ssh <projectname>

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"github.com/ddev/ddev/pkg/amplitude"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/ddev/ddev/pkg/amplitude"
 
 	"github.com/ddev/ddev/pkg/config/remoteconfig"
 	"github.com/ddev/ddev/pkg/config/state/storage/yaml"
@@ -22,9 +23,10 @@ var startAll bool
 
 // StartCmd provides the ddev start command
 var StartCmd = &cobra.Command{
-	Use:     "start [projectname ...]",
-	Aliases: []string{"add"},
-	Short:   "Start a DDEV project.",
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("inactive", 0),
+	Use:               "start [projectname ...]",
+	Aliases:           []string{"add"},
+	Short:             "Start a DDEV project.",
 	Long: `Start initializes and configures the web server and database containers
 to provide a local development environment. You can run 'ddev start' from a
 project directory to start that project, or you can start stopped projects in
@@ -150,5 +152,13 @@ func init() {
 	StartCmd.Flags().BoolVarP(&startAll, "all", "a", false, "Start all projects")
 	StartCmd.Flags().BoolP("skip-confirmation", "y", false, "Skip any confirmation steps")
 	StartCmd.Flags().BoolP("select", "s", false, "Interactively select a project to start")
+	err := StartCmd.Flags().MarkHidden("select")
+	if err != nil {
+		util.Warning("Unexpected error marking flag as hidden: %v", err)
+	}
+	err = StartCmd.Flags().MarkDeprecated("select", "Use tabbed autocompletion instead.")
+	if err != nil {
+		util.Warning("Unexpected error marking flag as deprecated: %v", err)
+	}
 	RootCmd.AddCommand(StartCmd)
 }

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // For single remove only: remove db and related data
@@ -27,9 +28,10 @@ var unlist bool
 
 // DdevStopCmd represents the remove command
 var DdevStopCmd = &cobra.Command{
-	Use:     "stop [projectname ...]",
-	Aliases: []string{"rm", "remove"},
-	Short:   "Stop and remove the containers of a project. Does not lose or harm anything unless you add --remove-data.",
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("active", 0),
+	Use:               "stop [projectname ...]",
+	Aliases:           []string{"rm", "remove"},
+	Short:             "Stop and remove the containers of a project. Does not lose or harm anything unless you add --remove-data.",
 	Long: `Stop and remove the containers of a project. You can run 'ddev stop'
 from a project directory to stop/remove that project, or you can stop/remove projects in
 any directory by running 'ddev stop projectname [projectname ...]' or 'ddev stop -a'.
@@ -130,6 +132,14 @@ func init() {
 	DdevStopCmd.Flags().BoolVarP(&createSnapshot, "snapshot", "S", false, "Create database snapshot")
 	DdevStopCmd.Flags().BoolVarP(&omitSnapshot, "omit-snapshot", "O", false, "Omit/skip database snapshot")
 	DdevStopCmd.Flags().BoolP("select", "s", false, "Interactively select a project to stop")
+	err := StartCmd.Flags().MarkHidden("select")
+	if err != nil {
+		util.Warning("Unexpected error marking flag as hidden: %v", err)
+	}
+	err = StartCmd.Flags().MarkDeprecated("select", "Use tabbed autocompletion instead.")
+	if err != nil {
+		util.Warning("Unexpected error marking flag as deprecated: %v", err)
+	}
 
 	DdevStopCmd.Flags().BoolVarP(&stopAll, "all", "a", false, "Stop and remove all running or container-stopped projects and remove from global projects list")
 	DdevStopCmd.Flags().BoolVarP(&stopSSHAgent, "stop-ssh-agent", "", false, "Stop the ddev-ssh-agent container")

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1298,7 +1298,6 @@ Start a DDEV project.
 Flags:
 
 * `--all`, `-a`: Start all projects.
-* `--select`, `-s`: Interactively select a project to start.
 * `--skip-confirmation`, `-y`: Skip any confirmation steps.
 
 Example:
@@ -1325,7 +1324,6 @@ Flags:
 * `--all`, `-a`: Stop and remove all running or container-stopped projects and remove from global projects list.
 * `--omit-snapshot`, `-O`: Omit/skip database snapshot.
 * `--remove-data`, `-R`: Remove stored project data (MySQL, logs, etc.).
-* `--select`, `-s`: Interactively select a project to stop.
 * `--snapshot`, `-S`: Create database snapshot.
 * `--stop-ssh-agent`: Stop the `ddev-ssh-agent` container.
 * `--unlist`, `-U`: Remove the project from global project list, so it won’t appear in [`ddev list`](#list) until started again.


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

Lots of the go commands take a project name as an argument, but don't provide autocompletion for those arguments.

## How This PR Solves The Issue

Adds autocompletion for commands that take a project name as an argument.

- If only one argument is allowed, it doesn't give completion for more.
- If multiple arguments are allowed, it gives completion for all of them.
- For `start` and `stop` specifically, if only gives names of the relevant (inactive and active respectively) projects - for all other commands, all names are given.

**NOTE** This makes the `--select` flag for `ddev start` and `ddev stop` redundant. I've marked the flag as hidden and deprecated for both of those commands - it can be removed in some future release.

I've also removed the docs about that flag - but if you want me to add it back with a note that they're deprecated, I can happily do that.

## Manual Testing Instructions

Type `ddev start <tab>` and see the autocompletion results.
- Try this with any command that takes a project name as an argument
- Check that commands that only accept one argument only perform completion for one argument
- Check that commands that accept multiple arguments perform completion for as many arguments as you like
- Check that `ddev start` only gives completion for currently inactive projects
- Check that `ddev stop` only gives completion for currently active projects
- Check that a project name isn't repeated if it's already included as an argument

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
I've added tests that work based on the `TestSites` array - though since these tests won't run with less than 2 test sites, the tests are skipped if there's not enough tests.

## Related Issue Link(s)

- https://github.com/ddev/ddev/issues/4880

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
This is fully backwards compatible and shouldn't affect anything else.

