### PR TITLE
docs: fix the scroll margin for links with anchors, for #6048

### DIFF
--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -34,10 +34,17 @@
 
   <!-- Warning banner -->
   {% if config.extra.version != "stable" %}
-    <!-- remove the shadow, as it looks strange with a warning banner next to it -->
     <style>
+      /* remove the shadow, as it looks strange with a warning banner next to it */
       .md-header--shadow {
         box-shadow: unset;
+      }
+      /* fix the scroll margin for links with anchors */
+      /* see https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/assets/stylesheets/main/extensions/markdown/_toc.scss */
+      .md-typeset {
+        :target {
+          --md-scroll-margin: 6rem;
+        }
       }
     </style>
     <div data-md-color-scheme="default" data-md-component="outdated">


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/6048#issuecomment-2040194194

Links with anchors open in the wrong position:

Stable:
https://ddev.readthedocs.io/en/stable/users/quickstart/#drupal
![2024-04-05_19-00](https://github.com/ddev/ddev/assets/24270994/7235416b-3661-49ae-a9b9-2d2ede249d36)

Latest:
https://ddev.readthedocs.io/en/latest/users/quickstart/#drupal
![2024-04-05_19-01](https://github.com/ddev/ddev/assets/24270994/77ffb857-c52e-4194-b20b-bd83f3a46dd2)

The code that calculates this:
https://github.com/squidfunk/mkdocs-material/blob/68126abb567ed9f9c5940af5ba31c6005c499596/src/templates/assets/stylesheets/main/extensions/markdown/_toc.scss#L61-L71

Ideally we would need to add another `+ 48px` here for a warning banner:

```scss
--md-scroll-margin: #{px2rem(48px + 24px)};
```

## How This PR Solves The Issue

Uses a fixed value of `6rem` for the margin. This is not ideal, as it may not work for all `font-size`, but at least it should satisfy most users.

## Manual Testing Instructions

Open on different devices https://ddev--6059.org.readthedocs.build/en/6059/users/quickstart/#drupal

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- https://stackoverflow.com/questions/4086107/fixed-page-header-overlaps-in-page-anchors

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

