### PR TITLE
fix: do not create project network programmatically on `ddev start`, fixes #5810

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -253,7 +253,6 @@ networks:
   ddev_default:
     name: ddev_default
     external: true
-  {{/* the default project network is created programmatically, see EnsureProjectNetwork() */}}
   default:
     name: ${COMPOSE_PROJECT_NAME}_default
     {{ if .IsGitpod }}{{/* see https://github.com/ddev/ddev/issues/3766 */}}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -80,40 +80,6 @@ func EnsureDdevNetwork() {
 	}
 }
 
-// EnsureProjectNetwork creates or ensures the project network exists or
-// exits with fatal.
-func EnsureProjectNetwork() {
-	if os.Getenv("COMPOSE_PROJECT_NAME") == "" {
-		log.Fatalf("dockerutil.EnsureProjectNetwork() must be called after app.DockerEnv()")
-	}
-	networkName := os.Getenv("COMPOSE_PROJECT_NAME") + "_default"
-	ctx, client := GetDockerClient()
-	netOptions := dockerTypes.NetworkCreate{
-		Driver:   "bridge",
-		Internal: false,
-		Labels: map[string]string{
-			"com.ddev.platform": "ddev",
-			// add docker-compose labels needed for "docker compose up"
-			"com.docker.compose.network": "default",
-			"com.docker.compose.project": os.Getenv("COMPOSE_PROJECT_NAME"),
-			"com.docker.compose.version": func() string {
-				version, _ := GetDockerComposeVersion()
-				return strings.TrimPrefix(version, "v")
-			}()},
-	}
-	// see https://github.com/ddev/ddev/issues/3766
-	if nodeps.IsGitpod() {
-		netOptions.Options = map[string]string{
-			"com.docker.network.driver.mtu": "1440",
-		}
-	}
-	err := EnsureNetwork(ctx, client, networkName, netOptions)
-
-	if err != nil {
-		log.Fatalf("Failed to ensure Docker network %s: %v", networkName, err)
-	}
-}
-
 // NetworkExists returns true if the named network exists
 // Mostly intended for tests
 func NetworkExists(netName string) bool {


### PR DESCRIPTION
## The Issue

- #5810

This PR may return this error during `ddev start`, see #5508:

```
Error response from daemon: network ddev-your-project_default is ambiguous (16 matches found on name)
```

But I really doubt it, because we have a test for this behavior, and after the migration from `fsouza/go-dockerclient` to `docker/docker/client` in #5787, I had to rewrite the `networks_test.go`, because neither Docker 24.0.7 nor Docker 25.0.3 could create a duplicate network.

https://github.com/ddev/ddev/blob/cbb96e3a666d33ce7fb7053cfdc7f2e31c1ad0a0/cmd/ddev/cmd/networks_test.go#L44-L53

## How This PR Solves The Issue

It only uses a check for network duplicates (which doesn't hurt at all), given that in Docker v25+ you can no longer have duplicates.

This allows users to create additional configurations for project networks in custom `docker-compose.yaml` files.

## Manual Testing Instructions

```
echo "networks:
  default:
    driver_opts:
      com.docker.network.driver.mtu: 1440" > .ddev/docker-compose.network.yaml

ddev restart
```

And inspect the Docker project network for this `mtu` value:
```
docker inspect ddev-$(ddev describe --json-output | jq -r .raw.name)_default | grep -C1 mtu
```
Should show this:
```json
"Options": {
    "com.docker.network.driver.mtu": "1440"
}
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

