### PR TITLE
docs: use PHP 8.3 for the TYPO3 Quickstart

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -444,7 +444,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
     ```bash
     mkdir my-typo3-site
     cd my-typo3-site
-    ddev config --project-type=typo3 --docroot=public --php-version 8.1
+    ddev config --project-type=typo3 --docroot=public --php-version 8.3
     ddev start
     ddev composer create "typo3/cms-base-distribution"
     ddev exec touch public/FIRST_INSTALL
@@ -456,7 +456,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
     ```bash
     git clone https://github.com/example/example-site
     cd example-site
-    ddev config --project-type=typo3 --docroot=public --php-version 8.1
+    ddev config --project-type=typo3 --docroot=public --php-version 8.3
     ddev composer install
     ddev restart
     ddev exec touch public/FIRST_INSTALL


### PR DESCRIPTION
The current stable requires PHP 8.2+ (making the current snippet fail) and v11+ supports PHP 8.3 so it seems like a good default.

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
PHP 8.1 is not supported by the latest stable TYPO3 version (v13.0.1) which gets installed by default
## How This PR Solves The Issue

## Manual Testing Instructions
Follow the steps from the paragraph.

## Automated Testing Overview
none
<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)
none
## Release/Deployment Notes
none
<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

