### PR TITLE
feat: output the VIRTUAL_HOST if specified in environment variables of a service

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -61,6 +61,8 @@ running 'ddev describe <projectname>'.`,
 // renderAppDescribe takes the map describing the app and renders it for plain-text output
 func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (string, error) {
 	status := desc["status"]
+	services := app.ComposeYaml["services"]
+
 	var out bytes.Buffer
 
 	t := table.NewWriter()
@@ -123,17 +125,33 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 
 		for _, k := range serviceNames {
 			v := serviceMap[k]
-
 			httpURL := ""
 			urlPortParts := []string{}
+			extraInfo := []string{}
+			hasVirtualHost := false
 
 			switch {
 			// Normal case, using ddev-router based URLs
 			case !ddevapp.IsRouterDisabled(app):
-				if httpsURL, ok := v["https_url"]; ok {
-					urlPortParts = append(urlPortParts, httpsURL)
-				} else if httpURL, ok = v["http_url"]; ok {
-					urlPortParts = append(urlPortParts, httpURL)
+				if services != nil && k != "web" {
+					service := services.(map[string]interface{})[k]
+
+					if env, ok := service.(map[string]interface{})["environment"]; ok {
+						if vhost, ok := env.(map[string]interface{})["VIRTUAL_HOST"].(string); ok {
+							if vhost != app.GetPrimaryURL() {
+								hasVirtualHost = true
+								urlPortParts = append(urlPortParts, vhost)
+							}
+						}
+					}
+				}
+
+				if !hasVirtualHost {
+					if httpsURL, ok := v["https_url"]; ok {
+						urlPortParts = append(urlPortParts, httpsURL)
+					} else if httpURL, ok = v["http_url"]; ok {
+						urlPortParts = append(urlPortParts, httpURL)
+					}
 				}
 			// Gitpod, web container only, using port proxied by Gitpod
 			case (nodeps.IsGitpod() || nodeps.IsCodespaces()) && k == "web":
@@ -148,13 +166,16 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 			}
 
 			if p, ok := v["exposed_ports"]; ok {
-				urlPortParts = append(urlPortParts, "InDocker: "+v["short_name"]+":"+p)
+				if p != "" {
+					urlPortParts = append(urlPortParts, "InDocker: "+v["short_name"]+":"+p)
+				} else {
+					urlPortParts = append(urlPortParts, "InDocker: "+v["short_name"])
+				}
 			}
+
 			if p, ok := v["host_ports"]; ok && p != "" {
 				urlPortParts = append(urlPortParts, "Host: 127.0.0.1:"+p)
 			}
-
-			extraInfo := []string{}
 
 			// Get extra info for web container
 			if k == "web" {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -350,7 +350,7 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 			}
 
 			for name, portMapping := range envMap {
-				if name == "VIRTUAL_HOST" {
+				if name != "HTTP_EXPOSE" && name != "HTTPS_EXPOSE" {
 					continue
 				}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -349,35 +349,33 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 				appHostname = appDesc["hostname"].(string)
 			}
 
-			if httpExpose, ok := envMap["HTTP_EXPOSE"]; ok {
-				envValStr := fmt.Sprintf("%s", httpExpose)
-				portSpecs := strings.Split(envValStr, ",")
-				// There might be more than one exposed UI port, but this only handles the first listed,
-				// most often there's only one.
-				if len(portSpecs) > 0 {
-					// HTTP portSpecs typically look like <exposed>:<containerPort>, for example - HTTP_EXPOSE=1359:1358
-					ports := strings.Split(portSpecs[0], ":")
-
-					services[shortName]["http_url"] = "http://" + appHostname
-
-					if ports[0] != "80" {
-						services[shortName]["http_url"] = services[shortName]["http_url"] + ":" + ports[0]
-					}
+			for name, port := range envMap {
+				if name == "VIRTUAL_HOST" {
+					continue
 				}
-			}
 
-			if httpsExpose, ok := envMap["HTTPS_EXPOSE"]; ok {
-				envValStr := fmt.Sprintf("%s", httpsExpose)
+				portCheck := "80"
+				serviceAttribute := "http_url"
+				protocol := "http://"
+
+				if name == "HTTPS_EXPOSE" {
+					portCheck = "443"
+					serviceAttribute = "https_url"
+					protocol = "https://"
+				}
+
+				envValStr := fmt.Sprintf("%s", port)
 				portSpecs := strings.Split(envValStr, ",")
 				// There might be more than one exposed UI port, but this only handles the first listed,
 				// most often there's only one.
 				if len(portSpecs) > 0 {
-					// HTTPS portSpecs typically look like <exposed>:<containerPort>, for example - HTTPS_EXPOSE=1359:1358
+					// HTTP(S) portSpecs typically look like <exposed>:<containerPort>, for example - HTTP_EXPOSE=1359:1358
 					ports := strings.Split(portSpecs[0], ":")
 
-					services[shortName]["https_url"] = "https://" + appHostname
-					if ports[0] != "443" {
-						services[shortName]["https_url"] = services[shortName]["https_url"] + ":" + ports[0]
+					services[shortName][serviceAttribute] = protocol + appHostname
+
+					if ports[0] != portCheck {
+						services[shortName][serviceAttribute] = services[shortName][serviceAttribute] + ":" + ports[0]
 					}
 				}
 			}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -349,33 +349,33 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 				appHostname = appDesc["hostname"].(string)
 			}
 
-			for name, port := range envMap {
+			for name, portMapping := range envMap {
 				if name == "VIRTUAL_HOST" {
 					continue
 				}
 
-				portCheck := "80"
-				serviceAttribute := "http_url"
+				portDefault := "80"
+				attributeName := "http_url"
 				protocol := "http://"
 
 				if name == "HTTPS_EXPOSE" {
-					portCheck = "443"
-					serviceAttribute = "https_url"
+					portDefault = "443"
+					attributeName = "https_url"
 					protocol = "https://"
 				}
 
-				envValStr := fmt.Sprintf("%s", port)
-				portSpecs := strings.Split(envValStr, ",")
+				portValStr := fmt.Sprintf("%s", portMapping)
+				portSpecs := strings.Split(portValStr, ",")
 				// There might be more than one exposed UI port, but this only handles the first listed,
 				// most often there's only one.
 				if len(portSpecs) > 0 {
 					// HTTP(S) portSpecs typically look like <exposed>:<containerPort>, for example - HTTP_EXPOSE=1359:1358
 					ports := strings.Split(portSpecs[0], ":")
 
-					services[shortName][serviceAttribute] = protocol + appHostname
+					services[shortName][attributeName] = protocol + appHostname
 
-					if ports[0] != portCheck {
-						services[shortName][serviceAttribute] = services[shortName][serviceAttribute] + ":" + ports[0]
+					if ports[0] != portDefault {
+						services[shortName][attributeName] = services[shortName][attributeName] + ":" + ports[0]
 					}
 				}
 			}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -312,34 +312,72 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 		}
 		services[shortName]["host_ports"] = strings.Join(hostPorts, ",")
 
-		// Extract HTTP_EXPOSE and HTTPS_EXPOSE for additional info
+		// Extract VIRTUAL_HOST, HTTP_EXPOSE and HTTPS_EXPOSE for additional info
 		if !IsRouterDisabled(app) {
+			envMap := make(map[string]string)
+
 			for _, e := range c.Config.Env {
 				split := strings.SplitN(e, "=", 2)
 				envName := split[0]
-				if len(split) == 2 && (envName == "HTTP_EXPOSE" || envName == "HTTPS_EXPOSE") {
-					envVal := split[1]
 
-					envValStr := fmt.Sprintf("%s", envVal)
-					portSpecs := strings.Split(envValStr, ",")
-					// There might be more than one exposed UI port, but this only handles the first listed,
-					// most often there's only one.
-					if len(portSpecs) > 0 {
-						// HTTPS portSpecs typically look like <exposed>:<containerPort>, for example - HTTPS_EXPOSE=1359:1358
-						ports := strings.Split(portSpecs[0], ":")
-						//services[shortName][envName.(string)] = ports[0]
-						switch envName {
-						case "HTTP_EXPOSE":
-							services[shortName]["http_url"] = "http://" + appDesc["hostname"].(string)
-							if ports[0] != "80" {
-								services[shortName]["http_url"] = services[shortName]["http_url"] + ":" + ports[0]
-							}
-						case "HTTPS_EXPOSE":
-							services[shortName]["https_url"] = "https://" + appDesc["hostname"].(string)
-							if ports[0] != "443" {
-								services[shortName]["https_url"] = services[shortName]["https_url"] + ":" + ports[0]
-							}
-						}
+				// Store the values first, so we can have them all before assigning
+				if len(split) == 2 && (envName == "VIRTUAL_HOST" || envName == "HTTP_EXPOSE" || envName == "HTTPS_EXPOSE") {
+					envMap[envName] = split[1]
+				}
+			}
+
+			if virtualHost, ok := envMap["VIRTUAL_HOST"]; ok {
+				vhostVal := virtualHost
+				vhostValStr := fmt.Sprintf("%s", vhostVal)
+				vhostsList := strings.Split(vhostValStr, ",")
+
+				// There might be more than one VIRTUAL_HOST value, but this only handles the first listed,
+				// most often there's only one.
+				if len(vhostsList) > 0 {
+					// VIRTUAL_HOSTS typically look like subdomain.domain.tld, for example - VIRTUAL_HOSTS=vhost1.myproject.ddev.site,vhost2.myproject.ddev.site
+					vhost := strings.Split(vhostsList[0], ",")
+					services[shortName]["virtual_host"] = vhost[0]
+				}
+			}
+
+			hostname, ok := services[shortName]["virtual_host"]
+			appHostname := ""
+
+			if ok {
+				appHostname = hostname
+			} else {
+				appHostname = appDesc["hostname"].(string)
+			}
+
+			if httpExpose, ok := envMap["HTTP_EXPOSE"]; ok {
+				envValStr := fmt.Sprintf("%s", httpExpose)
+				portSpecs := strings.Split(envValStr, ",")
+				// There might be more than one exposed UI port, but this only handles the first listed,
+				// most often there's only one.
+				if len(portSpecs) > 0 {
+					// HTTP portSpecs typically look like <exposed>:<containerPort>, for example - HTTP_EXPOSE=1359:1358
+					ports := strings.Split(portSpecs[0], ":")
+
+					services[shortName]["http_url"] = "http://" + appHostname
+
+					if ports[0] != "80" {
+						services[shortName]["http_url"] = services[shortName]["http_url"] + ":" + ports[0]
+					}
+				}
+			}
+
+			if httpsExpose, ok := envMap["HTTPS_EXPOSE"]; ok {
+				envValStr := fmt.Sprintf("%s", httpsExpose)
+				portSpecs := strings.Split(envValStr, ",")
+				// There might be more than one exposed UI port, but this only handles the first listed,
+				// most often there's only one.
+				if len(portSpecs) > 0 {
+					// HTTPS portSpecs typically look like <exposed>:<containerPort>, for example - HTTPS_EXPOSE=1359:1358
+					ports := strings.Split(portSpecs[0], ":")
+
+					services[shortName]["https_url"] = "https://" + appHostname
+					if ports[0] != "443" {
+						services[shortName]["https_url"] = services[shortName]["https_url"] + ":" + ports[0]
 					}
 				}
 			}


### PR DESCRIPTION
## The Issue

Right now, `ddev describe` outputs most of the information one needs to access the various services in a DDEV project. There are cases however where it neglects to output custom `VIRTUAL_HOST` values from `environment` sections of a Docker Compose service. These values can allow for vanity domains of a service. This could/would be common with add-on services like Solr, NodeJS applications or similar.

## How This PR Solves The Issue

This PR modifies describe.go to try and pull in the information of the `environment` section of a service.

## Manual Testing Instructions

- Build binary of this PR.
- Have a test DDEV project that has a service and set its VIRTUAL_HOST environment variable to "`VIRTUAL_HOST=site1.$DDEV_HOSTNAME`"
- Start the project with the test binary.
- Run the `describe` command.
- The output should contain your custom virtual host like the below example.

Before:

<img width="1015" alt="Screenshot 2024-04-27 at 4 27 01 PM" src="https://github.com/ddev/ddev/assets/362176/c103245b-7ea0-4feb-b305-675868369d22">

Note the NodeJS and Solr services.

After:

<img width="1015" alt="Screenshot 2024-04-27 at 4 26 42 PM" src="https://github.com/ddev/ddev/assets/362176/69fb343a-68d8-4015-9bea-3e23252541fa">

Note that the NodeJS and Solr services now show their correct `VIRTUAL_HOST` values.

These services are now available in the browser at those hostnames. Otherwise, it can appear to be unclear that this is possible to end users. There are cases where users may prefer to access services at custom hostnames instead of default + port and this will add the output to `ddev describe`.

I could not figure out however how to prepend http:// or https:// to these values.

## Automated Testing Overview

These changes do not modify the structure of the describe output, therefore the current `TestCmdDescribe` needs no change.

