### PR TITLE
feat: enable autocompletion for custom commands, fixes #5783

### DIFF
--- a/cmd/ddev/cmd/autocompletion_test.go
+++ b/cmd/ddev/cmd/autocompletion_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/fileutil"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -201,6 +205,152 @@ func TestAutocompletionForDescribeCmd(t *testing.T) {
 	assert.NoError(err)
 	filteredOut = getTestingSitesFromOutput(out)
 	assert.Empty(filteredOut)
+}
+
+// TestAutocompletionForCustomCmds checks custom autocompletion for custom host and container commands
+func TestAutocompletionForCustomCmds(t *testing.T) {
+	assert := asrt.New(t)
+
+	origDir, _ := os.Getwd()
+
+	site := TestSites[0]
+	err := os.Chdir(site.Dir)
+	require.NoError(t, err)
+
+	app, err := ddevapp.NewApp("", false)
+	assert.NoError(err)
+
+	tmpHome, _, err := makeTempHomeDir(app, t)
+	require.NoError(t, err)
+
+	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
+
+	t.Cleanup(func() {
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		// Stop the Mutagen daemon running in the bogus homedir
+		ddevapp.StopMutagenDaemon()
+		_ = os.RemoveAll(tmpHome)
+		_ = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", "commands"))
+		_ = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", ".global_commands"))
+	})
+	err = app.Start()
+	require.NoError(t, err)
+
+	// We can't use the standard getGlobalDDevDir here because *our* global hasn't changed.
+	// It's changed via $HOME for the DDEV subprocess
+	err = os.MkdirAll(filepath.Join(tmpHome, ".ddev"), 0755)
+	assert.NoError(err)
+
+	tmpHomeGlobalCommandsDir := filepath.Join(tmpHome, ".ddev", "commands")
+	projectCommandsDir := app.GetConfigPath("commands")
+	projectGlobalCommandsCopy := app.GetConfigPath(".global_commands")
+
+	// Remove existing commands
+	err = os.RemoveAll(tmpHomeGlobalCommandsDir)
+	assert.NoError(err)
+	err = os.RemoveAll(projectCommandsDir)
+	assert.NoError(err)
+	err = os.RemoveAll(projectGlobalCommandsCopy)
+	assert.NoError(err)
+	// Copy project and global commands into project
+	err = fileutil.CopyDir(filepath.Join(testdataCustomCommandsDir, "project_commands"), projectCommandsDir)
+	assert.NoError(err)
+	err = fileutil.CopyDir(filepath.Join(testdataCustomCommandsDir, "global_commands"), tmpHomeGlobalCommandsDir)
+	require.NoError(t, err)
+	_, _ = exec.RunHostCommand(DdevBin, "debug", "fix-commands")
+
+	// Must sync our added commands before using them.
+	err = app.MutagenSyncFlush()
+	assert.NoError(err)
+
+	// Check completion results are as expected for each command
+	for _, cmd := range []string{"global-host-cmd", "global-web-cmd", "project-host-cmd", "project-web-cmd"} {
+		out, err := exec.RunHostCommand(DdevBin, "__complete", cmd, "anArg")
+		assert.NoError(err)
+		expectedHost, _ := os.Hostname()
+		if !strings.Contains(cmd, "host") {
+			expectedHost = site.Name + "-web"
+		}
+		// We're not testing the internals of cobra's completion so we don't want to assert the exact output,
+		// just check that the suggestions we expect are included in the output.
+		assert.Contains(out, expectedHost)
+		assert.Contains(out, cmd)
+		assert.Contains(out, "anArg")
+	}
+}
+
+// TestAutocompleteTermsForCustomCmds tests the AutocompleteTerms annotation for custom host and container commands
+func TestAutocompleteTermsForCustomCmds(t *testing.T) {
+	assert := asrt.New(t)
+
+	origDir, _ := os.Getwd()
+
+	site := TestSites[0]
+	err := os.Chdir(site.Dir)
+	require.NoError(t, err)
+
+	app, err := ddevapp.NewApp("", false)
+	assert.NoError(err)
+
+	tmpHome, _, err := makeTempHomeDir(app, t)
+	require.NoError(t, err)
+
+	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
+
+	t.Cleanup(func() {
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		// Stop the Mutagen daemon running in the bogus homedir
+		ddevapp.StopMutagenDaemon()
+		_ = os.RemoveAll(tmpHome)
+		_ = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", "commands"))
+		_ = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", ".global_commands"))
+	})
+	err = app.Start()
+	require.NoError(t, err)
+
+	// We can't use the standard getGlobalDDevDir here because *our* global hasn't changed.
+	// It's changed via $HOME for the DDEV subprocess
+	err = os.MkdirAll(filepath.Join(tmpHome, ".ddev"), 0755)
+	assert.NoError(err)
+
+	tmpHomeGlobalCommandsDir := filepath.Join(tmpHome, ".ddev", "commands")
+	projectCommandsDir := app.GetConfigPath("commands")
+	projectGlobalCommandsCopy := app.GetConfigPath(".global_commands")
+
+	// Remove existing commands
+	err = os.RemoveAll(tmpHomeGlobalCommandsDir)
+	assert.NoError(err)
+	err = os.RemoveAll(projectCommandsDir)
+	assert.NoError(err)
+	err = os.RemoveAll(projectGlobalCommandsCopy)
+	assert.NoError(err)
+	// Copy project and global commands into project
+	err = fileutil.CopyDir(filepath.Join(testdataCustomCommandsDir, "project_commands"), projectCommandsDir)
+	assert.NoError(err)
+	err = fileutil.CopyDir(filepath.Join(testdataCustomCommandsDir, "global_commands"), tmpHomeGlobalCommandsDir)
+	require.NoError(t, err)
+	_, _ = exec.RunHostCommand(DdevBin, "debug", "fix-commands")
+
+	// Must sync our added commands before using them.
+	err = app.MutagenSyncFlush()
+	assert.NoError(err)
+
+	// Check completion results are as expected for each command
+	for _, cmd := range []string{"global-host-cmd", "global-web-cmd", "project-host-cmd", "project-web-cmd"} {
+		out, err := exec.RunHostCommand(DdevBin, "__complete", cmd, "")
+		assert.NoError(err)
+		// We're not testing the internals of cobra's completion so we don't want to assert the exact output,
+		// just check that the suggestions we expect are included in the output.
+		assert.Contains(out, strings.Replace(cmd, "cmd", "one", 1))
+		assert.Contains(out, "suggest two")
+		assert.Contains(out, "three")
+	}
 }
 
 // getTestingSitesFromOutput() finds only the ddev list items that

--- a/cmd/ddev/cmd/testdata/TestAutocompleteTermsForCustomCmds/global_commands/host/global-host-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompleteTermsForCustomCmds/global_commands/host/global-host-cmd
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: global-host-cmd
+## Usage: global-host-cmd
+## Example: "ddev global-host-cmd"
+## AutocompleteTerms: ["global-host-one", "suggest two", "three"]
+
+echo "this test doesn't need to be executed - just check the autocompletion."

--- a/cmd/ddev/cmd/testdata/TestAutocompleteTermsForCustomCmds/global_commands/web/global-web-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompleteTermsForCustomCmds/global_commands/web/global-web-cmd
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: global-web-cmd
+## Usage: global-web-cmd
+## Example: "ddev global-web-cmd"
+## AutocompleteTerms: ["global-web-one", "suggest two", "three"]
+
+echo "this test doesn't need to be executed - just check the autocompletion."

--- a/cmd/ddev/cmd/testdata/TestAutocompleteTermsForCustomCmds/project_commands/host/project-host-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompleteTermsForCustomCmds/project_commands/host/project-host-cmd
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: project-host-cmd
+## Usage: project-host-cmd
+## Example: "ddev project-host-cmd"
+## AutocompleteTerms: ["project-host-one", "suggest two", "three"]
+
+echo "this test doesn't need to be executed - just check the autocompletion."

--- a/cmd/ddev/cmd/testdata/TestAutocompleteTermsForCustomCmds/project_commands/web/project-web-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompleteTermsForCustomCmds/project_commands/web/project-web-cmd
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: project-web-cmd
+## Usage: project-web-cmd
+## Example: "ddev project-web-cmd"
+## AutocompleteTerms: ["project-web-one", "suggest two", "three"]
+
+echo "this test doesn't need to be executed - just check the autocompletion."

--- a/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/global_commands/host/autocomplete/global-host-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/global_commands/host/autocomplete/global-host-cmd
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ARGS=("$@")
+# prepend host name to args
+ARGS=( "$(hostname)" "${ARGS[@]}" )
+# print out all args, starting with the host name
+printf "%s\n" "${ARGS[@]}"

--- a/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/global_commands/host/global-host-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/global_commands/host/global-host-cmd
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: global-host-cmd
+## Usage: global-host-cmd
+## Example: "ddev global-host-cmd"
+
+echo "this test doesn't need to be executed - just check the autocompletion."

--- a/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/global_commands/web/autocomplete/global-web-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/global_commands/web/autocomplete/global-web-cmd
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ARGS=("$@")
+# prepend host name to args
+ARGS=( "$(hostname)" "${ARGS[@]}" )
+# print out all args, starting with the host name
+printf "%s\n" "${ARGS[@]}"

--- a/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/global_commands/web/global-web-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/global_commands/web/global-web-cmd
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: global-web-cmd
+## Usage: global-web-cmd
+## Example: "ddev global-web-cmd"
+
+echo "this test doesn't need to be executed - just check the autocompletion."

--- a/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/project_commands/host/autocomplete/project-host-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/project_commands/host/autocomplete/project-host-cmd
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ARGS=("$@")
+# prepend host name to args
+ARGS=( "$(hostname)" "${ARGS[@]}" )
+# print out all args, starting with the host name
+printf "%s\n" "${ARGS[@]}"

--- a/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/project_commands/host/project-host-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/project_commands/host/project-host-cmd
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: project-host-cmd
+## Usage: project-host-cmd
+## Example: "ddev project-host-cmd"
+
+echo "this test doesn't need to be executed - just check the autocompletion."

--- a/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/project_commands/web/autocomplete/project-web-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/project_commands/web/autocomplete/project-web-cmd
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ARGS=("$@")
+# prepend host name to args
+ARGS=( "$(hostname)" "${ARGS[@]}" )
+# print out all args, starting with the host name
+printf "%s\n" "${ARGS[@]}"

--- a/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/project_commands/web/project-web-cmd
+++ b/cmd/ddev/cmd/testdata/TestAutocompletionForCustomCmds/project_commands/web/project-web-cmd
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: project-web-cmd
+## Usage: project-web-cmd
+## Example: "ddev project-web-cmd"
+
+echo "this test doesn't need to be executed - just check the autocompletion."

--- a/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-etc-skel/etc/skel/.bashrc
@@ -116,6 +116,9 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
 [ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"
 
+# bash completion for npm
+[ -n "$(type -t npm)" ] && eval "$(npm completion)"
+
 for f in /etc/bashrc/*.bashrc; do
   source $f;
 done

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -65,6 +65,24 @@ Changes to the command files in the global `.ddev` directory need a `ddev start`
 
 There are many examples of [global](https://github.com/ddev/ddev/tree/master/pkg/ddevapp/global_dotddev_assets/commands) and [project-level](https://github.com/ddev/ddev/tree/master/pkg/ddevapp/dotddev_assets/commands) custom/shell commands that ship with DDEV you can adapt for your own use. They can be found in your `~/.ddev/commands/*` directories and in your project’s `.ddev/commands/*` directories. There you’ll see how to provide usage, examples, and how to use arguments provided to the commands. For example, the [`xdebug` command](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug) shows simple argument processing and the [launch command](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/global_dotddev_assets/commands/host/launch) demonstrates flag processing.
 
+## Command Line Completion
+
+If your custom command has a set of pre-determined valid arguments it can accept, you can use the [`AutocompleteTerms`](#autocompleteterms-annotation).
+
+For dynamic completion, you can create a separate script with the same name in a directory named `autocomplete`.
+For example, if your command is in `~/.ddev/commands/web/my-command`, your autocompletion script will be in `~/.ddev/commands/web/autocomplete/my-command`.
+
+When you press tab on the command line after your command, the associated autocomplete script will be executed. The current command line (starting with the name of your command) will be passed into the completion script as arguments. If there is a space at the end of the command line, an empty argument will be included.
+
+For example:
+
+* `ddev my-command <tab>` will pass `my-command` and an empty argument into the autocomplete script.
+* `ddev my-command som<tab>` will pass `my-command`, and `som` into the autocomplete script.
+
+The autocomplete script should echo the valid arguments as a string separated by line breaks. You don't need to filter the arguments by the last argument string (e.g. if the last argument is `som`, you don't need to filter out any arguments that don't start with `som`). That will be handled for you before the result is given to your shell as completion suggestions.
+
+The web container's [`nvm` autocomplete script](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/nvm) shows how this can be used to forward completion requests to a relevant script in the container.
+
 ## Environment Variables Provided
 
 A number of environment variables are provided to these command scripts. These are generally supported, but please avoid using undocumented environment variables. Useful variables for host scripts are:
@@ -185,6 +203,14 @@ The following fields can be used for a flag definition:
 * `DefValue`: default value for usage message
 * `NoOptDefVal`: default value, if the flag is on the command line without any options
 * `Annotations`: used by cobra.Command Bash autocomplete code (see <https://github.com/spf13/cobra/blob/main/site/content/completions/bash.md>)
+
+### `AutocompleteTerms` Annotation
+
+If your command accepts specific arguments, and you know ahead of time what those arguments are, you can use this annotation to provide those arguments for autocompletion.
+
+Usage: `## AutocompleteTerms: [<list-of-valid-arguments>]`
+
+Example: `## AutocompleteTerms: ["enable","disable","toggle","status"]`
 
 ### "CanRunGlobally" Annotation
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/npm
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/npm
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#ddev-generated
+# set env variables required for nvm's bash completion script
+COMP_WORDS=("$@")
+COMP_CWORD=$(($# - 1))
+# run the actual script
+_npm_completion
+# output the result (which was stored in COMPREPLY) as a new-line delimited string
+printf "%s\n" "${COMPREPLY[@]}"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/nvm
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/nvm
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#ddev-generated
+# set env variables required for nvm's bash completion script
+COMP_WORDS=("$@")
+COMP_CWORD=$(($# - 1))
+# run the actual script
+__nvm
+# output the result (which was stored in COMPREPLY) as a new-line delimited string
+printf "%s\n" "${COMPREPLY[@]}"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/blackfire
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/blackfire
@@ -6,6 +6,7 @@
 ## Example: "ddev blackfire" (default is "on"), "ddev blackfire off", "ddev blackfire on", "ddev blackfire status"
 ## ExecRaw: false
 ## Flags: []
+## AutocompleteTerms: ["start","stop","on","off","enable","disable","status"]
 
 function enable {
   if [ -z ${BLACKFIRE_SERVER_ID} ] || [ -z ${BLACKFIRE_SERVER_TOKEN} ]; then

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
@@ -6,6 +6,7 @@
 ## Example: "ddev xdebug" (default is "on"), "ddev xdebug off", "ddev xdebug on", "ddev xdebug toggle", "ddev xdebug status"
 ## Execraw: false
 ## Flags: []
+## AutocompleteTerms: ["on","off","enable","disable","toggle","status"]
 
 if [ $# -eq 0 ] ; then
   enable_xdebug

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/xhprof
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/xhprof
@@ -6,6 +6,7 @@
 ## Example: "ddev xhprof" (default is "on"), "ddev xhprof off", "ddev xhprof on", "ddev xhprof status"
 ## ExecRaw: false
 ## Flags: []
+## AutocompleteTerms: ["on","off","enable","disable","status"]
 
 if [ $# -eq 0 ]; then
   enable_xhprof


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #5783

## How This PR Solves The Issue

For static completions, a new annotation is introduced which provides an array of valid argument values. They aren't validated against, they're only used for completions.

For dynamic completions, if there's a script in the `autocompletions` subdirectory with the same name as a command in that service command directory, it'll be called and the current cli args will be passed in. That script can then use those args to generate a string of line-break-separated values which are valid (see edit to docs)

### Autocompletion scripts

All CLI args (including the name of the command, since this seems to be standard with bash autocompletion) are passed to the script as arguments. This includes an empty argument if `tab` is pressed after a space.

The return value from scripts should be a space-separated string of value arguments. The script doesn't have to check that what it's suggesting actually starts with the letters in the last argument - cobra handles that for us.
Note that we may want to do something other than space separated values, in case spaces are valid inside arguments somehow.... but for now this is more of a POC than anything.

I originally wanted to just set the `COMP_WORDS` and `COMP_CWORD` environment variables, and have the scripts check those and then set `COMPREPLY` with the result (see [this how-to to see why, and how those are involved in bash completion](https://www.baeldung.com/linux/shell-auto-completion)), but scripts can't set the environment variable in the shell docker is executing, so there'd be no way to get the result that way.
So since we can't use the normal bash completion result, we may as well make the arguments easier to pass in and parse as well.

I've added the new annotation to all the commands that seem to have obvious pre-determined valid arguments.

I've added dynamic completion for `nvm` and `npm`. There are other commands like `drush` that could probably also benefit from this, and I'd welcome developers who use those commands to submit PRs that introduce completion for them. The main purpose of this PR is not to add completion to all the commands, but to add the *capability* of adding completion to commands.

Wherever possible, completion should ideally be forwarded to a completion script being maintained by whoever maintains the underlying tool (such as I've done with `nvm` and `npm`). Sometimes (like with `yarn`) that won't be an option, so for some commands there will have to either not be any completion support, or the completion will need to be manually kept in sync with any changes to the underlying command.

## Manual Testing Instructions

`ddev restart`
`ddev debug fix-commands`
Try `ddev nvm <tab>`, or `ddev xdebug <tab>`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
Added tests both for the new annotation and for dynamic autocomplete scripts

## Related Issue Link(s)

- #5783

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
Developers will be able to add the new annotation and dynamic autocompletion scripts to their projects, global commands, and extensions.
There are no BC concerns with this approach.

There is a change to the `.bashrc` for the web image, so that image will need to be rebuilt.