### PR TITLE
docs: typo in faq "thew"

### DIFF
--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -256,7 +256,7 @@ Delete it and migrate it to a new project with your preferred name:
 1. Export the project’s database: `ddev export-db --file=/path/to/db.sql.gz`.
 2. Delete the project: `ddev delete <project>`. (This takes a snapshot by default for safety.)
 3. Rename the project: `ddev config --project-name=<new_name>`.
-4. Start thew new project with `ddev start`.
+4. Start the new project with `ddev start`.
 5. Import the database dump from step one: `ddev import-db --file=/path/to/db.sql.gz`.
 
 ### How can I move a project to another directory?


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue
Typo in the [current docs](https://ddev.readthedocs.io/en/stable/users/usage/faq/#how-can-i-change-a-projects-name). 
![image](https://github.com/ddev/ddev/assets/70238020/dbcd5772-2123-4957-8a87-36be85b85e25)

## How This PR Solves The Issue
Change "thew" to "the"