### PR TITLE
build: update .gitpod.yml for v1.23.1 release

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ddev/ddev-gitpod-base:20240426
+image: ddev/ddev-gitpod-base:20240516
 tasks:
   - name: build-run
     init: |


### PR DESCRIPTION
## The Issue

DDEV v1.23.1 is out.

## How This PR Solves The Issue

Pushes a new Gitpod image.
