### PR TITLE
docs: Update Drupal 9 & 10 CMS Quickstarts

### DIFF
--- a/docs/content/users/debugging-profiling/xhprof-profiling.md
+++ b/docs/content/users/debugging-profiling/xhprof-profiling.md
@@ -25,7 +25,7 @@ Another example: you could exclude memory profiling so there are fewer columns t
 ## Information Links
 
 * [php.net xhprof](https://www.php.net/manual/en/book.xhprof.php)
-* [Old facebook xhprof docs](http://web.archive.org/web/20110514095512/http://mirror.facebook.net/facebook/xhprof/doc.html)
+* [Old facebook xhprof docs](https://web.archive.org/web/20110514095512/http://mirror.facebook.net/facebook/xhprof/doc.html)
 * [rfay screencast on xhprof and blackfire.io](https://www.youtube.com/watch?v=6h2QMAtRjTA)
 * [pecl.php.net docs](https://pecl.php.net/package/xhprof)
 * [Upstream GitHub repository `lonngxhinH/xhprof`](https://github.com/longxinH/xhprof)

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -115,8 +115,11 @@ ddev launch
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
     ddev drush uli
-    ddev launch
     ```
+
+    `CTRL/CMD` + Click the one-time link in your terminal to open your site and edit your admin account details.
+
+    Use `ddev launch` for further visits to your site.
 
 === "Drupal 9"
 
@@ -129,8 +132,11 @@ ddev launch
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
     ddev drush uli
-    ddev launch
     ```
+    
+    `CTRL/CMD` + Click the one-time link in your terminal to open your site and edit your admin account details.
+
+    Use `ddev launch` for further visits to your site.
 
 === "Drupal 6/7"
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -114,12 +114,10 @@ ddev launch
     ddev composer create drupal/recommended-project
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
+    # use the one-time link (CTRL/CMD + Click) from the command below to edit your admin account details.
     ddev drush uli
+    ddev launch
     ```
-
-    `CTRL/CMD` + Click the one-time link in your terminal to open your site and edit your admin account details.
-
-    Use `ddev launch` for further visits to your site.
 
 === "Drupal 9"
 
@@ -131,12 +129,10 @@ ddev launch
     ddev composer create "drupal/recommended-project:^9"
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
+    # use the one-time link (CTRL/CMD + Click) from the command below to edit your admin account details.
     ddev drush uli
+    ddev launch
     ```
-    
-    `CTRL/CMD` + Click the one-time link in your terminal to open your site and edit your admin account details.
-
-    Use `ddev launch` for further visits to your site.
 
 === "Drupal 6/7"
 


### PR DESCRIPTION
## The Issue

`ddev drush uli` generates a one-time link to the page for editing the uid1 (admin) account details. If the site is opened with that, there is no need to also run `ddev launch`, so that is confusing.

## How This PR Solves The Issue

Add instructions on how to open the link generated by `ddev drush uli`. Remove `ddev launch` from the initial instructions but refer to its use for further site visits.

An alternative would be to drop the `ddev drush uli` line, but then the user would not be logged in when `ddev launch` is run.