### PR TITLE
build: Use new tag to get new deb.sury.org key (and updated php versions), fixes #5788

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local usage)
-FROM ddev/ddev-php-base:v1.22.6 as ddev-webserver-base
+FROM ddev/ddev-php-base:20240205_update_debsuryorg_key as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240104_redundant_chown" // Note that this can be overridden by make
+var WebTag = "20240205_update_debsuryorg_key" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

* #5788 

## How This PR Solves The Issue

The new key is out there now, but we have to rebuild the ddev-php-base and ddev-webserver images to get it

## Manual Testing Instructions

`ddev start` and `ddev exec gpg --list-options show-sig-expire /usr/share/keyrings/deb.sury.org-php.gpg` - check expiration date

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

