### PR TITLE
build: turn off verbose output of make build [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ $(TARGETS): mkcert $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER) GORACE=$(GORACE) CGO_ENABLED=$(CGO_ENABLED)";
 	@#echo "LDFLAGS=$(LDFLAGS)";
 	@rm -f $@
-	export TARGET=$(word 3, $(subst /, ,$@)) && \
+	@export TARGET=$(word 3, $(subst /, ,$@)) && \
 	export GOOS="$${TARGET%_*}" GOARCH="$${TARGET#*_}" GOPATH="$(PWD)/$(GOTMP)" GOCACHE="$(PWD)/$(GOTMP)/.cache" && \
 	mkdir -p $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
 	chmod 777 $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \


### PR DESCRIPTION

## The Issue

For the -race detection tests, I had turned on verbose output of the build in Makefile, but it's not necessary any more

## How This PR Solves The Issue

Turn it off

