### PR TITLE
build: bump docker-compose to v2.26.1

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -39,4 +39,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.17.2"
 
-const RequiredDockerComposeVersionDefault = "v2.26.0"
+const RequiredDockerComposeVersionDefault = "v2.26.1"


### PR DESCRIPTION
## The Issue

docker-compose v2.26.1 contains a few bugfixes that may not be important, but are still worth a try.

https://github.com/docker/compose/releases/tag/v2.26.1