### PR TITLE
build: bump traefik to 2.11

### DIFF
--- a/containers/ddev-traefik-router/Dockerfile
+++ b/containers/ddev-traefik-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:2.10
+FROM traefik:2.11
 
 ENV TRAEFIK_MONITOR_PORT=10999
 RUN apk add bash curl htop vim

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -24,7 +24,7 @@ var DBImg = "ddev/ddev-dbserver"
 var BaseDBTag = "v1.22.7"
 
 const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.22.7"
-const TraefikRouterImage = "ddev/ddev-traefik-router:v1.22.7"
+const TraefikRouterImage = "ddev/ddev-traefik-router:20240213_traefik_2.11"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"


### PR DESCRIPTION
## The Issue

Traefik got updated to version 2.11.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated Traefik to version 2.11 for improved routing capabilities.
	- Added monitoring capabilities with the `TRAEFIK_MONITOR_PORT` set to `10999`.
	- Enhanced container with utility tools (`bash`, `curl`, `htop`, `vim`) for better troubleshooting and debugging experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->