### PR TITLE
build: update hardened/prod healthcheck.sh, for #6033

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/healthcheck.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/healthcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This uses /bin/sh so it doesn't initialize profile/bashrc/etc
+# This uses /bin/sh, so it doesn't initialize profile/bashrc/etc
 
 # ddev-webserver healthcheck
 
@@ -8,7 +8,7 @@ set -e
 
 sleeptime=59
 
-# Make sure that mounted code, and mailpit
+# Make sure that phpstatus, mounted code, webserver and mailpit
 # are working.
 # Since docker doesn't provide a lazy period for startup,
 # we track health. If the last check showed healthy
@@ -16,7 +16,7 @@ sleeptime=59
 # sleep at startup. This requires the timeout to be set
 # higher than the sleeptime used here.
 if [ -f /tmp/healthy ]; then
-    printf "container was previously healthy, so sleeping ${sleeptime} seconds before continuing healthcheck...  "
+    printf "container was previously healthy, so sleeping %s seconds before continuing healthcheck... " ${sleeptime}
     sleep ${sleeptime}
 fi
 
@@ -61,9 +61,9 @@ if [ "${DDEV_WEBSERVER_TYPE#*-}" = "gunicorn" ]; then
 
 fi
 
-if [ "${DDEV_WEBSERVER_TYPE#*-}" = "fpm"  ]; then
+if [ "${DDEV_WEBSERVER_TYPE#*-}" = "fpm" ]; then
   gunicornstatus="true"
-  if curl --fail -s 127.0.0.1/phpstatus >/dev/null ; then
+  if curl --fail -s 127.0.0.1/phpstatus >/dev/null; then
     phpstatus="true"
     printf "phpstatus:OK "
   else
@@ -71,7 +71,7 @@ if [ "${DDEV_WEBSERVER_TYPE#*-}" = "fpm"  ]; then
   fi
 fi
 
-if [ "${phpstatus}" = "true" ] && [ "${gunicornstatus}" = "true" ] && [ "${htmlaccess}" = "true" ] &&  [ "${mailpit}" = "true" ] ; then
+if [ "${phpstatus}" = "true" ] && [ "${gunicornstatus}" = "true" ] && [ "${htmlaccess}" = "true" ] && [ "${mailpit}" = "true" ]; then
     touch /tmp/healthy
     exit 0
 fi

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/healthcheck.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/healthcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This uses /bin/sh so it doesn't initialize profile/bashrc/etc
+# This uses /bin/sh, so it doesn't initialize profile/bashrc/etc
 
 # ddev-webserver healthcheck
 
@@ -8,7 +8,7 @@ set -e
 
 sleeptime=59
 
-# Make sure that both phpstatus, mounted code NOT mailpit
+# Make sure that phpstatus, mounted code, webserver, NOT mailpit
 # (mailpit is excluded on hardened/prod)
 # are working.
 # Since docker doesn't provide a lazy period for startup,
@@ -17,9 +17,17 @@ sleeptime=59
 # sleep at startup. This requires the timeout to be set
 # higher than the sleeptime used here.
 if [ -f /tmp/healthy ]; then
-    printf "container was previously healthy, so sleeping ${sleeptime} seconds before continuing healthcheck...  "
+    printf "container was previously healthy, so sleeping %s seconds before continuing healthcheck... " ${sleeptime}
     sleep ${sleeptime}
 fi
+
+# Shutdown the supervisor if one of the critical processes is in the FATAL state
+for service in php-fpm nginx apache2; do
+  if supervisorctl status "${service}" 2>/dev/null | grep -q FATAL; then
+    printf "%s:FATAL " "${service}"
+    supervisorctl shutdown
+  fi
+done
 
 phpstatus="false"
 htmlaccess="false"
@@ -29,7 +37,7 @@ if ls /var/www/html >/dev/null; then
     htmlaccess="true"
     printf "/var/www/html:OK "
 else
-    printf "/var/www/html:FAILED"
+    printf "/var/www/html:FAILED "
 fi
 
 # If DDEV_WEBSERVER_TYPE is not set, use reasonable default
@@ -39,16 +47,16 @@ if [ "${DDEV_WEBSERVER_TYPE#*-}" = "gunicorn" ]; then
   phpstatus="true"
   if pkill -0 gunicorn; then
     gunicornstatus="true"
-    printf "gunicorn:OK"
+    printf "gunicorn:OK "
   else
     printf "gunicorn:FAILED "
   fi
 
 fi
 
-if [ "${DDEV_WEBSERVER_TYPE#*-}" = "fpm"  ]; then
+if [ "${DDEV_WEBSERVER_TYPE#*-}" = "fpm" ]; then
   gunicornstatus="true"
-  if curl --fail -s 127.0.0.1/phpstatus >/dev/null ; then
+  if curl --fail -s 127.0.0.1/phpstatus >/dev/null; then
     phpstatus="true"
     printf "phpstatus:OK "
   else
@@ -63,5 +71,3 @@ fi
 rm -f /tmp/healthy
 
 exit 1
-
-


### PR DESCRIPTION
## The Issue

- #6033

I noticed that I forgot to update `healthcheck.sh` for production.

## How This PR Solves The Issue

1. Copies the supervisorctl changes from #6033
2. Small reformatting (remove extra spaces, use `printf` output for variables)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

