### PR TITLE
fix: check for valid db version in `ddev debug migrate-database`

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -719,7 +719,7 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	// If the database already exists in volume and is not of this type, then throw an error
 	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
 		if dbType, err := app.GetExistingDBType(); err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
-			return fmt.Errorf("unable to configure project %s with database type %s because that database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s', and you can try a migration with 'ddev debug migrate-database %s' see docs at %s", app.Name, dbType, dbType, dbType, app.Database.Type+":"+app.Database.Version, "https://ddev.readthedocs.io/en/stable/users/extend/database-types/")
+			return fmt.Errorf("unable to configure project %s with database type %s because that database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s', and you can try a migration with 'ddev debug migrate-database %s' see docs at %s", app.Name, app.Database.Type+":"+app.Database.Version, dbType, dbType, app.Database.Type+":"+app.Database.Version, "https://ddev.readthedocs.io/en/stable/users/extend/database-types/")
 		}
 	}
 

--- a/cmd/ddev/cmd/debug-migrate-database.go
+++ b/cmd/ddev/cmd/debug-migrate-database.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
-	"os"
-	"strings"
 )
 
 // DebugMigrateDatabase Migrates a database to a new type
@@ -35,7 +36,7 @@ ddev debug migrate-database mariadb:10.7`,
 		if !strings.HasPrefix(newDBVersionType, nodeps.MariaDB) && !strings.HasPrefix(newDBVersionType, nodeps.MySQL) {
 			util.Failed("This command can only convert between MariaDB and MySQL")
 		}
-		if !(nodeps.IsValidMariaDBVersion(newDBVersionType) || nodeps.IsValidMySQLVersion(newDBVersionType)) && !(nodeps.IsValidMariaDBVersion(existingDBType) || nodeps.IsValidMySQLVersion(existingDBType)) {
+		if (nodeps.IsValidMariaDBVersion(newDBVersionType) || nodeps.IsValidMySQLVersion(newDBVersionType)) && (nodeps.IsValidMariaDBVersion(existingDBType) || nodeps.IsValidMySQLVersion(existingDBType)) {
 			if !util.Confirm(fmt.Sprintf("Is it OK to attempt conversion from %s to %s?\nThis will export your database, create a snapshot,\nthen destroy your current database and import into the new database type.\nIt only migrates the 'db' database", existingDBType, newDBVersionType)) {
 				util.Failed("migrate-database cancelled")
 			}
@@ -79,7 +80,7 @@ ddev debug migrate-database mariadb:10.7`,
 			util.Success("Database was converted to %s", newDBVersionType)
 			return
 		}
-		util.Failed("Invalid target source database type (%s) or target database type (%s)", existingDBType, newDBVersionType)
+		util.Failed("Invalid source database type (%s) or target database type (%s)", existingDBType, newDBVersionType)
 	},
 }
 

--- a/docs/content/users/extend/database-types.md
+++ b/docs/content/users/extend/database-types.md
@@ -15,7 +15,7 @@ You could set these using the [`ddev config`](../usage/commands.md#config) comma
 
 - `ddev config --database=mysql:5.7`
 - `ddev config --database=mariadb:10.11`
-- `ddev config --database=postgres:14`.
+- `ddev config --database=postgres:14`
 
 Or by editing the [`database`](../configuration/config.md#database) setting in `.ddev/config.yaml`:
 
@@ -45,7 +45,7 @@ Since the existing binary database may not be compatible with changes to your co
 - [`ddev debug check-db-match`](../usage/commands.md#debug-check-db-match) will show if your configured project matches the binary database type.
 - [`ddev debug migrate-database`](../usage/commands.md#debug-migrate-database) allows an automated attempt at migrating your database to a different type/version.
     - This only works with databases of type `mysql` or `mariadb`.
-    - MySQL 8.0 has diverged in syntax from most of its predecessors, including earlier MySQL and all MariaDB versions. As a result, you may not be able to migrated *from* databases of type `mysql:8.0` because dumps from MySQL 8.0 often have keywords or other features not supported elsewhere.
+    - MySQL 8.0 has diverged in syntax from most of its predecessors, including earlier MySQL and all MariaDB versions. As a result, you may not be able to migrate *from* databases of type `mysql:8.0` because dumps from MySQL 8.0 often have keywords or other features not supported elsewhere.
     - Examples: `ddev debug migrate-database mariadb:10.7`, `ddev debug migrate-database mysql:8.0`.
 
 ## Caveats

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -1,8 +1,10 @@
 package nodeps
 
 import (
-	"github.com/maruel/natural"
 	"sort"
+	"strings"
+
+	"github.com/maruel/natural"
 
 	"github.com/ddev/ddev/pkg/config/types"
 )
@@ -175,8 +177,8 @@ func GetValidDatabaseVersions() []string {
 
 // IsValidMariaDBVersion is a helper function to determine if a MariaDB version is valid, returning
 // true if the supplied MariaDB version is valid and false otherwise.
-func IsValidMariaDBVersion(MariaDBVersion string) bool {
-	if _, ok := ValidMariaDBVersions[MariaDBVersion]; !ok {
+func IsValidMariaDBVersion(v string) bool {
+	if _, ok := ValidMariaDBVersions[strings.TrimPrefix(v, MariaDB+":")]; !ok {
 		return false
 	}
 
@@ -186,7 +188,7 @@ func IsValidMariaDBVersion(MariaDBVersion string) bool {
 // IsValidMySQLVersion is a helper function to determine if a MySQL version is valid, returning
 // true if the supplied version is valid and false otherwise.
 func IsValidMySQLVersion(v string) bool {
-	if _, ok := ValidMySQLVersions[v]; !ok {
+	if _, ok := ValidMySQLVersions[strings.TrimPrefix(v, MySQL+":")]; !ok {
 		return false
 	}
 
@@ -207,7 +209,7 @@ func GetValidMariaDBVersions() []string {
 // IsValidPostgresVersion is a helper function to determine if a PostgreSQL version is valid, returning
 // true if the supplied version is valid and false otherwise.
 func IsValidPostgresVersion(v string) bool {
-	if _, ok := ValidPostgresVersions[v]; !ok {
+	if _, ok := ValidPostgresVersions[strings.TrimPrefix(v, Postgres+":")]; !ok {
 		return false
 	}
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

```
$ ddev debug migrate-database mariadb:12345
Is it OK to attempt conversion from mariadb:10.11 to mariadb:12345?
This will export your database, create a snapshot,
then destroy your current database and import into the new database type.
It only migrates the 'db' database [Y/n] (yes):
```

## How This PR Solves The Issue

Fixed the condition for valid db versions. I came across it and couldn't understand how it worked before. During debugging, I saw that instead of the version, for example, `8.0`, the whole string `mysql:8.0` was passed inside.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

