### PR TITLE
docs: make the shell completion page more consistent

### DIFF
--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -2,7 +2,7 @@
 
 Most people like to have shell completion on the command line. In other words, when you're typing a command, you can hit `<TAB>` and the shell will show you what the options are. For example, if you type `ddev <TAB>`, you'll see all the possible commands. `ddev debug <TAB>` will show you the options for the command. And `ddev list -<TAB>` will show you all the flags available for [`ddev list`](../usage/commands.md#list).
 
-Shells like Bash and Zsh need help to do this though, they have to know what the options are. DDEV provides the necessary hint scripts, and if you use Homebrew, they get installed automatically.
+Shells like Bash and Zsh need help to do this though, they have to know what the options are, and DDEV provides the necessary hint scripts.
 
 ## macOS Bash with Homebrew
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -137,7 +137,7 @@ On Debian and Yum based systems, if you installed DDEV using `apt install ddev`,
 
 Otherwise, you can download the completion files for manual installation as described [below](#tar-archive-of-completion-scripts-for-manual-deployment). Every Linux distro requires a different manual installation technique. On Debian/Ubuntu, you could deploy the `ddev_bash_completion.sh` script where it needs to be by running `sudo mkdir -p /usr/share/bash-completion/completions && sudo cp ddev_bash_completion.sh /usr/share/bash-completion/completions/ddev`.
 
-## Git Bash
+## Git Bash on Microsoft Windows
 
 Git Bash completions (`ddev_bash_completion.sh`) are provided in the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -6,18 +6,59 @@ Shells like Bash and Zsh need help to do this though, they have to know what the
 
 ## macOS Bash with Homebrew
 
-The easiest way to use Bash completion on macOS is install it with Homebrew ([docs](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash)). `brew install bash-completion`. When you install it though, it will warn you with something like this, which **may vary on your system**. Add the following line to your `~/.bash_profile` file (or if that doesn't exist, to your `~/.profile`:
+To make Homebrew completions available in Bash the Homebrew-managed path, either `etc/profile.d` or `etc/bash_completion.de` has to be sourced.
 
+=== "macOS Bash"
+
+     Add the following block to your `~/.bashprofile` or if it doesn't exist to your `~/.profile` file (see [docs](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash)):
+
+    ```bash
+    if type brew &>/dev/null
+    then
+      HOMEBREW_PREFIX="$(brew --prefix)"
+      if [[ -r "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]
+      then
+        source "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
+      else
+        for COMPLETION in "${HOMEBREW_PREFIX}/etc/bash_completion.d/"*
+        do
+          [[ -r "${COMPLETION}" ]] && source "${COMPLETION}"
+        done
+      fi
+    fi
+    ```
+
+=== "macOS Bash with Bash Completion"
+
+    If you install the bash-completion formula no addition to your bashprofile are necessary, the formula will source the completion initialisation script automatically (see [docs](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash)):
+
+    === "With macOS Bash <= 3.x"
+
+        ```bash
+        brew install bash-completion
+        ```
+
+    === "With macOS Bash >= 4.x"
+
+        ```bash
+        brew install bash-completion@2
+        ```
+
+Then make sure that completions are linked by running:
+
+```bash
+brew completions link
 ```
-[[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"
+Finally reload your shell with:
+
+```bash
+source ~/.bash_profile
 ```
+If it doesn't exist:
 
-!!!note "Bash profile"
-    You must add the include to your `.bash_profile` or `.profile` or nothing will work. Use `source ~/.bash_profile` or `source ~/.profile` to make it take effect immediately in your current terminal window.
-
-Link completions by running `brew completions link`.
-
-When you install DDEV via Homebrew, each new release will automatically get a refreshed completions script.
+```bash
+source ~/.profile
+```
 
 ## macOS Zsh with Homebrew
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -49,11 +49,13 @@ Then make sure that completions are linked by running:
 ```bash
 brew completions link
 ```
+
 Finally reload your shell with:
 
 ```bash
 source ~/.bash_profile
 ```
+
 If it doesn't exist:
 
 ```bash

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -143,7 +143,7 @@ Git Bash completions (`ddev_bash_completion.sh`) are provided in the tar archive
 
 Completions in Git Bash are sourced from at least the `~/bash_completion.d` directory. You can copy `ddev_bash_completion.sh` to that directory by running `mkdir -p ~/bash_completion.d && cp ddev_bash_completion.sh ~/bash_completion.d/ddev.bash`.
 
-## PowerShell
+## PowerShell on Microsoft Windows
 
 PowerShell completions (`ddev_powershell_completion.ps1`) are provided in the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -30,7 +30,7 @@ To make Homebrew completions available in Bash the Homebrew-managed path, either
 
 === "macOS Bash with Bash Completion"
 
-    If you install the bash-completion formula no addition to your bashprofile are necessary, the formula will source the completion initialisation script automatically (see [docs](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash)):
+    If you install the bash-completion formula no additions to your Bash profile file are necessary, the formula will source the completion initialisation script automatically (see [docs](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash)):
 
     === "With macOS Bash <= 3.x"
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -113,9 +113,23 @@ chmod -R go-w "$(brew --prefix)/share"
 
 ## macOS Fish with Homebrew
 
-`fish` shell completions are automatically installed at `/usr/local/share/fish/vendor_completions.d/ddev_fish_completion.sh` when you install DDEV via Homebrew.
+Fish shell completions are automatically installed at `/usr/local/share/fish/vendor_completions.d/ddev_fish_completion.sh` when you install DDEV via Homebrew. Just make sure that completions are linked by running:
 
-If you installed `fish` without Homebrew, you can extract the fish completions (`ddev_fish_completion.sh`) from the tar archive of completion scripts included with each release. See [below](#tar-archive-of-completion-scripts-for-manual-deployment).
+```bash
+brew completions link
+```
+
+If you have installed Fish with Homebrew no additional configuration is necessary. If you got Fish from somewhere else, add the following block to your `~/.config/fish/config.fish`:
+
+```bash
+if test -d (brew --prefix)"/share/fish/completions"
+    set -p fish_complete_path (brew --prefix)/share/fish/completions
+end
+
+if test -d (brew --prefix)"/share/fish/vendor_completions.d"
+    set -p fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
+end
+```
 
 ## Bash/Zsh/Fish on Linux including WSL2
 

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -87,6 +87,18 @@ To make Homebrew completions available in Zsh the Homebrew-managed path `zsh/sit
     FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
     ```
 
+First reload your shell with:
+
+```bash
+source ~/.zshrc
+```
+
+Then make sure that completions are linked by running:
+
+```bash
+brew completions link
+```
+
 To avoid any potential caching issue remove and rebuild the `.zcompdump` file, which is the index for Zsh completions:
 
 ```bash


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
Initial draft to make the shell completion sections more consistent among each other as well as more inline with https://docs.brew.sh/Shell-Completion . Not finished yet. Git Bash, PowerShell and the Tar archive section still need work. But feedback about bash and fish is welcome (as well as how consistent it is with the previous zsh changes) 

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

