### PR TITLE
test: minor updates to buildkite testbot_maintenance.sh [skip ci]

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -27,19 +27,20 @@ fi
 # Upgrade various items on various operating systems
 case $os in
 darwin)
+    brew upgrade
     for item in ddev/ddev/ddev golang golangci-lint libpq mkcert mkdocs; do
-        brew upgrade $item || brew install $item || true
+        brew install $item || true
     done
     brew link --force libpq
     ;;
 windows)
     (yes | choco upgrade -y golang nodejs markdownlint-cli mkcert mkdocs postgresql) || true
     ;;
-# linux is currently WSL2
+# linux is currently WSL2 only
 linux)
     # homebrew is only on amd64
     if [ "$(arch)" = "x86_64" ]; then
-      for item in libpq mkcert mkdocs; do
+      for item in libpq mkdocs; do
         brew upgrade $item || brew install $item || true
       done
       brew link --force libpq

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -27,6 +27,7 @@ fi
 # Upgrade various items on various operating systems
 case $os in
 darwin)
+    brew pin buildkite-agent
     brew upgrade
     for item in ddev/ddev/ddev golang golangci-lint libpq mkcert mkdocs; do
         brew install $item || true


### PR DESCRIPTION

## The Issue

I noticed in https://github.com/ddev/maintainer-info/issues/1#issuecomment-2015447823 that brew stuff wasn't getting generally updated

## How This PR Solves The Issue

* do `brew upgrade` on macOS instead of just doing a few packages
* In WSL2 we don't need mkcert because it's installed as dependency by ddev

The possible downside is that when buildkite-agent gets upgraded it may have the popups that prevent execution asking permissions.