### PR TITLE
docs: find all DDEV binaries using `which -a ddev`

### DIFF
--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1121,7 +1121,7 @@ Common commands:
 
 ## `self-upgrade`
 
-Output instructions for updating or upgrading DDEV. The command doesn’t perform the upgrade, but tries to provide instructions relevant to your installation. Must be executed from the project context.
+Output instructions for updating or upgrading DDEV. The command doesn’t perform the upgrade, but tries to provide instructions relevant to your installation.
 
 Example:
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -186,7 +186,7 @@ $ which -a ddev
 /usr/bin/ddev
 ```
 
-You can check each binary version by its full path (`/usr/bin/ddev version`) to find old versions. Remove them preferably in the same way you installed them, i.e. `/home/linuxbrew/.linuxbrew/bin/ddev` should be removed with Homebrew.
+You can check each binary version by its full path (`/usr/bin/ddev version`) to find old versions. Remove them preferably in the same way you installed them, i.e. `/home/linuxbrew/.linuxbrew/bin/ddev` should be removed with Homebrew: `brew uninstall ddev`.
 
 ### How can I back up or restore all project databases?
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -176,6 +176,18 @@ If you’re using Homebrew, first run `brew unlink ddev` to get rid of the versi
 3. On Debian/Ubuntu/WSL2 with DDEV installed via apt, you can run `sudo apt update && sudo apt install ddev=<version>`, for example `sudo apt install ddev=1.21.5`.
 4. If you want the very latest, unreleased version of DDEV, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD`.
 
+### Why do I have an old DDEV?
+
+You may have installed DDEV several times using different techniques. Use `which -a ddev` to find all installed binaries. For example, you could install a DDEV in WSL2 with Homebrew, forget about it for a while, and then install it again with `apt`:
+
+```bash
+$ which -a ddev
+/home/linuxbrew/.linuxbrew/bin/ddev
+/usr/bin/ddev
+```
+
+You can check each binary version by its full path (`/usr/bin/ddev version`) to find old versions. Remove them preferably in the same way you installed them, i.e. `/home/linuxbrew/.linuxbrew/bin/ddev` should be removed with Homebrew.
+
 ### How can I back up or restore all project databases?
 
 You can back up all projects that show in `ddev list` with `ddev snapshot -a`. This only snapshots projects displayed in `ddev list`; any projects not shown there will need to be started so they’re be registered in `ddev list`.

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -186,7 +186,7 @@ $ which -a ddev
 /usr/bin/ddev
 ```
 
-You can check each binary version by its full path (`/usr/bin/ddev version`) to find old versions. Remove them preferably in the same way you installed them, i.e. `/home/linuxbrew/.linuxbrew/bin/ddev` should be removed with Homebrew: `brew uninstall ddev`.
+You can check each binary version by its full path (`/usr/bin/ddev --version`) to find old versions. Remove them preferably in the same way you installed them, i.e. `/home/linuxbrew/.linuxbrew/bin/ddev` should be removed with Homebrew: `brew uninstall ddev`.
 
 ### How can I back up or restore all project databases?
 

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -246,6 +246,10 @@ docker rmi -f $(docker images -q)
 
 You should then be able to start your DDEV machine.
 
+## `ddev version` Shows the old version
+
+If you have installed the latest version of DDEV, and when you check the actual version with `ddev version`, it shows an older version, please refer to [Why do I have an old DDEV?](./faq.md#why-do-i-have-an-old-ddev)
+
 ## Trouble Building Dockerfiles
 
 The additional `.ddev/web-build/Dockerfile` capability in DDEV is wonderful, but it can be hard to figure out what to put in there.

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -246,9 +246,9 @@ docker rmi -f $(docker images -q)
 
 You should then be able to start your DDEV machine.
 
-## `ddev version` Shows the old version
+## `ddev --version` shows an old version
 
-If you have installed the latest version of DDEV, and when you check the actual version with `ddev version`, it shows an older version, please refer to [Why do I have an old DDEV?](./faq.md#why-do-i-have-an-old-ddev)
+If you have installed the latest version of DDEV, but when you check the actual version with `ddev --version`, it shows an older version, please refer to [Why do I have an old DDEV?](./faq.md#why-do-i-have-an-old-ddev)
 
 ## Trouble Building Dockerfiles
 

--- a/docs/content/users/usage/uninstall.md
+++ b/docs/content/users/usage/uninstall.md
@@ -33,6 +33,7 @@ Otherwise:
 
 To remove the `ddev` binary:
 
+* Find the binary location with `which -a ddev`, you may have several binaries installed in different ways. The output will give you a general idea of how you installed it.
 * On macOS or Linux with Homebrew, `brew uninstall ddev`.
 * For Linux or other simple installs, remove the binary. Example: `sudo rm /usr/local/bin/ddev`. For Linux installed via apt, `sudo apt remove ddev`.
 * On Windows, if you used the DDEV Windows installer, use the uninstall on the Start Menu or in the “Add or Remove Programs” section of Windows Settings.

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -7,38 +7,38 @@
 ## Example: "ddev self-upgrade"
 ## CanRunGlobally: true
 
-mypath=$(which ddev)
+for ddev_path in $(which -a ddev); do
+  case $ddev_path in
+    "/usr/bin/ddev")
+      if [[ ${OSTYPE} = "linux-gnu"* ]]; then
+        if command -v apt; then echo "You seem to have an apt-installed DDEV, upgrade with 'sudo apt update && sudo apt upgrade -y ddev'";
+        elif [ -f /etc/arch-release ] && command -v yay >/dev/null ; then echo "You seem to have yay-installed DDEV (AUR), upgrade with 'yay -Syu ddev-bin'";
+        elif command -v dnf; then echo "You seem to have dnf-installed DDEV, upgrade with 'sudo dnf install --refresh ddev'"; fi
+      fi
+      ;;
 
-case $mypath in
-  "/usr/bin/ddev")
-    if [[ ${OSTYPE} = "linux-gnu"* ]]; then
-      if command -v apt; then echo "You seem to have an apt-installed ddev, upgrade with 'sudo apt update && sudo apt upgrade -y ddev'";
-      elif [ -f /etc/arch-release ] && command -v yay >/dev/null ; then echo "You seem to have yay-installed ddev (AUR), upgrade with 'yay -Syu ddev-bin'";
-      elif command -v dnf; then echo "You seem to have dnf-installed ddev, upgrade with 'sudo dnf install --refresh ddev'"; fi
-    fi
-    ;;
+    "/usr/local/bin/ddev")
+      if [ ! -L /usr/local/bin/ddev ]; then
+        printf "DDEV appears to have been installed with install_ddev.sh, you can run that script again to update.\ncurl -fsSL https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh | bash\n"
+      elif command -v brew; then
+        echo "DDEV appears to have been installed with Homebrew, upgrade with 'brew update && brew upgrade ddev'"
+      fi
+      ;;
 
-  "/usr/local/bin/ddev")
-    if [ ! -L /usr/local/bin/ddev ]; then
-      printf "DDEV appears to have been installed with install_ddev.sh, you can run that script again to update.\ncurl -fsSL https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh | bash\n"
-    elif command -v brew; then
-      echo "DDEV appears to have been installed with homebrew, upgrade with 'brew update && brew upgrade ddev'"
-    fi
-    ;;
+    "/opt/homebrew/bin/ddev" | "/home/linuxbrew/.linuxbrew/bin/ddev")
+      if [ -L "$(which ddev)" ] && command -v brew; then
+        echo "DDEV appears to have been installed with Homebrew, upgrade with 'brew update && brew upgrade ddev'"
+      fi
+      ;;
 
-  "/opt/homebrew/bin/ddev" | "/home/linuxbrew/.linuxbrew/bin/ddev")
-    if [ -L "$(which ddev)" ] && command -v brew; then
-      echo "DDEV appears to have been installed with homebrew, upgrade with 'brew update && brew upgrade ddev'"
-    fi
-    ;;
+    "/c/Program Files/DDEV/ddev")
+      printf "DDEV was either installed with\nchoco install -y ddev\nor with the installer package.\n"
+      echo "You can upgrade with 'choco upgrade -y ddev'"
+      echo "Or by downloading the Windows installer from https://github.com/ddev/ddev/releases"
+      ;;
 
-  "/c/Program Files/DDEV/ddev")
-    printf "DDEV was either installed with\nchoco install -y ddev\nor with the installer package.\n"
-    echo "You can upgrade with 'choco upgrade -y ddev'"
-    echo "Or by downloading the Windows installer from https://github.com/ddev/ddev/releases"
-    ;;
+    *)
+      echo "Unable to determine how you installed DDEV, but you can remove $ddev_path and reinstall with one of the techniques in https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/"
 
-  *)
-    echo "Unable to determine how you installed ddev, but you can remove $mypath and reinstall with one of the techniques in https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/"
-
-esac
+  esac
+done


### PR DESCRIPTION
## The Issue

Multiple `ddev` can be in `PATH`.
And the older `ddev` may have a higher priority, so users wonder why their `ddev` is not "updating".

## How This PR Solves The Issue

Adds the `which -a ddev` technique in several places in the documentation. My priority is that when you type `old ddev` in the search, it will be shown.
Uses `which -a ddev` in `ddev self-upgrade`.

## Manual Testing Instructions

Run `ddev debug fix-commands`.
Run `ddev self-upgrade` with one `ddev` in `PATH`, repeat with multiple `ddev` in `PATH`.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

