### PR TITLE
docs: update ddev-drupal9-solr to ddev-drupal-solr

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -34,7 +34,7 @@ var Get = &cobra.Command{
 	Long:  `Get/Download a 3rd party add-on (service, provider, etc.). This can be a GitHub repo, in which case the latest release will be used, or it can be a link to a .tar.gz in the correct format (like a particular release's .tar.gz) or it can be a local directory. Use 'ddev get --list' or 'ddev get --list --all' to see a list of available add-ons. Without --all it shows only official DDEV add-ons. To list installed add-ons, 'ddev get --installed', to remove an add-on 'ddev get --remove <add-on>'.`,
 	Example: `ddev get ddev/ddev-redis
 ddev get ddev/ddev-redis --version v1.0.4
-ddev get https://github.com/ddev/ddev-drupal9-solr/archive/refs/tags/v0.0.5.tar.gz
+ddev get https://github.com/ddev/ddev-drupal-solr/archive/refs/tags/v1.2.3.tar.gz
 ddev get /path/to/package
 ddev get /path/to/tarball.tar.gz
 ddev get --list

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -15,40 +15,52 @@ For example,
 
 ```
 →  ddev get --list
-┌──────────────────────────────────────┬───────────────────────────────────────────────────┐
-│ ADD-ON                               │ DESCRIPTION                                       │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-adminer                    │ Adminer service for DDEV*                         │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-beanstalkd                 │ Beanstalkd for DDEV*                              │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-browsersync                │ Auto-refresh HTTPS page on changes with DDEV*     │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-cron                       │ Schedule commands to execute within DDEV*         │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-drupal9-solr               │ Drupal 9 Apache Solr installation for DDEV*       │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-elasticsearch              │ Elasticsearch add-on for DDEV*                    │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-memcached                  │ Install Memcached as an extra service in DDEV*    │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-mongo                      │ MongoDB add-on for DDEV*                          │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-pdfreactor                 │ PDFreactor service for DDEV*                      │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-platformsh                 │ Add integration with Platform.sh hosting service* │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-proxy-support              │ Support HTTP/HTTPS proxies with DDEV*             │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-redis                      │ Redis service for DDEV*                           │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-redis-commander            │ Redis Commander for use with DDEV Redis service*  │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-selenium-standalone-chrome │ A DDEV service for running standalone Chrome*     │
-├──────────────────────────────────────┼───────────────────────────────────────────────────┤
-│ ddev/ddev-varnish                    │ Varnish reverse proxy add-on for DDEV*            │
-└──────────────────────────────────────┴───────────────────────────────────────────────────┘
-Add-ons marked with '*' are official, maintained DDEV add-ons.
+┌──────────────────────────────────────┬────────────────────────────────────────────────────┐
+│ ADD-ON                               │ DESCRIPTION                                        │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-adminer                    │ Adminer service for DDEV*                          │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-beanstalkd                 │ Beanstalkd for DDEV*                               │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-browsersync                │ Auto-refresh HTTPS page on changes with DDEV*      │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-cron                       │ Schedule commands to execute within DDEV*          │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-drupal-contrib             │ DDEV integration for developing Drupal contrib     │
+│                                      │ projects*                                          │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-drupal-solr                │ Drupal Apache Solr installation for DDEV (please   │
+│                                      │ consider ddev/ddev-solr first)*                    │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-elasticsearch              │ Elasticsearch add-on for DDEV*                     │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-memcached                  │ Install Memcached as an extra service in DDEV*     │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-mongo                      │ MongoDB add-on for DDEV*                           │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-pdfreactor                 │ PDFreactor service for DDEV*                       │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-phpmyadmin                 │ phpMyAdmin Add-on For DDEV*                        │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-platformsh                 │ Add integration with Platform.sh hosting service*  │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-proxy-support              │ Support HTTP/HTTPS proxies with DDEV*              │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-redis                      │ Redis service for DDEV*                            │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-redis-7                    │ Redis 7 service for DDEV*                          │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-redis-commander            │ Redis Commander for use with DDEV Redis service*   │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-selenium-standalone-chrome │ A DDEV service for running standalone Chrome*      │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-solr                       │ Solr service for DDEV*                             │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-sqlsrv                     │ MS SQL server add-on for DDEV*                     │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-varnish                    │ Varnish reverse proxy add-on for DDEV*             │
+└──────────────────────────────────────┴────────────────────────────────────────────────────┘
+20 repositories found. Add-ons marked with '*' are officially maintained DDEV add-ons.
 ```
 
 !!!tip
@@ -57,7 +69,7 @@ Add-ons marked with '*' are official, maintained DDEV add-ons.
 Officially-supported add-ons:
 
 * [Adminer](https://github.com/ddev/ddev-adminer): `ddev get ddev/ddev-adminer`.
-* [Apache Solr for Drupal 9](https://github.com/ddev/ddev-drupal9-solr): `ddev get ddev/ddev-drupal9-solr`.
+* [Apache Solr for Drupal](https://github.com/ddev/ddev-drupal-solr): `ddev get ddev/ddev-drupal-solr`.
 * [Beanstalkd](https://github.com/ddev/ddev-beanstalkd): `ddev get ddev/ddev-beanstalkd`.
 * [Browsersync](https://github.com/ddev/ddev-browsersync): `ddev get ddev/ddev-browsersync`.
 * [cron](https://github.com/ddev/ddev-cron): `ddev get ddev/ddev-cron`.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -626,8 +626,8 @@ ddev get ddev/ddev-redis --verbose
 # Download the official Redis add-on, version v1.0.4
 ddev get ddev/ddev-redis --version v1.0.4
 
-# Download the Drupal 9 Solr add-on from its v0.0.5 release tarball
-ddev get https://github.com/ddev/ddev-drupal9-solr/archive/refs/tags/v0.0.5.tar.gz
+# Download the Drupal Solr add-on from its v1.2.3 release tarball
+ddev get https://github.com/ddev/ddev-drupal-solr/archive/refs/tags/v1.2.3.tar.gz
 
 # Copy an add-on available in another directory
 ddev get /path/to/package

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -166,7 +166,7 @@ func TestExtractTarballWithCleanup(t *testing.T) {
 func TestDownloadAndExtractTarball(t *testing.T) {
 	assert := asrt.New(t)
 
-	testTarball := "https://github.com/ddev/ddev-drupal9-solr/archive/refs/tags/v0.1.1.tar.gz"
+	testTarball := "https://github.com/ddev/ddev-drupal-solr/archive/refs/tags/v1.2.3.tar.gz"
 
 	dir, cleanup, err := archive.DownloadAndExtractTarball(testTarball, true)
 	require.NoError(t, err)


### PR DESCRIPTION

## The Issue

* https://github.com/ddev/ddev-drupal-solr/issues/36

* `ddev-drupal9-solr` renamed to `ddev-solr`
* Update output of `ddev get --list`
* Use newer tarball examples and in test

