### PR TITLE
feat: provide corepack_enable config, fixes #5987, replaces #5988

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -308,6 +308,7 @@ func init() {
 	ConfigCommand.Flags().Int("default-container-timeout", 120, `default time in seconds that DDEV waits for all containers to become ready on start`)
 	ConfigCommand.Flags().Bool("disable-upload-dirs-warning", true, `Disable warnings about upload-dirs not being set when using performance-mode=mutagen.`)
 	ConfigCommand.Flags().StringVar(&ddevVersionConstraint, "ddev-version-constraint", "", `Specify a ddev version constraint to validate ddev against.`)
+	ConfigCommand.Flags().Bool("corepack-enable", true, `Do 'corepack enable' to enable latest yarn/pnpm'`)
 
 	RootCmd.AddCommand(ConfigCommand)
 
@@ -645,6 +646,10 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 
 	if cmd.Flag("disable-upload-dirs-warning").Changed {
 		app.DisableUploadDirsWarning, _ = cmd.Flags().GetBool("disable-upload-dirs-warning")
+	}
+
+	if cmd.Flag("corepack-enable").Changed {
+		app.CorepackEnable, _ = cmd.Flags().GetBool("corepack-enable")
 	}
 
 	if webserverTypeArg != "" {

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -93,7 +93,7 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 # Make sure the TERMINUS_CACHE_DIR (/mnt/ddev-global-cache/terminus/cache) exists
 sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
-sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry}
+sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry,corepack}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 # The following ensures a persistent and shared "global" cache for
 # yarn1 (classic) and yarn2 (berry). In the case of yarn2, the global cache

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -90,7 +90,7 @@ disable_xhprof
 
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)
 
-mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry}
+mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry,corepack}
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ~/.nvm
 if [ ! -f ~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -84,11 +84,21 @@ The relative path, from the project root, to the directory containing `composer.
 
 ## `composer_version`
 
-Composer version for the web container and the [`ddev composer`](../usage/commands.md#composer) command.
+Composer version for the web container and the [`ddev composer`](../usage/commands.md#composer) command._
 
 | Type | Default | Usage
 | -- | -- | --
 | :octicons-file-directory-16: project | `2` | Can be `2`, `1`, or empty (`""`) for latest major version at container build time.<br><br>Can also be a minor version like `2.2` for the latest release of that branch, an explicit version like `1.0.22`, or a keyword like `stable`, `preview` or `snapshot`. See Composer documentation.
+
+## `corepack_enable`
+
+Whether to `corepack enable` on Node.js configuration.
+
+| Type | Default | Usage
+| -- | -- | --
+| :octicons-file-directory-16: project | `false` | Can be `true` or `false`.
+
+When `true`, `corepack_enable` will be executed, making latest `yarn` and `pnpm` package managers available.
 
 ## `database`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -84,7 +84,7 @@ The relative path, from the project root, to the directory containing `composer.
 
 ## `composer_version`
 
-Composer version for the web container and the [`ddev composer`](../usage/commands.md#composer) command._
+Composer version for the web container and the [`ddev composer`](../usage/commands.md#composer) command.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1447,7 +1447,10 @@ ddev xhprof off
 Run [`yarn` commands](https://yarnpkg.com/cli) inside the web container in the root of the project (global shell host container command).
 
 !!!tip
-    Use `--cwd` for another directory.
+    Use `--cwd` for another directory, or you can change directories to the desired directory and `ddev yarn` will act on the same relative directory inside the container.
+
+!!!tip
+    If you want latest yarn versions, set `corepack_enable: true` in `.ddev/config.yaml` or `ddev config --corepack-enable`
 
 Example:
 
@@ -1458,6 +1461,14 @@ ddev yarn install
 # Use Yarn to add the Lerna package
 ddev yarn add lerna
 
+# Use yarn in a relative directory
+cd web/core && ddev yarn add lerna
+
 # Use Yarn to add the Lerna package from the `web/core` directory
 ddev yarn --cwd web/core add lerna
+
+# Use latest yarn or specified yarn
+ddev config --corepack-enabled && ddev restart
+ddev yarn set version stable
+ddev -yarn --version
 ```

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1450,7 +1450,7 @@ Run [`yarn` commands](https://yarnpkg.com/cli) inside the web container in the r
     Use `--cwd` for another directory, or you can change directories to the desired directory and `ddev yarn` will act on the same relative directory inside the container.
 
 !!!tip
-    If you want latest yarn versions, set `corepack_enable: true` in `.ddev/config.yaml` or `ddev config --corepack-enable`
+    If you want to define your Yarn version on a per project basis, set `corepack_enable: true` in `.ddev/config.yaml` or `ddev config --corepack-enable`
 
 Example:
 
@@ -1468,7 +1468,7 @@ cd web/core && ddev yarn add lerna
 ddev yarn --cwd web/core add lerna
 
 # Use latest yarn or specified yarn
-ddev config --corepack-enabled && ddev restart
+ddev config --corepack-enable && ddev restart
 ddev yarn set version stable
-ddev -yarn --version
+ddev yarn --version
 ```

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -170,6 +170,7 @@ services:
     {{ end }}
     environment:
     - COLUMNS
+    - COREPACK_HOME=/mnt/ddev-global-cache/corepack
     - DOCROOT=${DDEV_DOCROOT}
     - DDEV_COMPOSER_ROOT
     - DDEV_DATABASE

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -939,7 +939,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		extraWebContent = extraWebContent + "\nRUN npm install -g n"
 		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN n install %s && ln -sf /usr/local/bin/node /usr/local/bin/nodejs", app.NodeJSVersion)
 	}
-	if app.CorepackEnabled && app.NodeJSVersion >= "18" {
+	if app.CorepackEnable && app.NodeJSVersion >= "18" {
 		extraWebContent = extraWebContent + "\nRUN corepack enable"
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -939,7 +939,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		extraWebContent = extraWebContent + "\nRUN npm install -g n"
 		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN n install %s && ln -sf /usr/local/bin/node /usr/local/bin/nodejs", app.NodeJSVersion)
 	}
-	if app.CorepackEnable && app.NodeJSVersion >= "18" {
+	if app.CorepackEnable {
 		extraWebContent = extraWebContent + "\nRUN corepack enable"
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -939,6 +939,9 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		extraWebContent = extraWebContent + "\nRUN npm install -g n"
 		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN n install %s && ln -sf /usr/local/bin/node /usr/local/bin/nodejs", app.NodeJSVersion)
 	}
+	if app.CorepackEnabled && app.NodeJSVersion >= "18" {
+		extraWebContent = extraWebContent + "\nRUN corepack enable"
+	}
 
 	// Some installed packages can change the permissions of /run/php
 	// First seen in Debian 12 Bookworm

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -127,6 +127,7 @@ type DdevApp struct {
 	DisableSettingsManagement bool                   `yaml:"disable_settings_management,omitempty"`
 	WebEnvironment            []string               `yaml:"web_environment"`
 	NodeJSVersion             string                 `yaml:"nodejs_version,omitempty"`
+	CorepackEnabled           bool                   `yaml:"corepack_enabled"`
 	DefaultContainerTimeout   string                 `yaml:"default_container_timeout,omitempty"`
 	WebExtraExposedPorts      []WebExposedPort       `yaml:"web_extra_exposed_ports,omitempty"`
 	WebExtraDaemons           []WebExtraDaemon       `yaml:"web_extra_daemons,omitempty"`

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -127,7 +127,7 @@ type DdevApp struct {
 	DisableSettingsManagement bool                   `yaml:"disable_settings_management,omitempty"`
 	WebEnvironment            []string               `yaml:"web_environment"`
 	NodeJSVersion             string                 `yaml:"nodejs_version,omitempty"`
-	CorepackEnabled           bool                   `yaml:"corepack_enabled"`
+	CorepackEnable            bool                   `yaml:"corepack_enable"`
 	DefaultContainerTimeout   string                 `yaml:"default_container_timeout,omitempty"`
 	WebExtraExposedPorts      []WebExposedPort       `yaml:"web_extra_exposed_ports,omitempty"`
 	WebExtraDaemons           []WebExtraDaemon       `yaml:"web_extra_daemons,omitempty"`

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -72,3 +72,59 @@ func TestNodeJSVersions(t *testing.T) {
 	assert.Contains(out, "v8.17")
 
 }
+
+// TestCorepackEnable tests behavior of corepack_enable
+func TestCorepackEnable(t *testing.T) {
+	assert := asrt.New(t)
+
+	site := TestSites[0]
+	origDir, _ := os.Getwd()
+	_ = os.Chdir(site.Dir)
+
+	runTime := util.TimeTrackC(t.Name())
+
+	testcommon.ClearDockerEnv()
+	app, err := ddevapp.NewApp(site.Dir, true)
+	assert.NoError(err)
+	t.Cleanup(func() {
+		runTime()
+		_ = os.Chdir(origDir)
+		_ = app.Restart()
+	})
+
+	err = app.Start()
+	require.NoError(t, err)
+
+	app.CorepackEnable = false
+	err = app.Start()
+	require.NoError(t, err)
+	out, _, err := app.Exec(&ddevapp.ExecOpts{
+		Cmd: `ls -l /usr/bin/yarn`,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, out, "corepack")
+	out, _, err = app.Exec(&ddevapp.ExecOpts{
+		Cmd: `yarn --version`,
+	})
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(out, "1."))
+
+	app.CorepackEnable = true
+	err = app.Start()
+	require.NoError(t, err)
+	out, _, err = app.Exec(&ddevapp.ExecOpts{
+		Cmd: `ls -l /usr/bin/yarn`,
+	})
+	require.NoError(t, err)
+	require.Contains(t, out, "corepack")
+	out, _, err = app.Exec(&ddevapp.ExecOpts{
+		Cmd: `yarn set version stable`,
+	})
+	require.NoError(t, err)
+
+	out, _, err = app.Exec(&ddevapp.ExecOpts{
+		Cmd: `yarn --version`,
+	})
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(out, "4."))
+}

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -117,7 +117,7 @@ func TestCorepackEnable(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Contains(t, out, "corepack")
-	out, _, err = app.Exec(&ddevapp.ExecOpts{
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Cmd: `yarn set version stable`,
 	})
 	require.NoError(t, err)

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -73,6 +73,9 @@ const ConfigInstructions = `
 # Note that you can continue using 'ddev nvm' or nvm inside the web container
 # to change the project's installed node version if you need to.
 
+# corepack_enable: false
+# Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
+
 # additional_hostnames:
 #  - somename
 #  - someothername

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240321_stasadev_platform" // Note that this can be overridden by make
+var WebTag = "20240324_corepack_config" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

* #5987
* Replaces #5988

## How This PR Solves The Issue

* New `corepack_enable` config for .ddev/config.yaml
* New `ddev config --corepack-enable`
* docs
* TestCorepackEnable

## TODO

- [x] Set COREPACK_HOME to point to /mnt/ddev-global-cache/corepack

## Manual Testing Instructions

* Use `ddev config --corepack-enable=true` and false (restart after)
* Review docs

## Automated Testing Overview

* TestCorepackEnable

