### PR TITLE
fix: rsync example should create db.sql.gz [skip ci]

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/rsync.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/rsync.yaml.example
@@ -31,7 +31,7 @@ db_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
-    rsync -az "${dburl}" /var/www/html/.ddev/.downloads
+    rsync -az "${dburl}" /var/www/html/.ddev/.downloads/db.sql.gz
   service: web
 
 files_pull_command:


### PR DESCRIPTION

## The Issue

* https://discord.com/channels/664580571770388500/1220763081211121674/1220763081211121674

It was pointed out that if the rsync provider brings down a file as a name other than db.sql.gz, the database gets created with the filename.

This is by design, https://github.com/ddev/ddev/blob/834a772de230c042c4d2d596482c699d0b83ba24/pkg/ddevapp/provider.go#L364-L374

But not useful when the rsync example doesn't explicitly control it.

## How This PR Solves The Issue

Change the rsync example to explicitly name the dump file as db.sql.gz

I checked the other examples and integrations and don't find any other example of this ambiguity.

## Manual Testing Instructions

Try out this `.ddev/providers/rsync.yaml`:
```yaml
environment_variables:
  dburl: rfay@jumphost.thefays.us:~/tmp/xyz.sql.gz

auth_command:
  command: |
    set -eu -o pipefail
    ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )

db_pull_command:
  command: |
    # set -x   # You can enable bash debugging output by uncommenting
    set -eu -o pipefail
    rsync -az "${dburl}" /var/www/html/.ddev/.downloads/db.sql.gz
  service: web
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

