### PR TITLE
fix: Gitpod and Codespaces can use HTTPS

### DIFF
--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -507,7 +507,7 @@ func (app *DdevApp) CanUseHTTPOnly() bool {
 	switch {
 	// Gitpod and Codespaces have their own router with TLS termination
 	case nodeps.IsGitpod() || nodeps.IsCodespaces():
-		return true
+		return false
 	// If we have no router, then no https otherwise
 	case IsRouterDisabled(app):
 		return true


### PR DESCRIPTION
## The Issue

- #5684

The refactored code had an incorrect condition for Gitpod and Codespaces.

- https://github.com/ddev/ddev/issues/6102#issuecomment-2106255867

The primary URL should point to the Gitpod or Codespaces URL.

```
$ ddev describe -j
...
"httpURLs": [
  "http://127.0.0.1:8080"
],
"httpsURLs": null,
```

## How This PR Solves The Issue

I tried to add Gitpod and Codespaces generated URLs to httpURLs, it worked, but the result was confusing:

```
$ ddev describe -j
"httpURLs": [
  "https://d10-8080.app.github.dev",
  "http://127.0.0.1:8080"
],
"httpsURLs": null,
```

So I reverted the check for HTTP, and now it works as it should:

```
$ ddev describe -j
...
"httpURLs": [
  "http://127.0.0.1:8080"
],
"httpsURLs": [
  "https://d10-8080.app.github.dev"
],
```

Also `ddev describe` did not show `All URLs` with disabled router, so I moved the condition.

## Manual Testing Instructions

Without using Codespaces:
```
export DDEV_PRETEND_CODESPACES=true CODESPACE_NAME=d10 GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN=app.github.dev
ddev start
ddev describe
```

A simple `ddev describe` comparison with stable DDEV will show the difference.

Before:
```
┌──────────────────────────────────────────────────────────────────────┐
│ Project: d10 ~/code/ddev/d10 http://127.0.0.1:8080                   │
│ Docker platform: linux-docker                                        │
│ Router: disabled                                                     │
├─────────┬──────┬────────────────────────────────┬────────────────────┤
│ SERVICE │ STAT │ URL/PORT                       │ INFO               │
├─────────┼──────┼────────────────────────────────┼────────────────────┤
│ web     │ OK   │ http://127.0.0.1:8080          │ php PHP8.3         │
│         │      │ InDocker: web:8025,443,80      │ nginx-fpm          │
│         │      │ Host: 127.0.0.1:8443,8080,8027 │ docroot:''         │
│         │      │                                │ Perf mode: none    │
│         │      │                                │ NodeJS:20          │
├─────────┼──────┼────────────────────────────────┼────────────────────┤
│ db      │ OK   │ InDocker: db:3306              │ mysql:8.0          │
│         │      │ Host: 127.0.0.1:3306           │ User/Pass: 'db/db' │
│         │      │                                │ or 'root/root'     │
├─────────┼──────┼────────────────────────────────┼────────────────────┤
│ Network │      │ bind-all-interfaces ENABLED    │                    │
└─────────┴──────┴────────────────────────────────┴────────────────────┘
```
After:
```
┌──────────────────────────────────────────────────────────────────────────┐
│ Project: d10 ~/code/ddev/d10 https://d10-8080.app.github.dev             │
│ Docker platform: linux-docker                                            │
│ Router: disabled                                                         │
├──────────┬──────┬───────────────────────────────────┬────────────────────┤
│ SERVICE  │ STAT │ URL/PORT                          │ INFO               │
├──────────┼──────┼───────────────────────────────────┼────────────────────┤
│ web      │ OK   │ https://d10-8080.app.github.dev   │ php PHP8.3         │
│          │      │ InDocker: web:443,80,8025         │ nginx-fpm          │
│          │      │ Host: 127.0.0.1:8443,8080,8027    │ docroot:''         │
│          │      │                                   │ Perf mode: none    │
│          │      │                                   │ NodeJS:20          │
├──────────┼──────┼───────────────────────────────────┼────────────────────┤
│ db       │ OK   │ InDocker: db:3306                 │ mysql:8.0          │
│          │      │ Host: 127.0.0.1:3306              │ User/Pass: 'db/db' │
│          │      │                                   │ or 'root/root'     │
├──────────┼──────┼───────────────────────────────────┼────────────────────┤
│ Network  │      │ bind-all-interfaces ENABLED       │                    │
└──────────┴──────┴───────────────────────────────────┴────────────────────┘
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

