### PR TITLE
docs: add maintainer docs about remote-config testing

### DIFF
--- a/docs/content/developers/remote-config.md
+++ b/docs/content/developers/remote-config.md
@@ -20,6 +20,23 @@ disabled (interval=0). Supported message types are `infos` and `warnings` where
 Messages will be shown as configured in the `remote-config` repository and the
 user cannot influence them.
 
+### Infos
+
+`infos` and `warnings` (yellow and red) can be specified like this:
+
+```yaml
+    "notifications": {
+      "interval": 20,
+      "infos": [
+        {
+          "message": "This is a message to users of DDEV before v1.22.7",
+          "versions": "<=v1.22.6"
+        }
+      ],
+      "warnings": []
+    }
+```
+
 ### Ticker
 
 Messages rotate, with one shown to the user every `interval` as long as it’s not
@@ -43,5 +60,22 @@ be found in the [Masterminds SemVer repository](https://github.com/Masterminds/s
 
 ## Testing
 
-While running tests a GitHub token maybe required to avoid rate limits and can
-be provided with the `DDEV_GITHUB_TOKEN` environment variable.
+To test, create a pull request on your fork or the main repo.
+
+1. Run `prettier -c remote-config.jsonc` to make sure prettier will not complain. Run `prettier -w remote-config.jsonc` to get it to update the file.
+2. For the fork is `rfay` and branch `20240215_note_about_key_exp` add configuration to your `~/.ddev/global_config.yaml`:
+
+    ```yaml
+   remote_config:
+    update_interval: 1
+    remote:
+        owner: rfay
+        repo: remote-config
+        ref: 20240215_note_about_key_exp
+        filepath: remote-config.jsonc
+    ```
+
+3. `rm ~/.ddev/.state.yaml ~/.ddev/.remote-config`
+4. `DDEV_VERBOSE=true ddev start <project>`
+
+Watch for failure to download or failure to parse the remote configuration.

--- a/docs/content/developers/remote-config.md
+++ b/docs/content/developers/remote-config.md
@@ -24,7 +24,9 @@ user cannot influence them.
 
 `infos` and `warnings` (yellow and red) can be specified like this:
 
-```yaml
+```json
+{
+  "messages": {
     "notifications": {
       "interval": 20,
       "infos": [
@@ -35,6 +37,8 @@ user cannot influence them.
       ],
       "warnings": []
     }
+  }
+}
 ```
 
 ### Ticker
@@ -60,15 +64,15 @@ be found in the [Masterminds SemVer repository](https://github.com/Masterminds/s
 
 ## Testing
 
-To test, create a pull request on your fork or the main repo.
+To test, create a pull request on your fork or the main repository.
 
 1. Run `prettier -c remote-config.jsonc` to make sure prettier will not complain. Run `prettier -w remote-config.jsonc` to get it to update the file.
-2. For the fork is `rfay` and branch `20240215_note_about_key_exp` add configuration to your `~/.ddev/global_config.yaml`:
+2. For the fork `rfay` and branch `20240215_note_about_key_exp`, add configuration to your `~/.ddev/global_config.yaml`:
 
     ```yaml
-   remote_config:
-    update_interval: 1
-    remote:
+    remote_config:
+      update_interval: 1
+      remote:
         owner: rfay
         repo: remote-config
         ref: 20240215_note_about_key_exp


### PR DESCRIPTION

## The Issue

I had to debug new remote config for 
* https://github.com/ddev/remote-config/pull/24

I learned/relearned a few things, so adding this info.

