### PR TITLE
fix: retrieve Drupal 11 sqlite3 packages from snapshot.debian.org

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -958,6 +958,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 	}
 	if app.Type == nodeps.AppTypeDrupal {
 		// TODO: When ddev-webserver has required drupal 11+ sqlite version we can remove this.
+		// These packages must be retrieved from snapshot.debian.org. We hope they'll be there
+		// when we need them.
 		drupalVersion, err := GetDrupalVersion(app)
 		if err == nil && drupalVersion == "11" {
 			extraWebContent = extraWebContent + "\n" + fmt.Sprintf(`
@@ -965,8 +967,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 ARG TARGETPLATFORM
 ENV SQLITE_VERSION=%s
 RUN mkdir -p /tmp/sqlite3 && \
-wget -O /tmp/sqlite3/sqlite3.deb https://ftp.debian.org/debian/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
-wget -O /tmp/sqlite3/libsqlite3.deb https://ftp.debian.org/debian/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
+wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
+wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
 apt install -y /tmp/sqlite3/*.deb && \
 rm -rf /tmp/sqlite3
 			`, versionconstants.Drupal11RequiredSqlite3Version)


### PR DESCRIPTION
## The Issue

Suddenly we're not able to support sqlite/libsqlite 3.45.1 because it's gone from the repo we were pulling it from, so Drupal 11 startup fails.

## How This PR Solves The Issue

Pull from snapshot.debian.org

I do wonder if we should only grab the 3.45 sqlite if they have omit_containers[db].

I don't understand why we didn't catch this in latest test on master (https://github.com/ddev/ddev/actions/runs/9035899711/job/24831603173) unless they just removed the package between the time that started and when I was testing. (Search for "DdevFullSiteSetup for TestPkgDrupal11").  Code is in https://github.com/ddev/ddev/blob/a96ab265933cc9c94c7533740fd40d78add0ccc5/pkg/ddevapp/ddevapp_test.go#L2221-L2232

I did manually test TestDdevFullSiteSetup with drupal11 on master and it failed there and succeeds here.

## Manual Testing Instructions

Start a d11 project

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

