### PR TITLE
fix: wording on install docs home page about Docker providers should be more generic

### DIFF
--- a/docs/content/users/install/index.md
+++ b/docs/content/users/install/index.md
@@ -1,5 +1,5 @@
 # Installation
 
-Whatever system you’re on, you’ll first need to [Install Docker or Colima](docker-installation.md), then [Install DDEV](ddev-installation.md).
+Whatever system you’re on, you’ll first need to [install a Docker provider](docker-installation.md), then [Install DDEV](ddev-installation.md).
 
 For the best experience, consider [performance tuning](performance.md) and [enabling shell completion](shell-completion.md).


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

The install docs home page at https://ddev.readthedocs.io/en/stable/users/install/ only mentions two Docker providers, but DDEV now recommends more than that.

## How This PR Solves The Issue

Change the wording to be generic, so we don't have a second list to maintain here.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

