### PR TITLE
docs: Replaced --target-db by --database

### DIFF
--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -82,10 +82,10 @@ The username, password, and database are each `db` regardless of how you connect
 
 ### Can I use additional databases with DDEV?
 
-Yes, you can create additional databases and manually do whatever you need on them. They’re created automatically if you use `ddev import-db` with the `--target-db` option. In this example, `extradb.sql.gz` is extracted and imported to a newly-created database named `extradb`:
+Yes, you can create additional databases and manually do whatever you need on them. They’re created automatically if you use `ddev import-db` with the `--database` option. In this example, `extradb.sql.gz` is extracted and imported to a newly-created database named `extradb`:
 
 ```
-ddev import-db --target-db=extradb --file=.tarballs/extradb.sql.gz
+ddev import-db --database=extradb --file=.tarballs/extradb.sql.gz
 ```
 
 You can use [`ddev mysql`](../usage/commands.md#mysql) or `ddev psql` to execute queries, or use the MySQL/PostgreSQL clients within `ddev ssh` or `ddev ssh -s db`. See the [Database Management](database-management.md) page.


### PR DESCRIPTION
## The Issue

"Flag --target-db has been deprecated, please use --database instead" when following instructions for multiple dbs on the FAQ page

## How This PR Solves The Issue

Replaces --target-db flag by --database

