### PR TITLE
fix: typo in auth ssh command description

### DIFF
--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
@@ -9,8 +12,6 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/spf13/cobra"
-	"os"
-	"path/filepath"
 )
 
 // sshKeyPath is the full path to the *directory* containing SSH keys.
@@ -19,7 +20,7 @@ var sshKeyPath string
 // AuthSSHCommand implements the "ddev auth ssh" command
 var AuthSSHCommand = &cobra.Command{
 	Use:     "ssh",
-	Short:   "Add SSH key authentication to the ddev-ssh-auth container",
+	Short:   "Add SSH key authentication to the ddev-ssh-agent container",
 	Long:    `Use this command to provide the password to your SSH key to the ddev-ssh-agent container, where it can be used by other containers. Normal usage is "ddev auth ssh", or if your key is not in ~/.ssh, ddev auth ssh --ssh-key-path=/some/path/.ssh"`,
 	Example: `ddev auth ssh`,
 	Run: func(_ *cobra.Command, args []string) {


### PR DESCRIPTION
## The Issue

I noticed the old image name in the `ddev auth -h`.

## How This PR Solves The Issue

Renames it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

