### PR TITLE
docs: add privacy plugins to not use external fonts, fixes #4982 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ theme:
 # Plugins
 plugins:
 - search
+- privacy
 - redirects:
     redirect_maps:
 - minify:


### PR DESCRIPTION
## The Issue

Fixes #4982.

We should keep an eye out for possibly slowed down automated builds, after this change.

## How This PR Solves The Issue

Bundles the fonts with the generated documents, as opposed to getting them from a third-party.

## Manual Testing Instructions

- **Now:**
    Open https://ddev--6027.org.readthedocs.build/en/6027/ in Firefox with uBlock Origin, and see that currently fonts are requested from fonts.googleapis.com
- **After adding the privacy plugin:**
    See that fonts are included and served from https://ddev--6027.org.readthedocs.build/en/6027/ 

Alternative method to verify that no third-parties are contacted:

1. Open developer tools in your browser with F12
1. Open "Network"
1. Reload the page, and see that no third-party resources are contacted, in this case Google and Plausible.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
