### PR TITLE
feat: disable password policies for TYPO3 12

### DIFF
--- a/pkg/ddevapp/typo3/AdditionalConfiguration.php
+++ b/pkg/ddevapp/typo3/AdditionalConfiguration.php
@@ -10,6 +10,9 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
     $GLOBALS['TYPO3_CONF_VARS'] = array_replace_recursive(
         $GLOBALS['TYPO3_CONF_VARS'],
         [
+            'BE' => [
+                'passwordPolicy' => '',
+            ],
             'DB' => [
                 'Connections' => [
                     'Default' => [
@@ -21,6 +24,9 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
                         'user' => 'db',
                     ],
                 ],
+            ],
+            'FE' => [
+                'passwordPolicy' => '',
             ],
             // This GFX configuration allows processing by installed ImageMagick 6
             'GFX' => [


### PR DESCRIPTION
Since TYPO3 12 there's a new feature to help hardening the passwords of TYPO3 backend and frontend users. This makes it unnecessarily complicated to developers to log into TYPO3.

## The Issue

TYPO3 12 forces users to follow a certain password policy. That's slowing developers down when working on their local machine.

## How This PR Solves The Issue

The autogenerated config for TYPO3 now makes sure that this feature is disabled, see https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/PasswordPolicies/Index.html#disable-password-policies-globally