### PR TITLE
fix: make `ddev --version` work even if not in project and ~/.ddev/commands not yet created

### DIFF
--- a/pkg/ddevapp/assets.go
+++ b/pkg/ddevapp/assets.go
@@ -2,10 +2,10 @@ package ddevapp
 
 import (
 	"embed"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"path/filepath"
 
 	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/globalconfig"
 )
 
 // The bundled assets for the project .ddev directory are in directory dotddev_assets
@@ -36,6 +36,12 @@ var bundledAssets embed.FS
 // directory's assets (if it's a project) and then later (when called with appName) update
 // the actual project's assets.
 func PopulateExamplesCommandsHomeadditions(appName string) error {
+
+	err := fileutil.CopyEmbedAssets(bundledAssets, "global_dotddev_assets", globalconfig.GetGlobalDdevDir())
+	if err != nil {
+		return err
+	}
+
 	app, err := GetActiveApp(appName)
 	// If we have an error from GetActiveApp, it means we're not in a project directory
 	// That is not an error. It means we can not do this work, so return nil.
@@ -44,10 +50,6 @@ func PopulateExamplesCommandsHomeadditions(appName string) error {
 	}
 
 	err = fileutil.CopyEmbedAssets(bundledAssets, "dotddev_assets", app.GetConfigPath(""))
-	if err != nil {
-		return err
-	}
-	err = fileutil.CopyEmbedAssets(bundledAssets, "global_dotddev_assets", globalconfig.GetGlobalDdevDir())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

## The Issue

If no ~/.ddev exists, and `ddev --version` is executed in a directory that is not a project, the global commands directory doesn't get created. You end up getting an error like this:

```
$ mv ~/.ddev ~/.ddev.bak
rfay@ub-2204:~/workspace/ddev$ ddev --version
Adding custom/shell commands failed: open /home/rfay/.ddev/commands/host: no such file or directory
ddev version v1.22.7-23-gefa8cea57
```

## How This PR Solves The Issue

Create the global directory structure before existing the test for "am I in a project"

## Manual Testing Instructions

```
mkdir -p ~/tmp/junk && cd ~/tmp/junk
mv ~/.ddev ~/.ddev.bak
ddev --version
```

You shouldn't get an error message. Don't forget to copy your ~/.ddev back into place if you care about it.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

