### PR TITLE
test: Fix TestPHPOverrides on Windows

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -3,6 +3,7 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
+	copy2 "github.com/otiai10/copy"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -779,7 +780,7 @@ func TestPHPOverrides(t *testing.T) {
 	require.NoError(t, err)
 
 	// Copy test overrides into the project .ddev directory
-	err = fileutil.CopyDir(filepath.Join(origDir, "testdata/"+t.Name()+"/.ddev/php"), filepath.Join(site.Dir, ".ddev/php"))
+	err = copy2.Copy(filepath.Join(origDir, "testdata/"+t.Name()+"/.ddev/php"), filepath.Join(site.Dir, ".ddev/php"))
 	assert.NoError(err)
 	err = fileutil.CopyFile(filepath.Join(origDir, "testdata/"+t.Name()+"/phpinfo.php"), filepath.Join(app.AppRoot, app.Docroot, "phpinfo.php"))
 	assert.NoError(err)


### PR DESCRIPTION

## The Issue

The recent introduction of pre-creating the project `.ddev/php` directory caused TestPHPOverrides to fail on traditional Windows:
https://buildkite.com/ddev/ddev-windows-mutagen/builds/4537#018ec0a3-1a37-4afa-9718-9930e764a04d

TestPHPOverrides was using fileutil.CopyDir(), which requires the target directory not to exist. 

## How This PR Solves The Issue

Use the better tool, github.com/otiai10/copy, for copying

