### PR TITLE
fix: add restart for database commands after ddev start, fixes #5949

### DIFF
--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -103,6 +103,7 @@ A number of environment variables are provided to these command scripts. These a
 * `DDEV_PHP_VERSION`: Current PHP version
 * `DDEV_PRIMARY_URL`: Primary project URL
 * `DDEV_PROJECT`: Project name, like `d8composer`
+* `DDEV_PROJECT_STATUS`: Project status determined from the `web` and `db` services health, like `starting`, `running`, `stopped`, `paused`, or another status returned from Docker, including `healthy`, `unhealthy`, `exited`, `restarting` 
 * `DDEV_PROJECT_TYPE`: `drupal8`, `typo3`, `backdrop`, `wordpress`, etc.
 * `DDEV_ROUTER_HTTP_PORT`: Router port for HTTP
 * `DDEV_ROUTER_HTTPS_PORT`: Router port for HTTPS

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -103,7 +103,7 @@ A number of environment variables are provided to these command scripts. These a
 * `DDEV_PHP_VERSION`: Current PHP version
 * `DDEV_PRIMARY_URL`: Primary project URL
 * `DDEV_PROJECT`: Project name, like `d8composer`
-* `DDEV_PROJECT_STATUS`: Project status determined from the `web` and `db` services health, like `starting`, `running`, `stopped`, `paused`, or another status returned from Docker, including `healthy`, `unhealthy`, `exited`, `restarting` 
+* `DDEV_PROJECT_STATUS`: Project status determined from the `web` and `db` services health, like `starting`, `running`, `stopped`, `paused`, or another status returned from Docker, including `healthy`, `unhealthy`, `exited`, `restarting`
 * `DDEV_PROJECT_TYPE`: `drupal8`, `typo3`, `backdrop`, `wordpress`, etc.
 * `DDEV_ROUTER_HTTP_PORT`: Router port for HTTP
 * `DDEV_ROUTER_HTTPS_PORT`: Router port for HTTPS

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -10,6 +10,9 @@
 if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
+  # run this script again with the updated environment
+  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  exit $?
 fi
 
 database="${1:-db}"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -7,11 +7,15 @@
 ## OSTypes: darwin,linux,wsl2
 ## HostBinaryExists: /mnt/c/Program Files/dbeaver/dbeaver.exe,/Applications/DBeaver.app,/usr/bin/dbeaver,/usr/bin/dbeaver-ce,/usr/bin/dbeaver-le,/usr/bin/dbeaver-ue,/usr/bin/dbeaver-ee,/var/lib/flatpak/exports/bin/io.dbeaver.DBeaverCommunity,/snap/bin/dbeaver-ce
 
-if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
-  # run this script again with the updated environment
-  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  start_exit_code=$?
+  if [ $start_exit_code -ne 0 ]; then
+    exit $start_exit_code
+  fi
+  # run this script again, as the environment is updated after "ddev start"
+  no_recursion=true ddev "$(basename "$0")" "$@"
   exit $?
 fi
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -12,6 +12,9 @@ arguments="--host=\"127.0.0.1\" --port=${DDEV_HOST_DB_PORT} --user=root --passwo
 if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
+  # run this script again with the updated environment
+  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  exit $?
 fi
 case $OSTYPE in
   "win*"* | "msys"*)

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -9,11 +9,15 @@
 
 arguments="--host=\"127.0.0.1\" --port=${DDEV_HOST_DB_PORT} --user=root --password=root --description=${DDEV_SITENAME}"
 
-if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
-  # run this script again with the updated environment
-  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  start_exit_code=$?
+  if [ $start_exit_code -ne 0 ]; then
+    exit $start_exit_code
+  fi
+  # run this script again, as the environment is updated after "ddev start"
+  no_recursion=true ddev "$(basename "$0")" "$@"
   exit $?
 fi
 case $OSTYPE in

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -6,11 +6,15 @@
 ## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php" or "ddev launch https://your.ddev.site" or "ddev launch $DDEV_PRIMARY_URL:3000", for Mailpit "ddev launch -m"
 ## Flags: [{"Name":"mailpit","Shorthand":"m","Usage":"ddev launch -m launches the mailpit UI"}]
 
-if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
-  # run this script again with the updated environment
-  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  start_exit_code=$?
+  if [ $start_exit_code -ne 0 ]; then
+    exit $start_exit_code
+  fi
+  # run this script again, as the environment is updated after "ddev start"
+  no_recursion=true ddev "$(basename "$0")" "$@"
   exit $?
 fi
 FULLURL=${DDEV_PRIMARY_URL}

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -9,6 +9,9 @@
 if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
+  # run this script again with the updated environment
+  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  exit $?
 fi
 FULLURL=${DDEV_PRIMARY_URL}
 HTTPS=""

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/mysqlworkbench.example
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/mysqlworkbench.example
@@ -8,11 +8,15 @@
 # Note that this example uses $DDEV_HOST_DB_PORT to get the port for the connection
 # Mysql Workbench can be obtained from https://dev.mysql.com/downloads/workbench/
 
-if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
-  # run this script again with the updated environment
-  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  start_exit_code=$?
+  if [ $start_exit_code -ne 0 ]; then
+    exit $start_exit_code
+  fi
+  # run this script again, as the environment is updated after "ddev start"
+  no_recursion=true ddev "$(basename "$0")" "$@"
   exit $?
 fi
 query="root:root@127.0.0.1:${DDEV_HOST_DB_PORT}"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/mysqlworkbench.example
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/mysqlworkbench.example
@@ -11,6 +11,9 @@
 if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
+  # run this script again with the updated environment
+  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  exit $?
 fi
 query="root:root@127.0.0.1:${DDEV_HOST_DB_PORT}"
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/querious
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/querious
@@ -12,8 +12,10 @@
 if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
+  # run this script again with the updated environment
+  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  exit $?
 fi
 DATABASE="${1:-db}"
 
 open "querious://connect/new?host=127.0.0.1&user=db&password=db&use-compression=false&database=${DATABASE}&port=${DDEV_HOST_DB_PORT}"
-

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/querious
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/querious
@@ -9,11 +9,15 @@
 ## HostBinaryExists: /Applications/Querious.app
 ## DBTypes: mysql,mariadb
 
-if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
-  # run this script again with the updated environment
-  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  start_exit_code=$?
+  if [ $start_exit_code -ne 0 ]; then
+    exit $start_exit_code
+  fi
+  # run this script again, as the environment is updated after "ddev start"
+  no_recursion=true ddev "$(basename "$0")" "$@"
   exit $?
 fi
 DATABASE="${1:-db}"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
@@ -13,9 +13,11 @@ DATABASE="${1:-db}"
 if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
+  # run this script again with the updated environment
+  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  exit $?
 fi
 query="mysql://root:root@${DDEV_PROJECT}.${DDEV_TLD}:${DDEV_HOST_DB_PORT}/${DATABASE}"
 
 set -x
 open "$query" -a "/Applications/Sequel Ace.app/Contents/MacOS/Sequel Ace"
-

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
@@ -10,11 +10,15 @@
 
 DATABASE="${1:-db}"
 
-if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
-  # run this script again with the updated environment
-  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  start_exit_code=$?
+  if [ $start_exit_code -ne 0 ]; then
+    exit $start_exit_code
+  fi
+  # run this script again, as the environment is updated after "ddev start"
+  no_recursion=true ddev "$(basename "$0")" "$@"
   exit $?
 fi
 query="mysql://root:root@${DDEV_PROJECT}.${DDEV_TLD}:${DDEV_HOST_DB_PORT}/${DATABASE}"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelpro
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelpro
@@ -11,6 +11,9 @@
 if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
+  # run this script again with the updated environment
+  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  exit $?
 fi
 tmpdir=$(mktemp -d -t sequelpro-XXXXXXXXXX)
 templatepath="$tmpdir/sequelpro.spf"
@@ -79,4 +82,3 @@ cat >$templatepath <<END
 END
 
 open  "${templatepath}"
-

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelpro
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelpro
@@ -8,11 +8,15 @@
 ## HostBinaryExists: /Applications/Sequel Pro.app
 ## DBTypes: mysql,mariadb
 
-if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
-  # run this script again with the updated environment
-  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  start_exit_code=$?
+  if [ $start_exit_code -ne 0 ]; then
+    exit $start_exit_code
+  fi
+  # run this script again, as the environment is updated after "ddev start"
+  no_recursion=true ddev "$(basename "$0")" "$@"
   exit $?
 fi
 tmpdir=$(mktemp -d -t sequelpro-XXXXXXXXXX)

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -9,11 +9,15 @@
 ## OSTypes: darwin,wsl2
 ## HostBinaryExists: /Applications/TablePlus.app,/Applications/Setapp/TablePlus.app,/mnt/c/Program Files/TablePlus/TablePlus.exe
 
-if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
-  # run this script again with the updated environment
-  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  start_exit_code=$?
+  if [ $start_exit_code -ne 0 ]; then
+    exit $start_exit_code
+  fi
+  # run this script again, as the environment is updated after "ddev start"
+  no_recursion=true ddev "$(basename "$0")" "$@"
   exit $?
 fi
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -12,6 +12,9 @@
 if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
+  # run this script again with the updated environment
+  DDEV_PROJECT_STATUS=running ddev "$(basename "$0")" "$@"
+  exit $?
 fi
 
 dbtype=${DDEV_DBIMAGE%:*}


### PR DESCRIPTION
## The Issue

- #5949

## How This PR Solves The Issue

The simplest way I found, is to restart the database command again after the project is running and all nessesary env variables are available.

I also added the same thing to `ddev launch`.

TODO: add the same thing to official add-ons:

https://github.com/ddev/ddev-phpmyadmin/pull/10
https://github.com/ddev/ddev-adminer/pull/20

## Manual Testing Instructions

```
ddev stop

ddev debug fix-commands

# or any other db command
ddev dbeaver

# the database should open normally
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

