### PR TITLE
docs: stop checking all stack overflow links

### DIFF
--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -46,7 +46,7 @@
       "pattern": "^https://analytics.amplitude.com"
     },
     {
-      "pattern": "^https://(stackoverflow|superuser).com/"
+      "pattern": "^https://(meta.stackoverflow|stackoverflow|superuser).com/"
     },
     {
       "pattern": "^https://packages.debian.org/stable/"

--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -46,7 +46,7 @@
       "pattern": "^https://analytics.amplitude.com"
     },
     {
-      "pattern": "^https://stackoverflow.com/"
+      "pattern": "^https://(stackoverflow|superuser).com/"
     },
     {
       "pattern": "^https://packages.debian.org/stable/"

--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -46,10 +46,10 @@
       "pattern": "^https://analytics.amplitude.com"
     },
     {
-      "pattern": "^https://stackoverflow.com/questions/tagged/ddev"
+      "pattern": "^https://stackoverflow.com/"
     },
     {
-      "pattern": "https://packages.debian.org/stable/"
+      "pattern": "^https://packages.debian.org/stable/"
     }
   ],
   "httpHeaders": [


### PR DESCRIPTION

## The Issue

Stack Overflow is giving us 403 for all URL link checks, so stop trying.

