### PR TITLE
feat: add pint command to laravel projects

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -249,7 +249,7 @@ func TestCustomCommands(t *testing.T) {
 	_, _ = exec.RunHostCommand(DdevBin)
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
-	for _, c := range []string{"artisan"} {
+	for _, c := range []string{"artisan", "pint"} {
 		_, err = exec.RunHostCommand(DdevBin, "help", c)
 		assert.NoError(err)
 	}

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/pint
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/pint
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#ddev-generated
+## Description: Run Pint inside the web container
+## Usage: pint [flags] [args]
+## Example: "ddev pint --dirty" for fixing your current changes lint errors or "ddev pint --test app/Models" for only analyzing your models without autofix. 
+## ProjectTypes: laravel
+
+./vendor/bin/pint "$@"
+

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/pint
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/pint
@@ -6,5 +6,10 @@
 ## Example: "ddev pint --dirty" for fixing your current changes lint errors or "ddev pint --test app/Models" for only analyzing your models without autofix. 
 ## ProjectTypes: laravel
 
-./vendor/bin/pint "$@"
+if ! command -v pint >/dev/null; then
+  echo "pint is not available. You may need to 'ddev composer require laravel/pint'"
+  exit 1
+fi
+
+pint "$@"
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

Laravel includes its own linter, pint, which is installed by default with 11.x

## How This PR Solves The Issue

Adds the pint shortcut command.

## Manual Testing Instructions

I've tested this on Gitpod:

* Clean the Drupal test data first:

```
ddev delete -Oy d10simple
rm d10simple/ -rf
```

* Create a laravel project:

```
mkdir laravel
cd laravel/
ddev config --project-type=laravel --docroot=public --php-version=8.2
ddev start
``` 

* As you didn't install laravel yet,  `pint` should fail with instructions to install:

```
ddev pint
```

* Install laravel:

```
ddev composer create --prefer-dist laravel/laravel:^11
```

* Now `ddev pint` should succeed:

```
ddev pint
```

* And you will see

```
PASS   26 files  
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
Added a test verifying the command is added to Laravel projects.

Run the individual test with `go test -v -run TestCustomCommands ./cmd/ddev/cmd/`

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

