### PR TITLE
build: bump upload-artifact to v4 and fix mkcert.exe in tarball/zipball [skip ci]

### DIFF
--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -73,7 +73,7 @@ popd >/dev/null
 
 # generate windows-amd64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
-curl --fail -JL -s -o mkcert "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe"
+curl --fail -JL -s -o mkcert.exe "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe"
 tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe  mkcert.exe
 popd >/dev/null
 

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -258,32 +258,32 @@ jobs:
         run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
       - name: Upload all artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: all-ddev-executables
           path: ${{ github.workspace }}/artifacts/*
       - name: Upload macos-amd64 binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ddev-macos-amd64
           path: .gotmp/bin/darwin_amd64/ddev
       - name: Upload macos-arm64 binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ddev-macos-arm64
           path: .gotmp/bin/darwin_arm64/ddev
       - name: Upload linux-arm64 binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ddev-linux-arm64
           path: .gotmp/bin/linux_arm64/ddev
       - name: Upload linux-amd64 binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ddev-linux-amd64
           path: .gotmp/bin/linux_amd64/ddev
       - name: Upload windows_amd64 installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-amd64-installer
           path: .gotmp/bin/windows_amd64/ddev_windows_installer*.exe

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -64,32 +64,32 @@ jobs:
         run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
       - name: Upload all artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: all-ddev-executables
           path: ${{ github.workspace }}/artifacts/*
       - name: Upload macos-amd64 binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ddev-macos-amd64
           path: .gotmp/bin/darwin_amd64/ddev
       - name: Upload macos-arm64 binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ddev-macos-arm64
           path: .gotmp/bin/darwin_arm64/ddev
       - name: Upload linux-arm64 binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ddev-linux-arm64
           path: .gotmp/bin/linux_arm64/ddev
       - name: Upload linux-amd64 binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ddev-linux-amd64
           path: .gotmp/bin/linux_amd64/ddev
       - name: Upload windows_amd64 installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-amd64-installer
           path: .gotmp/bin/windows_amd64/ddev_windows_installer*.exe


### PR DESCRIPTION

## The Issue

* upload-artifact is deprecated and needs to bump to v4
* mkcert.exe in tarball/zipball is wrong.

