### PR TITLE
fix: Improve instructional output on 'ddev config'

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -432,7 +432,7 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 		}
 
 		app.Type = projectTypeArg
-		util.Success("Auto-updating project configuration because update is requested.\nConfiguring a '%s' project with docroot '%s' at %s", app.Type, app.Docroot, fullPath)
+		util.Success("Auto-updating project configuration because update is requested.\nConfiguring a '%s' project with docroot '%s' at '%s'", app.Type, app.Docroot, fullPath)
 		err = app.ConfigFileOverrideAction(true)
 		if err != nil {
 			util.Warning("ConfigOverrideAction failed: %v")
@@ -445,7 +445,7 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 		}
 
 		app.Type = projectTypeArg
-		util.Success("Configuring a '%s' project with docroot '%s' at %s", app.Type, app.Docroot, fullPath)
+		util.Success("Configuring a '%s' project named '%s' with docroot '%s' at '%s'.\nFor full details use 'ddev describe'.", app.Type, app.Name, app.Docroot, fullPath)
 	}
 
 	// App overrides are done after app type is detected, but

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -115,13 +115,13 @@ func TestConfigWithSitenameFlagDetectsDocroot(t *testing.T) {
 	assert.NoError(err)
 
 	// Create a config
-	args := []string{"config", "--project-name=config-with-sitename", "--php-version=7.2"}
+	args := []string{"config", "--project-name", t.Name(), "--php-version=7.2"}
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
-	defer func() {
-		_, _ = exec.RunCommand(DdevBin, []string{"delete", "-Oy", "config-with-sitename"})
-	}()
-	assert.Contains(string(out), "Configuring a 'drupal6' project with docroot", nodeps.AppTypeDrupal6)
+	t.Cleanup(func() {
+		_, _ = exec.RunCommand(DdevBin, []string{"delete", "-Oy", t.Name()})
+	})
+	assert.Contains(out, fmt.Sprintf("Configuring a '%s' project named '%s' with docroot '", nodeps.AppTypeDrupal6, t.Name()))
 }
 
 // TestConfigSetValues sets all available configuration values using command flags, then confirms that the

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1567,7 +1567,7 @@ func (app *DdevApp) CheckExistingAppInApproot() error {
 	pList := globalconfig.GetGlobalProjectList()
 	for name, v := range pList {
 		if app.AppRoot == v.AppRoot && name != app.Name {
-			return fmt.Errorf(`this project root %s already contains a project named %s. You may want to remove the existing project with "ddev stop --unlist %s"`, v.AppRoot, name, name)
+			return fmt.Errorf(`this project root '%s' already contains a project named '%s'. You may want to remove the existing project with "ddev stop --unlist %s"`, v.AppRoot, name, name)
 		}
 	}
 	return nil

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3172,7 +3172,7 @@ func TestAppdirAlreadyInUse(t *testing.T) {
 
 	err = app.Start()
 	assert.Error(err)
-	assert.Contains(err.Error(), "already contains a project named "+originalProjectName)
+	assert.Contains(err.Error(), "already contains a project named '"+originalProjectName)
 	err = app.Stop(true, false)
 	assert.NoError(err)
 
@@ -3191,7 +3191,7 @@ func TestAppdirAlreadyInUse(t *testing.T) {
 	app.Name = secondProjectName
 	err = app.Start()
 	assert.Error(err)
-	assert.Contains(err.Error(), "already contains a project named "+originalProjectName)
+	assert.Contains(err.Error(), "already contains a project named '"+originalProjectName)
 }
 
 // TestHttpsRedirection tests to make sure that webserver and php redirect to correct


### PR DESCRIPTION

## The Issue

In testing @stasadev 's improvements in
* https://github.com/ddev/ddev/pull/6208

it seemed to me that the instructional output of `ddev config` could be improved

## How This PR Solves The Issue

New output, including project name and quoted dir:

```
rfay@rfay-xps13:~/workspace/j2$ ddev config --project-type=laravel --docroot=public --project-name=xxx
You are reconfiguring the project at /home/rfay/workspace/j2.
The existing configuration will be updated and replaced.
Created docroot directory at /home/rfay/workspace/j2/public
Configuring a 'laravel' project named 'xxx' with docroot 'public' at '/home/rfay/workspace/j2/public'.
For full details use 'ddev describe'.
Configuration complete. You may now run 'ddev start'.
```

## Manual Testing Instructions

Use `ddev config`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

