### PR TITLE
build: bump images to v1.22.7 for release, fixes #5633

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,22 +15,22 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240205_update_debsuryorg_key" // Note that this can be overridden by make
+var WebTag = "v1.22.7" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.22.6"
+var BaseDBTag = "v1.22.7"
 
-const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.22.6"
-const TraefikRouterImage = "ddev/ddev-traefik-router:v1.22.6"
+const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.22.7"
+const TraefikRouterImage = "ddev/ddev-traefik-router:v1.22.7"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.22.6"
+var SSHAuthTag = "v1.22.7"
 
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION
## The Issue

It's release time for v1.22.7, push new images

This should fix 
* #5633 

as it updated xdebug to 3.3.1
