### PR TITLE
fix: make sure CGO_ENABLED is normally off, fixes #6046

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -221,6 +221,9 @@ jobs:
         if: steps.notarizedmac.outputs.cache-hit != 'true'
         run: exit 1
 
+      - name: "Verify that cgo_enabled is 0 in Linux binary"
+        run: .gotmp/bin/linux_amd64/ddev version | grep "^cgo_enabled *0$"
+
       # Goreleaser does GitHub release artifacts, homebrew, AUR, deb/rpm
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -222,7 +222,10 @@ jobs:
         run: exit 1
 
       - name: "Verify that cgo_enabled is 0 in Linux binary"
-        run: .gotmp/bin/linux_amd64/ddev version | grep "^cgo_enabled *0$"
+        run: |
+          .gotmp/bin/$(go env GOOS)_$(go env GOARCH)/ddev version
+          cgo=$(".gotmp/bin/$(go env GOOS)_$(go env GOARCH)/ddev" version 2>/dev/null | awk '/cgo_enabled/ {print $2}')
+          if [ "${cgo}" != "0" ]; then echo "CGO_ENABLED=${cgo} but it must be 0 in released binary" && exit 10; fi
 
       # Goreleaser does GitHub release artifacts, homebrew, AUR, deb/rpm
       - name: goreleaser

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -230,6 +230,7 @@ jobs:
           version: latest
           args: release --clean
         env:
+          CGO_ENABLED: 0
           DOCKER_ORG: ddev
           GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           make CGO_ENABLED="${CGO_ENABLED}" BUILDARGS="${BUILDARGS}"
           cgo=$(.gotmp/bin/$(go env GOOS)_$(go env GOARCH)/ddev version 2>/dev/null | awk '/cgo_enabled/ { print $2 }')
-          if [ "${CGO_ENABLED}" != "${cgo} ]; then
+          if [ "${CGO_ENABLED}" != "${cgo}" ]; then
             echo "CGO_ENABLED=${CGO_ENABLED} but built cgo=${cgo}" && exit 5
           fi
           make CGO_ENABLED="${CGO_ENABLED}" BUILDARGS="${BUILDARGS}" TESTARGS="${TESTARGS}" ${MAKE_TARGET}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,13 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
       - name: DDEV tests
-        run: make CGO_ENABLED="${CGO_ENABLED}" BUILDARGS="${BUILDARGS}" TESTARGS="${TESTARGS}" ${MAKE_TARGET}
+        run: |
+          make CGO_ENABLED="${CGO_ENABLED}" BUILDARGS="${BUILDARGS}"
+          cgo=$(.gotmp/bin/$(go env GOOS)_$(go env GOARCH)/ddev version 2>/dev/null | awk '/cgo_enabled/ { print $2 }')
+          if [ "${CGO_ENABLED}" != "${cgo} ]; then
+            echo "CGO_ENABLED=${CGO_ENABLED} but built cgo=${cgo}" && exit 5
+          fi
+          make CGO_ENABLED="${CGO_ENABLED}" BUILDARGS="${BUILDARGS}" TESTARGS="${TESTARGS}" ${MAKE_TARGET}
 
       - name: Clean up Homebrew
         continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ $(TARGETS): mkcert $(GOFILES)
 	@#echo "LDFLAGS=$(LDFLAGS)";
 	@rm -f $@
 	@export TARGET=$(word 3, $(subst /, ,$@)) && \
-	export GOOS="$${TARGET%_*}" GOARCH="$${TARGET#*_}" GOPATH="$(PWD)/$(GOTMP)" GOCACHE="$(PWD)/$(GOTMP)/.cache" && \
+	export CGO_ENABLED=$(CGO_ENABLED) GOOS="$${TARGET%_*}" GOARCH="$${TARGET#*_}" GOPATH="$(PWD)/$(GOTMP)" GOCACHE="$(PWD)/$(GOTMP)/.cache" && \
 	mkdir -p $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
 	chmod 777 $(GOTMP)/{.cache,pkg,src,bin/$$TARGET} && \
 	go build -o $(GOTMP)/bin/$$TARGET -installsuffix static $(BUILDARGS) -ldflags " $(LDFLAGS) " $(SRC_AND_UNDER)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -25,7 +25,7 @@ func GetVersionInfo() map[string]string {
 	versionInfo := make(map[string]string)
 
 	versionInfo["DDEV version"] = versionconstants.DdevVersion
-	versionInfo["cgo_enabled"] = strconv.FormatBool(versionconstants.CGOEnabled)
+	versionInfo["cgo_enabled"] = strconv.FormatInt(versionconstants.CGOEnabled, 10)
 	versionInfo["web"] = docker.GetWebImage()
 	versionInfo["db"] = docker.GetDBImage(nodeps.MariaDB, "")
 	versionInfo["router"] = docker.GetRouterImage()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/docker"
@@ -24,6 +25,7 @@ func GetVersionInfo() map[string]string {
 	versionInfo := make(map[string]string)
 
 	versionInfo["DDEV version"] = versionconstants.DdevVersion
+	versionInfo["cgo_enabled"] = strconv.FormatBool(versionconstants.CGOEnabled)
 	versionInfo["web"] = docker.GetWebImage()
 	versionInfo["db"] = docker.GetDBImage(nodeps.MariaDB, "")
 	versionInfo["router"] = docker.GetRouterImage()

--- a/pkg/versionconstants/cgo_false.go
+++ b/pkg/versionconstants/cgo_false.go
@@ -2,4 +2,4 @@
 
 package versionconstants
 
-const CGOEnabled = false
+const CGOEnabled = 0

--- a/pkg/versionconstants/cgo_false.go
+++ b/pkg/versionconstants/cgo_false.go
@@ -1,0 +1,5 @@
+//go:build !cgo
+
+package versionconstants
+
+const CGOEnabled = false

--- a/pkg/versionconstants/cgo_true.go
+++ b/pkg/versionconstants/cgo_true.go
@@ -2,4 +2,4 @@
 
 package versionconstants
 
-const CGOEnabled = true
+const CGOEnabled = 1

--- a/pkg/versionconstants/cgo_true.go
+++ b/pkg/versionconstants/cgo_true.go
@@ -1,0 +1,5 @@
+//go:build cgo
+
+package versionconstants
+
+const CGOEnabled = true


### PR DESCRIPTION

## The Issue

* #6046 

In DDEV v1.23.0-alpha1, the released binaries were released with CGO_ENABLED=1, which means they can't run everywhere they're intended to run. This includes Ubuntu 20.04

## How This PR Solves The Issue

* Make sure we build it right
* Add cgo_enabled to `ddev version` so we can check it
* Update Makefile and github builds to test and make sure we have it right.

## Manual Testing Instructions

You can already test the artifacts built this way from the experimental release https://github.com/ddev-test/ddev/releases/tag/v1.22.10-aaa3 (Do not use this for anything but testing this issue). 

* `ddev version` should show cgo_enabled=0


## Automated Testing Overview

We now check in the build pipeline to make sure the CGO_ENABLED version is correct.

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

