### PR TITLE
fix: Remove Craft CMS PHP version override

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -126,7 +126,7 @@ Environment variables will be automatically added to your `.env` file to simplif
     ddev launch
     ```
 
-    Craft CMS projects use PHP 8.1 and MySQL 8.0, by default. You can override these settings during setup with [`config` command flags](./usage/commands.md#config) or after setup via the [configuration files](./configuration/config.md).
+    Craft CMS projects use MySQL 8.0, by default. You can override this setting (and the PHP version) during setup with [`config` command flags](./usage/commands.md#config) or after setup via the [configuration files](./configuration/config.md).
 
     !!!tip "Upgrading or using a generic project type?"
         If you previously set up DDEV in a Craft project using the generic `php` project type, update the `type:` setting in `.ddev/config.yaml` to `craftcms`, then run [`ddev restart`](../users/usage/commands.md#restart) apply the changes.

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -62,7 +62,7 @@ func TestConfigOverrideAction(t *testing.T) {
 	appTypes := map[string]string{
 		nodeps.AppTypeBackdrop:     nodeps.PHPDefault,
 		nodeps.AppTypeCakePHP:      nodeps.PHP83,
-		nodeps.AppTypeCraftCms:     nodeps.PHP81,
+		nodeps.AppTypeCraftCms:     nodeps.PHPDefault,
 		nodeps.AppTypeDrupal6:      nodeps.PHP56,
 		nodeps.AppTypeDrupal7:      nodeps.PHP82,
 		nodeps.AppTypeDrupal:       nodeps.PHPDefault,

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -150,7 +150,7 @@ func craftCmsPostStartAction(app *DdevApp) error {
 }
 
 func craftCmsConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = nodeps.PHP81
+	app.PHPVersion = nodeps.PHP82
 	app.Database = DatabaseDesc{nodeps.MySQL, nodeps.MySQL80}
 	return nil
 }

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -150,7 +150,6 @@ func craftCmsPostStartAction(app *DdevApp) error {
 }
 
 func craftCmsConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = nodeps.PHP82
 	app.Database = DatabaseDesc{nodeps.MySQL, nodeps.MySQL80}
 	return nil
 }


### PR DESCRIPTION
## The Issue

We have just tagged Craft 5.0.0-beta.1, and with that, are requiring PHP 8.2. The `craftcms` project type currently uses PHP 8.1, which will not satisfy the requirements.

Our upgrade guide covers switching PHP versions using the `config` command (`ddev config --php-version=8.2`), but we would like for all projects moving forward to use the most recent/default DDEV PHP version (8.2)—with which Craft 4 is also fully compatible.

The current database version (MySQL 8.0) is still our recommended engine, so no changes have been made to that configuration.

## How This PR Solves The Issue

The `craftCmsConfigOverrideAction()` function no longer overrides the PHP version used when creating new projects.

## Manual Testing Instructions

Create a new DDEV project:

```bash
mkdir craft-five
cd craft-five
ddev config --project-type=craftcms --docroot=web
ddev composer create -y --no-scripts craftcms/craft
ddev craft install
```

If Craft doesn't complain about the PHP version (or emit a lower-level language error), you’re all set!

## Automated Testing Overview

No automated tests have been added or updated.

## Related Issue Link(s)

## Release/Deployment Notes

- Craft CMS project types now use DDEV's default PHP version.