### PR TITLE
build: filter binaries for deb and rpm on release, fixes #5734

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -247,6 +247,9 @@ nfpms:
   homepage: https://github.com/ddev/ddev
   description: |
     Open-source local web development tool
+  builds:
+  - ddev
+  - mkcert
   formats:
   - deb
   - rpm


### PR DESCRIPTION
## The Issue

-  #5734

## How This PR Solves The Issue

Uses only `ddev` and `mkcert` for `builds`.

From https://goreleaser.com/customization/nfpm/?h=nfpms

```yaml
# Build IDs for the builds you want to create NFPM packages for.
# Defaults empty, which means no filtering.
builds:
```

## Manual Testing Instructions

Unpack deb and rpm to see what is inside `/usr/bin`
https://github.com/ddev-test/ddev/releases/tag/v1.22.8-pr5759-deb-rpm-binaries

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new build targets for `ddev` and `mkcert` in the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->