### PR TITLE
fix: update d9simple to d10simple

### DIFF
--- a/.devcontainer/setup_test_project.sh
+++ b/.devcontainer/setup_test_project.sh
@@ -11,7 +11,7 @@ ddev delete -Oy tmp >/dev/null || true
 ddev --version
 
 export DDEV_NONINTERACTIVE=true
-DDEV_REPO=${DDEV_REPO:-https://github.com/ddev/d9simple}
+DDEV_REPO=${DDEV_REPO:-https://github.com/ddev/d10simple}
 DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
 git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
 reponame=${DDEV_REPO##*/}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceRoot}/cmd/ddev",
-            "cwd": "${workspaceRoot}/../d9simple",
+            "cwd": "${workspaceRoot}/../d10simple",
             "env": {"DDEV_DEBUG": "true"},
             "args": ["start", "-y"],
             "showLog": true
@@ -18,7 +18,7 @@
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceRoot}/cmd/ddev",
-            "cwd": "${workspaceRoot}/../d9simple",
+            "cwd": "${workspaceRoot}/../d10simple",
             "env": {"DDEV_DEBUG": "true"},
             "args": ["snapshot"],
             "showLog": true
@@ -95,7 +95,7 @@
             "hostname": "0.0.0.0",
             "port": 9003,
             "pathMappings": {
-                "/var/www/html": "${workspaceRoot}/../d9simple"
+                "/var/www/html": "${workspaceRoot}/../d10simple"
             }
         }
     ]


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
I opened DDEV repo in Gitpod, and I wasn't able to run the debug tests.

## How This PR Solves The Issue
After making these updates - I can run VSCode debug scripts in Gitpod.

## Manual Testing Instructions
Open DDEV in Gitpod, open debugger, run the first option.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

