### PR TITLE
fix: do not send autocomplete commands to Amplitude, fixes #6189

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -50,7 +50,9 @@ Support: https://ddev.readthedocs.io/en/stable/users/support/`,
 		// We don't want to send to amplitude if using --json-output
 		// That captures an enormous number of PhpStorm running the
 		// ddev describe -j over and over again.
-		if !output.JSONOutput {
+		// And we don't want to send __complete commands,
+		// that are called each time you press <TAB>.
+		if !output.JSONOutput && cmdCopy.Name() != cobra.ShellCompRequestCmd {
 			amplitude.TrackCommand(&cmdCopy, argsCopy)
 		}
 


### PR DESCRIPTION
## The Issue

- #6189

## How This PR Solves The Issue

Adds a check for the `__complete` command before sending it to Amplitude.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

