### PR TITLE
feat: change php default version to 8.2, fixes #5767

### DIFF
--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -27,7 +27,7 @@ func TestCmdXdebug(t *testing.T) {
 
 	// TestDdevXdebugEnabled has already tested enough versions, so limit it here.
 	// and this is a pretty limited test, doesn't do much but turn on and off
-	phpVersions := []string{nodeps.PHP81, nodeps.PHP82}
+	phpVersions := []string{nodeps.PHP82, nodeps.PHP83}
 
 	pwd, _ := os.Getwd()
 	v := TestSites[0]

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
 ### Build ddev-php-base, which is the base for ddev-php-prod and ddev-webserver-*
 ### This combines the packages and features of DDEV’s ddev-webserver and PHP image
 FROM base AS ddev-php-base
-ARG PHP_DEFAULT_VERSION="8.1"
+ARG PHP_DEFAULT_VERSION="8.2"
 ENV DDEV_PHP_VERSION=$PHP_DEFAULT_VERSION
 ENV PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4 php8.0 php8.1 php8.2 php8.3"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -48,7 +48,7 @@ RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer
 ### Build ddev-webserver-dev-base from ddev-webserver-base
 FROM ddev-webserver-base as ddev-webserver-dev-base
 ENV CAROOT /mnt/ddev-global-cache/mkcert
-ENV PHP_DEFAULT_VERSION="8.1"
+ENV PHP_DEFAULT_VERSION="8.2"
 
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | apt-key add -
 RUN echo "deb http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
@@ -164,7 +164,7 @@ RUN update-alternatives --set php /usr/bin/php${PHP_DEFAULT_VERSION}
 ### But for historical reasons, it's just ddev-webserver
 ### Build ddev-webserver by turning ddev-webserver-dev-base into one layer
 FROM scratch as ddev-webserver
-ENV PHP_DEFAULT_VERSION="8.1"
+ENV PHP_DEFAULT_VERSION="8.2"
 ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.conf
 ENV APACHE_SITE_TEMPLATE /etc/apache2/apache-site.conf
 ENV TERMINUS_CACHE_DIR=/mnt/ddev-global-cache/terminus/cache
@@ -192,7 +192,7 @@ CMD ["/start.sh"]
 ### This image is aimed at actual hardened production environments
 FROM ddev-webserver-base as ddev-webserver-prod-base
 ENV CAROOT /mnt/ddev-global-cache/mkcert
-ENV PHP_DEFAULT_VERSION="8.1"
+ENV PHP_DEFAULT_VERSION="8.2"
 ARG TARGETPLATFORM
 
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | apt-key add -
@@ -271,7 +271,7 @@ RUN update-alternatives --set php /usr/bin/php${PHP_DEFAULT_VERSION}
 ### Build ddev-webserver-prod, the hardened version of ddev-webserver-base
 ### (Withut dev features, single layer)
 FROM scratch as ddev-webserver-prod
-ENV PHP_DEFAULT_VERSION="8.1"
+ENV PHP_DEFAULT_VERSION="8.2"
 ENV NGINX_SITE_TEMPLATE /etc/nginx/nginx-site.conf
 ENV APACHE_SITE_TEMPLATE /etc/apache2/apache-site.conf
 ENV TERMINUS_CACHE_DIR=/mnt/ddev-global-cache/terminus/cache

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20231024_peter-neumann-dev_nodejs_v20_lts as ddev-webserver-base
+FROM ddev/ddev-php-base:20240213_php_8.2_default as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docs/content/developers/project-types.md
+++ b/docs/content/developers/project-types.md
@@ -18,7 +18,7 @@ To add a new project type:
     * `apptypeSettingsPaths` returns the paths for the main settings file and the extra settings file that DDEV may create (like settings.ddev.php for Drupal).
     * `appTypeDetect` is a function that determines whether the project is of the type you’re implementing.
     * `postImportDBAction` can do something after db import. I don’t see it implemented anywhere.
-    * `configOverrideAction` can change default config for your project type. For example, magento2 now requires `php8.1`, so a `configOverrideAction` can change the php version.
+    * `configOverrideAction` can change default config for your project type. For example, your CMS may require `php8.3`, so a `configOverrideAction` can change the php version.
     * `postConfigAction` gives a chance to do something at the end of config, but it doesn’t seem to be used anywhere.
     * `postStartAction` adds actions at the end of [`ddev start`](../users/usage/commands.md#start). You'll see several implementations of this, for things like creating needed default directories, or setting permissions on files, etc.
     * `importFilesAction` defines how [`ddev import-files`](../users/usage/commands.md#import-files) works for this project type.

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -21,12 +21,12 @@ You can hand-edit the YAML files DDEV creates for you after running [`ddev confi
 === "config.yaml"
 
     ```yaml
-    php_version: "8.1"
+    php_version: "8.3"
     ```
 === "`ddev config`"
 
     ```shell
-    ddev config --php-version 8.1
+    ddev config --php-version 8.3
     ```
 
     Run `ddev help config` to see all the available config arguments.
@@ -94,9 +94,9 @@ Composer version for the web container and the [`ddev composer`](../usage/comman
 
 The type and version of the database engine the project should use.
 
-| Type | Default | Usage
-| -- | -- | --
-| :octicons-file-directory-16: project | MariaDB 10.4 | Can be MariaDB 5.5–10.8 or 10.11, MySQL 5.5–8.0, or PostgreSQL 9–15.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats.
+| Type | Default       | Usage
+| -- |---------------| --
+| :octicons-file-directory-16: project | MariaDB 10.11 | Can be MariaDB 5.5–10.8 or 10.11, MySQL 5.5–8.0, or PostgreSQL 9–15.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats.
 
 ## `dbimage_extra_packages`
 
@@ -410,8 +410,8 @@ This is typically a global setting. The project-specific value will override glo
 The PHP version the project should use.
 
 | Type | Default | Usage
-| -- | -- | --
-| :octicons-file-directory-16: project | `8.1` | Can be `5.6`, `7.0`, `7.1`, `7.2`, `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, or `8.3`.
+| -- |---------| --
+| :octicons-file-directory-16: project | `8.2`   | Can be `5.6`, `7.0`, `7.1`, `7.2`, `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, or `8.3`.
 
 You can only specify the major version (`7.3`), not a minor version (`7.3.2`), from those explicitly available.
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -9,7 +9,7 @@ DDEV provides several ways to customize and extend project environments.
 
 ## Changing PHP Version
 
-The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be changed to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, or `8.3`. The current default is `8.1`.
+The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be changed to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, or `8.3`.
 
 ### Older Versions of PHP
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -157,7 +157,6 @@ For example, a Dockerfile might want to build an extension for the configured PH
 ENV extension=xhprof
 ENV extension_repo=https://github.com/longxinH/xhprof
 ENV extension_version=v2.3.8
-# For versions <= DDEV v1.21.4 you must also declare DDEV_PHP_VERSION yourself: ENV DDEV_PHP_VERSION=8.1
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests autoconf build-essential libc-dev php-pear php${DDEV_PHP_VERSION}-dev pkg-config zlib1g-dev
 RUN mkdir -p /tmp/php-${extension} && cd /tmp/php-${extension} && git clone ${extension_repo} .

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -62,7 +62,7 @@ func TestPostConfigAction(t *testing.T) {
 
 	appTypes := map[string]string{
 		nodeps.AppTypeBackdrop:     nodeps.PHPDefault,
-		nodeps.AppTypeCraftCms:     nodeps.PHPDefault,
+		nodeps.AppTypeCraftCms:     nodeps.PHP81,
 		nodeps.AppTypeDrupal6:      nodeps.PHP56,
 		nodeps.AppTypeDrupal7:      nodeps.PHPDefault,
 		nodeps.AppTypeDrupal8:      nodeps.PHP74,

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -973,8 +973,8 @@ func TestDdevXdebugEnabled(t *testing.T) {
 			t.Errorf("Aborting Xdebug check for php%s: %v", v, err)
 			continue
 		}
-		// PHP 7.2 through 8.2 get Xdebug 3.0+
-		if nodeps.ArrayContainsString([]string{nodeps.PHP72, nodeps.PHP73, nodeps.PHP74, nodeps.PHP80, nodeps.PHP81, nodeps.PHP82}, app.PHPVersion) {
+		// PHP 7.2 through 8.3 get Xdebug 3.0+
+		if nodeps.ArrayContainsString([]string{nodeps.PHP72, nodeps.PHP73, nodeps.PHP74, nodeps.PHP80, nodeps.PHP81, nodeps.PHP82, nodeps.PHP83}, app.PHPVersion) {
 			assert.Contains(stdout, "xdebug.mode => debug,develop => debug,develop", "xdebug is not enabled for %s", v)
 			assert.Contains(stdout, "xdebug.client_host => host.docker.internal => host.docker.internal")
 		} else {

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -13,7 +13,7 @@ const ConfigInstructions = `
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "8.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"
+# php_version: "8.2"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"
 
 # You can explicitly specify the webimage but this
 # is not recommended, as the images are often closely tied to DDEV's' behavior,

--- a/pkg/nodeps/php_values.go
+++ b/pkg/nodeps/php_values.go
@@ -15,7 +15,7 @@ const (
 )
 
 // PHPDefault is the default PHP version, overridden by $DDEV_PHP_VERSION
-const PHPDefault = PHP81
+const PHPDefault = PHP82
 
 // ValidPHPVersions should be updated whenever PHP versions are added or removed, and should
 // be used to ensure user-supplied values are valid.

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20231024_peter-neumann-dev_nodejs_v20_lts" // Note that this can be overridden by make
+var WebTag = "20240213_php_8.2_default" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

* #5767 

## How This PR Solves The Issue

Change the default everywhere

## Manual Testing Instructions

Try it out. `ddev config --auto` in an empty directory should get a default of 8.2
Start it up. `ddev php --version` should have 8.2

**this won't be testable until I push new images. I'll wait to push new images until**
* https://github.com/ddev/ddev/pull/5453
is in

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

