### PR TITLE
fix: fix broken macos upgrade command in documentation 

### DIFF
--- a/docs/content/users/install/ddev-upgrade.md
+++ b/docs/content/users/install/ddev-upgrade.md
@@ -10,7 +10,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ```bash
     # Upgrade DDEV to the latest version
-    brew upgrade ddev/ddev/ddev
+    brew upgrade drud/ddev/ddev
     ```
 
     ### Install Script


### PR DESCRIPTION
Nothing big, seems like little mistake

```
➜  brew upgrade ddev/ddev/ddev
Error: No available formula or cask with the name "ddev/ddev/ddev".
Please tap it and then try again: brew tap ddev/ddev
➜   brew upgrade drud/ddev/ddev
Warning: drud/ddev/ddev 1.22.6 already installed
```