### PR TITLE
Update quickstart.md with Drupal 10 and 11 instructions

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -159,7 +159,7 @@ For all versions of Drupal 8+ the Composer techniques work. The settings configu
 
     ```bash
     mkdir my-drupal-site && cd my-drupal-site
-    ddev config --project-type=drupal --php-version=8.3 --docroot=web
+    ddev config --project-type=drupal10 --php-version=8.2 --docroot=web --create-docroot
     ddev start
     ddev composer create drupal/recommended-project:^10
     ddev config --update
@@ -174,7 +174,7 @@ For all versions of Drupal 8+ the Composer techniques work. The settings configu
 
     ```bash
     mkdir my-drupal-site && cd my-drupal-site
-    ddev config --project-type=drupal --php-version=8.3 --docroot=web
+    ddev config --project-type=drupal11 --php-version=8.2 --docroot=web --create-docroot
     ddev start
     ddev composer create drupal/recommended-project:^11.x-dev
     ddev config --update
@@ -190,7 +190,7 @@ For all versions of Drupal 8+ the Composer techniques work. The settings configu
 
     ```bash
     mkdir my-drupal-site && cd my-drupal-site
-    ddev config --project-type=drupal --php-version=8.1 --docroot=web
+    ddev config --project-type=drupal9 --php-version=8.2 --docroot=web --create-docroot
     ddev start
     ddev composer create drupal/recommended-project:^9
     ddev config --update


### PR DESCRIPTION
- Previous instructions were throwing an error:

You have specified a project type of drupal9 but no project of that type is found in /Users/alexmoreno/projects/promotedrupal/eca/web failed to validate config: unsupported PHP version: 8.3, ddev only supports the following versions: [5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2]

- Also: 

apptype must be one of backdrop, craftcms, drupal10, drupal6, drupal7, drupal8, drupal9, laravel, magento, magento2, php, shopware6, typo3, wordpress

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

