### PR TITLE
test: Skip TestAutocompletionForCustomCmds because of slow mount responses

### DIFF
--- a/cmd/ddev/cmd/autocompletion_test.go
+++ b/cmd/ddev/cmd/autocompletion_test.go
@@ -216,6 +216,9 @@ func TestAutocompletionForCustomCmds(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping because untested on Windows")
 	}
+	if dockerutil.IsColima() {
+		t.Skip("Skipping on Colima because of slow mount responses")
+	}
 	assert := asrt.New(t)
 
 	origDir, _ := os.Getwd()


### PR DESCRIPTION

## The Issue

On upstream/master tests, TestAutocompletionForCustomCmds fails intermittently on Colima.

There's no need to test this everywhere, and the problem appears to be colima, especially without virtiofs. 

Disable the test on Colima.