### PR TITLE
docs: add a sticky warning about the latest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /authors.json
 /docs/cache
 /dist
+/.cache
 /.ddev
 /artifacts
 *.DS_Store

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -5,8 +5,50 @@
   <meta name="google-site-verification" content="uFpolYSfqt2_75ubmaMBdPrmc9LjnEkhZUhSF0ejXWg" />
 {% endblock %}
 
+<!-- This is a copy of https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/partials/header.html with a warning banner added. -->
+<!-- This means that this part of the code can be changed upstream and may need to be updated in the future. -->
 {% block header %}
-  {% if config.extra.version != "stable" %}
+  <!--
+    Copyright (c) 2016-2024 Martin Donath <martin.donath@squidfunk.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+  -->
+
+  <!-- Determine classes -->
+  {% set class = "md-header" %}
+  {% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+  {% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
+  {% endif %}
+
+  <!-- Header -->
+  <header class="{{ class }}" data-md-component="header">
+
+    <!-- Warning Banner -->
+    {% if config.extra.version != "stable" %}
+    <!-- remove the shadow, as it looks strange with a warning banner next to it -->
+    <style>
+      .md-header--shadow {
+        box-shadow: unset;
+      }
+    </style>
     <div data-md-color-scheme="default" data-md-component="outdated">
       <aside class="md-banner md-banner--warning">
         <div class="md-banner__inner md-grid md-typeset">
@@ -15,11 +57,96 @@
             <strong>Click here to see the stable documentation.</strong>
           </a>
           <script>
-            document.getElementById('stable-docs-link').href = `https://ddev.readthedocs.io/${new URL(window.location.href).pathname.replace(/\/en\/[^/]+/, 'en/stable')}`;
+            document.getElementById('stable-docs-link').href = `https://ddev.readthedocs.io/${new URL(window.location.href).pathname.replace(/\/en\/[^/]+/, 'en/stable')}${window.location.hash}`;
           </script>
         </div>
       </aside>
     </div>
-  {% endif %}
-  {{ super() }}
+    {% endif %}
+
+    <nav
+        class="md-header__inner md-grid"
+        aria-label="{{ lang.t('header') }}"
+    >
+
+      <!-- Link to home -->
+      <a
+          href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"
+          title="{{ config.site_name | e }}"
+          class="md-header__button md-logo"
+          aria-label="{{ config.site_name }}"
+          data-md-component="logo"
+      >
+        {% include "partials/logo.html" %}
+      </a>
+
+      <!-- Button to open drawer -->
+      <label class="md-header__button md-icon" for="__drawer">
+        {% set icon = config.theme.icon.menu or "material/menu" %}
+        {% include ".icons/" ~ icon ~ ".svg" %}
+      </label>
+
+      <!-- Header title -->
+      <div class="md-header__title" data-md-component="header-title">
+        <div class="md-header__ellipsis">
+          <div class="md-header__topic">
+       <span class="md-ellipsis">
+        {{ config.site_name }}
+       </span>
+          </div>
+          <div class="md-header__topic" data-md-component="header-topic">
+       <span class="md-ellipsis">
+        {% if page.meta and page.meta.title %}
+         {{ page.meta.title }}
+        {% else %}
+         {{ page.title }}
+        {% endif %}
+       </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Color palette toggle -->
+      {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+      {% include "partials/palette.html" %}
+      {% endif %}
+      {% endif %}
+
+      <!-- User preference: color palette -->
+      {% if not config.theme.palette is mapping %}
+      {% include "partials/javascripts/palette.html" %}
+      {% endif %}
+
+      <!-- Site language selector -->
+      {% if config.extra.alternate %}
+      {% include "partials/alternate.html" %}
+      {% endif %}
+
+      <!-- Button to open search modal -->
+      {% if "material/search" in config.plugins %}
+      <label class="md-header__button md-icon" for="__search">
+        {% set icon = config.theme.icon.search or "material/magnify" %}
+        {% include ".icons/" ~ icon ~ ".svg" %}
+      </label>
+
+      <!-- Search interface -->
+      {% include "partials/search.html" %}
+      {% endif %}
+
+      <!-- Repository information -->
+      {% if config.repo_url %}
+      <div class="md-header__source">
+        {% include "partials/source.html" %}
+      </div>
+      {% endif %}
+    </nav>
+
+    <!-- Navigation tabs (sticky) -->
+    {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+    {% include "partials/tabs.html" %}
+    {% endif %}
+    {% endif %}
+  </header>
 {% endblock %}


### PR DESCRIPTION
## The Issue

People do not know that they are using the documentation for an unreleased version of DDEV when they open the page and scroll down.

## How This PR Solves The Issue

- I took the HTML code of the header from the upstream repo and added a warning banner to it.
- Add an anchor to the link leading to stable docs (`${window.location.hash}`)
- Add `/.cache` to `.gitignore` (follow up for #6027)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

