### PR TITLE
docs: Joomla Quickstart

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -80,6 +80,7 @@ IDEs
 IPv
 If
 IIS
+Joomla
 Kalabox
 Kubernetes
 Lando

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -321,8 +321,10 @@ Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/insta
 
 ```bash
 mkdir my-joomla-site && cd my-joomla-site
+tag=$(curl -L "https://api.github.com/repos/joomla/joomla-cms/releases/latest" | docker run -i --rm ddev/ddev-utilities jq -r .tag_name) && curl -L "https://github.com/joomla/joomla-cms/releases/download/$tag/Joomla_$tag-Stable-Full_Package.zip" -o joomla.zip
+unzip ./joomla.zip && rm joomla.zip
 ddev config --project-type=php
-# Download the latest version from https://downloads.joomla.org/latest and unarchive everything into the empty my-joomla-site directory
+ddev start
 ddev launch
 ```
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -323,7 +323,7 @@ Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/insta
 mkdir my-joomla-site && cd my-joomla-site
 tag=$(curl -L "https://api.github.com/repos/joomla/joomla-cms/releases/latest" | docker run -i --rm ddev/ddev-utilities jq -r .tag_name) && curl -L "https://github.com/joomla/joomla-cms/releases/download/$tag/Joomla_$tag-Stable-Full_Package.zip" -o joomla.zip
 unzip ./joomla.zip && rm joomla.zip
-ddev config --project-type=php --webserver-type=apache-fpm
+ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
 ddev start
 ddev launch
 ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -329,8 +329,6 @@ ddev php installation/joomla.php install --site-name="My Joomla Site" --admin-us
 ddev launch /administrator
 ```
 
-Now follow the instructions in the installer. The only detail to note, within the Database Configuration section, for the database type use the default `MySQLi`, and for the host name, the database user name, the database password, and the database name use `db`. The database prefix and the connection encryption settings can be left at the default settings.
-
 ## Kirby CMS
 
 Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -325,7 +325,7 @@ tag=$(curl -L "https://api.github.com/repos/joomla/joomla-cms/releases/latest" |
 unzip ./joomla.zip && rm joomla.zip
 ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
 ddev start
-ddev php installation/joomla.php install --site-name="My Joomla Site" --admin-user="John Doe" --admin-username=admin --admin-password=AdminAdmin1! --admin-email=admin@mail.com --db-type=mysql --db-encryption=0 --db-host=db --db-user=db --db-pass="db" --db-name=db --db-prefix=ddev_ --public-folder=""
+ddev php installation/joomla.php install --site-name="My Joomla Site" --admin-user="Administrator" --admin-username=admin --admin-password=AdminAdmin1! --admin-email=admin@example.com --db-type=mysql --db-encryption=0 --db-host=db --db-user=db --db-pass="db" --db-name=db --db-prefix=ddev_ --public-folder=""
 ddev launch /administrator
 ```
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -317,6 +317,15 @@ In the web browser, log into your account using `admin` and `publish`.
 
 Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/install_with_ddev/) for more cases.
 
+## Joomla
+
+```bash
+mkdir my-joomla-site && cd my-joomla-site
+ddev config --project-type=php
+# Download the latest version from https://downloads.joomla.org/latest and unarchive everything into the empty my-joomla-site directory
+ddev launch
+```
+
 ## Kirby CMS
 
 Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -323,7 +323,7 @@ Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/insta
 mkdir my-joomla-site && cd my-joomla-site
 tag=$(curl -L "https://api.github.com/repos/joomla/joomla-cms/releases/latest" | docker run -i --rm ddev/ddev-utilities jq -r .tag_name) && curl -L "https://github.com/joomla/joomla-cms/releases/download/$tag/Joomla_$tag-Stable-Full_Package.zip" -o joomla.zip
 unzip ./joomla.zip && rm joomla.zip
-ddev config --project-type=php
+ddev config --project-type=php --webserver-type=apache-fpm
 ddev start
 ddev launch
 ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -325,7 +325,8 @@ tag=$(curl -L "https://api.github.com/repos/joomla/joomla-cms/releases/latest" |
 unzip ./joomla.zip && rm joomla.zip
 ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
 ddev start
-ddev launch
+ddev php installation/joomla.php install --site-name="My Joomla Site" --admin-user="John Doe" --admin-username=admin --admin-password=AdminAdmin1! --admin-email=admin@mail.com --db-type=mysql --db-encryption=0 --db-host=db --db-user=db --db-pass="db" --db-name=db --db-prefix=ddev_ --public-folder=""
+ddev launch /administrator
 ```
 
 Now follow the instructions in the installer. The only detail to note, within the Database Configuration section, for the database type use the default `MySQLi`, and for the host name, the database user name, the database password, and the database name use `db`. The database prefix and the connection encryption settings can be left at the default settings.

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -327,6 +327,7 @@ ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
 ddev start
 ddev launch
 ```
+
 Now follow the instructions in the installer. The only detail to note, within the Database Configuration section, for the database type use the default `MySQLi`, and for the host name, the database user name, the database password, and the database name use `db`. The database prefix and the connection encryption settings can be left at the default settings.
 
 ## Kirby CMS

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -327,6 +327,7 @@ ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
 ddev start
 ddev launch
 ```
+Now follow the instructions in the installer. The only detail to note, within the Database Configuration section, for the database type use the default `MySQLi`, and for the host name, the database user name, the database password, and the database name use `db`. The database prefix and the connection encryption settings can be left at the default settings.
 
 ## Kirby CMS
 


### PR DESCRIPTION

## The Issue
Initial draft for adding a quickstart for joomla to https://ddev.readthedocs.io/en/latest/users/quickstart/ . Only downside unfortunately i havent found a static link for download the latest archive with curl. 

## Manual Testing Instructions

Use https://ddev--6255.org.readthedocs.build/en/6255/users/quickstart/#joomla

