### PR TITLE
docs: updating troubleshooting.md with instructions on how to solve ipv4 address pool issue

### DIFF
--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -246,6 +246,41 @@ docker rmi -f $(docker images -q)
 
 You should then be able to start your DDEV machine.
 
+## `ddev start` Fails with "could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network"
+
+This typically happens on a Linux installation like Ubuntu with many ddev projects where you have installed Docker manually rather than using
+something like Docker Desktop. Pruning the network generally solves this problem, but it does mean already existing non-running ddev projects
+will need a `ddev restart`. To prune the network run:
+```
+docker network prune
+```
+
+If you encounter this problem often you can add to your `/etc/docker/daemon.json`:
+
+```
+{
+  ...
+  "default-address-pools": [
+    {"base": "172.17.0.0/16", "size": 24}
+  ]
+  ...
+}
+```
+If the file does not exist, it can be created and set to:
+```
+{
+  "default-address-pools": [
+    {"base": "172.17.0.0/16", "size": 24}
+  ]
+}
+```
+To have the changes take effect you need to reload the configuration and restart docker (which will stop any running ddev projects). You can do this
+as follows:
+```
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+```
+
 ## `ddev --version` shows an old version
 
 If you have installed the latest version of DDEV, but when you check the actual version with `ddev --version`, it shows an older version, please refer to [Why do I have an old DDEV?](./faq.md#why-do-i-have-an-old-ddev)


### PR DESCRIPTION
## The Issue

At least for myself, I frequently hit this error, yet Troubleshooting section of docs does not cover it.

```
YYYY/MM/DD HH:II:SS Failed to ensure Docker network ddev-sitenamehere_default: API error (404): could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network
```
I decided to dig further to actually solve the error rather than just pruning the network. The error is now solved permanently for me and I would like to share the fix.

## How This PR Solves The Issue

This provides instructions as to how to solve it.

## Manual Testing Instructions

Attempt to add new `default-address-pools` to your `daemon.json` as per the instructions and see the
address pool size increase.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

Documentation only, no tests.

## Related Issue Link(s)

Could not find any related issues

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

Documentation only change