### PR TITLE
fix: revert removal of Colima host.docker.internal setting

### DIFF
--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -51,4 +51,9 @@ if command -v ddev >/dev/null && version_gt ${MIN_DDEV_VERSION} ${CURRENT_DDEV_V
   exit 4
 fi
 
+# Skip nfs check on linux/lima, as we won't run nfs there
+if [ ${OSTYPE%%-gnu} != "linux" ] && [ ${DOCKER_TYPE:-nothing} != "lima" ]; then
+  $(dirname $0)/nfstest.sh
+fi
+
 echo "-- testbot $HOSTNAME seems to be set up OK --"

--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -51,9 +51,4 @@ if command -v ddev >/dev/null && version_gt ${MIN_DDEV_VERSION} ${CURRENT_DDEV_V
   exit 4
 fi
 
-# Skip nfs check on linux/lima, as we won't run nfs there
-if [ ${OSTYPE%%-gnu} != "linux" ] && [ ${DOCKER_TYPE:-nothing} != "lima" ]; then
-  $(dirname $0)/nfstest.sh
-fi
-
 echo "-- testbot $HOSTNAME seems to be set up OK --"

--- a/cmd/ddev/cmd/debug-nfsmount_test.go
+++ b/cmd/ddev/cmd/debug-nfsmount_test.go
@@ -16,7 +16,7 @@ import (
 // TestDebugNFSMount tries out the `ddev debug nfsmount` command.
 // It requires nfsd running of course.
 func TestDebugNFSMount(t *testing.T) {
-	if nodeps.IsWSL2() || dockerutil.IsColima() || dockerutil.IsLima() {
+	if nodeps.IsWSL2() || dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsOrbstack() {
 		t.Skip("Skipping on WSL2/Lima/Colima since NFS is not used there")
 	}
 	assert := asrt.New(t)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3707,7 +3707,7 @@ func TestCaptureLogs(t *testing.T) {
 // This requires that the test machine must have NFS shares working
 // Tests using both app-specific performance_mode: nfs and etc
 func TestNFSMount(t *testing.T) {
-	if nodeps.IsWSL2() || dockerutil.IsColima() || dockerutil.IsLima() {
+	if nodeps.IsWSL2() || dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsOrbstack() {
 		t.Skip("Skipping on WSL2/Lima/Colima")
 	}
 	if nodeps.PerformanceModeDefault == types.PerformanceModeMutagen || nodeps.NoBindMountsDefault {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -903,9 +903,9 @@ func TestDdevNoProjectMount(t *testing.T) {
 
 // TestDdevXdebugEnabled tests running with xdebug_enabled = true, etc.
 func TestDdevXdebugEnabled(t *testing.T) {
-	if (dockerutil.IsColima() || dockerutil.IsLima()) && os.Getenv("DDEV_TEST_COLIMA_ANYWAY") != "true" {
-		t.Skip("Skipping on Lima/Colima because this test doesn't work although manual testing works")
-	}
+	//if (dockerutil.IsColima() || dockerutil.IsLima()) && os.Getenv("DDEV_TEST_COLIMA_ANYWAY") != "true" {
+	//	t.Skip("Skipping on Lima/Colima because this test doesn't work although manual testing works")
+	//}
 	if nodeps.IsWSL2() && dockerutil.IsDockerDesktop() {
 		t.Skip("Skipping on WSL2/Docker Desktop because this test doesn't work although manual testing works")
 	}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1253,6 +1253,11 @@ func GetNFSServerAddr() (string, error) {
 	nfsAddr := "host.docker.internal"
 
 	switch {
+	case IsColima():
+		// Lima specifies this as a named explicit IP address at this time
+		// see https://github.com/lima-vm/lima/blob/master/docs/network.md#host-ip-19216852
+		nfsAddr = "192.168.5.2"
+
 	// Gitpod has Docker 20.10+ so the docker-compose has already gotten the host-gateway
 	// However, NFS will never be used on Gitpod.
 	case nodeps.IsGitpod():

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1587,6 +1587,20 @@ func IsLima() bool {
 	return false
 }
 
+// IsOrbstack detects if running on Orbstack
+func IsOrbstack() bool {
+	ctx, client := GetDockerClient()
+	info, err := client.Info(ctx)
+	if err != nil {
+		util.Warning("IsLima(): Unable to get Docker info, err=%v", err)
+		return false
+	}
+	if strings.HasPrefix(info.Name, "orbstack") {
+		return true
+	}
+	return false
+}
+
 // CopyIntoContainer copies a path (file or directory) into a specified container and location
 func CopyIntoContainer(srcPath string, containerName string, dstPath string, exclusion string) error {
 	startTime := time.Now()

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1206,6 +1206,12 @@ func GetHostDockerInternalIP() (string, error) {
 		hostDockerInternal = "127.0.0.1"
 		util.Debug("host.docker.internal=%s because globalconfig.DdevGlobalConfig.XdebugIDELocation=%s", hostDockerInternal, globalconfig.XdebugIDELocationContainer)
 
+	case IsColima():
+		// Lima specifies this as a named explicit IP address at this time
+		// see https://github.com/lima-vm/lima/blob/master/docs/network.md#host-ip-19216852
+		hostDockerInternal = "192.168.5.2"
+		util.Debug("host.docker.internal=%s because running on Colima", hostDockerInternal)
+
 	// Gitpod has Docker 20.10+ so the docker-compose has already gotten the host-gateway
 	case nodeps.IsGitpod():
 		util.Debug("host.docker.internal='%s' because on Gitpod", hostDockerInternal)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1592,7 +1592,7 @@ func IsOrbstack() bool {
 	ctx, client := GetDockerClient()
 	info, err := client.Info(ctx)
 	if err != nil {
-		util.Warning("IsLima(): Unable to get Docker info, err=%v", err)
+		util.Warning("IsOrbstack(): Unable to get Docker info, err=%v", err)
 		return false
 	}
 	if strings.HasPrefix(info.Name, "orbstack") {


### PR DESCRIPTION
## The Issue

We're having a bit of trouble with NFS in colima/lima tb-macos-arm64-5/6/7, I'm not sure why. But we don't need to be testing NFS on macOS anyway, certainly not on orbstack/lima/colima.

* https://github.com/ddev/ddev/pull/5994


Lima provides 192.168.5.2 as host.docker.internal, but colima does not seem to have it any more. I assume colima lost it in a recent Lima upgrade.

This probably means that Xdebug is not working on colima since #5994 , but I don't know why it wouldn't have been caught by automated tests.

## How This PR Solves The Issue

Revert #5994 to put explicit host.docker.internal back in there again

## Manual Testing Instructions

`ddev debug nfsmount` using colima


