### PR TITLE
feat: add environment and name to TablePlus command

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -19,7 +19,7 @@ driver=mysql
 if [[ $dbtype == "postgres" ]]; then
     driver=$dbtype
 fi
-query="${driver}://db:db@127.0.0.1:${DDEV_HOST_DB_PORT}/db"
+query="${driver}://db:db@127.0.0.1:${DDEV_HOST_DB_PORT}/db?Enviroment=local&Name=ddev-${DDEV_SITENAME}"
 
 set -x
 open "$query" -a "/Applications/TablePlus.app/Contents/MacOS/TablePlus"


### PR DESCRIPTION
## The Issue
Running `ddev tableplus` opens the database tagged as production and without any description of the site being worked on

## How This PR Solves The Issue
It adds `Environment` and `Name` query parameters to the URI, which [TablePlus interprets](https://joshbutts.com/posts/tableplus-shortcuts/)

## Manual Testing Instructions
- Run `ddev tableplus` on a project
- Check out the toolbar, which should now show a green "loc" box and should show the site name

## Automated Testing Overview
I don't think this requires any extra testing beyond any pre-existing tests for `ddev tableplus`

## Related Issue Link(s)
- no known issue

## Release/Deployment Notes
- should not impact anything else