### PR TITLE
docs: add auto light / dark mode

### DIFF
--- a/docs/content/assets/extra.css
+++ b/docs/content/assets/extra.css
@@ -2,6 +2,12 @@
 :root {
     /* #4051b5 (indigo primary) in decimal RGB */
     --custom-bg-color: rgba(64, 81, 181, .1);
+    --custom-header-color: var(--md-primary-fg-color);
+}
+
+/* dark color scheme overrides */
+[data-md-color-scheme="slate"] {
+    --custom-header-color: var(--md-primary-fg-color--light);
 }
 
 /* table does not need a scrollbar, see https://github.com/ddev/ddev/pull/3290#issuecomment-942888867
@@ -38,7 +44,7 @@ dt {
 .md-typeset h6 {
     font-weight: 700;
     margin-bottom: .5em;
-    color: var(--md-primary-fg-color);
+    color: var(--custom-header-color);
 }
 
 .md-content {
@@ -82,13 +88,13 @@ dt {
 
 /* blockquote */
 [dir=ltr] .md-typeset blockquote {
-    border-left-color: var(--md-primary-fg-color);
+    border-left-color: var(--custom-header-color);
     background: var(--custom-bg-color);
     padding: .6rem 1rem;
 }
 
 [dir=ltr] .md-typeset blockquote strong {
-    color: var(--md-primary-fg-color);
+    color: var(--custom-header-color);
 }
 
 [dir=ltr] .md-typeset blockquote p:first-child {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,8 @@ theme:
     toggle:
       icon: material/brightness-4
       name: Switch to system preference
+    primary: indigo
+    accent: indigo
   features:
   - content.action.edit
   - content.code.copy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,9 +24,27 @@ theme:
   icon:
     edit: material/pencil
   palette:
-  - scheme: default
+  # Palette toggle for automatic mode
+  - media: "(prefers-color-scheme)"
+    toggle:
+      icon: material/brightness-auto
+      name: Switch to light mode
     primary: indigo
     accent: indigo
+  # Palette toggle for light mode
+  - media: "(prefers-color-scheme: light)"
+    scheme: default
+    toggle:
+      icon: material/brightness-7
+      name: Switch to dark mode
+    primary: indigo
+    accent: indigo
+  # Palette toggle for dark mode
+  - media: "(prefers-color-scheme: dark)"
+    scheme: slate
+    toggle:
+      icon: material/brightness-4
+      name: Switch to system preference
   features:
   - content.action.edit
   - content.code.copy


### PR DESCRIPTION
## The Issue

I want to try auto light / dark mode for the docs.

## How This PR Solves The Issue

Uses https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/?h=dark+mode#automatic-light-dark-mode

## Manual Testing Instructions

Try out https://ddev--5853.org.readthedocs.build/en/5853/

<img width="573" alt="image" src="https://github.com/ddev/ddev/assets/112444/90dab456-412d-4134-8d6b-37133d5d5e50">


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

