### PR TITLE
fix: don't panic in app.Describe() if container not found

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -251,9 +251,10 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 			dbinfo["dbname"] = "db"
 			dbinfo["host"] = "db"
 			dbPublicPort, err := app.GetPublishedPort("db")
-			util.CheckErr(err)
+			if err != nil {
+				util.Warning("failed to GetPublishedPort(db): %v", err)
+			}
 			dbinfo["dbPort"] = GetExposedPort(app, "db")
-			util.CheckErr(err)
 			dbinfo["published_port"] = dbPublicPort
 			dbinfo["database_type"] = nodeps.MariaDB // default
 			dbinfo["database_type"] = app.Database.Type


### PR DESCRIPTION

## The Issue

* https://github.com/ddev/ddev/issues/5861#issuecomment-1953304513

This is secondary to the actual problem we're chasing there, but there is no reason to do a panic in this situation.

## How This PR Solves The Issue

* Replace util.CheckErr() with a warning
* Remove a second util.CheckErr() which was checking the same `err`

