### PR TITLE
fix: nodejs in web container should be link to /usr/local/bin/node

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -36,7 +36,7 @@ There are many ways to deploy Node.js in any project, so DDEV tries to let you s
 * [`ddev npm`](../usage/commands.md#npm) and [`ddev yarn`](../usage/commands.md#yarn) provide shortcuts to the `npm` and `yarn` commands inside the container, and their caches are persistent.
 * You can run Node.js daemons using [`web_extra_daemons`](#running-extra-daemons-in-the-web-container).
 * You can expose Node.js ports via `ddev-router` by using [`web_extra_exposed_ports`](#exposing-extra-ports-via-ddev-router).
-* You can manually run Node.js scripts using [`ddev exec <script>`](../usage/commands.md#exec) or `ddev exec nodejs <script>`.
+* You can manually run Node.js scripts using [`ddev exec <script>`](../usage/commands.md#exec) or `ddev exec node <script>`.
 
 !!!tip "Please share your techniques!"
     There are several ways to share your favorite Node.js tips and techniques. Best are [ddev-get add-ons](additional-services.md#additional-service-configurations-and-add-ons-for-ddev), [Stack Overflow](https://stackoverflow.com/tags/ddev), and [ddev-contrib](https://github.com/ddev/ddev-contrib).

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -33,7 +33,7 @@ Type `ddev` or `ddev -h` in a terminal window to see the available DDEV [command
 
 ## Node.js, npm, nvm, and Yarn
 
-`nodejs`, `npm`, `nvm` and `yarn` are preinstalled in the web container. You can configure the default value of the installed Node.js version with the [`nodejs_version`](../configuration/config.md#nodejs_version) option in `.ddev/config.yaml` or with `ddev config --nodejs_version`. You can also override that with any value using the built-in `nvm` in the web container or with [`ddev nvm`](../usage/commands.md#nvm), for example `ddev nvm install 6`. There is also a [`ddev yarn`](../usage/commands.md#yarn) command.
+`node`, `nodejs`, `npm`, `nvm` and `yarn` are preinstalled in the web container. You can configure the default value of the installed Node.js version with the [`nodejs_version`](../configuration/config.md#nodejs_version) option in `.ddev/config.yaml` or with `ddev config --nodejs_version`. You can also override that with any value using the built-in `nvm` in the web container or with [`ddev nvm`](../usage/commands.md#nvm), for example `ddev nvm install 6`. There is also a [`ddev yarn`](../usage/commands.md#yarn) command. (Note that since `nodejs_version` configuration can now specify any `node` version, including patch versions, it's preferred to using the less robust `ddev nvm` way of specifying the `node` version.)
 
 ## More Bundled Tools
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -956,7 +956,7 @@ ddev npm update
 
 ## `nvm`
 
-Run [`nvm`](https://github.com/nvm-sh/nvm#usage) inside the web container (global shell web container command).
+Run [`nvm`](https://github.com/nvm-sh/nvm#usage) inside the web container (global shell web container command). (Use of `ddev nvm` is discouraged because `nodejs_version` is much easier to use, can specify any version, and is more robust than using `nvm`.)
 
 Example:
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -933,7 +933,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	extraWebContent = extraWebContent + "\nENV NVM_DIR=/home/$username/.nvm"
 	if app.NodeJSVersion != nodeps.NodeJSDefault {
 		extraWebContent = extraWebContent + "\nRUN npm install -g n"
-		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN n install %s && ln -s /usr/local/bin/node /usr/local/bin/nodejs", app.NodeJSVersion)
+		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN n install %s && ln -sf /usr/local/bin/node /usr/local/bin/nodejs", app.NodeJSVersion)
 	}
 
 	// Add supervisord config for WebExtraDaemons

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -933,7 +933,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	extraWebContent = extraWebContent + "\nENV NVM_DIR=/home/$username/.nvm"
 	if app.NodeJSVersion != nodeps.NodeJSDefault {
 		extraWebContent = extraWebContent + "\nRUN npm install -g n"
-		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN n install %s", app.NodeJSVersion)
+		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN n install %s && ln -s /usr/local/bin/node /usr/local/bin/nodejs", app.NodeJSVersion)
 	}
 
 	// Add supervisord config for WebExtraDaemons


### PR DESCRIPTION
## The Issue

Benny pointed out in [Discord](https://discord.com/channels/664580571770388500/1203395133580640327/1203395133580640327) that while `ddev exec node --version` works correctly, `ddev exec nodejs --version` gets the apt-install nodejs version instead.

* https://github.com/ddev/ddev/pull/5521#issuecomment-1925414133

## How This PR Solves The Issue

* Add a symlink for /usr/local/bin/nodejs
* Add to docs discouraging use of `ddev nvm`

## Manual Testing Instructions

`ddev exec nodejs --version` should show the version of `nodejs_version` configured.

## Automated Testing Overview

No changes

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

