### PR TITLE
fix: add debug logs to the compose render process

### DIFF
--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -36,6 +36,7 @@ func (app *DdevApp) WriteDockerComposeYAML() error {
 		return err
 	}
 	util.Debug("yaml-corruption: %s sha1: %s", app.DockerComposeYAMLPath(), hex.EncodeToString(dockerComposeBaseHash.Sum(nil)))
+	util.Debug("%s", rendered)
 
 	_, err = f.WriteString(rendered)
 	if err != nil {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1033,6 +1033,9 @@ RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -
 		return "", err
 	}
 
+	util.Debug("yaml-corruption: All .docker-compose-base.yaml template variables:")
+	util.Debug("%+v", templateVars)
+
 	err = t.Execute(&doc, templateVars)
 	return doc.String(), err
 }

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -684,7 +684,9 @@ func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
 	go func() {
 		for inOut.Scan() {
 			t := inOut.Bytes()
-			chanOut <- t
+			duplicate := make([]byte, len(t))
+			copy(duplicate, t)
+			chanOut <- duplicate
 		}
 		close(stopOut)
 	}()

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -683,7 +683,8 @@ func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
 
 	go func() {
 		for inOut.Scan() {
-			chanOut <- inOut.Bytes()
+			t := inOut.Bytes()
+			chanOut <- t
 		}
 		close(stopOut)
 	}()


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

The PR follows up from https://github.com/orgs/ddev/discussions/5470. I don't expect this to be merged, but the PR will at least create builds for all the environments that can be easily accessed.

## How This PR Solves The Issue

Users experiencing the above can pull a ddev build from the PR, and run their commands with `DDEV_DEBUG=true` to hopefully trace down where the corruption is happening.

All messages are prepended with `yaml-corruption:` to make it easier to find in logs.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

