### PR TITLE
feat: generalize HOMEDIR management and respect XDG_CONFIG_HOME, fixes #5807

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -192,9 +192,11 @@ fi
 # Make sure we start with mutagen daemon off.
 unset MUTAGEN_DATA_DIRECTORY
 if [ -f ~/.ddev/bin/mutagen -o -f ~/.ddev/bin/mutagen.exe ]; then
+  # This line can be removed when ~/.ddev/.mdd is well established in master, probably July 2024
   MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a || true
   MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd/ ~/.ddev/bin/mutagen sync terminate -a || true
   MUTAGEN_DATA_DIRECTORY=~/.mutagen ~/.ddev/bin/mutagen daemon stop || true
+  # This line can be removed when ~/.ddev/.mdd is well established in master, probably July 2024
   MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
   MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd/ ~/.ddev/bin/mutagen daemon stop || true
 fi

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -192,9 +192,9 @@ fi
 # Make sure we start with mutagen daemon off.
 unset MUTAGEN_DATA_DIRECTORY
 if [ -f ~/.ddev/bin/mutagen -o -f ~/.ddev/bin/mutagen.exe ]; then
-  MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a || true
+  MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a || true
   MUTAGEN_DATA_DIRECTORY=~/.mutagen ~/.ddev/bin/mutagen daemon stop || true
-  MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
+  MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
 fi
 if command -v killall >/dev/null ; then
   killall mutagen || true

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -192,8 +192,10 @@ fi
 # Make sure we start with mutagen daemon off.
 unset MUTAGEN_DATA_DIRECTORY
 if [ -f ~/.ddev/bin/mutagen -o -f ~/.ddev/bin/mutagen.exe ]; then
+  MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a || true
   MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a || true
   MUTAGEN_DATA_DIRECTORY=~/.mutagen ~/.ddev/bin/mutagen daemon stop || true
+  MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
   MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
 fi
 if command -v killall >/dev/null ; then

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -193,10 +193,10 @@ fi
 unset MUTAGEN_DATA_DIRECTORY
 if [ -f ~/.ddev/bin/mutagen -o -f ~/.ddev/bin/mutagen.exe ]; then
   MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a || true
-  MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a || true
+  MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd/ ~/.ddev/bin/mutagen sync terminate -a || true
   MUTAGEN_DATA_DIRECTORY=~/.mutagen ~/.ddev/bin/mutagen daemon stop || true
   MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
-  MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
+  MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd/ ~/.ddev/bin/mutagen daemon stop || true
 fi
 if command -v killall >/dev/null ; then
   killall mutagen || true

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -163,6 +163,7 @@ WSL2
 WantedBy
 Webhosting
 XDebug
+XDG
 Xhprof
 Zoho
 XSym

--- a/cmd/ddev/cmd/autocompletion_test.go
+++ b/cmd/ddev/cmd/autocompletion_test.go
@@ -220,14 +220,14 @@ func TestAutocompletionForCustomCmds(t *testing.T) {
 
 	origDir, _ := os.Getwd()
 
-	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
-
 	site := TestSites[0]
 	err := os.Chdir(site.Dir)
 	require.NoError(t, err)
 
 	app, err := ddevapp.NewApp("", false)
 	assert.NoError(err)
+
+	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 

--- a/cmd/ddev/cmd/autocompletion_test.go
+++ b/cmd/ddev/cmd/autocompletion_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/ddev/ddev/pkg/dockerutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,8 +8,11 @@ import (
 	"testing"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -218,15 +220,14 @@ func TestAutocompletionForCustomCmds(t *testing.T) {
 
 	origDir, _ := os.Getwd()
 
+	tmpXdgConfigHomeDir, originalMutagenDataDir := testcommon.SetTmpXdgConfigHomeDir(t)
+
 	site := TestSites[0]
 	err := os.Chdir(site.Dir)
 	require.NoError(t, err)
 
 	app, err := ddevapp.NewApp("", false)
 	assert.NoError(err)
-
-	tmpHome, _, err := makeTempHomeDir(app, t)
-	require.NoError(t, err)
 
 	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 
@@ -235,20 +236,13 @@ func TestAutocompletionForCustomCmds(t *testing.T) {
 		assert.NoError(err)
 		err = app.Stop(true, false)
 		assert.NoError(err)
-		// Stop the Mutagen daemon running in the bogus homedir
-		ddevapp.StopMutagenDaemon()
-		_ = os.RemoveAll(tmpHome)
+		testcommon.CleanupTmpXdgConfigHomeDir(t, tmpXdgConfigHomeDir, originalMutagenDataDir)
 		_ = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", "commands"))
 	})
 	err = app.Start()
 	require.NoError(t, err)
 
-	// We can't use the standard getGlobalDDevDir here because *our* global hasn't changed.
-	// It's changed via $HOME for the DDEV subprocess
-	err = os.MkdirAll(filepath.Join(tmpHome, ".ddev"), 0755)
-	assert.NoError(err)
-
-	tmpHomeGlobalCommandsDir := filepath.Join(tmpHome, ".ddev", "commands")
+	tmpHomeGlobalCommandsDir := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands")
 	projectCommandsDir := app.GetConfigPath("commands")
 
 	// Remove existing commands
@@ -299,8 +293,7 @@ func TestAutocompleteTermsForCustomCmds(t *testing.T) {
 	app, err := ddevapp.NewApp("", false)
 	assert.NoError(err)
 
-	tmpHome, _, err := makeTempHomeDir(app, t)
-	require.NoError(t, err)
+	tmpXdgConfigHomeDir, originalMutagenDataDir := testcommon.SetTmpXdgConfigHomeDir(t)
 
 	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 
@@ -309,20 +302,13 @@ func TestAutocompleteTermsForCustomCmds(t *testing.T) {
 		assert.NoError(err)
 		err = app.Stop(true, false)
 		assert.NoError(err)
-		// Stop the Mutagen daemon running in the bogus homedir
-		ddevapp.StopMutagenDaemon()
-		_ = os.RemoveAll(tmpHome)
+		testcommon.CleanupTmpXdgConfigHomeDir(t, tmpXdgConfigHomeDir, originalMutagenDataDir)
 		_ = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", "commands"))
 	})
 	err = app.Start()
 	require.NoError(t, err)
 
-	// We can't use the standard getGlobalDDevDir here because *our* global hasn't changed.
-	// It's changed via $HOME for the DDEV subprocess
-	err = os.MkdirAll(filepath.Join(tmpHome, ".ddev"), 0755)
-	assert.NoError(err)
-
-	tmpHomeGlobalCommandsDir := filepath.Join(tmpHome, ".ddev", "commands")
+	tmpHomeGlobalCommandsDir := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands")
 	projectCommandsDir := app.GetConfigPath("commands")
 
 	// Remove existing commands

--- a/cmd/ddev/cmd/autocompletion_test.go
+++ b/cmd/ddev/cmd/autocompletion_test.go
@@ -220,7 +220,7 @@ func TestAutocompletionForCustomCmds(t *testing.T) {
 
 	origDir, _ := os.Getwd()
 
-	tmpXdgConfigHomeDir, originalMutagenDataDir := testcommon.SetTmpXdgConfigHomeDir(t)
+	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	site := TestSites[0]
 	err := os.Chdir(site.Dir)
@@ -236,7 +236,7 @@ func TestAutocompletionForCustomCmds(t *testing.T) {
 		assert.NoError(err)
 		err = app.Stop(true, false)
 		assert.NoError(err)
-		testcommon.CleanupTmpXdgConfigHomeDir(t, tmpXdgConfigHomeDir, originalMutagenDataDir)
+		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
 		_ = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", "commands"))
 	})
 	err = app.Start()
@@ -293,7 +293,7 @@ func TestAutocompleteTermsForCustomCmds(t *testing.T) {
 	app, err := ddevapp.NewApp("", false)
 	assert.NoError(err)
 
-	tmpXdgConfigHomeDir, originalMutagenDataDir := testcommon.SetTmpXdgConfigHomeDir(t)
+	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 
@@ -302,7 +302,7 @@ func TestAutocompleteTermsForCustomCmds(t *testing.T) {
 		assert.NoError(err)
 		err = app.Stop(true, false)
 		assert.NoError(err)
-		testcommon.CleanupTmpXdgConfigHomeDir(t, tmpXdgConfigHomeDir, originalMutagenDataDir)
+		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
 		_ = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", "commands"))
 	})
 	err = app.Start()

--- a/cmd/ddev/cmd/autocompletion_test.go
+++ b/cmd/ddev/cmd/autocompletion_test.go
@@ -227,7 +227,7 @@ func TestAutocompletionForCustomCmds(t *testing.T) {
 	app, err := ddevapp.NewApp("", false)
 	assert.NoError(err)
 
-	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 
@@ -236,7 +236,7 @@ func TestAutocompletionForCustomCmds(t *testing.T) {
 		assert.NoError(err)
 		err = app.Stop(true, false)
 		assert.NoError(err)
-		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 		_ = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", "commands"))
 	})
 	err = app.Start()
@@ -293,7 +293,7 @@ func TestAutocompleteTermsForCustomCmds(t *testing.T) {
 	app, err := ddevapp.NewApp("", false)
 	assert.NoError(err)
 
-	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 
@@ -302,7 +302,7 @@ func TestAutocompleteTermsForCustomCmds(t *testing.T) {
 		assert.NoError(err)
 		err = app.Stop(true, false)
 		assert.NoError(err)
-		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 		_ = fileutil.PurgeDirectory(filepath.Join(site.Dir, ".ddev", "commands"))
 	})
 	err = app.Start()

--- a/cmd/ddev/cmd/autocompletion_test.go
+++ b/cmd/ddev/cmd/autocompletion_test.go
@@ -227,7 +227,7 @@ func TestAutocompletionForCustomCmds(t *testing.T) {
 	app, err := ddevapp.NewApp("", false)
 	assert.NoError(err)
 
-	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 
@@ -293,7 +293,7 @@ func TestAutocompleteTermsForCustomCmds(t *testing.T) {
 	app, err := ddevapp.NewApp("", false)
 	assert.NoError(err)
 
-	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -299,10 +299,6 @@ func TestCustomCommands(t *testing.T) {
 		assert.FileExists(filepath.Join(projectCommandsDir, f))
 	}
 
-	// Make sure we haven't accidentally created anything inappropriate in ~/.ddev
-	assert.False(fileutil.FileExists(filepath.Join(tmpHome, ".ddev", ".globalcommands")))
-	assert.False(fileutil.FileExists(filepath.Join(origHome, ".ddev", ".globalcommands")))
-
 	// Make sure that the old launch, mysql, and xdebug commands aren't in the project directory
 	for _, command := range []string{"db/mysql", "host/launch", "web/xdebug"} {
 		cmdPath := app.GetConfigPath(filepath.Join("commands", command))

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -35,7 +35,7 @@ func TestCustomCommands(t *testing.T) {
 	app, err := ddevapp.NewApp("", false)
 	assert.NoError(err)
 
-	tmpXdgConfigHomeDir, originalMutagenDataDir := testcommon.SetTmpXdgConfigHomeDir(t)
+	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 
@@ -45,7 +45,7 @@ func TestCustomCommands(t *testing.T) {
 		assert.NoError(err)
 		err = app.Stop(true, false)
 		assert.NoError(err)
-		testcommon.CleanupTmpXdgConfigHomeDir(t, tmpXdgConfigHomeDir, originalMutagenDataDir)
+		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
 		runTime()
 		app.Type = origType
 		err = app.WriteConfig()
@@ -69,7 +69,7 @@ func TestCustomCommands(t *testing.T) {
 	assert.NoError(err)
 
 	// We need to run some assertions outside of the context of a project first
-	err = os.Chdir(tmpXdgConfigHomeDir)
+	err = os.Chdir(tmpHomeDir)
 	require.NoError(t, err)
 
 	// Check that only global host commands with the XXX annotation display here

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -35,7 +35,7 @@ func TestCustomCommands(t *testing.T) {
 	app, err := ddevapp.NewApp("", false)
 	assert.NoError(err)
 
-	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -35,7 +35,7 @@ func TestCustomCommands(t *testing.T) {
 	app, err := ddevapp.NewApp("", false)
 	assert.NoError(err)
 
-	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	testdataCustomCommandsDir := filepath.Join(origDir, "testdata", t.Name())
 
@@ -45,7 +45,7 @@ func TestCustomCommands(t *testing.T) {
 		assert.NoError(err)
 		err = app.Stop(true, false)
 		assert.NoError(err)
-		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 		runTime()
 		app.Type = origType
 		err = app.WriteConfig()
@@ -69,7 +69,7 @@ func TestCustomCommands(t *testing.T) {
 	assert.NoError(err)
 
 	// We need to run some assertions outside of the context of a project first
-	err = os.Chdir(tmpHomeDir)
+	err = os.Chdir(tmpXdgConfigHomeDir)
 	require.NoError(t, err)
 
 	// Check that only global host commands with the XXX annotation display here

--- a/cmd/ddev/cmd/homeadditions_test.go
+++ b/cmd/ddev/cmd/homeadditions_test.go
@@ -23,7 +23,7 @@ func TestHomeadditions(t *testing.T) {
 	origDir, _ := os.Getwd()
 	testdata := filepath.Join(origDir, "testdata", t.Name())
 
-	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	tmpHomeGlobalHomeadditionsDir := filepath.Join(globalconfig.GetGlobalDdevDir(), "homeadditions")
 	err := os.RemoveAll(tmpHomeGlobalHomeadditionsDir)
@@ -42,7 +42,7 @@ func TestHomeadditions(t *testing.T) {
 		err = os.Chdir(origDir)
 		assert.NoError(err)
 		_ = fileutil.PurgeDirectory(projectHomeadditionsDir)
-		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 	})
 
 	// Before we can symlink global, need to make sure anything is already gone

--- a/cmd/ddev/cmd/homeadditions_test.go
+++ b/cmd/ddev/cmd/homeadditions_test.go
@@ -23,7 +23,7 @@ func TestHomeadditions(t *testing.T) {
 	origDir, _ := os.Getwd()
 	testdata := filepath.Join(origDir, "testdata", t.Name())
 
-	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	tmpHomeGlobalHomeadditionsDir := filepath.Join(globalconfig.GetGlobalDdevDir(), "homeadditions")
 	err := os.RemoveAll(tmpHomeGlobalHomeadditionsDir)

--- a/cmd/ddev/cmd/homeadditions_test.go
+++ b/cmd/ddev/cmd/homeadditions_test.go
@@ -23,7 +23,7 @@ func TestHomeadditions(t *testing.T) {
 	origDir, _ := os.Getwd()
 	testdata := filepath.Join(origDir, "testdata", t.Name())
 
-	tmpXdgConfigHomeDir, originalMutagenDataDir := testcommon.SetTmpXdgConfigHomeDir(t)
+	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	tmpHomeGlobalHomeadditionsDir := filepath.Join(globalconfig.GetGlobalDdevDir(), "homeadditions")
 	err := os.RemoveAll(tmpHomeGlobalHomeadditionsDir)
@@ -42,7 +42,7 @@ func TestHomeadditions(t *testing.T) {
 		err = os.Chdir(origDir)
 		assert.NoError(err)
 		_ = fileutil.PurgeDirectory(projectHomeadditionsDir)
-		testcommon.CleanupTmpXdgConfigHomeDir(t, tmpXdgConfigHomeDir, originalMutagenDataDir)
+		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
 	})
 
 	// Before we can symlink global, need to make sure anything is already gone

--- a/cmd/ddev/cmd/homeadditions_test.go
+++ b/cmd/ddev/cmd/homeadditions_test.go
@@ -6,12 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,32 +18,18 @@ import (
 // TestHomeadditions makes sure that extra files added to
 // .ddev/homeadditions and ~/.ddev/homeadditions get added into the container's ~/
 func TestHomeadditions(t *testing.T) {
-	if nodeps.PerformanceModeDefault == types.PerformanceModeMutagen ||
-		(globalconfig.DdevGlobalConfig.IsMutagenEnabled() &&
-			nodeps.PerformanceModeDefault != types.PerformanceModeNone) ||
-		nodeps.NoBindMountsDefault {
-		t.Skip("Skipping because this changes homedir and breaks Mutagen functionality")
-	}
 	assert := asrt.New(t)
 
 	origDir, _ := os.Getwd()
 	testdata := filepath.Join(origDir, "testdata", t.Name())
 
-	tmpHome := testcommon.CreateTmpDir(t.Name() + "tempHome")
-	// Change the homedir temporarily
-	t.Setenv("HOME", tmpHome)
-	t.Setenv("USERPROFILE", tmpHome)
+	tmpXdgConfigHomeDir, originalMutagenDataDir := testcommon.SetTmpXdgConfigHomeDir(t)
 
+	tmpHomeGlobalHomeadditionsDir := filepath.Join(globalconfig.GetGlobalDdevDir(), "homeadditions")
+	err := os.RemoveAll(tmpHomeGlobalHomeadditionsDir)
+	assert.NoError(err)
 	site := TestSites[0]
 	projectHomeadditionsDir := filepath.Join(site.Dir, ".ddev", "homeadditions")
-
-	// We can't use the standard getGlobalDDevDir here because *our* global hasn't changed.
-	// It's changed via $HOME for the DDEV subprocess
-	err := os.MkdirAll(filepath.Join(tmpHome, ".ddev"), 0755)
-	assert.NoError(err)
-	tmpHomeGlobalHomeadditionsDir := filepath.Join(tmpHome, ".ddev", "homeadditions")
-	err = os.RemoveAll(tmpHomeGlobalHomeadditionsDir)
-	assert.NoError(err)
 	err = os.RemoveAll(projectHomeadditionsDir)
 	assert.NoError(err)
 	err = fileutil.CopyDir(filepath.Join(testdata, "global"), tmpHomeGlobalHomeadditionsDir)
@@ -55,16 +39,10 @@ func TestHomeadditions(t *testing.T) {
 	err = os.Chdir(site.Dir)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_, err := os.Stat(globalconfig.GetMutagenPath())
-		if err == nil {
-			out, err := exec.RunHostCommand(DdevBin, "debug", "mutagen", "daemon", "stop")
-			assert.NoError(err, "mutagen daemon stop returned %s", string(out))
-		}
-
 		err = os.Chdir(origDir)
 		assert.NoError(err)
 		_ = fileutil.PurgeDirectory(projectHomeadditionsDir)
-		_ = os.RemoveAll(tmpHome)
+		testcommon.CleanupTmpXdgConfigHomeDir(t, tmpXdgConfigHomeDir, originalMutagenDataDir)
 	})
 
 	// Before we can symlink global, need to make sure anything is already gone

--- a/cmd/ddev/cmd/mutagen-version.go
+++ b/cmd/ddev/cmd/mutagen-version.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/styles"
+	"github.com/ddev/ddev/pkg/versionconstants"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+	"sort"
+)
+
+// MutagenVersionCmd implements the ddev mutagen version command
+var MutagenVersionCmd = &cobra.Command{
+	Use:     "version",
+	Short:   "Display the version of the Mutagen binary and the location of its components.",
+	Example: `"ddev mutagen version"`,
+	Run: func(_ *cobra.Command, _ []string) {
+
+		v := make(map[string]string)
+		v["version"] = versionconstants.RequiredMutagenVersion
+		v["binary"] = globalconfig.GetMutagenPath()
+		v["enabled"] = fmt.Sprintf("%t", globalconfig.DdevGlobalConfig.IsMutagenEnabled())
+		v["MUTAGEN_DATA_DIRECTORY"] = globalconfig.GetMutagenDataDirectory()
+
+		var out bytes.Buffer
+		t := table.NewWriter()
+		t.SetOutputMirror(&out)
+
+		// Use simplest possible output
+		s := styles.GetTableStyle("default")
+		s.Options.SeparateRows = false
+		s.Options.SeparateFooter = false
+		s.Options.SeparateColumns = false
+		s.Options.SeparateHeader = false
+		s.Options.DrawBorder = false
+		t.SetStyle(s)
+
+		t.AppendHeader(table.Row{"Item", "Value"})
+
+		// Ensure "version" is always the first row
+		t.AppendRow(table.Row{"version", v["version"]})
+
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			if k != "version" {
+				keys = append(keys, k)
+			}
+		}
+		sort.Strings(keys)
+
+		for _, label := range keys {
+			t.AppendRow(table.Row{
+				label, v[label],
+			})
+		}
+		t.Render()
+		output.UserOut.WithField("raw", v).Println(out.String())
+	},
+}
+
+func init() {
+	MutagenCmd.AddCommand(MutagenVersionCmd)
+}

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -139,7 +139,7 @@ func init() {
 	}
 
 	// Populate custom/script commands so they're visible.
-	// We really don't want ~/.ddev or .ddev/homeadditions or .ddev/.globalcommands to have root ownership, breaks things.
+	// We really don't want ~/.ddev or .ddev/homeadditions to have root ownership, breaks things.
 	if os.Geteuid() != 0 {
 		err := ddevapp.PopulateExamplesCommandsHomeadditions("")
 		if err != nil {

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -185,7 +185,7 @@ func TestGetActiveAppRoot(t *testing.T) {
 	assert.Equal(TestSites[0].Dir, appRoot)
 }
 
-// TestCreateGlobalDdevDir checks to make sure that DDEV will create a ~/.ddev (and updatecheck)
+// TestCreateGlobalDdevDir checks to make sure that DDEV will create a $XDG_CONFIG_HOME/.ddev (and updatecheck)
 func TestCreateGlobalDdevDir(t *testing.T) {
 	if nodeps.PerformanceModeDefault == types.PerformanceModeMutagen ||
 		(globalconfig.DdevGlobalConfig.IsMutagenEnabled() &&
@@ -225,8 +225,8 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	t.Setenv("HOME", tmpHomeDir)
 	t.Setenv("USERPROFILE", tmpHomeDir)
 
-	// Make sure that the tmpDir/.ddev and tmpDir/.ddev/.update don't exist before we run ddev.
-	_, err = os.Stat(filepath.Join(tmpHomeDir, ".ddev"))
+	// Make sure that the tmpDir/.config/ddev and tmpDir/.config/ddev/.update don't exist before we run ddev.
+	_, err = os.Stat(filepath.Join(tmpHomeDir, ".config", "ddev"))
 	require.Error(t, err)
 	assert.True(os.IsNotExist(err))
 
@@ -234,15 +234,15 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	require.NoError(t, err, "failed to ddev config --auto, out=%v, err=%v", out, err)
 
 	// Now global .ddev should exist
-	_, err = os.Stat(filepath.Join(tmpHomeDir, ".ddev"))
+	_, err = os.Stat(filepath.Join(tmpHomeDir, ".config", "ddev"))
 	require.NoError(t, err)
 
 	// Make sure we have the .ddev/bin dir we need for docker-compose and Mutagen
-	err = fileutil.CopyDir(filepath.Join(origHomeDir, ".ddev/bin"), filepath.Join(tmpHomeDir, ".ddev/bin"))
+	err = fileutil.CopyDir(filepath.Join(origHomeDir, ".ddev/bin"), filepath.Join(tmpHomeDir, ".config", "ddev/bin"))
 	require.NoError(t, err)
 
 	// Make sure that tmpHomeDir/.ddev/.update don't exist before we run ddev start
-	tmpUpdateFilePath := filepath.Join(tmpHomeDir, ".ddev", ".update")
+	tmpUpdateFilePath := filepath.Join(tmpHomeDir, ".config", "ddev", ".update")
 	_, err = os.Stat(tmpUpdateFilePath)
 	require.Error(t, err)
 	assert.True(os.IsNotExist(err))

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	osexec "os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -296,23 +295,16 @@ func TestCopyGlobalDdevDir(t *testing.T) {
 	assert.NoError(err)
 }
 
-// TestGetXdgConfigHomeDir checks to make sure that DDEV will use the correct $XDG_CONFIG_HOME
-// or the default location provided by os.UserConfigDir()
-func TestGetXdgConfigHomeDir(t *testing.T) {
+// TestGetGlobalConfigDirLocation checks to make sure that DDEV will use the correct $XDG_CONFIG_HOME
+func TestGetGlobalConfigDirLocation(t *testing.T) {
 	// Test when $XDG_CONFIG_HOME is not set
 	t.Setenv("XDG_CONFIG_HOME", "")
-	configHomeDir, err := globalconfig.GetXdgConfigHomeDir()
-	require.NoError(t, err)
-	defaultConfigHomeDir := ""
-	if runtime.GOOS == "linux" {
-		defaultConfigHomeDir = filepath.Join(os.Getenv("HOME"), ".config")
-	}
-	require.Equal(t, configHomeDir, defaultConfigHomeDir)
+	ddevDir := globalconfig.GetGlobalConfigDirLocation()
+	require.Equal(t, ddevDir, filepath.Join(os.Getenv("HOME"), ".ddev"))
 	// Test when $XDG_CONFIG_HOME is set
 	t.Setenv("XDG_CONFIG_HOME", "/tmp/test")
-	configHomeDir, err = globalconfig.GetXdgConfigHomeDir()
-	require.NoError(t, err)
-	require.Equal(t, configHomeDir, "/tmp/test")
+	ddevDir = globalconfig.GetGlobalConfigDirLocation()
+	require.Equal(t, ddevDir, "/tmp/test/ddev")
 }
 
 // TestPoweroffOnNewVersion checks that a poweroff happens when a new DDEV version is deployed

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -222,6 +222,8 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	// Change the homedir temporarily
 	t.Setenv("HOME", tmpHomeDir)
 	t.Setenv("USERPROFILE", tmpHomeDir)
+	// Set $XDG_CONFIG_HOME to empty string, otherwise it will take precedence over $HOME
+	t.Setenv("XDG_CONFIG_HOME", "")
 
 	// Make sure that the tmpDir/.ddev and tmpDir/.ddev/.update don't exist before we run ddev.
 	_, err = os.Stat(filepath.Join(tmpHomeDir, ".ddev"))

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -254,12 +254,12 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	assert.NoError(err)
 }
 
-// TestXdgConfigHomeGlobalDdevDir checks to make sure that DDEV will use
+// TestMoveGlobalDdevDir checks to make sure that DDEV will use
 // ddev folder in user's custom dir $XDG_CONFIG_HOME/ddev instead of ~/.ddev
-func TestXdgConfigHomeGlobalDdevDir(t *testing.T) {
+func TestMoveGlobalDdevDir(t *testing.T) {
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
-	tmpXdgConfigHomeDir, originalMutagenDataDir := testcommon.SetTmpXdgConfigHomeDir(t)
+	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	t.Cleanup(
 		func() {
@@ -267,7 +267,7 @@ func TestXdgConfigHomeGlobalDdevDir(t *testing.T) {
 			assert.NoError(err)
 			err = os.Chdir(origDir)
 			assert.NoError(err)
-			testcommon.CleanupTmpXdgConfigHomeDir(t, tmpXdgConfigHomeDir, originalMutagenDataDir)
+			testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
 
 			// Because the start will have done a poweroff (new version),
 			// make sure sites are running again.
@@ -338,7 +338,7 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	activeCount := len(apps)
 	assert.GreaterOrEqual(activeCount, 2)
 
-	tmpXdgConfigHomeDir, originalMutagenDataDir := testcommon.SetTmpXdgConfigHomeDir(t)
+	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	app, err := ddevapp.GetActiveApp("")
 	require.NoError(t, err)
@@ -362,7 +362,7 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 		_, err := exec.RunHostCommand(DdevBin, "poweroff")
 		assert.NoError(err)
 
-		testcommon.CleanupTmpXdgConfigHomeDir(t, tmpXdgConfigHomeDir, originalMutagenDataDir)
+		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
 	})
 
 	apps = ddevapp.GetActiveProjects()

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -224,12 +224,13 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	// Change the homedir temporarily
 	t.Setenv("HOME", tmpHomeDir)
 	t.Setenv("USERPROFILE", tmpHomeDir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHomeDir, ".config"))
 
 	// Make sure $HOME/.ddev and $XDG_CONFIG_HOME/ddev don't exist before we run ddev.
 	_, err = os.Stat(filepath.Join(tmpHomeDir, ".ddev"))
 	require.Error(t, err)
 	assert.True(os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(tmpHomeDir, "Library", "Application Support", "ddev"))
+	_, err = os.Stat(filepath.Join(tmpHomeDir, ".config", "ddev"))
 	require.Error(t, err)
 	assert.True(os.IsNotExist(err))
 
@@ -237,15 +238,15 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	require.NoError(t, err, "failed to ddev config --auto, out=%v, err=%v", out, err)
 
 	// Now $XDG_CONFIG_HOME/ddev should exist
-	_, err = os.Stat(filepath.Join(tmpHomeDir, "Library", "Application Support", "ddev"))
+	_, err = os.Stat(filepath.Join(tmpHomeDir, ".config", "ddev"))
 	require.NoError(t, err)
 
 	// Make sure we have the .ddev/bin dir we need for docker-compose and Mutagen
-	err = fileutil.CopyDir(filepath.Join(origHomeDir, ".ddev/bin"), filepath.Join(tmpHomeDir, "Library", "Application Support", "ddev/bin"))
+	err = fileutil.CopyDir(filepath.Join(origHomeDir, ".ddev/bin"), filepath.Join(tmpHomeDir, ".config", "ddev/bin"))
 	require.NoError(t, err)
 
 	// Make sure that tmpHomeDir/.ddev/.update don't exist before we run ddev start
-	tmpUpdateFilePath := filepath.Join(tmpHomeDir, "Library", "Application Support", "ddev", ".update")
+	tmpUpdateFilePath := filepath.Join(tmpHomeDir, ".config", "ddev", ".update")
 	_, err = os.Stat(tmpUpdateFilePath)
 	require.Error(t, err)
 	assert.True(os.IsNotExist(err))
@@ -295,12 +296,13 @@ func TestLegacyGlobalDdevDir(t *testing.T) {
 	// Change the homedir temporarily
 	t.Setenv("HOME", tmpHomeDir)
 	t.Setenv("USERPROFILE", tmpHomeDir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHomeDir, ".config"))
 
 	err = os.MkdirAll(filepath.Join(tmpHomeDir, ".ddev"), 0755)
 	assert.NoError(err)
 
 	// Make sure that the $XDG_CONFIG_HOME/ddev doesn't exist before we run ddev.
-	_, err = os.Stat(filepath.Join(tmpHomeDir, "Library", "Application Support", "ddev"))
+	_, err = os.Stat(filepath.Join(tmpHomeDir, ".config", "ddev"))
 	require.Error(t, err)
 	assert.True(os.IsNotExist(err))
 
@@ -308,7 +310,7 @@ func TestLegacyGlobalDdevDir(t *testing.T) {
 	require.NoError(t, err, "failed to ddev config --auto, out=%v, err=%v", out, err)
 
 	// $XDG_CONFIG_HOME/ddev should still not exist
-	_, err = os.Stat(filepath.Join(tmpHomeDir, "Library", "Application Support", "ddev"))
+	_, err = os.Stat(filepath.Join(tmpHomeDir, ".config", "ddev"))
 	require.Error(t, err)
 	assert.True(os.IsNotExist(err))
 }

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -296,7 +296,8 @@ func TestLegacyGlobalDdevDir(t *testing.T) {
 	t.Setenv("HOME", tmpHomeDir)
 	t.Setenv("USERPROFILE", tmpHomeDir)
 
-	os.MkdirAll(filepath.Join(tmpHomeDir, ".ddev"), 0755)
+	err = os.MkdirAll(filepath.Join(tmpHomeDir, ".ddev"), 0755)
+	assert.NoError(err)
 
 	// Make sure that the $XDG_CONFIG_HOME/ddev doesn't exist before we run ddev.
 	_, err = os.Stat(filepath.Join(tmpHomeDir, "Library", "Application Support", "ddev"))

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -255,12 +255,12 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	assert.NoError(err)
 }
 
-// TestMoveGlobalDdevDir checks to make sure that DDEV will use
+// TestCopyGlobalDdevDir checks to make sure that DDEV will use
 // ddev folder in user's custom dir $XDG_CONFIG_HOME/ddev instead of ~/.ddev
-func TestMoveGlobalDdevDir(t *testing.T) {
+func TestCopyGlobalDdevDir(t *testing.T) {
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
-	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {
 		_, err := exec.RunHostCommand(DdevBin, "poweroff")
@@ -357,7 +357,7 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	activeCount := len(apps)
 	assert.GreaterOrEqual(activeCount, 2)
 
-	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	app, err := ddevapp.GetActiveApp("")
 	require.NoError(t, err)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -303,12 +303,9 @@ func TestGetXdgConfigHomeDir(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	configHomeDir, err := globalconfig.GetXdgConfigHomeDir()
 	require.NoError(t, err)
-	defaultConfigHomeDir := filepath.Join(os.Getenv("HOME"), ".config")
-	switch runtime.GOOS {
-	case "windows":
-		defaultConfigHomeDir = os.Getenv("AppData")
-	case "darwin":
-		defaultConfigHomeDir = filepath.Join(os.Getenv("HOME"), "/Library/Application Support")
+	defaultConfigHomeDir := ""
+	if runtime.GOOS == "linux" {
+		defaultConfigHomeDir = filepath.Join(os.Getenv("HOME"), ".config")
 	}
 	require.Equal(t, configHomeDir, defaultConfigHomeDir)
 	// Test when $XDG_CONFIG_HOME is set

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -352,7 +352,8 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make sure we have starting version that is not v0.0
-	err = fileutil.AppendStringToFile(filepath.Join(globalconfig.GetGlobalDdevDir(), "global_config.yaml"), "last_started_version: v0.1")
+	globalconfig.DdevGlobalConfig.LastStartedVersion = "v0.1"
+	err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 	require.NoError(t, err)
 	out, err = exec.RunHostCommand(DdevBin, "start")
 	require.NoError(t, err, "start failed, out='%s', err=%v", out, err)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -259,22 +259,21 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 func TestMoveGlobalDdevDir(t *testing.T) {
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
-	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
 
-	t.Cleanup(
-		func() {
-			_, err := exec.RunHostCommand(DdevBin, "poweroff")
-			assert.NoError(err)
-			err = os.Chdir(origDir)
-			assert.NoError(err)
-			testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
+	t.Cleanup(func() {
+		_, err := exec.RunHostCommand(DdevBin, "poweroff")
+		assert.NoError(err)
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 
-			// Because the start will have done a poweroff (new version),
-			// make sure sites are running again.
-			for _, site := range TestSites {
-				_, _ = exec.RunCommand(DdevBin, []string{"start", "-y", site.Name})
-			}
-		})
+		// Because the start will have done a poweroff (new version),
+		// make sure sites are running again.
+		for _, site := range TestSites {
+			_, _ = exec.RunCommand(DdevBin, []string{"start", "-y", site.Name})
+		}
+	})
 
 	err := os.Chdir(TestSites[0].Dir)
 	require.NoError(t, err)
@@ -338,7 +337,7 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	activeCount := len(apps)
 	assert.GreaterOrEqual(activeCount, 2)
 
-	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	app, err := ddevapp.GetActiveApp("")
 	require.NoError(t, err)
@@ -363,7 +362,7 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 		_, err := exec.RunHostCommand(DdevBin, "poweroff")
 		assert.NoError(err)
 
-		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 	})
 
 	apps = ddevapp.GetActiveProjects()

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -202,8 +202,8 @@ Whether [`ddev start`](../usage/commands.md#start) should be interrupted by a fa
 
 Absolute path to the `global_config.yaml` file. Can be changed by [moving](../usage/architecture.md#global-files) the `~/.ddev` global directory.
 
-| Type | Default                          | Usage
-| -- |----------------------------------| --
+| Type | Default | Usage
+| -- | -- | --
 | :octicons-globe-16: global | `$HOME/.ddev/global_config.yaml` | Controlled by `$XDG_CONFIG_HOME` env variable.
 
 ## `hooks`

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -198,6 +198,14 @@ Whether [`ddev start`](../usage/commands.md#start) should be interrupted by a fa
 | -- | -- | --
 | :octicons-file-directory-16: project<br>:octicons-globe-16: global | `false` | Can be `true` or `false`.
 
+## `global_config_path`
+
+Absolute path to the `global_config.yaml` file. Can be changed by [moving](../usage/architecture.md#global-files) the `~/.ddev` global directory.
+
+| Type | Default                          | Usage
+| -- |----------------------------------| --
+| :octicons-globe-16: global | `$HOME/.ddev/global_config.yaml` | Controlled by `$XDG_CONFIG_HOME` env variable.
+
 ## `hooks`
 
 DDEV-specific lifecycle [hooks](hooks.md) to be executed.

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -198,14 +198,6 @@ Whether [`ddev start`](../usage/commands.md#start) should be interrupted by a fa
 | -- | -- | --
 | :octicons-file-directory-16: project<br>:octicons-globe-16: global | `false` | Can be `true` or `false`.
 
-## `global_config_path`
-
-Absolute path to the `global_config.yaml` file. Can be changed by [moving](../usage/architecture.md#global-files) the `~/.ddev` global directory.
-
-| Type | Default | Usage
-| -- | -- | --
-| :octicons-globe-16: global | `$HOME/.ddev/global_config.yaml` | Controlled by `$XDG_CONFIG_HOME` env variable.
-
 ## `hooks`
 
 DDEV-specific lifecycle [hooks](hooks.md) to be executed.

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -151,13 +151,13 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
     * Avoid having Mutagen sync large binaries, which can cause `ddev start` to take a long time. The `.tarballs` directory is automatically excluded, so Mutagen will ignore anything you move there. To see what Mutagen is trying to sync, run `ddev mutagen status -l` in another window.
     * `export DDEV_DEBUG=true` will provide more information about what’s going on with Mutagen.
     * As of DDEV v1.21.2, DDEV’s Mutagen daemon keeps its data in a DDEV-only `MUTAGEN_DATA_DIRECTORY`:
-        * `mutagen_data_directory` located in `~/.ddev/mutagen_data_directory` in DDEV v1.23.1+
-        * `.ddev_mutagen_data_directory` located in `~/.ddev_mutagen_data_directory` in DDEV v1.21.2 to v1.23.0
-    * DDEV’s private Mutagen binary is installed in `~/.ddev/bin/mutagen`. You can use all the features of Mutagen with `export MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory` and running the Mutagen binary in `~/.ddev/bin/mutagen`, for example:
+        * `.mdd` located in `~/.ddev/.mdd` in DDEV v1.23.2+
+        * `.ddev_mutagen_data_directory` located in `~/.ddev_mutagen_data_directory` in DDEV v1.21.2 to v1.23.1
+    * DDEV’s private Mutagen binary is installed in `~/.ddev/bin/mutagen`. You can use all the features of Mutagen with `export MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd` and running the Mutagen binary in `~/.ddev/bin/mutagen`, for example:
 
         ```bash
         export DDEV_DEBUG=true
-        export MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory
+        export MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd
         export PATH=~/.ddev/bin:$PATH
         mutagen sync list -l
         mutagen sync monitor

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -150,9 +150,7 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
     * Rename your project’s `.ddev/mutagen/mutagen.yml` file to `.ddev/mutagen/mutagen.yml.bak` and run `ddev restart`. This ensures you’ll have a fresh version in case the file has been changed and `#ddev-generated` removed.
     * Avoid having Mutagen sync large binaries, which can cause `ddev start` to take a long time. The `.tarballs` directory is automatically excluded, so Mutagen will ignore anything you move there. To see what Mutagen is trying to sync, run `ddev mutagen status -l` in another window.
     * `export DDEV_DEBUG=true` will provide more information about what’s going on with Mutagen.
-    * As of DDEV v1.21.2, DDEV’s Mutagen daemon keeps its data in a DDEV-only `MUTAGEN_DATA_DIRECTORY`:
-        * `.mdd` located in `~/.ddev/.mdd` in DDEV v1.23.2+
-        * `.ddev_mutagen_data_directory` located in `~/.ddev_mutagen_data_directory` in DDEV v1.21.2 to v1.23.1
+    * DDEV’s Mutagen daemon keeps its data in a DDEV-only `MUTAGEN_DATA_DIRECTORY`, by default in `~/.ddev/.mdd`.
     * DDEV’s private Mutagen binary is installed in `~/.ddev/bin/mutagen`. You can use all the features of Mutagen with `export MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd` and running the Mutagen binary in `~/.ddev/bin/mutagen`, for example:
 
         ```bash

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -149,23 +149,28 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
     * Please make sure that DDEV projects work *without* Mutagen before troubleshooting it. Run `ddev config --performance-mode=none && ddev restart`.
     * Rename your project’s `.ddev/mutagen/mutagen.yml` file to `.ddev/mutagen/mutagen.yml.bak` and run `ddev restart`. This ensures you’ll have a fresh version in case the file has been changed and `#ddev-generated` removed.
     * Avoid having Mutagen sync large binaries, which can cause `ddev start` to take a long time. The `.tarballs` directory is automatically excluded, so Mutagen will ignore anything you move there. To see what Mutagen is trying to sync, run `ddev mutagen status -l` in another window.
-    * `export DDEV_DEBUG=true` will provide more information about what’s going on with Mutagen.
+    * `DDEV_DEBUG=true ddev start` will provide more information about what’s going on with Mutagen.
     * DDEV’s Mutagen daemon keeps its data in a DDEV-only `MUTAGEN_DATA_DIRECTORY`, by default in `~/.ddev/.mdd`.
     * DDEV’s private Mutagen binary is installed in `~/.ddev/bin/mutagen`. You can use all the features of Mutagen with `export MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd` and running the Mutagen binary in `~/.ddev/bin/mutagen`, for example:
 
         ```bash
-        export DDEV_DEBUG=true
-        export MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd
-        export PATH=~/.ddev/bin:$PATH
+        export MUTAGEN_DATA_DIRECTORY=$(ddev mutagen version -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.MUTAGEN_DATA_DIRECTORY' 2>/dev/null)
+        export PATH=$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw."global-ddev-dir"' 2>/dev/null)/bin:$PATH
         mutagen sync list -l
         mutagen sync monitor
+        ```
+
+    * `ddev debug mutagen` will let you run any Mutagen command using the binary in `~/.ddev/bin/mutagen`, for example:
+
+        ```bash
+        ddev debug mutagen sync list -l
+        ddev debug mutagen monitor
         ```
 
     * You can run the [diagnose_mutagen.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/diagnose_mutagen.sh) script to gather information about Mutagen’s setup. Please share output from it when creating an issue or seeking support.
     * Try `ddev poweroff` or `~/.ddev/bin/mutagen daemon stop && ~/.ddev/bin/mutagen daemon start` to restart the Mutagen daemon if you suspect it’s hanging.
     * Use `ddev mutagen reset` if you suspect trouble, and *always* after changing `.ddev/mutagen/mutagen.yml`. This restarts the project’s Mutagen data (Docker volume + Mutagen session) from scratch.
     * `ddev mutagen monitor` can help watch Mutagen behavior. It’s the same as `~/.ddev/bin/mutagen sync monitor <syncname>`.
-    * `ddev debug mutagen` will let you run any Mutagen command using the binary in `~/.ddev/bin/mutagen`.
     * If you’re working on the host and expecting things to show up immediately inside the container, you can learn a lot by running `ddev mutagen monitor` in a separate window as you work. You’ll see when Mutagen responds to your changes and get an idea about how much delay there is.
     * Consider `ddev stop` before massive file change operations, like moving a directory.
     * If you get in real trouble, run `ddev stop`, reset your files with Git, and run `ddev mutagen reset` to throw away the Docker volume which may already have incorrect files on it.

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -150,12 +150,14 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
     * Rename your project’s `.ddev/mutagen/mutagen.yml` file to `.ddev/mutagen/mutagen.yml.bak` and run `ddev restart`. This ensures you’ll have a fresh version in case the file has been changed and `#ddev-generated` removed.
     * Avoid having Mutagen sync large binaries, which can cause `ddev start` to take a long time. The `.tarballs` directory is automatically excluded, so Mutagen will ignore anything you move there. To see what Mutagen is trying to sync, run `ddev mutagen status -l` in another window.
     * `export DDEV_DEBUG=true` will provide more information about what’s going on with Mutagen.
-    * As of DDEV v1.21.2, DDEV’s Mutagen daemon keeps its data in a DDEV-only `MUTAGEN_DATA_DIRECTORY`, `~/.ddev_mutagen_data_directory`.
-    * DDEV’s private Mutagen binary is installed in `~/.ddev/bin/mutagen`. You can use all the features of Mutagen with `export MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory` and running the Mutagen binary in `~/.ddev/bin/mutagen`, for example:and `~/.ddev/bin/mutagen daemon stop`.
+    * As of DDEV v1.21.2, DDEV’s Mutagen daemon keeps its data in a DDEV-only `MUTAGEN_DATA_DIRECTORY`:
+        * `mutagen_data_directory` located in `~/.ddev/mutagen_data_directory` in DDEV v1.23.1+
+        * `.ddev_mutagen_data_directory` located in `~/.ddev_mutagen_data_directory` in DDEV v1.21.2 to v1.23.0
+    * DDEV’s private Mutagen binary is installed in `~/.ddev/bin/mutagen`. You can use all the features of Mutagen with `export MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory` and running the Mutagen binary in `~/.ddev/bin/mutagen`, for example:
 
         ```bash
         export DDEV_DEBUG=true
-        export MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory
+        export MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory
         export PATH=~/.ddev/bin:$PATH
         mutagen sync list -l
         mutagen sync monitor

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -106,20 +106,20 @@ There’s only one global `.ddev` directory, which lives in your home directory:
     Use `ddev version` (look at `global-ddev-dir`) to check which location is currently used for the `.ddev` global directory.
 
 !!!tip "What if I don't want to clutter up my `$HOME` with a `.ddev` directory?"
-    `~/.ddev` can be moved to `$XDG_CONFIG_HOME/ddev` directory if `$XDG_CONFIG_HOME` is set:
+    DDEV can use the `$XDG_CONFIG_HOME` environment variable from [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) to move `~/.ddev` to the `$XDG_CONFIG_HOME/ddev` directory if `$XDG_CONFIG_HOME` is [defined](https://superuser.com/questions/365847/where-should-the-xdg-config-home-variable-be-defined/):
 
     ```bash
-    # permanently set environment variable depending on your OS (e.g. in ~/.bashrc):
+    # permanently set environment variable depending on your OS:
     export XDG_CONFIG_HOME="/my-desired-path"
     # restart the terminal and run:
     mv ~/.ddev ${XDG_CONFIG_HOME}/ddev
     ```
 
-    Otherwise, if `$XDG_CONFIG_HOME` is not set, `~/.ddev` can be moved to:
+    Otherwise (Linux and WSL2 only):
 
-    * `~/Library/Application Support/ddev` on macOS
-    * `~/.config/ddev` on Linux and WSL2
-    * `%AppData%\ddev` on Windows
+    ```bash
+    mv ~/.ddev ~/.config/ddev
+    ```
 
     Note that the custom global config directory `ddev` (if it exists) takes precedence over the `~/.ddev` directory.
 

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -103,13 +103,22 @@ Files beginning with `.` are hidden because they shouldn’t be fiddled with; mo
 There’s only one global `.ddev` directory, which lives in your home directory: `~/.ddev` (`$HOME/.ddev`).
 
 !!!tip
-    `~/.ddev` can be moved to:
+    `~/.ddev` can be moved to `$XDG_CONFIG_HOME/ddev` directory if `$XDG_CONFIG_HOME` is set:
+
+    ```bash
+    # permanently set environment variable depending on your OS (e.g. in ~/.bashrc):
+    export XDG_CONFIG_HOME="/my-desired-path"
+    # restart the terminal and run:
+    mv ~/.ddev /my-desired-path/ddev
+    ```
+
+    Otherwise, if `$XDG_CONFIG_HOME` is not set, `~/.ddev` can be moved to:
 
     * `~/Library/Application Support/ddev` on macOS
+    * `~/.config/ddev` on Linux and WSL2
     * `%APPDATA%\ddev` on Windows
-    * `~/.config/ddev` (or set `XDG_CONFIG_HOME` for `$XDG_CONFIG_HOME/ddev`) on Linux and WSL2
 
-    Note that `~/.ddev` must not exist, otherwise it will take precedence over the config folder.
+    Note that the custom global config directory `ddev` (if it exists) takes precedence over the `~/.ddev` directory.
 
 `global_config.yaml`
 : This YAML file defines your global configuration, which consists of various [config settings](../configuration/config.md).

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -112,7 +112,7 @@ There’s only one global `.ddev` directory, which lives in your home directory:
     # permanently set environment variable depending on your OS (e.g. in ~/.bashrc):
     export XDG_CONFIG_HOME="/my-desired-path"
     # restart the terminal and run:
-    mv ~/.ddev /my-desired-path/ddev
+    mv ~/.ddev ${XDG_CONFIG_HOME}/ddev
     ```
 
     Otherwise, if `$XDG_CONFIG_HOME` is not set, `~/.ddev` can be moved to:
@@ -145,7 +145,7 @@ Again, these files are mostly regenerated on every `ddev start` so it’s best t
 `.gitignore`
 : Prevents files from getting checked in when they shouldn’t be.
 
-`.mdd` (`~/.ddev_mutagen_data_directory` previously)
+`.mdd` 
 : Directory used for storing [Mutagen](../install/performance.md#mutagen) sync data.
 
 `.router-compose-full.yaml`

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -145,7 +145,7 @@ Again, these files are mostly regenerated on every `ddev start` so it’s best t
 `.gitignore`
 : Prevents files from getting checked in when they shouldn’t be.
 
-`.mdd` 
+`.mdd`
 : Directory used for storing [Mutagen](../install/performance.md#mutagen) sync data.
 
 `.router-compose-full.yaml`

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -138,6 +138,7 @@ Again, these files are mostly regenerated on every `ddev start` so it’s best t
 
 `.router-compose.yaml`
 : The base docker-compose directive used in generating `.router-compose-full.yaml`.
+
 `router-compose.*.yaml`
 : `docker-compose` files with the name `router-compose.*.yaml` can be used to override stanzas in the `.router-compose.yaml` file.
 
@@ -153,8 +154,8 @@ Again, these files are mostly regenerated on every `ddev start` so it’s best t
 `.update`
 : An empty file whose purpose is mysterious and intriguing.
 
-!!!tip "`.ddev_mutagen_data_directory`"
-    DDEV uses a global `~/.ddev_mutagen_data_directory` for storing [Mutagen](../install/performance.md#mutagen) sync data.
+!!!tip "`mutagen_data_directory` (`.ddev_mutagen_data_directory` previously)"
+    DDEV uses a global `~/.ddev/mutagen_data_directory` (`~/.ddev_mutagen_data_directory` in DDEV before v1.23.1) for storing [Mutagen](../install/performance.md#mutagen) sync data.
 
 ## Container Architecture
 

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -7,7 +7,7 @@ DDEV writes and uses [docker-compose](https://docs.docker.com/compose/) files fo
 
 ## Directory Tour
 
-DDEV stores configuration in two places: a single `.ddev` directory in your home folder, and a `.ddev` directory for each project you set up.
+DDEV stores configuration in two places: a single `.ddev` directory in your home folder (can be [moved](#global-files) to your config folder), and a `.ddev` directory for each project you set up.
 
 The [global configuration directory](#global-files) is used to keep track of your projects and any of the [global settings](../configuration/config.md) that apply across all projects. You’ll probably spend more time working with the [per-project `.ddev` directories](#project-files) for their configuration and overrides.
 
@@ -101,6 +101,15 @@ Files beginning with `.` are hidden because they shouldn’t be fiddled with; mo
 ### Global Files
 
 There’s only one global `.ddev` directory, which lives in your home directory: `~/.ddev` (`$HOME/.ddev`).
+
+!!!tip
+    `~/.ddev` can be moved to:
+
+    * `~/Library/Application Support/ddev` on macOS
+    * `%APPDATA%\ddev` on Windows
+    * `~/.config/ddev` (or set `XDG_CONFIG_HOME` for `$XDG_CONFIG_HOME/ddev`) on Linux and WSL2
+
+    Note that `~/.ddev` must not exist, otherwise it will take precedence over the config folder.
 
 `global_config.yaml`
 : This YAML file defines your global configuration, which consists of various [config settings](../configuration/config.md).

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -103,7 +103,7 @@ Files beginning with `.` are hidden because they shouldn’t be fiddled with; mo
 There’s only one global `.ddev` directory, which lives in your home directory: `~/.ddev` (`$HOME/.ddev`).
 
 !!!tip "Where is my global `.ddev` config?"
-    Use `ddev config global` (look at `global-config-path`) to check which location is currently used for the `.ddev` global directory.
+    Use `ddev version` (look at `global-ddev-dir`) to check which location is currently used for the `.ddev` global directory.
 
 !!!tip "What if I don't want to clutter up my `$HOME` with a `.ddev` directory?"
     `~/.ddev` can be moved to `$XDG_CONFIG_HOME/ddev` directory if `$XDG_CONFIG_HOME` is set:

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -109,13 +109,14 @@ There’s only one global `.ddev` directory, which lives in your home directory:
     DDEV can use the `$XDG_CONFIG_HOME` environment variable from [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) to move `~/.ddev` to the `$XDG_CONFIG_HOME/ddev` directory if `$XDG_CONFIG_HOME` is [defined](https://superuser.com/questions/365847/where-should-the-xdg-config-home-variable-be-defined/):
 
     ```bash
-    # permanently set environment variable depending on your OS:
-    export XDG_CONFIG_HOME="/my-desired-path"
+    ddev poweroff
+    # permanently set environment variable using a directory that works for you
+    export XDG_CONFIG_HOME="$HOME/.config"
     # restart the terminal and run:
     mv ~/.ddev ${XDG_CONFIG_HOME}/ddev
     ```
 
-    Otherwise (Linux and WSL2 only):
+    Otherwise, on Linux/WSL2 only, the default `$HOME/.config/ddev` can be used when you move the config:
 
     ```bash
     mv ~/.ddev ~/.config/ddev

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -163,8 +163,8 @@ Again, these files are mostly regenerated on every `ddev start` so it’s best t
 `.update`
 : An empty file whose purpose is mysterious and intriguing.
 
-!!!tip "`mutagen_data_directory` (`.ddev_mutagen_data_directory` previously)"
-    DDEV uses a global `~/.ddev/mutagen_data_directory` (`~/.ddev_mutagen_data_directory` in DDEV before v1.23.1) for storing [Mutagen](../install/performance.md#mutagen) sync data.
+!!!tip "`.mdd` (`.ddev_mutagen_data_directory` previously)"
+    DDEV uses a global `~/.ddev/.mdd` (`~/.ddev_mutagen_data_directory` in DDEV before v1.23.2) for storing [Mutagen](../install/performance.md#mutagen) sync data.
 
 ## Container Architecture
 

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -7,7 +7,7 @@ DDEV writes and uses [docker-compose](https://docs.docker.com/compose/) files fo
 
 ## Directory Tour
 
-DDEV stores configuration in two places: a single `.ddev` directory in your home folder (can be [moved](#global-files) to your config folder), and a `.ddev` directory for each project you set up.
+DDEV stores configuration in two places: a single `.ddev` directory in your home folder (can be [moved](#global-files) to another location), and a `.ddev` directory for each project you set up.
 
 The [global configuration directory](#global-files) is used to keep track of your projects and any of the [global settings](../configuration/config.md) that apply across all projects. You’ll probably spend more time working with the [per-project `.ddev` directories](#project-files) for their configuration and overrides.
 
@@ -102,7 +102,10 @@ Files beginning with `.` are hidden because they shouldn’t be fiddled with; mo
 
 There’s only one global `.ddev` directory, which lives in your home directory: `~/.ddev` (`$HOME/.ddev`).
 
-!!!tip
+!!!tip "Where is my global `.ddev` config?"
+    Use `ddev config global` (look at `global-config-path`) to check which location is currently used for the `.ddev` global directory.
+
+!!!tip "What if I don't want to clutter up my `$HOME` with a `.ddev` directory?"
     `~/.ddev` can be moved to `$XDG_CONFIG_HOME/ddev` directory if `$XDG_CONFIG_HOME` is set:
 
     ```bash
@@ -116,7 +119,7 @@ There’s only one global `.ddev` directory, which lives in your home directory:
 
     * `~/Library/Application Support/ddev` on macOS
     * `~/.config/ddev` on Linux and WSL2
-    * `%APPDATA%\ddev` on Windows
+    * `%AppData%\ddev` on Windows
 
     Note that the custom global config directory `ddev` (if it exists) takes precedence over the `~/.ddev` directory.
 
@@ -142,6 +145,9 @@ Again, these files are mostly regenerated on every `ddev start` so it’s best t
 `.gitignore`
 : Prevents files from getting checked in when they shouldn’t be.
 
+`.mdd` (`~/.ddev_mutagen_data_directory` previously)
+: Directory used for storing [Mutagen](../install/performance.md#mutagen) sync data.
+
 `.router-compose-full.yaml`
 : The complete, generated docker-compose directive used for DDEV’s router.
 
@@ -162,9 +168,6 @@ Again, these files are mostly regenerated on every `ddev start` so it’s best t
 
 `.update`
 : An empty file whose purpose is mysterious and intriguing.
-
-!!!tip "`.mdd` (`.ddev_mutagen_data_directory` previously)"
-    DDEV uses a global `~/.ddev/.mdd` (`~/.ddev_mutagen_data_directory` in DDEV before v1.23.2) for storing [Mutagen](../install/performance.md#mutagen) sync data.
 
 ## Container Architecture
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -953,6 +953,17 @@ ddev mutagen sync
 ddev mutagen sync my-project
 ```
 
+### `mutagen version`
+
+Display the version of the Mutagen binary and the location of its components.
+
+Example:
+
+```shell
+# Print Mutagen details
+ddev mutagen version
+```
+
 ## `mysql`
 
 Run MySQL client in the database container (global shell db container command). This is only available on projects that use the `mysql` or `mariadb` database types.

--- a/docs/content/users/usage/uninstall.md
+++ b/docs/content/users/usage/uninstall.md
@@ -5,7 +5,7 @@ A DDEV installation consists of:
 * The self-contained `ddev` binary.
 * Each project’s `.ddev` directory.
 * The global `~/.ddev` directory where various global items are stored. (This directory can be [moved](./architecture.md#global-files) to your config folder.)
-* The global `~/.ddev/mutagen_data_directory` (or `~/.ddev_mutagen_data_directory`) directory where Mutagen sync data may be stored.
+* The global `~/.ddev/mutagen_data_directory` directory where Mutagen sync data may be stored.
 * The associated Docker images and containers DDEV created.
 * Any entries in `/etc/hosts`.
 
@@ -18,8 +18,6 @@ To uninstall one project, run [`ddev delete <project>`](commands.md#delete). Thi
 To remove all DDEV-owned `/etc/hosts` entries: [`ddev hostname --remove-inactive`](commands.md#hostname).
 
 To remove the global `.ddev` directory: `rm -r ~/.ddev`.
-
-To remove the global `.ddev_mutagen_data_directory` directory: `rm -r ~/.ddev_mutagen_data_directory` (This directory was moved inside `~/.ddev` in DDEV v1.23.1 release.)
 
 If you installed Docker only for DDEV and want to uninstall it with all containers and images, uninstall it for your version of Docker.
 

--- a/docs/content/users/usage/uninstall.md
+++ b/docs/content/users/usage/uninstall.md
@@ -5,7 +5,7 @@ A DDEV installation consists of:
 * The self-contained `ddev` binary.
 * Each project’s `.ddev` directory.
 * The global `~/.ddev` directory where various global items are stored. (This directory can be [moved](./architecture.md#global-files) to your config folder.)
-* The global `~/.ddev_mutagen_data_directory` directory where Mutagen sync data may be stored.
+* The global `~/.ddev/mutagen_data_directory` (or `~/.ddev_mutagen_data_directory`) directory where Mutagen sync data may be stored.
 * The associated Docker images and containers DDEV created.
 * Any entries in `/etc/hosts`.
 
@@ -19,7 +19,7 @@ To remove all DDEV-owned `/etc/hosts` entries: [`ddev hostname --remove-inactive
 
 To remove the global `.ddev` directory: `rm -r ~/.ddev`.
 
-To remove the global `.ddev_mutagen_data_directory` directory: `rm -r ~/.ddev_mutagen_data_directory`.
+To remove the global `.ddev_mutagen_data_directory` directory: `rm -r ~/.ddev_mutagen_data_directory` (This directory was moved inside `~/.ddev` in DDEV v1.23.1 release.)
 
 If you installed Docker only for DDEV and want to uninstall it with all containers and images, uninstall it for your version of Docker.
 

--- a/docs/content/users/usage/uninstall.md
+++ b/docs/content/users/usage/uninstall.md
@@ -5,7 +5,7 @@ A DDEV installation consists of:
 * The self-contained `ddev` binary.
 * Each project’s `.ddev` directory.
 * The global `~/.ddev` directory where various global items are stored. (This directory can be [moved](./architecture.md#global-files) to your config folder.)
-* The global `~/.ddev/mutagen_data_directory` directory where Mutagen sync data may be stored.
+* The global `~/.ddev/.mdd` directory where Mutagen sync data may be stored.
 * The associated Docker images and containers DDEV created.
 * Any entries in `/etc/hosts`.
 

--- a/docs/content/users/usage/uninstall.md
+++ b/docs/content/users/usage/uninstall.md
@@ -4,7 +4,7 @@ A DDEV installation consists of:
 
 * The self-contained `ddev` binary.
 * Each project’s `.ddev` directory.
-* The global `~/.ddev` directory where various global items are stored.
+* The global `~/.ddev` directory where various global items are stored. (This directory can be [moved](./architecture.md#global-files) to your config folder.)
 * The global `~/.ddev_mutagen_data_directory` directory where Mutagen sync data may be stored.
 * The associated Docker images and containers DDEV created.
 * Any entries in `/etc/hosts`.

--- a/docs/content/users/usage/uninstall.md
+++ b/docs/content/users/usage/uninstall.md
@@ -4,8 +4,7 @@ A DDEV installation consists of:
 
 * The self-contained `ddev` binary.
 * Each project’s `.ddev` directory.
-* The global `~/.ddev` directory where various global items are stored. (This directory can be [moved](./architecture.md#global-files) to your config folder.)
-* The global `~/.ddev/.mdd` directory where Mutagen sync data may be stored.
+* The global `~/.ddev` directory where various global items are stored. (This directory can be [moved](./architecture.md#global-files) to another location.)
 * The associated Docker images and containers DDEV created.
 * Any entries in `/etc/hosts`.
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
+	"github.com/docker/docker/pkg/homedir"
 	copy2 "github.com/otiai10/copy"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -732,6 +733,18 @@ func (app *DdevApp) FixObsolete() {
 		}
 	}
 
+	// Remove old ~/.ddev_mutagen_data_directory directory
+	legacyMutagenDataDir := filepath.Join(homedir.Get(), ".ddev_mutagen_data_directory")
+	if fileutil.IsDirectory(legacyMutagenDataDir) {
+		originalMutagenDataDir := os.Getenv("MUTAGEN_DATA_DIRECTORY")
+		_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", legacyMutagenDataDir)
+		StopMutagenDaemon()
+		_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", originalMutagenDataDir)
+		err := os.RemoveAll(legacyMutagenDataDir)
+		if err != nil {
+			util.Warning("attempted to remove %s but failed, you may want to remove it manually: %v", legacyMutagenDataDir, err)
+		}
+	}
 }
 
 type composeYAMLVars struct {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -344,8 +344,8 @@ func mutagenSyncSessionExists(app *DdevApp) (bool, error) {
 func (app *DdevApp) MutagenStatus() (status string, shortResult string, mapResult map[string]interface{}, err error) {
 	syncName := MutagenSyncName(app.Name)
 
-	mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 	fullJSONResult, err := exec.RunHostCommandSeparateStreams(globalconfig.GetMutagenPath(), "sync", "list", "--template", `{{ json (index . 0) }}`, syncName)
+	mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 	if err != nil {
 		stderr := ""
 		if exitError, ok := err.(*osexec.ExitError); ok {
@@ -548,8 +548,8 @@ func DownloadMutagen() error {
 // But no problem if there wasn't one
 func StopMutagenDaemon() {
 	if fileutil.FileExists(globalconfig.GetMutagenPath()) {
-		mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 		out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "stop")
+		mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 		if err != nil && !strings.Contains(out, "unable to connect to daemon") {
 			util.Warning("Unable to stop Mutagen daemon: %v; MUTAGEN_DATA_DIRECTORY=%s", err, mutagenDataDirectory)
 		}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -561,8 +561,9 @@ func StopMutagenDaemon() {
 func StartMutagenDaemon() {
 	if fileutil.FileExists(globalconfig.GetMutagenPath()) {
 		out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "start")
+		mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 		if err != nil {
-			util.Warning("Failed to run Mutagen daemon start: %v, out=%s", err, out)
+			util.Warning("Failed to run Mutagen daemon start: %v, out=%s; MUTAGEN_DATA_DIRECTORY=%s", err, out, mutagenDataDirectory)
 		}
 	}
 }

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -127,8 +127,7 @@ func TestMutagenSimple(t *testing.T) {
 	}
 
 	out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "list")
-	mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
-	assert.NoError(err, "Mutagen sync list failed with MUTAGEN_DATA_DIRECTORY=%s: out=%s: %v", mutagenDataDirectory, out, err)
+	assert.NoError(err, "Mutagen sync list failed with MUTAGEN_DATA_DIRECTORY=%s: out=%s: %v", globalconfig.GetMutagenDataDirectory(), out, err)
 	assert.Contains(out, "Started Mutagen daemon in background")
 	if !strings.Contains(out, "Started Mutagen daemon in background") && (runtime.GOOS == "darwin" || runtime.GOOS == "linux") {
 		out, err := exec.RunHostCommand("bash", "-c", "ps -ef | grep mutagen")

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -126,8 +126,8 @@ func TestMutagenSimple(t *testing.T) {
 		assert.Error(err)
 	}
 
-	mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 	out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "list")
+	mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 	assert.NoError(err, "Mutagen sync list failed with MUTAGEN_DATA_DIRECTORY=%s: out=%s: %v", mutagenDataDirectory, out, err)
 	assert.Contains(out, "Started Mutagen daemon in background")
 	if !strings.Contains(out, "Started Mutagen daemon in background") && (runtime.GOOS == "darwin" || runtime.GOOS == "linux") {

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -25,10 +25,10 @@ func TestDockerComposeDownload(t *testing.T) {
 		DdevBin = os.Getenv("DDEV_BINARY_FULLPATH")
 	}
 
-	tmpXdgConfigHomeDir, originalMutagenDataDir := testcommon.SetTmpXdgConfigHomeDir(t)
+	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	t.Cleanup(func() {
-		testcommon.CleanupTmpXdgConfigHomeDir(t, tmpXdgConfigHomeDir, originalMutagenDataDir)
+		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
 	})
 
 	// Remove previous binary

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -25,7 +25,7 @@ func TestDockerComposeDownload(t *testing.T) {
 		DdevBin = os.Getenv("DDEV_BINARY_FULLPATH")
 	}
 
-	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {
 		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -25,10 +25,10 @@ func TestDockerComposeDownload(t *testing.T) {
 		DdevBin = os.Getenv("DDEV_BINARY_FULLPATH")
 	}
 
-	tmpHomeDir := testcommon.MoveGlobalDdevDir(t)
+	tmpXdgConfigHomeDir := testcommon.MoveGlobalDdevDir(t)
 
 	t.Cleanup(func() {
-		testcommon.ResetGlobalDdevDir(t, tmpHomeDir)
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 	})
 
 	// Remove previous binary

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -1,7 +1,6 @@
 package dockerutil_test
 
 import (
-	"github.com/ddev/ddev/pkg/ddevapp"
 	"os"
 	"os/exec"
 	"strings"
@@ -26,27 +25,15 @@ func TestDockerComposeDownload(t *testing.T) {
 		DdevBin = os.Getenv("DDEV_BINARY_FULLPATH")
 	}
 
-	tmpHome := testcommon.CreateTmpDir(t.Name() + "tempHome")
-	// Unusual case where we need to alter the RequiredDockerComposeVersion
-	// so we can make sure the one in PATH is different.
-	origRequiredComposeVersion := globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion
-
-	// Change the homedir temporarily
-	t.Setenv("HOME", tmpHome)
-	t.Setenv("USERPROFILE", tmpHome)
+	tmpXdgConfigHomeDir, originalMutagenDataDir := testcommon.SetTmpXdgConfigHomeDir(t)
 
 	t.Cleanup(func() {
-		_, err := os.Stat(globalconfig.GetMutagenPath())
-		if err == nil {
-			ddevapp.StopMutagenDaemon()
-		}
-
-		_ = os.RemoveAll(tmpHome)
-		globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = origRequiredComposeVersion
-		// Reset the cached DockerComposeVersion so it doesn't come into play again
-		globalconfig.DockerComposeVersion = ""
-		globalconfig.DdevGlobalConfig.UseDockerComposeFromPath = false
+		testcommon.CleanupTmpXdgConfigHomeDir(t, tmpXdgConfigHomeDir, originalMutagenDataDir)
 	})
+
+	// Remove previous binary
+	previousDockerCompose, _ := globalconfig.GetDockerComposePath()
+	_ = os.RemoveAll(previousDockerCompose)
 
 	// Download the normal required version specified in code
 	globalconfig.DockerComposeVersion = ""

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -569,7 +569,7 @@ func WriteProjectList(projects map[string]*ProjectInfo) error {
 func GetGlobalDdevDir() string {
 	// If user created a custom $XDG_CONFIG_HOME/ddev folder,
 	// for example ~/.config/ddev on Linux, use that folder instead.
-	xdgConfigHomeDir, err := getXdgConfigHomeDir()
+	xdgConfigHomeDir, err := GetXdgConfigHomeDir()
 	if err == nil {
 		ddevDir := filepath.Join(xdgConfigHomeDir, "ddev")
 		if _, err := os.Stat(ddevDir); err == nil {
@@ -605,8 +605,8 @@ func GetGlobalDdevDir() string {
 	return ddevDir
 }
 
-// getXdgConfigHomeDir returns $XDG_CONFIG_HOME
-func getXdgConfigHomeDir() (string, error) {
+// GetXdgConfigHomeDir returns $XDG_CONFIG_HOME
+func GetXdgConfigHomeDir() (string, error) {
 	dir := os.Getenv("XDG_CONFIG_HOME")
 	if dir == "" {
 		return os.UserConfigDir()

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -537,14 +537,14 @@ func WriteProjectList(projects map[string]*ProjectInfo) error {
 
 // GetGlobalDdevDir returns the global configuration directory, which varies by OS.
 func GetGlobalDdevDir() string {
-	// Check for legacy directory.
+	// Check for $HOME/.ddev for backwards compatibility.
 	userHome, err := os.UserHomeDir()
 	if err != nil {
 		logrus.Fatal("Could not get home directory for current user. Is it set?")
 	}
 	ddevDir := filepath.Join(userHome, ".ddev")
 
-	// If legacy directory doesn't exist, create new one.
+	// Create new configuration directory.
 	if _, err := os.Stat(ddevDir); os.IsNotExist(err) {
 		userConfigDir, err := os.UserConfigDir()
 		if err != nil {

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -171,9 +171,9 @@ func GetMutagenDataDirectory() string {
 	if currentMutagenDataDirectory != "" {
 		return currentMutagenDataDirectory
 	}
-	// If it's not already set, return ~/.ddev/mutagen_data_directory
+	// If it's not already set, return ~/.ddev.mdd
 	// This may be affected by tests that change $HOME and $XDG_CONFIG_HOME
-	return filepath.Join(GetGlobalDdevDir(), "mutagen_data_directory")
+	return filepath.Join(GetGlobalDdevDir(), ".mdd")
 }
 
 // GetDockerComposePath gets the full path to the docker-compose binary

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -417,7 +417,7 @@ func WriteGlobalConfig(config GlobalConfig) error {
 # Decide whether 'ddev start' should be interrupted by a failing hook
 
 # traefik_monitor_port: 10999
-# Change this only if you're having conflicts with some 
+# Change this only if you're having conflicts with some
 # service that needs port 10999
 
 # wsl2_no_windows_hosts_mgt: false

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -535,33 +535,34 @@ func WriteProjectList(projects map[string]*ProjectInfo) error {
 	return nil
 }
 
-// GetGlobalDdevDir returns the global configuration directory, which varies by OS.
+// GetGlobalDdevDir returns ~/.ddev, the global caching directory
 func GetGlobalDdevDir() string {
-	// Check for $HOME/.ddev for backwards compatibility.
 	userHome, err := os.UserHomeDir()
 	if err != nil {
 		logrus.Fatal("Could not get home directory for current user. Is it set?")
 	}
 	ddevDir := filepath.Join(userHome, ".ddev")
 
-	// Create new configuration directory.
+	// Create the directory if it is not already present.
 	if _, err := os.Stat(ddevDir); os.IsNotExist(err) {
+		// If there is no ~/.ddev, but they created a custom $XDG_CONFIG_HOME/ddev folder,
+		// for example ~/.config/ddev on Linux, use that folder instead.
 		userConfigDir, err := os.UserConfigDir()
-		if err != nil {
-			logrus.Fatal("Could not get config directory for current user. Is it set?")
-		}
-		ddevDir = filepath.Join(userConfigDir, "ddev")
-		if _, err := os.Stat(ddevDir); os.IsNotExist(err) {
-			// If they happen to be running as root/sudo, we won't create the directory
-			// but act like we did. This should only happen for ddev hostname, which
-			// doesn't need config or access to this dir anyway.
-			if os.Geteuid() == 0 {
+		if err == nil {
+			ddevDir := filepath.Join(userConfigDir, "ddev")
+			if _, err := os.Stat(ddevDir); err == nil {
 				return ddevDir
 			}
-			err = os.MkdirAll(ddevDir, 0755)
-			if err != nil {
-				logrus.Fatalf("Failed to create required directory %s, err: %v", ddevDir, err)
-			}
+		}
+		// If they happen to be running as root/sudo, we won't create the directory
+		// but act like we did. This should only happen for ddev hostname, which
+		// doesn't need config or access to this dir anyway.
+		if os.Geteuid() == 0 {
+			return ddevDir
+		}
+		err = os.MkdirAll(ddevDir, 0755)
+		if err != nil {
+			logrus.Fatalf("Failed to create required directory %s, err: %v", ddevDir, err)
 		}
 	}
 	// config.yaml is not allowed in ~/.ddev, can only result in disaster

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -569,7 +569,7 @@ func WriteProjectList(projects map[string]*ProjectInfo) error {
 
 // GetGlobalDdevDir returns the global caching directory, and creates it as needed.
 func GetGlobalDdevDir() string {
-	ddevDir := GetGlobalConfigDirLocation()
+	ddevDir := GetGlobalDdevDirLocation()
 	// Create the directory if it is not already present.
 	if _, err := os.Stat(ddevDir); os.IsNotExist(err) {
 		// If they happen to be running as root/sudo, we won't create the directory
@@ -592,12 +592,13 @@ func GetGlobalDdevDir() string {
 	return ddevDir
 }
 
-// GetGlobalConfigDirLocation returns the global caching directory location to be used by DDEV:
-// $XDG_CONFIG_HOME/ddev if $XDG_CONFIG_HOME is set,
-// ~/.config/ddev if on Linux and that directory exists,
+// GetGlobalDdevDirLocation returns the global caching directory location to be used by DDEV:
+// $XDG_CONFIG_HOME/ddev if this $XDG_CONFIG_HOME variable is not empty,
+// ~/.config/ddev if this directory exists on Linux/WSL2 only,
 // ~/.ddev otherwise.
-func GetGlobalConfigDirLocation() string {
-	// If $XDG_CONFIG_HOME is set, use $XDG_CONFIG_HOME/ddev
+func GetGlobalDdevDirLocation() string {
+	// If $XDG_CONFIG_HOME is set, use $XDG_CONFIG_HOME/ddev,
+	// we create this directory.
 	xdgConfigHomeDir := os.Getenv("XDG_CONFIG_HOME")
 	if xdgConfigHomeDir != "" {
 		return filepath.Join(xdgConfigHomeDir, "ddev")
@@ -614,6 +615,7 @@ func GetGlobalConfigDirLocation() string {
 		}
 	}
 	// Otherwise, use ~/.ddev
+	// It will be created if it doesn't exist.
 	userHome, err := os.UserHomeDir()
 	if err != nil {
 		logrus.Fatal("Could not get home directory for current user. Is it set?")

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -152,6 +152,11 @@ func checkMutagenSocketPathLength() {
 	if checkedMutagenSocketPathLength {
 		return
 	}
+	// Skip if not Linux or macOS.
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		checkedMutagenSocketPathLength = true
+		return
+	}
 	socketPathLength := len(filepath.Join(os.Getenv("MUTAGEN_DATA_DIRECTORY"), "daemon", "daemon.sock"))
 	// Limit from https://unix.stackexchange.com/a/367012
 	limit := 104

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -44,6 +44,7 @@ type GlobalConfig struct {
 	DeveloperMode                    bool                        `yaml:"developer_mode,omitempty"`
 	DisableHTTP2                     bool                        `yaml:"disable_http2"`
 	FailOnHookFailGlobal             bool                        `yaml:"fail_on_hook_fail"`
+	GlobalConfigPath                 string                      `yaml:"global_config_path"`
 	InstrumentationOptIn             bool                        `yaml:"instrumentation_opt_in"`
 	InstrumentationQueueSize         int                         `yaml:"instrumentation_queue_size,omitempty"`
 	InstrumentationReportingInterval time.Duration               `yaml:"instrumentation_reporting_interval,omitempty"`
@@ -240,6 +241,8 @@ func ReadGlobalConfig() error {
 	if GetCAROOT() == "" || !fileExists(filepath.Join(DdevGlobalConfig.MkcertCARoot, "rootCA.pem")) || (caRootEnv != "" && caRootEnv != DdevGlobalConfig.MkcertCARoot) {
 		DdevGlobalConfig.MkcertCARoot = readCAROOT()
 	}
+
+	DdevGlobalConfig.GlobalConfigPath = GetGlobalConfigPath()
 
 	// If they set the internetdetectiontimeout below default, reset to default
 	// and ignore the setting.

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -131,7 +131,10 @@ func GetDDEVBinDir() string {
 
 // GetMutagenPath gets the full path to the Mutagen binary
 func GetMutagenPath() string {
-	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", GetMutagenDataDirectory())
+	// Set MUTAGEN_DATA_DIRECTORY if it is unset
+	if os.Getenv("MUTAGEN_DATA_DIRECTORY") == "" {
+		_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", GetMutagenDataDirectory())
+	}
 	mutagenBinary := "mutagen"
 	if runtime.GOOS == "windows" {
 		mutagenBinary = mutagenBinary + ".exe"

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -44,7 +44,6 @@ type GlobalConfig struct {
 	DeveloperMode                    bool                        `yaml:"developer_mode,omitempty"`
 	DisableHTTP2                     bool                        `yaml:"disable_http2"`
 	FailOnHookFailGlobal             bool                        `yaml:"fail_on_hook_fail"`
-	GlobalConfigPath                 string                      `yaml:"global_config_path"`
 	InstrumentationOptIn             bool                        `yaml:"instrumentation_opt_in"`
 	InstrumentationQueueSize         int                         `yaml:"instrumentation_queue_size,omitempty"`
 	InstrumentationReportingInterval time.Duration               `yaml:"instrumentation_reporting_interval,omitempty"`
@@ -268,8 +267,6 @@ func ReadGlobalConfig() error {
 	if GetCAROOT() == "" || !fileExists(filepath.Join(DdevGlobalConfig.MkcertCARoot, "rootCA.pem")) || (caRootEnv != "" && caRootEnv != DdevGlobalConfig.MkcertCARoot) {
 		DdevGlobalConfig.MkcertCARoot = readCAROOT()
 	}
-
-	DdevGlobalConfig.GlobalConfigPath = GetGlobalConfigPath()
 
 	// If they set the internetdetectiontimeout below default, reset to default
 	// and ignore the setting.

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -143,9 +143,9 @@ func GetMutagenDataDirectory() string {
 	if currentMutagenDataDirectory != "" {
 		return currentMutagenDataDirectory
 	}
-	// If it's not already set, return ~/.ddev_mutagen_data_directory
-	// This may be affected by tests that change $HOME
-	return GetGlobalDdevDir() + "_" + "mutagen_data_directory"
+	// If it's not already set, return ~/.ddev/mutagen_data_directory
+	// This may be affected by tests that change $HOME and $XDG_CONFIG_HOME
+	return filepath.Join(GetGlobalDdevDir(), "mutagen_data_directory")
 }
 
 // GetDockerComposePath gets the full path to the docker-compose binary

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -605,7 +605,10 @@ func GetGlobalDdevDir() string {
 // GetXdgConfigHomeDir returns $XDG_CONFIG_HOME
 func GetXdgConfigHomeDir() (string, error) {
 	dir := os.Getenv("XDG_CONFIG_HOME")
-	if dir == "" {
+	// From XDG Base Directory Specification
+	// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+	// If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used.
+	if dir == "" && runtime.GOOS == "linux" {
 		return os.UserConfigDir()
 	}
 	return dir, nil

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -131,6 +131,7 @@ func GetDDEVBinDir() string {
 
 // GetMutagenPath gets the full path to the Mutagen binary
 func GetMutagenPath() string {
+	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", GetMutagenDataDirectory())
 	mutagenBinary := "mutagen"
 	if runtime.GOOS == "windows" {
 		mutagenBinary = mutagenBinary + ".exe"

--- a/pkg/globalconfig/schema.json
+++ b/pkg/globalconfig/schema.json
@@ -18,6 +18,10 @@
       "description": "Whether ddev start should be interrupted by a failing hook, on a single project or for all projects if used globally.",
       "type": "boolean"
     },
+    "global_config_path": {
+      "description": "The absolute path to the global_config.yaml which can be changed using $XDG_CONFIG_HOME env.",
+      "type": "string"
+    },
     "instrumentation_opt_in": {
       "description": "Whether to allow instrumentation reporting.",
       "type": "boolean"

--- a/pkg/globalconfig/schema.json
+++ b/pkg/globalconfig/schema.json
@@ -18,10 +18,6 @@
       "description": "Whether ddev start should be interrupted by a failing hook, on a single project or for all projects if used globally.",
       "type": "boolean"
     },
-    "global_config_path": {
-      "description": "The absolute path to the global_config.yaml which can be changed using $XDG_CONFIG_HOME env.",
-      "type": "string"
-    },
     "instrumentation_opt_in": {
       "description": "Whether to allow instrumentation reporting.",
       "type": "boolean"

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -215,11 +215,11 @@ func CreateTmpDir(prefix string) string {
 	return fullPath
 }
 
-// MoveGlobalDdevDir creates a temporary global config directory for DDEV
+// CopyGlobalDdevDir creates a temporary global config directory for DDEV
 // using a temporary directory which is set to $XDG_CONFIG_HOME/ddev
 // Don't forget to run ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 // in the test's cleanup function.
-func MoveGlobalDdevDir(t *testing.T) string {
+func CopyGlobalDdevDir(t *testing.T) string {
 	// Create $XDG_CONFIG_HOME
 	tmpXdgConfigHomeDir := CreateTmpDir("Home_" + util.RandString(5))
 	// Global DDEV config directory should be named "ddev"

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -229,7 +229,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 	require.Error(t, err)
 	require.True(t, os.IsNotExist(err))
 	// Original ~/.ddev dir location
-	originalGlobalDdevDir := filepath.Join(homedir.Get(), ".ddev")
+	originalGlobalDdevDir := globalconfig.GetGlobalDdevDirLocation()
 	// Make sure that the global config directory is set to ~/.ddev
 	require.Equal(t, originalGlobalDdevDir, globalconfig.GetGlobalDdevDir())
 	// Make sure that the original global config directory exists
@@ -284,7 +284,7 @@ func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 	err := os.RemoveAll(tmpXdgConfigHomeDir)
 	require.NoError(t, err)
 	// Make sure that the global config directory is set to ~/.ddev
-	originalGlobalDdevDir := filepath.Join(homedir.Get(), ".ddev")
+	originalGlobalDdevDir := globalconfig.GetGlobalDdevDirLocation()
 	require.Equal(t, originalGlobalDdevDir, globalconfig.GetGlobalDdevDir())
 	// Make sure that the original global config directory exists
 	require.DirExists(t, originalGlobalDdevDir)

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ddev/ddev/pkg/archive"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	exec2 "github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -220,6 +221,7 @@ func CreateTmpDir(prefix string) string {
 // Don't forget to run ResetGlobalDdevDir(t, tmpHomeDir)
 // in the test's cleanup function.
 func MoveGlobalDdevDir(t *testing.T) string {
+	assert := asrt.New(t)
 	// Create $XDG_CONFIG_HOME
 	tmpHomeDir := CreateTmpDir("Home" + t.Name())
 	// Global DDEV config directory should be named "ddev"
@@ -249,7 +251,9 @@ func MoveGlobalDdevDir(t *testing.T) string {
 		require.NoError(t, err)
 	}
 	// Stop the Mutagen daemon running in the ~/.ddev
-	ddevapp.StopMutagenDaemon()
+	out, err := exec2.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "stop")
+	mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
+	assert.NoError(err, "unable to run Mutagen daemon stop, out='%s', err=%v, MUTAGEN_DATA_DIRECTORY=%s", out, err, mutagenDataDirectory)
 	// Set $XDG_CONFIG_HOME for tests
 	t.Setenv("XDG_CONFIG_HOME", tmpHomeDir)
 	// refresh the global config from $XDG_CONFIG_HOME/ddev
@@ -263,9 +267,11 @@ func MoveGlobalDdevDir(t *testing.T) string {
 	require.NoError(t, err)
 	// Start mutagen daemon if it's enabled
 	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
-		ddevapp.StartMutagenDaemon()
+		out, err := exec2.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "start")
+		mutagenDataDirectory = os.Getenv("MUTAGEN_DATA_DIRECTORY")
+		assert.NoError(err, "unable to run Mutagen daemon start, out='%s', err=%v, MUTAGEN_DATA_DIRECTORY=%s", out, err, mutagenDataDirectory)
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
-		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), "mutagen_data_directory"))
+		assert.Equal(os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), "mutagen_data_directory"))
 	}
 
 	return tmpHomeDir
@@ -273,11 +279,14 @@ func MoveGlobalDdevDir(t *testing.T) string {
 
 // ResetGlobalDdevDir removes temporary $XDG_CONFIG_HOME directory
 func ResetGlobalDdevDir(t *testing.T, tmpHomeDir string) {
+	assert := asrt.New(t)
 	// Stop the Mutagen daemon running in the $XDG_CONFIG_HOME/ddev
-	ddevapp.StopMutagenDaemon()
+	out, err := exec2.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "stop")
+	mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
+	assert.NoError(err, "unable to run Mutagen daemon stop, out='%s', err=%v, MUTAGEN_DATA_DIRECTORY=%s", out, err, mutagenDataDirectory)
 	// After the $XDG_CONFIG_HOME directory is removed,
 	// globalconfig.GetGlobalDdevDir() should point to ~/.ddev
-	err := os.RemoveAll(tmpHomeDir)
+	err = os.RemoveAll(tmpHomeDir)
 	require.NoError(t, err)
 	// refresh the global config from ~/.ddev
 	globalconfig.EnsureGlobalConfig()
@@ -289,9 +298,11 @@ func ResetGlobalDdevDir(t *testing.T, tmpHomeDir string) {
 	require.NoError(t, err)
 	// Start mutagen daemon if it's enabled
 	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
-		ddevapp.StartMutagenDaemon()
+		out, err := exec2.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "start")
+		mutagenDataDirectory = os.Getenv("MUTAGEN_DATA_DIRECTORY")
+		assert.NoError(err, "unable to run Mutagen daemon start, out='%s', err=%v, MUTAGEN_DATA_DIRECTORY=%s", out, err, mutagenDataDirectory)
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
-		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), "mutagen_data_directory"))
+		assert.Equal(os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), "mutagen_data_directory"))
 	}
 }
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -255,10 +255,7 @@ func SetTmpXdgConfigHomeDir(t *testing.T) (string, string) {
 	// Set $XDG_CONFIG_HOME for tests
 	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
 	// refresh the global config from $XDG_CONFIG_HOME/ddev
-	err = globalconfig.ReadGlobalConfig()
-	require.NoError(t, err)
-	err = globalconfig.ReadProjectList()
-	require.NoError(t, err)
+	globalconfig.EnsureGlobalConfig()
 	err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 	require.NoError(t, err)
 	// Make sure that the global config directory is set to $XDG_CONFIG_HOME/ddev
@@ -281,10 +278,7 @@ func CleanupTmpXdgConfigHomeDir(t *testing.T, tmpXdgConfigHomeDir string, origin
 	err := os.RemoveAll(tmpXdgConfigHomeDir)
 	require.NoError(t, err)
 	// refresh the global config from ~/.ddev
-	err = globalconfig.ReadGlobalConfig()
-	require.NoError(t, err)
-	err = globalconfig.ReadProjectList()
-	require.NoError(t, err)
+	globalconfig.EnsureGlobalConfig()
 	// Make sure that the global config directory is set to ~/.ddev
 	originalGlobalDdevDir := filepath.Join(homedir.Get(), ".ddev")
 	require.Equal(t, originalGlobalDdevDir, globalconfig.GetGlobalDdevDir())

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -223,7 +223,7 @@ func CreateTmpDir(prefix string) string {
 func MoveGlobalDdevDir(t *testing.T) string {
 	assert := asrt.New(t)
 	// Create $XDG_CONFIG_HOME
-	tmpHomeDir := CreateTmpDir("Home" + t.Name())
+	tmpHomeDir := CreateTmpDir("Home" + nodeps.RandomString(5))
 	// Global DDEV config directory should be named "ddev"
 	tmpGlobalDdevDir := filepath.Join(tmpHomeDir, "ddev")
 	// Make sure that the tmpDir/ddev doesn't exist.

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -251,9 +251,11 @@ func MoveGlobalDdevDir(t *testing.T) string {
 		require.NoError(t, err)
 	}
 	// Stop the Mutagen daemon running in the ~/.ddev
-	out, err := exec2.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "stop")
-	mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
-	assert.NoError(err, "unable to run Mutagen daemon stop, out='%s', err=%v, MUTAGEN_DATA_DIRECTORY=%s", out, err, mutagenDataDirectory)
+	if fileutil.FileExists(globalconfig.GetMutagenPath()) {
+		out, err := exec2.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "stop")
+		mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
+		assert.NoError(err, "unable to run Mutagen daemon stop, out='%s', err=%v, MUTAGEN_DATA_DIRECTORY=%s", out, err, mutagenDataDirectory)
+	}
 	// Set $XDG_CONFIG_HOME for tests
 	t.Setenv("XDG_CONFIG_HOME", tmpHomeDir)
 	// refresh the global config from $XDG_CONFIG_HOME/ddev
@@ -266,9 +268,9 @@ func MoveGlobalDdevDir(t *testing.T) string {
 	err = os.Unsetenv("MUTAGEN_DATA_DIRECTORY")
 	require.NoError(t, err)
 	// Start mutagen daemon if it's enabled
-	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
+	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() && fileutil.FileExists(globalconfig.GetMutagenPath()) {
 		out, err := exec2.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "start")
-		mutagenDataDirectory = os.Getenv("MUTAGEN_DATA_DIRECTORY")
+		mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 		assert.NoError(err, "unable to run Mutagen daemon start, out='%s', err=%v, MUTAGEN_DATA_DIRECTORY=%s", out, err, mutagenDataDirectory)
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
 		assert.Equal(os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), "mutagen_data_directory"))
@@ -281,12 +283,14 @@ func MoveGlobalDdevDir(t *testing.T) string {
 func ResetGlobalDdevDir(t *testing.T, tmpHomeDir string) {
 	assert := asrt.New(t)
 	// Stop the Mutagen daemon running in the $XDG_CONFIG_HOME/ddev
-	out, err := exec2.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "stop")
-	mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
-	assert.NoError(err, "unable to run Mutagen daemon stop, out='%s', err=%v, MUTAGEN_DATA_DIRECTORY=%s", out, err, mutagenDataDirectory)
+	if fileutil.FileExists(globalconfig.GetMutagenPath()) {
+		out, err := exec2.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "stop")
+		mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
+		assert.NoError(err, "unable to run Mutagen daemon stop, out='%s', err=%v, MUTAGEN_DATA_DIRECTORY=%s", out, err, mutagenDataDirectory)
+	}
 	// After the $XDG_CONFIG_HOME directory is removed,
 	// globalconfig.GetGlobalDdevDir() should point to ~/.ddev
-	err = os.RemoveAll(tmpHomeDir)
+	err := os.RemoveAll(tmpHomeDir)
 	require.NoError(t, err)
 	// refresh the global config from ~/.ddev
 	globalconfig.EnsureGlobalConfig()
@@ -297,9 +301,9 @@ func ResetGlobalDdevDir(t *testing.T, tmpHomeDir string) {
 	err = os.Unsetenv("MUTAGEN_DATA_DIRECTORY")
 	require.NoError(t, err)
 	// Start mutagen daemon if it's enabled
-	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
+	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() && fileutil.FileExists(globalconfig.GetMutagenPath()) {
 		out, err := exec2.RunHostCommand(globalconfig.GetMutagenPath(), "daemon", "start")
-		mutagenDataDirectory = os.Getenv("MUTAGEN_DATA_DIRECTORY")
+		mutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 		assert.NoError(err, "unable to run Mutagen daemon start, out='%s', err=%v, MUTAGEN_DATA_DIRECTORY=%s", out, err, mutagenDataDirectory)
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
 		assert.Equal(os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), "mutagen_data_directory"))

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -243,6 +243,7 @@ func MoveGlobalDdevDir(t *testing.T) string {
 	originalGlobalConfig := globalconfig.DdevGlobalConfig
 	// Stop the Mutagen daemon running in the ~/.ddev
 	ddevapp.StopMutagenDaemon()
+	t.Log(fmt.Sprintf("stop mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 	// Set $XDG_CONFIG_HOME for tests
 	t.Setenv("XDG_CONFIG_HOME", tmpHomeDir)
 	// Create the global config in $XDG_CONFIG_HOME/ddev
@@ -260,6 +261,7 @@ func MoveGlobalDdevDir(t *testing.T) string {
 	// Start mutagen daemon if it's enabled
 	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 		ddevapp.StartMutagenDaemon()
+		t.Log(fmt.Sprintf("start mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
 		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), "mutagen_data_directory"))
 	}
@@ -271,6 +273,7 @@ func MoveGlobalDdevDir(t *testing.T) string {
 func ResetGlobalDdevDir(t *testing.T, tmpHomeDir string) {
 	// Stop the Mutagen daemon running in the $XDG_CONFIG_HOME/ddev
 	ddevapp.StopMutagenDaemon()
+	t.Log(fmt.Sprintf("stop mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 	// After the $XDG_CONFIG_HOME directory is removed,
 	// globalconfig.GetGlobalDdevDir() should point to ~/.ddev
 	err := os.RemoveAll(tmpHomeDir)
@@ -286,6 +289,7 @@ func ResetGlobalDdevDir(t *testing.T, tmpHomeDir string) {
 	// Start mutagen daemon if it's enabled
 	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 		ddevapp.StartMutagenDaemon()
+		t.Log(fmt.Sprintf("start mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
 		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), "mutagen_data_directory"))
 	}

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -248,7 +248,7 @@ func MoveGlobalDdevDir(t *testing.T) string {
 	t.Setenv("XDG_CONFIG_HOME", tmpHomeDir)
 	// Create the global config in $XDG_CONFIG_HOME/ddev
 	globalconfig.EnsureGlobalConfig()
-	// And set the original performance mode
+	// Copy some settings from ~/.ddev to $XDG_CONFIG_HOME/ddev
 	globalconfig.DdevGlobalConfig.PerformanceMode = originalGlobalConfig.PerformanceMode
 	globalconfig.DdevGlobalConfig.LastStartedVersion = originalGlobalConfig.LastStartedVersion
 	err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
@@ -263,7 +263,7 @@ func MoveGlobalDdevDir(t *testing.T) string {
 		ddevapp.StartMutagenDaemon()
 		t.Log(fmt.Sprintf("start mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
-		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), "mutagen_data_directory"))
+		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), ".mdd"))
 	}
 
 	return tmpHomeDir
@@ -291,7 +291,7 @@ func ResetGlobalDdevDir(t *testing.T, tmpHomeDir string) {
 		ddevapp.StartMutagenDaemon()
 		t.Log(fmt.Sprintf("start mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
-		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), "mutagen_data_directory"))
+		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), ".mdd"))
 	}
 }
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -240,20 +240,16 @@ func MoveGlobalDdevDir(t *testing.T) string {
 		err = copy2.Copy(sourceBinDir, filepath.Join(tmpGlobalDdevDir, "bin"))
 		require.NoError(t, err)
 	}
-	// Make sure we have global_config.yaml from the original ~/.ddev for performance_mode
-	globalConfigYamlFile := filepath.Join(originalGlobalDdevDir, "global_config.yaml")
-	_, err = os.Stat(globalConfigYamlFile)
-	if !os.IsNotExist(err) {
-		// Copy ~/.ddev/global_config.yaml to $XDG_CONFIG_HOME/ddev/global_config.yaml
-		err = copy2.Copy(globalConfigYamlFile, filepath.Join(tmpGlobalDdevDir, "global_config.yaml"))
-		require.NoError(t, err)
-	}
+	originalGlobalConfig := globalconfig.DdevGlobalConfig
 	// Stop the Mutagen daemon running in the ~/.ddev
 	ddevapp.StopMutagenDaemon()
 	// Set $XDG_CONFIG_HOME for tests
 	t.Setenv("XDG_CONFIG_HOME", tmpHomeDir)
-	// refresh the global config from $XDG_CONFIG_HOME/ddev
+	// Create the global config in $XDG_CONFIG_HOME/ddev
 	globalconfig.EnsureGlobalConfig()
+	// And set the original performance mode
+	globalconfig.DdevGlobalConfig.PerformanceMode = originalGlobalConfig.PerformanceMode
+	globalconfig.DdevGlobalConfig.LastStartedVersion = originalGlobalConfig.LastStartedVersion
 	err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 	require.NoError(t, err)
 	// Make sure that the global config directory is set to $XDG_CONFIG_HOME/ddev

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -217,13 +217,13 @@ func CreateTmpDir(prefix string) string {
 
 // MoveGlobalDdevDir creates a temporary global config directory for DDEV
 // using a temporary directory which is set to $XDG_CONFIG_HOME/ddev
-// Don't forget to run ResetGlobalDdevDir(t, tmpHomeDir)
+// Don't forget to run ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 // in the test's cleanup function.
 func MoveGlobalDdevDir(t *testing.T) string {
 	// Create $XDG_CONFIG_HOME
-	tmpHomeDir := CreateTmpDir("Home_" + util.RandString(5))
+	tmpXdgConfigHomeDir := CreateTmpDir("Home_" + util.RandString(5))
 	// Global DDEV config directory should be named "ddev"
-	tmpGlobalDdevDir := filepath.Join(tmpHomeDir, "ddev")
+	tmpGlobalDdevDir := filepath.Join(tmpXdgConfigHomeDir, "ddev")
 	// Make sure that the tmpDir/ddev doesn't exist.
 	_, err := os.Stat(tmpGlobalDdevDir)
 	require.Error(t, err)
@@ -245,7 +245,7 @@ func MoveGlobalDdevDir(t *testing.T) string {
 	ddevapp.StopMutagenDaemon()
 	t.Log(fmt.Sprintf("stop mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 	// Set $XDG_CONFIG_HOME for tests
-	t.Setenv("XDG_CONFIG_HOME", tmpHomeDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
 	// Create the global config in $XDG_CONFIG_HOME/ddev
 	globalconfig.EnsureGlobalConfig()
 	// Copy some settings from ~/.ddev to $XDG_CONFIG_HOME/ddev
@@ -266,17 +266,17 @@ func MoveGlobalDdevDir(t *testing.T) string {
 		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), ".mdd"))
 	}
 
-	return tmpHomeDir
+	return tmpXdgConfigHomeDir
 }
 
 // ResetGlobalDdevDir removes temporary $XDG_CONFIG_HOME directory
-func ResetGlobalDdevDir(t *testing.T, tmpHomeDir string) {
+func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 	// Stop the Mutagen daemon running in the $XDG_CONFIG_HOME/ddev
 	ddevapp.StopMutagenDaemon()
 	t.Log(fmt.Sprintf("stop mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 	// After the $XDG_CONFIG_HOME directory is removed,
 	// globalconfig.GetGlobalDdevDir() should point to ~/.ddev
-	err := os.RemoveAll(tmpHomeDir)
+	err := os.RemoveAll(tmpXdgConfigHomeDir)
 	require.NoError(t, err)
 	// refresh the global config from ~/.ddev
 	globalconfig.EnsureGlobalConfig()

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -223,7 +223,7 @@ func CreateTmpDir(prefix string) string {
 func MoveGlobalDdevDir(t *testing.T) string {
 	assert := asrt.New(t)
 	// Create $XDG_CONFIG_HOME
-	tmpHomeDir := CreateTmpDir("Home" + nodeps.RandomString(5))
+	tmpHomeDir := CreateTmpDir("Home_" + util.RandString(5))
 	// Global DDEV config directory should be named "ddev"
 	tmpGlobalDdevDir := filepath.Join(tmpHomeDir, "ddev")
 	// Make sure that the tmpDir/ddev doesn't exist.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,6 +26,7 @@ func GetVersionInfo() map[string]string {
 
 	versionInfo["DDEV version"] = versionconstants.DdevVersion
 	versionInfo["cgo_enabled"] = strconv.FormatInt(versionconstants.CGOEnabled, 10)
+	versionInfo["global-ddev-dir"] = globalconfig.GetGlobalDdevDir()
 	versionInfo["web"] = docker.GetWebImage()
 	versionInfo["db"] = docker.GetDBImage(nodeps.MariaDB, "")
 	versionInfo["router"] = docker.GetRouterImage()

--- a/scripts/diagnose_mutagen.sh
+++ b/scripts/diagnose_mutagen.sh
@@ -4,9 +4,8 @@
 # directory where you're having trouble and provide its
 # output in a gist at gist.github.com with any issue you open about mutagen.
 
-export MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd
-
 ddev list
 ddev describe
-~/.ddev/bin/mutagen sync list -l
-~/.ddev/bin/mutagen version
+ddev mutagen version
+ddev debug mutagen sync list -l
+ddev debug mutagen version

--- a/scripts/diagnose_mutagen.sh
+++ b/scripts/diagnose_mutagen.sh
@@ -4,7 +4,7 @@
 # directory where you're having trouble and provide its
 # output in a gist at gist.github.com with any issue you open about mutagen.
 
-export MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory
+export MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd
 
 ddev list
 ddev describe

--- a/scripts/diagnose_mutagen.sh
+++ b/scripts/diagnose_mutagen.sh
@@ -4,7 +4,7 @@
 # directory where you're having trouble and provide its
 # output in a gist at gist.github.com with any issue you open about mutagen.
 
-export MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory
+export MUTAGEN_DATA_DIRECTORY=~/.ddev/mutagen_data_directory
 
 ddev list
 ddev describe


### PR DESCRIPTION
## The Issue

- #5807 

This is my first time touching Go so please "go" easy on me! 😄 Thanks for having great documentation, good code, and an easy build process that made it a pretty easy learning process.

## How This PR Solves The Issue

1. Allows to move the global `~/.ddev` directory to `$XDG_CONFIG_HOME/ddev` or predefined OS specific location:

    * `~/.config/ddev` on Linux and WSL2 only

    **Important: if `$XDG_CONFIG_HOME` is set, DDEV will automatically create `$XDG_CONFIG_HOME/ddev` dir, if it doesn't exist.**

2. If there are multiple DDEV global configurations, they are checked with the following priority:

	1. `$XDG_CONFIG_HOME/ddev`
	2. `~/.config/ddev` on Linux and WSL2 only
	3. `~/.ddev`

	The current location of the configuration directory can be checked using `ddev version | grep global-ddev-dir`

3. Switches from `~/.ddev/mutagen_data_directory` to `~/.ddev/.mdd`

4. Adds check for Mutagen socket length. See:

	- https://github.com/mutagen-io/mutagen/issues/453
	- https://github.com/garden-io/garden/issues/4527#issuecomment-1584286590
	- https://unix.stackexchange.com/a/367012

## Manual Testing Instructions

1. Check moving ~/.ddev without using `$XDG_CONFIG_HOME` (on Linux and WSL2):
	1. Move `~/.ddev` to OS specific config folder:
	    * `~/.config/ddev` on Linux and WSL2
	2. Check that old Mutagen folder `~/.ddev_mutagen_data_directory` does exist.
	3. Run `ddev list`
	4. Run `ddev version | grep global-ddev-dir` to confirm that directory is different from `~/.ddev`
	5. Check that `~/.ddev` is not recreated
	6. Run `ddev start`
	7. Old `~/.ddev_mutagen_data_directory` should be deleted.
	8. Move `.ddev` back to `~/.ddev` and confirm that everything works as before

2. Repeat all steps from 1, but this time use `export $XDG_CONFIG_HOME=$HOME/.config && mkdir -p $XDG_CONFIG_HOME/ddev  && mv ~/.ddev $XDG_CONFIG_HOME/ddev`

3. Repeat all steps from 1, but this time use `export $XDG_CONFIG_HOME=$HOME/.config`, and run DDEV commands, the directory `$XDG_CONFIG_HOME/ddev` will be created automatically.

4. Check Mutagen error for really long path to its socket:
	1. `ddev config global --performance-mode=mutagen`
	2. check `ddev mutagen version` output
	3. Set `$XDG_CONFIG_HOME` to some really long path, in result the full path to `$XDG_CONFIG_HOME/ddev/.mdd/daemon/daemon.sock` should be at least 104 characters on macOS or 108 characters on Linux
	6. `mkdir -p $XDG_CONFIG_HOME/ddev`
	7. check `ddev mutagen version` output (the locations should be different).
	8. run `ddev start` and see a warning for too long path

## Automated Testing Overview

Tests that changed `$HOME` are rewritten to use `$XDG_CONFIG_HOME` (except for `TestCreateGlobalDdevDir`, that needs to create a directory).

## Related Issue Link(s)

Fixes #5807 

## Release/Deployment Notes

* This PR doesn't introduce any breaking changes, it adds more options for moving the DDEV global config directory to another location.
* However, `ddev poweroff` is required to get mutagen data into the new directory.