### PR TITLE
build: Update to latest ddev-webserver prior to v1.23.0 release, fixes #6086

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.23.0" // Note that this can be overridden by make
+var WebTag = "v1.23.0-1" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

* #6086 

We didn't get 100% of the PHP upgrades done upstream because the build process is hugely slow, but we have most now, and certainly almost all the ones that matter. 

## How This PR Solves The Issue

Point to new build with more up-to-date PHP packages.

## Manual Testing Instructions

`ddev ssh` and example PHP versions. Should have 

```
$ ddev php --version
PHP 8.3.6 (cli) (built: Apr 11 2024 22:03:32) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.3.6, Copyright (c) Zend Technologies
    with Zend OPcache v8.3.6, Copyright (c), by Zend Technologies
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

