### PR TITLE
fix: show error in `ddev debug refresh`

### DIFF
--- a/cmd/ddev/cmd/debug-refresh.go
+++ b/cmd/ddev/cmd/debug-refresh.go
@@ -54,7 +54,7 @@ var DebugRefreshCmd = &cobra.Command{
 
 		err = exec2.RunInteractiveCommand(composeBinaryPath, []string{"-f", composeRenderedPath, "build", "web", "--no-cache"})
 		if err != nil {
-			util.Failed("Failed to execute docker-compose -f %s build web --no-cache: %v", err)
+			util.Failed("Failed to execute %s -f %s build web --no-cache: %v", composeBinaryPath, composeRenderedPath, err)
 		}
 		buildDuration := util.FormatDuration(buildDurationStart())
 		util.Success("Refreshed Docker cache for project %s in %s", app.Name, buildDuration)


### PR DESCRIPTION
## The Issue

From Drupal DDEV Slack:
https://drupal.slack.com/archives/C5TQRQZRR/p1715061420332539

```
ddev debug refresh
...
Failed to execute docker-compose -f exit status 17 build web --no-cache: %!v(MISSING) 
```

## How This PR Solves The Issue

Adds missing variables to the output.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

