### PR TITLE
test: try to fix sshfs-based failures on TestGetProjectsMissingApp

### DIFF
--- a/.buildkite/macos-colima_vz.yml
+++ b/.buildkite/macos-colima_vz.yml
@@ -12,7 +12,6 @@
       - "colima=true"
       - "colima_vz=true"
       - "architecture=arm64"
-    #branches: "master"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/macos-docker-desktop-amd64.yml
+++ b/.buildkite/macos-docker-desktop-amd64.yml
@@ -11,7 +11,6 @@
       - "os=macos"
       - "docker-desktop=true"
       - "architecture=amd64"
-    branches: "master"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/macos-rancher-desktop.yml
+++ b/.buildkite/macos-rancher-desktop.yml
@@ -11,7 +11,6 @@
       - "os=macos"
       - "rancher-desktop=true"
       - "architecture=arm64"
-    branches: "master"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/wsl2-docker-desktop.yml
+++ b/.buildkite/wsl2-docker-desktop.yml
@@ -12,7 +12,6 @@
       - "os=wsl2"
       - "architecture=amd64"
       - "dockertype=dockerforwindows"
-    branches: "master"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3972,6 +3972,15 @@ func TestGetProjectsMissingApp(t *testing.T) {
 		_ = os.RemoveAll(tmpDir)
 	})
 
+	err = badApp.WriteConfig()
+	require.NoError(t, err)
+	// This would normally have been done early in root.go's init()
+	// but we can do it early here. sshfs is pretty slow
+	// so colima with sshfs or rancher desktop with sshfs might fail
+	// on /mnt/ddev_config
+	err = ddevapp.PopulateExamplesCommandsHomeadditions(badApp.Name)
+	require.NoError(t, err)
+
 	err = badApp.Start()
 	require.NoError(t, err)
 	// Make sure the new badApp is listed


### PR DESCRIPTION

## The Issue

After TestGetProjectsMissingApp went in, we had failures with both Rancher Desktop and Colima/basic (which is sshfs mount type).

For example, https://buildkite.com/ddev/macos-colima/builds/228#018e9a1f-6d07-429f-8d7c-1902a74ff956

## How This PR Solves The Issue

This is just an attempt to get the directories all created and built, especially .ddev/xhprof, which seems to be the one that was failing. 

I was able to make this fail locally at first, and then it stopped failing for me. 

I think since xhprof would be the last to be created...

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

