### PR TITLE
feat: Laravel 11 support, fixes #5962

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -574,7 +574,7 @@ socio
 solr
 somefile
 sql
-sqlite
+SQLite
 src
 ssh
 sshd

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -130,6 +130,7 @@ Silverstripe
 Snapshotting
 Solr
 SomeExternalDrive
+SQLite
 Starts
 Statamic
 Support
@@ -574,7 +575,6 @@ socio
 solr
 somefile
 sql
-SQLite
 src
 ssh
 sshd

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -340,6 +340,14 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ddev launch
     ```
 
+!!!tip "How to use SQLite database for Laravel?"
+    DDEV sets a default MariaDB database to better represent a production environment.
+
+    To select the [Laravel defaults](https://laravel.com/docs/releases#application-defaults) for SQLite, use this command for `ddev config`:
+    ```bash
+    ddev config --project-type=laravel --docroot=public --php-version=8.2 --omit-containers=db --disable-settings-management=true
+    ```
+
 ## Magento
 
 === "Magento 2"

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -323,7 +323,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ```bash
     mkdir my-laravel-app
     cd my-laravel-app
-    ddev config --project-type=laravel --docroot=public
+    ddev config --project-type=laravel --docroot=public --php-version=8.2
     ddev composer create --prefer-dist laravel/laravel -y
     ddev launch
     ```
@@ -333,7 +333,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ```bash
     git clone <your-laravel-repo>
     cd <your-laravel-project>
-    ddev config --project-type=laravel --docroot=public --php-version=8.1
+    ddev config --project-type=laravel --docroot=public --php-version=8.2
     ddev start
     ddev composer install
     ddev php artisan key:generate

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -346,7 +346,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
 
     Normal details of a Composer build for Magento 2 are on the [Magento 2 site](https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/composer.html). You must have a public and private key to install from Magento’s repository. When prompted for “username” and “password” in `composer create`, it’s asking for your public key as "username" and private key as "password".
 
-    Note that you can install the Adobe/Magento composer credentials in your global `~/.ddev/homeadditions/.composer/auth.json` and never have to find them again. See [In-Container Home Directory and Shell Configuration](../extend/in-container-configuration).
+    Note that you can install the Adobe/Magento composer credentials in your global `~/.ddev/homeadditions/.composer/auth.json` and never have to find them again. See [In-Container Home Directory and Shell Configuration](extend/in-container-configuration.md).
 
     ```bash
     SITENAME=ddev-magento2

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -343,7 +343,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
 !!!tip "How to use SQLite database for Laravel?"
     DDEV sets a default MariaDB database to better represent a production environment.
 
-    To select the [Laravel defaults](https://laravel.com/docs/releases#application-defaults) for SQLite, use this command for `ddev config`:
+    To select the [Laravel 11 defaults](https://laravel.com/docs/11.x/releases#application-defaults) for SQLite, use this command for `ddev config`:
     ```bash
     ddev config --project-type=laravel --docroot=public --php-version=8.2 --omit-containers=db --disable-settings-management=true
     ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -324,7 +324,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     mkdir my-laravel-app
     cd my-laravel-app
     ddev config --project-type=laravel --docroot=public --php-version=8.2
-    ddev composer create --prefer-dist laravel/laravel -y
+    ddev composer create --prefer-dist laravel/laravel:^11
     ddev launch
     ```
 
@@ -340,8 +340,8 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ddev launch
     ```
 
-!!!tip "How to use SQLite database for Laravel?"
-    DDEV sets a default MariaDB database to better represent a production environment.
+!!!tip "Want to use a SQLite database for Laravel?"
+    DDEV defaults to using a MariaDB database to better represent a production environment.
 
     To select the [Laravel 11 defaults](https://laravel.com/docs/11.x/releases#application-defaults) for SQLite, use this command for `ddev config`:
     ```bash

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -8,14 +8,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/stretchr/testify/require"
-
-	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestApptypeDetection does a simple test of various filesystem setups to make

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -1,16 +1,16 @@
 package ddevapp_test
 
 import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"testing"
-
-	"bufio"
-	"fmt"
-	"strings"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/testcommon"
@@ -68,7 +68,7 @@ func TestPostConfigAction(t *testing.T) {
 		nodeps.AppTypeDrupal8:      nodeps.PHP74,
 		nodeps.AppTypeDrupal9:      nodeps.PHPDefault,
 		nodeps.AppTypeDrupal10:     nodeps.PHP81,
-		nodeps.AppTypeLaravel:      nodeps.PHP81,
+		nodeps.AppTypeLaravel:      nodeps.PHP82,
 		nodeps.AppTypeMagento:      nodeps.PHP74,
 		nodeps.AppTypeMagento2:     nodeps.PHP81,
 		nodeps.AppTypeWordPress:    nodeps.PHPDefault,

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -184,11 +184,11 @@ var (
 		// 9: laravel
 		{
 			Name:                          "TestPkgLaravel",
-			SourceURL:                     "https://github.com/ddev/test-laravel/archive/refs/tags/11.0.1.1.tar.gz",
-			ArchiveInternalExtractionPath: "test-laravel-11.0.1.1/",
+			SourceURL:                     "https://github.com/ddev/test-laravel/archive/refs/tags/11.0.2.1.tar.gz",
+			ArchiveInternalExtractionPath: "test-laravel-11.0.2.1/",
 			FilesTarballURL:               "",
 			FilesZipballURL:               "",
-			DBTarURL:                      "https://github.com/ddev/test-laravel/releases/download/11.0.1.1/db.sql.tar.gz",
+			DBTarURL:                      "https://github.com/ddev/test-laravel/releases/download/11.0.2.1/db.sql.tar.gz",
 			DBZipURL:                      "",
 			FullSiteTarballURL:            "",
 			Type:                          nodeps.AppTypeLaravel,

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -184,11 +184,11 @@ var (
 		// 9: laravel
 		{
 			Name:                          "TestPkgLaravel",
-			SourceURL:                     "https://github.com/ddev/test-laravel/archive/refs/tags/10.0.5.2.tar.gz",
-			ArchiveInternalExtractionPath: "test-laravel-10.0.5.2/",
+			SourceURL:                     "https://github.com/ddev/test-laravel/archive/refs/tags/11.0.1.1.tar.gz",
+			ArchiveInternalExtractionPath: "test-laravel-11.0.1.1/",
 			FilesTarballURL:               "",
 			FilesZipballURL:               "",
-			DBTarURL:                      "https://github.com/ddev/test-laravel/releases/download/10.0.5.2/db.sql.tar.gz",
+			DBTarURL:                      "https://github.com/ddev/test-laravel/releases/download/11.0.1.1/db.sql.tar.gz",
 			DBZipURL:                      "",
 			FullSiteTarballURL:            "",
 			Type:                          nodeps.AppTypeLaravel,

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -184,11 +184,11 @@ var (
 		// 9: laravel
 		{
 			Name:                          "TestPkgLaravel",
-			SourceURL:                     "https://github.com/ddev/test-laravel/archive/refs/tags/11.0.2.1.tar.gz",
-			ArchiveInternalExtractionPath: "test-laravel-11.0.2.1/",
+			SourceURL:                     "https://github.com/ddev/test-laravel/archive/refs/tags/11.0.3.1.tar.gz",
+			ArchiveInternalExtractionPath: "test-laravel-11.0.3.1/",
 			FilesTarballURL:               "",
 			FilesZipballURL:               "",
-			DBTarURL:                      "https://github.com/ddev/test-laravel/releases/download/11.0.2.1/db.sql.tar.gz",
+			DBTarURL:                      "https://github.com/ddev/test-laravel/releases/download/11.0.3.1/db.sql.tar.gz",
 			DBZipURL:                      "",
 			FullSiteTarballURL:            "",
 			Type:                          nodeps.AppTypeLaravel,

--- a/pkg/ddevapp/envfile.go
+++ b/pkg/ddevapp/envfile.go
@@ -2,10 +2,11 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/joho/godotenv"
 	"regexp"
 	"strings"
+
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/joho/godotenv"
 )
 
 // ReadProjectEnvFile reads the .env in the project root into a envText and envMap
@@ -25,9 +26,9 @@ func WriteProjectEnvFile(envFilePath string, envMap map[string]string, envText s
 	for k, v := range envMap {
 		// If the item is already in envText, use regex to replace it
 		// otherwise, append it to the envText.
-		exp := regexp.MustCompile(fmt.Sprintf(`((^|[\r\n]+)%s)=(.*)`, k))
+		exp := regexp.MustCompile(fmt.Sprintf(`(^|[\r\n]+)#*\s*(%s)=(.*)`, k))
 		if exp.MatchString(envText) {
-			envText = exp.ReplaceAllString(envText, fmt.Sprintf(`$1="%s"`, v))
+			envText = exp.ReplaceAllString(envText, fmt.Sprintf(`$1$2="%s"`, v))
 		} else {
 			envText = strings.TrimSuffix(envText, "\n")
 			envText = fmt.Sprintf("%s\n%s=%s\n", envText, k, v)

--- a/pkg/ddevapp/envfile.go
+++ b/pkg/ddevapp/envfile.go
@@ -26,8 +26,12 @@ func WriteProjectEnvFile(envFilePath string, envMap map[string]string, envText s
 	for k, v := range envMap {
 		// If the item is already in envText, use regex to replace it
 		// otherwise, append it to the envText.
+		// (^|[\r\n]+) - first group $1 matches the start of a line or newline characters
+		// #*\s* - matches optional comments with whitespaces, i.e. find lines like '# FOO=BAR'
+		// (%s) - second group $2 matches the variable name
 		exp := regexp.MustCompile(fmt.Sprintf(`(^|[\r\n]+)#*\s*(%s)=(.*)`, k))
 		if exp.MatchString(envText) {
+			// Remove comments with whitespaces here using only $1 and $2 groups
 			envText = exp.ReplaceAllString(envText, fmt.Sprintf(`$1$2="%s"`, v))
 		} else {
 			envText = strings.TrimSuffix(envText, "\n")

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -59,6 +59,7 @@ func laravelPostStartAction(app *DdevApp) error {
 		"DB_USERNAME":   "db",
 		"DB_PASSWORD":   "db",
 		"DB_CONNECTION": dbConnection,
+		"MAIL_MAILER":   "smtp",
 		"MAIL_HOST":     "127.0.0.1",
 		"MAIL_PORT":     "1025",
 	}

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -45,18 +45,15 @@ func laravelPostStartAction(app *DdevApp) error {
 	}
 	port := "3306"
 	dbConnection := "mariadb"
-	hasMariaDbDriver, _ := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, "config/database.php"), "mariadb")
-	if app.Database.Type == nodeps.MySQL {
-		dbConnection = "mysql"
-		// Laravel team recommendation for MySQL 5.7 is to use "mariadb" driver
-		// https://github.com/laravel/laravel/pull/6369#issuecomment-1996875154
-		if app.Database.Version == nodeps.MySQL57 && hasMariaDbDriver {
-			dbConnection = "mariadb"
+	if app.Database.Type == nodeps.MariaDB {
+		hasMariaDbDriver, _ := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, "config/database.php"), "mariadb")
+		if !hasMariaDbDriver {
+			// Older versions of Laravel (before 11) use "mysql" driver for MariaDB
+			// This change is required to prevent this error on "php artisan migrate":
+			// InvalidArgumentException Database connection [mariadb] not configured
+			dbConnection = "mysql"
 		}
-	} else if app.Database.Type == nodeps.MariaDB && !hasMariaDbDriver {
-		// Older versions of Laravel (before 11) require "mysql" driver for MariaDB
-		// This change is required to prevent this error on "php artisan migrate":
-		// InvalidArgumentException Database connection [mariadb] not configured
+	} else if app.Database.Type == nodeps.MySQL {
 		dbConnection = "mysql"
 	} else if app.Database.Type == nodeps.Postgres {
 		dbConnection = "pgsql"

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -2,11 +2,12 @@ package ddevapp
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
-	"os"
-	"path/filepath"
 )
 
 const (
@@ -43,7 +44,7 @@ func laravelPostStartAction(app *DdevApp) error {
 		}
 	}
 	port := "3306"
-	dbConnection := "mysql"
+	dbConnection := "mariadb"
 	if app.Database.Type == nodeps.Postgres {
 		dbConnection = "pgsql"
 		port = "5432"
@@ -67,8 +68,8 @@ func laravelPostStartAction(app *DdevApp) error {
 	return nil
 }
 
-// laravelConfigOverrideAction overrides php_version for Laravel, requires PHP8.1
+// laravelConfigOverrideAction overrides php_version for Laravel, requires PHP8.2
 func laravelConfigOverrideAction(app *DdevApp) error {
-	app.PHPVersion = nodeps.PHP81
+	app.PHPVersion = nodeps.PHP82
 	return nil
 }

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -45,7 +45,9 @@ func laravelPostStartAction(app *DdevApp) error {
 	}
 	port := "3306"
 	dbConnection := "mariadb"
-	if app.Database.Type == nodeps.Postgres {
+	if app.Database.Type == nodeps.MySQL {
+		dbConnection = "mysql"
+	} else if app.Database.Type == nodeps.Postgres {
 		dbConnection = "pgsql"
 		port = "5432"
 	}


### PR DESCRIPTION
## The Issue

- #5962

The PHP version is set to 8.1 for Laravel in DDEV HEAD, so it cannot pull Laravel 11, and it pulls Laravel 10.

Laravel 11 introduced new skeleton, and now it has a new [`mariadb`](https://github.com/laravel/laravel/blob/6ea57d766ffc7948adbf02b6ac63670d43580316/config/database.php#L62-L80) database driver.

## How This PR Solves The Issue

- Uses `mariadb` driver by default.
- Sets PHP version to 8.2, including docs.
- Fix Mailpit (Laravel 11 sends emails to log file by default)
- Laravel 11 adds [commented](https://github.com/laravel/laravel/blob/6ea57d766ffc7948adbf02b6ac63670d43580316/.env.example#L22-L27) variables for database, like this:

```dotenv
DB_CONNECTION=sqlite
# DB_HOST=127.0.0.1
# DB_PORT=3306
# DB_DATABASE=laravel
# DB_USERNAME=root
# DB_PASSWORD=
```

And DDEV doesn't replace the commented lines with new values (it adds `DB_` variables at the end of `.env`), I fixed it.

## Manual Testing Instructions

Use the quickstart for Laravel https://ddev--5963.org.readthedocs.build/en/5963/users/quickstart/#laravel

Check `.env` file.

Check Mailpit:
```
ddev mailpit
ddev php artisan tinker --execute='Mail::raw("Hello World!", function($msg) { $msg->to("test@example.com")->subject("Test Email"); });'
```

Test it with:
```
ddev config --database=mysql:5.7
ddev config --database=mysql:8.0
ddev config --database=postgres:15
```

Check SQLite config from the quickstart.

Test older Laravel:
```
ddev composer create --prefer-dist laravel/laravel:^10
ddev php artisan migrate
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- https://github.com/laravel/laravel/pull/6367

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

