### PR TITLE
build: show badges for Gitpod and GitHub Codespaces in PRs

### DIFF
--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -55,8 +55,8 @@ jobs:
 
             body += `\n\n See [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr)` + `.`;
 
-            body += `\n\n* [Test on Gitpod](https://gitpod.io/?autostart=true#https://github.com/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `).`;
-            body += `\n* [Test on GitHub Codespaces](https://codespaces.new/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `).`;
+            body += `\n\n[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/?autostart=true#https://github.com/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `)`;
+            body += `\n\n[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `)`;
 
             // insert or update a bot comment
             async function upsertComment(owner, repo, issue_number, purpose, body) {


### PR DESCRIPTION
## The Issue

- https://github.com/gitpod-io/gitpod/issues/19519

## How This PR Solves The Issue

I tried https://pullrequestbadge.com/ from https://github.com/gitpod-io/gitpod/issues/19519#issuecomment-2093438752, but decided to do something else.

Found these:
- https://gist.github.com/tianhaoz95/5bf47c416b4b641d83a2022f977a0ec0
- https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/setting-up-your-repository/facilitating-quick-creation-and-resumption-of-codespaces#creating-an-open-in-github-codespaces-badge

## Manual Testing Instructions

I did not find the light/dark variants for the images:

Light background:

![image](https://github.com/ddev/ddev/assets/24270994/80886ae5-e133-403a-b249-23c72c410951)

Dark background:

![image](https://github.com/ddev/ddev/assets/24270994/74789e5a-4bba-479c-b147-996ed03af78a)


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

