### PR TITLE
test: make circleci setup noninteractive so doesn't hang [skip buildkite]

### DIFF
--- a/.ci-scripts/linux_arm64_setup.sh
+++ b/.ci-scripts/linux_arm64_setup.sh
@@ -5,7 +5,8 @@ set -o errexit
 # Basic tools
 
 set -x
-export GO_VERSION=1.21.6
+export GO_VERSION=1.22.1
+export DEBIAN_FRONTEND=noninteractive
 
 if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
   set +x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v32
+        - linux-homebrew-v33
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: NORMAL Circle VM setup
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-homebrew-v32
+        key: linux-homebrew-v33
         paths:
           - /home/linuxbrew
     - run:
@@ -64,7 +64,7 @@ jobs:
     - run: 'mkdir -p ~/.ngrok2 && echo "authtoken: ${NGROK_TOKEN}" >~/.ngrok2/ngrok.yml'
     - restore_cache:
         keys:
-        - linux-homebrew-v32
+        - linux-homebrew-v33
     - restore_cache:
         keys:
           - linux-testcache-v32
@@ -73,7 +73,7 @@ jobs:
         name: Circle VM setup
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-homebrew-v32
+        key: linux-homebrew-v33
         paths:
           - /home/linuxbrew
     - run: echo "$(docker --version) $(docker-compose --version)"
@@ -107,7 +107,7 @@ jobs:
             set -x
             if [ "${CIRCLE_PR_NUMBER}" != "" ] ; then
               echo "base_revision=<< pipeline.git.base_revision >>"
-              if ! git diff --name-only "<< pipeline.git.base_revision >>" | egrep "^(.circleci|Makefile|pkg|cmd|vendor|go\.)"; then
+              if ! git diff --name-only "<< pipeline.git.base_revision >>" | egrep "^(.circleci|.ci-scripts|Makefile|pkg|cmd|vendor|go\.)"; then
                 echo "Skipping build since no code changes found"
                 circleci-agent step halt
               fi
@@ -225,7 +225,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v32
+        - linux-homebrew-v33
     - attach_workspace:
         at: ~/
     - run:
@@ -242,7 +242,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-homebrew-v32
+        key: linux-homebrew-v33
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -260,7 +260,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v32
+        - linux-homebrew-v33
     - attach_workspace:
         at: ~/
     - run:
@@ -279,7 +279,7 @@ jobs:
     - store_test_results:
         path: /tmp/testresults
     - save_cache:
-        key: linux-homebrew-v32
+        key: linux-homebrew-v33
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -294,7 +294,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v32
+        - linux-homebrew-v33
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup
@@ -316,7 +316,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v32
+        - linux-homebrew-v33
     - run:
         command: ./.circleci/linux_circle_vm_setup.sh
         name: Circle VM setup
@@ -340,7 +340,7 @@ jobs:
         name: linux container test
 
     - save_cache:
-        key: linux-homebrew-v32
+        key: linux-homebrew-v33
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache
@@ -407,7 +407,7 @@ jobs:
     - run: sudo mkdir /home/linuxbrew && sudo chown $(id -u) /home/linuxbrew
     - restore_cache:
         keys:
-        - linux-homebrew-v32
+        - linux-homebrew-v33
     - attach_workspace:
         at: ~/
     - run:
@@ -415,7 +415,7 @@ jobs:
         name: tar/zip up artifacts and make hashes
         no_output_timeout: "40m"
     - save_cache:
-        key: linux-homebrew-v32
+        key: linux-homebrew-v33
         paths:
         - /home/linuxbrew
         - /home/circleci/.ddev/testcache


### PR DESCRIPTION
## The Issue

* Minor maintenance
* The CircleCI arm64 build has been failing waiting for interactive services restart:

<img width="716" alt="image" src="https://github.com/ddev/ddev/assets/112444/2b2495a2-2713-4c83-a666-9b6622137c95">


## How This PR Solves The Issue

Use DEBIAN_FRONTEND=noninteractive

