### PR TITLE
build: use new go-based platform.sh CLI, fixes #4668

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -101,7 +101,7 @@ RUN set -x && set -o pipefail && tag=$(curl -L --fail --silent "https://api.gith
 
 RUN curl -sSL --fail --output /usr/local/bin/phive "https://phar.io/releases/phive.phar" && chmod 777 /usr/local/bin/phive
 RUN set -o pipefail && curl --fail -sSL https://github.com/pantheon-systems/terminus/releases/download/$(curl -L --fail --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output /usr/local/bin/terminus && chmod 777 /usr/local/bin/terminus
-RUN set -o pipefail && curl --fail -sSL https://github.com/platformsh/platformsh-cli/releases/download/$(curl -L --fail --silent "https://api.github.com/repositories/16695539/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/platform.phar --output /usr/local/bin/platform && chmod 777 /usr/local/bin/platform
+RUN set -o pipefail && curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | bash
 
 # Install upsun cli
 RUN set -o pipefail && tag=$(curl -L --fail --silent "https://api.github.com/repos/platformsh/cli/releases/latest" | jq -r .tag_name) && curl --fail -sSL "https://github.com/platformsh/cli/releases/download/${tag}/upsun_${tag}_linux_${TARGETPLATFORM##linux/}.tar.gz" -o /tmp/upsun.tar.gz && tar -zx -C /usr/local/bin -f /tmp/upsun.tar.gz upsun && rm /tmp/upsun.tar.gz

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -15,7 +15,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240305_stasadev_remove_kill_supervisor" // Note that this can be overridden by make
+var WebTag = "20240320_new_platform_cli" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

* #4668

Previous attempt last summer was https://github.com/ddev/ddev/pull/5044

## How This PR Solves The Issue

New ddev-webserver image with the go-based platform binary

## Manual Testing Instructions

* Try `ddev pull platform`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

