### PR TITLE
fix: provide example .ddev/php folder and README, fixes #6052

### DIFF
--- a/pkg/ddevapp/dotddev_assets/php/README.txt
+++ b/pkg/ddevapp/dotddev_assets/php/README.txt
@@ -1,0 +1,14 @@
+#ddev-generated
+*.ini files in .ddev/php are added to the project's PHP configuration.
+
+More information is at
+https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-php-configuration-phpini
+
+For example, if you rename the provided php-example.ini.example
+to php-example.ini its configuration will be added to your PHP configuration.
+
+```
+[PHP]
+max_execution_time = 240;
+```
+

--- a/pkg/ddevapp/dotddev_assets/php/php-example.ini.example
+++ b/pkg/ddevapp/dotddev_assets/php/php-example.ini.example
@@ -1,0 +1,2 @@
+[PHP]
+max_execution_time = 240;


### PR DESCRIPTION

## The Issue

* #6052 

## How This PR Solves The Issue

Add .php directory with example and readme

## Manual Testing Instructions

* `ddev start`
* Review the provided files in .ddev/php
* Verify that nothing is added to the git index (`git status`) should not show anything.

