### PR TITLE
fix: create `working_dir` for `web` if it doesn't exist, fixes #6158

### DIFF
--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -24,7 +24,14 @@ func (app *DdevApp) WriteDockerComposeYAML() error {
 	}
 	defer util.CheckClose(f)
 
-	app.CreateWebWorkingDir()
+	// Create a host working_dir for the web service beforehand.
+	// Otherwise, Docker will create it as root user (when Mutagen is disabled).
+	// This problem (particularly for Docker volumes) is described in
+	// https://github.com/moby/moby/issues/2259
+	hostWorkingDir := app.GetHostWorkingDir("web", "")
+	if hostWorkingDir != "" {
+		_ = os.MkdirAll(hostWorkingDir, 0755)
+	}
 
 	rendered, err := app.RenderComposeYAML()
 	if err != nil {

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -1,11 +1,12 @@
 package ddevapp
 
 import (
+	"os"
+	"strings"
+
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/util"
 	"gopkg.in/yaml.v3"
-	"os"
-	"strings"
 	//compose_cli "github.com/compose-spec/compose-go/cli"
 	//compose_types "github.com/compose-spec/compose-go/types"
 )
@@ -22,6 +23,8 @@ func (app *DdevApp) WriteDockerComposeYAML() error {
 		return err
 	}
 	defer util.CheckClose(f)
+
+	app.CreateWebWorkingDir()
 
 	rendered, err := app.RenderComposeYAML()
 	if err != nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2903,6 +2903,22 @@ func (app *DdevApp) GetWorkingDir(service string, dir string) string {
 	return app.DefaultWorkingDirMap()[service]
 }
 
+// GetHostWorkingDir will determine the appropriate working directory for the service on the host side
+func (app *DdevApp) GetHostWorkingDir(service string, dir string) string {
+	// We have a corresponding host working_dir for the "web" service only
+	if service != "web" {
+		return ""
+	}
+	if dir == "" && app.WorkingDir != nil {
+		dir = app.WorkingDir[service]
+	}
+	containerWorkingDirPrefix := strings.TrimSuffix(app.GetAbsAppRoot(true), "/") + "/"
+	if !strings.HasPrefix(dir, containerWorkingDirPrefix) {
+		return ""
+	}
+	return filepath.Join(app.GetAbsAppRoot(false), strings.TrimPrefix(dir, containerWorkingDirPrefix))
+}
+
 // GetNFSMountVolumeName returns the Docker volume name of the nfs mount volume
 func (app *DdevApp) GetNFSMountVolumeName() string {
 	// This is lowercased because the automatic naming in docker-compose v1/2

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -522,27 +522,6 @@ func (app *DdevApp) CanUseHTTPOnly() bool {
 	return false
 }
 
-// CreateWebWorkingDir creates a web working_dir if it does not exist on the host side.
-// If the app has a custom working_dir for the web service, like `/var/www/html/some/deep/dir`,
-// where `/var/www/html/` path corresponds to the project root,
-// and `some/deep/dir` does not exist on the host side, we should create it.
-// Otherwise, Docker will create it as root user (when Mutagen is disabled).
-// This problem (particularly for Docker volumes) is described in
-// https://github.com/moby/moby/issues/2259
-func (app *DdevApp) CreateWebWorkingDir() {
-	if app.WorkingDir != nil {
-		if workingDir := app.WorkingDir["web"]; workingDir != "" {
-			workingDirPrefix := app.DefaultWorkingDirMap()["web"]
-			if strings.HasPrefix(workingDir, workingDirPrefix) {
-				fullPath := filepath.Join(app.AppRoot, strings.TrimPrefix(workingDir, workingDirPrefix))
-				if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-					_ = os.MkdirAll(fullPath, 0755)
-				}
-			}
-		}
-	}
-}
-
 // Turn a slice of *DdevApp into a map keyed by name
 func AppSliceToMap(appList []*DdevApp) map[string]*DdevApp {
 	nameMap := make(map[string]*DdevApp)

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -522,6 +522,27 @@ func (app *DdevApp) CanUseHTTPOnly() bool {
 	return false
 }
 
+// CreateWebWorkingDir creates a web working_dir if it does not exist on the host side.
+// If the app has a custom working_dir for the web service, like `/var/www/html/some/deep/dir`,
+// where `/var/www/html/` path corresponds to the project root,
+// and `some/deep/dir` does not exist on the host side, we should create it.
+// Otherwise, Docker will create it as root user (when Mutagen is disabled).
+// This problem (particularly for Docker volumes) is described in
+// https://github.com/moby/moby/issues/2259
+func (app *DdevApp) CreateWebWorkingDir() {
+	if app.WorkingDir != nil {
+		if workingDir := app.WorkingDir["web"]; workingDir != "" {
+			workingDirPrefix := app.DefaultWorkingDirMap()["web"]
+			if strings.HasPrefix(workingDir, workingDirPrefix) {
+				fullPath := filepath.Join(app.AppRoot, strings.TrimPrefix(workingDir, workingDirPrefix))
+				if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+					_ = os.MkdirAll(fullPath, 0755)
+				}
+			}
+		}
+	}
+}
+
 // Turn a slice of *DdevApp into a map keyed by name
 func AppSliceToMap(appList []*DdevApp) map[string]*DdevApp {
 	nameMap := make(map[string]*DdevApp)


### PR DESCRIPTION
## The Issue

- https://github.com/phenaproxima/starshot-prototype/issues/94
- #6158

If there is a config in `.ddev/config.yaml`:

```yaml
working_dir:
  web: /var/www/html/something
```

And the `something` directory doesn't exist on the host side, it will be created by Docker as root.

## How This PR Solves The Issue

We can create the directory beforehand and it is only needed if it is in the approot.

## Manual Testing Instructions

1. Use Linux/WSL2.
2. `ddev config global --performance-mode=none`
3. `ddev config --web-working-dir=/var/www/html/something`
4. `ddev start`
5. check file permissions `ls -l something`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

- https://github.com/moby/moby/issues/2259

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

