### PR TITLE
docs: update Drupal project types in quickstart code examples

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -159,7 +159,7 @@ For all versions of Drupal 8+ the Composer techniques work. The settings configu
 
     ```bash
     mkdir my-drupal-site && cd my-drupal-site
-    ddev config --project-type=drupal --php-version=8.3 --docroot=web
+    ddev config --project-type=drupal10 --php-version=8.3 --docroot=web
     ddev start
     ddev composer create drupal/recommended-project:^10
     ddev config --update
@@ -174,7 +174,7 @@ For all versions of Drupal 8+ the Composer techniques work. The settings configu
 
     ```bash
     mkdir my-drupal-site && cd my-drupal-site
-    ddev config --project-type=drupal --php-version=8.3 --docroot=web
+    ddev config --project-type=drupal10 --php-version=8.3 --docroot=web
     ddev start
     ddev composer create drupal/recommended-project:^11.x-dev
     ddev config --update
@@ -190,7 +190,7 @@ For all versions of Drupal 8+ the Composer techniques work. The settings configu
 
     ```bash
     mkdir my-drupal-site && cd my-drupal-site
-    ddev config --project-type=drupal --php-version=8.1 --docroot=web
+    ddev config --project-type=drupal9 --php-version=8.1 --docroot=web
     ddev start
     ddev composer create drupal/recommended-project:^9
     ddev config --update


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

Running the code examples in the Quickstart docs results in the following error:
```
Apptype must be one of backdrop, craftcms, django4, drupal10, drupal6, drupal7, drupal8, drupal9, laravel, magento, magento2, php, python, shopware6, silverstripe, typo3, wordpress 
```

## How This PR Solves The Issue
This PR updates the Quickstart docs to use one of the available project types. There is no drupal11 project type that I can find but drupal10 works.

## Manual Testing Instructions
Try running each code snippet. It should succeed without any errors.

## Automated Testing Overview

No tests. Docs only.

## Related Issue Link(s)

## Release/Deployment Notes

NA

