### PR TITLE
build: fix Codespaces link

### DIFF
--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -24,11 +24,15 @@ jobs:
             // get a PR number
             const {owner, repo} = context.repo;
             const pullHeadSHA = '${{github.event.workflow_run.head_sha}}';
-            const prNumber = await (async () => {
+            const {prNumber, prRef, prRepoId} = await (async () => {
               for await (const {data} of github.paginate.iterator(github.rest.pulls.list, {owner, repo})) {
                 for (const pull of data) {
                   if (pull.head.sha === pullHeadSHA) {
-                    return pull.number;
+                    return {
+                      prNumber: pull.number,
+                      prRef: pull.head.ref,
+                      prRepoId: pull.head.repo.id
+                    };
                   }
                 }
               }
@@ -55,8 +59,11 @@ jobs:
 
             body += `\n\n See [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr)` + `.`;
 
-            body += `\n\n[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/?autostart=true#https://github.com/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `)`;
-            body += `\n\n[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/` + context.repo.owner + `/` + context.repo.repo + `/pull/` + prNumber + `)`;
+            body += `\n\n[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber})`;
+            codespacesLink = prRef && prRepoId
+              ? `https://codespaces.new/?ref=${prRef}&repo=${prRepoId}`
+              : `https://codespaces.new/${context.repo.owner}/${context.repo.repo}`;
+            body += `\n\n[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](${codespacesLink})`;
 
             // insert or update a bot comment
             async function upsertComment(owner, repo, issue_number, purpose, body) {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ---
 
 [![CircleCI](https://circleci.com/gh/ddev/ddev.svg?style=shield)](https://circleci.com/gh/ddev/ddev) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
-[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/ddev/ddev) <a href="https://github.com/codespaces/new?hide_repo_select=true&amp;ref=20221220_codespaces&amp;repo=80669528&amp;machine=basicLinux32gb&amp;location=WestUs2"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/ddev/ddev) <a href="https://codespaces.new/ddev/ddev"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
 
 DDEV is an open-source tool for running local web development environments for PHP, Python and Node.js, ready in minutes. Its powerful, flexible per-project environment configurations can be extended, version controlled, and shared. DDEV allows development teams to adopt a consistent Docker workflow without the complexities of bespoke configuration.
 


### PR DESCRIPTION
## The Issue

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ddev/ddev/pull/6196)

The link above ⬆️ opens the wrong repo, and the branch is not selected:

![image](https://github.com/ddev/ddev/assets/24270994/095a6ed3-606c-4254-b720-e7e338fbe943)

## How This PR Solves The Issue

Fixes the link.
I also removes autostart from Gitpod link, because it should really have confirmation before creating a new workspace.

## Manual Testing Instructions

The link below works ⬇️

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/?ref=20240516_stasadev_fix_codespaces_link&repo=669738338)

![image](https://github.com/ddev/ddev/assets/24270994/2aaa8c56-181c-4a39-8ad1-c74f456731f7)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

