### PR TITLE
fix: handle wildcard hostnames when name resolution not available, fixes #4881

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -138,9 +138,7 @@ func init() {
 
 	// Populate custom/script commands so they're visible.
 	// We really don't want ~/.ddev or .ddev/homeadditions or .ddev/.globalcommands to have root ownership, breaks things.
-	if os.Geteuid() == 0 {
-		util.Warning("Not populating custom commands or hostadditions because running with root privileges")
-	} else {
+	if os.Geteuid() != 0 {
 		err := ddevapp.PopulateExamplesCommandsHomeadditions("")
 		if err != nil {
 			util.Warning("populateExamplesAndCommands() failed: %v", err)

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -51,6 +51,8 @@ An array of [extra fully-qualified domain names](../extend/additional-hostnames.
 
 Example: `additional_fqdns: ["example.com", "sub1.example.com"]` would provide HTTP and HTTPS URLs for `example.com` and `sub1.example.com`.
 
+See [Hostnames and Wildcards and DDEV, Oh My!](https://ddev.com/blog/ddev-name-resolution-wildcards/) for more information on DDEV hostname resolution.
+
 !!!warning
     Take care with `additional_fqdns`; it adds items to your `/etc/hosts` file which can cause confusion.
 
@@ -64,7 +66,9 @@ An array of [extra hostnames](../extend/additional-hostnames.md) to be used for 
 
 Example: `additional_hostnames: ["somename", "someothername", "*.thirdname"]` would provide HTTP and HTTPS URLs for `somename.ddev.site`, `someothername.ddev.site`, and `one.thirdname.ddev.site` + `two.thirdname.ddev.site`.
 
-The wildcard (`*`) setting only works if you’re using DNS to resolve hostnames (default) and connected to the internet.
+The wildcard (`*.<whatever>`) setting only works if you’re [using DNS to resolve hostnames (default)](#use_dns_when_possible) and connected to the internet and using `ddev.site` as your [`project_tld`](#project_tld).
+
+See [Hostnames and Wildcards and DDEV, Oh My!](https://ddev.com/blog/ddev-name-resolution-wildcards/) for more information on DDEV hostname resolution.
 
 ## `bind_all_interfaces`
 
@@ -427,11 +431,13 @@ You can only specify the major version (`7.3`), not a minor version (`7.3.2`), f
 
 ## `project_tld`
 
-Default TLD to be used for a project’s domains, or globally for all project domains.
+Default Top-Level-Domain (`TLD`) to be used for a project’s domains, or globally for all project domains. This defaults to `ddev.site` and it's easiest to work with DDEV using the default setting.
 
 | Type | Default | Usage
 | -- | -- | --
 | :octicons-file-directory-16: project<br>:octicons-globe-16: global | `ddev.site` | Can be changed to any TLD you’d prefer.
+
+See [Hostnames and Wildcards and DDEV, Oh My!](https://ddev.com/blog/ddev-name-resolution-wildcards/) for more information on DDEV hostname resolution.
 
 ## `required_docker_compose_version`
 

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -320,14 +320,16 @@ You may see one of several messages:
 
 Some DNS servers prevent the use of DNS records that resolve to `localhost` (127.0.0.1) because in uncontrolled environments this may be used as a form of attack called [DNS Rebinding](https://en.wikipedia.org/wiki/DNS_rebinding). Since `*.ddev.site` resolves to 127.0.0.1, they may refuse to resolve, and your browser may be unable to look up a hostname, and give you messages like “<url> server IP address could not be found” or “We can’t connect to the server at <url>”.
 
-You verify this is your problem by running `ping dkkd.ddev.site`. If you get “No address associated with hostname” or something of that type, your computer is unable to look up `*.ddev.site`.
+You verify this is your problem by running `ping -c 1 dkkd.ddev.site`. If you get “No address associated with hostname” or something of that type, your computer is unable to look up `*.ddev.site`.
 
 In this case, you can take any one of the following approaches:
 
 1. Reconfigure your router to allow DNS Rebinding. Many Fritzbox routers have added default DNS Rebinding disallowal, and they can be reconfigured to allow it. See [issue](https://github.com/ddev/ddev/issues/2409#issuecomment-686718237). If you have the local dnsmasq DNS server it may also be configured to disallow DNS rebinding, but it’s a simple change to a configuration directive to allow it.
-2. Most computers can use most relaxed DNS resolution if they are not on corporate intranets that have non-internet DNS. So for example, the computer can be set to use 8.8.8.8 (Google) or 1.1.1.1 (Cloudflare) for DNS name resolution.
+2. Most computers can use most relaxed DNS resolution if they are not on corporate intranets that have non-internet DNS. So for example, the computer can be set to use 8.8.8.8 (Google) or 1.1.1.1 (Cloudflare) for DNS name resolution, see [this article](https://www.hellotech.com/guide/for/how-to-change-dns-server-windows-mac).
 3. If you have control of the router, you can usually change its DHCP settings to choose a public, relaxed DNS server as in #2.
 4. You can live with DDEV trying to edit the `/etc/hosts` file, which it only has to do when a new name is added to a project.
+
+An extensive discussion of this class of problem is on [ddev.com](https://ddev.com/blog/ddev-name-resolution-wildcards).
 
 ## Windows WSL2 Network Issues
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/amplitude/analytics-go v1.0.1
+	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/cheggaaa/pb v1.0.29
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/docker/docker v26.0.0+incompatible
@@ -42,7 +43,6 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c // indirect
-	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/containerd/log v0.1.0 // indirect

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -481,7 +481,7 @@ func (app *DdevApp) ValidateConfig() error {
 		// If they have provided "*.<hostname>" then ignore the *. part.
 		hn = strings.TrimPrefix(hn, "*.")
 		if hn == nodeps.DdevDefaultTLD {
-			return fmt.Errorf("wildcarding the full hostname or using 'ddev.site' as FQDN for the project %s is not allowed because other projects would not work in that case", app.Name)
+			return fmt.Errorf("wildcarding the full hostname\nor using 'ddev.site' as FQDN for the project %s is not allowed\nbecause other projects would not work in that case", app.Name)
 		}
 		if !hostRegex.MatchString(hn) {
 			return fmt.Errorf("the %s project has an invalid hostname: '%s', see https://en.wikipedia.org/wiki/Hostname#Syntax for valid hostname requirements", app.Name, hn).(invalidHostname)

--- a/pkg/ddevapp/hostname_mgt.go
+++ b/pkg/ddevapp/hostname_mgt.go
@@ -112,7 +112,7 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 			continue
 		}
 		if !govalidator.IsDNSName(name) {
-			util.Warning("DDEV cannot add unresolvable hostnames like `%s` to your hosts file.\nSee docs for more info, https://ddev.readthedocs.io/en/stable/users/configuration/config/#additional_hostnames.", name)
+			util.Warning("DDEV cannot add unresolvable hostnames like `%s` to your hosts file.\nSee docs for more info, https://ddev.readthedocs.io/en/stable/users/configuration/config/#additional_hostnames", name)
 		} else {
 			util.Warning("The hostname %s is not currently resolvable, trying to add it to the hosts file", name)
 			out, err := escalateToAddHostEntry(name, dockerIP)

--- a/pkg/ddevapp/hostname_mgt.go
+++ b/pkg/ddevapp/hostname_mgt.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"fmt"
+	"github.com/asaskevich/govalidator"
 	"github.com/ddev/ddev/pkg/ddevhosts"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
@@ -110,8 +111,8 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 			util.Warning("Unable to open hosts file: %v", err)
 			continue
 		}
-		if strings.Contains(name, `*`) {
-			util.Warning("DDEV cannot add unresolvable wildcard hostnames like `%s` to your hosts file", name)
+		if !govalidator.IsDNSName(name) {
+			util.Warning("DDEV cannot add unresolvable hostnames like `%s` to your hosts file.\nSee docs for more info, https://ddev.readthedocs.io/en/stable/users/configuration/config/#additional_hostnames.", name)
 		} else {
 			util.Warning("The hostname %s is not currently resolvable, trying to add it to the hosts file", name)
 			out, err := escalateToAddHostEntry(name, dockerIP)


### PR DESCRIPTION

## The Issue

* #4881 

There are a few problems with creating hostnames in /etc/hosts when name lookup fails. 

## How This PR Solves The Issue

Tell when we can't do it and don't try doing it.

## Manual Testing Instructions

```
ddev config --use-dns-when-possible=false
ddev config --additional-hostnames="*.junk"
ddev start
```

You should get a warning that `*.junk.ddev.site`  can't be added to hosts file... because hosts file doesn't do wildcards.

## Release/Deployment Notes

- [ ] Followup: A ddev.com article explaining all of the issues with name resolution and wildcards.
