### PR TITLE
feat: support TablePlus application located in setapp directory (#5815)

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -7,7 +7,7 @@
 ## Usage: tableplus
 ## Example: "ddev tableplus"
 ## OSTypes: darwin,wsl2
-## HostBinaryExists: /Applications/TablePlus.app,/mnt/c/Program Files/TablePlus/TablePlus.exe
+## HostBinaryExists: /Applications/TablePlus.app,/Applications/Setapp/TablePlus.app,/mnt/c/Program Files/TablePlus/TablePlus.exe
 
 if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
@@ -26,7 +26,11 @@ case $OSTYPE in
     "/mnt/c/Program Files/TablePlus/TablePlus.exe" $query >/dev/null &
     ;;
   "darwin"*)
-    set -x
-    open "$query" -a "/Applications/TablePlus.app/Contents/MacOS/TablePlus"
+    set -eu -o pipefail
+    if [ -d "/Applications/Setapp/TablePlus.app" ]; then
+        open "$query" -a "/Applications/Setapp/TablePlus.app/Contents/MacOS/TablePlus"
+    else
+        open "$query" -a "/Applications/TablePlus.app/Contents/MacOS/TablePlus"
+    fi
     ;;
 esac


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

TablePlus is not only available via download from the vendor website but is  also part of the [SetApp subscription model](https://setapp.com/en/apps/tableplus). In that case, the application is installed in a different directory and thus  the `ddev tableplus` command doesn't work.

## How This PR Solves The Issue

This PR checks of tableplus is located in the setapp directory. If not, the default path is used.
Default path is `/Applications/TablePlus.app`
SetApp path is `/Applications/Setapp/TablePlus.app`

## Manual Testing Instructions

`ddev tableplus` works for both, normal users and SetApp users.


