### PR TITLE
test: only test macos amd64 on master

### DIFF
--- a/.buildkite/macos-docker-desktop-amd64.yml
+++ b/.buildkite/macos-docker-desktop-amd64.yml
@@ -7,6 +7,7 @@
       - "os=macos"
       - "docker-desktop=true"
       - "architecture=amd64"
+    branches: "master"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds


### PR DESCRIPTION

## The Issue

macOS AMD64 testing is becoming less and less relevant as people upgrade. We don't need to test it on every PR/push. 

It also really doesn't show any differences these days from arm64. And it's quite a bit slower.

## How This PR Solves The Issue

Only test it on master.


