### PR TITLE
Update ddev-upgrade.md

### DIFF
--- a/docs/content/users/install/ddev-upgrade.md
+++ b/docs/content/users/install/ddev-upgrade.md
@@ -10,7 +10,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ```bash
     # Upgrade DDEV to the latest version
-    brew upgrade ddev/ddev/ddev
+    brew upgrade drud/ddev/ddev
     ```
 
     ### Install Script


### PR DESCRIPTION
Corrected the code to upgrade DDEV via HomeBrew on macOS. "brew upgrade ddev/ddev/ddev" returns an error message, "Error: No available formula or cask with the name "ddev/ddev/ddev". Did you mean ddev/ddev-edge/ddev?
Please tap it and then try again: brew tap ddev/ddev". However using "brew upgrade drud/ddev/ddev works as intended.

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

