### PR TITLE
fix: add timeout for install_nvm.sh

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -105,7 +105,7 @@ sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ~/.nvm
-if [ ! -f ~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
+if [ ! -f ~/.nvm/nvm.sh ]; then (timeout 30 install_nvm.sh || true); fi
 
 # /mnt/ddev_config/.homeadditions may be either
 # a bind-mount, or a volume mount, but we don't care,

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -91,8 +91,6 @@ disable_xhprof
 ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/mounted; docker may not be mounting it., exiting" && exit 101)
 
 mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry,corepack}
-ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ~/.nvm
-if [ ! -f ~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
 
 # The following ensures a persistent and shared "global" cache for
 # yarn1 (classic) and yarn2 (berry). In the case of yarn2, the global cache
@@ -104,7 +102,7 @@ if [ ! -f ~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ~/.nvm
-if [ ! -f ~/.nvm/nvm.sh ]; then (install_nvm.sh || true); fi
+if [ ! -f ~/.nvm/nvm.sh ]; then (timeout 30 install_nvm.sh || true); fi
 
 # chown of ddev-global-cache must be done with privileged container in app.Start()
 # chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.23.0-1" // Note that this can be overridden by make
+var WebTag = "20240510_stasadev_nvm_timeout" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

From Discord https://discord.com/channels/664580571770388500/1238432307526897725/1238432307526897725

```
$ ddev start
...
Failed waiting for web/db containers to become ready: web container failed: log=, err=health check timed out after 2m0s: labels map[com.ddev.site-name:tryddevproject-12211 com.docker.compose.service:web] timed out without becoming healthy, status=, detail= ddev-tryddevproject-12211-web:starting - more info with [
        ddev logs -s web
        docker logs ddev-tryddevproject-12211-web
        docker inspect --format "{{ json .State.Health }}" ddev-tryddevproject-12211-web | docker run -i --rm ddev/ddev-utilities jq -r
] 
```

```
$ ddev logs -s web
...
+ install_nvm.sh
=> nvm is already installed in /home/mcdruid/.nvm, trying to update using git
(the log ends here)
```

```
$ docker run --rm -it ddev/ddev-webserver:v1.23.0-1 install_nvm.sh
=> Downloading nvm from git to '/root/.nvm'
=> Cloning into '/root/.nvm'...
fatal: unable to access 'https://github.com/nvm-sh/nvm.git/': Recv failure: Connection reset by peer
Failed to clone nvm repo. Please report this!
```

## How This PR Solves The Issue

The default timeout for `curl` is 120 seconds. If `install_nvm.sh` fails, the container will reach that timeout.

Although this error occurs due to the configuration of the wireguard tunnel (Tailscale VPN), we can at least change the timeout for the script to make the project start normally.

## Manual Testing Instructions

```
docker run --rm -it ddev/ddev-webserver:v1.23.0-1 bash -c "timeout 30 install_nvm.sh"
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- https://sinanbir.com/tls-communication-error-in-a-docker-container/

## Release/Deployment Notes

The Docker image build includes changes from:

- #6126

Pull that PR first, then fix a conflict in `versionconstants.go` and pull this one

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

