### PR TITLE
docs: add instructions for Grav CMS to quickstart.md

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -65,6 +65,7 @@ Get
 GitPod
 Gitter
 Gotenberg
+Grav
 Gzipped
 HOWTO
 HeidiSQL

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -260,7 +260,7 @@ ddev launch
      ddev exec bin/gpm update -f
      ```
 
-Visit the [Grav Documentation](https://learn.getgrav.org/17 for more information.
+Visit the [Grav Documentation](https://learn.getgrav.org/17 for more information about Grav in general and visit [Local Development with DDEV](https://learn.getgrav.org/17/webservers-hosting/local-development-with-ddev) for more details about the usage of Grav with DDEV.
 
 
 ## Ibexa DXP

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -247,18 +247,18 @@ ddev launch
     ddev exec bin/gpm install admin -y
     ```
 
- !!!tip "How to update?"
-     Upgrade Grave core:
+!!!tip "How to update?"
+    Upgrade Grave core:
 
-     ```bash
-     ddev exec bin/gpm selfupgrade -f
-     ```
+    ```bash
+    ddev exec bin/gpm selfupgrade -f
+    ```
 
-     Update plugins and themes:
+    Update plugins and themes:
 
-     ```bash
-     ddev exec bin/gpm update -f
-     ```
+    ```bash
+    ddev exec bin/gpm update -f
+    ```
 
 Visit the [Grav Documentation](https://learn.getgrav.org/17) for more information about Grav in general and visit [Local Development with DDEV](https://learn.getgrav.org/17/webservers-hosting/local-development-with-ddev) for more details about the usage of Grav with DDEV.
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -242,9 +242,10 @@ ddev launch
     git clone -b master https://github.com/getgrav/grav.git .
     ddev config --php-version=8.2 --omit-containers=db
     ddev start
-    ddev composer install --no-dev -o
+    ddev composer install
     ddev exec bin/grav install
     ddev exec bin/gpm install admin -y
+    ddev launch
     ```
 
 !!!tip "How to update?"

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -220,6 +220,49 @@ ddev launch
 
     When the installation wizard prompts for database settings, enter `db` for the _DB Server Address_, _DB Name_, _DB Username_, and _DB Password_.
 
+## Grav
+
+=== "Composer"
+
+    ```bash
+    mkdir grav
+    cd grav
+    ddev config --php-version=8.2 --omit-containers=db
+    ddev start
+    ddev composer create getgrav/grav
+    ddev exec bin/gpm install admin -y
+    ddev launch
+    ```
+
+=== "Git Clone"
+
+    ```bash
+    mkdir grav
+    cd grav
+    git clone -b master https://github.com/getgrav/grav.git .
+    ddev config --php-version=8.2 --omit-containers=db
+    ddev start
+    ddev composer install --no-dev -o
+    ddev exec bin/grav install
+    ddev exec bin/gpm install admin -y
+    ```
+
+ !!!tip "How to update?"
+     Upgrade Grave core:
+
+     ```bash
+     ddev exec bin/gpm selfupgrade -f
+     ```
+
+     Update plugins and themes:
+
+     ```bash
+     ddev exec bin/gpm update -f
+     ```
+
+Visit the [Grav Documentation](https://learn.getgrav.org/17 for more information.
+
+
 ## Ibexa DXP
 
 Install [Ibexa DXP](https://www.ibexa.co) OSS Edition.

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -260,8 +260,7 @@ ddev launch
      ddev exec bin/gpm update -f
      ```
 
-Visit the [Grav Documentation](https://learn.getgrav.org/17 for more information about Grav in general and visit [Local Development with DDEV](https://learn.getgrav.org/17/webservers-hosting/local-development-with-ddev) for more details about the usage of Grav with DDEV.
-
+Visit the [Grav Documentation](https://learn.getgrav.org/17) for more information about Grav in general and visit [Local Development with DDEV](https://learn.getgrav.org/17/webservers-hosting/local-development-with-ddev) for more details about the usage of Grav with DDEV.
 
 ## Ibexa DXP
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
There were no quickstart guide for Grav CMS

## How This PR Solves The Issue
It is adding instructions for a composer based install and a git clone based on to the quickstart.md

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

