### PR TITLE
docs: Update PHPStorm instructions to include COMPOSE_PROJECT_NAME in manual instructions

### DIFF
--- a/docs/content/users/install/phpstorm.md
+++ b/docs/content/users/install/phpstorm.md
@@ -38,8 +38,9 @@ If you’re not using the DDEV Integration Plugin, you can follow these steps in
     4. In the “Path mappings” of the “Server” you may have to map the local paths (which on WSL2 means `/home/...`) to the in-container paths, especially if you have Mutagen enabled. So “Virtual Machine Path” would be `/var/www/html` and “Local path” would be something like `/Users/rfay/workspace/drup` (on macOS) or `\\wsl$\Ubuntu\home\rfay\workspace\drup` on Windows using WSL2.
     5. Now back in the “Configure Remote PHP Interpreter” for “Configuration files” use `.ddev/.ddev-docker-compose-full.yaml`. On macOS, you may need to use <kbd>⌘</kbd> + <kbd>SHIFT</kbd> + <kbd>.</kbd>, to show hidden dotfiles.
     6. Service: `web`.
-    7. In the CLI interpreter “Lifecycle” select “Connect to existing container”.
-    8. Here’s an example filled out:
+    7. Environment variables: Set the `COMPOSE_PROJECT_NAME` variable to the name of the project prefixed with `ddev`. In the `drup` example this would become `ddev-drup`. You can find the name of the project in je `config.yaml` of your project. The result will be `COMPOSE_PROJECT_NAME=ddev-drup`.
+    8. In the CLI interpreter “Lifecycle” select “Connect to existing container”.
+    9. Here’s an example filled out:
         ![example configuration](../../images/phpstorm-cli-interpreter.png)
 6. In the main PHP setup dialog, add an entry to the path mappings, as it doesn’t correctly derive the full path mapping. Add an entry that maps your project location to `/var/www/html`. So in this example, the “Local Path” is `/Users/rfay/workspace/drup` and the “Remote Path” is `/var/www/html`:
     ![example mapping](../../images/phpstorm-mapping.png)

--- a/docs/content/users/install/phpstorm.md
+++ b/docs/content/users/install/phpstorm.md
@@ -38,7 +38,7 @@ If you’re not using the DDEV Integration Plugin, you can follow these steps in
     4. In the “Path mappings” of the “Server” you may have to map the local paths (which on WSL2 means `/home/...`) to the in-container paths, especially if you have Mutagen enabled. So “Virtual Machine Path” would be `/var/www/html` and “Local path” would be something like `/Users/rfay/workspace/drup` (on macOS) or `\\wsl$\Ubuntu\home\rfay\workspace\drup` on Windows using WSL2.
     5. Now back in the “Configure Remote PHP Interpreter” for “Configuration files” use `.ddev/.ddev-docker-compose-full.yaml`. On macOS, you may need to use <kbd>⌘</kbd> + <kbd>SHIFT</kbd> + <kbd>.</kbd>, to show hidden dotfiles.
     6. Service: `web`.
-    7. Environment variables: Set the `COMPOSE_PROJECT_NAME` variable to the name of the project prefixed with `ddev`. In the `drup` example this would become `ddev-drup`. You can find the name of the project in je `config.yaml` of your project. The result will be `COMPOSE_PROJECT_NAME=ddev-drup`.
+    7. Environment variables: Set the `COMPOSE_PROJECT_NAME` variable to the name of the project prefixed with `ddev`. In the `drup` example this would become `ddev-drup`. You can find the name of the project in je `config.yaml` of your project. The result will be `COMPOSE_PROJECT_NAME=ddev-drup`. Note that the content of COMPOSE_PROJECT_NAME needs to be lowercase even when project name itself has uppercase characters.
     8. In the CLI interpreter “Lifecycle” select “Connect to existing container”.
     9. Here’s an example filled out:
         ![example configuration](../../images/phpstorm-cli-interpreter.png)


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

The PHPStorm instructions are pretty clear, but setting the `COMPOSE_PROJECT_NAME` was missing from the instructions, making it impossible to set up PHPStorm. The screenshot already included this variable.

## How This PR Solves The Issue

It adds a step in the instructions that explains that you need to set it and what the value should be.

## Manual Testing Instructions

- Set up a new project.
- Open it in PHPStorm.
- Follow the instructions.

## Automated Testing Overview

You can't automate this afaik.

## Related Issue Link(s)

N/A

## Release/Deployment Notes

N/A
