### PR TITLE
build: add review in gitpod comment since badge doesn't work any more [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -52,7 +52,7 @@ github:
     # add a check to pull requests (defaults to true)
     addCheck: true
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
-    addComment: false
+    addComment: true
     # add a "Review in Gitpod" button to the pull request's description (defaults to false)
     addBadge: true
     # add a label once the prebuild is ready to pull requests (defaults to false)


### PR DESCRIPTION

## The Issue

We used to get a badge on every PR with the "review in gitpod" but they seem to have lost it.

Add the gitpod comment and see if it happens.

