### PR TITLE
fix: set permissions on /run/php so php-fpm can run

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -936,6 +936,11 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN n install %s && ln -sf /usr/local/bin/node /usr/local/bin/nodejs", app.NodeJSVersion)
 	}
 
+	// Some installed packages can change the permissions of /run/php
+	// First seen in Debian 12 Bookworm
+	// See https://github.com/ddev/ddev/issues/5898
+	extraWebContent = extraWebContent + "\nRUN chmod 777 /run/php"
+
 	// Add supervisord config for WebExtraDaemons
 	var supervisorGroup []string
 	for _, appStart := range app.WebExtraDaemons {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -984,7 +984,9 @@ func TestExtraPackages(t *testing.T) {
 	require.NoError(t, err)
 
 	addedDBPackage := "sudo"
-	addedWebPackage := "tmux"
+	// php-gmp is flaky on Debian 12 Bookworm,
+	// we can test it https://github.com/ddev/ddev/issues/5898
+	addedWebPackage := "php" + app.PHPVersion + "-" + "gmp"
 
 	// Test db container to make sure no sudo in there at beginning
 	_, _, err = app.Exec(&ddevapp.ExecOpts{


### PR DESCRIPTION
## The Issue

- #5898

## How This PR Solves The Issue

Although this seems to be a problem with php packaging, we can solve it on our side to prevent this in the future with `chmod 777 /run/php`.

## Manual Testing Instructions

```
mkdir php-gmp && cd php-gmp
ddev config --auto --php-version 8.2 --webimage-extra-packages php8.2-gmp --omit-containers db
ddev start
```

The project should be started normally.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

