### PR TITLE
docs: don't link check a couple of unstable external urls [skip ci]

### DIFF
--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -44,6 +44,12 @@
     },
     {
       "pattern": "^https://analytics.amplitude.com"
+    },
+    {
+      "pattern": "^https://stackoverflow.com/questions/tagged/ddev"
+    },
+    {
+      "pattern": "https://packages.debian.org/stable/"
     }
   ],
   "httpHeaders": [


### PR DESCRIPTION

## The Issue

There are a couple of external URLs that often fail the docs markdown links test, we just can't test them. We have no control over them and they should be stable anyway.

