### PR TITLE
fix: update project schema nodejs_version, for #5400

### DIFF
--- a/pkg/ddevapp/schema.json
+++ b/pkg/ddevapp/schema.json
@@ -218,13 +218,8 @@
       "type": "boolean"
     },
     "nodejs_version": {
-      "description": "Node.js version for the web container’s “system” version.",
-      "type": "string",
-      "enum": [
-        "16",
-        "18",
-        "20"
-      ]
+      "description": "Node.js version for the web container's \"system\" version.",
+      "type": "string"
     },
     "omit_containers": {
       "description": "A list of container types that should not be started when the project is started",


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #5400

After changes in `nodejs_version`, we should accept any possible value.

## How This PR Solves The Issue

Removes enum restrictions for `nodejs_version`.

Removes all unicode characters as in

- #5653

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

