### PR TITLE
fix: ddev debug test should check to make sure project is in homedir, for #3679

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -64,13 +64,13 @@ if [ ${OSTYPE%-*} != "linux" ]; then
 fi
 echo "docker version: " && docker version
 echo "DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM:-notset}"
-echo "======= Mutagen Info ========="
-if [ -f ~/.ddev/bin/mutagen ]; then
-  echo "Mutagen is installed in ddev, version=$(~/.ddev/bin/mutagen version)"
-  MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync list -l
-fi
 
 echo "======= Docker Info ========="
+
+if command -v colima >/dev/null 2>&1; then echo "colima: $(colima --version)"; fi
+if command -v limactl >/dev/null 2>&1; then echo "lima: $(lima --version)"; fi
+if command -v orb >/dev/null 2>&1; then echo "orbstack: $(orb version)"; fi
+if [ -f ~/.rd/bin/rdctl ]; then echo "rancher desktop: $(~/.rd/bin/rdctl version)"; fi
 
 if ddev debug dockercheck -h| grep dockercheck >/dev/null; then
   ddev debug dockercheck 2>/dev/null

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -32,7 +32,11 @@ function docker_desktop_version {
 
 if ! ddev describe >/dev/null 2>&1; then printf "Please try running this in an existing DDEV project directory, preferably the problem project.\nIt doesn't work in other directories.\n"; exit 2; fi
 
+
 echo "======= Existing project config ========="
+if [[ ${PWD} != ${HOME}* ]]; then
+  printf "\n\nWARNING: Project should be in a subdirectory of the user's home directory.\nInstead it's in ${PWD}\n\n"
+fi
 ddev debug configyaml | grep -v web_environment
 
 PROJECT_DIR=../${PROJECT_NAME}

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -8,6 +8,7 @@ Things might go wrong! In addition to this page, consider checking [Stack Overfl
 * Please use the current stable version of DDEV and of your Docker provider before going too far or asking for support.
 * Temporarily disable firewalls, VPNs, tunnels, network proxies, and virus checkers while you’re troubleshooting.
 * Temporarily disable any proxies you’ve established in Docker’s settings.
+* Please make sure that your project is in a subdirectory of your home directory and has normal ownership and privileges. For example, `ls -ld .` in your project directory should show you as owner of the directory and with write privileges.
 * Use [`ddev debug dockercheck`](commands.md#debug-dockercheck) and [`ddev debug test`](commands.md#debug-test) to help sort out Docker problems.
 * Make sure you do not have disk space problems on your computer. This can be especially tricky on WSL2, where you need to check both the main Windows disk space and WSL2 disk space as well.
 * On macOS, check to make sure Docker Desktop or Colima are not out of disk space. In *Settings* (or *Preferences*) → *Resources* → *Disk image size* there should be ample space left; try not to let usage exceed 80% because the reported number can be unreliable. If it says zero used, something is wrong.


### PR DESCRIPTION

## The Issue

* #3679

* `ddev debug test` should say if project is not in home directory
* Gather version numbers of colima/lima/orbstack/rancher
* Remove some mutagen output

