### PR TITLE
docs: limactl create needs --name=default, fixes #6068

### DIFF
--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -29,7 +29,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     2. If you don't have the `docker` client (if `docker help` fails) then install it with `brew install docker`.
     3. Create a 100GB VM in Lima with 4 CPUs, 6GB memory, and Cloudflare DNS. Adjust to your own needs:
     ```
-    limactl create --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
+    limactl create --name=default --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
     docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock"
     docker context use lima-default
     ```


### PR DESCRIPTION

## The Issue

* #6068 

Limactl create seems to have changed from using "default" as the default name and started using "docker"

## How This PR Solves The Issue

Use `limactl create --name=default` to force the name to be default.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

