### PR TITLE
docs: added sql:sanitize to Drupal hook examples.

### DIFF
--- a/docs/content/users/configuration/hooks.md
+++ b/docs/content/users/configuration/hooks.md
@@ -43,13 +43,13 @@ DDEV currently supports these tasks:
 
 Value: string providing the command to run. Commands requiring user interaction are not supported. You can also add a “service” key to the command, specifying to run it on the `db` container or any other container you use.
 
-Example: _Use Drush to clear the Drupal cache and get a user login link after database import_.
+Example: _Use Drush to rebuild all caches and get a user login link after database import_.
 
 ```yaml
 hooks:
   post-import-db:
-    - exec: drush cr
-    - exec: drush uli
+    - exec: drush cache:rebuild
+    - exec: drush user:login
 ```
 
 Example: _Use wp-cli to replace the production URL with development URL in a WordPress project’s database_.
@@ -58,6 +58,14 @@ Example: _Use wp-cli to replace the production URL with development URL in a Wor
 hooks:
   post-import-db:
     - exec: wp search-replace https://www.myproductionsite.com http://mydevsite.ddev.site
+```
+
+Example: _Use Drush to sanitize a database by removing or obfuscating user data_.
+
+```yaml
+hooks:
+  post-import-db:
+    - exec: drush sql:sanitize
 ```
 
 Example: _Add an extra database before `import-db`, executing in `db` container_.
@@ -143,24 +151,22 @@ hooks:
     - exec: "drush cc all"
 ```
 
-## Drupal 8 Example
+## Drupal 10 Example
 
 ```yaml
 hooks:
   post-start:
     # Install Composer dependencies from the web container
     - composer: install
-    # Install Drupal after start if not installed already
-    - exec: "(drush status bootstrap | grep -q Successful) || drush site-install -y --db-url=mysql://db:db@db/db"
     # Generate a one-time login link for the admin account
-    - exec: "drush uli 1"
+    - exec: "drush user:login"
   post-import-db:
-    # Set the site name
-    - exec: "drush config-set system.site name MyDevSite"
-    # Enable the environment indicator module
-    - exec: "drush en -y environment_indicator"
-    # Clear the cache
-    - exec: "drush cr"
+    # Sanitize the database
+    - exec: "drush sql:sanitize"
+    # Apply any database updates
+    - exec: "drush updatedb"
+    # Rebuild all caches
+    - exec: "drush cache:rebuild"
 ```
 
 ## TYPO3 Example

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -145,7 +145,7 @@ func init() {
 		nodeps.AppTypeDrupal9: {
 			settingsCreator:            createDrupalSettingsPHP,
 			uploadDirs:                 getDrupalUploadDirs,
-			hookDefaultComments:        getDrupal8Hooks,
+			hookDefaultComments:        getDrupal10Hooks,
 			appTypeSettingsPaths:       setDrupalSiteSettingsPaths,
 			appTypeDetect:              isDrupal9App,
 			postStartAction:            drupalPostStartAction,

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -156,7 +156,7 @@ func init() {
 		nodeps.AppTypeDrupal10: {
 			settingsCreator:            createDrupalSettingsPHP,
 			uploadDirs:                 getDrupalUploadDirs,
-			hookDefaultComments:        getDrupal8Hooks,
+			hookDefaultComments:        getDrupal10Hooks,
 			appTypeSettingsPaths:       setDrupalSiteSettingsPaths,
 			appTypeDetect:              isDrupal10App,
 			configOverrideAction:       drupal10ConfigOverrideAction,

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -258,9 +258,9 @@ func getDrupalUploadDirs(_ *DdevApp) []string {
 
 // Drupal10Hooks adds a d10-specific hooks example for post-import-db
 const Drupal10Hooks = `# post-import-db:
-#		- exec: drush sql:sanitize
-#		- exec: drush updatedb
-#		- exec: drush cache:rebuild
+#   - exec: drush sql:sanitize
+#   - exec: drush updatedb
+#   - exec: drush cache:rebuild
 `
 
 // Drupal8Hooks adds a d8-specific hooks example for post-import-db

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -256,6 +256,13 @@ func getDrupalUploadDirs(_ *DdevApp) []string {
 	return uploadDirs
 }
 
+// Drupal10Hooks adds a d10-specific hooks example for post-import-db
+const Drupal10Hooks = `# post-import-db:
+#		- exec: drush sql:sanitize
+#		- exec: drush updatedb
+#		- exec: drush cache:rebuild
+`
+
 // Drupal8Hooks adds a d8-specific hooks example for post-import-db
 const Drupal8Hooks = `# post-import-db:
 #   - exec: drush cr
@@ -281,6 +288,11 @@ func getDrupal6Hooks() []byte {
 // getDrupal8Hooks for appending as byte array
 func getDrupal8Hooks() []byte {
 	return []byte(Drupal8Hooks)
+}
+
+// getDrupal10Hooks for appending as byte array
+func getDrupal10Hooks() []byte {
+	return []byte(Drupal10Hooks)
 }
 
 // setDrupalSiteSettingsPaths sets the paths to settings.php/settings.ddev.php


### PR DESCRIPTION
## The Issue
It would be nice to encourage database sanitizing when importing a database to a local environment. 

## How This PR Solves The Issue
Updated examples to include sql:sanitize to post-import-db hooks for Drupal 10 installations.
Changed example heading from Drupal 8 to Drupal 10 to demonstrate this is the current Drupal version.
Also updated commands to use their full name instead of the alias, for better visibility.