### PR TITLE
docs: Fix "webimage_extra_packages" code example

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -10,7 +10,7 @@ It’s common to have a requirement for the `web` or `db` images which isn’t b
 You can add extra Debian packages with lines like this in `.ddev/config.yaml`:
 
 ```yaml
-webimage_extra_packages: [php${DDEV_PHP_VERSION}-yaml, php${DDEV_PHP_VERSION}-tidy]
+webimage_extra_packages: ["php${DDEV_PHP_VERSION}-yaml", "php${DDEV_PHP_VERSION}-tidy"]
 dbimage_extra_packages: [telnet, netcat, sudo]
 ```
 
@@ -20,7 +20,7 @@ Then the additional packages will be built into the containers during [`ddev sta
 
 ### PHP Extensions supported by `deb.sury.org`
 
-If a PHP extension is supported by the upstream package management from `deb.sury.org`, you'll be able to add it with minimal effort. Test to see if it's available using `ddev exec 'sudo apt update && sudo apt install php${DDEV_PHP_VERSION}-<extension>'`, for example, `ddev exec 'sudo apt update && sudo apt install php${DDEV_PHP_VERSION}-imap'`. If that works, then the extension is supported, and you can add `webimage_extra_packages: [php${DDEV_PHP_VERSION}-<extension>]` to your `.ddev/config.yaml` file.
+If a PHP extension is supported by the upstream package management from `deb.sury.org`, you'll be able to add it with minimal effort. Test to see if it's available using `ddev exec 'sudo apt update && sudo apt install php${DDEV_PHP_VERSION}-<extension>'`, for example, `ddev exec 'sudo apt update && sudo apt install php${DDEV_PHP_VERSION}-imap'`. If that works, then the extension is supported, and you can add `webimage_extra_packages: ["php${DDEV_PHP_VERSION}-<extension>"]` to your `.ddev/config.yaml` file.
 
 ### PECL PHP Extensions not supported by `deb.sury.org`
 


### PR DESCRIPTION
## The Issue

When I copied the original code into my config, the project did not start and I recieved the following error:

```shell
 ddev restart 
Failed to get project(s): /home/user13/code/drupal/modules/iq_ldap/.ddev/config.yaml exists but cannot be read. It may be invalid due to a syntax error: unable to load config file /home/user13/code/drupal/modules/iq_ldap/.ddev/config.yaml: invalid configuration in /home/user13/code/drupal/modules/iq_ldap/.ddev/config.yaml: yaml: line 14: did not find expected ',' or ']'
```

## How This PR Solves The Issue

This PR updates the doc to resolve this.

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

