### PR TITLE
docs: Explain how to switch from  nvm to `nodejs_version`, fixes #6204

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -394,7 +394,7 @@ Node.js version for the web container’s “system” version.
 There is no need to configure `nodejs_version` unless you want a version other than the default version.
 
 !!!note "Switching from `nvm` to `nodejs_version`"
-    If switching from using `nvm` to using `nodejs_version`, you may find that the container continues to use the previously specified version. If this happens, ssh into the container (`ddev ssh`) and run `rm -rf /mnt/ddev-global-cache/nvm_dir/${DDEV_PROJECT}-web`, then `ddev restart`.
+    If switching from using `nvm` to using `nodejs_version`, you may find that the container continues to use the previously specified version. If this happens, use `ddev nvm alias default system` or `ddev ssh` into the container (`ddev ssh`) and run `rm -rf /mnt/ddev-global-cache/nvm_dir/${DDEV_PROJECT}-web`, then `ddev restart`.
 
 ## `omit_containers`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -393,6 +393,9 @@ Node.js version for the web container’s “system” version.
 
 There is no need to configure `nodejs_version` unless you want a version other than the default version.
 
+!!!note "Switching from `nvm` to `nodejs_version`"
+    If switching from using `nvm` to using `nodejs_version`, you may find that the container continues to use the previously specified version. If this happens, ssh into the container (`ddev ssh`) and run `rm -rf /mnt/ddev-global-cache/nvm_dir/${DDEV_PROJECT}-web`, then `ddev restart`.
+
 ## `omit_containers`
 
 Containers that should not be loaded automatically for one or more projects.


### PR DESCRIPTION
## The Issue
Use of `nvm` and cached version of `node` can occur if updating config file to use `nodejs_version` after previously using `nvm` in `post-start` hooks.

## How This PR Solves The Issue
Adds a note to the `nodejs_version` documentation with instructions on how to clear the cache.

## Tests
No tests necessary.

## Related Issue Link(s)
Fixes #6204 

## Release/Deployment Notes
No special deployment actions needed. Documentation change only.