### PR TITLE
feat: add support for MariaDB 11.4 LTS, fixes #6061

### DIFF
--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -10,11 +10,11 @@ CURRENT_ARCH=$(shell ../get_arch.sh)
 # So has to explicitly declare anything it might need from there (like SHELL)
 SHELL = /bin/bash
 
-BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_both mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mariadb_10.7_both mariadb_10.8_both mariadb_10.11_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.33
+BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_both mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mariadb_10.7_both mariadb_10.8_both mariadb_10.11_both mariadb_11.4_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.33
 TEST_TARGETS=$(shell if [ "$(CURRENT_ARCH)" = "amd64" ] ; then \
-	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mariadb_10.11_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
+	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mariadb_10.11_test mariadb_11.4_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
 	else \
-	  echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mariadb_10.11_test mysql_5.7_test mysql_8.0_test"; \
+	  echo "mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mariadb_10.11_test mariadb_11.4_test mysql_5.7_test mysql_8.0_test"; \
   	fi )
 
 container: build
@@ -31,6 +31,7 @@ mariadb_10.6: mariadb_10.6_both
 mariadb_10.7: mariadb_10.7_both
 mariadb_10.8: mariadb_10.8_both
 mariadb_10.11: mariadb_10.11_both
+mariadb_11.4: mariadb_11.4_both
 
 mysql_5.5: mysql_5.5_amd64
 mysql_5.6: mysql_5.6_amd64

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -110,7 +110,7 @@ The type and version of the database engine the project should use.
 
 | Type | Default       | Usage
 | -- |---------------| --
-| :octicons-file-directory-16: project | MariaDB 10.11 | Can be MariaDB 5.5–10.8 or 10.11, MySQL 5.5–8.0, or PostgreSQL 9–15.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats.
+| :octicons-file-directory-16: project | MariaDB 10.11 | Can be MariaDB 5.5–10.8, 10.11, or 11.4, MySQL 5.5–8.0, or PostgreSQL 9–15.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats.
 
 ## `dbimage_extra_packages`
 

--- a/docs/content/users/extend/database-types.md
+++ b/docs/content/users/extend/database-types.md
@@ -4,7 +4,7 @@ DDEV supports many versions of the MariaDB, MySQL, and PostgreSQL database serve
 
 The following database types are currently supported:
 
-- MariaDB 5.5-10.8 and 10.11
+- MariaDB 5.5-10.8, 10.11, and 11.4
 - MySQL 5.5-8.0
 - Postgres 9-16
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -25,7 +25,8 @@ const ConfigInstructions = `
 # database:
 #   type: <dbtype> # mysql, mariadb, postgres
 #   version: <version> # database version, like "10.11" or "8.0"
-#   MariaDB versions can be 5.5-10.8 and 10.11, MySQL versions can be 5.5-8.0
+#   MariaDB versions can be 5.5-10.8, 10.11, and 11.4.
+#   MySQL versions can be 5.5-8.0
 #   PostgreSQL versions can be 9-16.
 
 # router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)

--- a/pkg/nodeps/mariadb_values.go
+++ b/pkg/nodeps/mariadb_values.go
@@ -18,6 +18,7 @@ var ValidMariaDBVersions = map[string]bool{
 	MariaDB107:  true,
 	MariaDB108:  true,
 	MariaDB1011: true,
+	MariaDB114:  true,
 }
 
 // MariaDB Versions
@@ -33,4 +34,5 @@ const (
 	MariaDB107  = "10.7"
 	MariaDB108  = "10.8"
 	MariaDB1011 = "10.11"
+	MariaDB114  = "11.4"
 )

--- a/pkg/nodeps/mariadb_values_darwin_arm64.go
+++ b/pkg/nodeps/mariadb_values_darwin_arm64.go
@@ -14,6 +14,7 @@ var ValidMariaDBVersions = map[string]bool{
 	MariaDB107:  true,
 	MariaDB108:  true,
 	MariaDB1011: true,
+	MariaDB114:  true,
 }
 
 // MariaDB Versions
@@ -29,4 +30,5 @@ const (
 	MariaDB107  = "10.7"
 	MariaDB108  = "10.8"
 	MariaDB1011 = "10.11"
+	MariaDB114  = "11.4"
 )

--- a/pkg/nodeps/mariadb_values_linux_arm64.go
+++ b/pkg/nodeps/mariadb_values_linux_arm64.go
@@ -14,6 +14,7 @@ var ValidMariaDBVersions = map[string]bool{
 	MariaDB107:  true,
 	MariaDB108:  true,
 	MariaDB1011: true,
+	MariaDB114:  true,
 }
 
 // MariaDB Versions
@@ -29,4 +30,5 @@ const (
 	MariaDB107  = "10.7"
 	MariaDB108  = "10.8"
 	MariaDB1011 = "10.11"
+	MariaDB114  = "11.4"
 )


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

MariaDB 11.4 is LTS. We can add support for that here.

## How This PR Solves The Issue

This PR adds MariaDB 11.4 to Makefile for the Docker image and to the allowed options list.

## Manual Testing Instructions

On a DDEV project, run `ddev config --database=mariadb:11.4` and make sure it works.


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

I mainly tried to copy the PR #4902 and I couldn't find any tests to change here.

## Related Issue Link(s)

Fixes #6061.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

