### PR TITLE
feat: Add native lima Docker provider support

### DIFF
--- a/.buildkite/macos-lima.yml
+++ b/.buildkite/macos-lima.yml
@@ -11,7 +11,7 @@
       - "os=macos"
       - "lima=true"
       - "architecture=arm64"
-    branches: "none"
+#    branches: "none"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -149,7 +149,7 @@ export DDEV_NONINTERACTIVE=true
 export DDEV_DEBUG=true
 
 # We can skip builds with commit message of [skip buildkite]
-if [[ $BUILDKITE_MESSAGE == *"[skip buildkite]"* ]] || [[ $BUILDKITE_MESSAGE == *"[skip ci]"* ]]; then
+if [[ ${BUILDKITE_MESSAGE:-} == *"[skip buildkite]"* ]] || [[ ${BUILDKITE_MESSAGE:-} == *"[skip ci]"* ]]; then
   echo "Skipping build because message has '[skip buildkite]' or '[skip ci]'"
   exit 0
 fi

--- a/cmd/ddev/cmd/autocompletion_test.go
+++ b/cmd/ddev/cmd/autocompletion_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -288,6 +289,9 @@ func TestAutocompletionForCustomCmds(t *testing.T) {
 
 // TestAutocompleteTermsForCustomCmds tests the AutocompleteTerms annotation for custom host and container commands
 func TestAutocompleteTermsForCustomCmds(t *testing.T) {
+	if dockerutil.IsColima() || dockerutil.IsLima() {
+		t.Skip("Skipping on Colima/Lima")
+	}
 	assert := asrt.New(t)
 
 	origDir, _ := os.Getwd()

--- a/cmd/ddev/cmd/debug-nfsmount_test.go
+++ b/cmd/ddev/cmd/debug-nfsmount_test.go
@@ -16,8 +16,8 @@ import (
 // TestDebugNFSMount tries out the `ddev debug nfsmount` command.
 // It requires nfsd running of course.
 func TestDebugNFSMount(t *testing.T) {
-	if nodeps.IsWSL2() || dockerutil.IsColima() {
-		t.Skip("Skipping on WSL2/Colima since NFS is not used there")
+	if nodeps.IsWSL2() || dockerutil.IsColima() || dockerutil.IsLima() {
+		t.Skip("Skipping on WSL2/Lima/Colima since NFS is not used there")
 	}
 	assert := asrt.New(t)
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -10,6 +10,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     * [OrbStack](#orbstack)
     * [Colima](#colima)
+    * [Lima](#lima)
     * [Docker Desktop](#docker-desktop-for-mac)
     * [Rancher Desktop](#rancher-desktop)
 
@@ -35,8 +36,6 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     After the initial run above, you can use `colima start` or use `colima start -e` to edit the configuration file. Run `colima status` at any time to check Colima’s status.
 
-    When your computer restarts, you’ll need to `colima start` again. If you prefer to start Colima automatically on reboot, use `brew services start colima` in Colima version 0.6+ to configure auto-start.
-
     !!!tip "Colima disk allocation"
         In Colima versions starting with 0.5.4 you can increase—but not decrease—the disk allocation by editing `~/.colima/default/colima.yaml` to change the `disk` setting to a higher value. For example, `disk: 200` will increase allocation to 200 gigabytes. Then `colima restart` will result in the new disk allocation.
 
@@ -46,6 +45,27 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     !!!warning "Colima can only work in your home directory unless you do further configuration"
         By default, Colima only mounts your home directory, so it’s easiest to use it in a subdirectory there. See the `~/.colima/default/colima.yaml` for more information, or notes in [colima.yaml](https://github.com/abiosoft/colima/blob/fc948f8f055600986f87e29e3e632daf56ac8774/embedded/defaults/colima.yaml#L130-L143).
 
+    ### Lima
+
+    [Lima](https://github.com/lima-vm/lima) is a free and open-source project supported by the [Cloud Native Computing Foundation](https://cncf.io/).
+
+    1. Install Lima with `brew install lima`.
+    2. Install the `docker` client if you don't already have it with `brew install docker`.
+    3. Create a default Lima setup with 4 CPUs, 6GB memory, 100GB storage, and Cloudflare DNS, adjusting as needed:
+    ```
+    limactl create --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
+    docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock"
+    docker context use lima-default
+    ```
+    After the initial run above, you can use `limactl start`.  Run `limactl list` to see configured setup.
+
+    When your computer restarts, you’ll need to `limactl start` again.
+
+    !!!warning "Docker contexts let the Docker client point at the right Docker server"
+        The Docker provider you're using is selected with `docker context`. You can see the available contexts with `docker context ls` and the currently selected one with `docker context show`. With the setup above you'll want `docker context use lima-default`.
+
+    !!!warning "Lima only mounts filesystems in your home directory unless you do further configuration"
+        The default configuration shown here can mount only subdirectories of your home directory. If your project is not in your home directory, you must add additional mounts, as described in [mounts example](https://github.com/lima-vm/lima/blob/a98743ee8d47b935cc94bf30f073d22bc0d97b5a/examples/docker.yaml#L25-L28).
 
     ### Docker Desktop for Mac
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -51,7 +51,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     1. Install Lima with `brew install lima`.
     2. Install the `docker` client if you don't already have it with `brew install docker`.
-    3. Create a default Lima setup with 4 CPUs, 6GB memory, 100GB storage, and Cloudflare DNS, adjusting as needed:
+    3. Create a 100GB VM in Lima with 4 CPUs, 6GB memory, and Cloudflare DNS. Adjust to your own needs:
     ```
     limactl create --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
     docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock"

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -6,13 +6,13 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     ## macOS
 
-    Install one of the supported Docker providers. OrbStack is the easiest to set up.
+    Install one of the supported Docker providers:
 
-    * [OrbStack](#orbstack)
-    * [Colima](#colima)
-    * [Lima](#lima)
-    * [Docker Desktop](#docker-desktop-for-mac)
-    * [Rancher Desktop](#rancher-desktop)
+    * [OrbStack](#orbstack): Recommended, easiest to install, most performant, commercial, not open-source.
+    * [Colima](#colima): Free, open-source, can be unstable.
+    * [Lima](#lima): Free, open-source.
+    * [Docker Desktop](#docker-desktop-for-mac): Familiar, popular, not open-source, may require license, may be unstable.
+    * [Rancher Desktop](#rancher-desktop): Free, open-source, simple installation, slower startup.
 
     ### OrbStack
 
@@ -24,10 +24,10 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     ### Colima
 
-    [Colima](https://github.com/abiosoft/colima) is a free and open-source project that bundles a container management tool called [Lima](https://github.com/lima-vm/lima) with a Docker (Linux) backend.
+    [Colima](https://github.com/abiosoft/colima) is a free and open-source project which bundles Lima.
 
-    1. Run `docker help` to make sure you’ve got the Docker client installed. If you get an error, install it with [Homebrew](https://brew.sh) by running `brew install docker`.
-    2. Install Colima with `brew install colima`.
+    1. Install Colima with `brew install colima`.
+    2. If you don't have the `docker` client (if `docker help` fails) then install it with `brew install docker`.
     3. Start Colima with 4 CPUs, 6GB memory, 100GB storage, and Cloudflare DNS, adjusting as needed:
     ```
     colima start --cpu 4 --memory 6 --disk 100 --vm-type=qemu --mount-type=sshfs --dns=1.1.1.1
@@ -50,7 +50,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     [Lima](https://github.com/lima-vm/lima) is a free and open-source project supported by the [Cloud Native Computing Foundation](https://cncf.io/).
 
     1. Install Lima with `brew install lima`.
-    2. Install the `docker` client if you don't already have it with `brew install docker`.
+    2. If you don't have the `docker` client (if `docker help` fails) then install it with `brew install docker`.
     3. Create a 100GB VM in Lima with 4 CPUs, 6GB memory, and Cloudflare DNS. Adjust to your own needs:
     ```
     limactl create --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
@@ -65,18 +65,18 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
         The Docker provider you're using is selected with `docker context`. You can see the available contexts with `docker context ls` and the currently selected one with `docker context show`. With the setup above you'll want `docker context use lima-default`.
 
     !!!warning "Lima only mounts filesystems in your home directory unless you do further configuration"
-        The default configuration shown here can mount only subdirectories of your home directory. If your project is not in your home directory, you must add additional mounts, as described in [mounts example](https://github.com/lima-vm/lima/blob/a98743ee8d47b935cc94bf30f073d22bc0d97b5a/examples/docker.yaml#L25-L28).
+        The default configuration shown here can mount only subdirectories of your home directory. If your project is not in your home directory, you must add additional mounts, as described in [mounts example](https://github.com/lima-vm/lima/blob/e9423da6b7c60083aaa455a0c6ecb5c729edfe1f/examples/docker.yaml#L25-L28).
 
     ### Docker Desktop for Mac
 
-    Docker Desktop for Mac can be installed via Homebrew (`brew install --cask docker`) or can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has long been supported by DDEV and has extensive automated testing.
+    Docker Desktop for Mac can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has long been supported by DDEV and has extensive automated testing. It is not open-source, may require a license for many users, and sometimes has stability problems.
 
     !!!warning "Ports unavailable?"
-        If you get messages like `Ports are not available... exposing port failed... is vmnetd running?` it means you need to check the "Allow privileged port mapping (requires password)" checkbox in the "Advanced" section of the Docker Desktop configuration. You may have to stop and restart Docker Desktop.
+        If you get messages like `Ports are not available... exposing port failed... is vmnetd running?` it means you need to check the "Allow privileged port mapping (requires password)" checkbox in the "Advanced" section of the Docker Desktop configuration. You may have to stop and restart Docker Desktop. (More extensive problem resolution is in [Docker Desktop issue](https://github.com/docker/for-mac/issues/6677).)
 
     ### Rancher Desktop
 
-    Rancher Desktop is another free and open-source Docker provider. Install from [Rancher Desktop.io](https://rancherdesktop.io/). It has automated testing with DDEV. When installing, choose only the Docker option and turn off Kubernetes.
+    Rancher Desktop is an easy-to-install free and open-source Docker provider. Install from [Rancher Desktop.io](https://rancherdesktop.io/). It has automated testing with DDEV. When installing, choose only the Docker option and turn off Kubernetes.
 
     #### Migrating Projects Between Docker Providers
 

--- a/pkg/config/remoteconfig/messages.go
+++ b/pkg/config/remoteconfig/messages.go
@@ -33,6 +33,7 @@ var conditionDefinitions = map[string]conditionDefinition{}
 func init() {
 	AddCondition("Disabled", "Permanently disables the message", func() bool { return false })
 	AddCondition("Colima", "Running on Colima", dockerutil.IsColima)
+	AddCondition("Lima", "Running on Lima", dockerutil.IsLima)
 	AddCondition("DockerDesktop", "Running on Docker Desktop", dockerutil.IsDockerDesktop)
 	AddCondition("WSL2", "Running on WSL2", nodeps.IsWSL2)
 }

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -25,7 +25,8 @@ services:
       {{ if .NoBindMounts }}
       - ddev-config:/mnt/ddev_config
       - snapshots:/mnt/snapshots
-      {{ else }} {{/* if .NoBindMounts */}}
+      {{ else }} {{/* if (not) .NoBindMounts */}}
+      # On db container ddev_config is mounted rw so we can create snapshots
       - .:/mnt/ddev_config
       - ./db_snapshots:/mnt/snapshots
       {{ end }} {{/* end if .NoBindMounts */}}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -460,8 +460,8 @@ func TestReadConfigCRLF(t *testing.T) {
 
 // TestConfigValidate tests validation of configuration values.
 func TestConfigValidate(t *testing.T) {
-	if nodeps.IsAppleSilicon() || dockerutil.IsColima() {
-		t.Skip("Skipping on Mac M1 and Colima, lots of network connections failed")
+	if nodeps.IsAppleSilicon() || dockerutil.IsColima() || dockerutil.IsLima() {
+		t.Skip("Skipping on Apple Silicon/Lima/Colima, lots of network connections failed")
 	}
 
 	assert := asrt.New(t)
@@ -753,8 +753,8 @@ func TestConfigOverrideDetection(t *testing.T) {
 
 // TestPHPOverrides tests to make sure that PHP overrides work in all webservers.
 func TestPHPOverrides(t *testing.T) {
-	if nodeps.IsAppleSilicon() || dockerutil.IsColima() {
-		t.Skip("Skipping on Apple Silicon and Colima to ignore problems with 'connection reset by peer or connection refused'")
+	if nodeps.IsAppleSilicon() || dockerutil.IsColima() || dockerutil.IsLima() {
+		t.Skip("Skipping on Apple Silicon/Lima/Colima to ignore problems with 'connection reset by peer or connection refused'")
 	}
 
 	assert := asrt.New(t)
@@ -1088,8 +1088,8 @@ func TestTimezoneConfig(t *testing.T) {
 
 // TestComposerVersionConfig tests to make sure setting Composer version takes effect in the container.
 func TestComposerVersionConfig(t *testing.T) {
-	if nodeps.IsAppleSilicon() || dockerutil.IsColima() {
-		t.Skip("Skipping on Mac M1 and Colima, lots of network connections failed")
+	if nodeps.IsAppleSilicon() || dockerutil.IsColima() || dockerutil.IsLima() {
+		t.Skip("Skipping on Apple Silicon/Lima/Colima, lots of network connections failed")
 	}
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1424,7 +1424,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		Cmd: `ls -l /mnt/ddev_config/nginx_full/nginx-site.conf >/dev/null`,
 	})
 	if err != nil {
-		util.Warning("Something is wrong with Docker or Colima and /mnt/ddev_config is not mounted from the project .ddev folder. This can cause all kinds of problems.")
+		util.Warning("Something is wrong with your Docker provider and /mnt/ddev_config is not mounted from the project .ddev folder. Your project cannot normally function successfully with this situation. Is your project in your home directory?")
 	}
 
 	if !IsRouterDisabled(app) {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1617,6 +1617,9 @@ func checkImportDbImports(t *testing.T, app *ddevapp.DdevApp) {
 
 // TestDdevAllDatabases tests db import/export/snapshot/restore/start with supported database versions
 func TestDdevAllDatabases(t *testing.T) {
+	if dockerutil.IsColima() || dockerutil.IsLima() {
+		t.Skip("Skipping on Lima/Colima")
+	}
 	assert := asrt.New(t)
 
 	dbVersions := nodeps.GetValidDatabaseVersions()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3054,7 +3054,7 @@ func TestRouterPortsCheck(t *testing.T) {
 		},
 	}
 
-	containerID, out, err := dockerutil.RunSimpleContainer(ddevImages.GetWebImage(), t.Name()+"occupyport", nil, []string{}, []string{}, []string{"testnfsmount" + ":/nfsmount"}, "", false, true, map[string]string{"ddevtestcontainer": t.Name()}, portBinding)
+	containerID, out, err := dockerutil.RunSimpleContainer(ddevImages.GetWebImage(), t.Name()+"occupyport", nil, []string{}, []string{}, nil, "", false, true, map[string]string{"ddevtestcontainer": t.Name()}, portBinding)
 
 	if err != nil {
 		t.Fatalf("Failed to run Docker command to occupy port 80/443, err=%v output=%v", err, out)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1768,8 +1768,10 @@ func TestDdevAllDatabases(t *testing.T) {
 		snapshotName := dbType + "_" + dbVersion + "_" + fileutil.RandomFilenameBase()
 		fullSnapshotName, err := app.Snapshot(snapshotName)
 		if err != nil {
-			assert.NoError(err, "could not create snapshot %s for %s: %v output=%v", snapshotName, dbTypeVersion, err, fullSnapshotName)
-			continue
+			dumpDir := fmt.Sprintf("~/%s-broken-%s", t.Name(), util.RandString(5))
+			_, _ = exec.RunHostCommand(`bash`, `-c`, fmt.Sprintf("cp -r %s %s", app.AppRoot, dumpDir))
+			t.Logf("project was in %s, copying to %s", app.AppRoot, dumpDir)
+			t.Fatalf("could not create snapshot %s for %s: %v output=%v, saved approot=%s", snapshotName, dbTypeVersion, err, fullSnapshotName, dumpDir)
 		}
 
 		snapshotPath, err := ddevapp.GetSnapshotFileFromName(fullSnapshotName, app)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1624,7 +1624,7 @@ func TestDdevAllDatabases(t *testing.T) {
 	dbVersions = nodeps.RemoveItemFromSlice(dbVersions, "postgres:9")
 	//Use a smaller list if GOTEST_SHORT
 	if os.Getenv("GOTEST_SHORT") != "" {
-		dbVersions = []string{"postgres:14", "mariadb:10.4", "mariadb:10.11", "mysql:8.0", "mysql:5.7"}
+		dbVersions = []string{"postgres:14", "mariadb:10.11", "mariadb:10.6", "mariadb:10.4", "mysql:8.0", "mysql:5.7"}
 		t.Logf("Using limited set of database servers because GOTEST_SHORT is set (%v)", dbVersions)
 	}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3674,7 +3674,7 @@ func TestCaptureLogs(t *testing.T) {
 // This requires that the test machine must have NFS shares working
 // Tests using both app-specific performance_mode: nfs and etc
 func TestNFSMount(t *testing.T) {
-	if nodeps.IsWSL2() || dockerutil.IsColima() {
+	if nodeps.IsWSL2() || dockerutil.IsColima() || dockerutil.IsLima() {
 		t.Skip("Skipping on WSL2/Colima")
 	}
 	if nodeps.PerformanceModeDefault == types.PerformanceModeMutagen || nodeps.NoBindMountsDefault {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -873,8 +873,8 @@ func TestDdevNoProjectMount(t *testing.T) {
 
 // TestDdevXdebugEnabled tests running with xdebug_enabled = true, etc.
 func TestDdevXdebugEnabled(t *testing.T) {
-	if dockerutil.IsColima() && os.Getenv("DDEV_TEST_COLIMA_ANYWAY") != "true" {
-		t.Skip("Skipping on Colima because this test doesn't work although manual testing works")
+	if (dockerutil.IsColima() || dockerutil.IsLima()) && os.Getenv("DDEV_TEST_COLIMA_ANYWAY") != "true" {
+		t.Skip("Skipping on Lima/Colima because this test doesn't work although manual testing works")
 	}
 	if nodeps.IsWSL2() && dockerutil.IsDockerDesktop() {
 		t.Skip("Skipping on WSL2/Docker Desktop because this test doesn't work although manual testing works")
@@ -2057,8 +2057,8 @@ func readLastLine(fileName string) (string, error) {
 // TestDdevFullSiteSetup tests a full import-db and import-files and then looks to see if
 // we have a spot-test success hit on a URL
 func TestDdevFullSiteSetup(t *testing.T) {
-	if runtime.GOOS == "windows" || dockerutil.IsColima() {
-		t.Skip("Skipping on Windows and Colima as this is tested adequately elsewhere")
+	if runtime.GOOS == "windows" || dockerutil.IsColima() || dockerutil.IsLima() {
+		t.Skip("Skipping on Windows/Lima/Colima as this is tested adequately elsewhere")
 	}
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
@@ -3544,8 +3544,8 @@ func TestPHPWebserverType(t *testing.T) {
 // TestInternalAndExternalAccessToURL checks we can access content
 // from host and from inside container by URL (with port)
 func TestInternalAndExternalAccessToURL(t *testing.T) {
-	if nodeps.IsAppleSilicon() || dockerutil.IsColima() {
-		t.Skip("Skipping on mac M1/Colima to ignore problems with 'connection reset by peer'")
+	if nodeps.IsAppleSilicon() || dockerutil.IsColima() || dockerutil.IsLima() {
+		t.Skip("Skipping on mac Apple Silicon/Lima/Colima to ignore problems with 'connection reset by peer'")
 	}
 
 	assert := asrt.New(t)
@@ -3677,7 +3677,7 @@ func TestCaptureLogs(t *testing.T) {
 // Tests using both app-specific performance_mode: nfs and etc
 func TestNFSMount(t *testing.T) {
 	if nodeps.IsWSL2() || dockerutil.IsColima() || dockerutil.IsLima() {
-		t.Skip("Skipping on WSL2/Colima")
+		t.Skip("Skipping on WSL2/Lima/Colima")
 	}
 	if nodeps.PerformanceModeDefault == types.PerformanceModeMutagen || nodeps.NoBindMountsDefault {
 		t.Skip("Skipping because mutagen/nobindmounts enabled")
@@ -3818,8 +3818,8 @@ func verifyNFSMount(t *testing.T, app *ddevapp.DdevApp) {
 
 // TestHostDBPort tests to make sure that the host_db_port specification has the intended effect
 func TestHostDBPort(t *testing.T) {
-	if dockerutil.IsColima() {
-		t.Skip("Skipping test on Colima because of constant port problems")
+	if dockerutil.IsColima() || dockerutil.IsLima() {
+		t.Skip("Skipping test on Lima/Colima because of constant port problems")
 	}
 	assert := asrt.New(t)
 	defer util.TimeTrackC(t.Name())()

--- a/pkg/ddevapp/mailpit_test.go
+++ b/pkg/ddevapp/mailpit_test.go
@@ -76,7 +76,7 @@ func TestMailpit(t *testing.T) {
 	resp, err := testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
 	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
 	// Colima tests on github don't respect https
-	if !dockerutil.IsColima() {
+	if !dockerutil.IsColima() && !dockerutil.IsLima() {
 		resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_https_url"].(string)+"/api/v1/messages", expectation)
 		require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
 	}
@@ -118,7 +118,7 @@ func TestMailpit(t *testing.T) {
 	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
 	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
 	// Colima tests on GitHub don't respect https
-	if !dockerutil.IsColima() {
+	if !dockerutil.IsColima() && !dockerutil.IsLima() {
 		resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_https_url"].(string)+"/api/v1/messages", expectation)
 		require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
 	}
@@ -156,7 +156,7 @@ func TestMailpit(t *testing.T) {
 	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
 	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
 	// Colima tests on github don't respect https
-	if !dockerutil.IsColima() {
+	if !dockerutil.IsColima() && !dockerutil.IsLima() {
 		resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_https_url"].(string)+"/api/v1/messages", expectation)
 		require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
 	}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1601,6 +1601,20 @@ func IsColima() bool {
 	return false
 }
 
+// IsLima detects if running on lima
+func IsLima() bool {
+	ctx, client := GetDockerClient()
+	info, err := client.Info(ctx)
+	if err != nil {
+		util.Warning("IsLima(): Unable to get Docker info, err=%v", err)
+		return false
+	}
+	if strings.HasPrefix(info.Name, "lima") {
+		return true
+	}
+	return false
+}
+
 // CopyIntoContainer copies a path (file or directory) into a specified container and location
 func CopyIntoContainer(srcPath string, containerName string, dstPath string, exclusion string) error {
 	startTime := time.Now()

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -107,8 +107,8 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on Windows as it always seems to fail starting 2023-04")
 	}
-	if dockerutil.IsColima() {
-		t.Skip("Skipping on Colima")
+	if dockerutil.IsColima() || dockerutil.IsLima() {
+		t.Skip("Skipping on Lima/Colima")
 	}
 	// We have to get globalconfig read so CA is known and installed.
 	err := globalconfig.ReadGlobalConfig()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -69,6 +69,8 @@ func GetDockerPlatform() (string, error) {
 		platform = "docker-desktop"
 	case strings.HasPrefix(info.Name, "colima"):
 		platform = "colima"
+	case strings.HasPrefix(info.Name, "lima"):
+		platform = "lima"
 	case platform == "OrbStack":
 		platform = "orbstack"
 	case strings.HasPrefix(platform, "Rancher Desktop") || strings.Contains(info.Name, "rancher-desktop"):


### PR DESCRIPTION
## The Issue

Colima has gotten quite unstable for lots of people, but it's just a wrapper on Lima, and so we should be able to use Lima directly as another open-source alternative.

## How This PR Solves The Issue

It's worth considering whether we should do this at all, as adding more options doesn't necessarily help people or our support environment.

## TODO

- [x] Docs
- [x] Turn on tests (preferably without putting red marks on other PRs)
- [ ] Make it pass tests

## Manual Testing Instructions

Use the docs to start a lima instance, then do a simple quickstart test.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

