### PR TITLE
fix: follow the zsh naming conventions for completion scripts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -191,12 +191,12 @@ brews:
         system "make", "build", "completions"
         system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
         bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "ddev"
+        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
     else
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install "ddev_zsh_completion.sh" => "ddev"
+        zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
 
@@ -229,18 +229,18 @@ brews:
         system "make", "build", "completions"
         system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
         bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "ddev"
+        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
     else
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install "ddev_zsh_completion.sh" => "ddev"
+        zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
 
   test: |
     system "#{bin}/ddev --version"
-    
+
 
 nfpms:
 - maintainer: Randy Fay
@@ -307,7 +307,7 @@ aurs:
     # bin
     install -Dm755 "./ddev" "${pkgdir}/usr/bin/ddev"
     install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/ddev/LICENSE"
-    
+
     # completions
     mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
     mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
@@ -345,7 +345,7 @@ aurs:
     # bin
     install -Dm755 "./ddev" "${pkgdir}/usr/bin/ddev"
     install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/ddev/LICENSE"
-    
+
     # completions
     mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
     mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"


### PR DESCRIPTION

## The Issue

* https://github.com/ddev/ddev/pull/4179 prepended an underscore to the zsh completion script following the zsh naming convention. The PR changed that only on the bump_homebrew.sh file. on .goreleaser.yaml which is used meanwhile that convention wasn't followed.

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

