### PR TITLE
docs: add more examples how to use `ddev nvm`, fixes #6013

### DIFF
--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -971,14 +971,32 @@ ddev npm update
 
 ## `nvm`
 
-Run [`nvm`](https://github.com/nvm-sh/nvm#usage) inside the web container (global shell web container command). (Use of `ddev nvm` is discouraged because `nodejs_version` is much easier to use, can specify any version, and is more robust than using `nvm`.)
+Run [`nvm`](https://github.com/nvm-sh/nvm#usage) inside the web container (global shell web container command).
+
+!!!tip
+    Use of `ddev nvm` is discouraged because `nodejs_version` is much easier to use, can specify any version, and is more robust than using `nvm`.
 
 Example:
 
 ```shell
 # Use `nvm` to switch to Node.js v20
 ddev nvm install 20
+
+# Check the installed Node.js version
+ddev nvm current
+
+# Reset Node.js to `nodejs_version`
+ddev nvm alias default system
+
+# Switch between two installed Node.js versions
+ddev nvm install 20
+ddev nvm install 18
+ddev nvm alias default 20
+ddev nvm alias default 18
 ```
+
+!!!warning "`nvm use` works only inside the web container after `ddev ssh`"
+    Use `ddev nvm alias default <version>` instead.
 
 ## `php`
 


### PR DESCRIPTION
## The Issue

- #6013

## How This PR Solves The Issue

Adds more examples of how to check and switch Node.js versions with `nvm`, creates a tip about `nodejs_version`, warns about `nvm use`.

## Manual Testing Instructions

https://ddev--6067.org.readthedocs.build/en/6067/users/usage/commands/#nvm

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

