### PR TITLE
docs: update the section about zsh completions

### DIFF
--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -4,64 +4,87 @@ Most people like to have shell completion on the command line. In other words, w
 
 Shells like Bash and zsh need help to do this though, they have to know what the options are. DDEV provides the necessary hint scripts, and if you use Homebrew, they get installed automatically. But if you use oh-my-zsh, for example, you may have to manually install the hint script.
 
-=== "macOS Bash + Homebrew"
 
-    ## macOS Bash + Homebrew
+## macOS Bash + Homebrew
 
-    The easiest way to use Bash completion on macOS is install it with Homebrew. `brew install bash-completion`. When you install it though, it will warn you with something like this, which **may vary on your system**. Add the following line to your `~/.bash_profile` file:
+The easiest way to use Bash completion on macOS is install it with Homebrew. `brew install bash-completion`. When you install it though, it will warn you with something like this, which **may vary on your system**. Add the following line to your `~/.bash_profile` file:
 
+```
+[[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"
+```
+
+!!!note "Bash profile"
+    You must add the include to your `.bash_profile` or `.profile` or nothing will work. Use `source ~/.bash_profile` or `source ~/.profile` to make it take effect immediately.
+
+Link completions by running `brew completions link`.
+
+When you install DDEV via Homebrew, each new release will automatically get a refreshed completions script.
+
+## MacOS Zsh + Homebrew
+
+To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/site-functions` has to be added to the FPATH. There are two scenarios:
+
+=== "Plain macOS Zsh"
+
+    Add the following block to your `~/.zshrc` file:
+
+    ```bash
+    if type brew &>/dev/null
+    then
+      FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
+      autoload -Uz compinit
+      compinit
+    fi
     ```
-    [[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"
+
+    Note that the sourcing of the FPATH has to happen before Zsh's completion facility is initialized with `compinit`.
+
+=== "macOS Zsh with Oh-My-Zsh"
+
+    Oh-My-Zsh is calling `compinit` for you when `oh-my-zsh.sh` is sourced. Instead of adding the block that was necessary for `Plain macOS Zsh` place the following line right before `oh-my-zsh.sh` is sourced:
+
+    ```bash
+    FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
     ```
 
-    !!!note "Bash profile"
-        You must add the include to your `.bash_profile` or `.profile` or nothing will work. Use `source ~/.bash_profile` or `source ~/.profile` to make it take effect immediately.
+To avoid any potential caching issue forcibly rebuild the `.zcompdump` file, which is the index for Zsh completions:
 
-    Link completions by running `brew completions link`.
+```bash
+rm -f ~/.zcompdump; compinit
+```
 
-    When you install DDEV via Homebrew, each new release will automatically get a refreshed completions script.
+In case you run into any `zsh compinit: insecure directories` warnings simply run:
 
-=== "Bash/Zsh/Fish on Linux"
+```bash
+chmod -R go-w "$(brew --prefix)/share"
+```
 
-    ## Bash/Zsh/Fish on Linux
+Otherwise, you can extract the zsh completions file (`ddev_zsh_completion.sh`) from the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
 
-    On Debian and Yum based systems, if you installed DDEV using `apt install ddev`, the `bash`, `zsh`, and `fish` completions should be automatically installed at `/usr/share/bash-completion/completions/ddev`, `/usr/share/zsh/vendor-completions/_ddev` and `/usr/share/fish/completions/ddev.fish` respectively, and the `bash` completions should be automatically installed at `/usr/share/bash-completion/completions/bash`.
 
-    Otherwise, you can download the completion files for manual installation as described [below](#tar-archive-of-completion-scripts-for-manual-deployment). Every Linux distro requires a different manual installation technique. On Debian/Ubuntu, you could deploy the `ddev_bash_completion.sh` script where it needs to be by running `sudo mkdir -p /usr/share/bash-completion/completions && sudo cp ddev_bash_completion.sh /usr/share/bash-completion/completions/ddev`.
+## Bash/Zsh/Fish on Linux
 
-=== "Oh-My-Zsh"
+On Debian and Yum based systems, if you installed DDEV using `apt install ddev`, the `bash`, `zsh`, and `fish` completions should be automatically installed at `/usr/share/bash-completion/completions/ddev`, `/usr/share/zsh/vendor-completions/_ddev` and `/usr/share/fish/completions/ddev.fish` respectively, and the `bash` completions should be automatically installed at `/usr/share/bash-completion/completions/bash`.
 
-    ## Oh-My-Zsh
+Otherwise, you can download the completion files for manual installation as described [below](#tar-archive-of-completion-scripts-for-manual-deployment). Every Linux distro requires a different manual installation technique. On Debian/Ubuntu, you could deploy the `ddev_bash_completion.sh` script where it needs to be by running `sudo mkdir -p /usr/share/bash-completion/completions && sudo cp ddev_bash_completion.sh /usr/share/bash-completion/completions/ddev`.
 
-    If you installed zsh using Homebrew, DDEV’s completions should be automatically installed when you install DDEV using `brew install ddev/ddev/ddev`.
+## Fish
 
-    Otherwise, you can extract the zsh completions file (`ddev_zsh_completion.sh`) from the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
-    
-    Oh-My-Zsh may be set up very differently in different places, so you’ll need to put `ddev_bash_completion.sh` where it belongs. `echo $fpath` will show you the places that it’s most likely to belong. To install in `~/.oh-my-zsh/completions` (an obvious choice), you can run `mkdir -p ~/.oh-my-zsh/completions && cp ddev_zsh_completion.sh ~/.oh-my-zsh/completions/_ddev`, then `autoload -Uz compinit && compinit`.
+`fish` shell completions are automatically installed at `/usr/local/share/fish/vendor_completions.d/ddev_fish_completion.sh` when you install DDEV via Homebrew.
 
-=== "Fish"
+If you installed `fish` without Homebrew, you can extract the fish completions (`ddev_fish_completion.sh`) from the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
 
-    ## Fish
+## Git Bash
 
-    `fish` shell completions are automatically installed at `/usr/local/share/fish/vendor_completions.d/ddev_fish_completion.sh` when you install DDEV via Homebrew.
-    
-    If you installed `fish` without Homebrew, you can extract the fish completions (`ddev_fish_completion.sh`) from the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
+Git Bash completions (`ddev_bash_completion.sh`) are provided in the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
 
-=== "Git Bash"
+Completions in Git Bash are sourced from at least the `~/bash_completion.d` directory. You can copy `ddev_bash_completion.sh` to that directory by running `mkdir -p ~/bash_completion.d && cp ddev_bash_completion.sh ~/bash_completion.d/ddev.bash`.
 
-    ## Git Bash
+## PowerShell
 
-    Git Bash completions (`ddev_bash_completion.sh`) are provided in the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
-    
-    Completions in Git Bash are sourced from at least the `~/bash_completion.d` directory. You can copy `ddev_bash_completion.sh` to that directory by running `mkdir -p ~/bash_completion.d && cp ddev_bash_completion.sh ~/bash_completion.d/ddev.bash`.
+PowerShell completions (`ddev_powershell_completion.ps1`) are provided in the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
 
-=== "PowerShell"
-
-    ## PowerShell
-
-    PowerShell completions (`ddev_powershell_completion.ps1`) are provided in the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
-    
-    You can run the `ddev_powershell_completion.ps1` script manually or install it so it will be run whenever PS is opened using the technique described at [Run PowerShell Script When You Open PowerShell](https://superuser.com/questions/886951/run-powershell-script-when-you-open-powershell).
+You can run the `ddev_powershell_completion.ps1` script manually or install it so it will be run whenever PS is opened using the technique described at [Run PowerShell Script When You Open PowerShell](https://superuser.com/questions/886951/run-powershell-script-when-you-open-powershell).
 
 ## tar Archive of Completion Scripts for Manual Deployment
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -2,7 +2,7 @@
 
 Most people like to have shell completion on the command line. In other words, when you're typing a command, you can hit `<TAB>` and the shell will show you what the options are. For example, if you type `ddev <TAB>`, you'll see all the possible commands. `ddev debug <TAB>` will show you the options for the command. And `ddev list -<TAB>` will show you all the flags available for [`ddev list`](../usage/commands.md#list).
 
-Shells like Bash and zsh need help to do this though, they have to know what the options are. DDEV provides the necessary hint scripts, and if you use Homebrew, they get installed automatically. But if you use oh-my-zsh, for example, you may have to manually install the hint script.
+Shells like Bash and Zsh need help to do this though, they have to know what the options are. DDEV provides the necessary hint scripts, and if you use Homebrew, they get installed automatically.
 
 
 ## macOS Bash + Homebrew
@@ -20,7 +20,7 @@ Link completions by running `brew completions link`.
 
 When you install DDEV via Homebrew, each new release will automatically get a refreshed completions script.
 
-## MacOS Zsh + Homebrew
+## macOS Zsh + Homebrew
 
 To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/site-functions` has to be added to the FPATH. There are two scenarios:
 
@@ -37,9 +37,9 @@ To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/sit
     fi
     ```
 
-    Note that the sourcing of the FPATH has to happen before Zsh's completion facility is initialized with `compinit`.
+    Note that the sourcing of the FPATH has to happen before the Zsh completion index is initialized with `compinit`.
 
-=== "macOS Zsh with Oh-My-Zsh"
+=== "macOS Zsh with Oh My Zsh"
 
     Oh-My-Zsh is calling `compinit` for you when `oh-my-zsh.sh` is sourced. Instead of adding the block that was necessary for `Plain macOS Zsh` place the following line right before `oh-my-zsh.sh` is sourced:
 
@@ -53,13 +53,13 @@ To avoid any potential caching issue forcibly rebuild the `.zcompdump` file, whi
 rm -f ~/.zcompdump; compinit
 ```
 
-In case you run into any `zsh compinit: insecure directories` warnings simply run:
+In case you run into any `zsh compinit: insecure directories` warnings, simply run:
 
 ```bash
 chmod -R go-w "$(brew --prefix)/share"
 ```
 
-Otherwise, you can extract the zsh completions file (`ddev_zsh_completion.sh`) from the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
+Otherwise, you can extract the Zsh completions file (`ddev_zsh_completion.sh`) from the tar archive of completion scripts included with each release. Read more in the [tar archive of completion scripts for manual deployment](#tar-archive-of-completion-scripts-for-manual-deployment) section.
 
 
 ## Bash/Zsh/Fish on Linux

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -19,13 +19,13 @@ Link completions by running `brew completions link`.
 
 When you install DDEV via Homebrew, each new release will automatically get a refreshed completions script.
 
-## macOS Zsh + Homebrew
+## macOS Zsh with Homebrew
 
 To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/site-functions` has to be added to the FPATH. There are two scenarios:
 
 === "macOS Zsh"
 
-    Add the following block to your `~/.zshrc` file:
+    Add the following block to your `~/.zshrc` file (see [docs](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh)):
 
     ```bash
     if type brew &>/dev/null
@@ -46,13 +46,13 @@ To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/sit
     FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
     ```
 
-To avoid any potential caching issue forcibly rebuild the `.zcompdump` file, which is the index for Zsh completions:
+To avoid any potential caching issue remove and rebuild the `.zcompdump` file, which is the index for Zsh completions:
 
 ```bash
 rm -f ~/.zcompdump; compinit
 ```
 
-In case you run into any `zsh compinit: insecure directories` warnings, simply run:
+In case you run into any `zsh compinit: insecure directories` warnings, run:
 
 ```bash
 chmod -R go-w "$(brew --prefix)/share"

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -40,7 +40,7 @@ To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/sit
 
 === "macOS Zsh with Oh My Zsh"
 
-    Oh-My-Zsh is calling `compinit` for you when `oh-my-zsh.sh` is sourced (see [docs](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh)). Instead of adding the block that was necessary for  simple `macOS Zsh` place the following line right before `oh-my-zsh.sh` is sourced:
+    Oh My Zsh is calling `compinit` for you when `oh-my-zsh.sh` is sourced (see [docs](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh)). Instead of adding the block that was necessary for `macOS Zsh` place the following line right before the `oh-my-zsh.sh` file is sourced in your `~/.zshrc` file:
 
     ```bash
     FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -4,7 +4,6 @@ Most people like to have shell completion on the command line. In other words, w
 
 Shells like Bash and Zsh need help to do this though, they have to know what the options are. DDEV provides the necessary hint scripts, and if you use Homebrew, they get installed automatically.
 
-
 ## macOS Bash + Homebrew
 
 The easiest way to use Bash completion on macOS is install it with Homebrew. `brew install bash-completion`. When you install it though, it will warn you with something like this, which **may vary on your system**. Add the following line to your `~/.bash_profile` file:
@@ -60,7 +59,6 @@ chmod -R go-w "$(brew --prefix)/share"
 ```
 
 Otherwise, you can extract the Zsh completions file (`ddev_zsh_completion.sh`) from the tar archive of completion scripts included with each release. Read more in the [tar archive of completion scripts for manual deployment](#tar-archive-of-completion-scripts-for-manual-deployment) section.
-
 
 ## Bash/Zsh/Fish on Linux
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -6,14 +6,14 @@ Shells like Bash and Zsh need help to do this though, they have to know what the
 
 ## macOS Bash with Homebrew
 
-The easiest way to use Bash completion on macOS is install it with Homebrew. `brew install bash-completion`. When you install it though, it will warn you with something like this, which **may vary on your system**. Add the following line to your `~/.bash_profile` file:
+The easiest way to use Bash completion on macOS is install it with Homebrew ([docs](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash)). `brew install bash-completion`. When you install it though, it will warn you with something like this, which **may vary on your system**. Add the following line to your `~/.bash_profile` file (or if that doesn't exist, to your `~/.profile`:
 
 ```
 [[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"
 ```
 
 !!!note "Bash profile"
-    You must add the include to your `.bash_profile` or `.profile` or nothing will work. Use `source ~/.bash_profile` or `source ~/.profile` to make it take effect immediately.
+    You must add the include to your `.bash_profile` or `.profile` or nothing will work. Use `source ~/.bash_profile` or `source ~/.profile` to make it take effect immediately in your current terminal window.
 
 Link completions by running `brew completions link`.
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -57,6 +57,7 @@ In case you run into any `zsh compinit: insecure directories` warnings, run:
 ```bash
 chmod -R go-w "$(brew --prefix)/share"
 ```
+
 ## macOS Fish with Homebrew
 
 `fish` shell completions are automatically installed at `/usr/local/share/fish/vendor_completions.d/ddev_fish_completion.sh` when you install DDEV via Homebrew.

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -21,7 +21,7 @@ When you install DDEV via Homebrew, each new release will automatically get a re
 
 ## macOS Zsh with Homebrew
 
-To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/site-functions` has to be added to the FPATH variable. There are two scenarios:
+To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/site-functions` has to be added to the FPATH variable.
 
 === "macOS Zsh"
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -4,7 +4,7 @@ Most people like to have shell completion on the command line. In other words, w
 
 Shells like Bash and Zsh need help to do this though, they have to know what the options are. DDEV provides the necessary hint scripts, and if you use Homebrew, they get installed automatically.
 
-## macOS Bash + Homebrew
+## macOS Bash with Homebrew
 
 The easiest way to use Bash completion on macOS is install it with Homebrew. `brew install bash-completion`. When you install it though, it will warn you with something like this, which **may vary on your system**. Add the following line to your `~/.bash_profile` file:
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -23,7 +23,7 @@ When you install DDEV via Homebrew, each new release will automatically get a re
 
 To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/site-functions` has to be added to the FPATH. There are two scenarios:
 
-=== "Plain macOS Zsh"
+=== "macOS Zsh"
 
     Add the following block to your `~/.zshrc` file:
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -57,18 +57,17 @@ In case you run into any `zsh compinit: insecure directories` warnings, run:
 ```bash
 chmod -R go-w "$(brew --prefix)/share"
 ```
+## macOS Fish with Homebrew
+
+`fish` shell completions are automatically installed at `/usr/local/share/fish/vendor_completions.d/ddev_fish_completion.sh` when you install DDEV via Homebrew.
+
+If you installed `fish` without Homebrew, you can extract the fish completions (`ddev_fish_completion.sh`) from the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
 
 ## Bash/Zsh/Fish on Linux
 
 On Debian and Yum based systems, if you installed DDEV using `apt install ddev`, the `bash`, `zsh`, and `fish` completions should be automatically installed at `/usr/share/bash-completion/completions/ddev`, `/usr/share/zsh/vendor-completions/_ddev` and `/usr/share/fish/completions/ddev.fish` respectively, and the `bash` completions should be automatically installed at `/usr/share/bash-completion/completions/bash`.
 
 Otherwise, you can download the completion files for manual installation as described [below](#tar-archive-of-completion-scripts-for-manual-deployment). Every Linux distro requires a different manual installation technique. On Debian/Ubuntu, you could deploy the `ddev_bash_completion.sh` script where it needs to be by running `sudo mkdir -p /usr/share/bash-completion/completions && sudo cp ddev_bash_completion.sh /usr/share/bash-completion/completions/ddev`.
-
-## Fish
-
-`fish` shell completions are automatically installed at `/usr/local/share/fish/vendor_completions.d/ddev_fish_completion.sh` when you install DDEV via Homebrew.
-
-If you installed `fish` without Homebrew, you can extract the fish completions (`ddev_fish_completion.sh`) from the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
 
 ## Git Bash
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -58,8 +58,6 @@ In case you run into any `zsh compinit: insecure directories` warnings, run:
 chmod -R go-w "$(brew --prefix)/share"
 ```
 
-Otherwise, you can extract the Zsh completions file (`ddev_zsh_completion.sh`) from the tar archive of completion scripts included with each release. Read more in the [tar archive of completion scripts for manual deployment](#tar-archive-of-completion-scripts-for-manual-deployment) section.
-
 ## Bash/Zsh/Fish on Linux
 
 On Debian and Yum based systems, if you installed DDEV using `apt install ddev`, the `bash`, `zsh`, and `fish` completions should be automatically installed at `/usr/share/bash-completion/completions/ddev`, `/usr/share/zsh/vendor-completions/_ddev` and `/usr/share/fish/completions/ddev.fish` respectively, and the `bash` completions should be automatically installed at `/usr/share/bash-completion/completions/bash`.

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -36,11 +36,11 @@ To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/sit
     fi
     ```
 
-    Note that the sourcing of the FPATH has to happen before the Zsh completion index is initialized with `compinit`.
+    Note that the updating of the FPATH variable has to happen before the Zsh completion index is initialized with `compinit`.
 
 === "macOS Zsh with Oh My Zsh"
 
-    Oh-My-Zsh is calling `compinit` for you when `oh-my-zsh.sh` is sourced. Instead of adding the block that was necessary for `Plain macOS Zsh` place the following line right before `oh-my-zsh.sh` is sourced:
+    Oh-My-Zsh is calling `compinit` for you when `oh-my-zsh.sh` is sourced (see [docs](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh)). Instead of adding the block that was necessary for  simple `macOS Zsh` place the following line right before `oh-my-zsh.sh` is sourced:
 
     ```bash
     FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -21,7 +21,7 @@ When you install DDEV via Homebrew, each new release will automatically get a re
 
 ## macOS Zsh with Homebrew
 
-To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/site-functions` has to be added to the FPATH. There are two scenarios:
+To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/site-functions` has to be added to the FPATH variable. There are two scenarios:
 
 === "macOS Zsh"
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -63,7 +63,7 @@ chmod -R go-w "$(brew --prefix)/share"
 
 If you installed `fish` without Homebrew, you can extract the fish completions (`ddev_fish_completion.sh`) from the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
 
-## Bash/Zsh/Fish on Linux
+## Bash/Zsh/Fish on Linux including WSL2
 
 On Debian and Yum based systems, if you installed DDEV using `apt install ddev`, the `bash`, `zsh`, and `fish` completions should be automatically installed at `/usr/share/bash-completion/completions/ddev`, `/usr/share/zsh/vendor-completions/_ddev` and `/usr/share/fish/completions/ddev.fish` respectively, and the `bash` completions should be automatically installed at `/usr/share/bash-completion/completions/bash`.
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
The doc for completions in Zsh are outdated.  

## How This PR Solves The Issue
the draft is mainly aligned to the instructions on https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh and as already noted on discord. aside the changes for the zsh section i've made some changes how the page in general is styled. that is only a proposal and could be rolled back at any point. but it is easier to see it in a preview than simply talking about it.


## Manual Testing Instructions

Review these changes in https://ddev--5825.org.readthedocs.build/en/5825/users/install/shell-completion/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Enhanced the guide for setting up shell completions for DDEV, now including detailed instructions for Zsh with Homebrew, addressing caching issues, and manual deployment on Linux.
	- Added guidance for Fish, Git Bash, and PowerShell completions, expanding support for various shells and operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->