### PR TITLE
build: bump docker-compose to v2.24.3

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -43,4 +43,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.17.2"
 
-const RequiredDockerComposeVersionDefault = "v2.23.3"
+const RequiredDockerComposeVersionDefault = "v2.24.3"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

It's time to update `docker-compose`.

The most significant change in [v2.24.0](https://github.com/docker/compose/releases/tag/v2.24.0):

Breaking change ⚠️
service hash computation logic has been updated to fully ignore replicas/scale. Due to this change, after upgrade all services will be recreated.