### PR TITLE
fix: close global traefik file after creation

### DIFF
--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -186,6 +186,7 @@ func pushGlobalTraefikConfig() error {
 		if err != nil {
 			util.Failed("Failed to create Traefik config file: %v", err)
 		}
+		defer f.Close()
 		t, err := template.New("traefik_global_config_template.yaml").Funcs(getTemplateFuncMap()).ParseFS(bundledAssets, "traefik_global_config_template.yaml")
 		if err != nil {
 			return fmt.Errorf("could not create template from traefik_global_config_template.yaml: %v", err)


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
Global traefik file not closed after creation
## How This PR Solves The Issue
close global traefik file after creation
## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

