### PR TITLE
fix: make TestCmdDebugTest work on trad Windows

### DIFF
--- a/cmd/ddev/cmd/debug-test_test.go
+++ b/cmd/ddev/cmd/debug-test_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/exec"
@@ -18,8 +19,6 @@ func TestCmdDebugTest(t *testing.T) {
 	err := os.Chdir(site.Dir)
 	require.NoError(t, err)
 
-	//app, err := ddevapp.NewApp(site.Dir, true)
-
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err = os.Chdir(origDir)
@@ -33,5 +32,7 @@ func TestCmdDebugTest(t *testing.T) {
 	// This is just a casual look at the output, not intended to look for all details.
 	require.Contains(t, out, "OS Information")
 	require.Contains(t, out, "webserver_type:")
-	require.Contains(t, out, "PING dkdkd.ddev.site")
+	if runtime.GOOS != "windows" {
+		require.Contains(t, out, "PING dkdkd.ddev.site")
+	}
 }


### PR DESCRIPTION

## The Issue

A recent PR had a test that didn't pass on traditional Windows through no fault of its own.

* https://github.com/ddev/ddev/pull/6002

## How This PR Solves The Issue

Don't do the thing that causes the failure.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

