### PR TITLE
feat: Improve container errors messages format, fixes #6042

### DIFF
--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -545,7 +545,7 @@ func getSuggestedCommandForContainerLog(container *dockerTypes.Container) (strin
 		name = "unknown"
 	}
 	if len(suggestedCommands) == 0 {
-		suggestedCommands = append(suggestedCommands, "ddev logs", "docker logs CONTAINER (find CONTAINER with 'docker ps')", "docker inspect --format \"{{ json .State.Health }}\" CONTAINER")
+		suggestedCommands = append(suggestedCommands, "ddev logs", "docker logs CONTAINER (find CONTAINER with 'docker ps')", "docker inspect --format \"{{ json .State.Health }}\" CONTAINER", "docker inspect --format \"{{ json .State.Health }}\" CONTAINER | jq -r")
 	}
 	suggestedCommand, _ := util.ArrayToReadableOutput(suggestedCommands)
 	return name, suggestedCommand

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -404,10 +404,10 @@ func ContainerWait(waittime int, labels map[string]string) (string, error) {
 				return logOutput, nil
 			case "unhealthy":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-				return logOutput, fmt.Errorf("%s container is unhealthy: %s, please use %s to find out why it failed", name, logOutput, suggestedCommand)
+				return logOutput, fmt.Errorf("%s container is unhealthy: %s, more info with %s", name, logOutput, suggestedCommand)
 			case "exited":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-				return logOutput, fmt.Errorf("%s container exited, please use %s to find out why it failed", name, suggestedCommand)
+				return logOutput, fmt.Errorf("%s container exited, more info with %s", name, suggestedCommand)
 			}
 		}
 	}
@@ -458,10 +458,10 @@ func ContainersWait(waittime int, labels map[string]string) error {
 					continue
 				case "unhealthy":
 					name, suggestedCommand := getSuggestedCommandForContainerLog(&container)
-					return fmt.Errorf("%s container is unhealthy: %s, please use %s to find out why it failed", name, logOutput, suggestedCommand)
+					return fmt.Errorf("%s container is unhealthy: %s, more info with %s", name, logOutput, suggestedCommand)
 				case "exited":
 					name, suggestedCommand := getSuggestedCommandForContainerLog(&container)
-					return fmt.Errorf("%s container exited, please use %s to find out why it failed", name, suggestedCommand)
+					return fmt.Errorf("%s container exited, more info with %s", name, suggestedCommand)
 				default:
 					allHealthy = false
 				}
@@ -516,10 +516,10 @@ func ContainerWaitLog(waittime int, labels map[string]string, expectedLog string
 				return logOutput, nil
 			case status == "unhealthy":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-				return logOutput, fmt.Errorf("%s container is unhealthy: %s, please use %s to find out why it failed", name, logOutput, suggestedCommand)
+				return logOutput, fmt.Errorf("%s container is unhealthy: %s, more info with %s", name, logOutput, suggestedCommand)
 			case status == "exited":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-				return logOutput, fmt.Errorf("%s container exited, please use %s to find out why it failed", name, suggestedCommand)
+				return logOutput, fmt.Errorf("%s container exited, more info with %s", name, suggestedCommand)
 			}
 		}
 	}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -538,14 +538,14 @@ func getSuggestedCommandForContainerLog(container *dockerTypes.Container) (strin
 	}
 	name := strings.TrimPrefix(container.Names[0], "/")
 	if name != "" {
-		suggestedCommands = append(suggestedCommands, fmt.Sprintf("docker logs %s", name), fmt.Sprintf("docker inspect --format \"{{ json .State.Health }}\" %s | docker run -i ddev/ddev-utilities jq -r", name))
+		suggestedCommands = append(suggestedCommands, fmt.Sprintf("docker logs %s", name), fmt.Sprintf("docker inspect --format \"{{ json .State.Health }}\" %s | docker run -i --rm ddev/ddev-utilities jq -r", name))
 	}
 	// Should never happen, but added just in case
 	if name == "" {
 		name = "unknown"
 	}
 	if len(suggestedCommands) == 0 {
-		suggestedCommands = append(suggestedCommands, "ddev logs", "docker logs CONTAINER (find CONTAINER with 'docker ps')", "docker inspect --format \"{{ json .State.Health }}\" CONTAINER", "docker inspect --format \"{{ json .State.Health }}\" CONTAINER | docker run -i ddev/ddev-utilities jq -r")
+		suggestedCommands = append(suggestedCommands, "ddev logs", "docker logs CONTAINER (find CONTAINER with 'docker ps')", "docker inspect --format \"{{ json .State.Health }}\" CONTAINER", "docker inspect --format \"{{ json .State.Health }}\" CONTAINER | docker run -i --rm ddev/ddev-utilities jq -r")
 	}
 	suggestedCommand, _ := util.ArrayToReadableOutput(suggestedCommands)
 	return name, suggestedCommand

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -538,14 +538,14 @@ func getSuggestedCommandForContainerLog(container *dockerTypes.Container) (strin
 	}
 	name := strings.TrimPrefix(container.Names[0], "/")
 	if name != "" {
-		suggestedCommands = append(suggestedCommands, fmt.Sprintf("docker logs %s", name), fmt.Sprintf("docker inspect --format \"{{ json .State.Health }}\" %s", name))
+		suggestedCommands = append(suggestedCommands, fmt.Sprintf("docker logs %s", name), fmt.Sprintf("docker inspect --format \"{{ json .State.Health }}\" %s | docker run -i ddev/ddev-utilities jq -r", name))
 	}
 	// Should never happen, but added just in case
 	if name == "" {
 		name = "unknown"
 	}
 	if len(suggestedCommands) == 0 {
-		suggestedCommands = append(suggestedCommands, "ddev logs", "docker logs CONTAINER (find CONTAINER with 'docker ps')", "docker inspect --format \"{{ json .State.Health }}\" CONTAINER", "docker inspect --format \"{{ json .State.Health }}\" CONTAINER | jq -r")
+		suggestedCommands = append(suggestedCommands, "ddev logs", "docker logs CONTAINER (find CONTAINER with 'docker ps')", "docker inspect --format \"{{ json .State.Health }}\" CONTAINER", "docker inspect --format \"{{ json .State.Health }}\" CONTAINER | docker run -i ddev/ddev-utilities jq -r")
 	}
 	suggestedCommand, _ := util.ArrayToReadableOutput(suggestedCommands)
 	return name, suggestedCommand


### PR DESCRIPTION
## The Issue

- #6042

Container errors messages contain commands to know more for debugging the issue embedded in the error message itself, which makes it harder to visually parse.

## How This PR Solves The Issue

Shows the commands that can provide more information in separate lines.

Message will look like:

```
Failed waiting for web/db containers to become ready: web container failed: log=, err=health check timed out after 2m0s: labels map[com.ddev.site-name:project-name com.docker.compose.service:web] timed out without becoming healthy, status=, detail= ddev-project-name-web:starting - more info with [
        ddev logs -s web
        docker logs ddev-project-name-web
        docker inspect --format "{{ json .State.Health }}" ddev-project-name-web
]
```

## Manual Testing Instructions

Try breaking project containers on ddev start and see what happens.

I don't really know how to break them, so I've only really tested a timeout scenario using:

```
echo 'RUN chmod 000 /run/php' > .ddev/web-build/Dockerfile
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- #5899
- #6030

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

