### PR TITLE
fix: do not validate config in ddev clean, delete -O, stop -U

### DIFF
--- a/cmd/ddev/cmd/clean.go
+++ b/cmd/ddev/cmd/clean.go
@@ -38,7 +38,12 @@ Additional commands that can help clean up resources:
 			util.Failed("No project provided. See ddev clean --help for usage")
 		}
 
+		// Skip project validation
+		originalRunValidateConfig := ddevapp.RunValidateConfig
+		ddevapp.RunValidateConfig = false
 		projects, err := getRequestedProjects(args, cleanAll)
+		ddevapp.RunValidateConfig = originalRunValidateConfig
+
 		if err != nil {
 			util.Failed("Failed to get project(s) '%v': %v", args, err)
 		}

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -453,7 +453,7 @@ func TestCmdDisasterConfig(t *testing.T) {
 		_, err = exec.RunHostCommand(DdevBin, "delete", "-Oy", t.Name())
 		assert.NoError(err)
 		_, err = exec.RunHostCommand(DdevBin, "delete", "-Oy", t.Name()+"_subdir")
-		assert.Error(err)
+		assert.NoError(err)
 		_ = os.RemoveAll(tmpDir)
 	})
 

--- a/cmd/ddev/cmd/delete.go
+++ b/cmd/ddev/cmd/delete.go
@@ -34,7 +34,7 @@ ddev delete --all`,
 		// Skip project validation if --omit-snapshot is provided
 		originalRunValidateConfig := ddevapp.RunValidateConfig
 		ddevapp.RunValidateConfig = !omitSnapshot
-		projects, err := getRequestedProjects(args, deleteAll)
+		projects, err := getRequestedProjectsExtended(args, deleteAll, true)
 		ddevapp.RunValidateConfig = originalRunValidateConfig
 
 		if err != nil {
@@ -48,6 +48,9 @@ ddev delete --all`,
 		for _, project := range projects {
 			if !noConfirm {
 				prompt := "OK to delete this project and its database?\n  %s in %s\nThe code and its .ddev directory will not be touched.\n"
+				if project.AppRoot == "" {
+					prompt = "OK to delete this project and its database?\n  %s in a non-existent directory %v\n"
+				}
 				if !omitSnapshot {
 					prompt = prompt + "A database snapshot will be made before the database is deleted.\n"
 				}

--- a/cmd/ddev/cmd/delete.go
+++ b/cmd/ddev/cmd/delete.go
@@ -30,7 +30,13 @@ ddev delete --all`,
 		if noConfirm && deleteAll {
 			util.Failed("Sorry, it's not possible to use flags --all and --yes together")
 		}
+
+		// Skip project validation if --omit-snapshot is provided
+		originalRunValidateConfig := ddevapp.RunValidateConfig
+		ddevapp.RunValidateConfig = !omitSnapshot
 		projects, err := getRequestedProjects(args, deleteAll)
+		ddevapp.RunValidateConfig = originalRunValidateConfig
+
 		if err != nil {
 			util.Failed("Failed to get project(s): %v", err)
 		}

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -91,7 +91,7 @@ ddev stop --remove-data`,
 		// Skip project validation if --unlist is provided
 		originalRunValidateConfig := ddevapp.RunValidateConfig
 		ddevapp.RunValidateConfig = !unlist
-		projects, err := getRequestedProjects(args, deleteAll)
+		projects, err := getRequestedProjects(args, stopAll)
 		ddevapp.RunValidateConfig = originalRunValidateConfig
 
 		if err != nil {

--- a/cmd/ddev/cmd/stop.go
+++ b/cmd/ddev/cmd/stop.go
@@ -88,7 +88,12 @@ ddev stop --remove-data`,
 			args = append(args, projectName)
 		}
 
-		projects, err := getRequestedProjects(args, stopAll)
+		// Skip project validation if --unlist is provided
+		originalRunValidateConfig := ddevapp.RunValidateConfig
+		ddevapp.RunValidateConfig = !unlist
+		projects, err := getRequestedProjects(args, deleteAll)
+		ddevapp.RunValidateConfig = originalRunValidateConfig
+
 		if err != nil {
 			util.Failed("Failed to get project(s): %v", err)
 		}

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -2,12 +2,19 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/globalconfig"
 )
 
 // getRequestedProjects will collect and return the requested projects from command line arguments and flags.
 func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) {
+	return getRequestedProjectsExtended(names, all, false)
+}
+
+// getRequestedProjectsExtended will collect and return the requested projects from command line arguments and flags.
+// If withNonExisting is true, it will return project stubs even if they don't exist.
+func getRequestedProjectsExtended(names []string, all bool, withNonExisting bool) ([]*ddevapp.DdevApp, error) {
 	requestedProjects := make([]*ddevapp.DdevApp, 0)
 
 	// If no project is specified, return the current project
@@ -54,6 +61,8 @@ func getRequestedProjects(names []string, all bool) ([]*ddevapp.DdevApp, error) 
 			p := globalconfig.GetProject(name)
 			if p != nil && p.AppRoot != "" {
 				requestedProjectsMap[name] = &ddevapp.DdevApp{Name: name, AppRoot: p.AppRoot}
+			} else if withNonExisting {
+				requestedProjectsMap[name] = &ddevapp.DdevApp{Name: name}
 			} else {
 				return nil, fmt.Errorf("could not find requested project '%s', you may need to use \"ddev start\" to add it to the project catalog", name)
 			}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -31,6 +31,11 @@ import (
 // Regexp pattern to determine if a hostname is valid per RFC 1123.
 var hostRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
 
+// RunValidateConfig controls whether to run ValidateConfig() function.
+// In some cases we don't actually need to check the config, e.g. when deleting the project.
+// It is enabled by default.
+var RunValidateConfig = true
+
 // init() is for testing situations only, allowing us to override the default webserver type
 // or caching behavior
 func init() {
@@ -441,6 +446,11 @@ func ValidateProjectName(name string) error {
 
 // ValidateConfig ensures the configuration meets ddev's requirements.
 func (app *DdevApp) ValidateConfig() error {
+	// Skip project validation on request.
+	if !RunValidateConfig {
+		return nil
+	}
+
 	// Validate ddev version constraint, if any
 	if app.DdevVersionConstraint != "" {
 		constraint := app.DdevVersionConstraint


### PR DESCRIPTION
## The Issue

While testing #6208 I noticed a regression in:

- #5452
- #5555

```
ddev config --project-name=d10
ddev config --project-name=d10-rename
ddev config --project-name=d10-rename2
this project root /home/stas/code/ddev/d10 already contains a project named d10. You may want to remove the existing project with "ddev stop --unlist d10"

ddev stop --unlist d10
Project 'd10-rename' was found in configured directory /home/stas/code/ddev/d10 and it is already used by project 'd10'. If you have changed the name of the project, please "ddev stop --unlist d10" 
Failed to get project(s): the d10 project has an invalid hostname: 'd10.', see https://en.wikipedia.org/wiki/Hostname#Syntax for valid hostname requirements
```

And you are stuck with `ddev stop --unlist d10` until you manually clean `~/.ddev/project_list.yaml` (or run `ddev list`)

---

Also the same problem occurs when you are working on some new project type, then you change the DDEV binary and try to delete the test project with this new type, for example, you have `foobar` type:

```
ddev delete -Oy
Failed to get project(s): the test project has an invalid app type: foobar
```

And there is no way to `ddev delete -Oy` until you fix the config.

## How This PR Solves The Issue

Do not run `ValidateConfig()` on a command with project arguments that don't actually need validation:
- `ddev clean`
- `ddev delete --omit-snapshot`
- `ddev stop --unlist`

The general idea is that we don't need to check the config if we delete something (I think it's annoying, just let me delete it, I don't care), and sometimes users can get stuck in a loop and we don't want that.

---

Allows to delete non-existent projects with `ddev delete -O`.

## Manual Testing Instructions

```
ddev config --project-name=d10
ddev config --project-name=d10-rename
ddev config --project-name=d10-rename2

ddev stop --unlist d10
Project d10 is already stopped. 
Project d10 has been stopped.

ddev stop --unlist d10-rename
Project d10-rename is already stopped. 
Project d10-rename has been stopped.

# manually edit `type` to something else in .ddev/config.yaml and run
ddev delete -Oy
```

And check Docker volumes and the contents of `ddev-global-cache` for:

```
ddev config --project-name=d10
ddev start
ddev stop --unlist
cd ..

docker volume ls | grep d10

docker run --rm -it -v ddev-global-cache:/mnt/ddev-global-cache ddev/ddev-webserver:v1.23.1 bash
ls /mnt/ddev-global-cache/*/d10-{web,db} /mnt/ddev-global-cache/traefik/*/d10.{yaml,crt,key}

ddev delete -O d10

docker volume ls | grep d10
# should show nothing

docker run --rm -it -v ddev-global-cache:/mnt/ddev-global-cache ddev/ddev-webserver:v1.23.1 bash
ls /mnt/ddev-global-cache/*/d10-{web,db} /mnt/ddev-global-cache/traefik/*/d10.{yaml,crt,key}
# should show nothing
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

