### PR TITLE
fix: Make export-db also remove new mariadb directive in dumpfile , fixes #6249

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -829,10 +829,10 @@ func (app *DdevApp) ExportDB(dumpFile string, compressionType string, targetDB s
 	} else {
 		confMsg = confMsg + " to stdout"
 	}
-	if compressionType != "" {
-		confMsg = fmt.Sprintf("%s in %s format", confMsg, compressionType)
-	} else {
+	if compressionType == "cat" {
 		confMsg = confMsg + " in plain text format"
+	} else {
+		confMsg = fmt.Sprintf("%s in %s format", confMsg, compressionType)
 	}
 
 	_, err = fmt.Fprintf(os.Stderr, confMsg+".\n")

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2041,12 +2041,12 @@ func TestDdevExportDB(t *testing.T) {
 		// Export an alternate database
 		importPath = filepath.Join(testDir, "testdata", t.Name(), dbType, "users.sql")
 		err = app.ImportDB(importPath, "", false, false, "anotherdb")
-		require.NoError(t, err)
+		require.NoError(t, err, `unable to ImportDB(%s, "", false, false anotherdb) with dbType=%s`, dbType)
 		err = app.ExportDB("tmp/anotherdb.sql.gz", "gzip", "anotherdb")
-		assert.NoError(err)
+		require.NoError(t, err, `dbType=%v: unable to ExportDB("/tmp/anotherdb.sql.gz", "gzip"", "anotherdb")`, dbType)
 		importPath = "tmp/anotherdb.sql.gz"
 		err = app.ImportDB(importPath, "", false, false, "thirddb")
-		assert.NoError(err)
+		require.NoError(t, err, `dbType=%v: unable to importDB importPath=%s targetDB=thirddb`, dbType, importPath)
 
 		c := map[string]string{
 			nodeps.MariaDB:  `echo "SELECT COUNT(*) FROM users;" | mysql -N thirddb`,

--- a/pkg/ddevapp/providerLagoon_test.go
+++ b/pkg/ddevapp/providerLagoon_test.go
@@ -39,7 +39,7 @@ func lagoonSetupSSHKey(t *testing.T) string {
 		t.Skipf("No DDEV_LAGOON_SSH_KEY env var has been set. Skipping %v", t.Name())
 	}
 	sshkey = strings.Replace(sshkey, "<SPLIT>", "\n", -1)
-	return sshkey
+	return sshkey + "\n"
 }
 
 // TestLagoonPull ensures we can pull from lagoon


### PR DESCRIPTION

## The Issue

* #6249

We've already done a lot to mitigate this. 
* Pushed updated ddev-dbserver images for v1.23.1 that have the new client binaries so folks on v1.23.1 can at least get by
* https://github.com/ddev/ddev/pull/6253 fixed import-db so it wouldn't stumble on the new line

But we still had trouble of course *pushing* to remote. So TestPantheonPush failed for all the same reasons.

Rather than adding workarounds to our push tests, I figured I should just make ExportDB() and `ddev export-db` also remove the offending line, which should fix all of our Push  tests. 

## How This PR Solves The Issue

ExportDB also removes the new mariadb line

## Manual Testing Instructions

Use `ddev export-db` with a new-style mariadb (10.11) and verify that the dump file does not have the offending directive.

## Automated Testing Overview

I think all the tests stand on their own. I had to run many of them to sort out all the issues.

## Related Issue Link(s)

## Release/Deployment Notes

The whole class of problem will be noted in release notes.
