### PR TITLE
test: Update drupal11 test to 11.0.0-beta1

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -353,10 +353,10 @@ var (
 		// 19: drupal11
 		{
 			Name:                          "TestPkgDrupal11",
-			SourceURL:                     "https://github.com/ddev/test-drupal11/archive/refs/tags/11.x-dev.1.tar.gz",
-			ArchiveInternalExtractionPath: "test-drupal11-11.x-dev.1/",
-			FilesTarballURL:               "https://github.com/ddev/test-drupal11/releases/download/11.x-dev.1/files.tgz",
-			DBTarURL:                      "https://github.com/ddev/test-drupal11/releases/download/11.x-dev.1/db.sql.tar.gz",
+			SourceURL:                     "https://github.com/ddev/test-drupal11/archive/refs/tags/11.0.0-beta1.tar.gz",
+			ArchiveInternalExtractionPath: "test-drupal11-11.0.0-beta1/",
+			FilesTarballURL:               "https://github.com/ddev/test-drupal11/releases/download/11.0.0-beta1/files.tgz",
+			DBTarURL:                      "https://github.com/ddev/test-drupal11/releases/download/11.0.0-beta1/db.sql.tar.gz",
 			FullSiteTarballURL:            "",
 			Type:                          nodeps.AppTypeDrupal,
 			Docroot:                       "web",


### PR DESCRIPTION

## The Issue

Drupal 11 has been moving along pretty fast, now at beta1. 

I updated ddev/test-drupal11 repo to 11.0.0-beta1 with a new release

## How This PR Solves The Issue

Use the new release of 11.0.0-beta1

