### PR TITLE
feat: add ddev ssh --cwd option, fixes #5839

### DIFF
--- a/cmd/ddev/cmd/ssh_test.go
+++ b/cmd/ddev/cmd/ssh_test.go
@@ -67,4 +67,10 @@ func TestCmdSSH(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal("/var/www/html\n", out)
 
+	err = os.Mkdir("docroot", 0750)
+	err = os.Mkdir("docroot/subdir", 0750)
+	err = os.Chdir("docroot/subdir")
+	out, err = exec.RunHostCommand(b, "-c", fmt.Sprintf("echo pwd | %s ssh --cwd", DdevBin))
+	assert.NoError(err)
+	assert.Equal("/var/www/html/docroot/subdir\n", out)
 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
* https://github.com/ddev/ddev/issues/5839

## How This PR Solves The Issue
Implements a `--cwd` option into `ddev ssh` so that you are logged into the equivalent directory _inside_ the guest.

## Manual Testing Instructions
1. Go to a `ddev` project
2. Browse into children directory under the `docroot`
3. `ddev ssh --cwd`
4. You should now be in the equivalent directory _inside_ the guest

## Automated Testing Overview

A _minimal_ test was hastily included. But I only tested against `GOTEST_SHORT=11`

## Release/Deployment Notes
* `ddev ssh` is now able to log you into the `web` container's equivalent directory to the host's current working directory. For example, if on the host your current working directory is `your-app/your-docroot/themes/custom/your-theme` and you call `ddev ssh --cwd` you will be logged into the guest under `/var/www/html/docroot/themes/custom/your-theme`. This option only works for `web` containers and is mutually exclusive with `--dir`.