### PR TITLE
build: bump images to v1.23.1 for release

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,16 +17,16 @@ var WebTag = "v1.23.1" // Note that this can be overridden by make
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.23.0"
+var BaseDBTag = "v1.23.1"
 
-const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.23.0"
-const TraefikRouterImage = "ddev/ddev-traefik-router:v1.23.0"
+const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.23.1"
+const TraefikRouterImage = "ddev/ddev-traefik-router:v1.23.1"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.23.0"
+var SSHAuthTag = "v1.23.1"
 
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION
## The Issue

It's release time for v1.23.1, push new images.