### PR TITLE
fix: Fix spelling for DEBUG_KIT_SAFE_TLD env variable

### DIFF
--- a/pkg/ddevapp/cakephp.go
+++ b/pkg/ddevapp/cakephp.go
@@ -61,7 +61,7 @@ func cakephpPostStartAction(app *DdevApp) error {
 		"export DATABASE_URL":                dbConnection + "://db:db@db:" + port + "/db",
 		"export EMAIL_TRANSPORT_DEFAULT_URL": "smtp://localhost:1025",
 		"export SECURITY_SALT":               util.HashSalt(app.GetName()),
-		"export DEBUGKIT_SAFE_TLD":           "site",
+		"export DEBUG_KIT_SAFE_TLD":          "site",
 	}
 	err = WriteProjectEnvFile(envFilePath, envMap, envText)
 	if err != nil {


### PR DESCRIPTION
## The Issue

DEBUG_KIT_SAFE_TLD was spelled like DEBUGKIT_SAFE_TLD

## How This PR Solves The Issue

Change env variable name to DEBUG_KIT_SAFE_TLD

## Manual Testing Instructions

1. Run ddev config in a `cakephp` project
2. Check .env in config folder. Variable must be spelled correctly.

## Automated Testing Overview

No change in tests
