### PR TITLE
feat: Provide flag for running ddev commands from any directory, not just project, for #2128

### DIFF
--- a/cmd/ddev/cmd/a.go
+++ b/cmd/ddev/cmd/a.go
@@ -2,19 +2,89 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/spf13/pflag"
 )
 
-// This file is a.go because global config must be loaded before anybody else
-// runs their init(), as they might overwrite global_config.yaml with
-// uninitialized data
+// This file is a.go because some code needs to be processed before any other
+// files run their init() to avoid conflicts and ensure certain functionality
+// is available.
 
 func init() {
+	// Set up logger
+	output.LogSetUp()
+
+	// Set up global config
 	globalconfig.EnsureGlobalConfig()
 	_ = os.Setenv("DOCKER_CLI_HINTS", "false")
 	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
+
 	// GetDockerClient should be called early to get DOCKER_HOST set
 	_, _ = dockerutil.GetDockerClient()
+
+	// Parse, and use the "--project" flag
+	handleProjectFlag()
+}
+
+// handleProjectFlag parses the "--project" flag, and sets the current working
+// directory to the named project, if any.
+func handleProjectFlag() {
+	// We need a new flag set so we can parse this early without affecting flags that belong to other commands.
+	tempFlags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	// Don't throw errors for unknown flags - we don't know ANY of the flags at this stage except the ones
+	// explicitly added below.
+	tempFlags.ParseErrorsWhitelist = pflag.ParseErrorsWhitelist{UnknownFlags: true}
+	// We need a dummy help flag to avoid pflag.ErrHelp
+	tempFlags.BoolP("help", "h", false, "")
+	tempFlags.String("project", "", "")
+
+	args := os.Args[1:]
+
+	// skip completion requests where we're trying to complete the project flag itself
+	lastArgIndex := len(args) - 1
+	if args[0] == "__complete" && (strings.HasPrefix(args[lastArgIndex], "--project=") || args[lastArgIndex-1] == "--project") {
+		return
+	}
+
+	// Parse the flag
+	err := tempFlags.Parse(args)
+	if err != nil {
+		output.UserErr.Fatal("Couldn't parse --project flag: ", err)
+	}
+	project, err := tempFlags.GetString("project")
+	if err != nil {
+		// This shouldn't ever happen - but go wants us to handle the error.
+		output.UserErr.Fatal("Unexpected error getting value from --project flag: ", err)
+	}
+
+	if project != "" {
+		// Find and change to the root dir for the project
+		approot, err := ddevapp.GetActiveAppRoot(project)
+		if err != nil {
+			output.UserErr.Fatal("Couldn't find project: ", err)
+		}
+		err = os.Chdir(approot)
+		if err != nil {
+			output.UserErr.Fatal("Couldn't change working directory to "+approot+": ", err)
+		}
+
+		// Remove project flag from os.Args so it doesn't interfere with anything.
+		// Completion gets a little stuffed up by it otherwise, and there could be other side-effects.
+		for i, arg := range os.Args {
+			if arg == "--project" || strings.HasPrefix(arg, "--project=") {
+				split := strings.SplitN(arg, "=", 2)
+				n := 2
+				if len(split) == 2 {
+					n = 1
+				}
+				os.Args = append(os.Args[:i], os.Args[i+n:]...)
+				break
+			}
+		}
+	}
 }

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -123,14 +123,17 @@ func Execute() {
 }
 
 func init() {
-
 	RootCmd.PersistentFlags().BoolVarP(&output.JSONOutput, "json-output", "j", false, "If true, user-oriented output will be in JSON format.")
-
-	output.LogSetUp()
+	// This copy of the "project" flag is only for help and completion. The functional flag is added and parsed in `a.go`
+	RootCmd.PersistentFlags().String("project", "", "The name of a project to run the command against. Include this flag before the command name. The command will run as though your working directory was inside that project.")
+	err := RootCmd.RegisterFlagCompletionFunc("project", ddevapp.GetProjectNamesFunc("all", 0))
+	if err != nil {
+		output.UserOut.Warn("Couldn't register completion function for --project flag")
+	}
 
 	// Determine if Docker is running by getting the version.
 	// This helps to prevent a user from seeing the Cobra error: "Error: unknown command "<custom command>" for ddev"
-	_, err := dockerutil.GetDockerVersion()
+	_, err = dockerutil.GetDockerVersion()
 	// ddev --version may be called without Docker available.
 	if err != nil && len(os.Args) > 1 && os.Args[1] != "--version" && os.Args[1] != "hostname" {
 		util.Failed("Could not connect to a Docker provider. Please start or install a Docker provider.\nFor install help go to: https://ddev.readthedocs.io/en/stable/users/install/docker-installation/")

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -49,14 +49,16 @@ Flags:
 
 Global Flags:
   -j, --json-output   If true, user-oriented output will be in JSON format.
+      --project string   The name of a project to run the command against. Include this flag before the command name. The command will run as though your working directory was inside that project.
 ```
 
 ## Global Flags
 
-Two flags are available for every command:
+Three flags are available for every command:
 
 * `--help` or `-h`: Outputs more information about a command rather than executing it.
 * `--json-output` or `-j`: Format user-oriented output in JSON.
+* `--project`: The name of a project to run the command against. Include this flag before the command name. The command will run as though your working directory was inside that project.
 
 ---
 


### PR DESCRIPTION
## TODO
- Add tests

## The Issue

* #2128 

Currently to run a command against a project you need to `cd` to a directory inside that project (with exception of some select commands, which take projects as arguments).

## How This PR Solves The Issue

Adds a new `--project` global flag.
If a project is passed to this flag, commands are run as though the user's current working directory was the project's root dir.
If the project doesn't exist, an error is thrown early.

The flag includes autocompletion of project names.

## Manual Testing Instructions

Run `ddev --project=<projectName>` and you should see all commands available to that project in the list.
Run any of those commands, using the `--project` flag to run them against any project.

Change directory to one project, and then run `ddev --project=<some-other-project> stop` - the project you named should be stopped, but the one you're in should not be.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
TBD

## Related Issue Link(s)
- #2128

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
And custom projects with a `--project` flag will conflict with the new global flag.
> [!CAUTION]
> For some people this may be a breaking change!

