### PR TITLE
fix: codespaces needs https port as base

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2684,7 +2684,7 @@ func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs
 		codespaceName := os.Getenv("CODESPACE_NAME")
 		previewDomain := os.Getenv("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN")
 		if codespaceName != "" && previewDomain != "" {
-			url := fmt.Sprintf("https://%s-%s.%s", codespaceName, app.HostWebserverPort, previewDomain)
+			url := fmt.Sprintf("https://%s-%s.%s", codespaceName, app.HostHTTPSPort, previewDomain)
 			httpsURLs = append(httpsURLs, url)
 		}
 	}


### PR DESCRIPTION
## The Issue

* https://github.com/ddev/ddev/issues/6102

The URL provided for codespaces doesn't seem to work right, see https://discord.com/channels/664580571770388500/1229209241714163802/1229209241714163802

## How This PR Solves The Issue

Use the https port for codespaces

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

