### PR TITLE
feat: Add toggle option for xhprof command, rework xdebug, fixes #5782

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
@@ -15,6 +15,25 @@ fi
 
 xdebug_version=$(php --version | awk '/Xdebug v/ {print $3}')
 
+get_xdebug_status() {
+    case ${xdebug_version} in
+    v3*)
+      status=$(php -r 'echo ini_get("xdebug.mode");' 2>/dev/null)
+      if [[ "${status}" =~ .*"debug".* ]]; then
+        echo "1"
+      else
+        echo "0"
+      fi
+      ;;
+    v2*)
+      echo $(php -r 'echo ini_get("xdebug.remote_enable");')
+      ;;
+    *)
+      echo "0"
+      ;;
+    esac
+} 
+
 case $1 in
   on|true|enable)
     enable_xdebug
@@ -23,51 +42,20 @@ case $1 in
     disable_xdebug
     ;;
   toggle)
-    case ${xdebug_version} in
-    v3*)
-      status=$(php -r 'echo ini_get("xdebug.mode");' 2>/dev/null)
-      if [[ "${status}" =~ .*"debug".* ]]; then
-        disable_xdebug
-      else
-        enable_xdebug
-      fi
-      ;;
-    v2*)
-      status=$(php -r 'echo ini_get("xdebug.remote_enable");')
-      if [ "${status}" = "1" ]; then
-        disable_xdebug
-      else
-        enable_xdebug
-      fi
-      ;;
-    *)
+    status=$(get_xdebug_status)
+    if [ "${status}" = "1" ]; then
+      disable_xdebug
+    else
       enable_xdebug
-      ;;
-    esac
+    fi
     ;;
   status)
-    case ${xdebug_version} in
-    v3*)
-      status=$(php -r 'echo ini_get("xdebug.mode");' 2>/dev/null)
-      if [[ "${status}" =~ .*"debug".* ]]; then
-        result="xdebug enabled"
-      else
-        result="xdebug disabled"
-      fi
-      ;;
-    v2*)
-      status=$(php -r 'echo ini_get("xdebug.remote_enable");')
-      if [ "${status}" = "1" ]; then
-        result="xdebug enabled"
-      else
-        result="xdebug disabled"
-      fi
-      ;;
-    *)
+    status=$(get_xdebug_status)
+    if [ "${status}" = "1" ]; then
+      result="xdebug enabled"
+    else
       result="xdebug disabled"
-      ;;
-    esac
-
+    fi
     echo $result
     ;;
   *)

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/xhprof
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/xhprof
@@ -2,11 +2,11 @@
 
 ## #ddev-generated
 ## Description: Enable or disable xhprof
-## Usage: xhprof on|off|enable|disable|true|false|status
-## Example: "ddev xhprof" (default is "on"), "ddev xhprof off", "ddev xhprof on", "ddev xhprof status"
+## Usage: xhprof on|off|enable|disable|true|false|toggle|status
+## Example: "ddev xhprof" (default is "on"), "ddev xhprof off", "ddev xhprof on", "ddev xhprof toggle", "ddev xhprof status"
 ## ExecRaw: false
 ## Flags: []
-## AutocompleteTerms: ["on","off","enable","disable","status"]
+## AutocompleteTerms: ["on","off","enable","disable","toggle","status"]
 
 if [ $# -eq 0 ]; then
   enable_xhprof
@@ -19,6 +19,14 @@ on | true | enable)
   ;;
 off | false | disable)
   disable_xhprof
+  ;;
+toggle)
+  status=$(php -m | grep 'xhprof')
+  if [ "${status}" = "xhprof" ]; then
+    disable_xhprof
+  else
+    enable_xhprof
+  fi
   ;;
 status)
   status=$(php -m | grep 'xhprof')


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

The `xdebug` command has a toggle option, but `xhprof` doesn't. They're both really similar in their operation so it makes sense to add a `ddev xhprof toggle` option.

## How This PR Solves The Issue

Adds the option.

Also some unrelated-but-adjacent refactoring of xdebug, which was pretty convoluted.

## Manual Testing Instructions

- Try `ddev xhprof toggle` and validate the status with `ddev xhprof status`
- Check that hitting `tab` after typing `ddev xhprof ` gives you `toggle` amongst the other options.
- Try `ddev xdebug toggle` and `ddev xdebug status` as a sanity check for the refactor

## Automated Testing Overview

Existing tests should cover the xdebug refactoring.

There's no tests at all for xhprof that I could find, so adding them seems out of scope. Happy to add if maintainers disagree with that assessment though.

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- #5782 

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
N/A

