### PR TITLE
docs: point to HEAD version of TestSites array

### DIFF
--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -272,7 +272,7 @@ Normal test invocation is `make test`. Run a single test with an invocation like
 
 To see which DDEV commands the tests are executing, set the environment variable `DDEV_DEBUG=true`.
 
-Use `GOTEST_SHORT=true` to run one CMS in each test, or `GOTEST_SHORT=<integer>` to run exactly one project type from the list of project types in the [TestSites array](https://github.com/ddev/ddev/blob/a4ab2827d8b6e706b2420700045d889a3a69f3f2/pkg/ddevapp/ddevapp_test.go#L43). For example, `GOTEST_SHORT=5 make test TESTARGS="-run TestDdevFullSiteSetup"` will run only `TestDdevFullSiteSetup` against TYPO3.
+Use `GOTEST_SHORT=true` to run one CMS in each test, or `GOTEST_SHORT=<integer>` to run exactly one project type from the list of project types in the [TestSites array](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/ddevapp_test.go#L43). For example, `GOTEST_SHORT=5 make test TESTARGS="-run TestDdevFullSiteSetup"` will run only `TestDdevFullSiteSetup` against TYPO3.
 
 To run a test (in the `cmd` package) against a individually-compiled DDEV binary, set the `DDEV_BINARY_FULLPATH` environment variable, for example `DDEV_BINARY_FULLPATH=$PWD/.gotmp/bin/linux_amd64/ddev make testcmd`.
 


### PR DESCRIPTION
## The Issue
NA

## How This PR Solves The Issue
* Point to latest version of file, not a specific commit (which is already outdated)

## Manual Testing Instructions
Go to equivalent https://ddev.readthedocs.io/en/stable/developers/building-contributing/#testing and examine the `TestSites array` link

## Automated Testing Overview
NA

## Related Issue Link(s)
NA

## Release/Deployment Notes
NA
