### PR TITLE
build: Remove concurrency/cancellation check on pr-build as it's useless [skip ci]

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,10 +4,6 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize, ready_for_review, review_requested]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   issues: write


### PR DESCRIPTION

## The Issue

Since we introduced the concurrency check, we've been getting useless emails about the pr-check concurrency.

Remove it.
