### PR TITLE
fix: ddev config should not change unspecified options, fixes #5882

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -424,7 +424,7 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	switch {
 	case app.Type != nodeps.AppTypeNone && projectTypeArg == "" && detectedApptype != app.Type: // apptype was not passed, but we found an app of a different type
 		util.Warning("A project of type '%s' was found in %s, but the project is configured with type '%s'", detectedApptype, fullPath, app.Type)
-		fallthrough
+		break
 	default:
 		if projectTypeArg == "" {
 			projectTypeArg = detectedApptype

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -1,25 +1,21 @@
 package cmd
 
 import (
-	"strconv"
-	"testing"
-
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/stretchr/testify/require"
-
+	"fmt"
 	"os"
 	"path/filepath"
-
+	"strconv"
 	"strings"
-
-	"fmt"
+	"testing"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
@@ -229,6 +225,11 @@ func TestConfigSetValues(t *testing.T) {
 
 	out, err := exec.RunHostCommand(DdevBin, args...)
 	assert.NoError(err, "error running ddev %v: %v, output=%s", args, err, out)
+
+	// The second run of the config should not change the unspecified options,
+	// using the auto option here should not change the config at all
+	out, err = exec.RunHostCommand(DdevBin, "config", "--auto")
+	assert.NoError(err, "error running ddev config --auto: %s", out)
 
 	configFile := filepath.Join(tmpDir, ".ddev", "config.yaml")
 	configContents, err := os.ReadFile(configFile)


### PR DESCRIPTION
## The Issue

- #5882

The bug introduced in

- #5631

The expected behavior for `ddev config` in the various situations:

* `config.yaml` specifies a set of configs but there's no code to match it (the bug here). (This can be more than just project type I think, docroot as well).

	Running `ddev config` on existing code should not change existing config options that are not specified.
For example, when you run `ddev config --web-environment-add FOO=bar` on a project with the latest config (updating the outdated configuration is mentioned later), it should only change the `web_environment` option, and nothing else. This is covered in this PR in `TestConfigSetValues` - this test checks a lot of configuration options, so I think we are safe here.

* `config.yaml` specifies a set of configs but the code found by DDEV discovers other things (configured for `drupal10`, finds `magento2`)

	If the auto-detected project type is different from the one specified by the user, an additional run of `ddev config` should just show a warning about it, and not add project-specific files of the auto-detected project type. The user's preference should be respected, and if they choose `drupal10`, the `drupal10` settings file (i.e. `settings.ddev.php`) should be added even if `magento2` is automatically detected. This is true until `disable_settings_management: true`, when all settings are ignored. The project type change is covered in this PR in `TestConfigSetValues` - if the type is auto changed, we will know about it immediately.

* Initial configuration autodetect, which is good, but of course doesn't work when there's no code.

	`ddev config --auto` should automatically detect the project type and set other options depending on the project type, but this only applies to the first project config run, all other `ddev config --auto` should respect the user's decision and only remove deprecated (i.e. outdated) or non-existent config options. This does not require testing, as `yaml.Marshal()` is used for `app.WriteConfig()` and all junk configs will always be removed. And auto-detection itself is covered by several tests with `Detection` in the name.

* `config.yaml` merges additional config.*.yaml, and you can override config instead of merging with `override_config: true`

	This is explained in the docs and covered with `TestConfigOverrideDetection`.

## How This PR Solves The Issue

Fixes an issue with overriding the project type when it should not have been changed.
Checks for this bug with a test.

## Manual Testing Instructions

1. `ddev config --auto && ddev config --project-type drupal10 && ddev config --auto`
2. check that project type is `drupal10`, not `php`.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

