### PR TITLE
build: show gitpod testing link in PR comment

### DIFF
--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -49,7 +49,9 @@ jobs:
               return acc;
             }, 'Download the artifacts for this pull request:\n');
 
-            body += `\n\n See [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr)`;
+            body += `\n\n See [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr)` + `.`;
+
+            body += `\n\n You can also [test this PR on Gitpod](https://gitpod.io/?autostart=true#https://github.com/${{context.repo_name}}/pull/${{ github.event.pull_request.number }}` + `.`;
 
             // insert or update a bot comment
             async function upsertComment(owner, repo, issue_number, purpose, body) {

--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -9,6 +9,7 @@ env:
 permissions:
   actions: write
   contents: write
+  pull-requests: write
 jobs:
   pr_comment:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -51,7 +51,7 @@ jobs:
 
             body += `\n\n See [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr)` + `.`;
 
-            body += `\n\n You can also [test this PR on Gitpod](https://gitpod.io/?autostart=true#https://github.com/${{context.repo_name}}/pull/${{ github.event.pull_request.number }}` + `.`;
+            body += `\n\n You can also [test this PR on Gitpod](https://gitpod.io/?autostart=true#https://github.com/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `.`;
 
             // insert or update a bot comment
             async function upsertComment(owner, repo, issue_number, purpose, body) {

--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -55,7 +55,7 @@ jobs:
 
             body += `\n\n See [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr)` + `.`;
 
-            body += `\n\n You can also [test this PR on Gitpod](https://gitpod.io/?autostart=true#https://github.com/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `.`;
+            body += `\n\n You can also [test this PR on Gitpod](https://gitpod.io/?autostart=true#https://github.com/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `).`;
 
             // insert or update a bot comment
             async function upsertComment(owner, repo, issue_number, purpose, body) {

--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -6,6 +6,9 @@ on:
 env:
   HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  actions: write
+  contents: write
 jobs:
   pr_comment:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -59,33 +59,9 @@ jobs:
       - name: Generate artifacts
         run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
-      - name: Upload all artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: all-ddev-executables
-          path: ${{ github.workspace }}/artifacts/*
       - name: Upload macos-amd64 binary
         uses: actions/upload-artifact@v3
         with:
           name: ddev-macos-amd64
           path: .gotmp/bin/darwin_amd64/ddev
-      - name: Upload macos-arm64 binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: ddev-macos-arm64
-          path: .gotmp/bin/darwin_arm64/ddev
-      - name: Upload linux-arm64 binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: ddev-linux-arm64
-          path: .gotmp/bin/linux_arm64/ddev
-      - name: Upload linux-amd64 binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: ddev-linux-amd64
-          path: .gotmp/bin/linux_amd64/ddev
-      - name: Upload windows_amd64 installer
-        uses: actions/upload-artifact@v3
-        with:
-          name: ddev-windows-amd64-installer
-          path: .gotmp/bin/windows_amd64/ddev_windows_installer*.exe
+

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -59,9 +59,33 @@ jobs:
       - name: Generate artifacts
         run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
+      - name: Upload all artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: all-ddev-executables
+          path: ${{ github.workspace }}/artifacts/*
       - name: Upload macos-amd64 binary
         uses: actions/upload-artifact@v3
         with:
           name: ddev-macos-amd64
           path: .gotmp/bin/darwin_amd64/ddev
-
+      - name: Upload macos-arm64 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ddev-macos-arm64
+          path: .gotmp/bin/darwin_arm64/ddev
+      - name: Upload linux-arm64 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ddev-linux-arm64
+          path: .gotmp/bin/linux_arm64/ddev
+      - name: Upload linux-amd64 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ddev-linux-amd64
+          path: .gotmp/bin/linux_amd64/ddev
+      - name: Upload windows_amd64 installer
+        uses: actions/upload-artifact@v3
+        with:
+          name: ddev-windows-amd64-installer
+          path: .gotmp/bin/windows_amd64/ddev_windows_installer*.exe


### PR DESCRIPTION

## The Issue

Gitpod long ago stopped showing its badge in a comment on a PR, but we should be able to do it ourselves. 

## How This PR Solves The Issue

Try to add the comment.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

