### PR TITLE
docs: encourage people to use latest stable version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,14 +1,21 @@
-name: 🐞 Bug report
+name: 🐞 Bug report or Support Request
 description: Create a report to help us improve.
 labels: [bug]
 body:
   - type: checkboxes
     attributes:
-      label: Is there an existing issue for this?
-      description: Please [search existing issues](https://github.com/ddev/ddev/issues) to see if yours has already been reported.
+      label: Preliminary checklist
+      description: Please complete the following checks before submitting an issue.
       options:
-        - label: I have searched the existing issues
+        - label: I am using the latest stable version of DDEV (see [upgrade guide](https://ddev.readthedocs.io/en/stable/users/install/ddev-upgrade/))
           required: true
+        - label: I have searched [existing issues](https://github.com/ddev/ddev/issues)
+          required: true
+        - label: I have checked the [troubleshooting guide](https://ddev.readthedocs.io/en/stable/users/usage/troubleshooting/)
+          required: true
+        - label: I have run `ddev debug test` to include output below
+          required: true
+
   - type: textarea
     attributes:
       label: Output of `ddev debug test`

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -35,7 +35,7 @@ header "Please make sure that you have already looked at troubleshooting guide"
 printf "Troubleshooting guide: https://ddev.readthedocs.io/en/stable/users/usage/troubleshooting/ \n"
 printf "Simple things to check:\n* ddev poweroff\n* Restart Docker Provider\n* Reboot computer\n* Temporarily disable VPN and firewall\n"
 printf "Press any key to continue:\n"
-read x
+[[ "${DDEV_NONINTERACTIVE:-}" == "true" ]] || read x
 
 header "Output file will be in $1"
 if ! ddev describe >/dev/null 2>&1; then printf "Please try running this in an existing DDEV project directory, preferably the problem project.\nIt doesn't work in other directories.\n"; exit 2; fi

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -30,6 +30,13 @@ function docker_desktop_version {
   fi
 }
 
+header "Please make sure that you have already looked at troubleshooting guide"
+
+printf "Troubleshooting guide: https://ddev.readthedocs.io/en/stable/users/usage/troubleshooting/ \n"
+printf "Simple things to check:\n* ddev poweroff\n* Restart Docker Provider\n* Reboot computer\n* Temporarily disable VPN and firewall\n"
+printf "Press any key to continue:\n"
+read x
+
 header "Output file will be in $1"
 if ! ddev describe >/dev/null 2>&1; then printf "Please try running this in an existing DDEV project directory, preferably the problem project.\nIt doesn't work in other directories.\n"; exit 2; fi
 
@@ -213,6 +220,9 @@ curl "${http_url}"
 
 header "Full curl of ${https_url} (router https URL) from outside"
 curl "${https_url}"
+
+header "Curl google.com to check internet access and VPN"
+curl -I https://www.google.com
 
 header "host.docker.internal status"
 ddev exec ping -c 1 host.docker.internal

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -4,8 +4,8 @@ Things might go wrong! In addition to this page, consider checking [Stack Overfl
 
 ## General Troubleshooting Strategies
 
+* Please use the [current stable version of DDEV](https://ddev.readthedocs.io/en/stable/users/install/ddev-upgrade/) and of your Docker provider before going too far or asking for support.
 * Start by running [`ddev poweroff`](commands.md#poweroff) to make sure all containers can start fresh.
-* Please use the current stable version of DDEV and of your Docker provider before going too far or asking for support.
 * Temporarily disable firewalls, VPNs, tunnels, network proxies, and virus checkers while you’re troubleshooting.
 * Temporarily disable any proxies you’ve established in Docker’s settings.
 * Check to see if you're out of disk space. On macOS, make sure that your Docker provider has adequate disk space allocated. (DDEV will normally warn you about problems in this situation.)

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -10,6 +10,7 @@ Things might go wrong! In addition to this page, consider checking [Stack Overfl
 * Temporarily disable any proxies you’ve established in Docker’s settings.
 * Check to see if you're out of disk space. On macOS, make sure that your Docker provider has adequate disk space allocated. (DDEV will normally warn you about problems in this situation.)
 * On macOS, if you have a particular heavyweight project or are encountering `kill` statements in `ddev logs`, increase your memory allocation in your Docker provider. (Most projects are fine with 5-6GB allocated.)
+* On macOS your Docker provider limits the amount of disk space available to Docker. Make sure that you increase it if you're seeing disk space problems.
 * Please make sure that your project is in a subdirectory of your home directory and has normal ownership and privileges. For example, `ls -ld .` in your project directory should show you as owner of the directory and with write privileges.
 * Use [`ddev debug dockercheck`](commands.md#debug-dockercheck) and [`ddev debug test`](commands.md#debug-test) to help sort out Docker problems.
 * Make sure you do not have disk space problems on your computer. This can be especially tricky on WSL2, where you need to check both the main Windows disk space and WSL2 disk space as well.

--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -4,7 +4,7 @@
       "pattern": "^https*://127.0.0.1"
     },
     {
-      "pattern": "^https://www.drupal.org/(u|project|about|forum|slack)"
+      "pattern": "^https://www.drupal.org/(u|project|about|forum|slack|join-slack)"
     },
     {
       "pattern": "^https://deb.sury.org"


### PR DESCRIPTION
## The Issue

People are often asking about issues that have been fixed in current stable.

## How This PR Solves The Issue

* Encourage them to upgrade before filing an issue.
* Minor improvements to checkboxes and suggestions to start with.
* Minor improvements to `ddev debug test`, including curl of google.com to test internet access
* Minor improvements to troubleshooting suggestions

Here's what it looks like:

<img width="1062" alt="image" src="https://github.com/ddev/ddev/assets/112444/6123db65-b5a9-41a4-a559-8ade0480b8ee">
