### PR TITLE
fix: isMagento2App() should detect version 2.4.5+, update test URLs

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -147,22 +147,23 @@ var (
 		// Create a project named testpkgmagento2 and use the magento2 quickstart
 		// Look at app/env.php and login at the key given by "backend->frontname" with the admin
 		// credentials in the quickstart.
-		// Create a product named Unicycle with a picture called randy_4th_of_july_unicycle.jpg
+		// Create a product named Unicycle with a picture called unicycle.jpg
+		// Full docs and management/upgrade at https://github.com/ddev/test-magento2
 		{
 			Name: "testpkgmagento2",
-			// echo "This is a junk" >pub/junk.txt && tar -czf .tarballs/testpkgmagento2_code_no_media.magento2.4.4.tgz --exclude=.ddev --exclude=var --exclude=pub/media --exclude=.tarballs --exclude=app/etc/env.php .
-			SourceURL:                     "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/testpkgmagento2_code_no_media.magento2.4.4.tgz",
+			// echo "This is a junk" >pub/junk.txt && tar -czf .tarballs/testpkgmagento2_code_no_media.magento2.4.6-p4.tgz --exclude=.ddev --exclude=var --exclude=pub/media --exclude=.tarballs --exclude=app/etc/env.php .
+			SourceURL:                     "https://github.com/ddev/test-magento2/releases/download/2.4.6-p4/testpkgmagento2_code_no_media.magento2.4.6-p4.tgz",
 			ArchiveInternalExtractionPath: "",
-			// ddev export-db --gzip=false --file=.tarballs/db.sql && tar -czf .tarballs/testpkgmagento2.magento2.4.4.db.tgz -C .tarballs db.sql
-			DBTarURL: "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/testpkgmagento2.magento2.4.4.db.tgz",
-			// tar -czf .tarballs/testpkgmagento2_files.magento2.4.4.tgz -C pub/media .
-			FilesTarballURL:           "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/testpkgmagento2_files.magento2.4.4.tgz",
+			// ddev export-db --gzip=false --file=.tarballs/db.sql && tar -czf .tarballs/testpkgmagento2.magento2.4.6-p4.db.tgz -C .tarballs db.sql
+			DBTarURL: "https://github.com/ddev/test-magento2/releases/download/2.4.6-p4/testpkgmagento2.magento2.4.6-p4.db.tgz",
+			// tar -czf .tarballs/testpkgmagento2_files.magento2.4.6-p4.tgz -C pub/media .
+			FilesTarballURL:           "https://github.com/ddev/test-magento2/releases/download/2.4.6-p4/testpkgmagento2_files.magento2.4.6-p4.tgz",
 			FullSiteTarballURL:        "",
 			Docroot:                   "pub",
 			Type:                      nodeps.AppTypeMagento2,
 			Safe200URIWithExpectation: testcommon.URIWithExpect{URI: "/junk.txt", Expect: `This is a junk`},
-			DynamicURI:                testcommon.URIWithExpect{URI: "/index.php/unicycle.html", Expect: "Unicycle"},
-			FilesImageURI:             "/media/catalog/product/r/a/randy_4th_of_july_unicycle_1.jpg",
+			DynamicURI:                testcommon.URIWithExpect{URI: "/index.php/unicycle.html", Expect: "unicycle"},
+			FilesImageURI:             "/media/catalog/product/u/n/unicycle.jpg",
 		},
 		// 8: drupal9
 		{

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -23,7 +23,7 @@ func isMagentoApp(app *DdevApp) bool {
 
 // isMagento2App returns true if the app is of type magento2
 func isMagento2App(app *DdevApp) bool {
-	ism2, err := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, app.Docroot, "..", "SECURITY.md"), `https://hackerone.com/magento`)
+	ism2, err := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, app.Docroot, "..", "SECURITY.md"), `https://hackerone.com/adobe`)
 	if err == nil && ism2 {
 		return true
 	}

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -23,7 +23,7 @@ func isMagentoApp(app *DdevApp) bool {
 
 // isMagento2App returns true if the app is of type magento2
 func isMagento2App(app *DdevApp) bool {
-	ism2, err := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, app.Docroot, "..", "SECURITY.md"), `https://hackerone.com/adobe`)
+	ism2, err := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, app.Docroot, "..", "SECURITY.md"), `https://hackerone.com/`)
 	if err == nil && ism2 {
 		return true
 	}


### PR DESCRIPTION

## The Issue

* If you run `ddev config --auto` on the latest Magento 2 version, the project type `magento2` is not detected and `php` is used.
* Magento2 test tarballs are unmaintainable and out-of-date

## How This PR Solves The Issue

* The check is for a string `https://hackerone.com/magento` in the root SECURITY.md.
(This is odd because that file is often deleted.)
However, the string has been changed to `https://hackerone.com/adobe` since version 2.4.5 as you can review here: https://github.com/magento/magento2/commit/3cb720f9ed01f3d53ba123fba9c048eb3b73f2b7
* Use new ddev/test-magento2 repository for tests.

## Manual Testing Instructions

Install Magento 2 version 2.4.5 or following via CMS Quickstart.
Run `ddev config --auto`.
See that the project type is still `magento2`.

## Automated Testing Overview

The test for `isMagento2App` already exists.

## Release/Deployment Notes

I don't think so.

