### PR TITLE
fix: just delete compose orphans, fixes #5755

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2082,6 +2082,8 @@ func (app *DdevApp) DockerEnv() {
 	envVars := map[string]string{
 		// The compose project name can no longer contain dots; must be lower-case
 		"COMPOSE_PROJECT_NAME":           strings.ToLower("ddev-" + strings.Replace(app.Name, `.`, "", -1)),
+		"COMPOSE_REMOVE_ORPHANS":         "true",
+		"COMPOSE_IGNORE_ORPHANS":         "true",
 		"COMPOSE_CONVERT_WINDOWS_PATHS":  "true",
 		"COMPOSER_EXIT_ON_PATCH_FAILURE": "1",
 		"DDEV_SITENAME":                  app.Name,


### PR DESCRIPTION

## The Issue

* #5755 

Sometimes orphaned containers are left around, probably due to removed `docker-compose.*.yaml`, etc.

However, docker-compose provides environment variables to ignore and remove.

Add them.

## Manual Testing Instructions

* Try to create an orphan on a project
* See if we get a complaint

