### PR TITLE
fix: prevent various Mutagen conflicts between daemons when changing versions or global directory, fixes #6234

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -192,12 +192,12 @@ fi
 # Make sure we start with mutagen daemon off.
 unset MUTAGEN_DATA_DIRECTORY
 if [ -f ~/.ddev/bin/mutagen -o -f ~/.ddev/bin/mutagen.exe ]; then
-  # This line can be removed when ~/.ddev/.mdd is well established in master, probably July 2024
   MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a || true
+  # This line can be removed when all PRs will not use ~/.ddev/.mdd
   MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd/ ~/.ddev/bin/mutagen sync terminate -a || true
   MUTAGEN_DATA_DIRECTORY=~/.mutagen ~/.ddev/bin/mutagen daemon stop || true
-  # This line can be removed when ~/.ddev/.mdd is well established in master, probably July 2024
   MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
+  # This line can be removed when all PRs will not use ~/.ddev/.mdd
   MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd/ ~/.ddev/bin/mutagen daemon stop || true
 fi
 if command -v killall >/dev/null ; then

--- a/cmd/ddev/cmd/a.go
+++ b/cmd/ddev/cmd/a.go
@@ -14,8 +14,7 @@ import (
 func init() {
 	globalconfig.EnsureGlobalConfig()
 	_ = os.Setenv("DOCKER_CLI_HINTS", "false")
-	_ = os.Unsetenv("DDEV_MUTAGEN_DATA_DIRECTORY")
-	// GetMutagenDataDirectory sets DDEV_MUTAGEN_DATA_DIRECTORY as a side-effect
+	// GetMutagenDataDirectory() sets MUTAGEN_DATA_DIRECTORY
 	_ = globalconfig.GetMutagenDataDirectory()
 	// GetDockerClient should be called early to get DOCKER_HOST set
 	_, _ = dockerutil.GetDockerClient()

--- a/cmd/ddev/cmd/a.go
+++ b/cmd/ddev/cmd/a.go
@@ -14,7 +14,9 @@ import (
 func init() {
 	globalconfig.EnsureGlobalConfig()
 	_ = os.Setenv("DOCKER_CLI_HINTS", "false")
-	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
+	_ = os.Unsetenv("DDEV_MUTAGEN_DATA_DIRECTORY")
+	// GetMutagenDataDirectory sets DDEV_MUTAGEN_DATA_DIRECTORY as a side-effect
+	_ = globalconfig.GetMutagenDataDirectory()
 	// GetDockerClient should be called early to get DOCKER_HOST set
 	_, _ = dockerutil.GetDockerClient()
 }

--- a/cmd/ddev/cmd/mutagen-logs.go
+++ b/cmd/ddev/cmd/mutagen-logs.go
@@ -1,14 +1,15 @@
 package cmd
 
 import (
-	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/util"
-	"github.com/spf13/cobra"
 	"os"
 	"os/exec"
 	"os/signal"
 	"syscall"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
 )
 
 // MutagenLogsCmd implements the ddev mutagen logs command
@@ -18,7 +19,7 @@ var MutagenLogsCmd = &cobra.Command{
 	Example: `"ddev mutagen logs"`,
 	Run: func(_ *cobra.Command, _ []string) {
 
-		ddevapp.StopMutagenDaemon()
+		ddevapp.StopMutagenDaemon("")
 		_ = os.Setenv("MUTAGEN_LOG_LEVEL", "trace")
 
 		sigs := make(chan os.Signal, 1)

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/globalconfig"
-
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
@@ -38,11 +36,6 @@ ddev restart --all`,
 		skip, err := cmd.Flags().GetBool("skip-confirmation")
 		if err != nil {
 			util.Failed(err.Error())
-		}
-
-		// Stop any running mutagen daemons we can find
-		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
-			ddevapp.StopOldMutagenDaemons()
 		}
 
 		// Look for version change and opt-in to instrumentation if it has changed.

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -43,10 +43,12 @@ ddev restart --all`,
 		// If the MUTAGEN_DATA_DIRECTORY has changed due to DDEV upgrade
 		// or due to XDG_CONFIG_HOME change, stop running daemons and remember the
 		// new LastMutagenDataDirectory
-		if globalconfig.DdevGlobalConfig.LastMutagenDataDirectory != globalconfig.GetMutagenDataDirectory() {
+		// These are unlikely to happen unless global performance_mode is set to mutagen, and that is
+		// unlikely to happen except on macOS and Windows
+		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() && globalconfig.DdevGlobalConfig.LastMutagenDataDirectory != globalconfig.GetMutagenDataDirectory() {
 			ddevapp.StopOldMutagenDaemons()
 			globalconfig.DdevGlobalConfig.LastMutagenDataDirectory = globalconfig.GetMutagenDataDirectory()
-			err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+			err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 			if err != nil {
 				util.Failed(err.Error())
 			}

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -40,18 +40,9 @@ ddev restart --all`,
 			util.Failed(err.Error())
 		}
 
-		// If the MUTAGEN_DATA_DIRECTORY has changed due to DDEV upgrade
-		// or due to XDG_CONFIG_HOME change, stop running daemons and remember the
-		// new LastMutagenDataDirectory
-		// These are unlikely to happen unless global performance_mode is set to mutagen, and that is
-		// unlikely to happen except on macOS and Windows
-		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() && globalconfig.DdevGlobalConfig.LastMutagenDataDirectory != globalconfig.GetMutagenDataDirectory() {
+		// Stop any running mutagen daemons we can find
+		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 			ddevapp.StopOldMutagenDaemons()
-			globalconfig.DdevGlobalConfig.LastMutagenDataDirectory = globalconfig.GetMutagenDataDirectory()
-			err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
-			if err != nil {
-				util.Failed(err.Error())
-			}
 		}
 
 		// Look for version change and opt-in to instrumentation if it has changed.

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -167,7 +167,7 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 	}
 	if globalconfig.DdevGlobalConfig.LastStartedVersion != versionconstants.DdevVersion && !skipConfirmation {
 
-		ddevapp.PauseOldMutagenSync()
+		ddevapp.StopOldMutagenDaemons()
 
 		// If they have a new version (but not first-timer) then prompt to poweroff
 		if globalconfig.DdevGlobalConfig.LastStartedVersion != "v0.0" {

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -167,6 +167,8 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 	}
 	if globalconfig.DdevGlobalConfig.LastStartedVersion != versionconstants.DdevVersion && !skipConfirmation {
 
+		ddevapp.PauseOldMutagenSync()
+
 		// If they have a new version (but not first-timer) then prompt to poweroff
 		if globalconfig.DdevGlobalConfig.LastStartedVersion != "v0.0" {
 			output.UserOut.Print("You seem to have a new DDEV version.")

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -165,9 +165,20 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 			globalconfig.DdevGlobalConfig.InstrumentationOptIn = true
 		}
 	}
-	if globalconfig.DdevGlobalConfig.LastStartedVersion != versionconstants.DdevVersion && !skipConfirmation {
 
+	// If the MUTAGEN_DATA_DIRECTORY has changed due to DDEV upgrade
+	// or due to XDG_CONFIG_HOME change, stop running daemons and remember the
+	// new LastMutagenDataDirectory
+	if globalconfig.DdevGlobalConfig.LastMutagenDataDirectory != globalconfig.GetMutagenDataDirectory() {
 		ddevapp.StopOldMutagenDaemons()
+		globalconfig.DdevGlobalConfig.LastMutagenDataDirectory = globalconfig.GetMutagenDataDirectory()
+		err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	if globalconfig.DdevGlobalConfig.LastStartedVersion != versionconstants.DdevVersion && !skipConfirmation {
 
 		// If they have a new version (but not first-timer) then prompt to poweroff
 		if globalconfig.DdevGlobalConfig.LastStartedVersion != "v0.0" {

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -166,18 +166,6 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 		}
 	}
 
-	// If the MUTAGEN_DATA_DIRECTORY has changed due to DDEV upgrade
-	// or due to XDG_CONFIG_HOME change, stop running daemons and remember the
-	// new LastMutagenDataDirectory
-	if globalconfig.DdevGlobalConfig.LastMutagenDataDirectory != globalconfig.GetMutagenDataDirectory() {
-		ddevapp.StopOldMutagenDaemons()
-		globalconfig.DdevGlobalConfig.LastMutagenDataDirectory = globalconfig.GetMutagenDataDirectory()
-		err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
-		if err != nil {
-			return err
-		}
-	}
-
 	if globalconfig.DdevGlobalConfig.LastStartedVersion != versionconstants.DdevVersion && !skipConfirmation {
 
 		// If they have a new version (but not first-timer) then prompt to poweroff

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -295,17 +295,22 @@ func TestCopyGlobalDdevDir(t *testing.T) {
 	assert.NoError(err)
 }
 
-// TestGetGlobalDdevDirLocation checks to make sure that DDEV will use the correct location for its global config.
+// TestGetGlobalDdevDirLocation checks to make sure that DDEV will use the
+// correct location for its global config. The correct location is:
+// ${XDG_CONFIG_HOME}/ddev if XDG_CONFIG_HOME is set or
+// ~/.ddev if it exists or
+// ~/.config/ddev if it exists
 func TestGetGlobalDdevDirLocation(t *testing.T) {
 	// Test when $XDG_CONFIG_HOME is not set
 	t.Setenv("XDG_CONFIG_HOME", "")
 	ddevDir := globalconfig.GetGlobalDdevDirLocation()
 	// Original ~/.ddev dir location
 	originalGlobalDdevDir := filepath.Join(homedir.Get(), ".ddev")
-	// If this test runs on Linux machine, where ~/.config/ddev is used by default:
-	if runtime.GOOS == "linux" {
+	// If test runs on Linux machine, where ~/.config/ddev is used
+	// if ~/.ddev does not exist:
+	if runtime.GOOS == "linux" && !fileutil.IsDirectory(originalGlobalDdevDir) {
 		linuxDdevDir := filepath.Join(homedir.Get(), ".config", "ddev")
-		if _, err := os.Stat(linuxDdevDir); err == nil {
+		if fileutil.IsDirectory(linuxDdevDir) {
 			originalGlobalDdevDir = linuxDdevDir
 		}
 	}

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -74,7 +74,9 @@ ddev start --all`,
 		// If the MUTAGEN_DATA_DIRECTORY has changed due to DDEV upgrade
 		// or due to XDG_CONFIG_HOME change, stop running daemons and remember the
 		// new LastMutagenDataDirectory
-		if globalconfig.DdevGlobalConfig.LastMutagenDataDirectory != globalconfig.GetMutagenDataDirectory() {
+		// These are unlikely to happen unless global performance_mode is set to mutagen, and that is
+		// unlikely to happen except on macOS and Windows
+		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() && globalconfig.DdevGlobalConfig.LastMutagenDataDirectory != globalconfig.GetMutagenDataDirectory() {
 			err := ddevapp.DownloadMutagenIfNeeded()
 			if err != nil {
 				util.Warning("Failed to download mutagen binary: %v", err)

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -71,6 +71,18 @@ ddev start --all`,
 			util.Failed(err.Error())
 		}
 
+		// If the MUTAGEN_DATA_DIRECTORY has changed due to DDEV upgrade
+		// or due to XDG_CONFIG_HOME change, stop running daemons and remember the
+		// new LastMutagenDataDirectory
+		if globalconfig.DdevGlobalConfig.LastMutagenDataDirectory != globalconfig.GetMutagenDataDirectory() {
+			ddevapp.StopOldMutagenDaemons()
+			globalconfig.DdevGlobalConfig.LastMutagenDataDirectory = globalconfig.GetMutagenDataDirectory()
+			err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+			if err != nil {
+				util.Failed(err.Error())
+			}
+		}
+
 		// Look for version change and opt-in to instrumentation if it has changed.
 		err = checkDdevVersionAndOptInInstrumentation(skip)
 		if err != nil {

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -75,9 +75,13 @@ ddev start --all`,
 		// or due to XDG_CONFIG_HOME change, stop running daemons and remember the
 		// new LastMutagenDataDirectory
 		if globalconfig.DdevGlobalConfig.LastMutagenDataDirectory != globalconfig.GetMutagenDataDirectory() {
+			err := ddevapp.DownloadMutagenIfNeeded()
+			if err != nil {
+				util.Warning("Failed to download mutagen binary: %v", err)
+			}
 			ddevapp.StopOldMutagenDaemons()
 			globalconfig.DdevGlobalConfig.LastMutagenDataDirectory = globalconfig.GetMutagenDataDirectory()
-			err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+			err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 			if err != nil {
 				util.Failed(err.Error())
 			}

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -77,10 +77,6 @@ ddev start --all`,
 		// These are unlikely to happen unless global performance_mode is set to mutagen, and that is
 		// unlikely to happen except on macOS and Windows
 		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() && globalconfig.DdevGlobalConfig.LastMutagenDataDirectory != globalconfig.GetMutagenDataDirectory() {
-			err := ddevapp.DownloadMutagenIfNeeded()
-			if err != nil {
-				util.Warning("Failed to download mutagen binary: %v", err)
-			}
 			ddevapp.StopOldMutagenDaemons()
 			globalconfig.DdevGlobalConfig.LastMutagenDataDirectory = globalconfig.GetMutagenDataDirectory()
 			err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -71,11 +71,6 @@ ddev start --all`,
 			util.Failed(err.Error())
 		}
 
-		// Stop any running mutagen daemons we can find
-		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
-			ddevapp.StopOldMutagenDaemons()
-		}
-
 		// Look for version change and opt-in to instrumentation if it has changed.
 		err = checkDdevVersionAndOptInInstrumentation(skip)
 		if err != nil {

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -71,18 +71,9 @@ ddev start --all`,
 			util.Failed(err.Error())
 		}
 
-		// If the MUTAGEN_DATA_DIRECTORY has changed due to DDEV upgrade
-		// or due to XDG_CONFIG_HOME change, stop running daemons and remember the
-		// new LastMutagenDataDirectory
-		// These are unlikely to happen unless global performance_mode is set to mutagen, and that is
-		// unlikely to happen except on macOS and Windows
-		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() && globalconfig.DdevGlobalConfig.LastMutagenDataDirectory != globalconfig.GetMutagenDataDirectory() {
+		// Stop any running mutagen daemons we can find
+		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 			ddevapp.StopOldMutagenDaemons()
-			globalconfig.DdevGlobalConfig.LastMutagenDataDirectory = globalconfig.GetMutagenDataDirectory()
-			err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
-			if err != nil {
-				util.Failed(err.Error())
-			}
 		}
 
 		// Look for version change and opt-in to instrumentation if it has changed.

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -150,23 +150,13 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
     * Rename your project’s `.ddev/mutagen/mutagen.yml` file to `.ddev/mutagen/mutagen.yml.bak` and run `ddev restart`. This ensures you’ll have a fresh version in case the file has been changed and `#ddev-generated` removed.
     * Avoid having Mutagen sync large binaries, which can cause `ddev start` to take a long time. The `.tarballs` directory is automatically excluded, so Mutagen will ignore anything you move there. To see what Mutagen is trying to sync, run `ddev mutagen status -l` in another window.
     * `DDEV_DEBUG=true ddev start` will provide more information about what’s going on with Mutagen.
-    * DDEV’s Mutagen daemon keeps its data in a DDEV-only `MUTAGEN_DATA_DIRECTORY`, by default in `~/.ddev/.mdd`.
-    * DDEV’s private Mutagen binary is installed in `~/.ddev/bin/mutagen`. You can use all the features of Mutagen with `export MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd` and running the Mutagen binary in `~/.ddev/bin/mutagen`, for example:
+    * DDEV’s Mutagen daemon keeps its data in a DDEV-only `MUTAGEN_DATA_DIRECTORY` in `~/.ddev_mutagen_data_directory`.
+    * DDEV’s private Mutagen binary is installed in `~/.ddev/bin/mutagen` (or `$XDG_CONFIG_BASE/ddev/bin/mutagen`. You can use all the features of Mutagen with `ddev debug mutagen`. For example:
 
         ```bash
-        export MUTAGEN_DATA_DIRECTORY=$(ddev mutagen version -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.MUTAGEN_DATA_DIRECTORY' 2>/dev/null)
-        export PATH=$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw."global-ddev-dir"' 2>/dev/null)/bin:$PATH
-        mutagen sync list -l
-        mutagen sync monitor
+        debug mutagen sync list --template "{{ json (index . 0) }}" | jq -r
+        ddev debug mutagen sync monitor <projectname> -l
         ```
-
-    * `ddev debug mutagen` will let you run any Mutagen command using the binary in `~/.ddev/bin/mutagen`, for example:
-
-        ```bash
-        ddev debug mutagen sync list -l
-        ddev debug mutagen monitor
-        ```
-
     * You can run the [diagnose_mutagen.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/diagnose_mutagen.sh) script to gather information about Mutagen’s setup. Please share output from it when creating an issue or seeking support.
     * Try `ddev poweroff` or `~/.ddev/bin/mutagen daemon stop && ~/.ddev/bin/mutagen daemon start` to restart the Mutagen daemon if you suspect it’s hanging.
     * Use `ddev mutagen reset` if you suspect trouble, and *always* after changing `.ddev/mutagen/mutagen.yml`. This restarts the project’s Mutagen data (Docker volume + Mutagen session) from scratch.

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -100,7 +100,7 @@ Files beginning with `.` are hidden because they shouldn’t be fiddled with; mo
 
 ### Global Files
 
-There’s only one global `.ddev` directory, which normally lives in your home directory: `~/.ddev` (`$HOME/.ddev`) or in `~/.config/ddev`. `~/.ddev` takes precedence if it exists, unless `$XDG_CONFIG_HOME` is set, in which case it is used.
+There’s only one global `.ddev` directory, which normally lives in your home directory: `~/.ddev` (`$HOME/.ddev`) or in `~/.config/ddev`. `~/.ddev` takes precedence if it exists, unless `$XDG_CONFIG_HOME` is set, in which case it will be `$XDG_CONFIG_HOME/ddev`.
 
 !!!tip "Where is my global `.ddev` config?"
     Use `ddev version` (look at `global-ddev-dir`) to check which location is used for the `.ddev` global directory.
@@ -116,7 +116,7 @@ There’s only one global `.ddev` directory, which normally lives in your home d
     mv ~/.ddev ${XDG_CONFIG_HOME}/ddev
     ```
 
-    Otherwise, on Linux/WSL2 only, the default `$HOME/.config/ddev` can be used when `~/.config/ddev` exists and `~/.ddev` does not exist.  You can move the config with:
+    Otherwise, on Linux/WSL2 only, the default `$HOME/.config/ddev` can be used when `~/.config/ddev` exists and `~/.ddev` does not exist.  You can move the config directory with:
 
     ```bash
     mv ~/.ddev ~/.config/ddev

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -144,9 +144,6 @@ Again, these files are mostly regenerated on every `ddev start` so it’s best t
 `.gitignore`
 : Prevents files from getting checked in when they shouldn’t be.
 
-`.mdd`
-: Directory used for storing [Mutagen](../install/performance.md#mutagen) sync data.
-
 `.router-compose-full.yaml`
 : The complete, generated docker-compose directive used for DDEV’s router.
 
@@ -167,6 +164,9 @@ Again, these files are mostly regenerated on every `ddev start` so it’s best t
 
 `.update`
 : An empty file whose purpose is mysterious and intriguing.
+
+!!!tip "`.ddev_mutagen_data_directory`"
+    DDEV uses a global `~/.ddev_mutagen_data_directory` for storing [Mutagen](../install/performance.md#mutagen) sync data.
 
 ## Container Architecture
 

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -100,10 +100,10 @@ Files beginning with `.` are hidden because they shouldn’t be fiddled with; mo
 
 ### Global Files
 
-There’s only one global `.ddev` directory, which lives in your home directory: `~/.ddev` (`$HOME/.ddev`).
+There’s only one global `.ddev` directory, which normally lives in your home directory: `~/.ddev` (`$HOME/.ddev`) or in `~/.config/ddev`. `~/.ddev` takes precedence if it exists, unless `$XDG_CONFIG_HOME` is set, in which case it is used.
 
 !!!tip "Where is my global `.ddev` config?"
-    Use `ddev version` (look at `global-ddev-dir`) to check which location is currently used for the `.ddev` global directory.
+    Use `ddev version` (look at `global-ddev-dir`) to check which location is used for the `.ddev` global directory.
 
 !!!tip "What if I don't want to clutter up my `$HOME` with a `.ddev` directory?"
     DDEV can use the `$XDG_CONFIG_HOME` environment variable from [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) to move `~/.ddev` to the `$XDG_CONFIG_HOME/ddev` directory if `$XDG_CONFIG_HOME` is [defined](https://superuser.com/questions/365847/where-should-the-xdg-config-home-variable-be-defined/):
@@ -116,13 +116,11 @@ There’s only one global `.ddev` directory, which lives in your home directory:
     mv ~/.ddev ${XDG_CONFIG_HOME}/ddev
     ```
 
-    Otherwise, on Linux/WSL2 only, the default `$HOME/.config/ddev` can be used when you move the config:
+    Otherwise, on Linux/WSL2 only, the default `$HOME/.config/ddev` can be used when `~/.config/ddev` exists and `~/.ddev` does not exist.  You can move the config with:
 
     ```bash
     mv ~/.ddev ~/.config/ddev
     ```
-
-    Note that the custom global config directory `ddev` (if it exists) takes precedence over the `~/.ddev` directory.
 
 `global_config.yaml`
 : This YAML file defines your global configuration, which consists of various [config settings](../configuration/config.md).

--- a/docs/content/users/usage/uninstall.md
+++ b/docs/content/users/usage/uninstall.md
@@ -5,6 +5,7 @@ A DDEV installation consists of:
 * The self-contained `ddev` binary.
 * Each project’s `.ddev` directory.
 * The global `~/.ddev` directory where various global items are stored. (This directory can be [moved](./architecture.md#global-files) to another location.)
+* The global `~/.ddev_mutagen_data_directory` directory where Mutagen sync data may be stored.
 * The associated Docker images and containers DDEV created.
 * Any entries in `/etc/hosts`.
 
@@ -17,6 +18,8 @@ To uninstall one project, run [`ddev delete <project>`](commands.md#delete). Thi
 To remove all DDEV-owned `/etc/hosts` entries: [`ddev hostname --remove-inactive`](commands.md#hostname).
 
 To remove the global `.ddev` directory: `rm -r ~/.ddev`.
+
+To remove the global `.ddev_mutagen_data_directory` directory: `ddev poweroff && rm -r ~/.ddev_mutagen_data_directory`.
 
 If you installed Docker only for DDEV and want to uninstall it with all containers and images, uninstall it for your version of Docker.
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -481,7 +481,7 @@ func DownloadAndExtractTarball(url string, removeTopLevel bool) (string, func(),
 		_ = f.Close()
 	}()
 
-	util.Success("Downloading %s", url)
+	util.Debug("Downloading %s to %s", url, f.Name())
 	tarball := f.Name()
 	defer func() {
 		_ = os.Remove(tarball)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
-	"github.com/docker/docker/pkg/homedir"
 	copy2 "github.com/otiai10/copy"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -730,19 +729,6 @@ func (app *DdevApp) FixObsolete() {
 		err := os.RemoveAll(legacyCommandDir)
 		if err != nil {
 			util.Warning("attempted to remove %s but failed, you may want to remove it manually: %v", legacyCommandDir, err)
-		}
-	}
-
-	// Remove old ~/.ddev_mutagen_data_directory directory
-	legacyMutagenDataDir := filepath.Join(homedir.Get(), ".ddev_mutagen_data_directory")
-	if fileutil.IsDirectory(legacyMutagenDataDir) {
-		originalMutagenDataDir := os.Getenv("MUTAGEN_DATA_DIRECTORY")
-		_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", legacyMutagenDataDir)
-		StopMutagenDaemon("")
-		_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", originalMutagenDataDir)
-		err := os.RemoveAll(legacyMutagenDataDir)
-		if err != nil {
-			util.Warning("attempted to remove %s but failed, you may want to remove it manually: %v", legacyMutagenDataDir, err)
 		}
 	}
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -738,7 +738,7 @@ func (app *DdevApp) FixObsolete() {
 	if fileutil.IsDirectory(legacyMutagenDataDir) {
 		originalMutagenDataDir := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 		_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", legacyMutagenDataDir)
-		StopMutagenDaemon()
+		StopMutagenDaemon("")
 		_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", originalMutagenDataDir)
 		err := os.RemoveAll(legacyMutagenDataDir)
 		if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1386,7 +1386,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 		err = CreateOrResumeMutagenSync(app)
 		if err != nil {
-			return fmt.Errorf("failed to CreateOrResultMutagenSync on Mutagen sync session '%s'. You may be able to resolve this problem using 'ddev mutagen reset' (err=%v)", MutagenSyncName(app.Name), err)
+			return fmt.Errorf("failed to CreateOrResumeMutagenSync on Mutagen sync session '%s'. You may be able to resolve this problem using 'ddev mutagen reset' (err=%v)", MutagenSyncName(app.Name), err)
 		}
 		mStatus, _, _, err := app.MutagenStatus()
 		if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1126,6 +1126,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		// Check again to make sure the Mutagen Docker volume exists. It's compatible if we found it above
 		// so we can keep it in that case.
 		if !dockerutil.VolumeExists(GetMutagenVolumeName(app)) {
+			util.Debug("Creating new docker volume '%s' with signature '%v'", GetMutagenVolumeName(app), GetDefaultMutagenVolumeSignature(app))
 			_, err = dockerutil.CreateVolume(GetMutagenVolumeName(app), "local", nil, map[string]string{mutagenSignatureLabelName: GetDefaultMutagenVolumeSignature(app)})
 			if err != nil {
 				return fmt.Errorf("unable to create new Mutagen Docker volume %s: %v", GetMutagenVolumeName(app), err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1386,7 +1386,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 		err = CreateOrResumeMutagenSync(app)
 		if err != nil {
-			return fmt.Errorf("failed to create Mutagen sync session '%s'. You may be able to resolve this problem using 'ddev mutagen reset' (err=%v)", MutagenSyncName(app.Name), err)
+			return fmt.Errorf("failed to CreateOrResultMutagenSync on Mutagen sync session '%s'. You may be able to resolve this problem using 'ddev mutagen reset' (err=%v)", MutagenSyncName(app.Name), err)
 		}
 		mStatus, _, _, err := app.MutagenStatus()
 		if err != nil {

--- a/pkg/ddevapp/hooks_test.go
+++ b/pkg/ddevapp/hooks_test.go
@@ -86,7 +86,7 @@ func TestProcessHooks(t *testing.T) {
 
 		out := captureOutputFunc()
 		userOut := userOutFunc()
-		assert.Contains(out, task.stdoutExpect, "task: %v", task.task)
+		require.Contains(t, out, task.stdoutExpect, "task: %v", task.task)
 		assert.Contains(userOut, task.fulloutputExpect, "task: %v", task.task)
 		assert.NotContains(userOut, "Task failed")
 	}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -135,7 +135,9 @@ func GetMutagenConfigFilePath(app *DdevApp) string {
 // GetMutagenConfigFileHash returns the SHA1 hash of the mutagen.yml
 func GetMutagenConfigFileHash(app *DdevApp) (string, error) {
 	f := GetMutagenConfigFilePath(app)
-	hash, err := fileutil.FileHash(f)
+	// Create hash based on mutagen.yml file contents, location,
+	//and global config
+	hash, err := fileutil.FileHash(f, globalconfig.GetGlobalDdevDirLocation())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -9,7 +9,6 @@ import (
 	osexec "os/exec"
 	"path"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -646,22 +645,8 @@ func MutagenReset(app *DdevApp) error {
 }
 
 // GetMutagenVolumeName returns the name for the Mutagen Docker volume
-// It's based on the app.Name, Docker host ID, and MUTAGEN_DATA_DIRECTORY
-// This should generate a unique volume name and prevent deleting a docker volume
-// which belongs to another docker host or MUTAGEN_DATA_DIRECTORY sync
 func GetMutagenVolumeName(app *DdevApp) string {
-	name := app.Name + "_" + "project_mutagen" + "_" + globalconfig.GetMutagenDataDirectory() + "_" + dockerutil.GetDockerHostID()
-	name = strings.ToLower(name)
-	re := regexp.MustCompile(`[^a-z0-9-_]`)
-	name = re.ReplaceAllString(name, "-")
-	// Docker volume name is probably 255, but not clearly documented
-	// We'll limit to 127. We probably won't hit that but if we do the
-	// Docker hostID will be the first thing truncated, and it's not likely
-	// part of the problem anyway.
-	if len(name) > 127 {
-		name = name[:127]
-	}
-	return name
+	return app.Name + "_" + "project_mutagen"
 }
 
 // MutagenMonitor shows the output of `mutagen sync monitor <syncName>`

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -101,6 +101,28 @@ func PauseAllMutagenSync(mutagenDataDirectory string) error {
 	return err
 }
 
+// PauseOldMutagenSync attempts to pause any mutagen sessions
+// that may belong to other configured DDEV setups
+// especially from previous versions
+func PauseOldMutagenSync() {
+	userHome, _ := os.UserHomeDir()
+
+	allKnownMutagenDataDirectories := []string{
+		filepath.Join(userHome, ".ddev_mutagen_data_directory"), // through v1.23.1
+		filepath.Join(userHome, ".ddev", ".mdd"),                // default current
+		filepath.Join(userHome, ".config", "ddev", ".mdd"),
+	}
+	ourMutagenDataDirectory := globalconfig.GetMutagenDataDirectory()
+	for _, d := range allKnownMutagenDataDirectories {
+		if d != ourMutagenDataDirectory {
+			err := PauseAllMutagenSync(d)
+			if err != nil {
+				util.Debug("Error pausing mutagen sync for directory %s", d)
+			}
+		}
+	}
+}
+
 // SyncAndPauseMutagenSession syncs and pauses a Mutagen sync session
 func SyncAndPauseMutagenSession(app *DdevApp) error {
 	if !app.IsMutagenEnabled() {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -632,10 +632,12 @@ func MutagenReset(app *DdevApp) error {
 	if app.IsMutagenEnabled() {
 		err := app.Stop(false, false)
 		if err != nil {
+			util.Warning("Failed to stop project '%s': %v", app.Name, err)
 			return errors.Errorf("Failed to stop project %s: %v", app.Name, err)
 		}
 		err = dockerutil.RemoveVolume(GetMutagenVolumeName(app))
 		if err != nil {
+			util.Warning("Failed to remove Docker volume '%s': %v", GetMutagenVolumeName(app), err)
 			return err
 		}
 		util.Debug("Removed Docker volume %s", GetMutagenVolumeName(app))

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -200,7 +200,7 @@ func CreateOrResumeMutagenSync(app *DdevApp) error {
 
 	container, err := GetContainer(app, "web")
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to GetContainer() service web, app=%v, err=%v", app, err)
 	}
 	if container == nil {
 		return fmt.Errorf("web container for %s not found", app.Name)
@@ -217,23 +217,23 @@ func CreateOrResumeMutagenSync(app *DdevApp) error {
 
 	sessionExists, err := mutagenSyncSessionExists(app)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to mutagenSyncSessionExists(): %v", err)
 	}
 	if sessionExists {
 		util.Verbose("Resume Mutagen sync if session already exists")
 		err := ResumeMutagenSync(app)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to resume Mutagen sync: %v", err)
 		}
 	} else {
 		vLabel, err := GetMutagenVolumeLabel(app)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to GetMutagenVolumeLabel(): %v", err)
 		}
 
 		hLabel, err := GetMutagenConfigFileHash(app)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to GetMutagenConfigFileHash(): %v", err)
 		}
 		// TODO: Consider using a function to specify the Docker beta
 		args := []string{"sync", "create", app.AppRoot, fmt.Sprintf("docker:/%s/var/www/html", container.Names[0]), "--no-global-configuration", "--name", syncName, "--label", mutagenSignatureLabelName + "=" + vLabel, "--label", mutagenConfigFileHashLabelName + "=" + hLabel}
@@ -248,7 +248,7 @@ func CreateOrResumeMutagenSync(app *DdevApp) error {
 		util.Debug("Creating Mutagen sync: mutagen %v", args)
 		out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), args...)
 		if err != nil {
-			return fmt.Errorf("failed to mutagen %v (%v), output=%s", args, err, out)
+			return fmt.Errorf("failed to mutagen %v (%v), output='%s'", args, err, out)
 		}
 	}
 
@@ -336,7 +336,7 @@ func ResumeMutagenSync(app *DdevApp) error {
 	util.Verbose("Resuming Mutagen sync: mutagen %v", args)
 	out, err := exec.RunHostCommand(globalconfig.GetMutagenPath(), args...)
 	if err != nil {
-		return fmt.Errorf("failed to mutagen %v (%v), output=%s", args, err, out)
+		return fmt.Errorf("failed to mutagen %v (%v), output='%s'", args, err, out)
 	}
 	return nil
 }

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -106,17 +106,11 @@ func StopOldMutagenDaemons() {
 		util.Warning("Failed to download mutagen binary: %v", err)
 	}
 
-	// If there was a previous "LastMutagenDataDirectory" then we need to get it stopped as well
-	lastMutagenDataDirectory := globalconfig.DdevGlobalConfig.LastMutagenDataDirectory
-
 	userHome, _ := os.UserHomeDir()
 	possibleMutagenDataDirectories := []string{
 		filepath.Join(userHome, ".ddev_mutagen_data_directory"), // used through v1.23.1
 		filepath.Join(userHome, ".ddev", ".mdd"),                // default current
 		filepath.Join(userHome, ".config", "ddev", ".mdd"),
-	}
-	if lastMutagenDataDirectory != "" {
-		possibleMutagenDataDirectories = append(possibleMutagenDataDirectories, lastMutagenDataDirectory)
 	}
 	for _, d := range possibleMutagenDataDirectories {
 		if d != ourMutagenDataDirectory && fileutil.FileExists(d) {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -514,7 +514,7 @@ func DownloadMutagen() error {
 	globalMutagenDir := filepath.Dir(globalconfig.GetMutagenPath())
 	destFile := filepath.Join(globalMutagenDir, "mutagen.tgz")
 	mutagenURL := fmt.Sprintf("https://github.com/mutagen-io/mutagen/releases/download/v%s/mutagen_%s_v%s.tar.gz", versionconstants.RequiredMutagenVersion, flavor, versionconstants.RequiredMutagenVersion)
-	output.UserOut.Printf("Downloading %s ...", mutagenURL)
+	util.Debug("Downloading %s to %s...", mutagenURL, destFile)
 
 	// Remove the existing file. This may help on macOS to prevent the Gatekeeper's
 	// caching bug from confusing with a previously downloaded file?

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -101,7 +101,7 @@ func PauseAllMutagenSync(mutagenDataDirectory string) error {
 	out, err := exec.RunHostCommandWithEnv(globalconfig.GetMutagenPath(), env, "sync", "pause", "-a")
 	util.Verbose("ran mutagen sync pause -a(%s) output=%s err=%v", mutagenDataDirectory, out, err)
 	out, err = exec.RunHostCommandWithEnv(globalconfig.GetMutagenPath(), env, "daemon", "stop")
-	util.Verbose("ran mutagen daemon stop output=%s err=%v", mutagenDataDirectory, out, err)
+	util.Verbose("ran mutagen daemon stop(%s) output=%s err=%v", mutagenDataDirectory, out, err)
 	return err
 }
 

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -94,6 +94,13 @@ func PauseMutagenSync(app *DdevApp) error {
 	return nil
 }
 
+// PauseAllMutagenSync pauses all mutagen sync sessions found in
+// a provided MUTAGEN_DATA_DIRECTORY
+func PauseAllMutagenSync(mutagenDataDirectory string) error {
+	_, err := exec.RunHostCommandWithEnv(globalconfig.GetMutagenPath(), []string{"MUTAGEN_DATA_DIRECTORY=" + mutagenDataDirectory}, "sync", "pause", "-a")
+	return err
+}
+
 // SyncAndPauseMutagenSession syncs and pauses a Mutagen sync session
 func SyncAndPauseMutagenSession(app *DdevApp) error {
 	if !app.IsMutagenEnabled() {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -825,7 +825,9 @@ func CheckMutagenVolumeSyncCompatibility(app *DdevApp) (ok bool, volumeExists bo
 // GetMutagenSyncLabel gets the com.ddev.volume-signature label from an existing sync session
 func GetMutagenSyncLabel(app *DdevApp) (string, error) {
 	status, _, mapResult, err := app.MutagenStatus()
-
+	if status == "not enabled" {
+		return "", fmt.Errorf("Mutagen sync session for app '%s' does not exist or is not enabled; status=%v; err=%v", app.Name, status, err)
+	}
 	if strings.HasPrefix(status, "nosession") || err != nil {
 		return "", fmt.Errorf("no session %s found: %v", MutagenSyncName(app.Name), status)
 	}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -9,6 +9,7 @@ import (
 	osexec "os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -645,8 +646,22 @@ func MutagenReset(app *DdevApp) error {
 }
 
 // GetMutagenVolumeName returns the name for the Mutagen Docker volume
+// It's based on the app.Name, Docker host ID, and MUTAGEN_DATA_DIRECTORY
+// This should generate a unique volume name and prevent deleting a docker volume
+// which belongs to another docker host or MUTAGEN_DATA_DIRECTORY sync
 func GetMutagenVolumeName(app *DdevApp) string {
-	return app.Name + "_" + "project_mutagen"
+	name := app.Name + "_" + "project_mutagen" + "_" + globalconfig.GetMutagenDataDirectory() + "_" + dockerutil.GetDockerHostID()
+	name = strings.ToLower(name)
+	re := regexp.MustCompile(`[^a-z0-9-_]`)
+	name = re.ReplaceAllString(name, "-")
+	// Docker volume name is probably 255, but not clearly documented
+	// We'll limit to 127. We probably won't hit that but if we do the
+	// Docker hostID will be the first thing truncated, and it's not likely
+	// part of the problem anyway.
+	if len(name) > 127 {
+		name = name[:127]
+	}
+	return name
 }
 
 // MutagenMonitor shows the output of `mutagen sync monitor <syncName>`
@@ -723,7 +738,7 @@ func IsMutagenVolumeMounted(app *DdevApp) (bool, error) {
 		return false, err
 	}
 	for _, m := range inspect.Mounts {
-		if m.Name == app.Name+"_project_mutagen" {
+		if m.Name == GetMutagenVolumeName(app) {
 			return true, nil
 		}
 	}

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -114,7 +114,7 @@ func TestMutagenSimple(t *testing.T) {
 	assert.Equal("paused", status, "wrong status: status=%s short=%s, long=%s", status, short, long)
 
 	// Make sure we can stop the daemon
-	ddevapp.StopMutagenDaemon()
+	ddevapp.StopMutagenDaemon("")
 	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
 		// Verify that the Mutagen daemon stopped/died
 		sleepWait := time.Second * 1

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -41,7 +41,7 @@ func PowerOff() {
 		util.Warning("Unable to run client.ListContainers(): %v", err)
 	}
 
-	StopMutagenDaemon()
+	StopMutagenDaemon("")
 
 	if err := RemoveSSHAgentContainer(); err != nil {
 		util.Error("Failed to remove ddev-ssh-agent: %v", err)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1543,7 +1543,7 @@ func DownloadDockerCompose() error {
 	if err != nil {
 		return err
 	}
-	output.UserOut.Printf("Downloading %s ...", composeURL)
+	util.Debug("Downloading '%s' to '%s' ...", composeURL, destFile)
 
 	_ = os.Remove(destFile)
 

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -123,6 +123,29 @@ func RunHostCommand(command string, args ...string) (string, error) {
 	return string(o), err
 }
 
+// RunHostCommandWithEnv executes a command on the host with optional
+// environment variables and returns the
+// combined stdout/stderr results and error
+func RunHostCommandWithEnv(command string, env []string, args ...string) (string, error) {
+	if globalconfig.DdevVerbose {
+		output.UserOut.Printf("RunHostCommandWithEnv(%v): %s %s", env, command, strings.Join(args, " "))
+	}
+
+	c := exec.Command(command, args...)
+	c.Env = append(os.Environ(), env...)
+	ddevExecutable, _ := os.Executable()
+	c.Env = append(os.Environ(),
+		"DDEV_EXECUTABLE="+ddevExecutable,
+	)
+	c.Stdin = os.Stdin
+	o, err := c.CombinedOutput()
+	if globalconfig.DdevVerbose {
+		output.UserOut.Printf("RunHostCommandWithEnv returned. output=%v err=%v", string(o), err)
+	}
+
+	return string(o), err
+}
+
 // RunHostCommandSeparateStreams executes a command on the host and returns the
 // stdout and error
 func RunHostCommandSeparateStreams(command string, args ...string) (string, error) {

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -126,17 +126,15 @@ func RunHostCommand(command string, args ...string) (string, error) {
 // RunHostCommandWithEnv executes a command on the host with optional
 // environment variables and returns the
 // combined stdout/stderr results and error
+// If all of the existing environment is required, it must be
+// passed in `env`, as it is not set by default
 func RunHostCommandWithEnv(command string, env []string, args ...string) (string, error) {
 	if globalconfig.DdevVerbose {
 		output.UserOut.Printf("RunHostCommandWithEnv(%v): %s %s", env, command, strings.Join(args, " "))
 	}
 
 	c := exec.Command(command, args...)
-	c.Env = append(os.Environ(), env...)
-	ddevExecutable, _ := os.Executable()
-	c.Env = append(os.Environ(),
-		"DDEV_EXECUTABLE="+ddevExecutable,
-	)
+	c.Env = env
 	c.Stdin = os.Stdin
 	o, err := c.CombinedOutput()
 	if globalconfig.DdevVerbose {

--- a/pkg/fileutil/file_hash.go
+++ b/pkg/fileutil/file_hash.go
@@ -9,7 +9,8 @@ import (
 )
 
 // FileHash returns string of hash of filePath passed in
-func FileHash(filePath string) (string, error) {
+// And optional string can be added to content that will be hashed
+func FileHash(filePath string, optionalExtraString string) (string, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return "", err
@@ -25,6 +26,19 @@ func FileHash(filePath string) (string, error) {
 	if _, err := io.Copy(hash, file); err != nil {
 		return "", err
 	}
+	// Include file location in the hash, if in a different
+	// place it should not hash the same
+	if _, err := hash.Write([]byte(file.Name())); err != nil {
+		return "", err
+	}
+
+	// Add optional string to hash if provided
+	if len(optionalExtraString) > 0 {
+		if _, err := hash.Write([]byte(optionalExtraString)); err != nil {
+			return "", err
+		}
+	}
+
 	sum := hash.Sum(nil)
 
 	return fmt.Sprintf("%x", sum), nil

--- a/pkg/fileutil/file_hash.go
+++ b/pkg/fileutil/file_hash.go
@@ -28,6 +28,7 @@ func FileHash(filePath string, optionalExtraString string) (string, error) {
 	}
 	// Include file location in the hash, if in a different
 	// place it should not hash the same
+	// file.Name() is the full path of the file
 	if _, err := hash.Write([]byte(file.Name())); err != nil {
 		return "", err
 	}

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/stretchr/testify/require"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -36,10 +35,19 @@ func TestFileHash(t *testing.T) {
 			err := fileutil.TemplateStringToFile(tc.content, nil, testFile)
 			require.NoError(t, err)
 
-			expectedHash, err := externalComputeSha1Sum(testFile)
+			// Use FileHash first
+			result, err := fileutil.FileHash(testFile, "")
 			require.NoError(t, err)
 
-			result, err := fileutil.FileHash(testFile, "")
+			// But we have to add the filepath to the testFile before
+			// we can use the externalComputeSha1Sum successfully
+			f, err := os.OpenFile(testFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			require.NoError(t, err)
+			_, err = f.WriteString(testFile)
+			require.NoError(t, err)
+			_ = f.Close()
+
+			expectedHash, err := externalComputeSha1Sum(testFile)
 			require.NoError(t, err)
 
 			require.Equal(t, expectedHash, result)
@@ -50,8 +58,7 @@ func TestFileHash(t *testing.T) {
 // externalComputeSha1Sum uses external tool (sha1sum for example) to compute shasum
 func externalComputeSha1Sum(filePath string) (string, error) {
 	dir := filepath.Dir(filePath)
-	fileName := filepath.Base(filePath)
-	_, out, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"sha1sum", path.Join("/var/tmp/checkdir/", fileName)}, nil, nil, []string{dir + ":" + "/var/tmp/checkdir"}, "0", true, false, nil, nil, nil)
+	_, out, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"sha1sum", filePath}, nil, nil, []string{dir + ":" + dir}, "0", true, false, nil, nil, nil)
 
 	if err != nil {
 		return "", err

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -39,7 +39,7 @@ func TestFileHash(t *testing.T) {
 			expectedHash, err := externalComputeSha1Sum(testFile)
 			require.NoError(t, err)
 
-			result, err := fileutil.FileHash(testFile)
+			result, err := fileutil.FileHash(testFile, "")
 			require.NoError(t, err)
 
 			require.Equal(t, expectedHash, result)

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -18,11 +18,13 @@ import (
 func TestFileHash(t *testing.T) {
 
 	testCases := []struct {
-		content string
+		content       string
+		optionalExtra string
 	}{
-		{"This is a test file for FileHash function."},
-		{"Another test case with different content."},
-		{"Test file with special characters: !@#$%^&*()_+-=[]{};':\"|,.<>?"},
+		{"This is a test file for FileHash function.", ""},
+		{"Another test case with different content.", ""},
+		{"Test file with special characters: !@#$%^&*()_+-=[]{};':\"|,.<>?", ""},
+		{"Test file with provided extra content", "random extra content"},
 	}
 
 	for i, tc := range testCases {
@@ -36,7 +38,7 @@ func TestFileHash(t *testing.T) {
 			require.NoError(t, err)
 
 			// Use FileHash first
-			result, err := fileutil.FileHash(testFile, "")
+			result, err := fileutil.FileHash(testFile, tc.optionalExtra)
 			require.NoError(t, err)
 
 			// But we have to add the filepath to the testFile before
@@ -45,6 +47,10 @@ func TestFileHash(t *testing.T) {
 			require.NoError(t, err)
 			_, err = f.WriteString(testFile)
 			require.NoError(t, err)
+			if tc.optionalExtra != "" {
+				_, err = f.WriteString(tc.optionalExtra)
+				require.NoError(t, err)
+			}
 			_ = f.Close()
 
 			expectedHash, err := externalComputeSha1Sum(testFile)

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -168,14 +168,15 @@ func checkMutagenSocketPathLength() {
 // GetMutagenDataDirectory gets the full path to the MUTAGEN_DATA_DIRECTORY
 // As a side-effect, it sets MUTAGEN_DATA_DIRECTORY if it's not set
 func GetMutagenDataDirectory() string {
-	currentMutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
-	if currentMutagenDataDirectory != "" {
-		_ = os.Setenv(`MUTAGEN_DATA_DIRECTORY`, currentMutagenDataDirectory)
-		return currentMutagenDataDirectory
+	envSpecifiedMutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
+	if envSpecifiedMutagenDataDirectory != "" {
+		return envSpecifiedMutagenDataDirectory
 	}
 	// If it's not already set, return ~/.ddev.mdd
 	// This may be affected by tests that change $HOME and $XDG_CONFIG_HOME
-	return filepath.Join(GetGlobalDdevDir(), ".mdd")
+	newMutagenDataDirectory := filepath.Join(GetGlobalDdevDir(), ".mdd")
+	_ = os.Setenv(`MUTAGEN_DATA_DIRECTORY`, newMutagenDataDirectory)
+	return newMutagenDataDirectory
 }
 
 // GetDockerComposePath gets the full path to the docker-compose binary

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -49,7 +49,6 @@ type GlobalConfig struct {
 	InstrumentationReportingInterval time.Duration               `yaml:"instrumentation_reporting_interval,omitempty"`
 	InstrumentationUser              string                      `yaml:"instrumentation_user,omitempty"`
 	InternetDetectionTimeout         int64                       `yaml:"internet_detection_timeout_ms"`
-	LastMutagenDataDirectory         string                      `yaml:"last_mutagen_data_dir,omitempty"`
 	LastStartedVersion               string                      `yaml:"last_started_version"`
 	LetsEncryptEmail                 string                      `yaml:"letsencrypt_email"`
 	Messages                         MessagesConfig              `yaml:"messages,omitempty"`

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -612,8 +612,9 @@ func GetGlobalDdevDirLocation() string {
 	// If Linux and ~/.ddev doesn't exist and
 	// ~/.config/ddev exists, use it,
 	// we don't create this directory.
-	_, userHomeDotDdevErr := os.Stat(userHomeDotDdev)
-	if runtime.GOOS == "linux" && os.IsNotExist(userHomeDotDdevErr) {
+	stat, userHomeDotDdevErr := os.Stat(userHomeDotDdev)
+	userHomeDotDdevIsDir := userHomeDotDdevErr == nil && stat.IsDir()
+	if runtime.GOOS == "linux" && !userHomeDotDdevIsDir {
 		userConfigDir, err := os.UserConfigDir()
 		if err == nil {
 			linuxDir := filepath.Join(userConfigDir, "ddev")

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -168,13 +168,13 @@ func checkMutagenSocketPathLength() {
 // GetMutagenDataDirectory gets the full path to the MUTAGEN_DATA_DIRECTORY
 // As a side-effect, it sets MUTAGEN_DATA_DIRECTORY if it's not set
 func GetMutagenDataDirectory() string {
-	// Return GetGlobalDdevDir() + .mdd
-	// This is affected by changes to $XDG_CONFIG_HOME
-	// or anything that changes the global DDEV config directory
-	// This may be affected by tests that change $HOME and $XDG_CONFIG_HOME
-	newMutagenDataDirectory := filepath.Join(GetGlobalDdevDir(), ".mdd")
-	_ = os.Setenv(`MUTAGEN_DATA_DIRECTORY`, newMutagenDataDirectory)
-	return newMutagenDataDirectory
+	home, err := os.UserHomeDir()
+	if err != nil {
+		logrus.Fatalf("Could not get home directory for current user. Is it set? err=%v", err)
+	}
+	mutagenDataDirectory := filepath.Join(home, ".ddev_mutagen_data_directory")
+	_ = os.Setenv(`MUTAGEN_DATA_DIRECTORY`, mutagenDataDirectory)
+	return mutagenDataDirectory
 }
 
 // GetDockerComposePath gets the full path to the docker-compose binary
@@ -596,7 +596,7 @@ func GetGlobalDdevDir() string {
 func GetGlobalDdevDirLocation() string {
 	userHome, err := os.UserHomeDir()
 	if err != nil {
-		logrus.Fatal("Could not get home directory for current user. Is it set?")
+		logrus.Fatalf("Could not get home directory for current user. Is it set? err=%v", err)
 	}
 	userHomeDotDdev := filepath.Join(userHome, ".ddev")
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -154,7 +154,7 @@ func checkMutagenSocketPathLength() {
 		checkedMutagenSocketPathLength = true
 		return
 	}
-	socketPathLength := len(filepath.Join(os.Getenv("MUTAGEN_DATA_DIRECTORY"), "daemon", "daemon.sock"))
+	socketPathLength := len(filepath.Join(GetMutagenDataDirectory(), "daemon", "daemon.sock"))
 	// Limit from https://unix.stackexchange.com/a/367012
 	limit := 104
 	if runtime.GOOS == "linux" {
@@ -169,11 +169,9 @@ func checkMutagenSocketPathLength() {
 // GetMutagenDataDirectory gets the full path to the MUTAGEN_DATA_DIRECTORY
 // As a side-effect, it sets MUTAGEN_DATA_DIRECTORY if it's not set
 func GetMutagenDataDirectory() string {
-	envSpecifiedMutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
-	if envSpecifiedMutagenDataDirectory != "" {
-		return envSpecifiedMutagenDataDirectory
-	}
-	// If it's not already set, return ~/.ddev.mdd
+	// Return GetGlobalDdevDir() + .ddev.mdd
+	// This is affected by changes to $XDG_CONFIG_HOME
+	// or anything that changes the global DDEV config directory
 	// This may be affected by tests that change $HOME and $XDG_CONFIG_HOME
 	newMutagenDataDirectory := filepath.Join(GetGlobalDdevDir(), ".mdd")
 	_ = os.Setenv(`MUTAGEN_DATA_DIRECTORY`, newMutagenDataDirectory)

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -166,9 +166,11 @@ func checkMutagenSocketPathLength() {
 }
 
 // GetMutagenDataDirectory gets the full path to the MUTAGEN_DATA_DIRECTORY
+// As a side-effect, it sets MUTAGEN_DATA_DIRECTORY if it's not set
 func GetMutagenDataDirectory() string {
 	currentMutagenDataDirectory := os.Getenv("MUTAGEN_DATA_DIRECTORY")
 	if currentMutagenDataDirectory != "" {
+		_ = os.Setenv(`MUTAGEN_DATA_DIRECTORY`, currentMutagenDataDirectory)
 		return currentMutagenDataDirectory
 	}
 	// If it's not already set, return ~/.ddev.mdd

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -565,7 +565,7 @@ func WriteProjectList(projects map[string]*ProjectInfo) error {
 	return nil
 }
 
-// GetGlobalDdevDir returns the global caching directory, and creates it as needed.
+// GetGlobalDdevDir returns the DDEV global config directory, and creates it as needed.
 func GetGlobalDdevDir() string {
 	ddevDir := GetGlobalDdevDirLocation()
 	// Create the directory if it is not already present.
@@ -604,6 +604,10 @@ func GetGlobalDdevDirLocation() string {
 	// If $XDG_CONFIG_HOME is set, use $XDG_CONFIG_HOME/ddev,
 	// we create this directory.
 	xdgConfigHomeDir := os.Getenv("XDG_CONFIG_HOME")
+	// Handle ~/xxx without failure; MUTAGEN_DATA_DIRECTORY, for example, can't have it.
+	if strings.HasPrefix(xdgConfigHomeDir, `~`) {
+		xdgConfigHomeDir = userHome + xdgConfigHomeDir[1:]
+	}
 	if xdgConfigHomeDir != "" {
 		return filepath.Join(xdgConfigHomeDir, "ddev")
 	}

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -49,6 +49,7 @@ type GlobalConfig struct {
 	InstrumentationReportingInterval time.Duration               `yaml:"instrumentation_reporting_interval,omitempty"`
 	InstrumentationUser              string                      `yaml:"instrumentation_user,omitempty"`
 	InternetDetectionTimeout         int64                       `yaml:"internet_detection_timeout_ms"`
+	LastMutagenDataDirectory         string                      `yaml:"last_mutagen_data_dir,omitempty"`
 	LastStartedVersion               string                      `yaml:"last_started_version"`
 	LetsEncryptEmail                 string                      `yaml:"letsencrypt_email"`
 	Messages                         MessagesConfig              `yaml:"messages,omitempty"`

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -169,7 +169,7 @@ func checkMutagenSocketPathLength() {
 // GetMutagenDataDirectory gets the full path to the MUTAGEN_DATA_DIRECTORY
 // As a side-effect, it sets MUTAGEN_DATA_DIRECTORY if it's not set
 func GetMutagenDataDirectory() string {
-	// Return GetGlobalDdevDir() + .ddev.mdd
+	// Return GetGlobalDdevDir() + .mdd
 	// This is affected by changes to $XDG_CONFIG_HOME
 	// or anything that changes the global DDEV config directory
 	// This may be affected by tests that change $HOME and $XDG_CONFIG_HOME

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -613,7 +613,7 @@ func GetGlobalDdevDirLocation() string {
 	// ~/.config/ddev exists, use it,
 	// we don't create this directory.
 	_, userHomeDotDdevErr := os.Stat(userHomeDotDdev)
-	if runtime.GOOS == "linux" && userHomeDotDdevErr != nil {
+	if runtime.GOOS == "linux" && os.IsNotExist(userHomeDotDdevErr) {
 		userConfigDir, err := os.UserConfigDir()
 		if err == nil {
 			linuxDir := filepath.Join(userConfigDir, "ddev")
@@ -625,7 +625,7 @@ func GetGlobalDdevDirLocation() string {
 	// Otherwise, use ~/.ddev
 	// It will be created if it doesn't exist.
 
-	return filepath.Join(userHome, ".ddev")
+	return userHomeDotDdev
 }
 
 // IsValidOmitContainers is a helper function to determine if the OmitContainers array is valid

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -597,15 +597,23 @@ func GetGlobalDdevDir() string {
 // ~/.config/ddev if this directory exists on Linux/WSL2 only,
 // ~/.ddev otherwise.
 func GetGlobalDdevDirLocation() string {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		logrus.Fatal("Could not get home directory for current user. Is it set?")
+	}
+	userHomeDotDdev := filepath.Join(userHome, ".ddev")
+
 	// If $XDG_CONFIG_HOME is set, use $XDG_CONFIG_HOME/ddev,
 	// we create this directory.
 	xdgConfigHomeDir := os.Getenv("XDG_CONFIG_HOME")
 	if xdgConfigHomeDir != "" {
 		return filepath.Join(xdgConfigHomeDir, "ddev")
 	}
-	// If Linux and ~/.config/ddev exists, use it,
+	// If Linux and ~/.ddev doesn't exist and
+	// ~/.config/ddev exists, use it,
 	// we don't create this directory.
-	if runtime.GOOS == "linux" {
+	_, userHomeDotDdevErr := os.Stat(userHomeDotDdev)
+	if runtime.GOOS == "linux" && userHomeDotDdevErr != nil {
 		userConfigDir, err := os.UserConfigDir()
 		if err == nil {
 			linuxDir := filepath.Join(userConfigDir, "ddev")
@@ -616,10 +624,7 @@ func GetGlobalDdevDirLocation() string {
 	}
 	// Otherwise, use ~/.ddev
 	// It will be created if it doesn't exist.
-	userHome, err := os.UserHomeDir()
-	if err != nil {
-		logrus.Fatal("Could not get home directory for current user. Is it set?")
-	}
+
 	return filepath.Join(userHome, ".ddev")
 }
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -130,10 +130,6 @@ func GetDDEVBinDir() string {
 
 // GetMutagenPath gets the full path to the Mutagen binary
 func GetMutagenPath() string {
-	// Set MUTAGEN_DATA_DIRECTORY if it is unset
-	if os.Getenv("MUTAGEN_DATA_DIRECTORY") == "" {
-		_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", GetMutagenDataDirectory())
-	}
 	// Check socket path length on first call to Mutagen
 	checkMutagenSocketPathLength()
 	mutagenBinary := "mutagen"

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -236,7 +236,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 	require.DirExists(t, originalGlobalDdevDir)
 	originalGlobalConfig := globalconfig.DdevGlobalConfig
 	// Stop the Mutagen daemon running in the ~/.ddev
-	ddevapp.StopMutagenDaemon()
+	ddevapp.StopMutagenDaemon("")
 	t.Log(fmt.Sprintf("stopped mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 	// Set $XDG_CONFIG_HOME for tests
 	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
@@ -278,7 +278,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 // ResetGlobalDdevDir removes temporary $XDG_CONFIG_HOME directory
 func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 	// Stop the Mutagen daemon running in the $XDG_CONFIG_HOME/ddev
-	ddevapp.StopMutagenDaemon()
+	ddevapp.StopMutagenDaemon("")
 	t.Log(fmt.Sprintf("stopped mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 	// After the $XDG_CONFIG_HOME directory is removed,
 	// globalconfig.GetGlobalDdevDir() should point to ~/.ddev

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -261,7 +261,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 	}
 	// Reset $MUTAGEN_DATA_DIRECTORY
 	_ = os.Unsetenv("MUTAGEN_DATA_DIRECTORY")
-	// globalconfig.GetMutagenDataDirectory gets new version of MUTAGEH_DATA_DIRECTORY
+	// globalconfig.GetMutagenDataDirectory gets new version of MUTAGEN_DATA_DIRECTORY
 	// when MUTAGEN_DATA_DIRECTORY is unset
 	_ = os.Setenv(`MUTAGEN_DATA_DIRECTORY`, globalconfig.GetMutagenDataDirectory())
 	// Start mutagen daemon if it's enabled

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -528,7 +528,7 @@ func CheckGoroutineOutput(t *testing.T, out string) {
 	// regex to find "goroutines=4 at exit of main()"
 	re := regexp.MustCompile(`goroutines=(\d+) at exit of main\(\)`)
 	matches := re.FindAllStringSubmatch(out, -1)
-	require.Equal(t, 1, len(matches), "must be exactly one match for goroutines=")
+	require.Equal(t, 1, len(matches), "must be exactly one match for goroutines=<value>, DDEV_GOROUTINES=%s actual output='%s'", os.Getenv(`DDEV_GOROUTINES`), out)
 	num, err := strconv.Atoi(matches[0][1])
 	require.NoError(t, err, "can't convert %s to number: %v", matches[0][1])
 	require.LessOrEqual(t, num, goroutineLimit, "number of goroutines=%v, higher than limit=%d", num, goroutineLimit)

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -237,7 +237,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 	originalGlobalConfig := globalconfig.DdevGlobalConfig
 	// Stop the Mutagen daemon running in the ~/.ddev
 	ddevapp.StopMutagenDaemon()
-	t.Log(fmt.Sprintf("stop mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
+	t.Log(fmt.Sprintf("stopped mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 	// Set $XDG_CONFIG_HOME for tests
 	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
 	// Make sure that the global config directory is set to $XDG_CONFIG_HOME/ddev
@@ -260,12 +260,14 @@ func CopyGlobalDdevDir(t *testing.T) string {
 		require.NoError(t, err)
 	}
 	// Reset $MUTAGEN_DATA_DIRECTORY
-	err = os.Unsetenv("MUTAGEN_DATA_DIRECTORY")
-	require.NoError(t, err)
+	_ = os.Unsetenv("MUTAGEN_DATA_DIRECTORY")
+	// globalconfig.GetMutagenDataDirectory gets new version of MUTAGEH_DATA_DIRECTORY
+	// when MUTAGEN_DATA_DIRECTORY is unset
+	_ = os.Setenv(`MUTAGEN_DATA_DIRECTORY`, globalconfig.GetMutagenDataDirectory())
 	// Start mutagen daemon if it's enabled
 	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 		ddevapp.StartMutagenDaemon()
-		t.Log(fmt.Sprintf("start mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
+		t.Log(fmt.Sprintf("started mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY='%s'", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
 		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), ".mdd"))
 	}
@@ -277,7 +279,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 	// Stop the Mutagen daemon running in the $XDG_CONFIG_HOME/ddev
 	ddevapp.StopMutagenDaemon()
-	t.Logf("stopped mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory())
+	t.Log(fmt.Sprintf("stopped mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 	// After the $XDG_CONFIG_HOME directory is removed,
 	// globalconfig.GetGlobalDdevDir() should point to ~/.ddev
 	t.Setenv("XDG_CONFIG_HOME", "")
@@ -290,12 +292,13 @@ func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 	// refresh the global config from ~/.ddev
 	globalconfig.EnsureGlobalConfig()
 	// Reset $MUTAGEN_DATA_DIRECTORY
-	err := os.Unsetenv("MUTAGEN_DATA_DIRECTORY")
-	require.NoError(t, err)
+	_ = os.Unsetenv("MUTAGEN_DATA_DIRECTORY")
+	_ = os.Setenv(`MUTAGEN_DATA_DIRECTORY`, globalconfig.GetMutagenDataDirectory())
+
 	// Start mutagen daemon if it's enabled
 	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 		ddevapp.StartMutagenDaemon()
-		t.Log(fmt.Sprintf("started mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
+		t.Log(fmt.Sprintf("started mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
 		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), ".mdd"))
 	}

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -259,17 +259,14 @@ func CopyGlobalDdevDir(t *testing.T) string {
 		err = copy2.Copy(sourceBinDir, filepath.Join(tmpGlobalDdevDir, "bin"))
 		require.NoError(t, err)
 	}
-	// Reset $MUTAGEN_DATA_DIRECTORY
-	_ = os.Unsetenv("MUTAGEN_DATA_DIRECTORY")
-	// globalconfig.GetMutagenDataDirectory gets new version of MUTAGEN_DATA_DIRECTORY
-	// when MUTAGEN_DATA_DIRECTORY is unset
-	_ = os.Setenv(`MUTAGEN_DATA_DIRECTORY`, globalconfig.GetMutagenDataDirectory())
+	// globalconfig.GetMutagenDataDirectory sets MUTAGEN_DATA_DIRECTORY
+	_ = globalconfig.GetMutagenDataDirectory()
 	// Start mutagen daemon if it's enabled
 	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 		ddevapp.StartMutagenDaemon()
 		t.Log(fmt.Sprintf("started mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY='%s'", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
-		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), ".mdd"))
+		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), globalconfig.GetMutagenDataDirectory())
 	}
 
 	return tmpXdgConfigHomeDir
@@ -291,16 +288,15 @@ func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 	require.DirExists(t, originalGlobalDdevDir)
 	// refresh the global config from ~/.ddev
 	globalconfig.EnsureGlobalConfig()
-	// Reset $MUTAGEN_DATA_DIRECTORY
-	_ = os.Unsetenv("MUTAGEN_DATA_DIRECTORY")
-	_ = os.Setenv(`MUTAGEN_DATA_DIRECTORY`, globalconfig.GetMutagenDataDirectory())
+	// Set $MUTAGEN_DATA_DIRECTORY
+	_ = globalconfig.GetMutagenDataDirectory()
 
 	// Start mutagen daemon if it's enabled
 	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 		ddevapp.StartMutagenDaemon()
 		t.Log(fmt.Sprintf("started mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
-		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), ".mdd"))
+		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), globalconfig.GetMutagenDataDirectory())
 	}
 }
 


### PR DESCRIPTION
## The Issue

* #6234 

With our new ability to change the global configuration directory from `~/.ddev` to other places come new risks for mutagen. 

(Removed): Mutagen now keeps its directory in `<globaldir>/.mdd` instead of `<home>/.ddev_mutagen_data_directory`. 


There's a risk in changing that mutagen could continue using an obsolete mutagen session or accidentally use a docker volume that did not match.

## How This PR Solves The Issue

* When computing the mutagen hash for uniqueness, include not only the `mutagen.yml` contents but also the location of the `mutagen.yml` and the global configuration location.
* Revert to using ~/.ddev_mutagen_data_directory to resolve risks of upgrades and environment variable changes (XDG_CONFIG_HOME)

## Manual Testing Instructions

Still working on explicit instructions that can demonstrate the underlying problem.

## Automated Testing Overview

I think the existing tests probably already do enough.

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

