### PR TITLE
feat: add cakephp project type, fixes #5713

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -9,6 +9,7 @@ amazee.io
 Autocompletion
 Available
 Bash
+CakePHP
 Callgraph
 CGroups
 CIFS

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -214,7 +214,7 @@ func TestCustomCommands(t *testing.T) {
 	app.Type = origAppType
 
 	// The various CMS commands should not be available here
-	for _, c := range []string{"artisan", "drush", "magento", "typo3", "typo3cms", "wp"} {
+	for _, c := range []string{"artisan", "cake", "drush", "magento", "typo3", "typo3cms", "wp"} {
 		_, err = exec.RunHostCommand(DdevBin, c, "-h")
 		assert.Error(err, "found command %s when it should not have been there (no error) app.Type=%s", c, app.Type)
 	}
@@ -272,6 +272,17 @@ func TestCustomCommands(t *testing.T) {
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
 	for _, c := range []string{"craft"} {
+		_, err = exec.RunHostCommand(DdevBin, "help", c)
+		assert.NoError(err)
+	}
+
+	// CakePHP commands should only be available for type cakephp
+	app.Type = nodeps.AppTypeCakePHP
+	_ = app.WriteConfig()
+	_, _ = exec.RunHostCommand(DdevBin)
+	err = app.MutagenSyncFlush()
+	assert.NoError(err)
+	for _, c := range []string{"cake"} {
 		_, err = exec.RunHostCommand(DdevBin, "help", c)
 		assert.NoError(err)
 	}

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -47,6 +47,35 @@ To get started with [Backdrop](https://backdropcms.org), clone the project repos
     ddev launch
     ```
 
+## CakePHP
+
+Use a new or existing Composer project, or clone a Git repository.
+
+The CakePHP project type can be used with any CakePHP project >= 3.x, but it has been fully tested with CakePHP 5.x. DDEV automatically creates the `.env` file with the database information, email transport configuration and a random salt. If `.env` file already exists, `.env.ddev` will be created so you can take any variable and put into your `.env` file.
+
+=== "Composer"
+
+    ```bash
+    mkdir my-cakephp-app
+    cd my-cakephp-app
+    ddev config --project-type=cakephp --docroot=webroot
+    ddev composer create --prefer-dist cakephp/app:~5.0
+    ddev cake
+    ddev launch
+    ```
+
+=== "Git Clone"
+
+    ```bash
+    git clone <your-cakephp-repo>
+    cd <your-cakephp-project>
+    ddev config --project-type=cakephp --docroot=webroot
+    ddev start
+    ddev composer install
+    ddev cake
+    ddev launch
+    ```
+
 ## Craft CMS
 
 Start a new [Craft CMS](https://craftcms.com) project or retrofit an existing one.

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -112,7 +112,7 @@ There’s only one global `.ddev` directory, which lives in your home directory:
 : This is where DDEV stores private executable binaries it needs, like `mutagen` and `docker-compose`.
 
 `commands` directory
-: Directory for storing DDEV commands that should be available in containers, like `npm`, `artisan`, and `drush` for example. These are organized in subdirectories named for where they’ll be used: `db`, `host`, and `web`. You can add your own [custom commands](../extend/custom-commands.md) here.
+: Directory for storing DDEV commands that should be available in containers, like `npm`, `artisan`, `cake` and `drush` for example. These are organized in subdirectories named for where they’ll be used: `db`, `host`, and `web`. You can add your own [custom commands](../extend/custom-commands.md) here.
 
 `homeadditions` directory
 : Like the per-project `homeadditions` directory, files you add here will automatically be copied into the web container’s home directory. Files from the _global_ homeadditions directory will be copied into **every** web container’s home directory.

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -30,6 +30,7 @@ Type `ddev` or `ddev -h` in a terminal window to see the available DDEV [command
 * `ddev magento` (Magento2 only) gives access to the `magento` CLI.
 * [`ddev craft`](../usage/commands.md#craft) (Craft CMS only) gives access to the `craft` CLI.
 * [`ddev yarn`](../usage/commands.md#yarn) and [`ddev npm`](../usage/commands.md#npm) give direct access to the `yarn` and `npm` CLIs.
+* `ddev cake` (CakePHP only) gives direct access to the CakePHP `cake` CLI.
 
 ## Node.js, npm, nvm, and Yarn
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -109,6 +109,15 @@ ddev blackfire off
     * `on`: `start`, `enable`, `true`
     * `off`: `stop`, `disable`, `false`
 
+## `cake`
+
+Run the `cake` command; available only in projects of type `cakephp`, and only available if `cake.php` is in bin folder.
+
+```shell
+# Show all cake subcommands
+ddev cake
+```
+
 ## `clean`
 
 Removes items DDEV has created. (See [Uninstalling DDEV](../usage/uninstall.md).)

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -90,6 +90,12 @@ func init() {
 			composerCreateAllowedPaths: getBackdropComposerCreateAllowedPaths,
 		},
 
+		nodeps.AppTypeCakePHP: {
+			appTypeDetect:        isCakephpApp,
+			configOverrideAction: cakephpConfigOverrideAction,
+			postStartAction:      cakephpPostStartAction,
+		},
+
 		nodeps.AppTypeCraftCms: {
 			importFilesAction:    craftCmsImportFilesAction,
 			appTypeDetect:        isCraftCmsApp,

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -61,6 +61,7 @@ func TestPostConfigAction(t *testing.T) {
 
 	appTypes := map[string]string{
 		nodeps.AppTypeBackdrop:     nodeps.PHPDefault,
+		nodeps.AppTypeCakePHP:      nodeps.PHP83,
 		nodeps.AppTypeCraftCms:     nodeps.PHP81,
 		nodeps.AppTypeDrupal6:      nodeps.PHP56,
 		nodeps.AppTypeDrupal7:      nodeps.PHPDefault,

--- a/pkg/ddevapp/cakephp.go
+++ b/pkg/ddevapp/cakephp.go
@@ -1,0 +1,94 @@
+package ddevapp
+
+import (
+	"fmt"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/util"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// isCakephpApp returns true if the app is of type cakephp
+func isCakephpApp(app *DdevApp) bool {
+	return fileutil.FileExists(filepath.Join(app.AppRoot, "bin/cake.php"))
+}
+
+func cakephpPostStartAction(app *DdevApp) error {
+	// We won't touch env if disable_settings_management: true
+	if app.DisableSettingsManagement {
+		return nil
+	}
+	envFileName := "config/.env"
+	envFilePath := filepath.Join(app.AppRoot, envFileName)
+	_, _, err := ReadProjectEnvFile(envFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("unable to read .env file in config folder: %v", err)
+	}
+	if err == nil {
+		envFileName = "config/.env.ddev"
+		envFilePath = filepath.Join(app.AppRoot, envFileName)
+		_, _, err = ReadProjectEnvFile(envFilePath)
+		if err == nil {
+			util.Warning("CakePHP: .env.ddev file exists already. Replacing it. You can rename it or copy settings to your .env file.")
+		} else {
+			util.Warning("CakePHP: .env file exists already. Creating .env.ddev. You can rename it or copy settings to your .env file.")
+		}
+	} else {
+		util.Success("CakePHP: Creating .env file to store your config settings.")
+	}
+	err = fileutil.CopyFile(filepath.Join(app.AppRoot, "config/.env.example"), envFilePath)
+	if err != nil {
+		util.Debug("CakePHP: .env.example does not exist yet in config folder, not trying to process it")
+		return nil
+	}
+	_, envText, err := ReadProjectEnvFile(envFilePath)
+	if err != nil {
+		return err
+	}
+	port := "3306"
+	dbConnection := "mysql"
+	if app.Database.Type == nodeps.Postgres {
+		dbConnection = "pgsql"
+		port = "5432"
+	}
+	envMap := map[string]string{
+		"export APP_NAME":                    app.GetName(),
+		"export DEBUG":                       "true",
+		"export APP_ENCODING":                "UTF-8",
+		"export APP_DEFAULT_LOCALE":          "en_US",
+		"export DATABASE_URL":                dbConnection + "://db:db@db:" + port + "/db",
+		"export EMAIL_TRANSPORT_DEFAULT_URL": "smtp://localhost:1025",
+		"export SECURITY_SALT":               util.HashSalt(app.GetName()),
+		"export DEBUGKIT_SAFE_TLD":           "site",
+	}
+	err = WriteProjectEnvFile(envFilePath, envMap, envText)
+	if err != nil {
+		return err
+	}
+	err = enableDotEnvLoading(app)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// cakephpConfigOverrideAction overrides php_version for CakePHP, requires PHP8.1
+func cakephpConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP83
+	app.DisableUploadDirsWarning = true
+	return nil
+}
+
+func enableDotEnvLoading(app *DdevApp) error {
+	bootstrapFileName := "config/bootstrap.php"
+	bootstrapFilePath := filepath.Join(app.AppRoot, bootstrapFileName)
+	envFunction := "// if (!env('APP_NAME') && file_exists(CONFIG . '.env')) {\n//     $dotenv = new \\josegonzalez\\Dotenv\\Loader([CONFIG . '.env']);\n//     $dotenv->parse()\n//         ->putenv()\n//         ->toEnv()\n//         ->toServer();\n// }\n"
+	err := fileutil.ReplaceStringInFile(envFunction, strings.ReplaceAll(envFunction, "// ", ""), bootstrapFilePath, bootstrapFilePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -334,6 +334,22 @@ var (
 			Type:                          nodeps.AppTypeSilverstripe,
 			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "<meta name=\"generator\" content=\"Silverstripe CMS 5.0\">"},
 		},
+		// 18: CakePHP
+		{
+			Name:                          "TestPkgCakePHP",
+			SourceURL:                     "https://github.com/ddev/test-cakephp/archive/refs/tags/5.0.1.1.tar.gz",
+			ArchiveInternalExtractionPath: "test-cakephp-5.0.1.1/",
+			FilesTarballURL:               "",
+			FilesZipballURL:               "",
+			DBTarURL:                      "https://github.com/ddev/test-cakephp/releases/download/5.0.1.1/db.sql.tar.gz",
+			DBZipURL:                      "",
+			FullSiteTarballURL:            "",
+			Type:                          nodeps.AppTypeCakePHP,
+			Docroot:                       "webroot",
+			Safe200URIWithExpectation:     testcommon.URIWithExpect{URI: "/static/page.html", Expect: "This is a static page"},
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "CakePHP is able to connect to the database"},
+			FilesImageURI:                 "/img/cake.logo.svg",
+		},
 	}
 
 	FullTestSites = TestSites

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/cake
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/cake
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#ddev-generated
+## Description: Run cake CLI inside the web container
+## Usage: cake [subcommand] [flags] [args]
+## Example: "ddev cake bake" or "ddev cake cache clear_all"
+## ProjectTypes: cakephp
+## ExecRaw: true
+
+php ./bin/cake.php "$@"
+

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -83,6 +83,7 @@ var ValidWebserverTypes = map[string]bool{
 const (
 	AppTypeNone         = ""
 	AppTypeBackdrop     = "backdrop"
+	AppTypeCakePHP      = "cakephp"
 	AppTypeCraftCms     = "craftcms"
 	AppTypeDjango4      = "django4"
 	AppTypeDrupal6      = "drupal6"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

CakePHP projects must use  generic `php` type which does not allow automatic configuration of settings, access to cake shell through command, etc

## How This PR Solves The Issue

This PR adds cakephp project type to DDEV

## Manual Testing Instructions

```bash
    mkdir my-cakephp-app
    cd my-cakephp-app
    ddev config --project-type=cakephp --docroot=webroot --create-docroot --php-version=8.3
    ddev composer create--prefer-dist cakephp/app:~5.0
    ddev composer install
    ddev cake
    ddev launch
```

## Automated Testing Overview

* Added `cakephp` app type to `pkg/ddevapp/ddevapp_test.go`
* Added `cake` command to `cmd/ddev/cmd/commands_test.go`

## Related Issue Link(s)

#5713 

## Release/Deployment Notes

* CakePHP test app: https://github.com/ddev/test-cakephp

