### PR TITLE
test: Fix TestPantheonPush, broken due to php8.2 default

### DIFF
--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -146,8 +146,8 @@ func TestPantheonPush(t *testing.T) {
 	err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 	assert.NoError(err)
 
-	// Use a D9 codebase for Drush to work right
-	d9code := FullTestSites[8]
+	// Use a D10 codebase for Drush to work right
+	d9code := FullTestSites[12]
 	d9code.Name = t.Name()
 	err = globalconfig.RemoveProjectInfo(t.Name())
 	require.NoError(t, err)
@@ -175,7 +175,8 @@ func TestPantheonPush(t *testing.T) {
 	})
 
 	app.Name = t.Name()
-	app.Type = nodeps.AppTypeDrupal9
+	app.Type = nodeps.AppTypeDrupal10
+	app.PHPVersion = nodeps.PHP82
 	app.Hooks = map[string][]ddevapp.YAMLTask{"post-push": {{"exec-host": "touch hello-post-push-" + app.Name}}, "pre-push": {{"exec-host": "touch hello-pre-push-" + app.Name}}}
 	_ = app.Stop(true, false)
 
@@ -216,10 +217,10 @@ func TestPantheonPush(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make sure we have Drush
-	_, _, err = app.Exec(&ddevapp.ExecOpts{
-		Cmd: "composer require --no-interaction drush/drush:* >/dev/null 2>/dev/null",
+	stdout, stderr, err := app.Exec(&ddevapp.ExecOpts{
+		Cmd: "composer require --no-interaction drush/drush >/dev/null 2>/dev/null",
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to composer require drush err=%v stdout='%s', stderr='%s'", err, stdout, stderr)
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
 


### PR DESCRIPTION

## The Issue

TestPantheonPush has been failing.

Studying the problem showed that it was the move to PHP8.2 as default that broke it; drush couldn't be installed on Drupal9.

## How This PR Solves The Issue

* Use Drupal10
* Use PHP8.2 

## Manual Testing Instructions

None needed.

