### PR TITLE
refactor: make "waiting for" message more generic

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1423,7 +1423,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
 		dependers = append(dependers, "db")
 	}
-	output.UserOut.Printf("Waiting for web/db containers to become ready: %v", dependers)
+	output.UserOut.Printf("Waiting for containers to become ready: %v", dependers)
 	waitErr := app.Wait(dependers)
 
 	err = PopulateGlobalCustomCommandFiles()


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

On a test project, I disabled the database using:

```yml
omit_containers: 
- "db"
```

When I started the project, I saw:

```
$ ddev start
...
Waiting for web/db containers to become ready: [web] 
```

## How This PR Solves The Issue

This (nitpic) PR makes the output more generic:

```diff
- Waiting for web/db containers to become ready: [web] 
+ Waiting for containers to become ready: [web] 
```

The line continues to show container names ('web') at the end.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

