### PR TITLE
build: bump docker-compose to v2.26.0

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -39,4 +39,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.17.2"
 
-const RequiredDockerComposeVersionDefault = "v2.25.0"
+const RequiredDockerComposeVersionDefault = "v2.26.0"


### PR DESCRIPTION
## The Issue

https://github.com/docker/compose/releases/tag/v2.26.0

## How This PR Solves The Issue

Updates docker-compose to v2.26.0

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

