### PR TITLE
build: standardize apt-get usage, remove blackfire from apt sources, for #6235, for #6078

### DIFF
--- a/.github/devcontainers/src/install-ddev/install.sh
+++ b/.github/devcontainers/src/install-ddev/install.sh
@@ -4,5 +4,4 @@ set -eu -o pipefail
 sudo install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/ddev.gpg > /dev/null
 echo "deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list
-sudo apt update >/dev/null && sudo apt install -y ddev xdg-utils >/dev/null
-
+sudo apt-get update >/dev/null && sudo apt-get install -y ddev xdg-utils >/dev/null

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -88,7 +88,7 @@ function cleanup {
 
 ddev config --project-type=php --docroot=web --disable-upload-dirs-warning || (printf "\n\nPlease run 'ddev debug test' in the root of the existing project where you're having trouble.\n\n" && exit 4)
 
-printf "RUN apt update\nRUN curl -I https://www.google.com\n" > .ddev/web-build/Dockerfile.test
+printf "RUN apt-get update\nRUN curl -I https://www.google.com\n" > .ddev/web-build/Dockerfile.test
 
 set +eu
 

--- a/containers/ddev-ssh-agent/Dockerfile
+++ b/containers/ddev-ssh-agent/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-RUN apt-get update && apt-get install -y bash expect file openssh-client socat psmisc && apt autoclean
+RUN apt-get update && apt-get install -y bash expect file openssh-client socat psmisc && apt-get autoclean
 
 # Copy container files
 COPY files /

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -90,6 +90,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     unzip \
     zip
 
+# Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
+RUN rm /etc/apt/sources.list.d/blackfire.list
+
 RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=${TARGETPLATFORM}" && chmod +x /usr/local/bin/mkcert
 
 # blackfire user by default is set up with /dev/null as homedir, and 999 as uid, which
@@ -141,7 +144,7 @@ RUN chmod -fR ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /var/lib/ngin
 RUN mkdir -p /var/xhprof && curl --fail  -o /tmp/xhprof.tgz -sSL https://pecl.php.net/get/xhprof && tar -zxf /tmp/xhprof.tgz --strip-components=1 -C /var/xhprof && chmod 777 /var/xhprof/xhprof_html && rm /tmp/xhprof.tgz
 
 RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && \
-  chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
+    chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
 
 RUN a2dismod mpm_event
 RUN a2enmod ssl headers expires
@@ -224,6 +227,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     unzip \
     zip
 
+# Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
+RUN rm /etc/apt/sources.list.d/blackfire.list
+
 RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=${TARGETPLATFORM}" && chmod +x /usr/local/bin/mkcert
 
 ADD ddev-webserver-prod-files /
@@ -250,7 +256,7 @@ RUN mkdir -p /mnt/ddev-global-cache/mkcert /run/php /var/cache/nginx /var/lib/ng
 RUN chmod -fR ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /var/lib/nginx /run /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/alternatives /usr/lib/node_modules /etc/php /etc/apache2 /var/lock/apache2 /var/log/apache2/ /var/run/apache2 /var/lib/apache2 /mnt/ddev-global-cache/*
 
 RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && \
-  chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
+    chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
 
 RUN a2dismod mpm_event
 RUN a2enmod ssl headers expires

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -9,7 +9,7 @@ search:
 There are several ways to use DDEV’s latest-committed HEAD version:
 
 * **Download** the latest master branch artifacts from [nightly.link](https://nightly.link/ddev/ddev/workflows/master-build/master). Each of these is built by the CI system, signed, and notarized. Get the one you need and place it in your `$PATH`.
-* **Homebrew install HEAD**: On macOS and Linux, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD --fetch-HEAD` to get the latest DDEV commit, even if it’s unreleased. Since you’re building this on your own computer, it’s not signed or notarized, and you’ll get a notification that instrumentation doesn’t work, which is fine. If you’re using Linux/WSL2, you’ll likely need to install build-essential by running the following command: `sudo apt install -y build-essential`.
+* **Homebrew install HEAD**: On macOS and Linux, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD --fetch-HEAD` to get the latest DDEV commit, even if it’s unreleased. Since you’re building this on your own computer, it’s not signed or notarized, and you’ll get a notification that instrumentation doesn’t work, which is fine. If you’re using Linux/WSL2, you’ll likely need to install build-essential by running the following command: `sudo apt-get install -y build-essential`.
 * **Build manually**: If you have normal build tools like `make` and `go` installed, you can check out the code and run `make`.
 * **Gitpod** You can use the latest build by visiting DDEV on [Gitpod](https://gitpod.io/#https://github.com/ddev/ddev).
 

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -64,12 +64,12 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
     curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/ddev.gpg > /dev/null
     echo "deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
     # Update package information and install DDEV
-    sudo apt update && sudo apt install -y build-essential ddev icinga2 mariadb-client
+    sudo apt-get update && sudo apt-get install -y build-essential ddev icinga2 mariadb-client
     brew install docker-compose golang 
 
     sudo mkdir -p /usr/sharekeyrings && curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
     echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
-    sudo apt update && sudo apt install -y build-essential buildkite-agent ca-certificates curl ddev etckeeper gnupg icinga2 nagios-plugins lsb-release make mariadb-client
+    sudo apt-get update && sudo apt-get install -y build-essential buildkite-agent ca-certificates curl ddev etckeeper gnupg icinga2 nagios-plugins lsb-release make mariadb-client
     (mkcert -uninstall || true); rm -rf $(mkcert -CAROOT) || true; mkcert -install
     sudo snap install --classic go
     sudo snap install ngrok
@@ -93,7 +93,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
     sudo mkdir -p /etc/apt/keyrings
     sudo mkdir -p /etc/apt/keyrings && sudo rm -f /etc/apt/keyrings/docker.gpg && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    sudo apt update && sudo apt install -y docker-ce docker-ce-cli etckeeper containerd.io docker-compose-plugin
+    sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli etckeeper containerd.io docker-compose-plugin
     sudo usermod -aG docker $USER
     ```
 
@@ -103,7 +103,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 
 1. Icinga Director web UI, configure the host on `newmonitor.thefays.us`, normally making a copy of an existing identical item.
 2. Deploy the new host using Icinga Director.
-3. On the WSL2 Ubuntu instance, install needed packages: `sudo apt update && sudo apt install -y etckeeper icinga2 monitoring-plugins-contrib nagios-plugins`
+3. On the WSL2 Ubuntu instance, install needed packages: `sudo apt-get update && sudo apt-get install -y etckeeper icinga2 monitoring-plugins-contrib nagios-plugins`
 4. Add `nagios` to the `docker` group in `/etc/group`.
 5. `sudo icinga2 node wizard` to configure the agent, see [docs](https://icinga.com/docs/icinga-2/latest/doc/06-distributed-monitoring/#agentsatellite-setup-on-linux)
 6. Restart `sudo systemctl restart icinga2`

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -20,7 +20,7 @@ Then the additional packages will be built into the containers during [`ddev sta
 
 ### PHP Extensions supported by `deb.sury.org`
 
-If a PHP extension is supported by the upstream package management from `deb.sury.org`, you'll be able to add it with minimal effort. Test to see if it's available using `ddev exec 'sudo apt update && sudo apt install php${DDEV_PHP_VERSION}-<extension>'`, for example, `ddev exec 'sudo apt update && sudo apt install php${DDEV_PHP_VERSION}-imap'`. If that works, then the extension is supported, and you can add `webimage_extra_packages: ["php${DDEV_PHP_VERSION}-<extension>"]` to your `.ddev/config.yaml` file.
+If a PHP extension is supported by the upstream package management from `deb.sury.org`, you'll be able to add it with minimal effort. Test to see if it's available using `ddev exec '(sudo apt update || true) && sudo apt install php${DDEV_PHP_VERSION}-<extension>'`, for example, `ddev exec '(sudo apt update || true) && sudo apt install php${DDEV_PHP_VERSION}-imap'`. If that works, then the extension is supported, and you can add `webimage_extra_packages: ["php${DDEV_PHP_VERSION}-<extension>"]` to your `.ddev/config.yaml` file.
 
 ### PECL PHP Extensions not supported by `deb.sury.org`
 
@@ -35,7 +35,7 @@ For example, a `.ddev/web-build/Dockerfile.mcrypt` might look like this:
 ENV extension=mcrypt
 SHELL ["/bin/bash", "-c"]
 # Install the needed development packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests build-essential php-pear php${DDEV_PHP_VERSION}-dev
+RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests build-essential php-pear php${DDEV_PHP_VERSION}-dev
 # mcrypt happens to require libmcrypt-dev
 RUN apt install -y libmcrypt-dev
 RUN pecl install ${extension}
@@ -49,7 +49,7 @@ A `.ddev/web-build/Dockerfile.xlswriter` to add `xlswriter` might be:
 ENV extension=xlswriter
 SHELL ["/bin/bash", "-c"]
 # Install the needed development packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests build-essential php-pear php${DDEV_PHP_VERSION}-dev
+RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests build-essential php-pear php${DDEV_PHP_VERSION}-dev
 # xlswriter requires libz-dev
 RUN sudo apt install -y libz-dev
 RUN echo | pecl install ${extension}
@@ -66,7 +66,7 @@ ENV extension=xdebug
 SHELL ["/bin/bash", "-c"]
 RUN phpdismod xdebug
 # Install the needed development packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests build-essential php-pear php${DDEV_PHP_VERSION}-dev
+RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests build-essential php-pear php${DDEV_PHP_VERSION}-dev
 # Remove the standard xdebug provided by deb.sury.org
 RUN apt remove php${DDEV_PHP_VERSION}-xdebug || true
 RUN pecl install ${extension}
@@ -85,7 +85,7 @@ Most PHP extensions are built within the `deb.sury.org` distribution. You can Go
 
 If you need a package that is *not* a PHP package, you can view and search standard Debian packages at [packages.debian.org/stable](https://packages.debian.org/stable/), or use Google.
 
-To test that a package will do what you want, you can [`ddev ssh`](../usage/commands.md#ssh) and `sudo apt-get update && sudo apt-get install <package>` to verify that you can install it and you get what you need. A PHP extension may require `killall -USR2 php-fpm` to take effect. After you’ve tried that, you can add the package to [`webimage_extra_packages`](../configuration/config.md#webimage_extra_packages).
+To test that a package will do what you want, you can [`ddev ssh`](../usage/commands.md#ssh) and `(sudo apt-get update || true) && sudo apt-get install <package>` to verify that you can install it and you get what you need. A PHP extension may require `killall -USR2 php-fpm` to take effect. After you’ve tried that, you can add the package to [`webimage_extra_packages`](../configuration/config.md#webimage_extra_packages).
 
 ## Adding Extra Dockerfiles for `webimage` and `dbimage`
 
@@ -158,7 +158,7 @@ ENV extension=xhprof
 ENV extension_repo=https://github.com/longxinH/xhprof
 ENV extension_version=v2.3.8
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests autoconf build-essential libc-dev php-pear php${DDEV_PHP_VERSION}-dev pkg-config zlib1g-dev
+RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests autoconf build-essential libc-dev php-pear php${DDEV_PHP_VERSION}-dev pkg-config zlib1g-dev
 RUN mkdir -p /tmp/php-${extension} && cd /tmp/php-${extension} && git clone ${extension_repo} .
 WORKDIR /tmp/php-${extension}/extension
 RUN git checkout ${extension_version}

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -20,7 +20,7 @@ Then the additional packages will be built into the containers during [`ddev sta
 
 ### PHP Extensions supported by `deb.sury.org`
 
-If a PHP extension is supported by the upstream package management from `deb.sury.org`, you'll be able to add it with minimal effort. Test to see if it's available using `ddev exec '(sudo apt update || true) && sudo apt install php${DDEV_PHP_VERSION}-<extension>'`, for example, `ddev exec '(sudo apt update || true) && sudo apt install php${DDEV_PHP_VERSION}-imap'`. If that works, then the extension is supported, and you can add `webimage_extra_packages: ["php${DDEV_PHP_VERSION}-<extension>"]` to your `.ddev/config.yaml` file.
+If a PHP extension is supported by the upstream package management from `deb.sury.org`, you'll be able to add it with minimal effort. Test to see if it's available using `ddev exec '(sudo apt-get update || true) && sudo apt-get install php${DDEV_PHP_VERSION}-<extension>'`, for example, `ddev exec '(sudo apt-get update || true) && sudo apt-get install php${DDEV_PHP_VERSION}-imap'`. If that works, then the extension is supported, and you can add `webimage_extra_packages: ["php${DDEV_PHP_VERSION}-<extension>"]` to your `.ddev/config.yaml` file.
 
 ### PECL PHP Extensions not supported by `deb.sury.org`
 
@@ -37,7 +37,7 @@ SHELL ["/bin/bash", "-c"]
 # Install the needed development packages
 RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests build-essential php-pear php${DDEV_PHP_VERSION}-dev
 # mcrypt happens to require libmcrypt-dev
-RUN apt install -y libmcrypt-dev
+RUN apt-get install -y libmcrypt-dev
 RUN pecl install ${extension}
 RUN echo "extension=${extension}.so" > /etc/php/${DDEV_PHP_VERSION}/mods-available/${extension}.ini && chmod 666 /etc/php/${DDEV_PHP_VERSION}/mods-available/${extension}.ini
 RUN phpenmod ${extension}
@@ -51,7 +51,7 @@ SHELL ["/bin/bash", "-c"]
 # Install the needed development packages
 RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests build-essential php-pear php${DDEV_PHP_VERSION}-dev
 # xlswriter requires libz-dev
-RUN sudo apt install -y libz-dev
+RUN sudo apt-get install -y libz-dev
 RUN echo | pecl install ${extension}
 RUN echo "extension=${extension}.so" > /etc/php/${DDEV_PHP_VERSION}/mods-available/${extension}.ini && chmod 666 /etc/php/${DDEV_PHP_VERSION}/mods-available/${extension}.ini
 RUN phpenmod ${extension}
@@ -68,7 +68,7 @@ RUN phpdismod xdebug
 # Install the needed development packages
 RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" --no-install-recommends --no-install-suggests build-essential php-pear php${DDEV_PHP_VERSION}-dev
 # Remove the standard xdebug provided by deb.sury.org
-RUN apt remove php${DDEV_PHP_VERSION}-xdebug || true
+RUN apt-get remove php${DDEV_PHP_VERSION}-xdebug || true
 RUN pecl install ${extension}
 # Use the standard xdebug.ini from source
 ADD https://raw.githubusercontent.com/ddev/ddev/master/containers/ddev-php-base/ddev-php-files/etc/php/8.2/mods-available/xdebug.ini /etc/php/${DDEV_PHP_VERSION}/mods-available

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -57,7 +57,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ```bash
     # Add DDEV’s GPG key to your keyring
     sudo sh -c 'echo ""'
-    sudo apt update && sudo apt install -y curl
+    sudo apt-get update && sudo apt-get install -y curl
     sudo install -m 0755 -d /etc/apt/keyrings
     curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/ddev.gpg > /dev/null
     sudo chmod a+r /etc/apt/keyrings/ddev.gpg
@@ -68,7 +68,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     # Update package information and install DDEV
     sudo sh -c 'echo ""'
-    sudo apt update && sudo apt install -y ddev
+    sudo apt-get update && sudo apt-get install -y ddev
     ```
 
     ??? "Need to remove a previously-installed variant?"
@@ -259,11 +259,11 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     12. Install DDEV:
 
         ```bash
-        sudo apt update && sudo apt install -y curl
+        sudo apt-get update && sudo apt-get install -y curl
         sudo install -m 0755 -d /etc/apt/keyrings
         curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/ddev.gpg > /dev/null
         echo "deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
-        sudo apt update && sudo apt install -y ddev
+        sudo apt-get update && sudo apt-get install -y ddev
         ```
 
     13. In WSL2, run `mkcert -install`.
@@ -316,7 +316,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
 
         # Update package information and install DDEV
-        sudo apt update && sudo apt install -y ddev
+        sudo apt-get update && sudo apt-get install -y ddev
         ```
 
         * You can install your web app there, or import a database.

--- a/docs/content/users/install/ddev-upgrade.md
+++ b/docs/content/users/install/ddev-upgrade.md
@@ -36,7 +36,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ```bash
     # Update package information and all packages including DDEV
-    sudo apt update && sudo apt upgrade
+    sudo apt-get update && sudo apt-get upgrade
     ```
 
     ### Fedora, Red Hat, etc.
@@ -65,7 +65,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ```bash
     # Upgrade the DDEV package
-    sudo apt update && sudo apt upgrade -y
+    sudo apt-get update && sudo apt-get upgrade -y
     ```
 
     ### Traditional Windows
@@ -87,7 +87,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ```bash
     # Update package information and all packages including DDEV
-    sudo apt update && sudo apt upgrade -y
+    sudo apt-get update && sudo apt-get upgrade -y
     ```
 
 === "Codespaces"
@@ -96,7 +96,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ```bash
     # Update package information and all packages including DDEV
-    sudo apt update && sudo apt upgrade -y
+    sudo apt-get update && sudo apt-get upgrade -y
     ```
 
 === "Manual"

--- a/docs/content/users/install/shell-completion.md
+++ b/docs/content/users/install/shell-completion.md
@@ -66,7 +66,7 @@ If you installed `fish` without Homebrew, you can extract the fish completions (
 
 ## Bash/Zsh/Fish on Linux including WSL2
 
-On Debian and Yum based systems, if you installed DDEV using `apt install ddev`, the `bash`, `zsh`, and `fish` completions should be automatically installed at `/usr/share/bash-completion/completions/ddev`, `/usr/share/zsh/vendor-completions/_ddev` and `/usr/share/fish/completions/ddev.fish` respectively, and the `bash` completions should be automatically installed at `/usr/share/bash-completion/completions/bash`.
+On Debian and Yum based systems, if you installed DDEV using `apt-get install ddev`, the `bash`, `zsh`, and `fish` completions should be automatically installed at `/usr/share/bash-completion/completions/ddev`, `/usr/share/zsh/vendor-completions/_ddev` and `/usr/share/fish/completions/ddev.fish` respectively, and the `bash` completions should be automatically installed at `/usr/share/bash-completion/completions/bash`.
 
 Otherwise, you can download the completion files for manual installation as described [below](#tar-archive-of-completion-scripts-for-manual-deployment). Every Linux distro requires a different manual installation technique. On Debian/Ubuntu, you could deploy the `ddev_bash_completion.sh` script where it needs to be by running `sudo mkdir -p /usr/share/bash-completion/completions && sudo cp ddev_bash_completion.sh /usr/share/bash-completion/completions/ddev`.
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -190,7 +190,7 @@ You can use the [`self-upgrade`](../usage/commands.md#self-upgrade) command for 
 
 * On macOS you likely installed via Homebrew; run `brew update && brew upgrade ddev`.
 <!-- markdownlint-disable-next-line -->
-* On Linux + WSL2 using Debian/Ubuntu’s `apt install` technique, run `sudo apt update && sudo apt upgrade ddev` like any other package on your system.
+* On Linux + WSL2 using Debian/Ubuntu’s `apt-get install` technique, run `sudo apt-get update && sudo apt-get upgrade ddev` like any other package on your system.
 <!-- markdownlint-disable-next-line -->
 * On Linux + WSL2 with a Homebrew install, run `brew update && brew upgrade ddev`.
 * On macOS or Linux (including WSL2) if you installed using the [install_ddev.sh script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh), run it again:
@@ -208,7 +208,7 @@ If you’re using Homebrew, first run `brew unlink ddev` to get rid of the versi
 
 1. Download the version you want from the [releases page](https://github.com/ddev/ddev/releases) and place it in your `$PATH`.
 2. Use the [install_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want v1.21.5, run `curl -fsSL https://ddev.com/install.sh | bash -s v1.21.5`.
-3. On Debian/Ubuntu/WSL2 with DDEV installed via apt, you can run `sudo apt update && sudo apt install ddev=<version>`, for example `sudo apt install ddev=1.21.5`.
+3. On Debian/Ubuntu/WSL2 with DDEV installed via apt, you can run `sudo apt-get update && sudo apt-get install ddev=<version>`, for example `sudo apt-get install ddev=1.21.5`.
 4. If you want the very latest, unreleased version of DDEV, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD`.
 
 ### Why do I have an old DDEV?

--- a/docs/content/users/usage/uninstall.md
+++ b/docs/content/users/usage/uninstall.md
@@ -32,5 +32,5 @@ To remove the `ddev` binary:
 
 * Find the binary location with `which -a ddev`, you may have several binaries installed in different ways. The output will give you a general idea of how you installed it.
 * On macOS or Linux with Homebrew, `brew uninstall ddev`.
-* For Linux or other simple installs, remove the binary. Example: `sudo rm /usr/local/bin/ddev`. For Linux installed via apt, `sudo apt remove ddev`.
+* For Linux or other simple installs, remove the binary. Example: `sudo rm /usr/local/bin/ddev`. For Linux installed via apt, `sudo apt-get remove ddev`.
 * On Windows, if you used the DDEV Windows installer, use the uninstall on the Start Menu or in the “Add or Remove Programs” section of Windows Settings.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -992,7 +992,7 @@ ENV SQLITE_VERSION=%s
 RUN mkdir -p /tmp/sqlite3 && \
 wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
 wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
-apt install -y /tmp/sqlite3/*.deb && \
+apt-get install -y /tmp/sqlite3/*.deb && \
 rm -rf /tmp/sqlite3
 			`, versionconstants.Drupal11RequiredSqlite3Version)
 		}

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -11,7 +11,7 @@ for ddev_path in $(which -a ddev); do
   case $ddev_path in
     "/usr/bin/ddev")
       if [[ ${OSTYPE} = "linux-gnu"* ]]; then
-        if command -v apt; then echo "You seem to have an apt-installed DDEV, upgrade with 'sudo apt update && sudo apt upgrade -y ddev'";
+        if command -v apt-get; then echo "You seem to have an apt-installed DDEV, upgrade with 'sudo apt-get update && sudo apt-get upgrade -y ddev'";
         elif [ -f /etc/arch-release ] && command -v yay >/dev/null ; then echo "You seem to have yay-installed DDEV (AUR), upgrade with 'yay -Syu ddev-bin'";
         elif command -v dnf; then echo "You seem to have dnf-installed DDEV, upgrade with 'sudo dnf install --refresh ddev'"; fi
       fi

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.23.1" // Note that this can be overridden by make
+var WebTag = "20240523_stasadev_apt_get_update_or_true" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
@@ -26,7 +26,7 @@ const TraefikRouterImage = "ddev/ddev-traefik-router:v1.23.1"
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.23.1"
+var SSHAuthTag = "20240523_stasadev_apt_get_update_or_true"
 
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -48,10 +48,10 @@ mkcert -install
 $env:CAROOT="$(mkcert -CAROOT)"
 setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
-wsl -u root -e bash -c "apt update && apt install -y curl"
+wsl -u root -e bash -c "apt-get update && apt-get install -y curl"
 wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/ddev.gpg > /dev/null"
 wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
-wsl -u root -e bash -c "apt update && apt install -y ddev wslu"
+wsl -u root -e bash -c "apt-get update && apt-get install -y ddev wslu"
 wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
 
 

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -52,7 +52,7 @@ wsl -u root -e bash -c 'echo deb [arch=$(dpkg --print-architecture) signed-by=/e
 
 wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/ddev.gpg > /dev/null"
 wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
-wsl -u root -e bash -c "apt update && apt install -y ddev docker-ce docker-ce-cli containerd.io wslu"
+wsl -u root -e bash -c "apt-get update && apt-get install -y ddev docker-ce docker-ce-cli containerd.io wslu"
 wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
 wsl bash -c 'sudo usermod -aG docker $USER'
 
@@ -70,5 +70,3 @@ refreshenv
 wsl -u root -e bash -c "touch /etc/wsl.conf && if ! fgrep '[boot]' /etc/wsl.conf >/dev/null; then printf '\n[boot]\nsystemd=true\n' >>/etc/wsl.conf; fi"
 
 wsl ddev version
-
-


### PR DESCRIPTION
## The Issue

- #6235

`apt-get update` can fail in the user's custom Dockerfiles.

I thought we could search for `apt-get update` using a regex and automatically replace it in the resulting Dockerfile, but that seems like overkill because people can write it with different variations, like:

- `apt-get update`
- `apt-get update -y`
- `apt-get update -qq`
- `apt-get update -qq >/dev/null`

And the same with `apt`, so it's probably impossible to write a good regex to cover all cases and not break anything.

## How This PR Solves The Issue

Replaces `apt-get update` with `(apt-get update || true)` in the docs.

Uses `apt-get` instead of `apt` everywhere.

Removes `/etc/apt/sources.list.d/blackfire.list` as we pin the blackfire package to a specific version and don't need it in `apt-get update`:

- #6078

## Manual Testing Instructions

1. `ddev start`
2. `ddev ssh`
3. `sudo apt-get update | grep blackfire` should give an empty result

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

