### PR TITLE
build: pin blackfire to working package, fixes #6078

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/apt/preferences.d/blackfire
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/apt/preferences.d/blackfire
@@ -1,0 +1,6 @@
+# 2024-04-10: blackfire upgrade was broken per https://github.com/ddev/ddev/issues/6078
+# Pinned to current installed version
+Package: blackfire
+Version: 2:2.26.1
+Pin: version 2:2.26.1
+Pin-Priority: 1001

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240410_add_symfony_cli" // Note that this can be overridden by make
+var WebTag = "20240410_blackfire_pin" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240410_blackfire_pin" // Note that this can be overridden by make
+var WebTag = "v1.23.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

* #6078 

## How This PR Solves The Issue

* Pin blackfire to the working version to make sure it doesn't try to update

## Manual Testing Instructions

Use blackfire. But that's impossible for anyone without an expensive subscription.

Anyway, `ddev ssh` and `sudo apt update && sudo apt upgrade` and nothing bad should happen.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

