### PR TITLE
fix: getDatabaseBackups() should check error on .downloads deletion

### DIFF
--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -325,8 +325,14 @@ func (p *Provider) doFilesPullCommand() (filename []string, error error) {
 // getDatabaseBackups retrieves database using `generic backup database`, then
 // describe until it appears, then download it.
 func (p *Provider) getDatabaseBackups() (filename []string, error error) {
-	_ = os.RemoveAll(p.getDownloadDir())
-	_ = os.Mkdir(p.getDownloadDir(), 0755)
+	err := os.RemoveAll(p.getDownloadDir())
+	if err != nil {
+		return nil, err
+	}
+	err = os.Mkdir(p.getDownloadDir(), 0755)
+	if err != nil {
+		return nil, err
+	}
 
 	if p.DBPullCommand.Command == "" {
 		return nil, nil
@@ -336,7 +342,7 @@ func (p *Provider) getDatabaseBackups() (filename []string, error error) {
 	if s == "" {
 		s = "web"
 	}
-	err := p.app.MutagenSyncFlush()
+	err = p.app.MutagenSyncFlush()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

## The Issue

From https://discord.com/channels/664580571770388500/1232668554550186024/1232668554550186024

The .ddev/.downloads/files directory may exist somehow when trying to just get databases. 

Currently in HEAD `ddev pull` ignores failure to delete and recreate the .downloads directory.

## How This PR Solves The Issue

Check the error.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

