### PR TITLE
feat: add WSL2 support to tableplus command

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -2,12 +2,12 @@
 
 #ddev-generated
 # Support for TablePlus, https://tableplus.com/
-# This command is available if macOS and TablePlus is installed in the normal place
+# This command is available on macOS and WSL2 if TablePlus is installed in the default location.
 ## Description: Run tableplus with current project database
 ## Usage: tableplus
 ## Example: "ddev tableplus"
-## OSTypes: darwin
-## HostBinaryExists: /Applications/TablePlus.app
+## OSTypes: darwin,wsl2
+## HostBinaryExists: /Applications/TablePlus.app,/mnt/c/Program Files/TablePlus/TablePlus.exe
 
 if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
@@ -21,6 +21,12 @@ if [[ $dbtype == "postgres" ]]; then
 fi
 query="${driver}://db:db@127.0.0.1:${DDEV_HOST_DB_PORT}/db"
 
-set -x
-open "$query" -a "/Applications/TablePlus.app/Contents/MacOS/TablePlus"
-
+case $OSTYPE in
+  "linux-gnu")
+    "/mnt/c/Program Files/TablePlus/TablePlus.exe" $query >/dev/null &
+    ;;
+  "darwin"*)
+    set -x
+    open "$query" -a "/Applications/TablePlus.app/Contents/MacOS/TablePlus"
+    ;;
+esac


### PR DESCRIPTION
## The Issue
Add WSL2 support to the ddev tableplus command
Looks like TablePlus have put out a release since the blocking issue was encountered here - https://github.com/ddev/ddev/pull/2679#issuecomment-740371838

## How This PR Solves The Issue
Adds a case that launches the Windows version of TablePlus, taking advantage of the WSL2 OS identifier 

## Manual Testing Instructions

## Automated Testing Overview

## Related Issue Link(s)

## Release/Deployment Notes


