### PR TITLE
fix: ddev debug configyaml shouldn't double-report upload_dirs, fixes #6036

### DIFF
--- a/cmd/ddev/cmd/debug-config-yaml.go
+++ b/cmd/ddev/cmd/debug-config-yaml.go
@@ -31,6 +31,12 @@ var DebugConfigYamlCmd = &cobra.Command{
 		if err != nil {
 			util.Failed("Failed to get active project: %v", err)
 		}
+		// Get fresh version of app so we don't recreate it
+		app, err = ddevapp.NewApp(app.AppRoot, false)
+		if err != nil {
+			util.Failed("NewApp() failed: %v", err)
+		}
+
 		configFiles, err := app.ReadConfig(true)
 		if err != nil {
 			util.Error("failed reading config for project %s: %v", app.Name, err)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -325,6 +325,7 @@ func (app *DdevApp) UpdateGlobalProjectList() error {
 
 // ReadConfig reads project configuration from the config.yaml file
 // It does not attempt to set default values; that's NewApp's job.
+// returns the list of config files read
 func (app *DdevApp) ReadConfig(includeOverrides bool) ([]string, error) {
 
 	// Load base .ddev/config.yaml - original config


### PR DESCRIPTION
## The Issue

* #6036 

`ddev debug configyaml` was showing this (double-report):
```
upload_dirs: [.ddev/tmp .ddev/tmp]
```
when a `.ddev/config.junk.yaml` had:

```
upload_dirs:
    - .ddev/tmp
```

## How This PR Solves The Issue

Load a clean, fresh "app" before loading additional configs

Affects only `ddev debug configyaml`

## Manual Testing Instructions

Use the config above and `ddev debug configyaml`, should report only one upload_dirs

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

