### PR TITLE
docs: Link to 'Upgrading DDEV' in 'Usage' section

### DIFF
--- a/docs/content/users/usage/index.md
+++ b/docs/content/users/usage/index.md
@@ -10,6 +10,7 @@ This section covers day-to-day DDEV usage, reference material, and common suppor
 - [Managing Projects](managing-projects.md)
 - [Troubleshooting](troubleshooting.md)
 - [Using DDEV Offline](offline.md)
+- [Upgrading DDEV](../install/ddev-upgrade.md)
 
 ## Reference
 


### PR DESCRIPTION
## The Issue

While upgrading and installing DDEV are functionally similar, they take place at different times during a user's engagement with DDEV. A new DDEV user may not remember or have ever been informed to check 'Start!' for instructions on upgrading. They should not have to rely on the site search to locate it. For example, the [Drupal's documentation](https://www.drupal.org/docs) takes this approach and provides separate sections for 'Getting started' and 'Updating Drupal'.

## How This PR Solves The Issue

It simply adds a link to the 'Upgrading DDEV' from within the 'Usage' > 'Common Tasks' documentation section.

## Manual Testing Instructions

## Automated Testing Overview

## Related Issue Link(s)

## Release/Deployment Notes