### PR TITLE
fix: clear omit_containers, additional_fqdns, additional_hostnames config with empty flag, fixes #6140

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -49,7 +49,7 @@ func handleGlobalConfig(cmd *cobra.Command, _ []string) {
 	}
 	if cmd.Flag("omit-containers").Changed {
 		omitContainers = strings.Replace(omitContainers, " ", "", -1)
-		if omitContainers == "" {
+		if omitContainers == "" || omitContainers == `""` || omitContainers == `''` {
 			globalconfig.DdevGlobalConfig.OmitContainersGlobal = []string{}
 		} else {
 			globalconfig.DdevGlobalConfig.OmitContainersGlobal = strings.Split(omitContainers, ",")
@@ -58,7 +58,7 @@ func handleGlobalConfig(cmd *cobra.Command, _ []string) {
 	}
 	if cmd.Flag("web-environment").Changed {
 		env := strings.TrimSpace(webEnvironmentGlobal)
-		if env == "" {
+		if env == "" || env == `""` || env == `''` {
 			globalconfig.DdevGlobalConfig.WebEnvironment = []string{}
 		} else {
 			globalconfig.DdevGlobalConfig.WebEnvironment = strings.Split(env, ",")

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -155,4 +155,13 @@ func TestCmdGlobalConfig(t *testing.T) {
 
 	assert.False(globalconfig.DdevGlobalConfig.IsMutagenEnabled())
 	assert.True(globalconfig.DdevGlobalConfig.IsNFSMountEnabled())
+
+	// Test that we can remove array elements with `--item=""`
+	args = []string{"config", "global", `--web-environment=""`, `--omit-containers=""`}
+	out, err = exec.RunCommand(DdevBin, args)
+	require.NoError(t, err, "output=%s", out)
+	err = globalconfig.ReadGlobalConfig()
+	require.NoError(t, err)
+	require.Empty(t, globalconfig.DdevGlobalConfig.WebEnvironment)
+	require.Empty(t, globalconfig.DdevGlobalConfig.OmitContainersGlobal)
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -547,10 +547,10 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 		// Remove all spaces from the argument
 		omitContainersArg = strings.Replace(omitContainersArg, " ", "", -1)
 
-		app.OmitContainers = []string{} // Initialize as empty slice
-
-		if omitContainersArg != "" {
-			// Split the argument string by commas
+		if omitContainersArg == "" {
+			app.OmitContainers = []string{} // Initialize as empty slice if no containers are specified
+		} else {
+			// Split the argument string by commas to get the list of containers to omit
 			app.OmitContainers = strings.Split(omitContainersArg, ",")
 		}
 	}

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -536,7 +536,6 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 
 	// Check if the 'additional-hostnames' flag has been set and not default
 	app.AdditionalHostnames = processFlag(cmd, "additional-hostnames", app.AdditionalHostnames)
-	util.Debug("app.AdditionalHostnames='%v'", app.AdditionalHostnames)
 
 	// Check if the 'additional-fqdns' flag has been set and not default
 	app.AdditionalFQDNs = processFlag(cmd, "additional-fqdns", app.AdditionalFQDNs)
@@ -546,7 +545,7 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 
 	if cmd.Flag("web-environment").Changed {
 		env := strings.TrimSpace(webEnvironmentLocal)
-		if env == "" {
+		if env == "" || env == `""` || env == `''` {
 			app.WebEnvironment = []string{}
 		} else {
 			app.WebEnvironment = strings.Split(env, ",")
@@ -735,25 +734,18 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 
 // processFlag checks if a flag has changed and processes its value accordingly.
 func processFlag(cmd *cobra.Command, flagName string, currentValue []string) []string {
-	util.Debug("processFlag(%s): changed=%v currentValue=%v", flagName, cmd.Flag(flagName).Changed, currentValue)
-
 	// If the flag hasn't changed, return the current value.
 	if !cmd.Flag(flagName).Changed {
 		return currentValue
 	}
 
 	arg := cmd.Flag(flagName).Value.String()
-	if arg == `""` || arg == `''` {
-		return []string{}
-	}
 
 	// Remove all spaces from the flag value.
 	arg = strings.Replace(arg, " ", "", -1)
 
-	util.Debug("processFlag(%s) arg=%v", flagName, arg)
-
 	// If the flag value is an empty string, return an empty slice.
-	if arg == "" {
+	if arg == "" || arg == `""` || arg == `''` {
 		return []string{}
 	}
 

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -542,8 +542,17 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 		app.AdditionalFQDNs = strings.Split(additionalFQDNsArg, ",")
 	}
 
-	if omitContainersArg != "" {
-		app.OmitContainers = strings.Split(omitContainersArg, ",")
+	// Check if the 'omit-containers' flag has been set and not default
+	if cmd.Flag("omit-containers").Changed {
+		// Remove all spaces from the argument
+		omitContainersArg = strings.Replace(omitContainersArg, " ", "", -1)
+
+		app.OmitContainers = []string{} // Initialize as empty slice
+
+		if omitContainersArg != "" {
+			// Split the argument string by commas
+			app.OmitContainers = strings.Split(omitContainersArg, ",")
+		}
 	}
 
 	if cmd.Flag("web-environment").Changed {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -738,9 +738,9 @@ func processFlag(cmd *cobra.Command, flagName string, currentValue []string) []s
 
 		if arg == "" {
 			return []string{} // Initialize as empty slice if no values are specified
-		} else {
-			return strings.Split(arg, ",")
 		}
+		return strings.Split(arg, ",")
+
 	}
 	return currentValue
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -572,18 +572,20 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	}
 
 	if cmd.Flag("webimage-extra-packages").Changed {
-		if cmd.Flag("webimage-extra-packages").Value.String() == "" {
+		val := cmd.Flag("webimage-extra-packages").Value.String()
+		if val == "" || val == `""` || val == `''` {
 			app.WebImageExtraPackages = nil
 		} else {
-			app.WebImageExtraPackages = strings.Split(cmd.Flag("webimage-extra-packages").Value.String(), ",")
+			app.WebImageExtraPackages = strings.Split(val, ",")
 		}
 	}
 
 	if cmd.Flag("dbimage-extra-packages").Changed {
-		if cmd.Flag("dbimage-extra-packages").Value.String() == "" {
+		val := cmd.Flag("dbimage-extra-packages").Value.String()
+		if val == "" || val == `""` || val == `''` {
 			app.DBImageExtraPackages = nil
 		} else {
-			app.DBImageExtraPackages = strings.Split(cmd.Flag("dbimage-extra-packages").Value.String(), ",")
+			app.DBImageExtraPackages = strings.Split(val, ",")
 		}
 	}
 

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -543,11 +543,21 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 			app.AdditionalHostnames = []string{} // Initialize as empty slice if no hostnames are specified
 		} else {
 			// Split the argument string by commas to get the list of additional hostnames
-		app.AdditionalHostnames = strings.Split(additionalHostnamesArg, ",")
+			app.AdditionalHostnames = strings.Split(additionalHostnamesArg, ",")
+		}
 	}
 
-	if additionalFQDNsArg != "" {
-		app.AdditionalFQDNs = strings.Split(additionalFQDNsArg, ",")
+	// Check if the 'additional-fqdns' flag has been set and not default
+	if cmd.Flag("additional-fqdns").Changed {
+		// Remove all spaces from the argument
+		additionalFQDNsArg = strings.Replace(additionalFQDNsArg, " ", "", -1)
+
+		if additionalFQDNsArg == "" {
+			app.AdditionalFQDNs = []string{} // Initialize as empty slice if no FQDNs are specified
+		} else {
+			// Split the argument string by commas to get the list of additional FQDNs
+			app.AdditionalFQDNs = strings.Split(additionalFQDNsArg, ",")
+		}
 	}
 
 	// Check if the 'omit-containers' flag has been set and not default

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -534,7 +534,15 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 		app.MailpitHTTPSPort = mailpitHTTPSPortArg
 	}
 
-	if additionalHostnamesArg != "" {
+	// Check if the 'additional-hostnames' flag has been set and not default
+	if cmd.Flag("additional-hostnames").Changed {
+		// Remove all spaces from the argument
+		additionalHostnamesArg = strings.Replace(additionalHostnamesArg, " ", "", -1)
+
+		if additionalHostnamesArg == "" {
+			app.AdditionalHostnames = []string{} // Initialize as empty slice if no hostnames are specified
+		} else {
+			// Split the argument string by commas to get the list of additional hostnames
 		app.AdditionalHostnames = strings.Split(additionalHostnamesArg, ",")
 	}
 

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -536,6 +536,7 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 
 	// Check if the 'additional-hostnames' flag has been set and not default
 	app.AdditionalHostnames = processFlag(cmd, "additional-hostnames", app.AdditionalHostnames)
+	util.Debug("app.AdditionalHostnames='%v'", app.AdditionalHostnames)
 
 	// Check if the 'additional-fqdns' flag has been set and not default
 	app.AdditionalFQDNs = processFlag(cmd, "additional-fqdns", app.AdditionalFQDNs)
@@ -734,13 +735,22 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 
 // processFlag checks if a flag has changed and processes its value accordingly.
 func processFlag(cmd *cobra.Command, flagName string, currentValue []string) []string {
+	util.Debug("processFlag(%s): changed=%v currentValue=%v", flagName, cmd.Flag(flagName).Changed, currentValue)
+
 	// If the flag hasn't changed, return the current value.
 	if !cmd.Flag(flagName).Changed {
 		return currentValue
 	}
 
+	arg := cmd.Flag(flagName).Value.String()
+	if arg == `""` || arg == `''` {
+		return []string{}
+	}
+
 	// Remove all spaces from the flag value.
-	arg := strings.Replace(cmd.Flag(flagName).Value.String(), " ", "", -1)
+	arg = strings.Replace(arg, " ", "", -1)
+
+	util.Debug("processFlag(%s) arg=%v", flagName, arg)
 
 	// If the flag value is an empty string, return an empty slice.
 	if arg == "" {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -732,15 +732,21 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	return nil
 }
 
+// processFlag checks if a flag has changed and processes its value accordingly.
 func processFlag(cmd *cobra.Command, flagName string, currentValue []string) []string {
-	if cmd.Flag(flagName).Changed {
-		arg := strings.Replace(cmd.Flag(flagName).Value.String(), " ", "", -1)
-
-		if arg == "" {
-			return []string{} // Initialize as empty slice if no values are specified
-		}
-		return strings.Split(arg, ",")
-
+	// If the flag hasn't changed, return the current value.
+	if !cmd.Flag(flagName).Changed {
+		return currentValue
 	}
-	return currentValue
+
+	// Remove all spaces from the flag value.
+	arg := strings.Replace(cmd.Flag(flagName).Value.String(), " ", "", -1)
+
+	// If the flag value is an empty string, return an empty slice.
+	if arg == "" {
+		return []string{}
+	}
+
+	// If the flag value is not an empty string, split it by commas and return the resulting slice.
+	return strings.Split(arg, ",")
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -535,43 +535,13 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	}
 
 	// Check if the 'additional-hostnames' flag has been set and not default
-	if cmd.Flag("additional-hostnames").Changed {
-		// Remove all spaces from the argument
-		additionalHostnamesArg = strings.Replace(additionalHostnamesArg, " ", "", -1)
-
-		if additionalHostnamesArg == "" {
-			app.AdditionalHostnames = []string{} // Initialize as empty slice if no hostnames are specified
-		} else {
-			// Split the argument string by commas to get the list of additional hostnames
-			app.AdditionalHostnames = strings.Split(additionalHostnamesArg, ",")
-		}
-	}
+	app.AdditionalHostnames = processFlag(cmd, "additional-hostnames", app.AdditionalHostnames)
 
 	// Check if the 'additional-fqdns' flag has been set and not default
-	if cmd.Flag("additional-fqdns").Changed {
-		// Remove all spaces from the argument
-		additionalFQDNsArg = strings.Replace(additionalFQDNsArg, " ", "", -1)
-
-		if additionalFQDNsArg == "" {
-			app.AdditionalFQDNs = []string{} // Initialize as empty slice if no FQDNs are specified
-		} else {
-			// Split the argument string by commas to get the list of additional FQDNs
-			app.AdditionalFQDNs = strings.Split(additionalFQDNsArg, ",")
-		}
-	}
+	app.AdditionalFQDNs = processFlag(cmd, "additional-fqdns", app.AdditionalFQDNs)
 
 	// Check if the 'omit-containers' flag has been set and not default
-	if cmd.Flag("omit-containers").Changed {
-		// Remove all spaces from the argument
-		omitContainersArg = strings.Replace(omitContainersArg, " ", "", -1)
-
-		if omitContainersArg == "" {
-			app.OmitContainers = []string{} // Initialize as empty slice if no containers are specified
-		} else {
-			// Split the argument string by commas to get the list of containers to omit
-			app.OmitContainers = strings.Split(omitContainersArg, ",")
-		}
-	}
+	app.OmitContainers = processFlag(cmd, "omit-containers", app.OmitContainers)
 
 	if cmd.Flag("web-environment").Changed {
 		env := strings.TrimSpace(webEnvironmentLocal)
@@ -760,4 +730,17 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	}
 
 	return nil
+}
+
+func processFlag(cmd *cobra.Command, flagName string, currentValue []string) []string {
+	if cmd.Flag(flagName).Changed {
+		arg := strings.Replace(cmd.Flag(flagName).Value.String(), " ", "", -1)
+
+		if arg == "" {
+			return []string{} // Initialize as empty slice if no values are specified
+		} else {
+			return strings.Split(arg, ",")
+		}
+	}
+	return currentValue
 }

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -129,34 +129,30 @@ func TestConfigWithSitenameFlagDetectsDocroot(t *testing.T) {
 func TestConfigSetValues(t *testing.T) {
 	assert := asrt.New(t)
 
+	projectName := strings.ToLower(t.Name())
 	origDir, _ := os.Getwd()
+	_, _ = exec.RunHostCommand(DdevBin, "stop", "--unlist", projectName)
 
 	// Create a temporary directory and switch to it.
 	tmpDir := testcommon.CreateTmpDir(t.Name())
-	err := os.Chdir(tmpDir)
-	assert.NoError(err)
+	_ = os.Chdir(tmpDir)
+
+	var err error
 
 	t.Cleanup(func() {
 		err = os.Chdir(origDir)
 		assert.NoError(err)
-		out, err := exec.RunHostCommand(DdevBin, "delete", "-Oy", t.Name())
+		out, err := exec.RunHostCommand(DdevBin, "delete", "-Oy", strings.ToLower(t.Name()))
 		assert.NoError(err, "output=%s", out)
 		_ = os.RemoveAll(tmpDir)
 	})
 
-	// Create an existing docroot
-	docroot := "web"
-	if err = os.MkdirAll(filepath.Join(tmpDir, docroot), 0755); err != nil {
-		t.Errorf("Could not create docroot %s in %s", docroot, tmpDir)
-	}
-
-	err = os.Chdir(tmpDir)
-	assert.NoError(err)
+	_ = os.Chdir(tmpDir)
 
 	// Build config args
-	projectName := t.Name()
-	projectType := nodeps.AppTypeTYPO3
-	phpVersion := nodeps.PHP71
+	docroot := "web"
+	projectType := nodeps.AppTypePHP
+	phpVersion := nodeps.PHP81
 	routerHTTPPort := "81"
 	routerHTTPSPort := "444"
 	hostDBPort := "60001"
@@ -224,26 +220,22 @@ func TestConfigSetValues(t *testing.T) {
 		"--timezone", timezone,
 		"--disable-upload-dirs-warning",
 	}
-
-	t.Logf("command=\n%s", strings.Join(args, " "))
-	out, err := exec.RunHostCommand(DdevBin, args...)
-	assert.NoError(err, "error running ddev %v: %v, output=%s", args, err, out)
+	args = []string{"-c", DdevBin + " " + strings.Join(args, " ")}
+	out, err := exec.RunHostCommand("bash", args...)
+	require.NoError(t, err, "error running bash %v: %v, output=%s", args, err, out)
 
 	// The second run of the config should not change the unspecified options,
 	// using the auto option here should not change the config at all
 	out, err = exec.RunHostCommand(DdevBin, "config", "--auto")
-	assert.NoError(err, "error running ddev config --auto: %s", out)
+	require.NoError(t, err, "error running ddev config --auto: '%s'", out)
 
 	configFile := filepath.Join(tmpDir, ".ddev", "config.yaml")
 	configContents, err := os.ReadFile(configFile)
-	if err != nil {
-		t.Errorf("Unable to read %s: %v", configFile, err)
-	}
+	require.NoError(t, err, "Unable to read '%s'", configFile)
 
 	app := &ddevapp.DdevApp{}
-	if err = yaml.Unmarshal(configContents, app); err != nil {
-		t.Errorf("Could not unmarshal %s: %v", configFile, err)
-	}
+	err = yaml.Unmarshal(configContents, app)
+	require.NoError(t, err, "Could not unmarshal '%s'", configFile)
 
 	assert.Equal(projectName, app.Name)
 	assert.Equal(docroot, app.Docroot)
@@ -284,21 +276,31 @@ func TestConfigSetValues(t *testing.T) {
 		"--db-image-default",
 		"--web-working-dir-default",
 		"--db-working-dir-default",
+		`--omit-containers=""`,
+		`--additional-hostnames=""`,
+		`--additional-fqdns=""`,
+		//`--webimage-extra-packages=""`,
+		//`--dbimage-extra-packages=""`,
+		//`--upload-dirs=""`,
+		//`--web-environment=""`,
 	}
 
-	_, err = exec.RunHostCommand(DdevBin, args...)
-	assert.NoError(err)
+	out, err = exec.RunHostCommand(DdevBin, args...)
+	require.NoError(t, err, "args=%v, output=%s", args, out)
 
 	configContents, err = os.ReadFile(configFile)
-	assert.NoError(err, "Unable to read %s: %v", configFile, err)
+	require.NoError(t, err, "Unable to read %s: %v", configFile, err)
 
 	app = &ddevapp.DdevApp{}
 	err = yaml.Unmarshal(configContents, app)
-	assert.NoError(err, "Could not unmarshal %s: %v", configFile, err)
+	require.NoError(t, err, "Could not unmarshal %s: %v", configFile, err)
 
 	assert.Equal(app.ComposerRoot, "")
 	assert.Equal(app.WebImage, "")
 	assert.Equal(len(app.WorkingDir), 0)
+	assert.Empty(app.AdditionalHostnames)
+	assert.Empty(app.AdditionalFQDNs)
+	assert.Empty(app.OmitContainers)
 
 	// Test that all container images and working dirs can each be unset with single default images flag
 	args = []string{
@@ -309,7 +311,7 @@ func TestConfigSetValues(t *testing.T) {
 	}
 
 	_, err = exec.RunHostCommand(DdevBin, args...)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	args = []string{
 		"config",
@@ -318,14 +320,14 @@ func TestConfigSetValues(t *testing.T) {
 	}
 
 	_, err = exec.RunHostCommand(DdevBin, args...)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	configContents, err = os.ReadFile(configFile)
-	assert.NoError(err, "Unable to read %s: %v", configFile, err)
+	require.NoError(t, err, "Unable to read %s: %v", configFile, err)
 
 	app = &ddevapp.DdevApp{}
 	err = yaml.Unmarshal(configContents, app)
-	assert.NoError(err, "Could not unmarshal %s: %v", configFile, err)
+	require.NoError(t, err, "Could not unmarshal %s: %v", configFile, err)
 
 	assert.Equal(app.WebImage, "")
 	assert.Equal(len(app.WorkingDir), 0)
@@ -337,14 +339,14 @@ func TestConfigSetValues(t *testing.T) {
 	}
 
 	_, err = exec.RunHostCommand(DdevBin, args...)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	configContents, err = os.ReadFile(configFile)
-	assert.NoError(err, "Unable to read %s: %v", configFile, err)
+	require.NoError(t, err, "Unable to read %s: %v", configFile, err)
 
 	app = &ddevapp.DdevApp{}
 	err = yaml.Unmarshal(configContents, app)
-	assert.NoError(err, "Could not unmarshal %s: %v", configFile, err)
+	require.NoError(t, err, "Could not unmarshal %s: %v", configFile, err)
 
 	assert.Equal(1, len(app.WebEnvironment))
 	assert.Equal([]string{webEnv}, app.WebEnvironment)
@@ -355,14 +357,14 @@ func TestConfigSetValues(t *testing.T) {
 	}
 
 	_, err = exec.RunHostCommand(DdevBin, args...)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	configContents, err = os.ReadFile(configFile)
-	assert.NoError(err, "Unable to read %s: %v", configFile, err)
+	require.NoError(t, err, "Unable to read %s: %v", configFile, err)
 
 	app = &ddevapp.DdevApp{}
 	err = yaml.Unmarshal(configContents, app)
-	assert.NoError(err, "Could not unmarshal %s: %v", configFile, err)
+	require.NoError(t, err, "Could not unmarshal %s: %v", configFile, err)
 
 	assert.Equal(4, len(app.WebEnvironment))
 	assert.Equal("BAR=baz", app.WebEnvironment[0])

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -220,9 +220,9 @@ func TestConfigSetValues(t *testing.T) {
 		"--timezone", timezone,
 		"--disable-upload-dirs-warning",
 	}
-	args = []string{"-c", DdevBin + " " + strings.Join(args, " ")}
-	out, err := exec.RunHostCommand("bash", args...)
-	require.NoError(t, err, "error running bash %v: %v, output=%s", args, err, out)
+
+	out, err := exec.RunHostCommand(DdevBin, args...)
+	require.NoError(t, err, "error running ddev %v: %v, output=%s", args, err, out)
 
 	// The second run of the config should not change the unspecified options,
 	// using the auto option here should not change the config at all
@@ -279,10 +279,10 @@ func TestConfigSetValues(t *testing.T) {
 		`--omit-containers=""`,
 		`--additional-hostnames=""`,
 		`--additional-fqdns=""`,
-		//`--webimage-extra-packages=""`,
-		//`--dbimage-extra-packages=""`,
-		//`--upload-dirs=""`,
-		//`--web-environment=""`,
+		`--webimage-extra-packages=""`,
+		`--dbimage-extra-packages=""`,
+		`--upload-dirs=""`,
+		`--web-environment=""`,
 	}
 
 	out, err = exec.RunHostCommand(DdevBin, args...)
@@ -301,6 +301,8 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Empty(app.AdditionalHostnames)
 	assert.Empty(app.AdditionalFQDNs)
 	assert.Empty(app.OmitContainers)
+	assert.Empty(app.UploadDirs)
+	assert.Empty(app.WebEnvironment)
 
 	// Test that all container images and working dirs can each be unset with single default images flag
 	args = []string{

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -142,7 +142,7 @@ func TestConfigSetValues(t *testing.T) {
 	t.Cleanup(func() {
 		err = os.Chdir(origDir)
 		assert.NoError(err)
-		out, err := exec.RunHostCommand(DdevBin, "delete", "-Oy", strings.ToLower(t.Name()))
+		out, err := exec.RunHostCommand(DdevBin, "delete", "-Oy", projectName)
 		assert.NoError(err, "output=%s", out)
 		_ = os.RemoveAll(tmpDir)
 	})
@@ -300,9 +300,11 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Equal(len(app.WorkingDir), 0)
 	assert.Empty(app.AdditionalHostnames)
 	assert.Empty(app.AdditionalFQDNs)
+	assert.Empty(app.DBImageExtraPackages)
 	assert.Empty(app.OmitContainers)
 	assert.Empty(app.UploadDirs)
 	assert.Empty(app.WebEnvironment)
+	assert.Empty(app.WebImageExtraPackages)
 
 	// Test that all container images and working dirs can each be unset with single default images flag
 	args = []string{

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -189,8 +189,8 @@ ddev config --webserver-type=apache-fpm
 
 Flags:
 
-* `--additional-fqdns`: Comma-delimited list of project FQDNs.
-* `--additional-hostnames`: Comma-delimited list of project hostnames.
+* `--additional-fqdns`: Comma-delimited list of project FQDNs or `--additional-fqdns=""` to remoe any configured FQDNs.
+* `--additional-hostnames`: Comma-delimited list of project hostnames or `--additional-hostnames=""` to remove any configured additional hostnames.
 * `--auto`: Automatically run config without prompting.
 * `--bind-all-interfaces`: Bind host ports on all interfaces, not only on localhost network interface.
 * `--composer-root`: Overrides the default Composer root directory for the web service.
@@ -201,7 +201,7 @@ Flags:
 * `--db-image-default`: Sets the default db container image for this DDEV version.
 * `--db-working-dir`: Overrides the default working directory for the db service.
 * `--db-working-dir-default`: Unsets a db service working directory override.
-* `--dbimage-extra-packages`: A comma-delimited list of Debian packages that should be added to db container when the project is started.
+* `--dbimage-extra-packages`: A comma-delimited list of Debian packages that should be added to db container when the project is started or `--dbimage-extra-packages=""` to remove previously configured packages.
 * `--default-container-timeout`: Default time in seconds that DDEV waits for all containers to become ready on start. (default `120`)
 * `--disable-settings-management`: Prevent DDEV from creating or updating CMS settings files.
 * `--disable-upload-dirs-warning`: Suppresses warning when a project is using `performance_mode: mutagen` but does not have `upload_dirs` set.
@@ -228,15 +228,15 @@ Flags:
 * `--show-config-location`: Output the location of the `config.yaml` file if it exists, or error that it doesn’t exist.
 * `--timezone`: Specify timezone for containers and PHP, like `Europe/London` or `America/Denver` or `GMT` or `UTC`.
 * `--update`: Automatically detect and update settings by inspecting the code.
-* `--upload-dirs`: Sets the project’s upload directories, the destination directories of the import-files command.
+* `--upload-dirs`: Sets the project’s upload directories, the destination directories of the import-files command, or `--upload-dirs=""` to remove previously configured values.
 * `--use-dns-when-possible`: Use DNS for hostname resolution instead of `/etc/hosts` when possible. (default `true`)
-* `--web-environment`: Set the environment variables in the web container: `--web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"`
+* `--web-environment`: Set the environment variables in the web container: `--web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"` or `--web-environment=""` to remove previously configured values.
 * `--web-environment-add`: Append environment variables to the web container: `--web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"`
 * `--web-image`: Sets the web container image.
 * `--web-image-default`: Sets the default web container image for this DDEV version.
 * `--web-working-dir`: Overrides the default working directory for the web service.
 * `--web-working-dir-default`: Unsets a web service working directory override.
-* `--webimage-extra-packages`: A comma-delimited list of Debian packages that should be added to web container when the project is started.
+* `--webimage-extra-packages`: A comma-delimited list of Debian packages that should be added to web container when the project is started or `--webimage-extra-packages=""` to remove any previously configured packages.
 * `--webserver-type`: Sets the project’s desired web server type: `nginx-fpm`, `nginx-gunicorn`, or `apache-fpm`.
 * `--working-dir-defaults`: Unsets all service working directory overrides.
 * `--xdebug-enabled`: Whether or not Xdebug is enabled in the web container.
@@ -261,7 +261,7 @@ ddev config global --omit-containers=ddev-ssh-agent
 * `--mailpit-http-port`: The Mailpit HTTP port *default* for all projects; can be overridden by project configuration.
 * `--mailpit-https-port`: The Mailpit HTTPS port *default* for all projects; can be overridden by project configuration.
 * `--no-bind-mounts`: If `true`, don’t use bind-mounts. Useful for environments like remote Docker where bind-mounts are impossible. (default is equal to `--no-bind-mounts=true`)
-* `--omit-containers`: For example, `--omit-containers=ddev-ssh-agent`.
+* `--omit-containers`: For example, `--omit-containers=ddev-ssh-agent` or `--omit-containers=""".
 * `--performance-mode`: Performance optimization mode, possible values are `none`, `mutagen`, `nfs`.
 * `--performance-mode-reset`: Reset performance optimization mode to operating system default (`none` for Linux and WSL2, `mutagen` for macOS and traditional Windows).
 * `--project-tld`: Set the default top-level domain to be used for all projects. (default `"ddev.site"`). Note that this will be overridden in a project that defines `project_tld`.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -189,7 +189,7 @@ ddev config --webserver-type=apache-fpm
 
 Flags:
 
-* `--additional-fqdns`: Comma-delimited list of project FQDNs or `--additional-fqdns=""` to remoe any configured FQDNs.
+* `--additional-fqdns`: Comma-delimited list of project FQDNs or `--additional-fqdns=""` to remove any configured FQDNs.
 * `--additional-hostnames`: Comma-delimited list of project hostnames or `--additional-hostnames=""` to remove any configured additional hostnames.
 * `--auto`: Automatically run config without prompting.
 * `--bind-all-interfaces`: Bind host ports on all interfaces, not only on localhost network interface.
@@ -261,7 +261,7 @@ ddev config global --omit-containers=ddev-ssh-agent
 * `--mailpit-http-port`: The Mailpit HTTP port *default* for all projects; can be overridden by project configuration.
 * `--mailpit-https-port`: The Mailpit HTTPS port *default* for all projects; can be overridden by project configuration.
 * `--no-bind-mounts`: If `true`, don’t use bind-mounts. Useful for environments like remote Docker where bind-mounts are impossible. (default is equal to `--no-bind-mounts=true`)
-* `--omit-containers`: For example, `--omit-containers=ddev-ssh-agent` or `--omit-containers=""".
+* `--omit-containers`: For example, `--omit-containers=ddev-ssh-agent` or `--omit-containers=""`.
 * `--performance-mode`: Performance optimization mode, possible values are `none`, `mutagen`, `nfs`.
 * `--performance-mode-reset`: Reset performance optimization mode to operating system default (`none` for Linux and WSL2, `mutagen` for macOS and traditional Windows).
 * `--project-tld`: Set the default top-level domain to be used for all projects. (default `"ddev.site"`). Note that this will be overridden in a project that defines `project_tld`.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -487,7 +487,6 @@ func (app *DdevApp) ValidateConfig() error {
 		return nil
 	}
 
-	util.Debug("app.AdditionalHostnames='%v' app.AdditionalFQDNs='%v' app.GetHostnames()='%v'", app.AdditionalHostnames, app.AdditionalFQDNs, app.GetHostnames())
 	// Validate hostnames
 	for _, hn := range app.GetHostnames() {
 		// If they have provided "*.<hostname>" then ignore the *. part.
@@ -495,7 +494,6 @@ func (app *DdevApp) ValidateConfig() error {
 		if hn == nodeps.DdevDefaultTLD {
 			return fmt.Errorf("wildcarding the full hostname\nor using 'ddev.site' as FQDN for the project %s is not allowed\nbecause other projects would not work in that case", app.Name)
 		}
-		util.Debug("Checking hostname validity of '%v' in app.GetHostnames=%v", hn, app.GetHostnames())
 		if !hostRegex.MatchString(hn) {
 			return fmt.Errorf("the %s project has an invalid hostname: '%s', see https://en.wikipedia.org/wiki/Hostname#Syntax for valid hostname requirements", app.Name, hn).(invalidHostname)
 		}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -487,6 +487,7 @@ func (app *DdevApp) ValidateConfig() error {
 		return nil
 	}
 
+	util.Debug("app.AdditionalHostnames='%v' app.AdditionalFQDNs='%v' app.GetHostnames()='%v'", app.AdditionalHostnames, app.AdditionalFQDNs, app.GetHostnames())
 	// Validate hostnames
 	for _, hn := range app.GetHostnames() {
 		// If they have provided "*.<hostname>" then ignore the *. part.
@@ -494,6 +495,7 @@ func (app *DdevApp) ValidateConfig() error {
 		if hn == nodeps.DdevDefaultTLD {
 			return fmt.Errorf("wildcarding the full hostname\nor using 'ddev.site' as FQDN for the project %s is not allowed\nbecause other projects would not work in that case", app.Name)
 		}
+		util.Debug("Checking hostname validity of '%v' in app.GetHostnames=%v", hn, app.GetHostnames())
 		if !hostRegex.MatchString(hn) {
 			return fmt.Errorf("the %s project has an invalid hostname: '%s', see https://en.wikipedia.org/wiki/Hostname#Syntax for valid hostname requirements", app.Name, hn).(invalidHostname)
 		}


### PR DESCRIPTION
## Issue

* `ddev config --omit-containers=""` doesn't remove `omit_containers` from `.ddev/config.yaml` as expected (#6140).
* `ddev config --additional-hostnames` and `ddev config --additional-fqdns` have the same problem.

## Solution

This PR clears `omit-containers` when an empty string is passed. It uses the `Changed` method, consistent with the global version of the command. Changes are made in `handleMainConfigArgs` in `cmd/ddev/cmd/config.go`.

## Testing

Manual testing involves running `ddev config --omit-containers=db` and `ddev config --omit-containers=""` and checking `.ddev/config.yaml`. Automated tests will be added to verify the flag's functionality.

## Related Issues

Fixes issue #6140.

## Deployment

No special deployment actions needed. This change doesn't affect other code.
