### PR TITLE
fix: clean up missing project if it's gone, fixes #5322

### DIFF
--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -4,15 +4,12 @@ import (
 	"fmt"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/stretchr/testify/require"
-	"runtime"
 	"strings"
 	"testing"
 
 	"encoding/json"
 
 	"os"
-
-	"path/filepath"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
@@ -226,51 +223,4 @@ func unmarshalJSONLogs(in string) ([]log.Fields, error) {
 		}
 	}
 	return logData, nil
-}
-
-// TestCmdDescribeMissingProjectDirectory ensures the `ddev describe` command returns the expected help text when
-// a project's directory no longer exists.
-func TestCmdDescribeMissingProjectDirectory(t *testing.T) {
-	var err error
-	var out string
-
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping because unreliable on Windows")
-	}
-
-	assert := asrt.New(t)
-
-	projDir, _ := os.Getwd()
-
-	projectName := util.RandString(6)
-
-	tmpDir := testcommon.CreateTmpDir(t.Name())
-	defer testcommon.CleanupDir(tmpDir)
-	defer testcommon.Chdir(tmpDir)()
-
-	_, err = exec.RunCommand(DdevBin, []string{"config", "--project-type", "php", "--project-name", projectName})
-	assert.NoError(err)
-
-	_, err = exec.RunCommand(DdevBin, []string{"start", "-y"})
-	assert.NoError(err)
-
-	t.Cleanup(func() {
-		_, err = exec.RunCommand(DdevBin, []string{"delete", "-Oy", projectName})
-		assert.NoError(err)
-	})
-
-	_, err = exec.RunCommand(DdevBin, []string{"stop"})
-	assert.NoError(err)
-
-	err = os.Chdir(projDir)
-	assert.NoError(err)
-	copyDir := filepath.Join(testcommon.CreateTmpDir(t.Name()), util.RandString(4))
-	err = os.Rename(tmpDir, copyDir)
-	assert.NoError(err)
-
-	out, err = exec.RunCommand(DdevBin, []string{"describe", projectName})
-	assert.Error(err, "Expected an error when describing project with no project directory")
-	assert.Contains(out, "ddev can no longer find your project files")
-	err = os.Rename(copyDir, tmpDir)
-	assert.NoError(err)
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -76,8 +76,8 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 		return nil, fmt.Errorf("ddev config is not useful in your home directory (%s)", homeDir)
 	}
 
-	if !fileutil.FileExists(app.AppRoot) {
-		return app, fmt.Errorf("project root %s does not exist", app.AppRoot)
+	if _, err := os.Stat(app.AppRoot); err != nil {
+		return app, err
 	}
 
 	app.ConfigPath = app.GetConfigPath("config.yaml")

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2869,51 +2869,6 @@ func TestDdevLogs(t *testing.T) {
 	switchDir()
 }
 
-// TestDdevStopMissingDirectory tests that the 'ddev stop' command works properly on sites with missing directories or DDEV configs.
-func TestDdevStopMissingDirectory(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping because unreliable on Windows")
-	}
-
-	assert := asrt.New(t)
-
-	site := TestSites[0]
-	testcommon.ClearDockerEnv()
-	app := &ddevapp.DdevApp{}
-	err := app.Init(site.Dir)
-	assert.NoError(err)
-
-	startErr := app.StartAndWait(0)
-	//nolint: errcheck
-	defer app.Stop(true, false)
-	if startErr != nil {
-		logs, health, err := ddevapp.GetErrLogsFromApp(app, startErr)
-		assert.NoError(err)
-		t.Fatalf("app.StartAndWait failed err=%v health=\n%s\n\nlogs from broken container: \n=======\n%s\n========\n", startErr, health, logs)
-	}
-
-	tempPath := testcommon.CreateTmpDir("site-copy")
-	siteCopyDest := filepath.Join(tempPath, "site")
-	defer removeAllErrCheck(tempPath, assert)
-
-	_ = app.Stop(false, false)
-
-	// Move the site directory to a temp location to mimic a missing directory.
-	err = os.Rename(site.Dir, siteCopyDest)
-	assert.NoError(err)
-
-	//nolint: errcheck
-	defer os.Rename(siteCopyDest, site.Dir)
-
-	// ddev stop (in cmd) actually does the check for missing project files,
-	// so we imitate that here.
-	err = ddevapp.CheckForMissingProjectFiles(app)
-	assert.Error(err)
-	if err != nil {
-		assert.Contains(err.Error(), "If you would like to continue using DDEV to manage this project please restore your files to that directory.")
-	}
-}
-
 // TestDdevDescribe tests that the describe command works properly on a running
 // and also a stopped project.
 func TestDdevDescribe(t *testing.T) {
@@ -2968,44 +2923,6 @@ func TestDdevDescribe(t *testing.T) {
 	err = os.Remove("hello-pre-describe-" + app.Name)
 	assert.NoError(err)
 	err = os.Remove("hello-post-describe-" + app.Name)
-	assert.NoError(err)
-}
-
-// TestDdevDescribeMissingDirectory tests that the describe command works properly on sites with missing directories or DDEV configs.
-func TestDdevDescribeMissingDirectory(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping because unreliable on Windows")
-	}
-
-	assert := asrt.New(t)
-	site := TestSites[0]
-	tempPath := testcommon.CreateTmpDir("site-copy")
-	siteCopyDest := filepath.Join(tempPath, "site")
-	defer removeAllErrCheck(tempPath, assert)
-
-	app := &ddevapp.DdevApp{}
-	err := app.Init(site.Dir)
-	assert.NoError(err)
-	startErr := app.StartAndWait(0)
-	//nolint: errcheck
-	defer app.Stop(true, false)
-	if startErr != nil {
-		logs, health, err := ddevapp.GetErrLogsFromApp(app, startErr)
-		assert.NoError(err)
-		t.Fatalf("app.StartAndWait failed err=%v health:\n%s\nlogs from broken container: \n=======\n%s\n========\n", startErr, health, logs)
-	}
-	// Move the site directory to a temp location to mimic a missing directory.
-	err = app.Stop(false, false)
-	assert.NoError(err)
-	err = os.Rename(site.Dir, siteCopyDest)
-	assert.NoError(err)
-
-	desc, err := app.Describe(false)
-	assert.NoError(err)
-	assert.Equal(ddevapp.SiteDirMissing, desc["status"])
-	assert.Contains(desc["status_desc"], ddevapp.SiteDirMissing, "Status did not include the phrase '%s' when describing a site with missing directories.", ddevapp.SiteDirMissing)
-	// Move the site directory back to its original location.
-	err = os.Rename(siteCopyDest, site.Dir)
 	assert.NoError(err)
 }
 

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -363,7 +363,15 @@ func GetProjects(activeOnly bool) ([]*DdevApp, error) {
 
 		app, err := NewApp(info.AppRoot, true)
 		if err != nil {
-			util.Warning("Unable to create project at project root '%s': %v", info.AppRoot, err)
+			if os.IsNotExist(err) {
+				util.Warning("The project '%s' no longer exists in the filesystem, removing it from registry", info.AppRoot)
+				err = globalconfig.RemoveProjectInfo(name)
+				if err != nil {
+					util.Warning("unable to RemoveProjectInfo(%s): %v", name, err)
+				}
+			} else {
+				util.Warning("Something went wrong with %s: %v", info.AppRoot, err)
+			}
 			continue
 		}
 

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -521,3 +521,12 @@ func (app *DdevApp) CanUseHTTPOnly() bool {
 	// Default case is OK to use https
 	return false
 }
+
+// Turn a slice of *DdevApp into a map keyed by name
+func AppSliceToMap(appList []*DdevApp) map[string]*DdevApp {
+	nameMap := make(map[string]*DdevApp)
+	for _, app := range appList {
+		nameMap[app.Name] = app
+	}
+	return nameMap
+}


### PR DESCRIPTION

## The Issue

* #5322

People periodically delete a project's filesystem without doing a `ddev delete` first

## How This PR Solves The Issue

When the filesystem is gone, remove the project from the project list

## Manual Testing Instructions

```
mkdir junk && cd junk && ddev config --auto
cd .. && rm -r junk
ddev list
```

You should see the project mentioned while it's being removed from registry,  but it won't error and won't show up on the next `ddev list`.

## Automated Testing Overview

Added TestGetProjectsMissingApp

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

