### PR TITLE
fix: add Docker filter by label without value, fixes #6088

### DIFF
--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -28,7 +28,7 @@ func PowerOff() {
 	}
 
 	// Any straggling containers that have label "com.ddev.site-name" should be removed.
-	containers, err := dockerutil.FindContainersByLabels(map[string]string{"label": "com.ddev.site-name"})
+	containers, err := dockerutil.FindContainersByLabels(map[string]string{"com.ddev.site-name": ""})
 
 	if err == nil {
 		for _, c := range containers {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -302,7 +302,12 @@ func FindContainersByLabels(labels map[string]string) ([]dockerTypes.Container, 
 	}
 	filterList := dockerFilters.NewArgs()
 	for k, v := range labels {
-		filterList.Add("label", fmt.Sprintf("%s=%s", k, v))
+		label := fmt.Sprintf("%s=%s", k, v)
+		// If no value is specified, filter any value by the key.
+		if v == "" {
+			label = k
+		}
+		filterList.Add("label", label)
 	}
 
 	ctx, client := GetDockerClient()


### PR DESCRIPTION
## The Issue

- #6088

## How This PR Solves The Issue

The Docker filter used the old syntax from `fsouza/go-dockerclient`, and as a result, it was looking for `label=label=com.ddev.site-name` instead of `label=com.ddev.site-name`.

I also finally figured out the syntax for filtering by label only.

## Manual Testing Instructions

See #6088.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- #5787

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

