### PR TITLE
build: fix devcontainers postCreateCommand permissions, fixes #6187

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "/workspaces/ddev/.devcontainer/setup_test_project.sh",
+	"postCreateCommand": "./.devcontainer/setup_test_project.sh",
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/setup_test_project.sh
+++ b/.devcontainer/setup_test_project.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 echo "You don't need to wait for the test project to be set up."
 set -x
 make
-sudo ln -sf /workspaces/ddev/.gotmp/bin/linux_amd64/ddev /usr/local/bin/ddev
+sudo ln -sf ${PWD}/.gotmp/bin/linux_amd64/ddev /usr/local/bin/ddev
 ddev debug download-images
 ddev delete -Oy tmp >/dev/null || true
 ddev --version
@@ -15,7 +15,7 @@ DDEV_REPO=${DDEV_REPO:-https://github.com/ddev/d10simple}
 DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
 git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
 reponame=${DDEV_REPO##*/}
-mkdir -p /workspaces/${reponame} && cd /workspaces/${reponame}
+sudo mkdir -p /workspaces/${reponame} && sudo chown ${USER}:${USER} /workspaces/${reponame} && cd /workspaces/${reponame}
 if [ ! -d /workspaces/${reponame}/.git ]; then
     git clone ${DDEV_REPO} /workspaces/${reponame}
 fi


### PR DESCRIPTION
## The Issue

- #6187

## How This PR Solves The Issue

Sets directory permissions for `/workspaces/d10simple`
Removes hard-coded path for `/workspaces/ddev` (because users can clone the repo to a different directory).

## Manual Testing Instructions

```
git clone https://github.com/ddev/ddev.git my-ddev-copy
code my-ddev-copy

# install Dev Containers extension
# Menu > View > Command Palette... > Dev Containers: Reopen in Container
# wait some time, I had to wait ~10 minutes

ls -l /workspaces
total 8
drwxr-xr-x  7 codespace codespace 4096 May 16 12:40 d10simple
drwxr-xr-x 25 codespace codespace 4096 May 16 11:46 my-ddev-copy
```

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?ref=20240516_stasadev_devcontainers&repo=669738338)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

