### PR TITLE
test: Fix test failures on master of Rancher, Colima, Windows

### DIFF
--- a/cmd/ddev/cmd/homeadditions_test.go
+++ b/cmd/ddev/cmd/homeadditions_test.go
@@ -41,7 +41,7 @@ func TestHomeadditions(t *testing.T) {
 	t.Cleanup(func() {
 		err = os.Chdir(origDir)
 		assert.NoError(err)
-		_ = fileutil.PurgeDirectory(projectHomeadditionsDir)
+		_ = os.RemoveAll(projectHomeadditionsDir)
 		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 	})
 

--- a/cmd/ddev/cmd/import-db_test.go
+++ b/cmd/ddev/cmd/import-db_test.go
@@ -1,14 +1,15 @@
 package cmd
 
 import (
-	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/testcommon"
-	asrt "github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/testcommon"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCmdImportDB does an import from stdin; many other cases are covered in
@@ -32,7 +33,7 @@ func TestCmdImportDB(t *testing.T) {
 		assert.NoError(err)
 	})
 
-	err = app.Start()
+	err = app.Restart()
 	require.NoError(t, err)
 
 	if app.IsMutagenEnabled() {

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -361,10 +361,13 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 		err = os.Chdir(origDir)
 		assert.NoError(err)
 
+		t.Logf("attempting to remove project %s", junkName)
 		_, err = exec.RunHostCommand(DdevBin, "delete", "-Oy", junkName)
 		assert.NoError(err)
 
-		_ = os.RemoveAll(tmpJunkProjectDir)
+		t.Logf("attempting to remove project files in %s", tmpJunkProjectDir)
+		err = os.RemoveAll(tmpJunkProjectDir)
+		assert.NoError(err)
 
 		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -354,13 +354,19 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	assert.NoError(err, "out=%s", out)
 	_, err = exec.RunHostCommand(DdevBin, "start", "-y")
 	assert.NoError(err)
+
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
+
 	t.Cleanup(func() {
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+
 		_, err = exec.RunHostCommand(DdevBin, "delete", "-Oy", junkName)
 		assert.NoError(err)
 
-		err = os.Chdir(origDir)
-		assert.NoError(err)
 		_ = os.RemoveAll(tmpJunkProjectDir)
+
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 
 		// Because the start has done a poweroff (new DDEV version),
 		// make sure sites are running again.
@@ -372,8 +378,6 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	apps := ddevapp.GetActiveProjects()
 	activeCount := len(apps)
 	assert.GreaterOrEqual(activeCount, 2)
-
-	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	app, err := ddevapp.GetActiveApp("")
 	require.NoError(t, err)
@@ -394,12 +398,6 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	require.NoError(t, err, "start failed, out='%s', err=%v", out, err)
 	assert.Contains(out, "ddev-ssh-agent container has been removed")
 	assert.Contains(out, "ssh-agent container is running")
-	t.Cleanup(func() {
-		_, err := exec.RunHostCommand(DdevBin, "poweroff")
-		assert.NoError(err)
-
-		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
-	})
 
 	apps = ddevapp.GetActiveProjects()
 	activeCount = len(apps)

--- a/pkg/ddevapp/hooks_test.go
+++ b/pkg/ddevapp/hooks_test.go
@@ -78,11 +78,11 @@ func TestProcessHooks(t *testing.T) {
 		assert.NoError(err)
 
 		captureOutputFunc, err := util.CaptureOutputToFile()
-		assert.NoError(err)
+		require.NoError(t, err, `failed to capture output to file for taxk='%v' err=%v`, task, err)
 		userOutFunc := util.CaptureUserOut()
 
 		err = app.Start()
-		assert.NoError(err)
+		require.NoError(t, err, `failed to app.Start() for task '%v' err=%v`, task, err)
 
 		out := captureOutputFunc()
 		userOut := userOutFunc()
@@ -105,7 +105,7 @@ func TestProcessHooks(t *testing.T) {
 	}
 	// With default setting, ProcessHooks should succeed
 	err = app.ProcessHooks("hook-test")
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	// With FailOnHookFail or FailOnHookFailGlobal or both, it should fail.
 	app.FailOnHookFail = true


### PR DESCRIPTION

## The Issue

We've had some master test failures since https://github.com/ddev/ddev/commit/5b0e640a8dca6d0ee327de75495290a25efab3dc in Rancher desktop, older Colima, and traditional Windows

## How This PR Solves The Issue

* Rancher and Colima seem to be a result of the docker provider not syncing bind-mounted directories fast enough. Fix with a `app.Restart()` at the top of offending test instead of `app.Start()`
* Windows failure looks like it's a result of previous test (TestPoweroffOnNewVersion) not cleaning up its tmp project correctly, and then TestCmdStart() fails to start that broken project.

## Manual Testing Instructions

Review, look for problems, look at test.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

