### PR TITLE
docs: use stable URL for 404 [skip ci]

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
 site_name: DDEV Docs
 # todo: Make sure to set this to the correct one; otherwise it breaks 404 page
-site_url: https://ddev.readthedocs.io/en/latest/
+site_url: https://ddev.readthedocs.io/en/stable/
 repo_url: https://github.com/ddev/ddev
 repo_name: ddev/ddev
 edit_uri: blob/master/docs/content


### PR DESCRIPTION
## The Issue

I noticed that 404 links always point to the latest docs.

## How This PR Solves The Issue

Uses stable URL.
I was concerned about `# todo: Make sure to set this to the correct one; otherwise it breaks 404 page` for the `site_url`, so I tested this on my own fork before making this change.

## Manual Testing Instructions

**Current stable**: https://ddev.readthedocs.io/en/stable/404 and click any link, see the **latest** docs.
**Current latest**: https://ddev.readthedocs.io/en/latest/404 and click any link, see the **latest** docs.

**Latest after merge**: https://ddev.readthedocs.io/en/latest/404 (Hard reload the page) and click any link, see the **stable** docs.
**Stable after merge**: remains the same.

This change will not fix 404 for stable until the next stable release is out.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

