### PR TITLE
fix: error message 'Error converting to int' on `ddev import-db`

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -722,10 +722,13 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 				util.Warning("mysqladmin command failed: %v", err)
 			}
 			stdout = strings.Trim(stdout, "\r\n\t ")
-			newRowsImported, err := strconv.Atoi(stdout)
-			if err != nil {
-				util.Warning("Error converting '%s' to int", stdout)
-				break
+			newRowsImported := 0
+			if stdout != "" {
+				newRowsImported, err = strconv.Atoi(stdout)
+				if err != nil {
+					util.Warning("Error converting '%s' to int", stdout)
+					break
+				}
 			}
 			// See if mysqld is still importing. If it is, sleep and try again
 			if newRowsImported == rowsImported {


### PR DESCRIPTION
## The Issue

I've been noticing in tests and in manual testing of `ddev import-db` the message "Error converting '' to int":

```
% ddev import-db --file=.tarballs/db.sql.gz
13.9MiB 0:00:01 [7.00MiB/s] [================================>] 100%
Error converting '' to int
Successfully imported database 'db' for d10
```

## How This PR Solves The Issue

Allow empty and don't try to convert it to a zero. I'm not sure this is a change in go's behavior.

I was unable to find a replacement technique for this stanza. The original idea was to watch the rows come in until they stopped coming in. I don't see how to do that now. But I did my traditional huge database import-db and it seemed to work fine.

## Manual Testing Instructions

- [x] `ddev import-db` shouldn't show this
- [x] Make sure `ddev import-db` is behaving OK on huge db import, which is what this code is for.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

