### PR TITLE
docs: several maintenance items

### DIFF
--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -37,6 +37,8 @@ The following “Repository secret” environment variables must be added to <ht
 * `DDEV_MACOS_SIGNING_PASSWORD`: Password for the macOS signing key, see [signing_tools](https://github.com/ddev/signing_tools).
 * `DDEV_MAIN_REPO_ORGNAME`: The organization to be used for testing, normally `ddev` but it may be `ddev-test` for the test organization.
 * `DDEV_WINDOWS_SIGNING_PASSWORD`: Windows signing password.
+* `DOCKERHUB_USERNAME`: Username for pushing to `hub.docker.com` or updating image descriptions.
+* `DOCKERHUB_TOKEN`: Token for pushing to `hub.docker.com`. or updating image descriptions.
 * `FURY_ACCOUNT`: [Gemfury](https://gemfury.com) account that receives package pushes.
 * `FURY_TOKEN`: Push token assigned to the above Gemfury account.
 * `GORELEASER_KEY`: License key for GoReleaser Pro.

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -544,7 +544,7 @@ The former DDEV project types `drupal8`, `drupal9`, and `drupal10` can still be 
 
 Paths from the project’s docroot to the user-generated files directory targeted by `ddev import-files`. Can be outside the docroot but must be within the project directory e.g. `../private`. Some CMSes and frameworks have default `upload_dirs`, like Drupal's `sites/default/files`; `upload_dirs` will override the defaults, so if you want Drupal to use both `sites/default/files` and `../private` you would list both, `upload_dirs: ["sites/default/files", "../private"]`. `upload_dirs` is used for targeting `ddev import-files` and also, when Mutagen is enabled, to bind-mount those directories so their contents does not need to be synced into Mutagen.
 
-If you do not have directories of static assets of this type, or they're small and you don't care about them, you can disable the warning `You have Mutagen enabled and your 'php' project type doesn't have `upload_dirs` set.` by setting [disable_upload_dirs_warning](#disable_upload_dirs_warning) with `ddev config --disable-upload-dirs-warning`. 
+If you do not have directories of static assets of this type, or they are small and you don't care about them, you can disable the warning `You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set.` by setting [disable_upload_dirs_warning](#disable_upload_dirs_warning) with `ddev config --disable-upload-dirs-warning`.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -544,7 +544,7 @@ The former DDEV project types `drupal8`, `drupal9`, and `drupal10` can still be 
 
 Paths from the project’s docroot to the user-generated files directory targeted by `ddev import-files`. Can be outside the docroot but must be within the project directory e.g. `../private`. Some CMSes and frameworks have default `upload_dirs`, like Drupal's `sites/default/files`; `upload_dirs` will override the defaults, so if you want Drupal to use both `sites/default/files` and `../private` you would list both, `upload_dirs: ["sites/default/files", "../private"]`. `upload_dirs` is used for targeting `ddev import-files` and also, when Mutagen is enabled, to bind-mount those directories so their contents does not need to be synced into Mutagen.
 
-If you do not have directories of static assets of this type, or they are small and you don't care about them, you can disable the warning `You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set.` by setting [disable_upload_dirs_warning](#disable_upload_dirs_warning) with `ddev config --disable-upload-dirs-warning`.
+If you do not have directories of static assets of this type, or they are small and you don't care about them, you can disable the warning `You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set.` by setting [`disable_upload_dirs_warning`](#disable_upload_dirs_warning) with `ddev config --disable-upload-dirs-warning`.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -544,6 +544,8 @@ The former DDEV project types `drupal8`, `drupal9`, and `drupal10` can still be 
 
 Paths from the project’s docroot to the user-generated files directory targeted by `ddev import-files`. Can be outside the docroot but must be within the project directory e.g. `../private`. Some CMSes and frameworks have default `upload_dirs`, like Drupal's `sites/default/files`; `upload_dirs` will override the defaults, so if you want Drupal to use both `sites/default/files` and `../private` you would list both, `upload_dirs: ["sites/default/files", "../private"]`. `upload_dirs` is used for targeting `ddev import-files` and also, when Mutagen is enabled, to bind-mount those directories so their contents does not need to be synced into Mutagen.
 
+If you do not have directories of static assets of this type, or they're small and you don't care about them, you can disable the warning `You have Mutagen enabled and your 'php' project type doesn't have `upload_dirs` set.` by setting [disable_upload_dirs_warning](#disable_upload_dirs_warning) with `ddev config --disable-upload-dirs-warning`. 
+
 | Type | Default | Usage
 | -- | -- | --
 | :octicons-file-directory-16: project | | A list of directories.

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # Custom Commands
 
 Custom commands can easily be added to DDEV, to be executed on the host or in containers.

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -134,11 +134,6 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     You can set up [GitHub Codespaces](https://github.com/features/codespaces) following the instructions in the [DDEV Installation](ddev-installation.md#github-codespaces) section.
 
 <a name="troubleshooting"></a>
-
-## Alternate Docker Providers
-
-There are a number of [alternate Docker providers](../usage/faq.md#are-there-alternate-docker-providers-i-can-use) that can be used with DDEV.
-
 ## Testing and Troubleshooting Your Docker Installation
 
 Docker needs to be able to do a few things for DDEV to work:

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -134,6 +134,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     You can set up [GitHub Codespaces](https://github.com/features/codespaces) following the instructions in the [DDEV Installation](ddev-installation.md#github-codespaces) section.
 
 <a name="troubleshooting"></a>
+
 ## Testing and Troubleshooting Your Docker Installation
 
 Docker needs to be able to do a few things for DDEV to work:


### PR DESCRIPTION

## The Issue

* Mention `disable_upload_dirs_warning` in the `upload_dirs` section
* Improve search likelihood on "custom commands"
* Remove "Alternate docker providers" as it's a basic FAQ section
* Add DOCKERHUB_USERNAME/TOKEN to list of required secrets