### PR TITLE
docs: Use backticks when referencing custom command annotations, fixes #5820

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -47,7 +47,6 @@ Dump
 DXP
 Enable
 EndeavourOS
-ExecRaw
 ExecStart
 ExecStop
 Execute
@@ -260,7 +259,6 @@ dbimage
 dbname
 dbpass
 dbserver
-DBTypes
 dbuser
 ddev
 ddev's
@@ -352,12 +350,10 @@ help
 homeadditions
 homebrew
 host
-HostBinaryExists
 hostenv
 hostfile
 hostname
 hostnames
-HostWorkingDir
 htaccess
 html
 http
@@ -471,7 +467,6 @@ one
 oneshot
 or
 oriented
-OSTypes
 output
 pause
 pdfreactor
@@ -512,7 +507,6 @@ projdir
 project
 projectname
 projects
-ProjectTypes
 proot
 proto
 provided
@@ -544,7 +538,6 @@ rfay
 rmi
 rsync
 running
-CanRunGlobally
 runtime
 rw
 s

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -135,7 +135,7 @@ Useful variables for container scripts are:
 
 Custom commands support various annotations in the header for providing additional information to the user.
 
-### “Description” Annotation
+### `Description` Annotation
 
 `Description` should briefly describe the command in its help message.
 
@@ -143,7 +143,7 @@ Usage: `## Description: <command-description>`
 
 Example: `## Description: my great custom command`
 
-### “Usage” Annotation
+### `Usage` Annotation
 
 `Usage` should explain how to use the command in its help message.
 
@@ -151,7 +151,7 @@ Usage: `## Usage: <command-usage>`
 
 Example: `## Usage: commandname [flags] [args]`
 
-### “Example” Annotation
+### `Example` Annotation
 
 `Example` should demonstrate how the command might be used. Use `\n` to force a line break.
 
@@ -159,7 +159,7 @@ Usage: `## Example: <command-example>`
 
 Example: `## Example: commandname\ncommandname -h`
 
-### “Flags” Annotation
+### `Flags` Annotation
 
 `Flags` should explain any available flags, including their shorthand when relevant, for the help message. It has to be encoded according the following definition:
 
@@ -212,7 +212,7 @@ Usage: `## AutocompleteTerms: [<list-of-valid-arguments>]`
 
 Example: `## AutocompleteTerms: ["enable","disable","toggle","status"]`
 
-### "CanRunGlobally" Annotation
+### `CanRunGlobally` Annotation
 
 This annotation is only available for global host commands.
 
@@ -227,7 +227,7 @@ This annotation will have no effect if you are also using one of the following a
 
 Example: `## CanRunGlobally: true`
 
-### “ProjectTypes” Annotation
+### `ProjectTypes` Annotation
 
 If your command should only be visible for a specific project type, `ProjectTypes` will allow you to define the supported types. This is especially useful for global custom commands. See [Quickstart for many CMSes](../../users/quickstart.md) for more information about the supported project types. Multiple types are separated by a comma.
 
@@ -235,7 +235,7 @@ Usage: `## ProjectTypes: <list-of-project-types>`
 
 Example: `## ProjectTypes: drupal7,drupal8,drupal9,backdrop`
 
-### “OSTypes” Annotation (Host Commands Only)
+### `OSTypes` Annotation (Host Commands Only)
 
 If your host command should only run on one or more operating systems, add the `OSTypes` annotation. Multiple types are separated by a comma. Valid types are:
 
@@ -247,7 +247,7 @@ Usage: `## OSTypes: <list-of-os-types>`
 
 Example: `## OSTypes: darwin,linux`
 
-### “HostBinaryExists” Annotation (Host Commands Only)
+### `HostBinaryExists` Annotation (Host Commands Only)
 
 If your host command should only run if a particular file exists, add the `HostBinaryExists` annotation.
 
@@ -255,7 +255,7 @@ Usage: `## HostBinaryExists: <path/to/file>`
 
 Example: `## HostBinaryExists: /Applications/Sequel ace.app`
 
-### “DBTypes” Annotation
+### `DBTypes` Annotation
 
 If your command should only be available for a particular database type, add the `DBTypes` annotation. Multiple types are separated by a comma. Valid types the available database types.
 
@@ -263,13 +263,13 @@ Usage: `## DBTypes: <type>`
 
 Example: `## DBTypes: postgres`
 
-### “HostWorkingDir” Annotation (Container Commands Only)
+### `HostWorkingDir` Annotation (Container Commands Only)
 
 If your container command should run from the directory you are running the command in the host, add the `HostWorkingDir` annotation.
 
 Example: `## HostWorkingDir: true`
 
-### "ExecRaw" Annotation (Container Commands Only)
+### `ExecRaw` Annotation (Container Commands Only)
 
 Use `ExecRaw: true` to pass command arguments directly to the container as-is.
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
Most annotations are references using quotes, except the newest one where I was told to use backticks.
They should all use backticks - it looks silly with one being rendered differently.

## How This PR Solves The Issue
Use backticks when referencing annotations for custom commands in the docs.
Remove annotations from the spelling words list, since anything in backticks is ignored for spelling checks.

## Manual Testing Instructions
Take a look at [custom commands page](https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/) in the docs.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
N/A

## Related Issue Link(s)
- https://github.com/ddev/ddev/issues/5820

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
N/A

