### PR TITLE
docs: use Stack Overflow email filter for maintainers

### DIFF
--- a/docs/content/developers/maintainers.md
+++ b/docs/content/developers/maintainers.md
@@ -11,7 +11,7 @@ Not all maintainers can do all these things at any given time, but these are the
 * **Support**: We try to give friendly, accurate, and timely responses to those who need help in:
     * [Issue queue](https://github.com/ddev/ddev/issues) (and discussions, etc). Please follow all in at least the ddev/ddev project. On the Watch/Unwatch button at the top of the repository, consider selecting "All Activity". Also consider this on other projects in the `ddev` organization or other projects that are in your interest area.
     * Discord: Please read everything that happens in the [DDEV Discord](https://discord.gg/5wjP76mBJD) and respond to questions that you can help with.
-    * Stack Overflow. You can subscribe to the [ddev tag on Stack Overflow](https://stackoverflow.com/questions/tagged/ddev) and answer or comment on questions there.
+    * Stack Overflow. You can subscribe to the [ddev tag on Stack Overflow](https://stackoverflow.com/questions/tagged/ddev) using the [email filter](https://meta.stackoverflow.com/a/400613/8097891) and answer or comment on questions there.
     * Often in [Drupal Slack](https://www.drupal.org/join-slack) #ddev channel. We have tried and tried to get people over to Discord, but it's still pretty active there.
     * Other add-on repositories or related repos where we can help.
 * **Test Runner and Test System Maintenance**: The testing system is complex, and most tests are end-to-end tests, which can be fragile due to design, internet problems, changes upstream, etc. When something goes wrong, we want to figure out what it is and make it better. This can include debugging or rebooting Buildkite-runners, etc.


### PR DESCRIPTION
## The Issue

Not receiving email notifications on Stack Overflow after adding the `ddev` tag to watched:

> Stack Overflow. You can subscribe to the [ddev tag on Stack Overflow](https://stackoverflow.com/questions/tagged/ddev) and answer or comment on questions there.

## How This PR Solves The Issue

Add a link to information on how to create a new email filter to receive notifications by tag.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

