### PR TITLE
fix: Skip hidden directories when creating commands

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -82,6 +82,10 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 			if !fileutil.IsDirectory(serviceDirOnHost) {
 				continue
 			}
+			// Skip hidden directories as well.
+			if strings.HasPrefix(filepath.Base(serviceDirOnHost), ".") {
+				continue
+			}
 			commandFiles, err := fileutil.ListFilesInDir(serviceDirOnHost)
 			if err != nil {
 				return err

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -89,6 +89,7 @@ func TestCustomCommands(t *testing.T) {
 	assert.NotContains(out, "testwebglobal global (global shell web container command)")
 	assert.NotContains(out, "testhostcmd global")
 	assert.NotContains(out, "testwebcmd global")
+	assert.NotContains(out, "not-a-command")
 
 	out, err = exec.RunHostCommand(DdevBin, "testhostglobal-noproject", "hostarg1", "hostarg2", "--hostflag1")
 	assert.NoError(err)
@@ -140,6 +141,7 @@ func TestCustomCommands(t *testing.T) {
 	assert.Contains(out, "testwebglobal global (global shell web container command)")
 	assert.NotContains(out, "testhostcmd global") //the global testhostcmd should have been overridden by the project one
 	assert.NotContains(out, "testwebcmd global")  //the global testwebcmd should have been overridden by the project one
+	assert.NotContains(out, "not-a-command")
 
 	// Have to do app.Start() because commands are copied into containers on start
 	err = app.Start()

--- a/cmd/ddev/cmd/testdata/TestCustomCommands/global_commands/.hiddendir/not-a-command
+++ b/cmd/ddev/cmd/testdata/TestCustomCommands/global_commands/.hiddendir/not-a-command
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: not-a-command global
+## Usage: not-a-command
+## Example: "ddev not-a-command"
+
+echo "this file shouldn't display in the commands list"


### PR DESCRIPTION
## The Issue

DDEV thinks hidden directories in `~/.ddev/commands/` hold commands for services with names that start with a `.`

This can result in commands like this showing up:

![Screenshot from 2024-04-11 17-53-05](https://github.com/ddev/ddev/assets/36352093/c12bda46-0f43-4a2b-a3b4-fee06e944bad)

Note that the `composer.lock`, `composer.json`, and `config.yml` files all live in a hidden directory.

(For reference, `.php-utils/` here contains code and dependencies that my global host commands share - see https://github.com/GuySartorelli/my-ddev-commands if you're curious)

## How This PR Solves The Issue

Skips hidden directories, so that files in those directories are not treated like commands.

## Manual Testing Instructions

Add a hidden directory in `~/.ddev/commands/` with some files in it and run `ddev` - before the PR they will show up in the commands list, but afterwards they shouldn't.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
Tests that a command in a hidden directory doesn't show in the commands list

## Related Issue Link(s)
N/A

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
In the very unlikely scenario where someone does actually have a service where the name of the services starts with a `.`, they will no longer be able to add global commands for it. That strikes me as exceedingly unlikely though.

