### PR TITLE
fix: clean up test project on signal, fixes #6111

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -103,7 +103,8 @@ header "DDEV global info"
 ddev config global | (grep -v "^web-environment" || true)
 
 header "DOCKER provider info"
-printf "docker client location: ls -l \"$(which docker)\"\n\n"
+docker_client="$(which docker)"
+printf "docker client location: $(ls -l "${docker_client}")\n\n"
 
 echo "docker client alternate locations:"
 which -a docker
@@ -200,7 +201,7 @@ curl --fail -I ${host_http_url}
 header "curl -I of ${http_url} (router http URL) from outside"
 curl --fail -I "${http_url}"
 
-header "Full curl of ${http_url} (router https URL) from outside"
+header "Full curl of ${http_url} (router http URL) from outside"
 curl "${http_url}"
 
 header "Full curl of ${https_url} (router https URL) from outside"

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -75,7 +75,9 @@ function cleanup {
 ddev config --project-type=php --docroot=web --disable-upload-dirs-warning || (printf "\n\nPlease run 'ddev debug test' in the root of the existing project where you're having trouble.\n\n" && exit 4)
 printf "\nhost_mailpit_port: 60004\n" >.ddev/config.local.yaml
 
-#set +eu
+printf "RUN apt update\nRUN curl -I https://www.google.com\n" > .ddev/web-build/Dockerfile.test
+
+set +eu
 
 trap cleanup SIGINT SIGTERM SIGQUIT EXIT
 
@@ -165,6 +167,9 @@ cat <<END >web/index.php
   printf("The output file for Discord or issue queue is in\n<b>%s</b><br />\nfile://%s<br />\n", "$1", "$1", "$1");
 END
 
+header "ddev debug refresh"
+ddev debug refresh
+
 header "Project startup"
 DDEV_DEBUG=true ddev start -y || ( \
   set +x && \
@@ -211,8 +216,5 @@ header 'Thanks for running the diagnostic!'
 echo "Running ddev launch in 3 seconds" && sleep 3
 echo "Running ddev launch"
 ddev launch
-# Launch may take some time on some systems
-echo "Waiting 10 seconds to run ddev stop --unlist"
+echo "Waiting for ddev launch to complete before deleting project"
 sleep 10
-echo "running ddev stop --unlist"
-ddev stop --unlist

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -65,10 +65,19 @@ header "Creating dummy project named ${PROJECT_NAME} in ${PROJECT_DIR}"
 set -eu
 mkdir -p "${PROJECT_DIR}/web" || (echo "Unable to create test project at ${PROJECT_DIR}/web, please check ownership and permissions" && exit 2 )
 cd "${PROJECT_DIR}" || exit 3
-ddev config --project-type=php --docroot=web --disable-upload-dirs-warning --host-db-port=60001 --host-https-port=60002 --host-webserver-port=60003 || (printf "\n\nPlease run 'ddev debug test' in the root of the existing project where you're having trouble.\n\n" && exit 4)
+
+function cleanup {
+  printf "\n\nCleanup: deleting test project ${PROJECT_NAME}\n"
+  ddev delete -Oy ${PROJECT_NAME}
+  printf "\nPlease remove the files from this test with 'rm -r ${PROJECT_DIR}'\n"
+}
+
+ddev config --project-type=php --docroot=web --disable-upload-dirs-warning || (printf "\n\nPlease run 'ddev debug test' in the root of the existing project where you're having trouble.\n\n" && exit 4)
 printf "\nhost_mailpit_port: 60004\n" >.ddev/config.local.yaml
 
-set +eu
+#set +eu
+
+trap cleanup SIGINT SIGTERM SIGQUIT EXIT
 
 header "OS Information"
 uname -a

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -73,7 +73,6 @@ function cleanup {
 }
 
 ddev config --project-type=php --docroot=web --disable-upload-dirs-warning || (printf "\n\nPlease run 'ddev debug test' in the root of the existing project where you're having trouble.\n\n" && exit 4)
-printf "\nhost_mailpit_port: 60004\n" >.ddev/config.local.yaml
 
 printf "RUN apt update\nRUN curl -I https://www.google.com\n" > .ddev/web-build/Dockerfile.test
 
@@ -175,7 +174,7 @@ DDEV_DEBUG=true ddev start -y || ( \
   set +x && \
   ddev list && \
   ddev describe && \
-  printf "============= ddev-${PROJECT_NAME}-web healtcheck run =========\n" && \
+  printf "============= ddev-${PROJECT_NAME}-web healthcheck run =========\n" && \
   docker exec ddev-${PROJECT_NAME}-web bash -x 'rm -f /tmp/healthy && /healthcheck.sh' && \
   printf "========= web container healthcheck ======\n" && \
   docker inspect --format "{{json .State.Health }}" ddev-${PROJECT_NAME}-web && \


### PR DESCRIPTION

## The Issue

* #6111 
* Adding build-time connectivity test

## How This PR Solves The Issue

* Catch signal and clean up on exit
* Check docker build-time connectivity to internet

## Manual Testing Instructions

- [ ] Ctrl-C during run, it should clean up or give a good try
- [ ] It should completely clean up after a normal run
- [ ] If not internet is available, or google.com not accessible, the failure should show

