### PR TITLE
docs: add link to contributor trainings

### DIFF
--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -395,4 +395,4 @@ If you are having trouble getting into the mood of idiomatic Go, we recommend re
 
 ## Contributor trainings
 
-We’re actively trying to increase the DDEV community of contributors and maintainers. To do that, we’re going to start a series of trainings, and we’d love to have you come. The trainings will be recorded for everybody’s benefit. The recordings and upcoming session dates can be found here: [DDEV Contributor Live Training](https://ddev.com/blog/contributor-training/).
+We’re actively trying to increase the DDEV community of contributors and maintainers. To do that, we regularly do contributor training, and we’d love to have you come. The trainings are recorded for everybody’s benefit. The recordings and upcoming session dates can be found here: [DDEV Contributor Live Training](https://ddev.com/blog/contributor-training/).

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -392,3 +392,7 @@ The rules:
 9. Even though we call these “rules” above, they are guidelines. Since you’ve read all the rules, you now know that.
 
 If you are having trouble getting into the mood of idiomatic Go, we recommend reading through [Effective Go](https://golang.org/doc/effective_go.html). The [Go Blog](https://blog.golang.org) is also a great resource. Drinking the kool-aid is a lot easier than going thirsty.
+
+## Contributor trainings
+
+We’re actively trying to increase the DDEV community of contributors and maintainers. To do that, we’re going to start a series of trainings, and we’d love to have you come. The trainings will be recorded for everybody’s benefit. The recordings and upcoming session dates can be found here: [DDEV Contributor Live Training](https://ddev.com/blog/contributor-training/).

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -393,6 +393,6 @@ The rules:
 
 If you are having trouble getting into the mood of idiomatic Go, we recommend reading through [Effective Go](https://golang.org/doc/effective_go.html). The [Go Blog](https://blog.golang.org) is also a great resource. Drinking the kool-aid is a lot easier than going thirsty.
 
-## Contributor trainings
+## Contributor Live Training
 
 We’re actively trying to increase the DDEV community of contributors and maintainers. To do that, we regularly do contributor training, and we’d love to have you come. The trainings are recorded for everybody’s benefit. The recordings and upcoming session dates can be found here: [DDEV Contributor Live Training](https://ddev.com/blog/contributor-training/).


### PR DESCRIPTION
## The Issue

https://ddev.com/blog/contributor-training/ not yet mentioned on https://ddev.readthedocs.io/en/stable/developers/building-contributing/

## How This PR Solves The Issue

- link to https://ddev.com/blog/contributor-training/

## Manual Testing Instructions

none

## Automated Testing Overview

none

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

