### PR TITLE
refactor: Use project_list.yaml as source of truth, fixes #5918

### DIFF
--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -514,6 +514,8 @@ func TestConfigDatabaseVersion(t *testing.T) {
 	// add a database into the config and nothing else
 	for _, dbTypeVersion := range versionsToTest {
 		_ = app.Stop(true, false)
+		_, err := exec.RunHostCommand(DdevBin, "delete", "-Oy", t.Name())
+		assert.NoError(err)
 		parts := strings.Split(dbTypeVersion, ":")
 		err = os.RemoveAll(filepath.Join(testDir, ".ddev"))
 		assert.NoError(err)

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -514,8 +514,6 @@ func TestConfigDatabaseVersion(t *testing.T) {
 	// add a database into the config and nothing else
 	for _, dbTypeVersion := range versionsToTest {
 		_ = app.Stop(true, false)
-		_, err := exec.RunHostCommand(DdevBin, "delete", "-Oy", t.Name())
-		assert.NoError(err)
 		parts := strings.Split(dbTypeVersion, ":")
 		err = os.RemoveAll(filepath.Join(testDir, ".ddev"))
 		assert.NoError(err)

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -106,7 +106,10 @@ Files beginning with `.` are hidden because they shouldn’t be fiddled with; mo
 There’s only one global `.ddev` directory, which lives in your home directory: `~/.ddev` (`$HOME/.ddev`).
 
 `global_config.yaml`
-: This YAML file defines your global configuration, which consists of various [config settings](../configuration/config.md) along with an important `project_info` key that lets DDEV keep track of the projects you’ve added.
+: This YAML file defines your global configuration, which consists of various [config settings](../configuration/config.md).
+
+`project_list.yaml`
+: This YAML file defines your project list that lets DDEV keep track of the projects you’ve added.
 
 `bin` directory
 : This is where DDEV stores private executable binaries it needs, like `mutagen` and `docker-compose`.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2517,10 +2517,6 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 			return fmt.Errorf("failed to remove hosts entries: %v", err)
 		}
 		app.RemoveGlobalProjectInfo()
-		err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
-		if err != nil {
-			util.Warning("Could not WriteGlobalConfig: %v", err)
-		}
 
 		vols := []string{app.GetMariaDBVolumeName(), app.GetPostgresVolumeName(), GetMutagenVolumeName(app)}
 		if globalconfig.DdevGlobalConfig.NoBindMounts {

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -691,12 +691,9 @@ func RemoveProjectInfo(projectName string) error {
 	_, ok := DdevProjectList[projectName]
 	if ok {
 		delete(DdevProjectList, projectName)
-		err := WriteProjectList(DdevProjectList)
-		if err != nil {
-			return err
-		}
 	}
-	return nil
+	err := WriteProjectList(DdevProjectList)
+	return err
 }
 
 // GetGlobalProjectList returns the global project list map

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -500,12 +500,11 @@ func ReadProjectList() error {
 			}
 
 			// Write an empty file - we have no known projects
-			err := os.WriteFile(GetProjectListPath(), make([]byte, 0), 0644)
-			// Whether there's an error or nil here we want to return
-			return err
-		} else {
-			return err
+			err = os.WriteFile(GetProjectListPath(), make([]byte, 0), 0644)
 		}
+
+		// Whether there's an error or nil here we want to return
+		return err
 	}
 
 	source, err := os.ReadFile(globalProjectsFile)

--- a/pkg/globalconfig/schema.json
+++ b/pkg/globalconfig/schema.json
@@ -168,14 +168,6 @@
       },
       "uniqueItems": true
     },
-    "project_info": {
-      "description": "List of all projects DDEV currently knows about. DDEV manages this list when using `config` and `delete` commands.",
-      "type": "array",
-      "items": {
-        "type": "array"
-      },
-      "uniqueItems": true
-    },
     "performance_mode": {
       "description": "Defines the performance optimization mode to be used. Currently Mutagen asynchronous caching and NFS are supported. Mutagen is enabled by default on Mac and Windows.",
       "type": "string",


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
Users have been confused by having two copies of the project list, and haven't known which to update if they need to manually update the list.

## How This PR Solves The Issue
1. If there's no `project_list.yaml` file and the `global_config.yaml` file contains a project list (i.e. if someone is upgrading from an older version of DDEV), copy the list into `project_list.yaml`
    - This is a departure from the previous behaviour which would copy the list from `global_config.yaml` if there was any difference between the two lists
1. Remove `ProjectList` from the `GlobalConfig` type
    - This means the next time `global_config.yaml` is written, the project list will be removed from that file.

Note that I have done this in two commits to show why some of the changes are necessary. I'll add PR comments to help clarify this.

## Manual Testing Instructions
1. Ensure you have at least one project in your project list prior to checking out this PR
1. Remove `project_list.yaml` if you have it
1. Run `ddev list` - it should list the project(s) correctly, regardless of what state they were in
1. Confirm that you now have a `project_list.yaml` file
1. Run any command that will result in global config being written (e.g. if your `last_started_version` has changed, run `ddev start` in a project)
1. Confirm that `global_config.yaml` no longer has a list pf projects

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
No automated tests need to change - they were all already relying on `project_list.yaml`.

## Related Issue Link(s)
- https://github.com/ddev/ddev/issues/5918

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
This shouldn't affect anyone other than reducing confusion.

