### PR TITLE
feat: Replace underscores with hyphens in project-name, fixes #6206

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -381,7 +381,7 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	} else { // No siteNameArg passed, c.Name not set: use c.Name from the directory
 		pwd, err := os.Getwd()
 		util.CheckErr(err)
-		app.Name = filepath.Base(pwd)
+		app.Name = ddevapp.NormalizeProjectName(filepath.Base(pwd))
 	}
 
 	err = app.CheckExistingAppInApproot()

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -102,7 +102,7 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	app.FailOnHookFailGlobal = globalconfig.DdevGlobalConfig.FailOnHookFailGlobal
 
 	// Provide a default app name based on directory name
-	app.Name = filepath.Base(app.AppRoot)
+	app.Name = NormalizeProjectName(filepath.Base(app.AppRoot))
 
 	// Gather containers to omit, adding ddev-router for gitpod/codespaces
 	app.OmitContainersGlobal = globalconfig.DdevGlobalConfig.OmitContainersGlobal
@@ -1284,8 +1284,8 @@ func (app *DdevApp) promptForName() error {
 	if app.Name == "" {
 		dir, err := os.Getwd()
 		// If working directory name is invalid for hostnames, we shouldn't suggest it
-		if err == nil && hostRegex.MatchString(filepath.Base(dir)) {
-			app.Name = filepath.Base(dir)
+		if err == nil && hostRegex.MatchString(NormalizeProjectName(filepath.Base(dir))) {
+			app.Name = NormalizeProjectName(filepath.Base(dir))
 		}
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1283,7 +1283,6 @@ func WriteImageDockerfile(fullpath string, contents []byte) error {
 func (app *DdevApp) promptForName() error {
 	if app.Name == "" {
 		dir, err := os.Getwd()
-		// If working directory name is invalid for hostnames, we shouldn't suggest it
 		if err == nil && hostRegex.MatchString(NormalizeProjectName(filepath.Base(dir))) {
 			app.Name = NormalizeProjectName(filepath.Base(dir))
 		}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -258,51 +258,23 @@ func TestConfigCommand(t *testing.T) {
 		name := strings.ToLower(util.RandString(16))
 		invalidAppType := strings.ToLower(util.RandString(8))
 
-		// Create an example input buffer that uses the default projectname, then a
-		// valid document root, then a valid app type.
-		input := fmt.Sprintf("\ndocroot\n%s", testValues[apptypePos])
+		// Create an example input buffer that writes the sitename, a valid document root,
+		// an invalid app type, and finally a valid app type (from test matrix)
+		input := fmt.Sprintf("%s\ndocroot\n%s\n%s", name, invalidAppType, testValues[apptypePos])
 		scanner := bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 
 		restoreOutput := util.CaptureUserOut()
 		err = app.PromptForConfig()
-		assert.NoError(err)
-		out := restoreOutput()
-
-		// Ensure we have expected vales in output.
-		projectRoot := filepath.Base(testDir)
-		assert.Contains(out, testDir)
-		assert.NotContains(out, fmt.Sprintf("%s is not a valid project name", projectRoot))
-
-		// Ensure values were properly set on the app struct.
-		// Project root contains an underscore. Make sure it was replaced with a
-		// hyphen for the project name.
-		// One of the test directories has a capital letter to ensure that the site
-		// name is lowercased.
-		assert.Equal(strings.ReplaceAll(projectRoot, "_", "-"), app.Name)
-		assert.Equal(testValues[apptypePos], app.Type)
-		assert.Equal("docroot", app.Docroot)
-		assert.EqualValues(testValues[phpVersionPos], app.PHPVersion, "PHP value incorrect for apptype %v (expected %s got %s) (%v)", app.Type, testValues[phpVersionPos], app.PHPVersion, app)
-		err = ddevapp.PrepDdevDirectory(app)
-		assert.NoError(err)
-
-		// Create an example input buffer that writes the sitename, a valid document root,
-		// an invalid app type, and finally a valid app type (from test matrix)
-		input = fmt.Sprintf("%s\ndocroot\n%s\n%s", name, invalidAppType, testValues[apptypePos])
-		scanner = bufio.NewScanner(strings.NewReader(input))
-		util.SetInputScanner(scanner)
-
-		restoreOutput = util.CaptureUserOut()
-		err = app.PromptForConfig()
 		require.Error(t, err, "invalid project type error should have been caught")
-		out = restoreOutput()
+		out := restoreOutput()
 
 		// Ensure we have expected vales in output.
 		assert.Contains(out, testDir)
 		assert.Contains(out, fmt.Sprintf("'%s' is not a valid project type", invalidAppType))
 
 		// Create an example input buffer that writes an invalid projectname, then a valid-project-name,
-		// a valid document root, then a valid app type.
+		// a valid document root, a valid app type
 		input = fmt.Sprintf("invalid_project_name\n%s\ndocroot\n%s", name, testValues[apptypePos])
 		scanner = bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -279,7 +279,7 @@ func TestConfigCommand(t *testing.T) {
 		// hyphen for the project name.
 		// One of the test directories has a capital letter to ensure that the site
 		// name is lowercased.
-		assert.Equal(ddevapp.NormalizeProjectName(projectRoot), app.Name)
+		assert.Equal(strings.ReplaceAll(projectRoot, "_", "-"), app.Name)
 		assert.Equal(testValues[apptypePos], app.Type)
 		assert.Equal("docroot", app.Docroot)
 		assert.EqualValues(testValues[phpVersionPos], app.PHPVersion, "PHP value incorrect for apptype %v (expected %s got %s) (%v)", app.Type, testValues[phpVersionPos], app.PHPVersion, app)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -230,7 +230,7 @@ func TestConfigCommand(t *testing.T) {
 	testMatrix := map[string][]string{
 		"magentophpversion": {nodeps.AppTypeMagento, nodeps.PHPDefault},
 		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHP82},
-		"drupalphpversion":  {nodeps.AppTypeDrupal, nodeps.PHPDefault},
+		"Drupalphpversion":  {nodeps.AppTypeDrupal, nodeps.PHPDefault},
 	}
 
 	for testName, testValues := range testMatrix {
@@ -258,23 +258,51 @@ func TestConfigCommand(t *testing.T) {
 		name := strings.ToLower(util.RandString(16))
 		invalidAppType := strings.ToLower(util.RandString(8))
 
-		// Create an example input buffer that writes the sitename, a valid document root,
-		// an invalid app type, and finally a valid app type (from test matrix)
-		input := fmt.Sprintf("%s\ndocroot\n%s\n%s", name, invalidAppType, testValues[apptypePos])
+		// Create an example input buffer that uses the default projectname, then a
+		// valid document root, then a valid app type.
+		input := fmt.Sprintf("\ndocroot\n%s", testValues[apptypePos])
 		scanner := bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 
 		restoreOutput := util.CaptureUserOut()
 		err = app.PromptForConfig()
-		require.Error(t, err, "invalid project type error should have been caught")
+		assert.NoError(err)
 		out := restoreOutput()
+
+		// Ensure we have expected vales in output.
+		projectRoot := filepath.Base(testDir)
+		assert.Contains(out, testDir)
+		assert.NotContains(out, fmt.Sprintf("%s is not a valid project name", projectRoot))
+
+		// Ensure values were properly set on the app struct.
+		// Project root contains an underscore. Make sure it was replaced with a
+		// hyphen for the project name.
+		// One of the test directories has a capital letter to ensure that the site
+		// name is lowercased.
+		assert.Equal(ddevapp.NormalizeProjectName(projectRoot), app.Name)
+		assert.Equal(testValues[apptypePos], app.Type)
+		assert.Equal("docroot", app.Docroot)
+		assert.EqualValues(testValues[phpVersionPos], app.PHPVersion, "PHP value incorrect for apptype %v (expected %s got %s) (%v)", app.Type, testValues[phpVersionPos], app.PHPVersion, app)
+		err = ddevapp.PrepDdevDirectory(app)
+		assert.NoError(err)
+
+		// Create an example input buffer that writes the sitename, a valid document root,
+		// an invalid app type, and finally a valid app type (from test matrix)
+		input = fmt.Sprintf("%s\ndocroot\n%s\n%s", name, invalidAppType, testValues[apptypePos])
+		scanner = bufio.NewScanner(strings.NewReader(input))
+		util.SetInputScanner(scanner)
+
+		restoreOutput = util.CaptureUserOut()
+		err = app.PromptForConfig()
+		require.Error(t, err, "invalid project type error should have been caught")
+		out = restoreOutput()
 
 		// Ensure we have expected vales in output.
 		assert.Contains(out, testDir)
 		assert.Contains(out, fmt.Sprintf("'%s' is not a valid project type", invalidAppType))
 
 		// Create an example input buffer that writes an invalid projectname, then a valid-project-name,
-		// a valid document root, a valid app type
+		// a valid document root, then a valid app type.
 		input = fmt.Sprintf("invalid_project_name\n%s\ndocroot\n%s", name, testValues[apptypePos])
 		scanner = bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2845,6 +2845,7 @@ func GetActiveAppRoot(siteName string) (string, error) {
 // To use the current working directory, siteName should be ""
 func GetActiveApp(siteName string) (*DdevApp, error) {
 	app := &DdevApp{}
+	siteName = NormalizeProjectName(siteName)
 	activeAppRoot, err := GetActiveAppRoot(siteName)
 	if err != nil {
 		return app, err
@@ -2868,6 +2869,11 @@ func GetActiveApp(siteName string) (*DdevApp, error) {
 	}
 
 	return app, nil
+}
+
+// Lowercase and replace underscores in the site name with hyphens.
+func NormalizeProjectName(siteName string) string {
+	return strings.ToLower(strings.ReplaceAll(siteName, "_", "-"))
 }
 
 // restoreApp recreates an AppConfig's Name and returns an error

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2845,7 +2845,6 @@ func GetActiveAppRoot(siteName string) (string, error) {
 // To use the current working directory, siteName should be ""
 func GetActiveApp(siteName string) (*DdevApp, error) {
 	app := &DdevApp{}
-	siteName = NormalizeProjectName(siteName)
 	activeAppRoot, err := GetActiveAppRoot(siteName)
 	if err != nil {
 		return app, err

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2873,7 +2873,7 @@ func GetActiveApp(siteName string) (*DdevApp, error) {
 
 // Lowercase and replace underscores in the site name with hyphens.
 func NormalizeProjectName(siteName string) string {
-	return strings.ToLower(strings.ReplaceAll(siteName, "_", "-"))
+	return strings.ReplaceAll(siteName, "_", "-")
 }
 
 // restoreApp recreates an AppConfig's Name and returns an error

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2871,7 +2871,7 @@ func GetActiveApp(siteName string) (*DdevApp, error) {
 	return app, nil
 }
 
-// Lowercase and replace underscores in the site name with hyphens.
+// NormalizeProjectName replaces underscores in the site name with hyphens.
 func NormalizeProjectName(siteName string) string {
 	return strings.ReplaceAll(siteName, "_", "-")
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3219,9 +3219,7 @@ func TestRouterPortsCheck(t *testing.T) {
 	}
 
 	app, err = ddevapp.GetActiveApp(site.Name)
-	if err != nil {
-		t.Fatalf("Failed to GetActiveApp(%s), err:%v", site.Name, err)
-	}
+	require.NoError(t, err, "Failed to GetActiveApp(%s), err:%v", site.Name, err)
 	startErr = app.StartAndWait(5)
 	//nolint: errcheck
 	defer app.Stop(true, false)


### PR DESCRIPTION

## The Issue

* #6206 

Drupal modules frequently contain underscores in the project names. It's annoying to have to specify a different project name, or manually convert underscores to hyphens, each time I create a DDEV project for one. It seems a bit arbitrary that underscores aren't allowed.

## How This PR Solves The Issue

When getting the project name from the directory name, underscores are replaced with hyphens.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

This needs an additional test to ensure that a project directory containing underscores now has the default project-name working.

## Related Issue Link(s)

https://github.com/ddev/ddev/issues/6206

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

