### PR TITLE
docs: Use mysql:8.0 instead of mariadb for ExpressionEngine quickstart

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -178,7 +178,7 @@ ddev launch
     ```bash
     mkdir my-ee && cd my-ee
     unzip /path/to/ee-zipfile.zip
-    ddev config --auto
+    ddev config --database=mysql:8.0
     ddev start
     ddev launch /admin.php # Open installation wizard in browser
     ```


### PR DESCRIPTION
## The Issue

Even if mariadb works, there are times that specific joins can be much slower than in mysql. 

## How This PR Solves The Issue

ExpressionEngine documentation (and team) recommends using mysql instead of the default mariadb.