### PR TITLE
test: Run colima tests native instead of github, fixes #5598

### DIFF
--- a/.buildkite/macos-colima.yml
+++ b/.buildkite/macos-colima.yml
@@ -1,0 +1,17 @@
+  - command: ".buildkite/test.sh"
+    plugins:
+      - docker-login#v2.1.0:
+          password-env: DOCKERHUB_PULL_PASSWORD
+    agents:
+      - "os=macos"
+      - "colima=true"
+      - "architecture=arm64"
+    #branches: "master"
+    env:
+      BUILDKITE_CLEAN_CHECKOUT: true
+      BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds
+      BUILDKIT_PROGRESS: plain
+      DDEV_TEST_SHARE_CMD: "false"
+      DDEV_RUN_GET_TESTS: "false"
+      DOCKER_TYPE: "colima"
+    parallelism: 1

--- a/.buildkite/macos-colima.yml
+++ b/.buildkite/macos-colima.yml
@@ -1,6 +1,7 @@
   - command: ".buildkite/test.sh"
     plugins:
       - docker-login#v2.1.0:
+          username: druddockerpullaccount
           password-env: DOCKERHUB_PULL_PASSWORD
     agents:
       - "os=macos"

--- a/.buildkite/macos-colima.yml
+++ b/.buildkite/macos-colima.yml
@@ -1,3 +1,7 @@
+# Colima with qemu and sshfs
+# See https://buildkite.com/ddev/macos-colima/settings/repository
+# Runs on master and PRs, including forked PRs
+
   - command: ".buildkite/test.sh"
     plugins:
       - docker-login#v2.1.0:
@@ -7,7 +11,6 @@
       - "os=macos"
       - "colima=true"
       - "architecture=arm64"
-    #branches: "master"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/macos-colima_vz.yml
+++ b/.buildkite/macos-colima_vz.yml
@@ -1,3 +1,7 @@
+# Colima with VZ and virtiofs
+# See https://buildkite.com/ddev/macos-colima-vz/settings/repository
+# Runs on master and PRs, including forked PRs
+
   - command: ".buildkite/test.sh"
     plugins:
       - docker-login#v2.1.0:

--- a/.buildkite/macos-colima_vz.yml
+++ b/.buildkite/macos-colima_vz.yml
@@ -1,0 +1,19 @@
+  - command: ".buildkite/test.sh"
+    plugins:
+      - docker-login#v2.1.0:
+          username: druddockerpullaccount
+          password-env: DOCKERHUB_PULL_PASSWORD
+    agents:
+      - "os=macos"
+      - "colima=true"
+      - "colima_vz=true"
+      - "architecture=arm64"
+    #branches: "master"
+    env:
+      BUILDKITE_CLEAN_CHECKOUT: true
+      BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds
+      BUILDKIT_PROGRESS: plain
+      DDEV_TEST_SHARE_CMD: "false"
+      DDEV_RUN_GET_TESTS: "false"
+      DOCKER_TYPE: "colima_vz"
+    parallelism: 1

--- a/.buildkite/macos-docker-desktop-amd64.yml
+++ b/.buildkite/macos-docker-desktop-amd64.yml
@@ -1,3 +1,7 @@
+# Docker Desktop on macOS amd64
+# See https://buildkite.com/ddev/ddev-macos-amd64-mutagen/settings/repository
+# Runs on master only
+
   - command: ".buildkite/test.sh"
     plugins:
       - docker-login#v2.1.0:

--- a/.buildkite/macos-docker-desktop-arm64.yml
+++ b/.buildkite/macos-docker-desktop-arm64.yml
@@ -1,3 +1,7 @@
+# Docker Desktop on macOS arm64
+# See https://buildkite.com/ddev/ddev-macos-arm64-mutagen/settings/repository
+# Runs on master and PRs, including forked PRs
+
   - command: ".buildkite/test.sh"
     plugins:
       - docker-login#v2.1.0:

--- a/.buildkite/macos-lima.yml
+++ b/.buildkite/macos-lima.yml
@@ -1,0 +1,18 @@
+  - command: ".buildkite/test.sh"
+    plugins:
+      - docker-login#v2.1.0:
+          username: druddockerpullaccount
+          password-env: DOCKERHUB_PULL_PASSWORD
+    agents:
+      - "os=macos"
+      - "lima=true"
+      - "architecture=arm64"
+    #branches: "master"
+    env:
+      BUILDKITE_CLEAN_CHECKOUT: true
+      BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds
+      BUILDKIT_PROGRESS: plain
+      DDEV_TEST_SHARE_CMD: "false"
+      DDEV_RUN_GET_TESTS: "false"
+      DOCKER_TYPE: "lima"
+    parallelism: 1

--- a/.buildkite/macos-lima.yml
+++ b/.buildkite/macos-lima.yml
@@ -7,7 +7,7 @@
       - "os=macos"
       - "lima=true"
       - "architecture=arm64"
-    #branches: "master"
+    branches: "none"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/macos-lima.yml
+++ b/.buildkite/macos-lima.yml
@@ -1,3 +1,7 @@
+ # macOS Lima on arm64 with VZ/Virtiofs
+ # Experimental, not yet enabled
+ # See https://buildkite.com/ddev/macos-lima/settings/repository
+
   - command: ".buildkite/test.sh"
     plugins:
       - docker-login#v2.1.0:

--- a/.buildkite/macos-orbstack.yml
+++ b/.buildkite/macos-orbstack.yml
@@ -1,3 +1,7 @@
+# Orbstack on macOS arm64
+# See https://buildkite.com/ddev/macos-orbstack/settings/repository
+# Runs on master and PRs, including forked PRs
+
   - command: ".buildkite/test.sh"
     plugins:
       - docker-login#v2.1.0:

--- a/.buildkite/macos-orbstack.yml
+++ b/.buildkite/macos-orbstack.yml
@@ -7,7 +7,7 @@
       - "os=macos"
       - "orbstack=true"
       - "architecture=arm64"
-    #branches: "master"
+    branches: "master"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/macos-orbstack.yml
+++ b/.buildkite/macos-orbstack.yml
@@ -7,7 +7,7 @@
       - "os=macos"
       - "orbstack=true"
       - "architecture=arm64"
-    branches: "master"
+#    branches: "master"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/macos-rancher-desktop.yml
+++ b/.buildkite/macos-rancher-desktop.yml
@@ -1,3 +1,7 @@
+# Rancher Desktop on macOS arm64
+# See https://buildkite.com/ddev/macos-rancher-desktop/settings/repository
+# Runs on ddev/ddev only, not on PRs
+
   - command: ".buildkite/test.sh"
     plugins:
       - docker-login#v2.1.0:

--- a/.buildkite/nfstest.sh
+++ b/.buildkite/nfstest.sh
@@ -9,5 +9,6 @@ mkdir -p ${NFS_PROJECT_DIR} || true && cd ${NFS_PROJECT_DIR}
 
 ddev config --auto
 ddev debug nfsmount
+ddev delete -Oy
 
 echo "nfsd seems to be set up ok"

--- a/.buildkite/nfstest.sh
+++ b/.buildkite/nfstest.sh
@@ -4,22 +4,10 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-function cleanup {
-    docker volume rm nfstest >/dev/null || true
-}
-trap cleanup EXIT
+NFS_PROJECT_DIR=~/tmp/ddev-nfs-test
+mkdir -p ${NFS_PROJECT_DIR} || true && cd ${NFS_PROJECT_DIR}
 
-mkdir -p ~/.ddev
+ddev config --auto
+ddev debug nfsmount
 
-# Handle new macOS Catalina /System/Volumes/Data share path.
-share=${HOME}/.ddev
-if [ -d "/System/Volumes/Data${HOME}/.ddev" ] ; then
-    share="/System/Volumes/Data${HOME}/.ddev"
-fi
-
-# Find host.docker.internal name using host-docker-internal.sh script
-hostDockerInternal=$($(dirname $0)/../scripts/host-docker-internal.sh)
-
-docker volume create --driver local --opt type=nfs --opt o=addr=${hostDockerInternal},hard,nolock,rw --opt device=:${share} nfstest >/dev/null
-docker run -t --rm -v nfstest:/tmp/nfs busybox:stable ls //tmp/nfs >/dev/null
 echo "nfsd seems to be set up ok"

--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -51,8 +51,8 @@ if command -v ddev >/dev/null && version_gt ${MIN_DDEV_VERSION} ${CURRENT_DDEV_V
   exit 4
 fi
 
-# Skip nfs check on linux, as we won't run nfs there
-if [ ${OSTYPE%%-gnu} != "linux" ]; then
+# Skip nfs check on linux/lima, as we won't run nfs there
+if [ ${OSTYPE%%-gnu} != "linux" ] && [ ${DOCKER_TYPE:-nothing} != "lima" ]; then
   $(dirname $0)/nfstest.sh
 fi
 

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -20,6 +20,14 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
   echo "original docker context situation:"
   docker context ls
   case ${DOCKER_TYPE} in
+    "colima")
+      ~/.rd/bin/rdctl shutdown || true
+      orb stop &
+      killall com.docker.backend || true
+      colima start
+      docker context use colima
+      ;;
+
     "docker-desktop")
       orb stop &
       ~/.rd/bin/rdctl shutdown || true

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -44,11 +44,10 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
     "lima")
       ~/.rd/bin/rdctl shutdown || true
       colima stop || true
-      limactl stop lima-vz || true
+      colima stop vz || true
       orb stop &
       killall com.docker.backend || true
-      colima stop vz || true
-      lima start lima-vz
+      limactl start lima-vz
       docker context use lima-vz
       ;;
 

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -26,6 +26,7 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
       orb stop &
       killall com.docker.backend || true
       colima start
+      colima restart
       docker context use colima
       ;;
     "colima_vz")
@@ -34,7 +35,8 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
       orb stop &
       killall com.docker.backend || true
       colima start vz
-      docker context use colima
+      colima restart vz
+      docker context use colima-vz
       ;;
 
     "docker-desktop")

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -21,10 +21,19 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
   docker context ls
   case ${DOCKER_TYPE} in
     "colima")
+      colima stop vz || true
       ~/.rd/bin/rdctl shutdown || true
       orb stop &
       killall com.docker.backend || true
       colima start
+      docker context use colima
+      ;;
+    "colima_vz")
+      ~/.rd/bin/rdctl shutdown || true
+      colima stop || true
+      orb stop &
+      killall com.docker.backend || true
+      colima start vz
       docker context use colima
       ;;
 
@@ -32,12 +41,14 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
       orb stop &
       ~/.rd/bin/rdctl shutdown || true
       colima stop || true
+      colima stop vz || true
       open -a Docker &
       docker context use desktop-linux
       ;;
     "orbstack")
       ~/.rd/bin/rdctl shutdown || true
       colima stop || true
+      colima stop vz || true
       killall com.docker.backend || true
       orb start &
       docker context use orbstack
@@ -45,6 +56,7 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
     "rancher-desktop")
       killall com.docker.backend || true
       colima stop || true
+      colima stop vz || true
       orb stop &
       ~/.rd/bin/rdctl start
       for i in {1..120}; do

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -171,7 +171,7 @@ if command -v killall >/dev/null ; then
 fi
 
 echo "--- Running tests..."
-make test TESTARGS="-run TestExtraPortExpose -failfast"
+make test TESTARGS="-failfast"
 RV=$?
 echo "test.sh completed with status=$RV"
 ddev poweroff || true

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -169,7 +169,7 @@ if command -v killall >/dev/null ; then
 fi
 
 echo "--- Running tests..."
-make test TESTARGS="-failfast"
+make test TESTARGS="-run TestExtraPortExpose -failfast"
 RV=$?
 echo "test.sh completed with status=$RV"
 ddev poweroff || true

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -22,6 +22,7 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
   case ${DOCKER_TYPE} in
     "colima")
       colima stop vz || true
+      limactl stop lima-vz || true
       ~/.rd/bin/rdctl shutdown || true
       orb stop &
       killall com.docker.backend || true
@@ -32,6 +33,7 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
     "colima_vz")
       ~/.rd/bin/rdctl shutdown || true
       colima stop || true
+      limactl stop lima-vz || true
       orb stop &
       killall com.docker.backend || true
       colima start vz
@@ -39,10 +41,22 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
       docker context use colima-vz
       ;;
 
+    "lima")
+      ~/.rd/bin/rdctl shutdown || true
+      colima stop || true
+      limactl stop lima-vz || true
+      orb stop &
+      killall com.docker.backend || true
+      colima stop vz || true
+      lima start lima-vz
+      docker context use lima-vz
+      ;;
+
     "docker-desktop")
       orb stop &
       ~/.rd/bin/rdctl shutdown || true
       colima stop || true
+      limactl stop lima-vz || true
       colima stop vz || true
       open -a Docker &
       docker context use desktop-linux
@@ -51,6 +65,7 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
       ~/.rd/bin/rdctl shutdown || true
       colima stop || true
       colima stop vz || true
+      limactl stop lima-vz || true
       killall com.docker.backend || true
       orb start &
       docker context use orbstack
@@ -58,6 +73,7 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
     "rancher-desktop")
       killall com.docker.backend || true
       colima stop || true
+      limactl stop lima-vz || true
       colima stop vz || true
       orb stop &
       ~/.rd/bin/rdctl start

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -31,17 +31,20 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
     "docker-desktop")
       orb stop &
       ~/.rd/bin/rdctl shutdown || true
+      colima stop || true
       open -a Docker &
       docker context use desktop-linux
       ;;
     "orbstack")
       ~/.rd/bin/rdctl shutdown || true
+      colima stop || true
       killall com.docker.backend || true
       orb start &
       docker context use orbstack
       ;;
     "rancher-desktop")
       killall com.docker.backend || true
+      colima stop || true
       orb stop &
       ~/.rd/bin/rdctl start
       for i in {1..120}; do

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -48,7 +48,7 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
       orb stop &
       killall com.docker.backend || true
       limactl start lima-vz
-      docker context use lima-vz
+      docker context use lima-lima-vz
       ;;
 
     "docker-desktop")

--- a/.buildkite/windows10_container.yml
+++ b/.buildkite/windows10_container.yml
@@ -1,3 +1,5 @@
+# Not currently used. This would build and run containers on Windows.
+
   - command: ".buildkite/test_containers.cmd"
     plugins:
       - docker-login#v2.1.0:

--- a/.buildkite/windows10dockerforwindows.yml
+++ b/.buildkite/windows10dockerforwindows.yml
@@ -1,3 +1,7 @@
+# Windows native with Mutagen, used by ddev-windows-mutagen
+# See https://buildkite.com/ddev/ddev-windows-mutagen/settings/repository
+# Runs on master only
+
   - command: ".buildkite/test.cmd"
     plugins:
       - docker-login#v2.1.0:

--- a/.buildkite/wsl2-docker-desktop.yml
+++ b/.buildkite/wsl2-docker-desktop.yml
@@ -1,3 +1,8 @@
+# WSL2 using Docker Desktop
+# See https://buildkite.com/ddev/wsl2-docker-desktop/settings/repository
+# Runs on master only because DD is pretty flaky, so we can't keep up with
+# restarts on PRs
+
   - command: ".buildkite/test.sh"
     plugins:
       - docker-login#v2.1.0:

--- a/.buildkite/wsl2-docker-inside.yml
+++ b/.buildkite/wsl2-docker-inside.yml
@@ -1,3 +1,7 @@
+# WSL2 with docker-ce (docker native inside WSL2 == Docker inside)
+# See https://buildkite.com/ddev/wsl2-docker-inside/settings/repository
+# Runs on master and all PRs, including forked PRs
+
   - command: ".buildkite/test.sh"
     plugins:
       - docker-login#v2.1.0:

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -105,6 +105,7 @@ jobs:
           brew install colima
           colima version
           colima start --cpu 3 --memory 6 --disk 100 --vm-type=qemu --mount-type=sshfs --dns=1.1.1.1
+          colima restart
 
       - name: Build ddev
         run: | 

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -179,7 +179,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 1. `brew install colima`
 2. `colima start --cpu 4 --memory 6 --disk 100 --vm-type=qemu --mount-type=sshfs --dns=1.1.1.1`
 3. `colima stop`
-4. `colima start vz --cpu 4 --memory 6 --disk 100 --vm-type=vz --mount-type=virtiofs --dns=1.1.1.1`
+4. `colima start vz --cpu 4 --memory 6 --disk 60 --vm-type=vz --mount-type=virtiofs --dns=1.1.1.1`
 5. `colima stop vz`
 
 Then the Buildkite agent must be configured with tags `colima=true` and `colima_vz=true`.

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -183,3 +183,11 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 5. `colima stop vz`
 
 Then the Buildkite agent must be configured with tags `colima=true` and `colima_vz=true`.
+
+## Additional Lima macOS setup
+
+1. `limactl create --name=lima-vz --vm-type=vz --mount-type=virtiofs --mount="~/:rw" --memory=6 --cpus=4 --disk=100 template://docker`
+2. `limactl start lima-vz`
+3. `docker context use lima-lima-vz`
+
+Then the Buildkite agent must be configured with tags `lima=true`.

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -184,9 +184,9 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 
 Then the Buildkite agent must be configured with tags `colima=true` and `colima_vz=true`.
 
-## Additional Lima macOS setup
+## Additional Lima macOS setup (not yet working)
 
-1. `limactl create --name=lima-vz --vm-type=vz --mount-type=virtiofs --mount="~/:rw" --memory=6 --cpus=4 --disk=100 template://docker`
+1. `limactl create --name=lima-vz --vm-type=vz --mount-type=virtiofs --mount="~/:w" --memory=6 --cpus=4 --disk=100 template://docker`
 2. `limactl start lima-vz`
 3. `docker context use lima-lima-vz`
 

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -122,7 +122,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 6. Restart `sudo systemctl restart icinga2`
 7. Hope that it can all work sometime.
 
-## macOS Test Agent Setup (Intel and Apple Silicon)
+## macOS Docker Desktop Test Agent Setup (Intel and Apple Silicon)
 
 1. Create the user “testbot” on the machine. Use the password for `ddevtestbot@gmail.com`, available in 1Password.
 2. Change the name of the machine to something in keeping with current style, perhaps `testbot-macos-arm64-8`. This is done in **Settings** → **General** → **About** → **Name** and in **Sharing** → **Computer Name** and in **Sharing** → **Local Hostname**.
@@ -173,3 +173,13 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
     ```bash
     PATH=$PATH:/usr/local/bin:/opt/homebrew/bin
     ```
+
+## Additional Colima macOS setup
+
+1. `brew install colima`
+2. `colima start --cpu 4 --memory 6 --disk 100 --vm-type=qemu --mount-type=sshfs --dns=1.1.1.1`
+3. `colima stop`
+4. `colima start vz --cpu 4 --memory 6 --disk 100 --vm-type=vz --mount-type=virtiofs --dns=1.1.1.1`
+5. `colima stop vz`
+
+Then the Buildkite agent must be configured with tags `colima=true` and `colima_vz=true`.

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -63,7 +63,7 @@ func TestExtraPortExpose(t *testing.T) {
 	for i, p := range portsToTest {
 		url := fmt.Sprintf("%s:%s/testfile.html", app.GetPrimaryURL(), p)
 		out, resp, err := testcommon.GetLocalHTTPResponse(t, url)
-		assert.NoError(err, "failed to get hit url %s, out=%s, resp=%v err=%v", url, out, resp, err)
-		assert.Contains(out, fmt.Sprintf("this is test%d", i+1))
+		require.NoError(t, err, "failed to get hit url %s, out=%s, resp=%v err=%v", url, out, resp, err)
+		require.Contains(t, out, fmt.Sprintf("this is test%d", i+1))
 	}
 }


### PR DESCRIPTION
## The Issue

* #5598 

We have never been able to get predictable results from colima tests on Github Actions. Maybe the VMs are too small
Also, we were never able to do normal https tests, so there are a bunch of things that require http, we might be able to remove those.

## How This PR Solves The Issue

Run the builds on our larger buildkite test machines.

## Detail

Testing by running TestExtraPortExpose with:
`GOTEST_SHORT=true make testpkg TESTARGS="-run TestExtraPortExpose -count=1"`

It seems to work after a `colima start` and then a `colima restart`. And then it stays working. So weird.
