### PR TITLE
fix: tail for mariadb export-db doesn't work on older mariadb

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -788,13 +788,13 @@ func (app *DdevApp) ExportDB(dumpFile string, compressionType string, targetDB s
 	}
 
 	if app.Database.Type == nodeps.MariaDB {
-		// The `tail +2` is a workaround that removes the new mariadb directive added
+		// The `tail --lines=+2` is a workaround that removes the new mariadb directive added
 		// 2024-05 in mariadb-dump. It removes the first line of the dump, which has
 		// the offending /*!999999\- enable the sandbox mode */. See
 		// https://mariadb.org/mariadb-dump-file-compatibility-change/
 		// If not on a newer MariaDB version, this will remove the identification
 		// line from the top of the dump.
-		exportCmd = exportCmd + " | tail +2 "
+		exportCmd = exportCmd + " | tail --lines=+2 "
 	}
 
 	if compressionType == "" {


### PR DESCRIPTION

## The Issue

TestDdevAllDatabases was failing since we added the fix to use a `tail +2` on ExportDB to mitigate the mariadb-dump change of format. 

It turned out this was failing on mariadb:5.5 and mariadb:10.0, neither of which are available on arm64, and neither of which are tested routinely (only on full github test)

## How This PR Solves The Issue

Use `tail --lines=+2` which seems to work on all versions of tail.

## Manual Testing Instructions

Use `ddev export-db` with mariadb:5.5 and 10.0

## Automated Testing Overview

The tests caught this. That should be good enough :)

