### PR TITLE
fix: provide sqlite 3.45 for drupal11, fixes #6110

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -956,6 +956,22 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	if app.CorepackEnable {
 		extraWebContent = extraWebContent + "\nRUN corepack enable"
 	}
+	if app.Type == nodeps.AppTypeDrupal {
+		// TODO: When ddev-webserver has required drupal 11+ sqlite version we can remove this.
+		drupalVersion, err := GetDrupalVersion(app)
+		if err == nil && drupalVersion == "11" {
+			extraWebContent = extraWebContent + "\n" + fmt.Sprintf(`
+### Drupal 11+ requires a miniumum sqlite3 version (3.45 currently)
+ARG TARGETPLATFORM
+ENV SQLITE_VERSION=%s
+RUN mkdir -p /tmp/sqlite3 && \
+wget -O /tmp/sqlite3/sqlite3.deb https://ftp.debian.org/debian/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
+wget -O /tmp/sqlite3/libsqlite3.deb https://ftp.debian.org/debian/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
+apt install -y /tmp/sqlite3/*.deb && \
+rm -rf /tmp/sqlite3
+			`, versionconstants.Drupal11RequiredSqlite3Version)
+		}
+	}
 
 	// Add supervisord config for WebExtraDaemons
 	var supervisorGroup []string

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -961,7 +961,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		drupalVersion, err := GetDrupalVersion(app)
 		if err == nil && drupalVersion == "11" {
 			extraWebContent = extraWebContent + "\n" + fmt.Sprintf(`
-### Drupal 11+ requires a miniumum sqlite3 version (3.45 currently)
+### Drupal 11+ requires a minimum sqlite3 version (3.45 currently)
 ARG TARGETPLATFORM
 ENV SQLITE_VERSION=%s
 RUN mkdir -p /tmp/sqlite3 && \

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2217,6 +2217,19 @@ func TestDdevFullSiteSetup(t *testing.T) {
 			assert.Error(err)
 			assert.Contains(err.Error(), "upload_dirs is not set", app.Type)
 		}
+
+		// Special installed sqlite3 test for drupal11.
+		if app.Type == nodeps.AppTypeDrupal {
+			drupalVersion, err := ddevapp.GetDrupalVersion(app)
+			if err == nil && drupalVersion == "11" {
+				stdout, stderr, err := app.Exec(&ddevapp.ExecOpts{
+					Cmd: "sqlite3 --version | awk '{print $1}'",
+				})
+				require.NoError(t, err, "sqlite3 --version failed, output=%v, stderr=%v", stdout, stderr)
+				stdout = strings.Trim(stdout, "\r\n")
+				require.Equal(t, versionconstants.Drupal11RequiredSqlite3Version, stdout)
+			}
+		}
 		// We don't want all the projects running at once.
 		err = app.Stop(true, false)
 		assert.NoError(err)

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -2,15 +2,15 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/dockerutil"
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/output"
-	"github.com/ddev/ddev/pkg/util"
-
 	"os"
 	"path"
 	"path/filepath"
 	"text/template"
+
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
 
 	"github.com/ddev/ddev/pkg/fileutil"
 
@@ -172,7 +172,7 @@ func writeDrupalSettingsDdevPhp(settings *DrupalSettings, filePath string, app *
 		}
 	}
 
-	drupalVersion, err := getDrupalVersion(app)
+	drupalVersion, err := GetDrupalVersion(app)
 	if err != nil || drupalVersion == "" {
 		// todo: Reconsider this logic for default version
 		drupalVersion = "10"
@@ -306,10 +306,10 @@ func isDrupal7App(app *DdevApp) bool {
 	return false
 }
 
-// getDrupalVersion finds the drupal8+ version so it can be used
+// GetDrupalVersion finds the drupal8+ version so it can be used
 // for setting requirements.
 // It can only work if there is configured Drupal8+ code
-func getDrupalVersion(app *DdevApp) (string, error) {
+func GetDrupalVersion(app *DdevApp) (string, error) {
 	// For drupal6/7 we use the apptype provided as version
 	switch app.Type {
 	case nodeps.AppTypeDrupal6:
@@ -329,7 +329,7 @@ func getDrupalVersion(app *DdevApp) (string, error) {
 
 // isDrupalApp returns true if the app is drupal
 func isDrupalApp(app *DdevApp) bool {
-	v, err := getDrupalVersion(app)
+	v, err := GetDrupalVersion(app)
 	if err == nil && v != "" {
 		return true
 	}
@@ -358,7 +358,7 @@ func drupal7ConfigOverrideAction(app *DdevApp) error {
 
 // drupalConfigOverrideAction selects proper versions for
 func drupalConfigOverrideAction(app *DdevApp) error {
-	v, err := getDrupalVersion(app)
+	v, err := GetDrupalVersion(app)
 	if err != nil || v == "" {
 		util.Warning("Unable to detect Drupal version, continuing")
 		return nil

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -40,3 +40,6 @@ var MutagenVersion = ""
 const RequiredMutagenVersion = "0.17.2"
 
 const RequiredDockerComposeVersionDefault = "v2.27.0"
+
+// Drupal11RequiredSqlite3Version for ddev-webserver
+const Drupal11RequiredSqlite3Version = "3.45.1"


### PR DESCRIPTION

## The Issue

* #6110 

Drupal 11 added an arbitrary sqlite3 version constraint that is hard to meet with Debian Bookworm

## How This PR Solves The Issue

Install it using debs from Debian 13 Trixie

## Manual Testing Instructions

* Install drupal 11 site
* `ddev exec sqlite3 --version` should show 3.45.1

## Automated Testing Overview

It's a sad location, but I added a test in TestDdevFullSiteSetup for drupal 11 that is specific to this case. I'm open to better suggestions. It could have its own test, but that seemed even worse.

## Related Issue Link(s)

* #6110 
* https://www.drupal.org/project/drupal/issues/3346338#comment-15572139
* https://github.com/justafish/ddev-drupal-core-dev/pull/23#discussion_r1581724491