### PR TITLE
test: Don't use php package in TestExtraPackages

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -3,7 +3,6 @@ package ddevapp_test
 import (
 	"bufio"
 	"fmt"
-	copy2 "github.com/otiai10/copy"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -11,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	copy2 "github.com/otiai10/copy"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ddev/ddev/pkg/ddevapp"
@@ -986,9 +987,7 @@ func TestExtraPackages(t *testing.T) {
 	require.NoError(t, err)
 
 	addedDBPackage := "sudo"
-	// php-gmp is flaky on Debian 12 Bookworm,
-	// we can test it https://github.com/ddev/ddev/issues/5898
-	addedWebPackage := "php" + app.PHPVersion + "-" + "gmp"
+	addedWebPackage := "dnsutils"
 
 	// Test db container to make sure no sudo in there at beginning
 	_, _, err = app.Exec(&ddevapp.ExecOpts{


### PR DESCRIPTION

## The Issue

Failures from packages.sury.org have broken our tests for a day or so, and this has happened before. 

TestExtraPackages doesn't really need to test a PHP package, so at least for now it would be nice to move forward, so using a non-deb.sury.org package there.

* https://github.com/oerdnj/deb.sury.org/issues/2046#issuecomment-2143131325

## How This PR Solves The Issue

Use a non-deb.sury.org package for TestExtraPackages.

