### PR TITLE
fix: Revert setting 192.168.5.2 for host.docker.internal on colima, fixes #5537

### DIFF
--- a/docs/content/users/debugging-profiling/step-debugging.md
+++ b/docs/content/users/debugging-profiling/step-debugging.md
@@ -136,7 +136,7 @@ Here are basic steps to take to sort out any difficulty:
 * Check to make sure that Xdebug is enabled. You can use `php -i | grep -i xdebug` inside the container, or use any other technique you want that gives the output of `phpinfo()`, including Drupal’s `admin/reports/status/php`. You should see `with Xdebug v3` and `php -i | grep xdebug.mode` should give you `xdebug.mode => debug,develop => debug,develop"`.
 * Set a breakpoint in the first relevant line of your `index.php` and then visit the site in a browser. It should stop at that first line.
 * If you're using a flavor of IDE that connects directly into the web container like VS Code Language Server, you may want to use the [global `xdebug_ide_location` setting](../configuration/config.md#xdebugidelocation) to explain to DDEV the situation. For example, `ddev config global --xdebug-ide-location=container`, which tells the PHP/Xdebug to connect directly to the listener inside the container.
-* To find out what DDEV is using for the value of `host.docker.internal` you can run `DDEV_DEBUG=true ddev start` and it will explain how it's getting that value, which help troubleshoot some problems. You'll see something like `host.docker.internal=192.168.5.2 because running on Colima` which can explain the usage.
+* To find out what DDEV is using for the value of `host.docker.internal` you can run `DDEV_DEBUG=true ddev start` and it will explain how it's getting that value, which help troubleshoot some problems. You'll see something like `host.docker.internal='' because no other case was discovered` which can explain the usage.
 
 ### WSL2 Xdebug Troubleshooting
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1205,12 +1205,6 @@ func GetHostDockerInternalIP() (string, error) {
 		hostDockerInternal = "127.0.0.1"
 		util.Debug("host.docker.internal=%s because globalconfig.DdevGlobalConfig.XdebugIDELocation=%s", hostDockerInternal, globalconfig.XdebugIDELocationContainer)
 
-	case IsColima():
-		// Lima specifies this as a named explicit IP address at this time
-		// see https://github.com/lima-vm/lima/blob/master/docs/network.md#host-ip-19216852
-		hostDockerInternal = "192.168.5.2"
-		util.Debug("host.docker.internal=%s because running on Colima", hostDockerInternal)
-
 	// Gitpod has Docker 20.10+ so the docker-compose has already gotten the host-gateway
 	case nodeps.IsGitpod():
 		util.Debug("host.docker.internal='%s' because on Gitpod", hostDockerInternal)
@@ -1258,11 +1252,6 @@ func GetNFSServerAddr() (string, error) {
 	nfsAddr := "host.docker.internal"
 
 	switch {
-	case IsColima():
-		// Lima specifies this as a named explicit IP address at this time
-		// see https://github.com/lima-vm/lima/blob/master/docs/network.md#host-ip-19216852
-		nfsAddr = "192.168.5.2"
-
 	// Gitpod has Docker 20.10+ so the docker-compose has already gotten the host-gateway
 	// However, NFS will never be used on Gitpod.
 	case nodeps.IsGitpod():


### PR DESCRIPTION

## The Issue

* #5537

Lima has long since been providing `host.docker.internal` as needed, and colima picks that up, so we don't need to add an override of host.docker.internal any more.

## How This PR Solves The Issue

* Remove the Colima host.docker.internal override (and the override for nfs, which should be irrelevant)
* Update docs so they don't show that as an example

## Manual Testing Instructions

- [x] On colima instance, make sure xdebug works properly

