### PR TITLE
feat: don't override ddev-generated built-in project files created by add-on, fixes #6173, fixes #6190

### DIFF
--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/ddev/ddev/cmd/ddev/cmd"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/stretchr/testify/require"
-
-	"github.com/ddev/ddev/pkg/exec"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCmdAuthSSH runs `ddev auth ssh` and checks that it actually worked out.
@@ -68,7 +67,7 @@ func TestCmdAuthSSH(t *testing.T) {
 
 	// Now we add the key with passphrase
 	testAuthSSHDir := filepath.Join(origDir, "testdata", "TestCmdAuthSSH")
-	err = os.Chmod(filepath.Join(testAuthSSHDir, ".ssh", "id_rsa"), 0600)
+	err = util.Chmod(filepath.Join(testAuthSSHDir, ".ssh", "id_rsa"), 0600)
 	assert.NoError(err)
 	sshDir := filepath.Join(testAuthSSHDir, ".ssh")
 	out, err := exec.RunCommand("expect", []string{filepath.Join(testAuthSSHDir, "ddevauthssh.expect"), cmd.DdevBin, sshDir, "testkey"})

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -120,7 +120,7 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 		// Any command we find will want to be executable on Linux
 		// Note that this only affects host commands and project-level commands.
 		// Global container commands are made executable on `ddev start` instead.
-		_ = os.Chmod(onHostFullPath, 0755)
+		_ = util.Chmod(onHostFullPath, 0755)
 		if hasCR, _ := fileutil.FgrepStringInFile(onHostFullPath, "\r\n"); hasCR {
 			util.Warning("Command '%s' contains CRLF, please convert to Linux-style linefeeds with dos2unix or another tool, skipping %s", commandName, onHostFullPath)
 			continue
@@ -269,7 +269,7 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 			commandToAdd.Run = makeHostCmd(app, onHostFullPath, commandName)
 			if fileutil.FileExists(autocompletePathOnHost) {
 				// Make sure autocomplete script can be executed
-				_ = os.Chmod(autocompletePathOnHost, 0755)
+				_ = util.Chmod(autocompletePathOnHost, 0755)
 				if hasCR, _ := fileutil.FgrepStringInFile(autocompletePathOnHost, "\r\n"); hasCR {
 					util.Warning("Command '%s' contains CRLF, please convert to Linux-style linefeeds with dos2unix or another tool, skipping %s", commandName, onHostFullPath)
 					continue
@@ -288,7 +288,7 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 			commandToAdd.Run = makeContainerCmd(app, inContainerFullPath, commandName, service, execRaw, relative)
 			if fileutil.FileExists(autocompletePathOnHost) {
 				// Make sure autocomplete script can be executed
-				_ = os.Chmod(autocompletePathOnHost, 0755)
+				_ = util.Chmod(autocompletePathOnHost, 0755)
 				if hasCR, _ := fileutil.FgrepStringInFile(autocompletePathOnHost, "\r\n"); hasCR {
 					util.Warning("Autocomplete script for command '%s' contains CRLF, please convert to Linux-style linefeeds with dos2unix or another tool, skipping %s", commandName, autocompletePathOnHost)
 					continue

--- a/cmd/ddev/cmd/debug-test.go
+++ b/cmd/ddev/cmd/debug-test.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"github.com/ddev/ddev/pkg/ddevapp"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/util"
@@ -26,7 +26,7 @@ var DebugTestCmdCmd = &cobra.Command{
 		outputFilename := filepath.Join(tmpDir, "ddev-debug-test.txt")
 		outputFilename = filepath.ToSlash(outputFilename)
 		bashPath := util.FindBashPath()
-		err := fileutil.CopyEmbedAssets(bundledAssets, "scripts", tmpDir)
+		err := fileutil.CopyEmbedAssets(bundledAssets, "scripts", tmpDir, nil)
 		if err != nil {
 			util.Failed("Failed to copy test_ddev.sh to %s: %v", tmpDir, err)
 		}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -7,7 +7,6 @@ import (
 	"compress/bzip2"
 	"compress/gzip"
 	"fmt"
-	"github.com/ddev/ddev/pkg/fileutil"
 	"io"
 	"io/fs"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ulikunitz/xz"
 )
@@ -248,7 +248,7 @@ func Untar(source string, dest string, extractionDir string) error {
 				return err
 			}
 
-			err = os.Chmod(fullPath, fs.FileMode(file.Mode))
+			err = util.Chmod(fullPath, fs.FileMode(file.Mode))
 			if err != nil {
 				return fmt.Errorf("failed to chmod %v dir %v, err: %v", fs.FileMode(file.Mode), fullPath, err)
 			}
@@ -271,7 +271,7 @@ func Untar(source string, dest string, extractionDir string) error {
 			if err != nil {
 				return fmt.Errorf("failed to copy to file %v, err: %v", fullPath, err)
 			}
-			err = os.Chmod(fullPath, fs.FileMode(file.Mode))
+			err = util.Chmod(fullPath, fs.FileMode(file.Mode))
 			if err != nil {
 				return fmt.Errorf("failed to chmod %v file %v, err: %v", fs.FileMode(file.Mode), fullPath, err)
 			}

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -94,6 +94,22 @@ func GetInstalledAddonNames(app *DdevApp) []string {
 	return names
 }
 
+// GetInstalledAddonProjectFiles returns a list of project files installed by add-ons
+func GetInstalledAddonProjectFiles(app *DdevApp) []string {
+	manifests := GetInstalledAddons(app)
+	uniqueFilesMap := make(map[string]struct{})
+	for _, manifest := range manifests {
+		for _, file := range manifest.ProjectFiles {
+			uniqueFilesMap[filepath.Join(app.AppConfDir(), file)] = struct{}{}
+		}
+	}
+	uniqueFiles := make([]string, 0, len(uniqueFilesMap))
+	for file := range uniqueFilesMap {
+		uniqueFiles = append(uniqueFiles, file)
+	}
+	return uniqueFiles
+}
+
 // ProcessAddonAction takes a stanza from yaml exec section and executes it.
 func ProcessAddonAction(action string, dict map[string]interface{}, bashPath string, verbose bool) error {
 	action = "set -eu -o pipefail\n" + action

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -261,7 +261,7 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 				perms = 0755
 			}
 
-			err = os.Chmod(fp, os.FileMode(perms))
+			err = util.Chmod(fp, os.FileMode(perms))
 			if err != nil {
 				return "", fmt.Errorf("could not change permissions on file %s to make it writeable: %v", fp, err)
 			}

--- a/pkg/ddevapp/assets.go
+++ b/pkg/ddevapp/assets.go
@@ -2,10 +2,12 @@ package ddevapp
 
 import (
 	"embed"
+	"fmt"
 	"path/filepath"
 
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/util"
 )
 
 // The bundled assets for the project .ddev directory are in directory dotddev_assets
@@ -36,6 +38,7 @@ var bundledAssets embed.FS
 // directory's assets (if it's a project) and then later (when called with appName) update
 // the actual project's assets.
 func PopulateExamplesCommandsHomeadditions(appName string) error {
+	defer util.TimeTrackC(fmt.Sprintf("CopyEmbedAssets in PopulateExamplesCommandsHomeadditions(%s)", appName))()
 
 	err := fileutil.CopyEmbedAssets(bundledAssets, "global_dotddev_assets", globalconfig.GetGlobalDdevDir(), nil)
 	if err != nil {

--- a/pkg/ddevapp/assets.go
+++ b/pkg/ddevapp/assets.go
@@ -2,10 +2,10 @@ package ddevapp
 
 import (
 	"embed"
-	"github.com/ddev/ddev/pkg/globalconfig"
 	"path/filepath"
 
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 )
 
 // The bundled assets for the project .ddev directory are in directory dotddev_assets
@@ -37,7 +37,7 @@ var bundledAssets embed.FS
 // the actual project's assets.
 func PopulateExamplesCommandsHomeadditions(appName string) error {
 
-	err := fileutil.CopyEmbedAssets(bundledAssets, "global_dotddev_assets", globalconfig.GetGlobalDdevDir())
+	err := fileutil.CopyEmbedAssets(bundledAssets, "global_dotddev_assets", globalconfig.GetGlobalDdevDir(), nil)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func PopulateExamplesCommandsHomeadditions(appName string) error {
 		return nil
 	}
 
-	err = fileutil.CopyEmbedAssets(bundledAssets, "dotddev_assets", app.GetConfigPath(""))
+	err = fileutil.CopyEmbedAssets(bundledAssets, "dotddev_assets", app.GetConfigPath(""), GetInstalledAddonProjectFiles(app))
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -111,7 +111,7 @@ func writeBackdropSettingsDdevPHP(settings *BackdropSettings, filePath string, _
 
 	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+	if err = util.Chmod(dir, 0755); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
@@ -176,7 +176,7 @@ func backdropImportFilesAction(app *DdevApp, uploadDir, importPath, extPath stri
 	}
 
 	// parent of destination dir should be writable.
-	if err := os.Chmod(filepath.Dir(destPath), 0755); err != nil {
+	if err := util.Chmod(filepath.Dir(destPath), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1053,7 +1053,7 @@ RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -
 	// CopyEmbedAssets of postgres healthcheck has to be done after we WriteBuildDockerfile
 	// because that deletes the .dbimageBuild directory
 	if app.Database.Type == nodeps.Postgres {
-		err = fileutil.CopyEmbedAssets(bundledAssets, "healthcheck/db/postgres", app.GetConfigPath(".dbimageBuild"))
+		err = fileutil.CopyEmbedAssets(bundledAssets, "healthcheck/db/postgres", app.GetConfigPath(".dbimageBuild"), nil)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -28,7 +28,7 @@ func craftCmsImportFilesAction(app *DdevApp, uploadDir, importPath, extPath stri
 	}
 
 	// parent of destination dir should be writable.
-	if err := os.Chmod(filepath.Dir(destPath), 0755); err != nil {
+	if err := util.Chmod(filepath.Dir(destPath), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -563,7 +563,7 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 	if err != nil {
 		return err
 	}
-	err = os.Chmod(dbPath, 0777)
+	err = util.Chmod(dbPath, 0777)
 	if err != nil {
 		return err
 	}
@@ -1287,7 +1287,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 	}
 	// db_snapshots gets mounted into container, may have different user/group, so need 777
-	err = os.Chmod(app.GetConfigPath("db_snapshots"), 0777)
+	err = util.Chmod(app.GetConfigPath("db_snapshots"), 0777)
 	if err != nil {
 		return err
 	}
@@ -1700,7 +1700,7 @@ func (app *DdevApp) GeneratePostgresConfig() error {
 		}
 
 		if fileutil.FileExists(configPath) {
-			err = os.Chmod(configPath, 0666)
+			err = util.Chmod(configPath, 0666)
 			if err != nil {
 				return err
 			}
@@ -1722,7 +1722,7 @@ func (app *DdevApp) GeneratePostgresConfig() error {
 		if err != nil {
 			return err
 		}
-		err = os.Chmod(configPath, 0666)
+		err = util.Chmod(configPath, 0666)
 		if err != nil {
 			return err
 		}
@@ -3013,7 +3013,7 @@ func genericImportFilesAction(app *DdevApp, uploadDir, importPath, extPath strin
 	}
 
 	// parent of destination dir should be writable.
-	if err := os.Chmod(filepath.Dir(destPath), 0755); err != nil {
+	if err := util.Chmod(filepath.Dir(destPath), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/django.go
+++ b/pkg/ddevapp/django.go
@@ -2,15 +2,16 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/output"
-	"github.com/ddev/ddev/pkg/util"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
 )
 
 const siteSettingsDdevPy = "settings.ddev.py"
@@ -164,7 +165,7 @@ func writeDjango4SettingsDdevPy(filePath string, app *DdevApp) error {
 
 	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+	if err = util.Chmod(dir, 0755); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -118,7 +118,7 @@ func writeDrupalSettingsPHP(filePath string, appType string) error {
 
 	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+	if err = util.Chmod(dir, 0755); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
@@ -183,7 +183,7 @@ func writeDrupalSettingsDdevPhp(settings *DrupalSettings, filePath string, app *
 
 	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+	if err = util.Chmod(dir, 0755); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
@@ -237,7 +237,7 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
 
 	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	if err := os.Chmod(dir, 0755); os.IsNotExist(err) {
+	if err := util.Chmod(dir, 0755); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
@@ -493,7 +493,7 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 			continue
 		}
 
-		if err := os.Chmod(o, stat.Mode()|writePerms); err != nil {
+		if err := util.Chmod(o, stat.Mode()|writePerms); err != nil {
 			// Warn the user, but continue.
 			util.Warning("Unable to set permissions: %v", err)
 		}
@@ -569,7 +569,7 @@ func drupalImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string
 	}
 
 	// Parent of destination dir should be writable.
-	if err := os.Chmod(filepath.Dir(destPath), 0755); err != nil {
+	if err := util.Chmod(filepath.Dir(destPath), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -2,7 +2,6 @@ package ddevapp
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/ddev/ddev/pkg/archive"
@@ -78,7 +77,7 @@ func magentoImportFilesAction(app *DdevApp, uploadDir, importPath, extPath strin
 	}
 
 	// parent of destination dir should be writable.
-	if err := os.Chmod(filepath.Dir(destPath), 0755); err != nil {
+	if err := util.Chmod(filepath.Dir(destPath), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -536,7 +536,7 @@ func DownloadMutagen() error {
 	if err != nil {
 		return err
 	}
-	err = os.Chmod(globalconfig.GetMutagenPath(), 0755)
+	err = util.Chmod(globalconfig.GetMutagenPath(), 0755)
 	return err
 }
 

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -6,10 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ddev/ddev/pkg/util"
-
 	"github.com/ddev/ddev/pkg/archive"
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/util"
 	copy2 "github.com/otiai10/copy"
 )
 
@@ -37,7 +36,7 @@ func shopware6ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath str
 	}
 
 	// parent of destination dir should be writable.
-	if err := os.Chmod(filepath.Dir(destPath), 0755); err != nil {
+	if err := util.Chmod(filepath.Dir(destPath), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -14,9 +14,8 @@ import (
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
-	"github.com/stretchr/testify/require"
-
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSSHAuth tests basic SSH authentication
@@ -52,11 +51,11 @@ func TestSSHAuth(t *testing.T) {
 	srcDdev := filepath.Join(origDir, "testdata", t.Name(), ".ddev")
 	err = fileutil.CopyDir(filepath.Join(srcDdev, ".ssh"), app.GetConfigPath(".ssh"))
 	require.NoError(t, err)
-	err = os.Chmod(app.GetConfigPath(".ssh"), 0700)
+	err = util.Chmod(app.GetConfigPath(".ssh"), 0700)
 	require.NoError(t, err)
-	err = os.Chmod(app.GetConfigPath(".ssh/authorized_keys"), 0600)
+	err = util.Chmod(app.GetConfigPath(".ssh/authorized_keys"), 0600)
 	require.NoError(t, err)
-	err = os.Chmod(app.GetConfigPath(".ssh/id_rsa"), 0600)
+	err = util.Chmod(app.GetConfigPath(".ssh/id_rsa"), 0600)
 	require.NoError(t, err)
 	err = fileutil.CopyFile(filepath.Join(srcDdev, "docker-compose.sshserver.yaml"), app.GetConfigPath("docker-compose.sshserver.yaml"))
 	require.NoError(t, err)

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -64,7 +64,7 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 	// Ensure target directory is writable.
 	dir := filepath.Dir(filePath)
 	var perms os.FileMode = 0755
-	if err := os.Chmod(dir, perms); err != nil {
+	if err := util.Chmod(dir, perms); err != nil {
 		if !os.IsNotExist(err) {
 			// The directory exists, but chmod failed.
 			return err
@@ -82,7 +82,7 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 	settings := map[string]interface{}{"DBHostname": "db", "DBDriver": dbDriver, "DBPort": GetExposedPort(app, "db")}
 
 	// Ensure target directory exists and is writable
-	if err := os.Chmod(dir, 0755); os.IsNotExist(err) {
+	if err := util.Chmod(dir, 0755); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
@@ -177,7 +177,7 @@ func typo3ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string)
 	}
 
 	// parent of destination dir should be writable.
-	if err := os.Chmod(filepath.Dir(destPath), 0755); err != nil {
+	if err := util.Chmod(filepath.Dir(destPath), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -171,7 +171,7 @@ func writeWordpressSettingsFile(wordpressConfig *WordpressConfig, filePath strin
 
 	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+	if err = util.Chmod(dir, 0755); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
@@ -216,7 +216,7 @@ func writeWordpressDdevSettingsFile(config *WordpressConfig, filePath string) er
 
 	// Ensure target directory exists and is writable
 	dir := filepath.Dir(filePath)
-	if err = os.Chmod(dir, 0755); os.IsNotExist(err) {
+	if err = util.Chmod(dir, 0755); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
@@ -271,7 +271,7 @@ func wordpressImportFilesAction(app *DdevApp, target, importPath, extPath string
 	}
 
 	// Parent of destination dir should be writable.
-	if err := os.Chmod(filepath.Dir(destPath), 0755); err != nil {
+	if err := util.Chmod(filepath.Dir(destPath), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1545,7 +1545,7 @@ func DownloadDockerCompose() error {
 	// Remove the cached DockerComposeVersion
 	globalconfig.DockerComposeVersion = ""
 
-	err = os.Chmod(destFile, 0755)
+	err = util.Chmod(destFile, 0755)
 	if err != nil {
 		return err
 	}

--- a/pkg/fileutil/embed.go
+++ b/pkg/fileutil/embed.go
@@ -41,10 +41,10 @@ func CopyEmbedAssets(fsys embed.FS, sourceDir string, targetDir string, excluded
 					return err
 				}
 				if sigFound {
-					// TODO If the file already exists and has the same content, don't overwrite it.
-					//if existingContent, err := fsys.ReadFile(localPath); err == nil && string(existingContent) == string(content) {
-					//	continue
-					//}
+					// If the file already exists and has the same content, don't overwrite it.
+					if existingContent, err := os.ReadFile(localPath); err == nil && string(existingContent) == string(content) {
+						continue
+					}
 					// If the file already exists and is excluded, don't overwrite it.
 					if excludedFiles != nil && slices.Contains(excludedFiles, localPath) {
 						continue

--- a/pkg/fileutil/embed.go
+++ b/pkg/fileutil/embed.go
@@ -2,14 +2,17 @@ package fileutil
 
 import (
 	"embed"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
+
+	"github.com/ddev/ddev/pkg/nodeps"
 )
 
 // CopyEmbedAssets copies files in the named embed.FS sourceDir to the local targetDir (full path)
-func CopyEmbedAssets(fsys embed.FS, sourceDir string, targetDir string) error {
+// Some files may be excluded if they are in the excludedFiles list and contain #ddev-generated.
+func CopyEmbedAssets(fsys embed.FS, sourceDir string, targetDir string, excludedFiles []string) error {
 	subdirs, err := fsys.ReadDir(sourceDir)
 	if err != nil {
 		return err
@@ -17,7 +20,7 @@ func CopyEmbedAssets(fsys embed.FS, sourceDir string, targetDir string) error {
 	for _, d := range subdirs {
 		sourcePath := path.Join(sourceDir, d.Name())
 		if d.IsDir() {
-			err = CopyEmbedAssets(fsys, path.Join(sourceDir, d.Name()), path.Join(targetDir, d.Name()))
+			err = CopyEmbedAssets(fsys, path.Join(sourceDir, d.Name()), path.Join(targetDir, d.Name()), excludedFiles)
 			if err != nil {
 				return err
 			}
@@ -36,6 +39,16 @@ func CopyEmbedAssets(fsys embed.FS, sourceDir string, targetDir string) error {
 				err = os.MkdirAll(filepath.Dir(localPath), 0755)
 				if err != nil {
 					return err
+				}
+				if sigFound {
+					// TODO If the file already exists and has the same content, don't overwrite it.
+					//if existingContent, err := fsys.ReadFile(localPath); err == nil && string(existingContent) == string(content) {
+					//	continue
+					//}
+					// If the file already exists and is excluded, don't overwrite it.
+					if excludedFiles != nil && slices.Contains(excludedFiles, localPath) {
+						continue
+					}
 				}
 				err = os.WriteFile(localPath, content, 0755)
 				if err != nil {

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -54,7 +54,7 @@ func CopyFile(src string, dst string) error {
 			return err
 		}
 
-		err = os.Chmod(dst, si.Mode())
+		err = util.Chmod(dst, si.Mode())
 		if err != nil {
 			return fmt.Errorf("failed to chmod file %v to mode %v, err=%v", dst, si.Mode(), err)
 		}
@@ -160,7 +160,7 @@ func PurgeDirectory(path string) error {
 	}
 
 	for _, file := range files {
-		err = os.Chmod(filepath.Join(path, file), 0777)
+		err = util.Chmod(filepath.Join(path, file), 0777)
 		if err != nil {
 			return err
 		}

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -2,7 +2,6 @@ package fileutil_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,7 +9,9 @@ import (
 
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/ddev/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testFileLocation = "testdata/regular_file"
@@ -100,7 +101,7 @@ func TestPurgeDirectory(t *testing.T) {
 	err = fileutil.CopyFile(testFileLocation, tmpPurgeSubFile)
 	assert.NoError(err)
 
-	err = os.Chmod(tmpPurgeSubFile, 0444)
+	err = util.Chmod(tmpPurgeSubFile, 0444)
 	assert.NoError(err)
 
 	err = fileutil.PurgeDirectory(tmpPurgeDir)

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -211,7 +211,7 @@ func CreateTmpDir(prefix string) string {
 		log.Fatalf("Failed to create temp directory %s, err=%v", fullPath, err)
 	}
 	// Make the tmpdir fully writeable/readable, NFS problems
-	_ = os.Chmod(fullPath, 0777)
+	_ = util.Chmod(fullPath, 0777)
 	return fullPath
 }
 

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -372,3 +372,19 @@ func WindowsPathToCygwinPath(windowsPath string) string {
 	}
 	return windowsPath
 }
+
+// Chmod changes the file permissions of the named path,
+// if the path already has the necessary permissions, do nothing.
+// This is needed so that Mutagen doesn't track this change,
+// don't use os.Chmod in the DDEV code, use util.Chmod instead.
+func Chmod(path string, mode os.FileMode) error {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	// If the mode is the same, do nothing
+	if fileInfo.Mode().Perm() == mode {
+		return nil
+	}
+	return os.Chmod(path, mode)
+}


### PR DESCRIPTION
## The Issue

Add-ons can't properly manage built-in DDEV resources because when you remove `#ddev-generated` the file is no longer "installed" with the add-on. When you remove the add-on the file without the `#ddev-generated` is not removed. But when you leave out `#ddev-generated`, the file is replaced with DDEV:

- #6173

Built-in DDEV assets are copied every time:
- #6190

## How This PR Solves The Issue

Do not override bundled assets in the project directory if they are listed in add-on manifest in `project_files` and have `#ddev-generated`.

This will allow to override files generated by DDEV in `.ddev` directory, by moving control over them to the add-on.

And do not copy the embedded assets if their content is the same.

## Manual Testing Instructions

```
mkdir test-pr && cd test-pr
ddev config --auto
mkdir -p test-addon/xhprof && printf "name: test-addon\nproject_files:\n- xhprof/xhprof_prepend.php\n" > test-addon/install.yaml && printf "<?php\n#ddev-generated\n" > test-addon/xhprof/xhprof_prepend.php
ddev get test-addon
ddev start
```

Check the contents of `.ddev/xhprof/xhprof_prepend.php`.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

