### PR TITLE
docs: stop checking link to community.chocolatey.org

### DIFF
--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -50,6 +50,9 @@
     },
     {
       "pattern": "^https://packages.debian.org/stable/"
+    },
+    {
+      "pattern": "^https://community.chocolatey.org"
     }
   ],
   "httpHeaders": [


### PR DESCRIPTION

## The Issue

docs linkcheck shouldn't be trying for community.chocolatey.org, which requires login I think

