### PR TITLE
feat: Add symfony cli

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -138,6 +138,7 @@ SQLite
 Starts
 Statamic
 Support
+Symfony
 TablePlus
 Traefik
 TravisCI

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -21,8 +21,11 @@ ARG BUILDPLATFORM
 ADD ddev-webserver-etc-skel /
 RUN /sbin/mkhomedir_helper www-data
 
+# symfony cli
+RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | bash
+
 RUN apt-get -qq update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y libcap2-bin locales-all pv supervisor
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y libcap2-bin locales-all pv supervisor symfony-cli
 
 # Arbitrary user needs to be able to bind to privileged ports (for nginx and apache2)
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/nginx

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -2,7 +2,7 @@
 
 @test "Verify required binaries are installed in normal image" {
     if [ "${IS_HARDENED}" == "true" ]; then skip "Skipping because IS_HARDENED==true"; fi
-    COMMANDS="composer drush8 git magerun magerun2 mkcert node npm platform sudo terminus wp"
+    COMMANDS="composer drush8 git magerun magerun2 mkcert node npm platform sudo symfony terminus wp"
     for item in $COMMANDS; do
 #      echo "# looking for $item" >&3
       docker exec $CONTAINER_NAME bash -c "command -v $item >/dev/null"

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -632,14 +632,10 @@ If your project uses a database you'll want to set the [DB connection string](ht
 
 === "Symfony CLI"
 
-    In a future release the Symfony CLI will be provided by default in `ddev-webserver`, but for now it needs to be configured.
-
     ```bash
     mkdir my-symfony && cd my-symfony
     ddev config --docroot=public
-    echo "RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | sudo -E bash
-    RUN sudo apt install -y symfony-cli" >.ddev/web-build/Dockerfile.symfony-cli
-    ddev restart
+    ddev start
     ddev exec symfony check:requirements
     ddev exec symfony new temp --version="7.0.*" --webapp
     ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -41,7 +41,7 @@ Type `ddev` or `ddev -h` in a terminal window to see the available DDEV [command
 In addition to the [*commands*](../usage/commands.md) listed above, there are lots of tools included inside the containers:
 
 * [`ddev describe`](../usage/commands.md#describe) tells how to access **Mailpit**, which captures email in your development environment.
-* Composer, Git, Node.js, npm, nvm, and dozens of other tools are installed in the web container, and you can access them via [`ddev ssh`](../usage/commands.md#ssh) or [`ddev exec`](../usage/commands.md#exec).
+* Composer, Git, Node.js, npm, nvm, symfony, and dozens of other tools are installed in the web container, and you can access them via [`ddev ssh`](../usage/commands.md#ssh) or [`ddev exec`](../usage/commands.md#exec).
 * [`ddev logs`](../usage/commands.md#logs) gets you web server logs; `ddev logs -s db` gets database server logs.
 * `sqlite3` and the `mysql` and `psql` clients are inside the web container (and `mysql` or `psql` client is also in the `db` container).
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.23.0" // Note that this can be overridden by make
+var WebTag = "20240410_add_symfony_cli" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

In
* https://github.com/ddev/ddev/pull/6060

we added the symfony quickstart. But we had the awkward duty of adding it with a Dockerfile.

If we're going to push another ddev-webserver:v1.23.0-1... why not get this in?

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

