### PR TITLE
test: fix TestConfigGitignore on Windows

### DIFF
--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -684,10 +684,10 @@ func TestConfigGitignore(t *testing.T) {
 	out = strings.ReplaceAll(out, "new file:   .ddev/config.yaml", "")
 	assert.NotContains(out, "new file:")
 
-	_, err = exec.RunHostCommand("bash", "-c", fmt.Sprintf(`touch "/%s" "/%s"`, filepath.Join(globalDdevDir, "commands", "web", t.Name()), filepath.Join(globalDdevDir, "homeadditions", t.Name())))
+	_, err = exec.RunHostCommand("bash", "-c", fmt.Sprintf(`touch "%s" "%s"`, filepath.Join(globalDdevDir, "commands", "web", t.Name()), filepath.Join(globalDdevDir, "homeadditions", t.Name())))
 	assert.NoError(err)
 	if err != nil {
-		out, err = exec.RunHostCommand("bash", "-c", fmt.Sprintf(`ls -l "/%s" && ls -lR "/%s" "/%s"`, globalDdevDir, filepath.Join(globalDdevDir, "commands"), filepath.Join(globalDdevDir, "homeadditions")))
+		out, err = exec.RunHostCommand("bash", "-c", fmt.Sprintf(`ls -l "%s" && ls -lR "%s" "%s"`, globalDdevDir, filepath.Join(globalDdevDir, "commands"), filepath.Join(globalDdevDir, "homeadditions")))
 		assert.NoError(err)
 		t.Logf("Contents of global .ddev: \n=====\n%s\n====", out)
 	}


### PR DESCRIPTION
## The Issue

Buildkite [error](https://buildkite.com/ddev/ddev-windows-mutagen/builds/4587#018f9da8-3c29-4a0e-a0d1-80631cf1d19e/12929-12950):

```
ls: cannot access '/C:\Users\testbot\tmp\ddevtest\Home_VRAjq683975830\ddev': No such file or directory
```

## How This PR Solves The Issue

The error is a result of my refactoring in:

- #5813

I thought the path would look like `/c/Users/...`, but it is `C:\Users\...`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

