### PR TITLE
fix: detect Rancher Desktop, fixes #6259

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -73,15 +73,14 @@ func GetDockerPlatform() (string, error) {
 	switch {
 	case strings.HasPrefix(platform, "Docker Desktop"):
 		platform = "docker-desktop"
+	case strings.HasPrefix(platform, "Rancher Desktop") || strings.Contains(info.Name, "rancher-desktop"):
+		platform = "rancher-desktop"
 	case strings.HasPrefix(info.Name, "colima"):
 		platform = "colima"
 	case strings.HasPrefix(info.Name, "lima"):
 		platform = "lima"
 	case platform == "OrbStack":
 		platform = "orbstack"
-	case strings.HasPrefix(platform, "Rancher Desktop") || strings.Contains(info.Name, "rancher-desktop"):
-
-		platform = "rancher-desktop"
 	case nodeps.IsWSL2() && info.OSType == "linux":
 		platform = "wsl2-docker-ce"
 	case !nodeps.IsWSL2() && info.OSType == "linux":


### PR DESCRIPTION
## The Issue

- #6259

```
docker info | grep rancher
 Context:    rancher-desktop
 Name: lima-rancher-desktop
```

The name has `lima` prefix (it was added at some point?), and `lima` is checked earlier.

## How This PR Solves The Issue

Moves up the condition for Rancher Desktop detection.

## Manual Testing Instructions

1. Use Rancher Desktop
2. `ddev version`
3. See `docker-platform  rancher-desktop`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

