### PR TITLE
docs: Add Pimcore quickstart, fixes #5843

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -109,6 +109,7 @@ PHIVE
 PHP
 PHPUnit
 PID
+Pimcore
 PWD
 PartOf
 PathMaps

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -428,7 +428,7 @@ ddev config --docroot=public
 ddev start
 ddev composer create pimcore/skeleton
 ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin --no-interaction
-ddev launch
+ddev launch /admin
 ```
 
 ## Python/Flask (Experimental)

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -418,6 +418,19 @@ Visit the [Moodle Admin Quick Guide](https://docs.moodle.org/400/en/Admin_quick_
 !!!tip
     Moodle relies on a periodic cron job—don’t forget to set that up! See [ddev/ddev-cron](https://github.com/ddev/ddev-cron).
 
+## Pimcore
+
+Using the [Pimcore skeleton](https://github.com/pimcore/skeleton) repository:
+
+``` bash
+mkdir my-pimcore && cd my-pimcore
+ddev config --docroot=public
+ddev start
+ddev composer create pimcore/skeleton
+ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin --no-interaction
+ddev launch
+```
+
 ## Python/Flask (Experimental)
 
 ```bash

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -425,9 +425,17 @@ Using the [Pimcore skeleton](https://github.com/pimcore/skeleton) repository:
 ``` bash
 mkdir my-pimcore && cd my-pimcore
 ddev config --docroot=public
+
+
 ddev start
 ddev composer create pimcore/skeleton
 ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin --no-interaction
+echo "web_extra_daemons:
+  - name: consumer
+    command: 'while true; do /var/www/html/bin/console messenger:consume pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update --memory-limit=250M --time-limit=3600; done'
+    directory: /var/www/html" >.ddev/config.pimcore.yaml
+
+ddev start
 ddev launch /admin
 ```
 


### PR DESCRIPTION
## The Issue

* #5843 requests Pimcore support

We'll want more input from the Pimcore community, but this adds a basic quickstart.

Docs example at https://ddev--5909.org.readthedocs.build/en/5909/users/quickstart/#pimcore
