### PR TITLE
test: CircleCI upgrade to go v1.21

### DIFF
--- a/.ci-scripts/linux_arm64_setup.sh
+++ b/.ci-scripts/linux_arm64_setup.sh
@@ -5,7 +5,7 @@ set -o errexit
 # Basic tools
 
 set -x
-export GO_VERSION=1.21
+export GO_VERSION=1.21.6
 
 if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
   set +x

--- a/.ci-scripts/linux_arm64_setup.sh
+++ b/.ci-scripts/linux_arm64_setup.sh
@@ -5,7 +5,7 @@ set -o errexit
 # Basic tools
 
 set -x
-export GO_VERSION=1.20
+export GO_VERSION=1.21
 
 if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
   set +x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v31
+        - linux-homebrew-v32
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-homebrew-v31
+        key: linux-homebrew-v32
         paths:
           - /home/linuxbrew
     - run:
@@ -64,16 +64,16 @@ jobs:
     - run: 'mkdir -p ~/.ngrok2 && echo "authtoken: ${NGROK_TOKEN}" >~/.ngrok2/ngrok.yml'
     - restore_cache:
         keys:
-        - linux-homebrew-v31
+        - linux-homebrew-v32
     - restore_cache:
         keys:
-          - linux-testcache-v31
+          - linux-testcache-v32
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-homebrew-v31
+        key: linux-homebrew-v32
         paths:
           - /home/linuxbrew
     - run: echo "$(docker --version) $(docker-compose --version)"
@@ -84,7 +84,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-testcache-v31
+        key: linux-testcache-v32
         paths:
         - /home/circleci/.ddev/testcache
 
@@ -225,7 +225,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v31
+        - linux-homebrew-v32
     - attach_workspace:
         at: ~/
     - run:
@@ -242,7 +242,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-homebrew-v31
+        key: linux-homebrew-v32
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -260,7 +260,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v31
+        - linux-homebrew-v32
     - attach_workspace:
         at: ~/
     - run:
@@ -279,7 +279,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-homebrew-v31
+        key: linux-homebrew-v32
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -294,7 +294,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v31
+        - linux-homebrew-v32
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup
@@ -316,7 +316,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v31
+        - linux-homebrew-v32
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup
@@ -340,7 +340,7 @@ jobs:
         name: linux container test
 
     - save_cache:
-        key: linux-homebrew-v31
+        key: linux-homebrew-v32
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -407,7 +407,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v31
+        - linux-homebrew-v32
     - attach_workspace:
         at: ~/
     - run:
@@ -415,7 +415,7 @@ jobs:
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-homebrew-v31
+        key: linux-homebrew-v32
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,7 +521,6 @@ workflows:
     - lx_arm64_fpm_test:
         filters:
           branches:
-            only: master
             ignore:
               - gh-pages
 #    - lx_arm64_container_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,6 +521,7 @@ workflows:
     - lx_arm64_fpm_test:
         filters:
           branches:
+            only: master
             ignore:
               - gh-pages
 #    - lx_arm64_container_test


### PR DESCRIPTION
## The Issue

* #5732 introduced the slices package which appeared in go v1.21, and CircleCI was set up for v1.20

## How This PR Solves The Issue

Update CircleCI config

I'm not 100% sure that we need to keep testing Linux arm64. It's very lightly used, just by people with Raspberry Pi or MS Surface Pro. And the actual testing is probably adequate on macOS. We *could* make a mistake with images, etc.