### PR TITLE
feat: add Docker API version to `ddev version`

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -36,6 +36,9 @@ func GetVersionInfo() map[string]string {
 	if versionInfo["docker"], err = dockerutil.GetDockerVersion(); err != nil {
 		versionInfo["docker"] = fmt.Sprintf("Failed to GetDockerVersion(): %v", err)
 	}
+	if versionInfo["docker-api"], err = dockerutil.GetDockerAPIVersion(); err != nil {
+		versionInfo["docker-api"] = fmt.Sprintf("Failed to GetDockerAPIVersion(): %v", err)
+	}
 	if versionInfo["docker-platform"], err = GetDockerPlatform(); err != nil {
 		versionInfo["docker-platform"] = fmt.Sprintf("Failed to GetDockerPlatform(): %v", err)
 	}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,13 +1,14 @@
 package version
 
 import (
+	"os"
+	"runtime"
+	"testing"
+
 	exec2 "github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/stretchr/testify/require"
-	"os"
-	"runtime"
-	"testing"
 
 	asrt "github.com/stretchr/testify/assert"
 )
@@ -34,8 +35,8 @@ func TestGetVersionInfo(t *testing.T) {
 	assert.Contains(v["db"], nodeps.MariaDBDefaultVersion)
 	assert.Equal(runtime.GOOS, v["os"])
 	assert.Equal(versionconstants.BUILDINFO, v["build info"])
+	assert.NotEmpty(v["docker"])
+	assert.NotEmpty(v["docker-api"])
 	assert.NotEmpty(v["docker-compose"])
 	assert.NotEmpty(v["docker-platform"])
-
-	assert.NotEmpty(v["docker"])
 }


### PR DESCRIPTION
## The Issue

Noticed that we can show Docker API version.

## How This PR Solves The Issue

Adds API version output.

## Manual Testing Instructions

Look for `docker-api`:

```
$ ddev version
 ITEM             VALUE                                    
 DDEV version     v1.23.0-beta1-10-g5cb608f31              
 architecture     amd64                                    
 cgo_enabled      0                                        
 db               ddev/ddev-dbserver-mariadb-10.11:v1.23.0 
 ddev-ssh-agent   ddev/ddev-ssh-agent:v1.23.0              
 docker           25.0.3                                   
 docker-api       1.44                                     
 docker-compose   v2.26.0                                  
 docker-platform  linux-docker                             
 mutagen          0.17.2                                   
 os               linux                                    
 router           ddev/ddev-traefik-router:v1.23.0         
 web              ddev/ddev-webserver:v1.23.0
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

