### PR TITLE
docs: add Vite infobox for Laravel quickstart

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -216,6 +216,7 @@ bugfix
 bugfixes
 buildkite
 buildx
+bundler
 busybox
 by
 cd

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -216,6 +216,7 @@ bugfix
 bugfixes
 buildkite
 buildx
+bundler
 busybox
 by
 cd
@@ -280,6 +281,7 @@ detailed
 dev
 devcontainer
 development
+devserver
 dir
 directory
 disable

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -216,7 +216,6 @@ bugfix
 bugfixes
 buildkite
 buildx
-bundler
 busybox
 by
 cd
@@ -281,7 +280,6 @@ detailed
 dev
 devcontainer
 development
-devserver
 dir
 directory
 disable

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -398,42 +398,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ```
 
 !!!tip "Add Vite support?"
-    Since Laravel v9.19.0, Vite is included as the default [asset bundler](https://laravel.com/docs/11.x/vite). There are two tweaks needed for usage in DDEV.
-
-    First, expose the port in `.ddev/config.yaml` and run `ddev restart`:
-
-    ```yaml
-    web_extra_exposed_ports:
-      - name: vite
-        container_port: 5173
-        http_port: 5172
-        https_port: 5173
-    ```
-    
-    Secondly, adjust your `vite.config.js` and start the Vite devserver with `ddev npm run dev`:
-
-    ```js
-    import { defineConfig } from 'vite';
-    import laravel from 'laravel-vite-plugin';
-
-    const port = 5173;
-    const origin = `${process.env.DDEV_PRIMARY_URL}:${port}`;
-
-    export default defineConfig({
-        plugins: [
-            laravel({
-                input: ['resources/css/app.css', 'resources/js/app.js'],
-                refresh: true,
-            }),
-        ],
-        server: {
-            host: '0.0.0.0',
-            port: port,
-            strictPort: true,
-            origin: origin
-        }
-    });
-    ```
+    Since Laravel v9.19.0, Vite is included as the default [asset bundler](https://laravel.com/docs/11.x/vite). There are small tweaks needed in order to use  Vite in DDEV: [Working with Vite in DDEV - Laravel](https://ddev.com/blog/working-with-vite-in-ddev/#laravel).
 
 ## Magento
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -397,6 +397,33 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
     ```
 
+!!!tip "Add Vite support?"
+    Since Laravel v9.19.0, Vite will be shipped as default [asset bundler](https://laravel.com/docs/11.x/vite). There are two tweaks needed for usage in DDEV.
+
+    First, expose the port in `.ddev/config.yaml` and run `ddev restart`:
+
+    ```yaml
+    web_extra_exposed_ports:
+      - name: vite
+        container_port: 5173
+        http_port: 5172
+        https_port: 5173
+    ```
+    
+    Secondly, add this to your `vite.config.js` and start the Vite devserver with `ddev npm run dev`:
+
+    ```js
+    server: {
+        host: '0.0.0.0',
+        strictPort: true,
+        port: 5173,
+        hmr: {
+            protocol: 'wss',
+            host: `${process.env.DDEV_HOSTNAME}`
+        }
+    }
+    ```
+
 ## Magento
 
 === "Magento 2"

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -398,7 +398,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ```
 
 !!!tip "Add Vite support?"
-    Since Laravel v9.19.0, Vite is included as the default [asset bundler](https://laravel.com/docs/11.x/vite). There are small tweaks needed in order to use it: [Working with Vite in DDEV - Laravel](https://ddev.com/blog/working-with-vite-in-ddev/#laravel).
+    Since Laravel v9.19, Vite is included as the default [asset bundler](https://laravel.com/docs/master/vite). There are small tweaks needed in order to use it: [Working with Vite in DDEV - Laravel](https://ddev.com/blog/working-with-vite-in-ddev/#laravel).
 
 ## Magento
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -398,7 +398,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ```
 
 !!!tip "Add Vite support?"
-    Since Laravel v9.19.0, Vite will be shipped as default [asset bundler](https://laravel.com/docs/11.x/vite). There are two tweaks needed for usage in DDEV.
+    Since Laravel v9.19.0, Vite is included as the default [asset bundler](https://laravel.com/docs/11.x/vite). There are two tweaks needed for usage in DDEV.
 
     First, expose the port in `.ddev/config.yaml` and run `ddev restart`:
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -410,18 +410,29 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
         https_port: 5173
     ```
     
-    Secondly, add this to your `vite.config.js` and start the Vite devserver with `ddev npm run dev`:
+    Secondly, adjust your `vite.config.js` and start the Vite devserver with `ddev npm run dev`:
 
     ```js
-    server: {
-        host: '0.0.0.0',
-        strictPort: true,
-        port: 5173,
-        hmr: {
-            protocol: 'wss',
-            host: `${process.env.DDEV_HOSTNAME}`
+    import { defineConfig } from 'vite';
+    import laravel from 'laravel-vite-plugin';
+
+    const port = 5173;
+    const origin = `${process.env.DDEV_PRIMARY_URL}:${port}`;
+
+    export default defineConfig({
+        plugins: [
+            laravel({
+                input: ['resources/css/app.css', 'resources/js/app.js'],
+                refresh: true,
+            }),
+        ],
+        server: {
+            host: '0.0.0.0',
+            port: port,
+            strictPort: true,
+            origin: origin
         }
-    }
+    });
     ```
 
 ## Magento

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -398,7 +398,7 @@ The Laravel project type can be used for [Lumen](https://lumen.laravel.com/) lik
     ```
 
 !!!tip "Add Vite support?"
-    Since Laravel v9.19.0, Vite is included as the default [asset bundler](https://laravel.com/docs/11.x/vite). There are small tweaks needed in order to use  Vite in DDEV: [Working with Vite in DDEV - Laravel](https://ddev.com/blog/working-with-vite-in-ddev/#laravel).
+    Since Laravel v9.19.0, Vite is included as the default [asset bundler](https://laravel.com/docs/11.x/vite). There are small tweaks needed in order to use it: [Working with Vite in DDEV - Laravel](https://ddev.com/blog/working-with-vite-in-ddev/#laravel).
 
 ## Magento
 


### PR DESCRIPTION
## The Issue

Saw a reddit post, which stated that it was not clear how to use Vite within DDEV, at least in the past https://www.reddit.com/r/laravel/comments/1cuietp/dockers_is_ddev_worth_the_hassle/

## How This PR Solves The Issue

Add the most basic Vite usage information for Laravel + DDEV

Optional:
- a link to https://ddev.com/blog/working-with-vite-in-ddev/ would also be possible
- additionally we could say that more ways of exposing the port / exposing Vite are possible (like https://www.lullabot.com/articles/nodejs-development-ddev), but I think that would be too much for the quickstart docs.

## Manual Testing Instructions

- Check instructions after fresh install, I already did a fresh install of v11 and used the instructions in https://github.com/mandrasch/ddev-laravel-vite

## Automated Testing Overview

- docs change

## Related Issue Link(s)

- https://github.com/ddev/ddev.com/pull/204

## Release/Deployment Notes