### PR TITLE
fix: Rewrite ComposeCmd() with just dots goroutine, fixes #5913

### DIFF
--- a/cmd/ddev/cmd/debug-refresh.go
+++ b/cmd/ddev/cmd/debug-refresh.go
@@ -42,13 +42,6 @@ var DebugRefreshCmd = &cobra.Command{
 			util.Failed("Failed to get project: %v", err)
 		}
 
-		status, _ := app.SiteStatus()
-		if status != ddevapp.SiteRunning {
-			if err = app.Start(); err != nil {
-				util.Failed("Failed to start %s: %v", app.Name, err)
-			}
-		}
-
 		app.DockerEnv()
 		if err = app.WriteDockerComposeYAML(); err != nil {
 			util.Failed("Failed to get compose-config: %v", err)

--- a/cmd/ddev/cmd/debug-refresh.go
+++ b/cmd/ddev/cmd/debug-refresh.go
@@ -49,7 +49,7 @@ var DebugRefreshCmd = &cobra.Command{
 		_, stderr, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
 			ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
 			Action:       []string{"build", "--no-cache"},
-			RealTime:     true,
+			PrintStdout:  true,
 		})
 		if err != nil {
 			util.Failed("Failed to execute docker-compose -f %s build --no-cache: %v; stderr=\n%s\n\n", err, stderr)

--- a/cmd/ddev/cmd/debug-refresh.go
+++ b/cmd/ddev/cmd/debug-refresh.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	exec2 "github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
@@ -26,6 +28,15 @@ var DebugRefreshCmd = &cobra.Command{
 			projectName = args[0]
 		}
 
+		_, err := dockerutil.DownloadDockerComposeIfNeeded()
+		if err != nil {
+			util.Failed("could not download docker-compose: %v", err)
+		}
+		composeBinaryPath, err := globalconfig.GetDockerComposePath()
+		if err != nil {
+			util.Failed("could not GetDockerComposePath(): %v", err)
+		}
+
 		app, err := ddevapp.GetActiveApp(projectName)
 		if err != nil {
 			util.Failed("Failed to get project: %v", err)
@@ -45,14 +56,12 @@ var DebugRefreshCmd = &cobra.Command{
 
 		output.UserOut.Printf("Rebuilding project images...")
 		buildDurationStart := util.ElapsedDuration(time.Now())
-		util.Debug("Executing docker-compose -f %s build --no-cache", app.DockerComposeFullRenderedYAMLPath())
-		_, stderr, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-			ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
-			Action:       []string{"build", "--no-cache"},
-			RealTime:     true,
-		})
+		composeRenderedPath := app.DockerComposeFullRenderedYAMLPath()
+		util.Debug("Executing %s -f %s build web --no-cache", composeBinaryPath, composeRenderedPath)
+
+		err = exec2.RunInteractiveCommand(composeBinaryPath, []string{"-f", composeRenderedPath, "build", "web", "--no-cache"})
 		if err != nil {
-			util.Failed("Failed to execute docker-compose -f %s build --no-cache: %v; stderr=\n%s\n\n", err, stderr)
+			util.Failed("Failed to execute docker-compose -f %s build web --no-cache: %v", err)
 		}
 		buildDuration := util.FormatDuration(buildDurationStart())
 		util.Success("Refreshed Docker cache for project %s in %s", app.Name, buildDuration)

--- a/cmd/ddev/cmd/debug-refresh.go
+++ b/cmd/ddev/cmd/debug-refresh.go
@@ -49,7 +49,7 @@ var DebugRefreshCmd = &cobra.Command{
 		_, stderr, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
 			ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
 			Action:       []string{"build", "--no-cache"},
-			PrintStdout:  true,
+			RealTime:     true,
 		})
 		if err != nil {
 			util.Failed("Failed to execute docker-compose -f %s build --no-cache: %v; stderr=\n%s\n\n", err, stderr)

--- a/cmd/ddev/cmd/debug-refresh.go
+++ b/cmd/ddev/cmd/debug-refresh.go
@@ -50,7 +50,7 @@ var DebugRefreshCmd = &cobra.Command{
 		output.UserOut.Printf("Rebuilding project images...")
 		buildDurationStart := util.ElapsedDuration(time.Now())
 		composeRenderedPath := app.DockerComposeFullRenderedYAMLPath()
-		util.Debug("Executing %s -f %s build web --no-cache", composeBinaryPath, composeRenderedPath)
+		util.Success("Rebuilding web image with `%s -f %s build web --no-cache`", composeBinaryPath, composeRenderedPath)
 
 		err = exec2.RunInteractiveCommand(composeBinaryPath, []string{"-f", composeRenderedPath, "build", "web", "--no-cache"})
 		if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1254,7 +1254,6 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
 		Action:       []string{"--progress=" + progress, "build"},
 		Progress:     true,
-		PrintStdout:  globalconfig.DdevDebug,
 	})
 	if err != nil {
 		return fmt.Errorf("docker-compose build failed: %v, output='%s', stderr='%s'", err, out, stderr)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1254,6 +1254,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
 		Action:       []string{"--progress=" + progress, "build"},
 		Progress:     true,
+		PrintStdout:  globalconfig.DdevDebug,
 	})
 	if err != nil {
 		return fmt.Errorf("docker-compose build failed: %v, output='%s', stderr='%s'", err, out, stderr)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -634,7 +634,7 @@ func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
 		return "", "", fmt.Errorf("failed to exec docker-compose: %v", err)
 	}
 
-	in := bufio.NewScanner(stderrPipe)
+	stderrOutput := bufio.NewScanner(stderrPipe)
 
 	// Ignore chatty things from docker-compose like:
 	// Container (or Volume) ... Creating or Created or Stopping or Starting or Removing
@@ -646,8 +646,8 @@ func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
 		util.Warning("Failed to compile regex %v: %v", ignoreRegex, err)
 	}
 
-	for in.Scan() {
-		line := in.Text()
+	for stderrOutput.Scan() {
+		line := stderrOutput.Text()
 		if len(stderr) > 0 {
 			stderr = stderr + "\n"
 		}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -46,7 +46,6 @@ type ComposeCmdOpts struct {
 	ComposeFiles []string
 	Action       []string
 	Progress     bool // Add dots every second while the compose command is running
-	RealTime     bool // Print stdout as it happens
 }
 
 // EnsureNetwork will ensure the Docker network for DDEV is created.

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -46,7 +46,7 @@ type ComposeCmdOpts struct {
 	ComposeFiles []string
 	Action       []string
 	Progress     bool // Add dots every second while the compose command is running
-	PrintStdout  bool // Print stdout as it happens
+	RealTime     bool // Print stdout as it happens
 }
 
 // EnsureNetwork will ensure the Docker network for DDEV is created.
@@ -622,12 +622,8 @@ func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
 	}
 
 	proc := exec.Command(path, arg...)
+	proc.Stdout = &stdout
 	proc.Stdin = os.Stdin
-
-	stdoutPipe, err := proc.StdoutPipe()
-	if err != nil {
-		return "", "", fmt.Errorf("failed to proc.StdoutPipe(): %v", err)
-	}
 
 	stderrPipe, err := proc.StderrPipe()
 	if err != nil {
@@ -638,22 +634,6 @@ func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
 		return "", "", fmt.Errorf("failed to exec docker-compose: %v", err)
 	}
 
-	if cmd.PrintStdout {
-		outScanner := bufio.NewScanner(stdoutPipe)
-		go func() {
-			for outScanner.Scan() {
-				line := outScanner.Text()
-				stdout.WriteString(line + "\n")
-				output.UserOut.Println(line)
-			}
-		}()
-	} else {
-		outScanner := bufio.NewScanner(stdoutPipe)
-		for outScanner.Scan() {
-			line := outScanner.Text()
-			stdout.WriteString(line + "\n")
-		}
-	}
 	in := bufio.NewScanner(stderrPipe)
 
 	// Ignore chatty things from docker-compose like:

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -645,9 +645,9 @@ func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
 		util.Warning("Failed to compile regex %v: %v", ignoreRegex, err)
 	}
 
-	done := make(chan bool)
+	var done chan bool
 	if cmd.Progress {
-		util.ShowDots(done)
+		done = util.ShowDots()
 	}
 	for stderrOutput.Scan() {
 		line := stderrOutput.Text()

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -647,17 +647,7 @@ func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
 
 	done := make(chan bool)
 	if cmd.Progress {
-		go func() {
-			for {
-				select {
-				case <-done:
-					return
-				default:
-					fmt.Printf(".")
-					time.Sleep(1 * time.Second)
-				}
-			}
-		}()
+		util.ShowDots(done)
 	}
 	for stderrOutput.Scan() {
 		line := stderrOutput.Text()

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	osexec "os/exec"
 	"os/user"
 	"runtime"
@@ -92,7 +93,7 @@ func ShowDots() chan bool {
 			case <-done:
 				return
 			default:
-				fmt.Printf(".")
+				_, _ = fmt.Fprintf(os.Stderr, ".")
 				time.Sleep(1 * time.Second)
 			}
 		}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -83,9 +83,8 @@ func Verbose(format string, a ...interface{}) {
 	}
 }
 
-// ShowDots displays dots one per second until the channel
-// passed to gets true
-func ShowDots(chan bool) {
+// ShowDots displays dots one per second until done gets true
+func ShowDots() chan bool {
 	done := make(chan bool)
 	go func() {
 		for {
@@ -98,6 +97,7 @@ func ShowDots(chan bool) {
 			}
 		}
 	}()
+	return done
 }
 
 // FormatPlural is a simple wrapper which returns different strings based on the count value.

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -83,6 +83,23 @@ func Verbose(format string, a ...interface{}) {
 	}
 }
 
+// ShowDots displays dots one per second until the channel
+// passed to gets true
+func ShowDots(chan bool) {
+	done := make(chan bool)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				fmt.Printf(".")
+				time.Sleep(1 * time.Second)
+			}
+		}
+	}()
+}
+
 // FormatPlural is a simple wrapper which returns different strings based on the count value.
 func FormatPlural(count int, single string, plural string) string {
 	if count == 1 {


### PR DESCRIPTION
## The Issue

* #5913 
* #5893
* #5470 

## How This PR Solves The Issue

* Only use goroutine when we need it, which is just for outputting dots during build.

## Manual Testing Instructions

- [x] Try out `ddev start` and `ddev debug refresh` and `DDEV_DEBUG=true ddev start`
- [x] Verify number of goroutines left over at exit

## Release notes

`ddev debug refresh` builds only the web image, making the output less confusing.
