### PR TITLE
feat: more readable formatting of lists of files, fixes #5985

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -614,7 +614,8 @@ func (app *DdevApp) CheckCustomConfig() {
 		nginxFiles, err := filepath.Glob(nginxPath + "/*.conf")
 		util.CheckErr(err)
 		if len(nginxFiles) > 0 {
-			util.Warning("Using nginx snippets: %v", nginxFiles)
+			printableFiles, _ := util.FilesToReadableOutput(nginxFiles)
+			util.Warning("Using nginx snippets: %v", printableFiles)
 			customConfig = true
 		}
 	}
@@ -624,7 +625,8 @@ func (app *DdevApp) CheckCustomConfig() {
 		mysqlFiles, err := filepath.Glob(mysqlPath + "/*.cnf")
 		util.CheckErr(err)
 		if len(mysqlFiles) > 0 {
-			util.Warning("Using custom MySQL configuration: %v", mysqlFiles)
+			printableFiles, _ := util.FilesToReadableOutput(mysqlFiles)
+			util.Warning("Using custom MySQL configuration: %v", printableFiles)
 			customConfig = true
 		}
 	}
@@ -634,7 +636,8 @@ func (app *DdevApp) CheckCustomConfig() {
 		phpFiles, err := filepath.Glob(phpPath + "/*.ini")
 		util.CheckErr(err)
 		if len(phpFiles) > 0 {
-			util.Warning("Using custom PHP configuration: %v", phpFiles)
+			printableFiles, _ := util.FilesToReadableOutput(phpFiles)
+			util.Warning("Using custom PHP configuration: %v", printableFiles)
 			customConfig = true
 		}
 	}
@@ -644,7 +647,8 @@ func (app *DdevApp) CheckCustomConfig() {
 		entrypointFiles, err := filepath.Glob(webEntrypointPath + "/*.sh")
 		util.CheckErr(err)
 		if len(entrypointFiles) > 0 {
-			util.Warning("Using custom web-entrypoint.d configuration: %v", entrypointFiles)
+			printableFiles, _ := util.FilesToReadableOutput(entrypointFiles)
+			util.Warning("Using custom web-entrypoint.d configuration: %v", printableFiles)
 			customConfig = true
 		}
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -614,7 +614,7 @@ func (app *DdevApp) CheckCustomConfig() {
 		nginxFiles, err := filepath.Glob(nginxPath + "/*.conf")
 		util.CheckErr(err)
 		if len(nginxFiles) > 0 {
-			printableFiles, _ := util.FilesToReadableOutput(nginxFiles)
+			printableFiles, _ := util.ArrayToReadableOutput(nginxFiles)
 			util.Warning("Using nginx snippets: %v", printableFiles)
 			customConfig = true
 		}
@@ -625,7 +625,7 @@ func (app *DdevApp) CheckCustomConfig() {
 		mysqlFiles, err := filepath.Glob(mysqlPath + "/*.cnf")
 		util.CheckErr(err)
 		if len(mysqlFiles) > 0 {
-			printableFiles, _ := util.FilesToReadableOutput(mysqlFiles)
+			printableFiles, _ := util.ArrayToReadableOutput(mysqlFiles)
 			util.Warning("Using custom MySQL configuration: %v", printableFiles)
 			customConfig = true
 		}
@@ -636,7 +636,7 @@ func (app *DdevApp) CheckCustomConfig() {
 		phpFiles, err := filepath.Glob(phpPath + "/*.ini")
 		util.CheckErr(err)
 		if len(phpFiles) > 0 {
-			printableFiles, _ := util.FilesToReadableOutput(phpFiles)
+			printableFiles, _ := util.ArrayToReadableOutput(phpFiles)
 			util.Warning("Using custom PHP configuration: %v", printableFiles)
 			customConfig = true
 		}
@@ -647,7 +647,7 @@ func (app *DdevApp) CheckCustomConfig() {
 		entrypointFiles, err := filepath.Glob(webEntrypointPath + "/*.sh")
 		util.CheckErr(err)
 		if len(entrypointFiles) > 0 {
-			printableFiles, _ := util.FilesToReadableOutput(entrypointFiles)
+			printableFiles, _ := util.ArrayToReadableOutput(entrypointFiles)
 			util.Warning("Using custom web-entrypoint.d configuration: %v", printableFiles)
 			customConfig = true
 		}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -350,4 +351,12 @@ func SliceToUniqueSlice(inSlice *[]string) []string {
 		return nil
 	}
 	return newSlice
+}
+
+// FilesToReadableOutput generates a printable list of files in a readable way
+func FilesToReadableOutput(slice []string) (response string, err error) {
+	if len(slice) == 0 {
+		return "", errors.New("empty slice")
+	}
+	return "[\n\t" + strings.Join(slice, ", \n\t") + "\n]", nil
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -356,7 +355,7 @@ func SliceToUniqueSlice(inSlice *[]string) []string {
 // FilesToReadableOutput generates a printable list of files in a readable way
 func FilesToReadableOutput(slice []string) (response string, err error) {
 	if len(slice) == 0 {
-		return "", errors.New("empty slice")
+		return "", fmt.Errorf("empty slice")
 	}
 	return "[\n\t" + strings.Join(slice, ", \n\t") + "\n]", nil
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -357,5 +357,5 @@ func FilesToReadableOutput(slice []string) (response string, err error) {
 	if len(slice) == 0 {
 		return "", fmt.Errorf("empty slice")
 	}
-	return "[\n\t" + strings.Join(slice, ", \n\t") + "\n]", nil
+	return "[\n\t" + strings.Join(slice, ",\n\t") + "\n]", nil
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -352,10 +352,10 @@ func SliceToUniqueSlice(inSlice *[]string) []string {
 	return newSlice
 }
 
-// FilesToReadableOutput generates a printable list of files in a readable way
-func FilesToReadableOutput(slice []string) (response string, err error) {
+// ArrayToReadableOutput generates a printable list of files in a readable way
+func ArrayToReadableOutput(slice []string) (response string, err error) {
 	if len(slice) == 0 {
 		return "", fmt.Errorf("empty slice")
 	}
-	return "[\n\t" + strings.Join(slice, ",\n\t") + "\n]", nil
+	return "[\n\t" + strings.Join(slice, "\n\t") + "\n]", nil
 }

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -179,3 +179,22 @@ func TestSliceToUniqueSlice(t *testing.T) {
 		assert.Equal(testBedExpectations[i], res)
 	}
 }
+
+// TestFilesToReadableOutput tests FilesToReadableOutput
+func TestFilesToReadableOutput(t *testing.T) {
+	assert := asrt.New(t)
+
+	testSource := []string{
+		"file1.conf",
+		"file2.conf",
+	}
+	expectation := `[
+	file1.conf,
+	file2.conf
+]`
+	res, _ := util.FilesToReadableOutput(testSource)
+	assert.Equal(expectation, res)
+
+	_, err := util.FilesToReadableOutput([]string{})
+	assert.EqualErrorf(err, "empty slice", "Expected error when passing an empty slice")
+}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -180,8 +180,8 @@ func TestSliceToUniqueSlice(t *testing.T) {
 	}
 }
 
-// TestFilesToReadableOutput tests FilesToReadableOutput
-func TestFilesToReadableOutput(t *testing.T) {
+// TestArrayToReadableOutput tests ArrayToReadableOutput
+func TestArrayToReadableOutput(t *testing.T) {
 	assert := asrt.New(t)
 
 	testSource := []string{
@@ -189,12 +189,12 @@ func TestFilesToReadableOutput(t *testing.T) {
 		"file2.conf",
 	}
 	expectation := `[
-	file1.conf,
+	file1.conf
 	file2.conf
 ]`
-	res, _ := util.FilesToReadableOutput(testSource)
+	res, _ := util.ArrayToReadableOutput(testSource)
 	assert.Equal(expectation, res)
 
-	_, err := util.FilesToReadableOutput([]string{})
+	_, err := util.ArrayToReadableOutput([]string{})
 	assert.EqualErrorf(err, "empty slice", "Expected error when passing an empty slice")
 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

E.g. nginx snippets are printed as 

```
Using nginx snippets: [/Users/diego/some-project/.ddev/nginx/some.conf /Users/diego/some-project/.ddev/nginx/some-other.conf]
```

which some users said wasn't very readable.

This provides a new formatting of 
```
Using nginx snippets: [
  /Users/diego/some-project/.ddev/nginx/some.conf,
  /Users/diego/some-project/.ddev/nginx/some-other.conf
]
```

## How This PR Solves The Issue

Added new util function `func FilesToReadableOutput(slice []string) (response string, err error)` and uses that when warning about nginx snippets, mysql conf, php conf and entrypoint scripts.

## Manual Testing Instructions

Create a new project or use an existing one.

Create a couple of snippets:

```
mkdir -p .ddev/nginx/
touch .ddev/nginx/redirect.conf
touch .ddev/nginx/another-redirect.conf
```

Run `ddev start` and you should see those files listed.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

Added test. Run with `go test -v -run TestFilesToReadableOutput ./pkg/util/`

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

