### PR TITLE
test: Revert "test: bump docker-login buildkite plugin to 3.0.0"

### DIFF
--- a/.buildkite/macos-docker-desktop-amd64.yml
+++ b/.buildkite/macos-docker-desktop-amd64.yml
@@ -1,6 +1,6 @@
   - command: ".buildkite/test.sh"
     plugins:
-      - docker-login#v3.0.0:
+      - docker-login#v2.1.0:
           username: druddockerpullaccount
           password-env: DOCKERHUB_PULL_PASSWORD
     agents:

--- a/.buildkite/macos-docker-desktop-arm64.yml
+++ b/.buildkite/macos-docker-desktop-arm64.yml
@@ -1,6 +1,6 @@
   - command: ".buildkite/test.sh"
     plugins:
-      - docker-login#v3.0.0:
+      - docker-login#v2.1.0:
           username: druddockerpullaccount
           password-env: DOCKERHUB_PULL_PASSWORD
     agents:

--- a/.buildkite/macos-orbstack.yml
+++ b/.buildkite/macos-orbstack.yml
@@ -1,6 +1,6 @@
   - command: ".buildkite/test.sh"
     plugins:
-      - docker-login#v3.0.0:
+      - docker-login#v2.1.0:
           username: druddockerpullaccount
           password-env: DOCKERHUB_PULL_PASSWORD
     agents:

--- a/.buildkite/macos-rancher-desktop.yml
+++ b/.buildkite/macos-rancher-desktop.yml
@@ -1,6 +1,6 @@
   - command: ".buildkite/test.sh"
     plugins:
-      - docker-login#v3.0.0:
+      - docker-login#v2.1.0:
           username: druddockerpullaccount
           password-env: DOCKERHUB_PULL_PASSWORD
     agents:

--- a/.buildkite/windows10_container.yml
+++ b/.buildkite/windows10_container.yml
@@ -1,6 +1,6 @@
   - command: ".buildkite/test_containers.cmd"
     plugins:
-      - docker-login#v3.0.0:
+      - docker-login#v2.1.0:
           username: druddockerpullaccount
           password-env: DOCKERHUB_PULL_PASSWORD
     agents:

--- a/.buildkite/windows10dockerforwindows.yml
+++ b/.buildkite/windows10dockerforwindows.yml
@@ -1,6 +1,6 @@
   - command: ".buildkite/test.cmd"
     plugins:
-      - docker-login#v3.0.0:
+      - docker-login#v2.1.0:
           username: druddockerpullaccount
           password-env: DOCKERHUB_PULL_PASSWORD
     agents:

--- a/.buildkite/wsl2-docker-desktop.yml
+++ b/.buildkite/wsl2-docker-desktop.yml
@@ -1,6 +1,6 @@
   - command: ".buildkite/test.sh"
     plugins:
-      - docker-login#v3.0.0:
+      - docker-login#v2.1.0:
           username: druddockerpullaccount
           password-env: DOCKERHUB_PULL_PASSWORD
     agents:

--- a/.buildkite/wsl2-docker-inside.yml
+++ b/.buildkite/wsl2-docker-inside.yml
@@ -1,6 +1,6 @@
   - command: ".buildkite/test.sh"
     plugins:
-      - docker-login#v3.0.0:
+      - docker-login#v2.1.0:
           username: druddockerpullaccount
           password-env: DOCKERHUB_PULL_PASSWORD
     agents:


### PR DESCRIPTION
Reverts 
* ddev/ddev#5769

#5769 broke the use of `docker context`, so our setup for orbstack and rancher desktop couldn't work.