### PR TITLE
build: revert implementation of 'head' release, fixes #5830

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -172,14 +172,6 @@ jobs:
     env:
       DDEV_GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
       CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
-      # For goreleaser
-      GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
-      GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-      FURY_ACCOUNT: ${{ secrets.FURY_ACCOUNT }}
-      FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
-      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-      AUR_STABLE_GIT_URL: ${{ secrets.AUR_STABLE_GIT_URL }}
-      AUR_EDGE_GIT_URL: ${{ secrets.AUR_EDGE_GIT_URL }}
 
     steps:
       # The upload-artifacts section often fails. This may give us a recovery technique
@@ -230,8 +222,6 @@ jobs:
         run: exit 1
 
       # Goreleaser does GitHub release artifacts, homebrew, AUR, deb/rpm
-
-      # Actual release
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v5
         if: startsWith( github.ref, 'refs/tags/v1')
@@ -239,15 +229,14 @@ jobs:
           distribution: goreleaser-pro
           version: latest
           args: release --clean
-
-      # HEAD release, if we don't have a `v` tag
-      - name: goreleaser
-        uses: goreleaser/goreleaser-action@v5
-        if: startsWith( github.ref, 'refs/tags/v1') != true
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          args: release --clean --nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          FURY_ACCOUNT: ${{ secrets.FURY_ACCOUNT }}
+          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          AUR_STABLE_GIT_URL: ${{ secrets.AUR_STABLE_GIT_URL }}
+          AUR_EDGE_GIT_URL: ${{ secrets.AUR_EDGE_GIT_URL }}
 
       # Do artifacts for upload to workflow URL
       - name: Generate artifacts

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,4 @@
 ##### BUILDS ######
-nightly:
-  publish_release: true
-  keep_single_release: true
-  tag_name: head
-  name_template: '{{ incpatch .Version }}-{{ .ShortCommit }}-head'
-
 builds:
 - id: ddev
   main: ./cmd/ddev

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -8,7 +8,7 @@ search:
 
 There are several ways to use DDEV’s latest-committed HEAD version:
 
-* **Download** artifacts from the latest HEAD pre-release in [releases](https://github.com/ddev/ddev/releases), which are signed and notarized. Get the one you need and place it in your `$PATH`.
+* **Download** the latest master branch artifacts from [nightly.link](https://nightly.link/ddev/ddev/workflows/master-build/master). Each of these is built by the CI system, signed, and notarized. Get the one you need and place it in your `$PATH`.
 * **Homebrew install HEAD**: On macOS and Linux, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD --fetch-HEAD` to get the latest DDEV commit, even if it’s unreleased. Since you’re building this on your own computer, it’s not signed or notarized, and you’ll get a notification that instrumentation doesn’t work, which is fine. If you’re using Linux/WSL2, you’ll likely need to install build-essential by running the following command: `sudo apt install -y build-essential`.
 * **Build manually**: If you have normal build tools like `make` and `go` installed, you can check out the code and run `make`.
 * **Gitpod** You can use the latest build by visiting DDEV on [Gitpod](https://gitpod.io/#https://github.com/ddev/ddev).


### PR DESCRIPTION

## The Issue

* #5830

Implementation of a new "head" release in https://github.com/ddev/ddev/pull/5824 caused all hell to break loose.

* Packages were inappropriately pushed to our apt/yum repositories
* `ddev start` notified about a new release inappropriately (it was a prerelease anyway)
* People got repeated email notifications about the head release as it cycled back and forth.

## How This PR Solves The Issue

Revert the implementation of the "head" release. 

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

