### PR TITLE
docs: clarify additional compose service configuration

### DIFF
--- a/docs/content/users/extend/custom-compose-files.md
+++ b/docs/content/users/extend/custom-compose-files.md
@@ -52,7 +52,7 @@ To better understand how DDEV parses your custom docker-compose files, run `ddev
 
 When defining additional services for your project, we recommended following these conventions to ensure DDEV handles your service the same way DDEV handles default services.
 
-* The container name should be `ddev-${DDEV_SITENAME}-<servicename>`.
+* The container name should be `ddev-${DDEV_SITENAME}-<servicename>`. This ensures the auto-generated [traefik routing configuration](./traefik-router.md#project-traefik-configuration) matches your custom service.
 * Provide containers with required labels:
 
     ```yaml
@@ -67,7 +67,7 @@ When defining additional services for your project, we recommended following the
 
     * To expose a web interface to be accessible over HTTP, define the following environment variables in the `environment` section for docker-compose:
 
-        * `VIRTUAL_HOST=$DDEV_HOSTNAME`
+        * `VIRTUAL_HOST=$DDEV_HOSTNAME` You can also specify an arbitrary hostname like `VIRTUAL_HOST=extra.ddev.site`.
         * `HTTP_EXPOSE=portNum` The `hostPort:containerPort` convention may be used here to expose a container’s port to a different external port. To expose multiple ports for a single container, define the ports as comma-separated values.
         * `HTTPS_EXPOSE=<exposedPortNumber>:portNum` This will expose an HTTPS interface on `<exposedPortNumber>` to the host (and to the `web` container) as `https://<project>.ddev.site:exposedPortNumber`. To expose multiple ports for a single container, use comma-separated definitions, as in `HTTPS_EXPOSE=9998:80,9999:81`, which would expose HTTP port 80 from the container as `https://<project>.ddev.site:9998` and HTTP port 81 from the container as `https://<project>.ddev.site:9999`.
 

--- a/docs/content/users/extend/custom-compose-files.md
+++ b/docs/content/users/extend/custom-compose-files.md
@@ -50,9 +50,9 @@ To better understand how DDEV parses your custom docker-compose files, run `ddev
 
 ## Conventions for Defining Additional Services
 
-When defining additional services for your project, we recommended following these conventions to ensure DDEV handles your service the same way DDEV handles default services.
+When defining additional services for your project, we recommend following these conventions to ensure DDEV handles your service the same way DDEV handles default services.
 
-* The container name should be `ddev-${DDEV_SITENAME}-<servicename>`. This ensures the auto-generated [traefik routing configuration](./traefik-router.md#project-traefik-configuration) matches your custom service.
+* The container name should be `ddev-${DDEV_SITENAME}-<servicename>`. This ensures the auto-generated [Traefik routing configuration](./traefik-router.md#project-traefik-configuration) matches your custom service.
 * Provide containers with required labels:
 
     ```yaml


### PR DESCRIPTION
## The Issue
We made the mistake, of naming the container differently from the service, and thus not being able to access the service. We somehow overlooked the part about the container name. Also we wanted to have a different hostname and did not know if we have to set `VIRTUAL_HOST=$DDEV_HOSTNAME` or if this has side effects. If everything is configured correctly we can expose a completely different service on an arbitrary hostname.

## How This PR Solves The Issue
I've clarified the wording. I mention traefik in the hostname conventions to explain why this is needed for smooth operations.
I've added an example in the VIRTUAL_HOST part to show what would be possible there. (hostname taken from a [ddev test](https://github.com/ddev/ddev/blob/v1.22.7/pkg/ddevapp/testdata/TestTraefikVirtualHost/docker-compose.extra.yaml#L12))

Maybe it would be sensible to add a note to https://ddev.readthedocs.io/en/stable/users/extend/additional-hostnames/ and mention the ability to set arbitrary hostnames for custom services besides the `web` service.