### PR TITLE
docs: remove errant comma in codespaces devcontainer.json

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -339,7 +339,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
       "image": "mcr.microsoft.com/devcontainers/universal:2",
       "features": {
         "ghcr.io/ddev/ddev/install-ddev:latest": {}
-      },
+      }
     }
     ```
 


### PR DESCRIPTION

## The Issue

There's a trailing comma in the provided devcontainer.json, and codespaces won't have it.

