### PR TITLE
fix: revert additions to php/craftcms expires in nginx-site.conf, fixes #6087

### DIFF
--- a/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
@@ -62,15 +62,6 @@ server {
         fastcgi_param HTTPS $fcgi_https;
     }
 
-    # Expire rules for static content
-
-    # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
-        expires 1M;
-        access_log off;
-        add_header Cache-Control "public";
-    }
-
     # Prevent clients from accessing hidden files (starting with a dot)
     # This is particularly important if you store .htpasswd files in the site hierarchy
     # Access to `/.well-known/` is allowed.

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
@@ -52,15 +52,6 @@ server {
         fastcgi_param HTTPS $fcgi_https;
     }
 
-    # Expire rules for static content
-
-    # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
-        expires 1M;
-        access_log off;
-        add_header Cache-Control "public";
-    }
-
     # Prevent clients from accessing hidden files (starting with a dot)
     # This is particularly important if you store .htpasswd files in the site hierarchy
     # Access to `/.well-known/` is allowed.


### PR DESCRIPTION

## The Issue

* #6087 

This seems to have been a result of adding image file cache expirations to the nginx php setup in 
* https://github.com/ddev/ddev/pull/5580

## How This PR Solves The Issue

Remove the image cache expiration that was added to the base 'php' type and `craftcms`.

## Manual Testing Instructions

Start a Kirby project using the quickstart, https://ddev.readthedocs.io/en/latest/users/quickstart/#kirby-cms

The images presented should load and show.

## Automated Testing Overview


## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

