### PR TITLE
docs: show initial and project-checkout Backdrop installation

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -9,9 +9,9 @@ Before proceeding, make sure your installation of DDEV is up to date. In a new a
 To get started with [Backdrop](https://backdropcms.org), clone the project repository and navigate to the project directory.
 
 ```bash
-git clone https://github.com/example/example-site
-cd example-site
-ddev config
+git clone https://github.com/backdrop/backdrop my-backdrop-site
+cd my-backdrop-site
+ddev config --project-type=backdrop
 ddev start
 ddev launch
 ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -8,13 +8,44 @@ Before proceeding, make sure your installation of DDEV is up to date. In a new a
 
 To get started with [Backdrop](https://backdropcms.org), clone the project repository and navigate to the project directory.
 
+=== "New projects"
+
 ```bash
+# Create a project directory and move into it:
 git clone https://github.com/backdrop/backdrop my-backdrop-site
 cd my-backdrop-site
+
+# Set up the DDEV environment:
 ddev config --project-type=backdrop
+
+# Boot the project and install the starter project:
 ddev start
+
+# Launch the website and step through the initial setup
 ddev launch
 ```
+
+=== "Existing projects"
+
+    You can start using DDEV with an existing project, too—but make sure you have a database backup handy!
+
+
+    ```bash
+    # Clone an existing repository (or navigate to a local project directory):
+    git clone https://github.com/example/example-site example-site
+    cd example-site
+
+    # Set up the DDEV environment:
+    ddev config --project-type=backdrop
+
+    # Boot the project and install Composer packages (if required):
+    ddev start
+    ddev composer install
+
+    # Import a database backup and open the site in your browser:
+    ddev import-db --file=/path/to/db.sql.gz
+    ddev launch
+    ```
 
 ## Craft CMS
 


### PR DESCRIPTION
## The Issue
The current Backdrop quickstart fails:

```shell
git clone https://github.com/example/example-site
Cloning into 'example-site'...
remote: Repository not found.
fatal: repository 'https://github.com/example/example-site/' not found
```

## How This PR Solves The Issue
This PR fixes 2 issues with the current documenation:

- Corrects clone target
- Sets DDEV config to "backdrop"

As I don't use Backdrop, I'm not sure if this "best practises". However, these steps did result in the "site setup" screen displaying.

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

![image](https://github.com/ddev/ddev/assets/7234392/449144ef-d4bd-437c-885c-df4750ffc4b3)


## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

