### PR TITLE
fix: don't start 'mutagen daemon run' during ddev stop/delete

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2472,9 +2472,11 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 		}
 	}
 
-	err = SyncAndPauseMutagenSession(app)
-	if err != nil {
-		util.Warning("Unable to SyncAndterminateMutagenSession: %v", err)
+	if app.IsMutagenEnabled() {
+		err = SyncAndPauseMutagenSession(app)
+		if err != nil {
+			util.Warning("Unable to SyncAndPauseMutagenSession: %v", err)
+		}
 	}
 
 	if globalconfig.DdevGlobalConfig.IsTraefikRouter() && status == SiteRunning {
@@ -2509,11 +2511,12 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 
 	// Remove data/database/projectInfo/hosts entry if we need to.
 	if removeData {
-		err = TerminateMutagenSync(app)
-		if err != nil {
-			util.Warning("Unable to terminate Mutagen session %s: %v", MutagenSyncName(app.Name), err)
+		if !app.IsMutagenEnabled() {
+			err = TerminateMutagenSync(app)
+			if err != nil {
+				util.Warning("Unable to terminate Mutagen session %s: %v", MutagenSyncName(app.Name), err)
+			}
 		}
-
 		// Remove .ddev/settings if it exists
 		if fileutil.FileExists(app.GetConfigPath("settings")) {
 			err = os.RemoveAll(app.GetConfigPath("settings"))

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2511,7 +2511,7 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 
 	// Remove data/database/projectInfo/hosts entry if we need to.
 	if removeData {
-		if !app.IsMutagenEnabled() {
+		if app.IsMutagenEnabled() {
 			err = TerminateMutagenSync(app)
 			if err != nil {
 				util.Warning("Unable to terminate Mutagen session %s: %v", MutagenSyncName(app.Name), err)

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -67,6 +67,9 @@ func MutagenSyncName(name string) string {
 // TerminateMutagenSync destroys a Mutagen sync session
 // It is not an error if the sync session does not exist
 func TerminateMutagenSync(app *DdevApp) error {
+	if !app.IsMutagenEnabled() {
+		return nil
+	}
 	syncName := MutagenSyncName(app.Name)
 	if MutagenSyncExists(app) {
 		_, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), "sync", "terminate", syncName)
@@ -93,6 +96,9 @@ func PauseMutagenSync(app *DdevApp) error {
 
 // SyncAndPauseMutagenSession syncs and pauses a Mutagen sync session
 func SyncAndPauseMutagenSession(app *DdevApp) error {
+	if !app.IsMutagenEnabled() {
+		return nil
+	}
 	if app.Name == "" {
 		return fmt.Errorf("no app.Name provided to SyncAndPauseMutagenSession")
 	}


### PR DESCRIPTION

## The Issue

In testing a completely unrelated issue on Linux/WSL2, I happened to notice that `mutagen daemon run` was running (`ps -ef |grep mutagen`) even though nothing in the system had `performance_mode: mutagen`. 

It turned out that SyncAndPauseMutagenSession() and TerminateMutagenSession() were not protected by app.IsMutagenEnabled(), and even though their activities didn't cause trouble, there was the side-effect of starting the mutagen daemon, which is not needed.

## How This PR Solves The Issue

Properly protect against use of those functions in non-mutagen setup.

## Manual Testing Instructions

With mutagen disabled
* Check to make sure `mutagen daemon run` isn't running
* `ddev start`, `ddev stop`, `ddev poweroff`, `ddev delete` - none of these should result in the mutagen daemon running

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

