### PR TITLE
feat: add PR build link to test on Codespaces [skip ci]

### DIFF
--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -55,7 +55,8 @@ jobs:
 
             body += `\n\n See [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr)` + `.`;
 
-            body += `\n\n You can also [test this PR on Gitpod](https://gitpod.io/?autostart=true#https://github.com/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `).`;
+            body += `\n\n* [Test on Gitpod](https://gitpod.io/?autostart=true#https://github.com/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `).`;
+            body += `\n* [Test on GitHub Codespaces](https://codespaces.new/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `).`;
 
             // insert or update a bot comment
             async function upsertComment(owner, repo, issue_number, purpose, body) {


### PR DESCRIPTION

## The Issue

We now provide a link on PRs to test in gitpod.. Why not codespaces also?

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

