### PR TITLE
feat: accept port in `ddev launch`, for #5525

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -350,6 +350,8 @@ func TestLaunchCommand(t *testing.T) {
 		"nested/path":                      app.GetPrimaryURL() + "/nested/path",
 		"/path-with-slash":                 app.GetPrimaryURL() + "/path-with-slash",
 		app.GetPrimaryURL() + "/full-path": app.GetPrimaryURL() + "/full-path",
+		"http://example.com":               "http://example.com",
+		"https://example.com:443/test":     "https://example.com:443/test",
 		":8080":                            desc["httpurl"].(string),
 		":8080/http-port-path":             desc["httpurl"].(string) + "/http-port-path",
 		":8443":                            desc["httpsurl"].(string),
@@ -357,10 +359,8 @@ func TestLaunchCommand(t *testing.T) {
 		":18025":                           "http://" + app.GetHostname() + ":18025",
 		":18026":                           "https://" + app.GetHostname() + ":18026",
 		// if it is impossible to determine the http/https scheme, the default site protocol should be used
-		":3000":                        primaryURLWithoutPort + ":3000",
-		":3000/with-default-scheme":    "https://" + app.GetHostname() + ":3000/with-default-scheme",
-		"http://example.com":           "http://example.com",
-		"https://example.com:443/test": "https://example.com:443/test",
+		":3000":                     primaryURLWithoutPort + ":3000",
+		":3000/with-default-scheme": "https://" + app.GetHostname() + ":3000/with-default-scheme",
 	}
 	if runtime.GOOS == "windows" {
 		// Git-Bash converts single forward slashes to a Windows path
@@ -368,8 +368,9 @@ func TestLaunchCommand(t *testing.T) {
 		cases["//path-with-slash"] = app.GetPrimaryURL() + "/path-with-slash"
 		delete(cases, "/path-with-slash")
 	}
-	if globalconfig.DdevGlobalConfig.MkcertCARoot == "" {
+	if app.CanUseHTTPOnly() {
 		cases["-m"] = desc["mailpit_url"].(string)
+		cases[":3000/with-default-scheme"] = "http://" + app.GetHostname() + ":3000/with-default-scheme"
 	}
 	for partialCommand, expect := range cases {
 		// Try with the base URL, simplest case

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -331,6 +331,7 @@ func TestLaunchCommand(t *testing.T) {
 		_ = os.RemoveAll(testDir)
 	})
 
+	primaryURLWithoutPort := app.GetPrimaryURL()
 	// This only tests the https port changes, but that might be enough
 	app.RouterHTTPSPort = "8443"
 	err = app.WriteConfig()
@@ -347,6 +348,7 @@ func TestLaunchCommand(t *testing.T) {
 		"nested/path":                      app.GetPrimaryURL() + "/nested/path",
 		"/path-with-slash":                 app.GetPrimaryURL() + "/path-with-slash",
 		app.GetPrimaryURL() + "/full-path": app.GetPrimaryURL() + "/full-path",
+		":3000":                            primaryURLWithoutPort + ":3000",
 		"http://example.com":               "http://example.com",
 		"https://example.com:443/test":     "https://example.com:443/test",
 	}

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -332,8 +332,10 @@ func TestLaunchCommand(t *testing.T) {
 	})
 
 	primaryURLWithoutPort := app.GetPrimaryURL()
-	// This only tests the https port changes, but that might be enough
+	app.RouterHTTPPort = "8080"
 	app.RouterHTTPSPort = "8443"
+	app.MailpitHTTPPort = "18025"
+	app.MailpitHTTPSPort = "18026"
 	err = app.WriteConfig()
 	assert.NoError(err)
 	err = app.Start()
@@ -348,9 +350,17 @@ func TestLaunchCommand(t *testing.T) {
 		"nested/path":                      app.GetPrimaryURL() + "/nested/path",
 		"/path-with-slash":                 app.GetPrimaryURL() + "/path-with-slash",
 		app.GetPrimaryURL() + "/full-path": app.GetPrimaryURL() + "/full-path",
-		":3000":                            primaryURLWithoutPort + ":3000",
-		"http://example.com":               "http://example.com",
-		"https://example.com:443/test":     "https://example.com:443/test",
+		":8080":                            desc["httpurl"].(string),
+		":8080/http-port-path":             desc["httpurl"].(string) + "/http-port-path",
+		":8443":                            desc["httpsurl"].(string),
+		":8443/https-port-path":            desc["httpsurl"].(string) + "/https-port-path",
+		":18025":                           "http://" + app.GetHostname() + ":18025",
+		":18026":                           "https://" + app.GetHostname() + ":18026",
+		// if it is impossible to determine the http/https scheme, the default site protocol should be used
+		":3000":                        primaryURLWithoutPort + ":3000",
+		":3000/with-default-scheme":    "https://" + app.GetHostname() + ":3000/with-default-scheme",
+		"http://example.com":           "http://example.com",
+		"https://example.com:443/test": "https://example.com:443/test",
 	}
 	if runtime.GOOS == "windows" {
 		// Git-Bash converts single forward slashes to a Windows path

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -764,6 +764,13 @@ Flags:
 
 * `--mailpit`, `-m`: Open Mailpit.
 
+!!!tip "How to disable HTTP redirect to HTTPS?"
+    Recommendations for:
+
+    * [Google Chrome](https://stackoverflow.com/q/73875589)
+    * [Mozilla Firefox](https://stackoverflow.com/q/30532471)
+    * [Safari](https://stackoverflow.com/q/46394682)
+
 Example:
 
 ```shell

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -780,7 +780,7 @@ ddev launch temp/phpinfo.php
 ddev launch https://your.ddev.site
 
 # Open your project’s base URL using a specific port
-ddev launch $DDEV_PRIMARY_URL:3000
+ddev launch :3000
 ```
 
 ## `list`

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -55,13 +55,20 @@ while :; do
 if [ -n "${1:-}" ]; then
   if [[ $1 =~ ^https?:// ]]; then
     # full url
-    FULLURL="${1}";
+    FULLURL="${1}"
   elif [[ $1 =~ ^: ]]; then
     # specific port
-    FULLURL="${FULLURL%:[0-9]*}${1}";
+    FULLURL="${FULLURL%:[0-9]*}${1}"
+    # check if the port is running on https or http
+    port=$(docker run -i --rm ddev/ddev-utilities sh -c "echo '${1}' | grep -o ':[0-9]\+' | awk -F':' '{print \$2}'" 2>/dev/null)
+    if [[ "${port}" != "" ]] && ddev status -j | docker run -i --rm ddev/ddev-utilities sh -c "jq -r '.raw' | grep -w ${port} | grep -q https" 2>/dev/null; then
+      FULLURL="${FULLURL/http:/https:}"
+    elif [[ "${port}" != "" ]] && ddev status -j | docker run -i --rm ddev/ddev-utilities sh -c "jq -r '.raw' | grep -w ${port} | grep -q http" 2>/dev/null; then
+      FULLURL="${FULLURL/https:/http:}"
+    fi
   else
     # relative path
-    FULLURL="${FULLURL%/}/${1#/}";
+    FULLURL="${FULLURL%/}/${1#/}"
   fi
 fi
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -3,7 +3,7 @@
 ## #ddev-generated: If you want to edit and own this file, remove this line.
 ## Description: Launch a browser with the current site
 ## Usage: launch [path] [-m|--mailpit]
-## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php" or "ddev launch https://your.ddev.site" or "ddev launch $DDEV_PRIMARY_URL:3000", for Mailpit "ddev launch -m"
+## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php" or "ddev launch https://your.ddev.site" or "ddev launch :3000", for Mailpit "ddev launch -m"
 ## Flags: [{"Name":"mailpit","Shorthand":"m","Usage":"ddev launch -m launches the mailpit UI"}]
 
 if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
@@ -52,15 +52,16 @@ while :; do
      shift
  done
 
-if [ -n "${1:-}" ] ; then
-  if [[ ${1::1} != "/" ]] ; then
-    FULLURL="${FULLURL}/";
-  fi
-
+if [ -n "${1:-}" ]; then
   if [[ $1 =~ ^https?:// ]]; then
+    # full url
     FULLURL="${1}";
+  elif [[ $1 =~ ^: ]]; then
+    # specific port
+    FULLURL="${FULLURL%:[0-9]*}${1}";
   else
-    FULLURL="${FULLURL}${1}";
+    # relative path
+    FULLURL="${FULLURL%/}/${1#/}";
   fi
 fi
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -72,6 +72,11 @@ if [ -n "${1:-}" ]; then
   fi
 fi
 
+if [[ "${FULLURL}" =~ ^http:// ]]; then
+  echo "HTTP may redirect to HTTPS in your browser"
+  echo "See https://ddev.readthedocs.io/en/stable/users/usage/commands/#launch"
+fi
+
 if [ ! -z ${DDEV_DEBUG:-} ]; then
     printf "FULLURL $FULLURL\n" && exit 0
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -61,9 +61,9 @@ if [ -n "${1:-}" ]; then
     FULLURL="${FULLURL%:[0-9]*}${1}"
     # check if the port is running on https or http
     port=$(docker run -i --rm ddev/ddev-utilities sh -c "echo '${1}' | grep -o ':[0-9]\+' | awk -F':' '{print \$2}'" 2>/dev/null)
-    if [[ "${port}" != "" ]] && ddev status -j | docker run -i --rm ddev/ddev-utilities sh -c "jq -r '.raw' | grep -w ${port} | grep -q https" 2>/dev/null; then
+    if [[ "${port}" != "" ]] && ddev describe -j | docker run -i --rm ddev/ddev-utilities sh -c "jq -r '.raw' | grep -w ${port} | grep -q https" 2>/dev/null; then
       FULLURL="${FULLURL/http:/https:}"
-    elif [[ "${port}" != "" ]] && ddev status -j | docker run -i --rm ddev/ddev-utilities sh -c "jq -r '.raw' | grep -w ${port} | grep -q http" 2>/dev/null; then
+    elif [[ "${port}" != "" ]] && ddev describe -j | docker run -i --rm ddev/ddev-utilities sh -c "jq -r '.raw' | grep -w ${port} | grep -q http" 2>/dev/null; then
       FULLURL="${FULLURL/https:/http:}"
     fi
   else


### PR DESCRIPTION
## The Issue

- #5525

I added an example in #5986 to run `ddev launch` with a specific port:

```
# Open your project’s base URL using a specific port
ddev launch $DDEV_PRIMARY_URL:3000
```

But this never actually worked:

```
DDEV_DEBUG=true ddev launch $DDEV_PRIMARY_URL:3000
FULLURL https://d10.ddev.site/:3900
```

`$DDEV_PRIMARY_URL` is not expanded because it is not available on the host side and `$DDEV_PRIMARY_URL:3000` and `:3000` are the same thing.

`ddev launch $DDEV_PRIMARY_URL:3000` only works if it is run in another DDEV custom script.

## How This PR Solves The Issue

Adds actual support to launch ports.

## Manual Testing Instructions

```
ddev debug fix-commands
```

```
$ DDEV_DEBUG=true ddev launch :3000
FULLURL https://d10.ddev.site:3000
```

```
$ DDEV_DEBUG=true ddev launch :3000/test
FULLURL https://d10.ddev.site:3000/test
```

See a tip for HTTP to HTTPS redirect at https://ddev--6024.org.readthedocs.build/en/6024/users/usage/commands/#launch

```
$ DDEV_DEBUG=true ddev launch :8025
HTTP may redirect to HTTPS in your browser
See https://ddev.readthedocs.io/en/stable/users/usage/commands/#launch
FULLURL http://d10.ddev.site:8025
```

```
$ DDEV_DEBUG=true ddev launch :8026
FULLURL https://d10.ddev.site:8026
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

