### PR TITLE
fix: alphabetize global config storage and output, fixes #5046

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -260,32 +260,6 @@ func handleGlobalConfig(cmd *cobra.Command, _ []string) {
 			util.Failed("Failed to write global config: %v", err)
 		}
 	}
-
-	v := reflect.ValueOf(globalconfig.DdevGlobalConfig)
-	typeOfVal := v.Type()
-
-	keys := make([]string, 0, v.NumField())
-	valMap := map[string]string{}
-	for i := 0; i < v.NumField(); i++ {
-		tag := typeOfVal.Field(i).Tag.Get("yaml")
-		parts := strings.Split(tag, ",")
-		tag = parts[0]
-		//name := typeOfVal.Field(i).Name
-		fieldValue := v.Field(i).Interface()
-		if tag != "build info" && tag != "web_environment" && tag != "project_info" && tag != "remote_config" && tag != "messages" {
-			tagWithDashes := strings.Replace(tag, "_", "-", -1)
-			valMap[tagWithDashes] = fmt.Sprintf("%v", fieldValue)
-			keys = append(keys, tagWithDashes)
-		}
-	}
-	sort.Strings(keys)
-	if !output.JSONOutput {
-		for _, label := range keys {
-			output.UserOut.Printf("%s=%v", label, valMap[label])
-		}
-	} else {
-		output.UserOut.WithField("raw", valMap).Println("")
-	}
 }
 
 func init() {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -80,6 +80,7 @@ type WebExtraDaemon struct {
 type DdevApp struct {
 	Name                      string                 `yaml:"name"`
 	Type                      string                 `yaml:"type"`
+	AppRoot                   string                 `yaml:"-"`
 	Docroot                   string                 `yaml:"docroot"`
 	PHPVersion                string                 `yaml:"php_version"`
 	WebserverType             string                 `yaml:"webserver_type"`
@@ -98,7 +99,6 @@ type DdevApp struct {
 	BindAllInterfaces         bool                   `yaml:"bind_all_interfaces,omitempty"`
 	FailOnHookFailGlobal      bool                   `yaml:"-"`
 	ConfigPath                string                 `yaml:"-"`
-	AppRoot                   string                 `yaml:"-"`
 	DataDir                   string                 `yaml:"-"`
 	SiteSettingsPath          string                 `yaml:"-"`
 	SiteDdevSettingsFile      string                 `yaml:"-"`

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -42,39 +42,39 @@ type ProjectInfo struct {
 
 // GlobalConfig is the struct defining ddev's global config
 type GlobalConfig struct {
-	OmitContainersGlobal             []string                    `yaml:"omit_containers,flow"`
-	PerformanceMode                  configTypes.PerformanceMode `yaml:"performance_mode"`
+	DeveloperMode                    bool                        `yaml:"developer_mode,omitempty"`
+	DisableHTTP2                     bool                        `yaml:"disable_http2"`
+	FailOnHookFailGlobal             bool                        `yaml:"fail_on_hook_fail"`
 	InstrumentationOptIn             bool                        `yaml:"instrumentation_opt_in"`
 	InstrumentationQueueSize         int                         `yaml:"instrumentation_queue_size,omitempty"`
 	InstrumentationReportingInterval time.Duration               `yaml:"instrumentation_reporting_interval,omitempty"`
-	RouterBindAllInterfaces          bool                        `yaml:"router_bind_all_interfaces"`
-	InternetDetectionTimeout         int64                       `yaml:"internet_detection_timeout_ms"`
-	DeveloperMode                    bool                        `yaml:"developer_mode,omitempty"`
 	InstrumentationUser              string                      `yaml:"instrumentation_user,omitempty"`
+	InternetDetectionTimeout         int64                       `yaml:"internet_detection_timeout_ms"`
 	LastStartedVersion               string                      `yaml:"last_started_version"`
-	UseHardenedImages                bool                        `yaml:"use_hardened_images"`
-	UseLetsEncrypt                   bool                        `yaml:"use_letsencrypt"`
 	LetsEncryptEmail                 string                      `yaml:"letsencrypt_email"`
-	FailOnHookFailGlobal             bool                        `yaml:"fail_on_hook_fail"`
-	WebEnvironment                   []string                    `yaml:"web_environment"`
-	DisableHTTP2                     bool                        `yaml:"disable_http2"`
-	TableStyle                       string                      `yaml:"table_style"`
-	SimpleFormatting                 bool                        `yaml:"simple_formatting"`
-	RequiredDockerComposeVersion     string                      `yaml:"required_docker_compose_version,omitempty"`
-	UseDockerComposeFromPath         bool                        `yaml:"use_docker_compose_from_path,omitempty"`
+	Messages                         MessagesConfig              `yaml:"messages,omitempty"`
 	MkcertCARoot                     string                      `yaml:"mkcert_caroot"`
-	ProjectTldGlobal                 string                      `yaml:"project_tld"`
-	XdebugIDELocation                string                      `yaml:"xdebug_ide_location"`
 	NoBindMounts                     bool                        `yaml:"no_bind_mounts"`
+	OmitContainersGlobal             []string                    `yaml:"omit_containers,flow"`
+	PerformanceMode                  configTypes.PerformanceMode `yaml:"performance_mode"`
+	ProjectTldGlobal                 string                      `yaml:"project_tld"`
+	RemoteConfig                     RemoteConfig                `yaml:"remote_config,omitempty"`
+	RequiredDockerComposeVersion     string                      `yaml:"required_docker_compose_version,omitempty"`
 	Router                           string                      `yaml:"router"`
-	TraefikMonitorPort               string                      `yaml:"traefik_monitor_port,omitempty"`
-	WSL2NoWindowsHostsMgt            bool                        `yaml:"wsl2_no_windows_hosts_mgt"`
+	RouterBindAllInterfaces          bool                        `yaml:"router_bind_all_interfaces"`
 	RouterHTTPPort                   string                      `yaml:"router_http_port"`
 	RouterHTTPSPort                  string                      `yaml:"router_https_port"`
 	RouterMailpitHTTPPort            string                      `yaml:"mailpit_http_port,omitempty"`
 	RouterMailpitHTTPSPort           string                      `yaml:"mailpit_https_port,omitempty"`
-	Messages                         MessagesConfig              `yaml:"messages,omitempty"`
-	RemoteConfig                     RemoteConfig                `yaml:"remote_config,omitempty"`
+	SimpleFormatting                 bool                        `yaml:"simple_formatting"`
+	TableStyle                       string                      `yaml:"table_style"`
+	TraefikMonitorPort               string                      `yaml:"traefik_monitor_port,omitempty"`
+	UseDockerComposeFromPath         bool                        `yaml:"use_docker_compose_from_path,omitempty"`
+	UseHardenedImages                bool                        `yaml:"use_hardened_images"`
+	UseLetsEncrypt                   bool                        `yaml:"use_letsencrypt"`
+	WSL2NoWindowsHostsMgt            bool                        `yaml:"wsl2_no_windows_hosts_mgt"`
+	WebEnvironment                   []string                    `yaml:"web_environment"`
+	XdebugIDELocation                string                      `yaml:"xdebug_ide_location"`
 	ProjectList                      map[string]*ProjectInfo     `yaml:"project_info"`
 }
 


### PR DESCRIPTION
## The Issue

* #5046 

Mostly all the work was done in 
* https://github.com/ddev/ddev/pull/6002

This still reorganizes the actual global_config.yaml.

This should just be cosmetic. I find it nearly impossible to parse `ddev config global` right now, this alphabetizes it.

In DdevApp, the Approot is moved up so I can see it in the debugger without breaking my eyes. Should have no effect on user.


