### PR TITLE
fix: supervisord should not bring down the whole web container when non-essential service fails, fixes #5358

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/kill_supervisor.py
@@ -2,27 +2,74 @@
 import sys
 import os
 import signal
+import subprocess
+
 
 # From https://blog.zhaw.ch/icclab/process-management-in-docker-containers/
+# http://supervisord.org/events.html#example-event-listener-implementation
 
 def write_stdout(s):
-   sys.stdout.write(s)
-   sys.stdout.flush()
+    sys.stdout.write(s)
+    sys.stdout.flush()
 def write_stderr(s):
-   sys.stderr.write(s)
-   sys.stderr.flush()
+    sys.stderr.write(s)
+    sys.stderr.flush()
+# Function to check if a process is running using ps, grep, and awk
+def is_process_running(process_identifier):
+    try:
+        # Use ps and grep to search for the process, excluding the grep command itself
+        output = subprocess.check_output(
+            f"ps aux | grep '[{process_identifier[0]}]{process_identifier[1:]}' | grep -v grep", shell=True)
+        # If the output is not empty, then the process is considered running
+        return bool(output.decode('utf-8').strip())
+    except subprocess.CalledProcessError:
+        # If the grep command does not find anything, it will raise a CalledProcessError
+        return False
+# Function to parse the config.yaml file for the webserver_type
+def read_webserver_type_from_yaml(file_path):
+    webserver_type = None
+    try:
+        with open(file_path, 'r') as file:
+            for line in file:
+                if line.strip().startswith('webserver_type:'):
+                    webserver_type = line.split(':', 1)[1].strip()
+                    break
+    except Exception as e:
+        write_stderr(f"Error reading webserver_type from YAML: {str(e)}\n")
+    return webserver_type
 def main():
-   while 1:
-       write_stdout('READY\n')
-       line = sys.stdin.readline()
-       write_stdout('This line kills supervisor: ' + line)
-       try:
-               pidfile = open('/var/run/supervisord.pid','r')
-               pid = int(pidfile.readline())
-               os.kill(pid, signal.SIGQUIT)
-       except Exception as e:
-               write_stdout('Could not kill supervisor: ' + e.strerror + '\n')
-       write_stdout('RESULT 2\nOK')
+    # Read the webserver_type from the config.yaml
+    webserver_type = read_webserver_type_from_yaml('/var/www/html/.ddev/config.yaml')
+    critical_processes = {
+        'nginx-fpm': ['nginx: ', 'php-fpm: '],
+        'apache-fpm': ['apache2 ', 'php-fpm: '],
+        'nginx-gunicorn': ['nginx: ', 'start-gunicorn.py'],
+    }.get(webserver_type, [])
+
+    while 1:
+        write_stdout('READY\n')
+        line = sys.stdin.readline()
+        try:
+            # Check if any critical process is not running
+            process_failure = False
+            for process in critical_processes:
+                if not is_process_running(process):
+                    process_failure = True
+                    write_stderr(f'Critical process {process} for {webserver_type} is not running. Action required.\n')
+                    break
+
+            if process_failure:
+                # Proceed with original behavior if a critical process is not running
+                write_stdout('This line kills supervisor: ' + line)
+                pidfile = open('/var/run/supervisord.pid', 'r')
+                pid = int(pidfile.readline())
+                os.kill(pid, signal.SIGQUIT)
+                write_stderr('Supervisor killed because a critical process is not running.\n')
+
+        except Exception as e:
+            write_stdout('Could not kill supervisor: ' + e.strerror + '\n')
+
+        write_stdout('RESULT 2\nOK')
 if __name__ == '__main__':
-   main()
-   import sys
+    main()
+    import sys

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240213_php_8.2_default" // Note that this can be overridden by make
+var WebTag = "20240228_tjarrett_fixes_kill_supervisor" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

If a user loads an extra daemon (in my case a laravel worker queue) into supervisor and that worker dies for whatever reason (in my case, because it's PHP, I don't want it too live too long... also I'm developing so I want it to reload the code base often) it takes the whole container with it.

Also Mailpit failing will bring down the whole server.

I'd like to be able to restart Laravel queue workers while developing without needing to restart the whole container.

## How This PR Solves The Issue

This adjusts the the kill_supervisor.py (aka child_exit_monitor supervisor event listener) so that it does not bring down the container unless one of the core services is down (nginx, apache2, php-fpm, gunicorn). It knows which ones to check for by peaking inside of the config.yaml for the project.

## Manual Testing Instructions

This needs to go into the container as I understand it (I am new to DDEV). However you can test with the default DDEV project by:

First, put the file from this pull request at `.dev/web-build/kill_supervisor.py`.

Then add these lines to `.ddev/web-build/Dockerfile`:
```
ADD kill_supervisor.py /usr/local/bin/kill_supervisor.py
RUN chmod 777 /usr/local/bin/kill_supervisor.py
```

Do a `ddev restart`.

Then do a `ddev ssh` and try something like:
```
killall mailpit
```

Note that the container does not come down (and mailpit restarts).

Then try something like:
```
killall php-fpm
```

Note that the container does indeed come down.

You can change the `webserver_type` in `.ddev/config.yaml` to any of the allowed options and repeat the tests with the essential services.

## Automated Testing Overview

I was unsure how to do an automated test for this.

## Related Issue Link(s)

#5358

Also previous pull request that was closed at #5423 

## Release/Deployment Notes

I do not think so. I don't think we really want the container coming down if a queue worker fails. But we do want it to come down if nginx fails. This accomplishes that.

