### PR TITLE
fix: don't call app.WriteConfig twice

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -171,6 +171,10 @@ func handleConfigRun(cmd *cobra.Command, args []string) {
 		if err != nil {
 			util.Failed("There was a problem configuring your project: %v", err)
 		}
+		err = app.WriteConfig()
+		if err != nil {
+			util.Failed("Failed to write config: %v", err)
+		}
 	} else {
 		err = handleMainConfigArgs(cmd, args, app)
 		if err != nil {
@@ -182,11 +186,6 @@ func handleConfigRun(cmd *cobra.Command, args []string) {
 				util.Failed("failed to handle per-provider extra flags: %v", err)
 			}
 		}
-	}
-
-	err = app.WriteConfig()
-	if err != nil {
-		util.Failed("Failed to write config: %v", err)
 	}
 
 	_, err = app.CreateSettingsFile()


### PR DESCRIPTION

## The Issue

@ajibarra points out in 
* https://github.com/ddev/ddev/pull/5888#issuecomment-1972943332 

that the PostConfigAction is being called twice. It's being called twice because when `ddev config` is called with args, the WriteConfig() happens both inside handleMainConfigArgs() and also in the parent handleConfigRun. It should only be called once. 

## How This PR Solves The Issue

* When `ddev config` is called without args, we do the WriteConfig() in its context
* When called *with* args, let handleMainConfigArgs() do the write

## Manual Testing Instructions

I think it requires debugger or adding a print statement, but just add a print statement to a PostConfigAction or to WriteConfig.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

