### PR TITLE
fix: shutdown supervisor in healthcheck.sh on fatal error, fixes #5993

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/apache.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/apache.conf
@@ -1,6 +1,5 @@
 [program:apache2]
 stopwaitsecs = 20
-startretries=10
 stopsignal = WINCH
 command=/usr/sbin/apache2ctl -D "FOREGROUND"
 # Great hints at https://advancedweb.hu/supervisor-with-docker-lessons-learned/
@@ -13,4 +12,4 @@ redirect_stderr=true
 exitcodes=0
 startsecs=1 # Must stay up 1 sec
 autorestart=true
-startretries=10
+startretries=3

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/gunicorn.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/gunicorn.conf
@@ -6,4 +6,4 @@ stdout_logfile=/var/tmp/logpipe
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 autorestart=true
-startretries=10
+startretries=3

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/php-fpm.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/php-fpm.conf
@@ -5,4 +5,4 @@ stdout_logfile=/var/tmp/logpipe
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 autorestart=true
-startretries=10
+startretries=3

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/supervisord-nginx-fpm.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/supervisord-nginx-fpm.conf
@@ -8,4 +8,4 @@ stdout_logfile=/var/tmp/logpipe
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 autorestart=true
-startretries=10
+startretries=3

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/supervisord-nginx-gunicorn.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/supervisord-nginx-gunicorn.conf
@@ -8,4 +8,4 @@ stdout_logfile=/var/tmp/logpipe
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 autorestart=true
-startretries=10
+startretries=3

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/healthcheck.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/healthcheck.sh
@@ -21,7 +21,7 @@ if [ -f /tmp/healthy ]; then
 fi
 
 # Shutdown the supervisor if one of the critical processes is in the FATAL state
-for service in php-fpm nginx apache2 gunicorn; do
+for service in php-fpm nginx apache2; do
   if supervisorctl status "${service}" 2>/dev/null | grep -q FATAL; then
     printf "%s:FATAL " "${service}"
     supervisorctl shutdown

--- a/containers/ddev-webserver/ddev-webserver-dev-base-files/etc/supervisor/conf.d/mailhog.conf
+++ b/containers/ddev-webserver/ddev-webserver-dev-base-files/etc/supervisor/conf.d/mailhog.conf
@@ -1,4 +1,4 @@
 [program:mailpit]
 command=/usr/local/bin/mailpit
 autorestart=true
-startretries=10
+startretries=3

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -342,7 +342,7 @@ In these case you can create a `.ddev/web-build/<daemonname>.conf` with configur
 command=/var/www/html/path/to/daemon
 directory=/var/www/html/
 autorestart=true
-startretries=10
+startretries=3
 stdout_logfile=/var/tmp/logpipe
 stdout_logfile_maxbytes=0
 redirect_stderr=true

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240324_corepack_config" // Note that this can be overridden by make
+var WebTag = "20240329_stasadev_healthcheck" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #5993

## How This PR Solves The Issue

I checked https://docs.docker.com/reference/dockerfile/#healthcheck before doing any change and when we use `start_period`, no matter what we do during this period, the container cannot become `unhealthy`.

> start period provides initialization time for containers that need time to bootstrap. Probe failure during that period will not be counted towards the maximum number of retries.

I also searched for a fast fail when starting the container, but that's all I found:
https://forums.docker.com/t/healthcheck-fail-fast-feature-during-container-start-up/121201

So, in the end, I decided to do the same thing as suggested in:

- #5906

but in a simpler way.

Also I decreased `startretries=10` to `startretries=3` in supervisor, there is no reason to try more and wait longer, if the process cannot start several times already.

## Manual Testing Instructions

See error for php-fpm after 20-30 seconds (without waiting for 2 minutes default timeout):

```
echo 'RUN chmod 000 /run/php' > .ddev/web-build/Dockerfile
ddev restart
...
Failed waiting for web/db containers to become ready: web container failed: log=&{2024-03-29 21:42:41.347467771 +0200 EET 2024-03-29 21:42:42.086281673 +0200 EET 143 php-fpm:FATAL Shut down
}, err=ddev-d10-web container is unhealthy: &{2024-03-29 21:42:41.347467771 +0200 EET 2024-03-29 21:42:42.086281673 +0200 EET 143 php-fpm:FATAL Shut down
}, please use 'ddev logs -s web' and 'docker logs ddev-d10-web' and 'docker inspect --format "{{ json .State.Health }}" ddev-d10-web' to find out why it failed
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

