### PR TITLE
feat: accept full URLs in `ddev launch`, fixes #5685

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -330,8 +330,10 @@ func TestLaunchCommand(t *testing.T) {
 	desc, err := app.Describe(false)
 	require.NoError(t, err)
 	cases := map[string]string{
-		"":   app.GetPrimaryURL(),
-		"-m": desc["mailpit_https_url"].(string),
+		"":                       app.GetPrimaryURL(),
+		"-m":                     desc["mailpit_https_url"].(string),
+		"/test":                  app.GetPrimaryURL() + "/test",
+		"https://www.google.com": "https://www.google.com",
 	}
 	if globalconfig.DdevGlobalConfig.MkcertCARoot == "" {
 		cases["-m"] = desc["mailpit_url"].(string)
@@ -342,7 +344,7 @@ func TestLaunchCommand(t *testing.T) {
 		out, err := exec.RunHostCommand("bash", "-c", c)
 		out = strings.Trim(out, "\r\n")
 		assert.NoError(err, `couldn't run "%s"", output=%s`, c, out)
-		assert.Contains(out, expect, "output of %s is incorrect with app.RouterHTTPSPort=%s: %s", c, app.RouterHTTPSPort, out)
+		assert.Equal(out, expect, "output of %s is incorrect with app.RouterHTTPSPort=%s: %s", c, app.RouterHTTPSPort, out)
 	}
 }
 

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -330,10 +330,14 @@ func TestLaunchCommand(t *testing.T) {
 	desc, err := app.Describe(false)
 	require.NoError(t, err)
 	cases := map[string]string{
-		"":                       app.GetPrimaryURL(),
-		"-m":                     desc["mailpit_https_url"].(string),
-		"/test":                  app.GetPrimaryURL() + "/test",
-		"https://www.google.com": "https://www.google.com",
+		"":                             app.GetPrimaryURL(),
+		"-m":                           desc["mailpit_https_url"].(string),
+		"test":                         app.GetPrimaryURL() + "/test",
+		"test/file":                    app.GetPrimaryURL() + "/test/file",
+		"/test":                        app.GetPrimaryURL() + "/test",
+		app.GetPrimaryURL() + "/test":  app.GetPrimaryURL() + "/test",
+		"http://example.com":           "http://example.com",
+		"https://example.com:443/test": "https://example.com:443/test",
 	}
 	if globalconfig.DdevGlobalConfig.MkcertCARoot == "" {
 		cases["-m"] = desc["mailpit_url"].(string)

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -766,6 +766,12 @@ ddev launch --mailpit
 
 # Open your project’s base URL appended with `temp/phpinfo.php`
 ddev launch temp/phpinfo.php
+
+# Open the full URL (any website) in the default browser
+ddev launch https://your.ddev.site
+
+# Open your project’s base URL using a specific port
+ddev launch $DDEV_PRIMARY_URL:3000
 ```
 
 ## `list`

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -50,7 +50,11 @@ if [ -n "${1:-}" ] ; then
     FULLURL="${FULLURL}/";
   fi
 
-  FULLURL="${FULLURL}${1}";
+  if [[ $1 =~ ^https?:// ]]; then
+    FULLURL="${1}";
+  else
+    FULLURL="${FULLURL}${1}";
+  fi
 fi
 
 if [ ! -z ${DDEV_DEBUG:-} ]; then
@@ -72,4 +76,3 @@ case $OSTYPE in
     start ${FULLURL}
     ;;
 esac
-

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -3,7 +3,7 @@
 ## #ddev-generated: If you want to edit and own this file, remove this line.
 ## Description: Launch a browser with the current site
 ## Usage: launch [path] [-m|--mailpit]
-## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php", for Mailpit "ddev launch -m"
+## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php" or "ddev launch https://your.ddev.site" or "ddev launch $DDEV_PRIMARY_URL:3000", for Mailpit "ddev launch -m"
 ## Flags: [{"Name":"mailpit","Shorthand":"m","Usage":"ddev launch -m launches the mailpit UI"}]
 
 if [ "${DDEV_PROJECT_STATUS}" != "running" ]; then


### PR DESCRIPTION
## The Issue

- #5685

## How This PR Solves The Issue

Opens user-defined full URLs, so users are not limited to using `$DDEV_PRIMARY_URL` all the time.

## Manual Testing Instructions

```
DDEV_DEBUG=true ddev launch https://www.google.com
DDEV_DEBUG=true ddev launch https://www.google.com:1234
DDEV_DEBUG=true ddev launch http://example.com
DDEV_DEBUG=true ddev launch $DDEV_PRIMARY_URL/test
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

