### PR TITLE
fix: do not explicitly set the backdrop_drupal_compatibility and update_free_access settings, fixes #6090

### DIFF
--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -32,6 +32,16 @@ type BackdropSettings struct {
 	DBPublishedPort  int
 }
 
+// backdropSettingsLocalAnchorPattern defines a pattern to search for settings.local.php in settings.php with a comment.
+//
+//	/**
+//	 * Include a local settings file...
+//	 */
+//	if (file_exists(__DIR__ . '/settings.local.php')) {
+//	  include __DIR__ . '/settings.local.php';
+//	}
+const backdropSettingsLocalAnchorPattern = `(?s)\n/\*\*\s*\*\s*Include a local settings file.*?\*/\s*if\s*\(\s*file_exists\s*\(\s*__DIR__\s*\.\s*'\/settings\.local\.php'\s*\)\s*\)\s*{\s*include\s*__DIR__\s*\.\s*'\/settings\.local\.php'\s*;\s*}`
+
 // NewBackdropSettings produces a BackdropSettings object with default values.
 func NewBackdropSettings(app *DdevApp) *BackdropSettings {
 	dockerIP, _ := dockerutil.GetDockerIP()
@@ -76,7 +86,7 @@ func createBackdropSettingsFile(app *DdevApp) (string, error) {
 	} else {
 		output.UserOut.Printf("Existing %s file does not include %s, modifying to include ddev settings", settings.SiteSettings, settings.SiteSettingsDdev)
 
-		if err = appendIncludeToDrupalSettingsFile(app); err != nil {
+		if err = appendIncludeToDrupalSettingsFile(app, backdropSettingsLocalAnchorPattern); err != nil {
 			return "", fmt.Errorf("failed to include %s in %s: %v", settings.SiteSettingsDdev, settings.SiteSettings, err)
 		}
 	}

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -32,16 +32,6 @@ type BackdropSettings struct {
 	DBPublishedPort  int
 }
 
-// backdropSettingsLocalAnchorPattern defines a pattern to search for settings.local.php in settings.php with a comment.
-//
-//	/**
-//	 * Include a local settings file...
-//	 */
-//	if (file_exists(__DIR__ . '/settings.local.php')) {
-//	  include __DIR__ . '/settings.local.php';
-//	}
-const backdropSettingsLocalAnchorPattern = `(?s)\n/\*\*\s*\*\s*Include a local settings file.*?\*/\s*if\s*\(\s*file_exists\s*\(\s*__DIR__\s*\.\s*'\/settings\.local\.php'\s*\)\s*\)\s*{\s*include\s*__DIR__\s*\.\s*'\/settings\.local\.php'\s*;\s*}`
-
 // NewBackdropSettings produces a BackdropSettings object with default values.
 func NewBackdropSettings(app *DdevApp) *BackdropSettings {
 	dockerIP, _ := dockerutil.GetDockerIP()
@@ -86,7 +76,7 @@ func createBackdropSettingsFile(app *DdevApp) (string, error) {
 	} else {
 		output.UserOut.Printf("Existing %s file does not include %s, modifying to include ddev settings", settings.SiteSettings, settings.SiteSettingsDdev)
 
-		if err = appendIncludeToDrupalSettingsFile(app, backdropSettingsLocalAnchorPattern); err != nil {
+		if err = appendIncludeToDrupalSettingsFile(app); err != nil {
 			return "", fmt.Errorf("failed to include %s in %s: %v", settings.SiteSettingsDdev, settings.SiteSettings, err)
 		}
 	}

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"text/template"
 
 	"github.com/ddev/ddev/pkg/archive"
@@ -105,7 +106,7 @@ func manageDrupalSettingsFile(app *DdevApp, drupalConfig *DrupalSettings) error 
 	} else {
 		util.Debug("Existing %s file does not include %s, modifying to include DDEV settings", drupalConfig.SiteSettings, drupalConfig.SiteSettingsDdev)
 
-		if err := appendIncludeToDrupalSettingsFile(app); err != nil {
+		if err := appendIncludeToDrupalSettingsFile(app, ""); err != nil {
 			return fmt.Errorf("failed to include %s in %s: %v", drupalConfig.SiteSettingsDdev, drupalConfig.SiteSettings, err)
 		}
 	}
@@ -116,12 +117,18 @@ func manageDrupalSettingsFile(app *DdevApp, drupalConfig *DrupalSettings) error 
 // writeDrupalSettingsPHP creates the project's settings.php if it doesn't exist
 func writeDrupalSettingsPHP(app *DdevApp) error {
 
-	drupalVersion, err := GetDrupalVersion(app)
-	if err != nil || drupalVersion == "" {
-		drupalVersion = DefaultDrupalSettingsVersion
+	var appType string
+	if app.Type == nodeps.AppTypeBackdrop {
+		appType = app.Type
+	} else {
+		drupalVersion, err := GetDrupalVersion(app)
+		if err != nil || drupalVersion == "" {
+			drupalVersion = DefaultDrupalSettingsVersion
+		}
+		appType = "drupal" + drupalVersion
 	}
 
-	content, err := bundledAssets.ReadFile(path.Join("drupal", "drupal"+drupalVersion, "settings.php"))
+	content, err := bundledAssets.ReadFile(path.Join("drupal", appType, "settings.php"))
 	if err != nil {
 		return err
 	}
@@ -542,7 +549,7 @@ func settingsHasInclude(drupalConfig *DrupalSettings, siteSettingsPath string) (
 
 // appendIncludeToDrupalSettingsFile modifies the settings.php file to include the settings.ddev.php
 // file, which contains ddev-specific configuration.
-func appendIncludeToDrupalSettingsFile(app *DdevApp) error {
+func appendIncludeToDrupalSettingsFile(app *DdevApp, anchorPattern string) error {
 	// Check if file is empty
 	contents, err := os.ReadFile(app.SiteSettingsPath)
 	if err != nil {
@@ -554,14 +561,38 @@ func appendIncludeToDrupalSettingsFile(app *DdevApp) error {
 		return writeDrupalSettingsPHP(app)
 	}
 
-	// The file is not empty, open it for appending
-	file, err := os.OpenFile(app.SiteSettingsPath, os.O_RDWR|os.O_APPEND, 0644)
+	// Determine where to insert the settingsIncludeStanza
+	var newContent string
+	// Use appending mode
+	fileOpenMode := os.O_APPEND
+	if anchorPattern == "" {
+		// If no anchorPattern is provided, append to the end of the file
+		newContent = settingsIncludeStanza
+	} else {
+		// If anchorPattern is provided, find its position
+		anchorPattern := regexp.MustCompile(anchorPattern)
+		index := anchorPattern.FindStringIndex(string(contents))
+		if index == nil {
+			// If anchorPattern not found, append to the end of the file
+			newContent = settingsIncludeStanza
+		} else {
+			// Split the file content at the anchorPattern and insert the settingsIncludeStanza
+			part1 := string(contents[:index[0]])
+			part2 := string(contents[index[0]:])
+			newContent = part1 + settingsIncludeStanza + part2
+			// Use truncating mode
+			fileOpenMode = os.O_TRUNC
+		}
+	}
+
+	// The file is not empty, open it for appending/truncating
+	file, err := os.OpenFile(app.SiteSettingsPath, os.O_RDWR|fileOpenMode, 0644)
 	if err != nil {
 		return err
 	}
 	defer util.CheckClose(file)
 
-	_, err = file.Write([]byte(settingsIncludeStanza))
+	_, err = file.Write([]byte(newContent))
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/drupal/backdrop/settings.ddev.php
+++ b/pkg/ddevapp/drupal/backdrop/settings.ddev.php
@@ -19,6 +19,4 @@ if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == "true")) {
 
 $database = "$driver://{{ $config.DatabaseUsername }}:{{ $config.DatabasePassword }}@$host:$port/{{ $config.DatabaseName }}";
 
-$settings['update_free_access'] = FALSE;
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
-$settings['backdrop_drupal_compatibility'] = TRUE;

--- a/pkg/ddevapp/drupal/backdrop/settings.php
+++ b/pkg/ddevapp/drupal/backdrop/settings.php
@@ -11,7 +11,7 @@
  * Database configuration:
  *
  * Most sites can configure their database by entering the connection string
- * below. If using master/slave databases or multiple connections, see the
+ * below. If using primary/replica databases or multiple connections, see the
  * advanced database documentation at
  * https://api.backdropcms.org/database-configuration
  */
@@ -19,7 +19,25 @@ $database = 'mysql://user:pass@localhost/database_name';
 $database_prefix = '';
 
 /**
- * Site configuration files location.
+ * Configuration storage
+ *
+ * By default configuration will be stored in the filesystem, using the
+ * directories specified in the $config_directories setting. Optionally,
+ * configuration can be store in the database instead of the filesystem.
+ * Switching this option on a live site is not currently supported without some
+ * manual work.
+ *
+ * Example using the database for live and file storage for staging:
+ * @code
+ * $settings['config_active_class'] = 'ConfigDatabaseStorage';
+ * $settings['config_staging_class'] = 'ConfigFileStorage';
+ * @endcode
+ */
+// $settings['config_active_class'] = 'ConfigFileStorage';
+// $settings['config_staging_class'] = 'ConfigFileStorage';
+
+/**
+ * Site configuration files location (if using file storage for configuration)
  *
  * By default these directories are stored within the files directory with a
  * hashed path. For the best security, these directories should be in a location
@@ -39,6 +57,14 @@ $database_prefix = '';
  */
 $config_directories['active'] = 'files/config_' . md5($database) . '/active';
 $config_directories['staging'] = 'files/config_' . md5($database) . '/staging';
+
+/**
+ * Skip the configuration staging directory cleanup
+ *
+ * When the configuration files are in version control, it may be preferable to
+ * not empty the staging directory after each sync.
+ */
+// $config['system.core']['config_sync_clear_staging'] = 0;
 
 /**
  * Access control for update.php script.
@@ -329,7 +355,7 @@ $settings['locale_custom_strings_en'][''] = array(
  */
 $settings['404_fast_paths_exclude'] = '/\/(?:styles)|(?:system\/files)\//';
 $settings['404_fast_paths'] = '/\.(?:txt|png|gif|jpe?g|css|js|ico|swf|flv|cgi|bat|pl|dll|exe|asp)$/i';
-$settings['404_fast_html'] = '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
+$settings['404_fast_html'] = '<!DOCTYPE html><html lang="en"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
 
 /**
  * By default, fast 404s are returned as part of the normal page request
@@ -395,12 +421,30 @@ $settings['404_fast_html'] = '<!DOCTYPE html><html><head><title>404 Not Found</t
 /**
  * Drupal backwards compatibility.
  *
- * By default, Backdrop 1.0 includes a compatibility layer to keep it compatible
+ * By default, Backdrop 1.x includes a compatibility layer to keep it compatible
  * with Drupal 7 APIs. Backdrop core itself does not use this compatibility
- * layer however. You may disable it if all the modules you're running were
- * built for Backdrop.
+ * layer however. You may disable it if all the modules and themes used on the
+ * site were built for Backdrop.
  */
 $settings['backdrop_drupal_compatibility'] = TRUE;
+
+/**
+ * Suppress warnings of multiple versions of the same module being found.
+ *
+ * When scanning for module files, if Backdrop encounters multiple instances of
+ * the same module (for example, a version of a module in the /modules directory
+ * that has the same name as a module in /core), then only the last module will
+ * be loaded. In such cases, Backdrop will show a warning on the status report
+ * page.
+ *
+ * Having multiple versions of the same module may be intentional in certain use
+ * cases though, such as in some multisite configurations, when there is need to
+ * override a core or contrib module with a different version in the /sites
+ * folder. In such cases, you may want to disable the status report warnings.
+ *
+ * Uncomment the line below to disable the warnings.
+ */
+// $settings['disable_multiple_modules_warnings'] = TRUE;
 
 /**
  * Configuration overrides.
@@ -416,8 +460,67 @@ $settings['backdrop_drupal_compatibility'] = TRUE;
  * such as views, content types, vocabularies, etc. may not work as expected.
  * Use any available API functions for complex systems instead.
  */
-//$config['system.core']['site_name'] = 'My Backdrop site';
-//$config['system.core']['file_temporary_path'] = '/tmp';
+// $config['system.core']['site_name'] = 'My Backdrop site';
+// $config['system.core']['file_temporary_path'] = '/tmp';
+
+/**
+ * File schemes whose paths should not be normalized.
+ *
+ * Normally, Backdrop normalizes '/./' and '/../' segments in file URIs in order
+ * to prevent unintended file access. For example, 'private://css/../image.png'
+ * is normalized to 'private://image.png' before checking access to the file.
+ *
+ * On Windows, Backdrop also replaces '\' with '/' in file URIs.
+ *
+ * If file URIs with one or more scheme should not be normalized like this, then
+ * list the schemes here. For example, if 'example://path/./filename.png' should
+ * not be normalized to 'example://path/filename.png', then add 'example' to
+ * this array. In this case, make sure that the module providing the 'example'
+ * scheme does not allow unintended file access when using '/../' to move up the
+ * directory tree.
+ */
+// $config['system.core']['file_not_normalized_schemes'] = array('example');
+
+/**
+ * Additional public file schemes.
+ *
+ * Public schemes are URI schemes that allow download access to all users for
+ * all files within that scheme.
+ *
+ * The "public" scheme is always public, and the "private" scheme is always
+ * private, but other schemes, such as "https", "s3", "example", or others,
+ * can be either public or private depending on the site. By default, they're
+ * private, and access to individual files is controlled via
+ * hook_file_download().
+ *
+ * Typically, if a scheme should be public, a module makes it public by
+ * implementing hook_file_download(), and granting access to all users for all
+ * files. This could be either the same module that provides the stream wrapper
+ * for the scheme, or a different module that decides to make the scheme
+ * public. However, in cases where a site needs to make a scheme public, but
+ * is unable to add code in a module to do so, the scheme may be added to this
+ * variable, the result of which is that system_file_download() grants public
+ * access to all files within that scheme.
+ */
+// $config['system.core']['file_additional_public_schemes'] = array('example');
+
+/**
+ * Sensitive request headers in backdrop_http_request() when following a
+ * redirect.
+ *
+ * By default backdrop_http_request() will strip sensitive request headers when
+ * following a redirect if the redirect location has a different http host to
+ * the original request, or if the scheme downgrades from https to http.
+ *
+ * These variables allow opting out of this behaviour. Careful consideration of
+ * the security implications of opting out is recommended. To opt out, set to
+ * FALSE.
+ *
+ * @see _backdrop_should_strip_sensitive_headers_on_http_redirect()
+ * @see backdrop_http_request()
+ */
+// $config['system.core']['backdrop_http_request']['strip_sensitive_headers_on_host_change'] = TRUE;
+// $config['system.core']['backdrop_http_request']['strip_sensitive_headers_on_https_downgrade'] = TRUE;
 
 /**
  * Include a local settings file, if available.
@@ -427,7 +530,7 @@ $settings['backdrop_drupal_compatibility'] = TRUE;
  * environment (staging, development, etc).
  *
  * Typically used to specify a different database connection information, to
- * disable caching, JavaScript/CSS compression, re-routing of outgoing e-mails,
+ * disable caching, JavaScript/CSS compression, re-routing of outgoing emails,
  * Google Analytics, and other things that should not happen on development and
  * testing sites.
  *
@@ -437,12 +540,12 @@ $settings['backdrop_drupal_compatibility'] = TRUE;
  *
  * Keep this code block at the end of this file to take full effect.
  */
-
-// Automatically generated include for settings managed by ddev.
-if (getenv('IS_DDEV_PROJECT') == 'true' && file_exists(__DIR__ . '/settings.ddev.php')) {
-  include __DIR__ . '/settings.ddev.php';
-}
-
 if (file_exists(__DIR__ . '/settings.local.php')) {
   include __DIR__ . '/settings.local.php';
+}
+
+// Automatically generated include for settings managed by ddev.
+$ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
+if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
+  require $ddev_settings;
 }

--- a/pkg/ddevapp/drupal/backdrop/settings.php
+++ b/pkg/ddevapp/drupal/backdrop/settings.php
@@ -522,6 +522,12 @@ $settings['backdrop_drupal_compatibility'] = TRUE;
 // $config['system.core']['backdrop_http_request']['strip_sensitive_headers_on_host_change'] = TRUE;
 // $config['system.core']['backdrop_http_request']['strip_sensitive_headers_on_https_downgrade'] = TRUE;
 
+// Automatically generated include for settings managed by ddev.
+$ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
+if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
+  require $ddev_settings;
+}
+
 /**
  * Include a local settings file, if available.
  *
@@ -542,10 +548,4 @@ $settings['backdrop_drupal_compatibility'] = TRUE;
  */
 if (file_exists(__DIR__ . '/settings.local.php')) {
   include __DIR__ . '/settings.local.php';
-}
-
-// Automatically generated include for settings managed by ddev.
-$ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
-if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
-  require $ddev_settings;
 }


### PR DESCRIPTION
## The Issue
As described in https://github.com/ddev/ddev/issues/6090, if these settings are explicitly set in settings.ddev.php, trying to set them in settings.php or settings.local.php never takes.

## How This PR Solves The Issue
This PR removes the lines in settings.ddev.php that explicitly set these two settings, which allows the values to be set in settings.php or settings.local.php (which unlike Drupal is provided by default OOTB in Backdrop).

## Manual Testing Instructions
1. Install a vanilla Backdrop CMS site using the DDEV recipe.
2. Edit your `settings.php` file or the `settings.local.php` file and set `$settings['backdrop_drupal_compatibility'] = FALSE;`.
3. Try reading that setting via `settings_get('backdrop_drupal_compatibility')` (for instance using the devel module and `dpm()` or something) -> regardless of how that setting is configured, it is always returned as `TRUE` 👎🏼 
4. Apply this PR/patch -> try reading the setting again -> this time it should return the value as set in the `settings.php` file or the `settings.local.php` file 👍🏼 

## Automated Testing Overview
N/A

## Related Issue Link(s)
Fixes https://github.com/ddev/ddev/issues/6090

## Release/Deployment Notes
N/A

