### PR TITLE
build: Update Drupal10 to PHP82, fixes #5735

### DIFF
--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -67,7 +67,7 @@ func TestPostConfigAction(t *testing.T) {
 		nodeps.AppTypeDrupal7:      nodeps.PHPDefault,
 		nodeps.AppTypeDrupal8:      nodeps.PHP74,
 		nodeps.AppTypeDrupal9:      nodeps.PHPDefault,
-		nodeps.AppTypeDrupal10:     nodeps.PHP81,
+		nodeps.AppTypeDrupal10:     nodeps.PHP82,
 		nodeps.AppTypeLaravel:      nodeps.PHP81,
 		nodeps.AppTypeMagento:      nodeps.PHP74,
 		nodeps.AppTypeMagento2:     nodeps.PHP81,

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -229,7 +229,7 @@ func TestConfigCommand(t *testing.T) {
 		"magentophpversion":  {nodeps.AppTypeMagento, nodeps.PHP74},
 		"drupal7phpversion":  {nodeps.AppTypeDrupal7, nodeps.PHPDefault},
 		"drupal9phpversion":  {nodeps.AppTypeDrupal9, nodeps.PHPDefault},
-		"drupal10phpversion": {nodeps.AppTypeDrupal10, nodeps.PHP81},
+		"drupal10phpversion": {nodeps.AppTypeDrupal10, nodeps.PHP82},
 	}
 
 	for testName, testValues := range testMatrix {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -353,9 +353,9 @@ func drupal8ConfigOverrideAction(app *DdevApp) error {
 //	return nil
 //}
 
-// drupal10ConfigOverrideAction overrides php_version for D10, requires PHP8.0
+// drupal10ConfigOverrideAction overrides php_version for D10, requires PHP8.2
 func drupal10ConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = nodeps.PHP81
+	app.PHPVersion = nodeps.PHP82
 	return nil
 }
 


### PR DESCRIPTION
## The Issue
Drupal 10 using Commerce_authnet module has dependencies that require at least PHP 8.2.
The latest stable version of PHP is 8.2.6 so seems logical to apply to all Drupal 10 installations.

## How This PR Solves The Issue

Updated drupal10 installation to use PHP82

