### PR TITLE
fix: do not remove mounted files directory, fixes #6188

### DIFF
--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	copy2 "github.com/otiai10/copy"
 )
 
 // BackdropSettings holds database connection details for Backdrop.
@@ -179,9 +180,9 @@ func backdropImportFilesAction(app *DdevApp, uploadDir, importPath, extPath stri
 		return err
 	}
 
-	// If the destination path exists, remove it as was warned
+	// If the destination path exists, purge it
 	if fileutil.FileExists(destPath) {
-		if err := os.RemoveAll(destPath); err != nil {
+		if err := fileutil.PurgeDirectory(destPath); err != nil {
 			return fmt.Errorf("failed to cleanup %s before import: %v", destPath, err)
 		}
 	}
@@ -202,8 +203,7 @@ func backdropImportFilesAction(app *DdevApp, uploadDir, importPath, extPath stri
 		return nil
 	}
 
-	//nolint: revive
-	if err := fileutil.CopyDir(importPath, destPath); err != nil {
+	if err := copy2.Copy(importPath, destPath); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
+	copy2 "github.com/otiai10/copy"
 )
 
 // isCraftCmsApp returns true if the app is of type craftcms
@@ -31,9 +32,9 @@ func craftCmsImportFilesAction(app *DdevApp, uploadDir, importPath, extPath stri
 		return err
 	}
 
-	// If the destination path exists, remove it as was warned
+	// If the destination path exists, purge it as was warned
 	if fileutil.FileExists(destPath) {
-		if err := os.RemoveAll(destPath); err != nil {
+		if err := fileutil.PurgeDirectory(destPath); err != nil {
 			return fmt.Errorf("failed to cleanup %s before import: %v", destPath, err)
 		}
 	}
@@ -54,8 +55,7 @@ func craftCmsImportFilesAction(app *DdevApp, uploadDir, importPath, extPath stri
 		return nil
 	}
 
-	//nolint: revive
-	if err := fileutil.CopyDir(importPath, destPath); err != nil {
+	if err := copy2.Copy(importPath, destPath); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2966,9 +2966,9 @@ func genericImportFilesAction(app *DdevApp, uploadDir, importPath, extPath strin
 		return err
 	}
 
-	// If the destination path exists, remove it as was warned
+	// If the destination path exists, purge it as was warned
 	if fileutil.FileExists(destPath) {
-		if err := os.RemoveAll(destPath); err != nil {
+		if err := fileutil.PurgeDirectory(destPath); err != nil {
 			return fmt.Errorf("failed to cleanup %s before import: %v", destPath, err)
 		}
 	}
@@ -2989,8 +2989,7 @@ func genericImportFilesAction(app *DdevApp, uploadDir, importPath, extPath strin
 		return nil
 	}
 
-	//nolint: revive
-	if err := fileutil.CopyDir(importPath, destPath); err != nil {
+	if err := copy.Copy(importPath, destPath); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2081,8 +2081,8 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_COMPOSER_ROOT":             app.GetComposerRoot(true, false),
 		"DDEV_DATABASE_FAMILY":           dbFamily,
 		"DDEV_DATABASE":                  app.Database.Type + ":" + app.Database.Version,
-		"DDEV_FILES_DIR":                 app.getContainerUploadDir(),
-		"DDEV_FILES_DIRS":                strings.Join(app.getContainerUploadDirs(), ","),
+		"DDEV_FILES_DIR":                 app.GetContainerUploadDir(),
+		"DDEV_FILES_DIRS":                strings.Join(app.GetContainerUploadDirs(), ","),
 
 		"DDEV_HOST_DB_PORT":        dbPortStr,
 		"DDEV_HOST_MAILHOG_PORT":   app.HostMailpitPort,

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	copy2 "github.com/otiai10/copy"
 )
 
 // DrupalSettings encapsulates all the configurations for a Drupal site.
@@ -572,9 +573,11 @@ func drupalImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string
 		return err
 	}
 
-	// If the destination path exists, remove it as was warned
+	// If the destination path exists, remove contents as was warned
+	// We do not remove the directory as it may be a docker bind-mount in
+	// various situations, especially when mutagen is in use.
 	if fileutil.FileExists(destPath) {
-		if err := os.RemoveAll(destPath); err != nil {
+		if err := fileutil.PurgeDirectory(destPath); err != nil {
 			return fmt.Errorf("failed to cleanup %s before import: %v", destPath, err)
 		}
 	}
@@ -595,8 +598,7 @@ func drupalImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string
 		return nil
 	}
 
-	//nolint: revive
-	if err := fileutil.CopyDir(importPath, destPath); err != nil {
+	if err := copy2.Copy(importPath, destPath); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	copy2 "github.com/otiai10/copy"
 )
 
 // isMagentoApp returns true if the app is of type magento
@@ -83,7 +84,7 @@ func magentoImportFilesAction(app *DdevApp, uploadDir, importPath, extPath strin
 
 	// If the destination path exists, remove it as was warned
 	if fileutil.FileExists(destPath) {
-		if err := os.RemoveAll(destPath); err != nil {
+		if err := fileutil.PurgeDirectory(destPath); err != nil {
 			return fmt.Errorf("failed to cleanup %s before import: %v", destPath, err)
 		}
 	}
@@ -104,8 +105,7 @@ func magentoImportFilesAction(app *DdevApp, uploadDir, importPath, extPath strin
 		return nil
 	}
 
-	//nolint: revive
-	if err := fileutil.CopyDir(importPath, destPath); err != nil {
+	if err := copy2.Copy(importPath, destPath); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -3,12 +3,14 @@ package ddevapp
 import (
 	"errors"
 	"fmt"
-	"github.com/ddev/ddev/pkg/util"
 	"os"
 	"path/filepath"
 
+	"github.com/ddev/ddev/pkg/util"
+
 	"github.com/ddev/ddev/pkg/archive"
 	"github.com/ddev/ddev/pkg/fileutil"
+	copy2 "github.com/otiai10/copy"
 )
 
 // isShopware6App returns true if the app is of type shopware6
@@ -39,9 +41,9 @@ func shopware6ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath str
 		return err
 	}
 
-	// If the destination path exists, remove it as was warned
+	// If the destination path exists, purge it as was warned
 	if fileutil.FileExists(destPath) {
-		if err := os.RemoveAll(destPath); err != nil {
+		if err := fileutil.PurgeDirectory(destPath); err != nil {
 			return fmt.Errorf("failed to cleanup %s before import: %v", destPath, err)
 		}
 	}
@@ -62,8 +64,7 @@ func shopware6ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath str
 		return nil
 	}
 
-	//nolint: revive
-	if err := fileutil.CopyDir(importPath, destPath); err != nil {
+	if err := copy2.Copy(importPath, destPath); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	copy2 "github.com/otiai10/copy"
 )
 
 // createTypo3SettingsFile creates the app's LocalConfiguration.php and
@@ -180,9 +181,9 @@ func typo3ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string)
 		return err
 	}
 
-	// If the destination path exists, remove it as was warned
+	// If the destination path exists, purge it as was warned
 	if fileutil.FileExists(destPath) {
-		if err := os.RemoveAll(destPath); err != nil {
+		if err := fileutil.PurgeDirectory(destPath); err != nil {
 			return fmt.Errorf("failed to cleanup %s before import: %v", destPath, err)
 		}
 	}
@@ -203,8 +204,7 @@ func typo3ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string)
 		return nil
 	}
 
-	//nolint: revive
-	if err := fileutil.CopyDir(importPath, destPath); err != nil {
+	if err := copy2.Copy(importPath, destPath); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -104,9 +104,9 @@ func (app *DdevApp) calculateContainerUploadDirFullPath(uploadDir string) string
 	return ""
 }
 
-// getContainerUploadDir returns the full path to the first upload
+// GetContainerUploadDir returns the full path to the first upload
 // directory in container or "" if there is none.
-func (app *DdevApp) getContainerUploadDir() string {
+func (app *DdevApp) GetContainerUploadDir() string {
 	uploadDirs := app.GetUploadDirs()
 	if len(uploadDirs) > 0 {
 		return app.calculateContainerUploadDirFullPath(uploadDirs[0])
@@ -115,9 +115,9 @@ func (app *DdevApp) getContainerUploadDir() string {
 	return ""
 }
 
-// getContainerUploadDirs returns a slice of the full path to the upload
+// GetContainerUploadDirs returns a slice of the full path to the upload
 // directories in container.
-func (app *DdevApp) getContainerUploadDirs() []string {
+func (app *DdevApp) GetContainerUploadDirs() []string {
 	uploadDirs := app.GetUploadDirs()
 	containerUploadDirs := make([]string, 0, len(uploadDirs))
 

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
+	copy2 "github.com/otiai10/copy"
 )
 
 // WordpressConfig encapsulates all the configurations for a WordPress site.
@@ -274,9 +275,9 @@ func wordpressImportFilesAction(app *DdevApp, target, importPath, extPath string
 		return err
 	}
 
-	// If the destination path exists, remove it as was warned
+	// If the destination path exists, purge it as was warned
 	if fileutil.FileExists(destPath) {
-		if err := os.RemoveAll(destPath); err != nil {
+		if err := fileutil.PurgeDirectory(destPath); err != nil {
 			return fmt.Errorf("failed to cleanup %s before import: %v", destPath, err)
 		}
 	}
@@ -297,8 +298,7 @@ func wordpressImportFilesAction(app *DdevApp, target, importPath, extPath string
 		return nil
 	}
 
-	//nolint: revive
-	if err := fileutil.CopyDir(importPath, destPath); err != nil {
+	if err := copy2.Copy(importPath, destPath); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## The Issue

* #6188 

It turns out that with mutagen enabled, all of our import-files and `ddev pull` actions will fail because the host-side target files directory gets removed during the import process.

When mutagen is enabled, then each of the `upload_dirs` are bind-mounted from the host. In this situation, the existing code removes the host-side directory, breaking the bind-mount because the host source dir has been removed.

`ddev restart` fixes everything, but that's just a workaround.

## How This PR Solves The Issue

* Purge the source directory instead of removing it
* Use otiai10/copy to do the copying instead of fileutil.CopyDir (which requires the target directory not to exist)

## Manual Testing Instructions

With a Drupal (and all other CMS) directory, and with mutagen enabled, `ddev import-files --src=<tarball>` and verify that the files get loaded into the target directory

Same with `ddev pull <anything>`

## Automated Testing Overview

- [x] I improved TestDdevImportFiles to verify with import-files that this succeeds. Our tests should have caught this before, especially in the import-files testing. It makes sense that we didn't catch it in the TestPantheonPull test because we don't use mutagen there.

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

