### PR TITLE
fix: ddev start should not continue if web/db containers aren't healthy

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1428,7 +1428,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	if waitErr != nil {
-		util.Failed("Failed waiting for web/db containers to become ready: %v", err)
+		util.Failed("Failed waiting for web/db containers to become ready: %v", waitErr)
 	}
 
 	// WebExtraDaemons have to be started after Mutagen sync is done, because so often

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1416,10 +1416,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		dependers = append(dependers, "db")
 	}
 	output.UserOut.Printf("Waiting for web/db containers to become ready: %v", dependers)
-	err = app.Wait(dependers)
-	if err != nil {
-		util.Warning("Failed waiting for web/db containers to become ready: %v", err)
-	}
+	waitErr := app.Wait(dependers)
 
 	if globalconfig.DdevVerbose {
 		out, err = app.CaptureLogs("web", true, "200")
@@ -1428,6 +1425,10 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		} else {
 			util.Debug("docker-compose up output:\n%s\n\n", out)
 		}
+	}
+
+	if waitErr != nil {
+		util.Failed("Failed waiting for web/db containers to become ready: %v", err)
 	}
 
 	// WebExtraDaemons have to be started after Mutagen sync is done, because so often


### PR DESCRIPTION

## The Issue

On a number of [rancher desktop tests](https://buildkite.com/ddev/macos-rancher-desktop/builds/586#018dc0d5-43b7-4b9d-87ee-30c8d521908b) we're seeing docker having failed, and DDEV having detected startup failure, but continuing on in processing app.Start(), eventually seeing the misleading "Something is wrong with Docker or Colima and /mnt/ddev_config is not mounted from the project .ddev folder. This can cause all kinds of problems."
 
We also saw this misleading output on 
* https://github.com/ddev/ddev-sqlsrv/issues/20

## How This PR Solves The Issue

If the web and db containers can't come up, stop the app.Start() and error out.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

