### PR TITLE
build: install deb.sury.org key from debsuryorg-archive-keyring, fixes #6143

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -59,7 +59,8 @@ RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
 RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
 http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
 
-RUN curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg && \
+RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
+    dpkg -i /tmp/debsuryorg-archive-keyring.deb && rm -f /tmp/debsuryorg-archive-keyring.deb && \
     echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && apt-get update
 RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:v1.23.0 as ddev-webserver-base
+FROM ddev/ddev-php-base:20240513_stasadev_debsuryorg as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240510_stasadev_nvm_timeout" // Note that this can be overridden by make
+var WebTag = "20240513_stasadev_debsuryorg" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6143

## How This PR Solves The Issue

Uses the `debsuryorg-archive-keyring` package for PHP keyring.

## Manual Testing Instructions

```
$ ddev exec dpkg -L debsuryorg-archive-keyring
/.
/etc
/etc/apt
/etc/apt/trusted.gpg.d
/etc/apt/trusted.gpg.d/debsuryorg-archive.gpg
/usr
/usr/share
/usr/share/doc
/usr/share/doc/debsuryorg-archive-keyring
/usr/share/doc/debsuryorg-archive-keyring/changelog.gz
/usr/share/doc/debsuryorg-archive-keyring/copyright
/usr/share/keyrings
/usr/share/keyrings/deb.sury.org-apache2.gpg
/usr/share/keyrings/deb.sury.org-bind-dev.gpg
/usr/share/keyrings/deb.sury.org-bind-esv.gpg
/usr/share/keyrings/deb.sury.org-bind.gpg
/usr/share/keyrings/deb.sury.org-nginx-mainline.gpg
/usr/share/keyrings/deb.sury.org-nginx.gpg
/usr/share/keyrings/deb.sury.org-php.gpg
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

