### PR TITLE
test: Try to fix windows problems with TestPoweroffOnNewVersion

### DIFF
--- a/.buildkite/windows10dockerforwindows.yml
+++ b/.buildkite/windows10dockerforwindows.yml
@@ -1,6 +1,6 @@
 # Windows native with Mutagen, used by ddev-windows-mutagen
 # See https://buildkite.com/ddev/ddev-windows-mutagen/settings/repository
-# Runs on master only
+# Runs on branches/PRs on ddev/ddev only
 
   - command: ".buildkite/test.cmd"
     agents:

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -2,15 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	osexec "os/exec"
-	"path/filepath"
-	"runtime"
-	"strconv"
-	"strings"
-	"testing"
-	"time"
-
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
@@ -25,6 +16,13 @@ import (
 	log "github.com/sirupsen/logrus"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
 )
 
 func init() {
@@ -344,6 +342,8 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	err = os.Chdir(TestSites[0].Dir)
 	assert.NoError(err)
 
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
+
 	// Create an extra junk project to make sure it gets shut down on our start
 	junkName := t.Name() + "-tmpjunkproject"
 	_, _ = exec.RunHostCommand(DdevBin, "delete", "-Oy", junkName)
@@ -356,25 +356,14 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	_, err = exec.RunHostCommand(DdevBin, "start", "-y")
 	assert.NoError(err)
 
-	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
-
 	t.Cleanup(func() {
 		err = os.Chdir(origDir)
 		assert.NoError(err)
 
 		t.Logf("attempting to remove project %s", junkName)
-		_, err = exec.RunHostCommand(DdevBin, "delete", "-Oy", junkName)
-		assert.NoError(err)
-
-		if runtime.GOOS == "windows" {
-			t.Logf("Windows: sleeping to let Windows finish deleting %s", junkName)
-			time.Sleep(3 * time.Second)
-		}
-		t.Logf("attempting to remove project files in %s", tmpJunkProjectDir)
-		err = os.RemoveAll(tmpJunkProjectDir)
-		if err != nil {
-			t.Logf("failed to remove junk project files in %s: %v", tmpJunkProjectDir, err)
-		}
+		out, err = exec.RunHostCommand(DdevBin, "delete", "-Oy", junkName)
+		require.NoError(t, err, "failed to remove project %s, out='%s' err=%v", junkName, out, err)
+		t.Logf("Output from 'ddev delete -Oy %s' was '%s'", junkName, out)
 
 		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 
@@ -382,6 +371,12 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 		// make sure sites are running again.
 		for _, site := range TestSites {
 			_, _ = exec.RunCommand(DdevBin, []string{"start", "-y", site.Name})
+		}
+
+		t.Logf("attempting to remove project files in %s", tmpJunkProjectDir)
+		err = os.RemoveAll(tmpJunkProjectDir)
+		if err != nil {
+			t.Logf("failed to remove junk project files in %s: %v", tmpJunkProjectDir, err)
 		}
 	})
 

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -367,7 +367,7 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 		assert.NoError(err)
 
 		if runtime.GOOS == "windows" {
-			t.Log("Windows: sleeping to let Windows finish deleting %s", junkName)
+			t.Logf("Windows: sleeping to let Windows finish deleting %s", junkName)
 			time.Sleep(3 * time.Second)
 		}
 		t.Logf("attempting to remove project files in %s", tmpJunkProjectDir)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
@@ -365,9 +366,15 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 		_, err = exec.RunHostCommand(DdevBin, "delete", "-Oy", junkName)
 		assert.NoError(err)
 
+		if runtime.GOOS == "windows" {
+			t.Log("Windows: sleeping to let Windows finish deleting %s", junkName)
+			time.Sleep(3 * time.Second)
+		}
 		t.Logf("attempting to remove project files in %s", tmpJunkProjectDir)
 		err = os.RemoveAll(tmpJunkProjectDir)
-		assert.NoError(err)
+		if err != nil {
+			t.Logf("failed to remove junk project files in %s: %v", tmpJunkProjectDir, err)
+		}
 
 		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -23,26 +23,16 @@ func TestCmdStart(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stop all sites.
-	_, err = exec.RunCommand(DdevBin, []string{"stop", "--all"})
+	out, err := exec.RunCommand(DdevBin, []string{"stop", "--all"})
 	assert.NoError(err)
-
-	// Ensure all sites are started after ddev start --all.
-	out, err := exec.RunCommand(DdevBin, []string{"start", "--all", "-y"})
-	assert.NoError(err, "ddev start --all should succeed but failed, err: %v, output: %s", err, out)
 	testcommon.CheckGoroutineOutput(t, out)
 
-	// Confirm all sites are running.
-	apps := ddevapp.GetActiveProjects()
-	for _, app := range apps {
-		status, statusDesc := app.SiteStatus()
-		assert.Equal(ddevapp.SiteRunning, status, "All sites should be running, but project=%s status=%sstatus description=%s", app.GetName(), status, statusDesc)
-		assert.Equal(ddevapp.SiteRunning, statusDesc, "The status description should be \"running\", but %s status description is: %s", app.GetName(), statusDesc)
+	apps := []*ddevapp.DdevApp{}
+	for _, testSite := range TestSites {
+		app, err := ddevapp.NewApp(testSite.Dir, false)
+		require.NoError(t, err)
+		apps = append(apps, app)
 	}
-
-	// Stop all sites.
-	out, err = exec.RunCommand(DdevBin, []string{"stop", "--all"})
-	assert.NoError(err)
-	testcommon.CheckGoroutineOutput(t, out)
 
 	// Build start command startMultipleArgs
 	startMultipleArgs := []string{"start", "-y"}
@@ -59,6 +49,6 @@ func TestCmdStart(t *testing.T) {
 	for _, app := range apps {
 		status, statusDesc := app.SiteStatus()
 		assert.Equal(ddevapp.SiteRunning, status, "All sites should be running, but project=%s status=%s statusDesc=%s", app.GetName(), status, statusDesc)
-		assert.Equal(ddevapp.SiteRunning, statusDesc, "The status description should be \"running\", but %s status description is: %s", app.GetName(), statusDesc)
+		assert.Equal(ddevapp.SiteRunning, statusDesc, `The status description should be "running", but project %s status  is: %s`, app.GetName(), statusDesc)
 	}
 }

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -277,7 +277,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 	// Stop the Mutagen daemon running in the $XDG_CONFIG_HOME/ddev
 	ddevapp.StopMutagenDaemon()
-	t.Log(fmt.Sprintf("stop mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
+	t.Logf("stopped mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory())
 	// After the $XDG_CONFIG_HOME directory is removed,
 	// globalconfig.GetGlobalDdevDir() should point to ~/.ddev
 	t.Setenv("XDG_CONFIG_HOME", "")
@@ -295,7 +295,7 @@ func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 	// Start mutagen daemon if it's enabled
 	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 		ddevapp.StartMutagenDaemon()
-		t.Log(fmt.Sprintf("start mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
+		t.Log(fmt.Sprintf("started mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
 		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), filepath.Join(globalconfig.GetGlobalDdevDir(), ".mdd"))
 	}


### PR DESCRIPTION

## The Issue

Debugging Windows TestPoweroffOnNewVersion (and fallout from its failure)

## How This PR Solves The Issue

One windows, give NTFS a few seconds to finish cleanup after `ddev delete`

