### PR TITLE
test: Check goroutine count on several tests at completion, fixes #5920

### DIFF
--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -30,9 +30,9 @@ func TestLogsNoConfig(t *testing.T) {
 
 // TestCmdLogs tests that the ddev logs functionality is working.
 func TestCmdLogs(t *testing.T) {
-	//if nodeps.IsAppleSilicon() {
-	//	t.Skip("Skipping on mac M1 to ignore problems with 'connection reset by peer'")
-	//}
+	// Gather reporting about goroutines at exit
+	_ = os.Setenv("DDEV_GOROUTINES", "true")
+
 	assert := asrt.New(t)
 
 	origDir, _ := os.Getwd()
@@ -66,6 +66,7 @@ func TestCmdLogs(t *testing.T) {
 
 	out, err := exec.RunHostCommand(DdevBin, "logs")
 	require.NoError(t, err)
+	testcommon.CheckGoroutineOutput(t, out)
 	assert.Contains(string(out), "Server started")
 	assert.Contains(string(out), "Notice to demonstrate logging", "PHP notice not found for project %s output='%s", site.Name, string(out))
 }

--- a/cmd/ddev/cmd/snapshot_restore_test.go
+++ b/cmd/ddev/cmd/snapshot_restore_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -12,6 +13,8 @@ import (
 // TestCmdSnapshotRestore runs `ddev snapshot restore` on the test apps
 func TestCmdSnapshotRestore(t *testing.T) {
 	assert := asrt.New(t)
+	// Gather reporting about goroutines at exit
+	_ = os.Setenv("DDEV_GOROUTINES", "true")
 
 	origDir, _ := os.Getwd()
 	site := TestSites[0]
@@ -37,6 +40,7 @@ func TestCmdSnapshotRestore(t *testing.T) {
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
 	assert.Contains(out, "Created database snapshot test-snapshot")
+	testcommon.CheckGoroutineOutput(t, out)
 
 	// Try interactive command
 	// Doesn't seem to work without pty, 2021-12-14
@@ -50,4 +54,5 @@ func TestCmdSnapshotRestore(t *testing.T) {
 	out, err = exec.RunHostCommand(DdevBin, "snapshot", "restore", "--latest")
 	assert.NoError(err)
 	assert.Contains(out, "Database snapshot test-snapshot was restored")
+	testcommon.CheckGoroutineOutput(t, out)
 }

--- a/cmd/ddev/cmd/snapshot_test.go
+++ b/cmd/ddev/cmd/snapshot_test.go
@@ -53,7 +53,6 @@ func TestCmdSnapshot(t *testing.T) {
 	out, err = exec.RunHostCommand(DdevBin, "snapshot", "--name", "not-existing-snapshot", "--cleanup", "--yes")
 	assert.Error(err)
 	assert.Contains(out, "Failed to delete snapshot")
-	testcommon.CheckGoroutineOutput(t, out)
 
 	// Ensure that an existing snapshot can be deleted
 	out, err = exec.RunHostCommand(DdevBin, "snapshot", "--name", snapshotName, "--cleanup", "--yes")

--- a/cmd/ddev/cmd/snapshot_test.go
+++ b/cmd/ddev/cmd/snapshot_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -12,6 +13,8 @@ import (
 // TestCmdSnapshot runs `ddev snapshot` on the test apps
 func TestCmdSnapshot(t *testing.T) {
 	assert := asrt.New(t)
+	// Gather reporting about goroutines at exit
+	_ = os.Setenv("DDEV_GOROUTINES", "true")
 
 	site := TestSites[0]
 	origDir, _ := os.Getwd()
@@ -32,14 +35,17 @@ func TestCmdSnapshot(t *testing.T) {
 
 	err = app.Start()
 	require.NoError(t, err)
+	out, err := exec.RunHostCommand(DdevBin, "snapshot", "--cleanup", "--yes")
+	testcommon.CheckGoroutineOutput(t, out)
 
 	snapshotName := "test-snapshot"
 	// Ensure that there are no snapshots available before we create one
-	_, err = exec.RunHostCommand(DdevBin, "snapshot", "--cleanup", "--yes")
+	out, err = exec.RunHostCommand(DdevBin, "snapshot", "--cleanup", "--yes")
 	assert.NoError(err)
+	testcommon.CheckGoroutineOutput(t, out)
 
 	// Ensure that a snapshot can be created
-	out, err := exec.RunHostCommand(DdevBin, "snapshot", "--name", snapshotName)
+	out, err = exec.RunHostCommand(DdevBin, "snapshot", "--name", snapshotName)
 	assert.NoError(err)
 	require.Contains(t, out, "Created database snapshot "+snapshotName)
 
@@ -47,9 +53,11 @@ func TestCmdSnapshot(t *testing.T) {
 	out, err = exec.RunHostCommand(DdevBin, "snapshot", "--name", "not-existing-snapshot", "--cleanup", "--yes")
 	assert.Error(err)
 	assert.Contains(out, "Failed to delete snapshot")
+	testcommon.CheckGoroutineOutput(t, out)
 
 	// Ensure that an existing snapshot can be deleted
 	out, err = exec.RunHostCommand(DdevBin, "snapshot", "--name", snapshotName, "--cleanup", "--yes")
 	assert.NoError(err, "failed to delete snapshot %s: %s", snapshotName, out)
 	assert.Contains(out, "Deleted database snapshot '"+snapshotName)
+	testcommon.CheckGoroutineOutput(t, out)
 }

--- a/cmd/ddev/cmd/ssh_test.go
+++ b/cmd/ddev/cmd/ssh_test.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
@@ -64,7 +65,5 @@ func TestCmdSSH(t *testing.T) {
 
 	b := util.FindBashPath()
 	out, err := exec.RunHostCommand(b, "-c", fmt.Sprintf("echo pwd | %s ssh", DdevBin))
-	assert.NoError(err)
-	assert.Equal("/var/www/html\n", out)
-
+	require.True(t, strings.HasPrefix(out, "/var/www/html\n"), "output should start with /var/www/html but is actually '%s'", out)
 }

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -19,6 +19,8 @@ import (
 func TestCmdStart(t *testing.T) {
 	assert := asrt.New(t)
 
+	// Gather reporting about goroutines at exit
+	_ = os.Setenv("DDEV_GOROUTINES", "true")
 	// Make sure we have running sites.
 	err := addSites()
 	require.NoError(t, err)
@@ -30,6 +32,7 @@ func TestCmdStart(t *testing.T) {
 	// Ensure all sites are started after ddev start --all.
 	out, err := exec.RunCommand(DdevBin, []string{"start", "--all", "-y"})
 	assert.NoError(err, "ddev start --all should succeed but failed, err: %v, output: %s", err, out)
+	testcommon.CheckGoroutineOutput(t, out)
 
 	// Confirm all sites are running.
 	apps := ddevapp.GetActiveProjects()
@@ -40,8 +43,9 @@ func TestCmdStart(t *testing.T) {
 	}
 
 	// Stop all sites.
-	_, err = exec.RunCommand(DdevBin, []string{"stop", "--all"})
+	out, err = exec.RunCommand(DdevBin, []string{"stop", "--all"})
 	assert.NoError(err)
+	testcommon.CheckGoroutineOutput(t, out)
 
 	// Build start command startMultipleArgs
 	startMultipleArgs := []string{"start", "-y"}
@@ -52,6 +56,7 @@ func TestCmdStart(t *testing.T) {
 	// Start multiple projects in one command
 	out, err = exec.RunCommand(DdevBin, startMultipleArgs)
 	assert.NoError(err, "ddev start with multiple project names should have succeeded, but failed, err: %v, output %s", err, out)
+	testcommon.CheckGoroutineOutput(t, out)
 
 	// Confirm all sites are running
 	for _, app := range apps {

--- a/cmd/ddev/main.go
+++ b/cmd/ddev/main.go
@@ -1,14 +1,34 @@
 package main
 
 import (
-	"os"
-
+	"bytes"
 	"github.com/ddev/ddev/cmd/ddev/cmd"
 	"github.com/ddev/ddev/pkg/amplitude"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/util"
+	"os"
+	"runtime"
+	"runtime/pprof"
 )
 
 func main() {
+
+	defer func() {
+		globalconfig.GoroutineCount = runtime.NumGoroutine()
+		if globalconfig.DdevDebug {
+
+			if globalconfig.DdevVerbose {
+				buf := new(bytes.Buffer)
+
+				// Lookup "goroutine" profile
+				p := pprof.Lookup("goroutine")
+				// Write it to stderr
+				_ = p.WriteTo(buf, 2)
+				util.Verbose(buf.String())
+			}
+		}
+		util.Debug("goroutines=%d at exit of main()", globalconfig.GoroutineCount)
+	}()
 	defer util.TimeTrack()()
 
 	// Initialization is currently done before via init() func somewhere while
@@ -25,4 +45,5 @@ func main() {
 	}
 
 	cmd.Execute()
+
 }

--- a/cmd/ddev/main.go
+++ b/cmd/ddev/main.go
@@ -1,34 +1,14 @@
 package main
 
 import (
-	"bytes"
 	"github.com/ddev/ddev/cmd/ddev/cmd"
 	"github.com/ddev/ddev/pkg/amplitude"
-	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/util"
 	"os"
-	"runtime"
-	"runtime/pprof"
 )
 
 func main() {
-
-	defer func() {
-		globalconfig.GoroutineCount = runtime.NumGoroutine()
-		if globalconfig.DdevDebug {
-
-			if globalconfig.DdevVerbose {
-				buf := new(bytes.Buffer)
-
-				// Lookup "goroutine" profile
-				p := pprof.Lookup("goroutine")
-				// Write it to stderr
-				_ = p.WriteTo(buf, 2)
-				util.Verbose(buf.String())
-			}
-		}
-		util.Debug("goroutines=%d at exit of main()", globalconfig.GoroutineCount)
-	}()
+	defer util.CheckGoroutines()
 	defer util.TimeTrack()()
 
 	// Initialization is currently done before via init() func somewhere while

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -33,6 +34,7 @@ var hostRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-z
 // init() is for testing situations only, allowing us to override the default webserver type
 // or caching behavior
 func init() {
+	var err error
 	// This is for automated testing only. It allows us to override the webserver type.
 	if testWebServerType := os.Getenv("DDEV_TEST_WEBSERVER_TYPE"); testWebServerType != "" {
 		nodeps.WebserverDefault = testWebServerType
@@ -48,6 +50,12 @@ func init() {
 	}
 	if os.Getenv("DDEV_TEST_USE_NGINX_PROXY_ROUTER") == "true" {
 		nodeps.UseNginxProxyRouter = true
+	}
+	if g := os.Getenv("DDEV_TEST_GOROUTINE_LIMIT"); g != "" {
+		nodeps.GoroutineLimit, err = strconv.Atoi(g)
+		if err != nil {
+			util.Failed("DDEV_TEST_GOROUTINE_LIMIT must be empty or numeric value, not '%v'", g)
+		}
 	}
 }
 

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -33,6 +33,9 @@ var DdevVerbose = (os.Getenv("DDEV_VERBOSE") == "true")
 
 var ValidXdebugIDELocations = []string{XdebugIDELocationContainer, XdebugIDELocationWSL2, ""}
 
+// GoroutineCount for tests
+var GoroutineCount = 0
+
 // IsValidXdebugIDELocation limits the choices for XdebugIDELocation
 func IsValidXdebugIDELocation(loc string) bool {
 	switch {

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -68,6 +68,7 @@ var SimpleFormatting = false
 var FailOnHookFailDefault = false
 
 // GoroutineLimit is the number of goroutines allowed at exit in parts of some tests
+// Can be overridden by setting DDEV_TEST_GOROUTINE_LIMIT=<somenumber>
 var GoroutineLimit = 10
 
 // ValidWebserverTypes should be updated whenever supported webserver types are added or

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -67,6 +67,9 @@ var SimpleFormatting = false
 // FailOnHookFailDefault is the default value for app.FailOnHookFail
 var FailOnHookFailDefault = false
 
+// GoroutineLimit is the number of goroutines allowed at exit in parts of some tests
+var GoroutineLimit = 10
+
 // ValidWebserverTypes should be updated whenever supported webserver types are added or
 // removed, and should be used to ensure user-supplied values are valid.
 var ValidWebserverTypes = map[string]bool{

--- a/pkg/util/debug.go
+++ b/pkg/util/debug.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"bytes"
+	"github.com/ddev/ddev/pkg/output"
+	"os"
 	"runtime"
 	"runtime/pprof"
 	"strconv"
@@ -84,8 +86,7 @@ func timeTrack(name *string) func() {
 // Use with `defer util.CheckGoroutines()`
 func CheckGoroutines() {
 	globalconfig.GoroutineCount = runtime.NumGoroutine()
-	if globalconfig.DdevDebug {
-
+	if os.Getenv("DDEV_GOROUTINES") != "" {
 		if globalconfig.DdevVerbose {
 			buf := new(bytes.Buffer)
 
@@ -96,5 +97,5 @@ func CheckGoroutines() {
 			Verbose(buf.String())
 		}
 	}
-	Debug("goroutines=%d at exit of main()", globalconfig.GoroutineCount)
+	output.UserOut.Printf("goroutines=%d at exit of main()", globalconfig.GoroutineCount)
 }

--- a/pkg/util/debug.go
+++ b/pkg/util/debug.go
@@ -96,6 +96,6 @@ func CheckGoroutines() {
 			_ = p.WriteTo(buf, 2)
 			Verbose(buf.String())
 		}
+		output.UserOut.Printf("goroutines=%d at exit of main()", globalconfig.GoroutineCount)
 	}
-	output.UserOut.Printf("goroutines=%d at exit of main()", globalconfig.GoroutineCount)
 }

--- a/pkg/util/debug.go
+++ b/pkg/util/debug.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"bytes"
 	"runtime"
+	"runtime/pprof"
 	"strconv"
 	"time"
 
@@ -75,4 +77,24 @@ func timeTrack(name *string) func() {
 	return func() {
 		logrus.Print("PERF: exit " + *name + " at " + time.Now().Format("15:04:05.000000000") + " after " + strconv.FormatInt(time.Since(start).Milliseconds(), 10) + "ms")
 	}
+}
+
+// CheckGoroutines() updates the number of goroutines
+// and optionally outputs the list of them on verbose.
+// Use with `defer util.CheckGoroutines()`
+func CheckGoroutines() {
+	globalconfig.GoroutineCount = runtime.NumGoroutine()
+	if globalconfig.DdevDebug {
+
+		if globalconfig.DdevVerbose {
+			buf := new(bytes.Buffer)
+
+			// Lookup "goroutine" profile
+			p := pprof.Lookup("goroutine")
+			// Write it to stderr
+			_ = p.WriteTo(buf, 2)
+			Verbose(buf.String())
+		}
+	}
+	Debug("goroutines=%d at exit of main()", globalconfig.GoroutineCount)
 }


### PR DESCRIPTION
## The Issue

* #5920 

We want to know if goroutines get out of control as they did in https://github.com/ddev/ddev/pull/5878

## How This PR Solves The Issue

Test on several of the TestCmd tests to make sure we have a reasonable number of goroutines at stop.

## Manual testing

- [ ] `DDEV_GOROUTINES=true ddev start`
- [ ] `DDEV_GOROUTINES=true DDEV_VERBOSE=true DDEV_DEBUG=true ddev start`

You can also use any other command, not just `ddev start`