### PR TITLE
fix: make `ddev launch` test work on Windows, for #5986

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -330,14 +330,20 @@ func TestLaunchCommand(t *testing.T) {
 	desc, err := app.Describe(false)
 	require.NoError(t, err)
 	cases := map[string]string{
-		"":                             app.GetPrimaryURL(),
-		"-m":                           desc["mailpit_https_url"].(string),
-		"test":                         app.GetPrimaryURL() + "/test",
-		"test/file":                    app.GetPrimaryURL() + "/test/file",
-		"/test":                        app.GetPrimaryURL() + "/test",
-		app.GetPrimaryURL() + "/test":  app.GetPrimaryURL() + "/test",
-		"http://example.com":           "http://example.com",
-		"https://example.com:443/test": "https://example.com:443/test",
+		"":                                 app.GetPrimaryURL(),
+		"-m":                               desc["mailpit_https_url"].(string),
+		"path":                             app.GetPrimaryURL() + "/path",
+		"nested/path":                      app.GetPrimaryURL() + "/nested/path",
+		"/path-with-slash":                 app.GetPrimaryURL() + "/path-with-slash",
+		app.GetPrimaryURL() + "/full-path": app.GetPrimaryURL() + "/full-path",
+		"http://example.com":               "http://example.com",
+		"https://example.com:443/test":     "https://example.com:443/test",
+	}
+	if runtime.GOOS == "windows" {
+		// Git-Bash converts single forward slashes to a Windows path
+		// Escape it with a second slash, see https://stackoverflow.com/q/58677021
+		cases["//path-with-slash"] = app.GetPrimaryURL() + "/path-with-slash"
+		delete(cases, "/path-with-slash")
 	}
 	if globalconfig.DdevGlobalConfig.MkcertCARoot == "" {
 		cases["-m"] = desc["mailpit_url"].(string)


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/5986#issuecomment-2010306973

## How This PR Solves The Issue

Fixes a test, changes the path in the test cases to make it clear which one failed.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

