### PR TITLE
fix: magento2 requires mariadb 10.6, for #5919

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -363,7 +363,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
 
     ```bash
     mkdir ddev-magento2 && cd ddev-magento2
-    ddev config --project-type=magento2 --php-version=8.1 --docroot=pub --disable-settings-management
+    ddev config --project-type=magento2 --php-version=8.1 --database=mariadb:10.6 --docroot=pub --disable-settings-management
     ddev get ddev/ddev-elasticsearch
     ddev start
     ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition -y

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -165,8 +165,10 @@ func magentoConfigOverrideAction(app *DdevApp) error {
 	return nil
 }
 
-// Latest magento2 requires php8.1
+// Magento2 2.4.6 requires php8.1/2 and MariaDB 10.6
+// https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/system-requirements.html
 func magento2ConfigOverrideAction(app *DdevApp) error {
 	app.PHPVersion = nodeps.PHP81
+	app.Database = DatabaseDesc{Type: nodeps.MariaDB, Version: nodeps.MariaDB106}
 	return nil
 }


### PR DESCRIPTION

## The Issue

* #5919

@stasadev discovered that Magento2 refuses to run with updated MariaDB 10.11 (now default).

## How This PR Solves The Issue

Use config override action to use MariaDB 10.6 per https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/system-requirements.html

## Manual Testing Instructions

Run through the quickstart using this version.

It should not even require the use of `--database=mariadb:10.6` - that should happen by default, but it's reasonable to make it explicit in the quickstart.

## Automated Testing Overview

Nothing new.

