### PR TITLE
docs: auto-enable/disable Xdebug when step debugging with VS Code

### DIFF
--- a/docs/content/users/debugging-profiling/step-debugging.md
+++ b/docs/content/users/debugging-profiling/step-debugging.md
@@ -11,7 +11,7 @@ All IDEs basically work the same, listening on a port and reacting when they’r
 
 **Key facts:**
 
-* Enable Xdebug by running [`ddev xdebug`](../usage/commands.md#xdebug) or `ddev xdebug on` from your project directory.  
+* Enable Xdebug by running [`ddev xdebug`](../usage/commands.md#xdebug) or `ddev xdebug on` from your project directory.
 It will remain enabled until you start or restart the project.
 * Disable Xdebug for better performance when not debugging with `ddev xdebug off`.
 * Toggle Xdebug on and off easily with `ddev xdebug toggle`.
@@ -81,10 +81,10 @@ If you encounter the error: "Can't find a source position. Server with name 'SIT
 ### Visual Studio Code (VS Code) Debugging Setup
 
 1. Install the [PHP Debug](https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug) extension.
-2. Update the project’s `.vscode/launch.json` to add the “Listen for Xdebug” configuration from [this config snippet](../snippets/launch.json). For more on customizing `launch.json`, see the [VS Code docs](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations).
-3. Set a breakpoint in your `index.php`. If it isn’t solid red, restart.
-4. In the menu, choose *Run* → *Start Debugging*. You may have to select “Listen for Xdebug” by the green arrowhead at the top left. The bottom pane of VS Code should now be orange (live) and should say “Listen for Xdebug”.
-5. Enable Xdebug with `ddev xdebug on`.
+2. In the menu, choose *Run* → *Open Configuration* and add the [“Listen for Xdebug” configuration snippet](../snippets/launch.json) to the project’s `.vscode/launch.json`.
+3. In the menu, choose *Terminal* → *Configure tasks* → *Create task.json from template* → *Others* and add the [“Enable Ddev Xdebug” and “Disable Ddev Xdebug” task snippet](../snippets/tasks.json) to the project’s `.vscode/tasks.json`.
+4. Set a breakpoint in your `index.php`. If it isn’t solid red, restart.
+5. In the menu, choose *Run* → *Start Debugging*. You may have to select “Listen for Xdebug” by the green arrowhead at the top left. The bottom pane of VS Code should now be orange (live) and should say “Listen for Xdebug”.
 6. In a browser, visit your project and confirm you hit the breakpoint.
 
 !!!tip "If you’re using VS Code on Windows with WSL2"

--- a/docs/content/users/snippets/launch.json
+++ b/docs/content/users/snippets/launch.json
@@ -1,4 +1,6 @@
 {
+    // See https://code.visualstudio.com/docs/editor/debugging#_launch-configurations
+    // for the documentation about the launch.json format
     "version": "0.2.0",
     "configurations": [
         {
@@ -9,7 +11,9 @@
             "port": 9003,
             "pathMappings": {
                 "/var/www/html": "${workspaceFolder}"
-            }
+            },
+            "preLaunchTask": "Ddev: Enable Xdebug",
+            "postDebugTask": "Ddev: Disable Xdebug"
         }
     ]
 }

--- a/docs/content/users/snippets/tasks.json
+++ b/docs/content/users/snippets/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Ddev: Enable Xdebug",
+            "type": "shell",
+            "command": "ddev xdebug on"
+        },
+        {
+            "label": "Ddev: Disable Xdebug",
+            "type": "shell",
+            "command": "ddev xdebug off"
+        }
+    ]
+}


### PR DESCRIPTION
## The Issue

Turning Xdebug on and off with ddev is a cheap operation:

```
ddev xdebug [on|off]
```

Cheap, but also expensive, in that I often forget to one or both of these tasks when Step Debugging with Visual Studio Code ([docs]).

It would be nice to automatically execute the shell command `ddev xdebug [on|off]` when starting and stopping the “Listen for Xdebug” command inside Visual Studio Code. This would remove extra steps, breaking context, as well as avoiding accidentally leaving it on after finishing a debugging session.

## How This PR Solves The Issue

This PR updates the Step Debugging docs for Visual Studio Code ([docs]) with the following:

* Introduce a step to create the `.vscode/tasks.json` where the `ddev xdebug on|off` commands are housed.
* Add a `preLaunchTask` and `postDebugTask` step to the existing `.vscode/launch.json` configuration snippet provided by docs.
* Provide a `tasks.json` snippet file with Ddev docs from which to copy/paste the new configs.
* Remove the manual step of requiring to turn `ddev xdebug on`.

 
## Manual Testing Instructions

### 1.- Setup

Follow the complete steps as modified in this PR, copied here for ease of use, 

1. Install the [PHP Debug](https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug) extension.
2. In the menu, choose *Run* → *Open Configuration* and add the [“Listen for Xdebug” configuration snippet](../snippets/launch.json) to the project’s `.vscode/launch.json`.
3. In the menu, choose *Terminal* → *Configure tasks* → *Create task.json from template* → *Others* and add the [“Enable Ddev Xdebug” and “Disable Ddev Xdebug” task snippet](../snippets/tasks.json) to the project’s `.vscode/tasks.json`.
4. Set a breakpoint in your `index.php`. If it isn’t solid red, restart.
5. In the menu, choose *Run* → *Start Debugging*. You may have to select “Listen for Xdebug” by the green arrowhead at the top left. The bottom pane of VS Code should now be orange (live) and should say “Listen for Xdebug”.
6. In a browser, visit your project and confirm you hit the breakpoint.

For step 2 and 3, use the following snippets:

.vscode/launch.json:
```json
{
    // See https://code.visualstudio.com/docs/editor/debugging#_launch-configurations
    // for the documentation about the launch.json format
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Listen for Xdebug",
            "type": "php",
            "request": "launch",
            "hostname": "0.0.0.0",
            "port": 9003,
            "pathMappings": {
                "/var/www/html": "${workspaceFolder}"
            },
            "preLaunchTask": "Ddev: Enable Xdebug",
            "postDebugTask": "Ddev: Disable Xdebug"
        }
    ]
}
```


.vscode/tasks.json:
```json
{
  // See https://go.microsoft.com/fwlink/?LinkId=733558
  // for the documentation about the tasks.json format
  "version": "2.0.0",
  "tasks": [
    {
      "label": "Enable DDEV Xdebug",
      "type": "shell",
      "command": "ddev xdebug on"
    },
    {
      "label": "Disable DDEV Xdebug",
      "type": "shell",
      "command": "ddev xdebug off"
    }
  ]
}
```

### 2.- Test

Between step 4 and step 5 confirm that Xdebug is off, by typing in your terminal `ddev xdebug status`  (result should say "xdebug disabled").

At step 5, confirm that VS Code's Terminal shows the following output, indicating that the step debugger was able to find and execute the task:

```
 *  Executing task: ddev xdebug on 

Enabled xdebug
 *  Terminal will be reused by tasks, press any key to close it. 
```

At step 6, confirm that VS Code hits the breakpoint set in index.php, and step debugging works, as normal.  At this time you can also go manually check in terminal to confirm that Xdebug is on with `ddev xdebug status`.

When finished step debugging, tap the red block to Stop debugging in VS Code. The Terminal window should display the following:

```
 *  Executing task: ddev xdebug off 

Disabled xdebug
 *  Terminal will be reused by tasks, press any key to close it. 
```

Finally, confirm that Xdebug is actually off, by manually typing into your terminal the following command: `ddev xdebug status`. The status should be disabled.

## Related Issue Link(s)

This came about in a support request thread on the Ddev Discord server:
  
https://discord.com/channels/664580571770388500/1203038681322102804

Related docs:

https://code.visualstudio.com/docs/editor/debugging


## Release/Deployment Notes

Not applicable

[docs]: https://ddev.readthedocs.io/en/latest/users/debugging-profiling/step-debugging/#visual-studio-code-vs-code-debugging-setup