### PR TITLE
fix: remove mutually exclusive COMPOSE_IGNORE_ORPHANS variable, for #5950

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2083,7 +2083,6 @@ func (app *DdevApp) DockerEnv() {
 		// The compose project name can no longer contain dots; must be lower-case
 		"COMPOSE_PROJECT_NAME":           strings.ToLower("ddev-" + strings.Replace(app.Name, `.`, "", -1)),
 		"COMPOSE_REMOVE_ORPHANS":         "true",
-		"COMPOSE_IGNORE_ORPHANS":         "true",
 		"COMPOSE_CONVERT_WINDOWS_PATHS":  "true",
 		"COMPOSER_EXIT_ON_PATCH_FAILURE": "1",
 		"DDEV_SITENAME":                  app.Name,


### PR DESCRIPTION
## The Issue

- #5950

`docker-compose up` didn't respect `COMPOSE_REMOVE_ORPHANS` until v2.24.7:

- https://github.com/docker/compose/pull/11462

But now it does, and we cannot use two env variables at the same time.

## How This PR Solves The Issue

`COMPOSE_IGNORE_ORPHANS` and `COMPOSE_REMOVE_ORPHANS` are mutually exclusive:

https://github.com/docker/compose/blob/4efb89709ccb9f11ce0b6571a1c4674be37a42b7/cmd/compose/up.go#L92-L95

This did not appear in the tests because we use v2.24.5.

## Manual Testing Instructions

```
$ ddev config global --required-docker-compose-version=v2.24.7
$ ddev start
Starting d10... 
cannot combine COMPOSE_IGNORE_ORPHANS and --remove-orphans
Failed to start d10: composeCmd failed to run 'COMPOSE_PROJECT_NAME=ddev-d10 docker-compose -f /home/stas/code/ddev/d10/.ddev/.ddev-docker-compose-full.yaml up -d', action='[]', err='exit status 1', stdout='', stderr='cannot combine COMPOSE_IGNORE_ORPHANS and --remove-orphans'
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

