### PR TITLE
docs: Improve suggestions about WSL2 docker options

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -141,7 +141,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     2. **Commercial, often problematic:** [Using WSL2 with Docker Desktop](#wsl2-docker-desktop-install-script)
     3. **Old school:** [Installing directly on traditional Windows](#traditional-windows) with an installer
 
-    **We strongly recommend using WSL2.** While its Linux experience may be new for some Windows users, it’s worth the performance benefit and common experience of working with Ubuntu and Bash.
+    **We strongly recommend using WSL2 for your Windows DDEV development environment.** While its Linux experience may be new for some Windows users, it’s worth the performance benefit and common experience of working with Ubuntu and Bash.
 
     ### Important Considerations for WSL2 and DDEV
 
@@ -204,7 +204,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### WSL2 + Docker Desktop Install Script
 
-    WSL2 with Docker Desktop is a less-favored choice because Docker Desktop is often buggy and lightly supported, and has many features not required for use with DDEV. It is also not free software (although smaller organizations can use it free of charge) and it is not open-source.
+    WSL2 with Docker Desktop is a less-favored choice because Docker Desktop may be lightly supported, and has many features not required for use with DDEV that do not add particular value. It is also not free software (although smaller organizations can use it free of charge) and it is not open-source.
     
     The script here prepares your default WSL2 Ubuntu distro for use with Docker Desktop, and you can run the script multiple times without breaking anything.
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -137,9 +137,9 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     You can install DDEV on Windows three ways:
 
-    1. [Using WSL2 with Docker inside](#wsl2-docker-ce-inside-install-script)
-    2. [Using WSL2 with Docker Desktop](#wsl2-docker-desktop-install-script)
-    3. [Installing directly on traditional Windows](#traditional-windows) with an installer
+    1. **Most reliable, free, open-source:** [Using WSL2 with Docker inside](#wsl2-docker-ce-inside-install-script)
+    2. **Commercial, often problematic:** [Using WSL2 with Docker Desktop](#wsl2-docker-desktop-install-script)
+    3. **Old school:** [Installing directly on traditional Windows](#traditional-windows) with an installer
 
     **We strongly recommend using WSL2.** While its Linux experience may be new for some Windows users, it’s worth the performance benefit and common experience of working with Ubuntu and Bash.
 
@@ -172,7 +172,9 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### WSL2 + Docker CE Inside Install Script
 
-    This prepares your default WSL2 Ubuntu distro and doesn’t require Docker Desktop, and you can run the script multiple times without breaking anything.
+    This technique is our favorite, as it uses the most reliable WSL2 Docker provider (`docker-ce`), which is also free and open-source. 
+    
+    This script prepares your default WSL2 Ubuntu distro and doesn’t require Docker Desktop, and you can run the script multiple times without breaking anything.
         
     In all cases:
 
@@ -202,7 +204,9 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### WSL2 + Docker Desktop Install Script
 
-    This prepares your default WSL2 Ubuntu distro for use with Docker Desktop, and you can run the script multiple times without breaking anything.
+    WSL2 with Docker Desktop is a less-favored choice because Docker Desktop is often buggy and lightly supported, and has many features not required for use with DDEV. It is also not free software (although smaller organizations can use it free of charge) and it is not open-source.
+    
+    The script here prepares your default WSL2 Ubuntu distro for use with Docker Desktop, and you can run the script multiple times without breaking anything.
 
     In all cases:
 
@@ -270,7 +274,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### Traditional Windows
 
-    If you must use traditional Windows without WSL2, you’ll probably want to enable [Mutagen](performance.md/#system-requirements) for the best performance.
+    If you must use traditional Windows, then Docker Desktop is your only choice of a Docker provider. DDEV is supported in this configuration but it's not as performant as the WSL2 options.
 
     * We recommend using [Chocolatey](https://chocolatey.org/). Once installed, you can run `choco install ddev docker-desktop git` from an administrative shell. You can upgrade by running `ddev poweroff && choco upgrade ddev`.
     * Each [DDEV release](https://github.com/ddev/ddev/releases) includes a Windows installer (`ddev_windows_installer.<version>.exe`). After running that, you can open a new Git Bash, PowerShell, or cmd.exe window and start using DDEV.

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -137,9 +137,9 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     You can install DDEV on Windows three ways:
 
-    1. **Most reliable, free, open-source:** [Using WSL2 with Docker inside](#wsl2-docker-ce-inside-install-script)
-    2. **Commercial, often problematic:** [Using WSL2 with Docker Desktop](#wsl2-docker-desktop-install-script)
-    3. **Old school:** [Installing directly on traditional Windows](#traditional-windows) with an installer
+    1. [Using WSL2 with Docker inside](#wsl2-docker-ce-inside-install-script) **Recommended, best performance, most reliable**
+    2. [Using WSL2 with Docker Desktop](#wsl2-docker-desktop-install-script) **May require license, less reliable**
+    3. [Installing directly on traditional Windows](#traditional-windows) with an installer **Legacy, slower performance**
 
     **We strongly recommend using WSL2 for your Windows DDEV development environment.** While its Linux experience may be new for some Windows users, it’s worth the performance benefit and common experience of working with Ubuntu and Bash.
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -233,7 +233,6 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
         iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_desktop.ps1'))
         ```
-    10. In *Windows Update Settings* → *Advanced Options* enable *Receive updates for other Microsoft products*. You may want to occasionally run `wsl.exe --update` as well.
 
     Now you can use the "Ubuntu" terminal app or Windows Terminal to access your Ubuntu distro, which has DDEV and Docker Desktop integrated with it.
 


### PR DESCRIPTION

## The Issue

The WSL2 install docs don't make clear that docker-ce is considered best.

## How This PR Solves The Issue

Improve the wording.

