### PR TITLE
build: use traefik 3.0

### DIFF
--- a/containers/ddev-traefik-router/Dockerfile
+++ b/containers/ddev-traefik-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:2.11
+FROM traefik:3.0
 
 ENV TRAEFIK_MONITOR_PORT=10999
 RUN apk add bash curl htop vim

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -24,7 +24,7 @@ var DBImg = "ddev/ddev-dbserver"
 var BaseDBTag = "20240213_mariadb_1011_default"
 
 const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.22.7"
-const TraefikRouterImage = "ddev/ddev-traefik-router:20240213_traefik_2.11"
+const TraefikRouterImage = "ddev/ddev-traefik-router:20240312_traefik_3.0"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"


### PR DESCRIPTION

## The Issue

Traefik 3.0 is near release, currently in rc2.

## How This PR Solves The Issue

See if we can use it.

## Release/Deployment Notes

It's possible that we need to check the docs for customization, and that something might be impacted in customization.
