### PR TITLE
docs: update faq with new questions, fix menus

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -59,6 +59,7 @@ Flags
 Flatpak
 FQDNs
 Fritzbox
+GitLab
 GUI
 GUIs
 Get

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ mkdocs:
 # see https://www.mkdocs.org/user-guide/installation/
 # But it will also work using docker.
 mkdocs-serve:
-	$(shell if command -v mkdocsx >/dev/null ; then \
+	$(shell if command -v mkdocs >/dev/null ; then \
 			mkdocs serve; \
 		else \
 			TAG=1.5.2; \

--- a/Makefile
+++ b/Makefile
@@ -164,16 +164,11 @@ mkdocs:
 # see https://www.mkdocs.org/user-guide/installation/
 # But it will also work using docker.
 mkdocs-serve:
-	$(shell if command -v mkdocs >/dev/null ; then \
-			mkdocs serve; \
-		else \
-			TAG=1.5.2; \
-			set -x; \
-			if [ $(BUILD_ARCH) = 'arm64' ]; then TAG="arm64v8-$${TAG}"; fi; \
-			docker run -it --rm -v "${PWD}:/docs" -p 8000:8000 -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs:$${TAG}; \
-			set +x; \
-		fi \
-	)
+	if command -v mkdocs >/dev/null ; then \
+  		mkdocs serve; \
+	else \
+		docker run -it --rm -p 8000:8000 -v "${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs:1.2.3; \
+	fi
 
 # Install markdown-link-check locally with "npm install -g markdown-link-check"
 markdown-link-check:

--- a/Makefile
+++ b/Makefile
@@ -164,11 +164,16 @@ mkdocs:
 # see https://www.mkdocs.org/user-guide/installation/
 # But it will also work using docker.
 mkdocs-serve:
-	if command -v mkdocs >/dev/null ; then \
-  		mkdocs serve; \
-	else \
-		docker run -it --rm --name=mkdocs -p 8000:8000 -v "${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs:1.2.3; \
-	fi
+	$(shell if command -v mkdocsx >/dev/null ; then \
+			mkdocs serve; \
+		else \
+			TAG=1.5.2; \
+			set -x; \
+			if [ $(BUILD_ARCH) = 'arm64' ]; then TAG="arm64v8-$${TAG}"; fi; \
+			docker run -it --rm -v "${PWD}:/docs" -p 8000:8000 -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs:$${TAG}; \
+			set +x; \
+		fi \
+	)
 
 # Install markdown-link-check locally with "npm install -g markdown-link-check"
 markdown-link-check:

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ mkdocs-serve:
 	if command -v mkdocs >/dev/null ; then \
   		mkdocs serve; \
 	else \
-		docker run -it -p 8000:8000 -v "${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs:1.2.3; \
+		docker run -it --rm --name=mkdocs -p 8000:8000 -v "${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs:1.2.3; \
 	fi
 
 # Install markdown-link-check locally with "npm install -g markdown-link-check"

--- a/docs/content/users/providers/index.md
+++ b/docs/content/users/providers/index.md
@@ -2,6 +2,8 @@
 
 DDEV offers hosting provider integration and sample integrations for [Pantheon](https://pantheon.io), [Platform.sh](https://platform.sh) and [Acquia](https://www.acquia.com) hosting, along with other examples.
 
+Hosting provider integration (`ddev pull <provider>` and `ddev push <provider>`) does *not* deploy or pull your code. Your code should be under git control, and you pull and push it using your team's strategy. `ddev pull` pulls the **database** and the **user-generated files** from an upstream provider.
+
 DDEV provides ready-to-go integrations for Platform.sh, Acquia, and Lagoon in every project, see the .ddev/providers directory. These can be used as is, or they can be modified as you see fit (but remove the `#ddev-generated` line so DDEV doesn't replace them with the defaults).
 
 In addition, each project includes [example recipes](https://github.com/ddev/ddev/tree/master/pkg/ddevapp/dotddev_assets/providers) for Pantheon, Git, local files, and `rsync` in its `.ddev/providers` directory, which you can use and adapt however you’d like.

--- a/docs/content/users/providers/index.md
+++ b/docs/content/users/providers/index.md
@@ -2,7 +2,7 @@
 
 DDEV offers hosting provider integration and sample integrations for [Pantheon](https://pantheon.io), [Platform.sh](https://platform.sh) and [Acquia](https://www.acquia.com) hosting, along with other examples.
 
-Hosting provider integration allows connecting with your upstream hosting. `ddev pull <provider>` downloads and `ddev push <provider>` uploads the **database** and the **user-generated files** to an upstream provider. It does *not* push (deploy) or pull your code. Your code should be under version control in for example Git. 
+Hosting provider integration allows connecting with your upstream hosting. `ddev pull <provider>` downloads and `ddev push <provider>` uploads the **database** and the **user-generated files** to an upstream provider. It does *not* push (deploy) or pull your code. Your code should be under version control in for example Git.
 
 DDEV provides ready-to-go integrations for Platform.sh, Acquia, and Lagoon in every project, see the .ddev/providers directory. These can be used as is, or they can be modified as you see fit (but remove the `#ddev-generated` line so DDEV doesn't replace them with the defaults).
 

--- a/docs/content/users/providers/index.md
+++ b/docs/content/users/providers/index.md
@@ -2,7 +2,7 @@
 
 DDEV offers hosting provider integration and sample integrations for [Pantheon](https://pantheon.io), [Platform.sh](https://platform.sh) and [Acquia](https://www.acquia.com) hosting, along with other examples.
 
-Hosting provider integration (`ddev pull <provider>` and `ddev push <provider>`) does *not* deploy or pull your code. Your code should be under git control, and you pull and push it using your team's strategy. `ddev pull` pulls the **database** and the **user-generated files** from an upstream provider.
+Hosting provider integration (`ddev pull <provider>` and `ddev push <provider>`) allows connecting with upstream hosting to get database and user-generated (volatile) files. It does *not* deploy or pull your code. Your code should be under git control, and you pull and push it using your team's strategy. `ddev pull` pulls the **database** and the **user-generated files** from an upstream provider.
 
 DDEV provides ready-to-go integrations for Platform.sh, Acquia, and Lagoon in every project, see the .ddev/providers directory. These can be used as is, or they can be modified as you see fit (but remove the `#ddev-generated` line so DDEV doesn't replace them with the defaults).
 

--- a/docs/content/users/providers/index.md
+++ b/docs/content/users/providers/index.md
@@ -2,7 +2,7 @@
 
 DDEV offers hosting provider integration and sample integrations for [Pantheon](https://pantheon.io), [Platform.sh](https://platform.sh) and [Acquia](https://www.acquia.com) hosting, along with other examples.
 
-Hosting provider integration (`ddev pull <provider>` and `ddev push <provider>`) allows connecting with upstream hosting to get database and user-generated (volatile) files. It does *not* deploy or pull your code. Your code should be under git control, and you pull and push it using your team's strategy. `ddev pull` pulls the **database** and the **user-generated files** from an upstream provider.
+Hosting provider integration allows connecting with your upstream hosting. `ddev pull <provider>` downloads and `ddev push <provider>` uploads the **database** and the **user-generated files** to an upstream provider. It does *not* push (deploy) or pull your code. Your code should be under version control in for example Git. 
 
 DDEV provides ready-to-go integrations for Platform.sh, Acquia, and Lagoon in every project, see the .ddev/providers directory. These can be used as is, or they can be modified as you see fit (but remove the `#ddev-generated` line so DDEV doesn't replace them with the defaults).
 

--- a/docs/content/users/topics/index.md
+++ b/docs/content/users/topics/index.md
@@ -1,6 +1,6 @@
 # Hosting, Deployment, and Sharing
 
-DDEV does not provide capabilities for deploying your code, as it's focused on being a **local development** solution. Teams almost universally use Git to manage their code and some Git provider like GitHub or GitLab to store it. They use many different types of deployment tools to actually get the code to their upstream servers or integration environments. But for local development, DDEV provides capabilities to pull upstream databases and user-generated files (and to push them in some circumstances).
+DDEV does not provide capabilities for deploying your code, as it's focused on being a **local development** solution. Teams almost universally use Git to manage their code and some Git provider like GitHub or GitLab to store it. They use many different types of deployment tools to actually get the code to their upstream servers or integration environments. For local development, DDEV provides capabilities to pull upstream databases and user-generated files as well as push those in some circumstances.
 
 * [Sharing your project](sharing.md)
 * [Casual hosting with DDEV](hosting.md)

--- a/docs/content/users/topics/index.md
+++ b/docs/content/users/topics/index.md
@@ -1,0 +1,8 @@
+# Hosting, Deployment, and Sharing
+
+DDEV does not provide capabilities for deploying your code, as it's focused on being a **local development** solution. Teams almost universally use Git to manage their code and some Git provider like GitHub or GitLab to store it. They use many different types of deployment tools to actually get the code to their upstream servers or integration environments. But for local development, DDEV provides capabilities to pull upstream databases and user-generated files (and to push them in some circumstances).
+
+* [Sharing your project](sharing.md)
+* [Casual hosting with DDEV](hosting.md)
+* [Remote Docker environments](remote-docker.md)
+* [Hosting integrations](../providers/index.md) including Acquia, Lagoon, Pantheon, Platform.sh, Upsun, rsync-based solutions, Git-based solutions, local files (like Dropbox), etc.

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -13,7 +13,7 @@ Frequently-asked questions organized into high-level functionality, investigatin
 
 DDEV works nearly anywhere Docker will run, including macOS, WSL2, Windows 10/11 Pro/Enterprise and Home, and every Linux variant we’ve ever tried. It also runs in many Linux-like environments, like ChromeOS (in Linux machine). DDEV works the same on each of these platforms since the important work is done inside identical Docker containers. This means that a team using diverse environments can share everything just fine.
 
-### Does DDEV change my code?
+### Does DDEV change or deploy my code?
 
 You are responsible for your code and its deployment. DDEV does not alter it (or fix any bugs in it). DDEV *does* add DDEV-specific settings for some CMSes if [settings management](cms-settings.md) is enabled. These items are excluded by `.gitignore` so they won't affect a deployed project, but in most cases they would do no harm if deployed, because they check to see if they're running in DDEV context.
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -1,7 +1,8 @@
 ---
 search:
-boost: 1.0
+  boost: 2
 ---
+
 # FAQ
 
 Frequently-asked questions organized into high-level functionality, investigating issues, daily usage, and connecting with our community.
@@ -54,7 +55,7 @@ Check out [this Stack Overflow answer](https://stackoverflow.com/a/69964995/8972
 
 ### Do I need to install PHP, Composer, nginx, or Node.js/npm on my workstation?
 
-No. These tools live inside DDEV’s Docker containers, so you only need to [install Docker](../install/docker-installation.md) and [install DDEV](../install/ddev-installation.md). This is especially handy for Windows users where there’s more friction getting these things installed.
+No. Tools like PHP, Composer, nginx, and Node.js/npm live inside DDEV’s Docker containers, so you only need to [install Docker](../install/docker-installation.md) and [install DDEV](../install/ddev-installation.md).
 
 For most users we recommend that you do *not* install PHP or composer on your workstation, so you get in the habit of using `ddev composer`, which will use the configured composer and PHP versions for your project, which can be different for each project. See [DDEV and Composer](developer-tools.md#ddev-and-composer).
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -15,7 +15,7 @@ DDEV works nearly anywhere Docker will run, including macOS, WSL2, Windows 10/11
 
 ### Does DDEV change my code?
 
-You are responsible for your code and its deployment. DDEV does not alter it (or fix any bugs in it). DDEV *does* add DDEV-specific settings for some CMSs if [settings management](cms-settings.md) is enabled. These items are excluded by `.gitignore` so they won't affect a deployed project, but in most cases they would do no harm if deployed, because they check to see if they're running in DDEV context.
+You are responsible for your code and its deployment. DDEV does not alter it (or fix any bugs in it). DDEV *does* add DDEV-specific settings for some CMSes if [settings management](cms-settings.md) is enabled. These items are excluded by `.gitignore` so they won't affect a deployed project, but in most cases they would do no harm if deployed, because they check to see if they're running in DDEV context.
 
 ### Where is my database stored in my DDEV project?
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -15,11 +15,11 @@ DDEV works nearly anywhere Docker will run, including macOS, WSL2, Windows 10/11
 
 ### Does DDEV change or deploy my code?
 
-You are responsible for your code and its deployment. DDEV does not alter it (or fix any bugs in it). DDEV *does* add DDEV-specific settings for some CMSes if [settings management](cms-settings.md) is enabled. These items are excluded by `.gitignore` so they won't affect a deployed project, but in most cases they would do no harm if deployed, because they check to see if they're running in DDEV context.
+You are responsible for your code and its deployment. DDEV does not alter any code or fix any bugs in it. DDEV *does* add DDEV-specific settings for some CMSes if the [settings management](cms-settings.md) is enabled. These items are excluded by `.gitignore` so they won't affect a deployed project, but in most cases they would do no harm if deployed, because they check to see if they're running in DDEV context.
 
 ### Where is my database stored in my DDEV project?
 
-The MariaDB, MySQL, or PostgreSQL database in your project lives in a Docker volume, which means it does not live in your DDEV project, and is not checked in. This configuration is for performance and portability reasons, but it means that if you change Docker providers or do a factory reset on your Docker provider, you will lose databases. By default many Docker providers do not keep Docker volumes where they are backed up by normal backup solutions. Remember to keep backups using `ddev export-db` or `ddev snapshot`. See [#How can I migrate from one Docker provider to another](#how-can-i-migrate-from-one-docker-provider-to-another).
+The MariaDB, MySQL, or PostgreSQL database for your project lives in a Docker volume, which means it does not appear in your DDEV project's filesystem, and is not checked in. This configuration is for performance and portability reasons, but it means that if you change Docker providers or do a factory reset on your Docker provider, you will lose databases. By default many Docker providers do not keep Docker volumes where they are backed up by normal backup solutions. Remember to keep backups using `ddev export-db` or `ddev snapshot`. See [#How can I migrate from one Docker provider to another](#how-can-i-migrate-from-one-docker-provider-to-another).
 
 ### What Docker providers can I use?
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -1,3 +1,7 @@
+---
+search:
+boost: 1.0
+---
 # FAQ
 
 Frequently-asked questions organized into high-level functionality, investigating issues, daily usage, and connecting with our community.
@@ -6,21 +10,29 @@ Frequently-asked questions organized into high-level functionality, investigatin
 
 ### What operating systems will DDEV work with?
 
-DDEV works nearly anywhere Docker will run, including macOS, Windows 10/11 Pro/Enterprise and Home, and every Linux variant we’ve ever tried. It also runs in many Linux-like environments, like ChromeOS (in Linux machine) and Windows 10/11’s WSL2. DDEV works the same on each of these platforms since the important work is done inside identical Docker containers.
+DDEV works nearly anywhere Docker will run, including macOS, WSL2, Windows 10/11 Pro/Enterprise and Home, and every Linux variant we’ve ever tried. It also runs in many Linux-like environments, like ChromeOS (in Linux machine). DDEV works the same on each of these platforms since the important work is done inside identical Docker containers. This means that a team using diverse environments can share everything just fine.
 
-### Are there alternate Docker providers I can use?
+### Does DDEV change my code?
 
-Many users report good results with alternate Docker providers.
+You are responsible for your code and its deployment. DDEV does not alter it (or fix any bugs in it). DDEV *does* add DDEV-specific settings for some CMSs if [settings management](cms-settings.md) is enabled. These items are excluded by `.gitignore` so they won't affect a deployed project, but in most cases they would do no harm if deployed, because they check to see if they're running in DDEV context.
 
-| Docker Provider            | Support Level                                                              |
-|----------------------------|----------------------------------------------------------------------------|
-| OrbStack (macOS)           | officially tested and supported on macOS                                   |
-| Docker Desktop for Mac     | officially tested and supported on both Intel and Apple Silicon            |
-| Docker Desktop for Windows | officially tested and supported on WSL2 and traditional Windows            |
-| Colima (macOS)             | officially tested and supported                                            |
-| Colima (Linux)             | reported working in DDEV v1.22.2+, but poor solution compared to docker-ce |
-| docker-ce (Linux/WSL2)     | Officially supported with automated tests on WSL2/Ubuntu                   |
-| Rancher Desktop (macOS)    | officially tested and supported on macOS                                   |
+### Where is my database stored in my DDEV project?
+
+The MariaDB, MySQL, or PostgreSQL database in your project lives in a Docker volume, which means it does not live in your DDEV project, and is not checked in. This configuration is for performance and portability reasons, but it means that if you change Docker providers or do a factory reset on your Docker provider, you will lose databases. By default many Docker providers do not keep Docker volumes where they are backed up by normal backup solutions. Remember to keep backups using `ddev export-db` or `ddev snapshot`. See [#How can I migrate from one Docker provider to another](#how-can-i-migrate-from-one-docker-provider-to-another).
+
+### What Docker providers can I use?
+
+We have automated testing and support for a staggering range of Docker providers.
+
+| Docker Provider            | Support Level                                                            |
+|----------------------------|--------------------------------------------------------------------------|
+| OrbStack (macOS)           | officially tested and supported on macOS                                 |
+| Docker Desktop for Mac     | officially tested and supported on both Intel and Apple Silicon          |
+| Docker Desktop for Windows | officially tested and supported on WSL2 and traditional Windows          |
+| Colima (macOS)             | officially tested and supported                                          |
+| Colima (Linux)             | reported working in DDEV v1.22+, but poor solution compared to docker-ce |
+| docker-ce (Linux/WSL2)     | Officially supported with automated tests on WSL2/Ubuntu                 |
+| Rancher Desktop (macOS)    | officially tested and supported on macOS                                 |
 
 * Docker Desktop for Linux does *not* work with DDEV because it mounts all files into the container owned as root.
 * Rancher Desktop for Windows does not work with DDEV.
@@ -43,6 +55,8 @@ Check out [this Stack Overflow answer](https://stackoverflow.com/a/69964995/8972
 ### Do I need to install PHP, Composer, nginx, or Node.js/npm on my workstation?
 
 No. These tools live inside DDEV’s Docker containers, so you only need to [install Docker](../install/docker-installation.md) and [install DDEV](../install/ddev-installation.md). This is especially handy for Windows users where there’s more friction getting these things installed.
+
+For most users we recommend that you do *not* install PHP or composer on your workstation, so you get in the habit of using `ddev composer`, which will use the configured composer and PHP versions for your project, which can be different for each project. See [DDEV and Composer](developer-tools.md#ddev-and-composer).
 
 ### Do I lose data when I run `ddev poweroff`, `ddev stop`, or `ddev restart`?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -196,12 +196,13 @@ nav:
           - users/debugging-profiling/xhprof-profiling.md
           - users/debugging-profiling/xdebug-profiling.md
   - 'Hosting & Deployment':
-    - users/providers/index.md
+    - users/topics/index.md
     - 'Beyond Local':
       - users/topics/sharing.md
       - users/topics/hosting.md
       - users/topics/remote-docker.md
     - 'Hosting Provider Integrations':
+      - users/providers/index.md
       - 'Acquia': users/providers/acquia.md
       - 'Lagoon': users/providers/lagoon.md
       - 'Pantheon': users/providers/pantheon.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,10 +197,9 @@ nav:
           - users/debugging-profiling/xdebug-profiling.md
   - 'Hosting & Deployment':
     - users/topics/index.md
-    - 'Beyond Local':
-      - users/topics/sharing.md
-      - users/topics/hosting.md
-      - users/topics/remote-docker.md
+    - users/topics/sharing.md
+    - users/topics/hosting.md
+    - users/topics/remote-docker.md
     - 'Hosting Provider Integrations':
       - users/providers/index.md
       - 'Acquia': users/providers/acquia.md


### PR DESCRIPTION
## The Issue

Noticed FAQs that people ask... about code and DDEV, about where the databases live.

## How This PR Solves The Issue

* Minor change to `make mkdocs-serve` - delete the container on exit
* Fix menus on hosting provider integration. They've been messed up forever
* Add new FAQs

## Manual Testing Instructions

Built docs at https://ddev--5924.org.readthedocs.build/en/5924/users/usage/faq/

* Review "hosting provider integration" and related menus at 
* Review FAQ

## Notes

For the mkdocs-not-installed case `make mkdocs-serve` provides a docker-based mkdocs setup thanks to @tyler36 

The [polinux/mkdocs](https://registry.hub.docker.com/r/polinux/mkdocs)  docker image has moved along, and now has arm64 version (not pushed properly), but the current image does not seem to work right on either arm64 or amd64.

I experimented with this, though, to handle arm64, but neither the amd64 nor arm64 images worked right with 1.5.2, so I gave up:

```
mkdocs-serve:
	$(shell if command -v mkdocsx >/dev/null ; then \
			mkdocs serve; \
		else \
			TAG=1.5.2; \
			set -x; \
			if [ $(BUILD_ARCH) = 'arm64' ]; then TAG="arm64v8-$${TAG}"; fi; \
			docker run -it --rm -v "${PWD}:/docs" -p 8000:8000 -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" polinux/mkdocs:$${TAG}; \
			set +x; \
		fi \
	)

```