### PR TITLE
build: keep ddev-ssh-agent on gitpod, fixes #6132 [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ddev/ddev-gitpod-base:20240417
+image: ddev/ddev-gitpod-base:20240426
 tasks:
   - name: build-run
     init: |

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -25,7 +25,7 @@ RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" 
 RUN echo 'export PATH=~/bin:$PATH' >>~/.bashrc && mkdir -p ~/bin
 RUN echo ". /usr/share/autojump/autojump.sh" >> ~/.bashrc
 RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
-RUN mkdir -p ~/.ddev && echo "omit_containers: [ddev-router,ddev-ssh-agent]" >> ~/.ddev/global_config.yaml
+RUN mkdir -p ~/.ddev && echo "omit_containers: [ddev-router]" >> ~/.ddev/global_config.yaml
 RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
 # a gcc instance named gcc-5 is required for some vscode installations


### PR DESCRIPTION

## The Issue

It's awkward to use ddev-ssh-agent on gitpod

## How This PR Solves The Issue

Put it in there again.

(this has already been pushed)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

