### PR TITLE
build: download mkcert from github

### DIFF
--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-MKCERT_VERSION=v1.4.6
+MKCERT_VERSION=v1.4.4
 BUILD_IMAGE_TARBALLS=${BUILD_IMAGE_TARBALLS:-false}
 
 ARTIFACTS=${1:-/artifacts}
@@ -45,33 +45,35 @@ if [ "${BUILD_IMAGE_TARBALLS}" = "true" ]; then
 fi
 
 
+echo "Using github as source for mkcert binaries for tarballs"
+
 # Generate macOS-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/darwin_amd64 >/dev/null
-curl --fail -JL -s -o mkcert "https://dl.filippo.io/mkcert/latest?for=darwin/amd64" && chmod +x mkcert
+curl --fail -JL -s -o mkcert "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-amd64" && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_macos-amd64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # Generate macOS-arm64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/darwin_arm64 >/dev/null
-curl --fail -JL -s -o mkcert "https://dl.filippo.io/mkcert/latest?for=darwin/arm64" && chmod +x mkcert
+curl --fail -JL -s -o mkcert "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-darwin-arm64" && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_macos-arm64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # Generate linux-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/linux_amd64 >/dev/null
-curl --fail -JL -s -o mkcert "https://dl.filippo.io/mkcert/latest?for=linux/amd64" && chmod +x mkcert
+curl --fail -JL -s -o mkcert "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64" && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_linux-amd64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # Generate linux-arm64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/linux_arm64 >/dev/null
-curl --fail -JL -s -o mkcert "https://dl.filippo.io/mkcert/latest?for=linux/arm64" && chmod +x mkcert
+curl --fail -JL -s -o mkcert "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-arm64" && chmod +x mkcert
 tar -czf $ARTIFACTS/ddev_linux-arm64.$VERSION.tar.gz ddev  mkcert
 popd >/dev/null
 
 # generate windows-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
-curl --fail -JL -s -o mkcert "https://dl.filippo.io/mkcert/latest?for=windows/amd64"
+curl --fail -JL -s -o mkcert "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe"
 tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe  mkcert.exe
 popd >/dev/null
 


### PR DESCRIPTION

## The Issue

In generate_artifacts.sh (which builds the tarball versions for the release page) the curl download `curl --fail -JL -s -o mkcert "https://dl.filippo.io/mkcert/latest?for=windows/amd64"` was hanging, timing out, and causing build failure. 

## How This PR Solves The Issue

Download from the github release instead of downloading from dl.filippo.io.

