### PR TITLE
build: bump docker-compose to 2.27.0

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -39,4 +39,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.17.2"
 
-const RequiredDockerComposeVersionDefault = "v2.26.1"
+const RequiredDockerComposeVersionDefault = "v2.27.0"


### PR DESCRIPTION

## The Issue

docker-compose 2.27.0 is out. See if it works.

