### PR TITLE
docs: add link to TYPO3 ddev guides

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -646,6 +646,8 @@ If your project uses a database you'll want to set the [DB connection string](ht
 
 ## TYPO3
 
+TYPO3 provides a [detailed DDEV installation guide](https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/TutorialDdev.html) for each major version.
+
 === "Composer"
 
     ```bash


### PR DESCRIPTION
## The Issue

[Quickstart docs for TYPO3](https://ddev.readthedocs.io/en/latest/users/quickstart/#typo3) do not mention the official guide made by the TYPO3 organisation.

## How This PR Solves The Issue

Add link to https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/TutorialDdev.html

## Manual Testing Instructions

None, only docs change

## Automated Testing Overview

None, only docs change

## Related Issue Link(s)

## Release/Deployment Notes
