### PR TITLE
test: exclude TestPHPOverrides on Colima

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -753,8 +753,8 @@ func TestConfigOverrideDetection(t *testing.T) {
 
 // TestPHPOverrides tests to make sure that PHP overrides work in all webservers.
 func TestPHPOverrides(t *testing.T) {
-	if nodeps.IsAppleSilicon() {
-		t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
+	if nodeps.IsAppleSilicon() || dockerutil.IsColima() {
+		t.Skip("Skipping on Apple Silicon and Colima to ignore problems with 'connection reset by peer or connection refused'")
 	}
 
 	assert := asrt.New(t)

--- a/pkg/ddevapp/hooks_test.go
+++ b/pkg/ddevapp/hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
@@ -15,6 +16,9 @@ import (
 
 // TestProcessHooks tests execution of commands defined in config.yaml
 func TestProcessHooks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows, as it always hangs")
+	}
 	assert := asrt.New(t)
 
 	site := TestSites[0]


### PR DESCRIPTION


## The Issue

Colima is always difficult to get through a run. Lately we're seeing TestPHPOverrides fail a lot, and it seems no reason to work any harder on it.

## How This PR Solves The Issue

Don't test it on Colima.

HOWEVER: Run local tests with colima on TestPHPOverrides and see if it can be reproduced.

