### PR TITLE
docs: fix mutagen example command

### DIFF
--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -154,7 +154,7 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
     * DDEV’s private Mutagen binary is installed in `~/.ddev/bin/mutagen` (or `$XDG_CONFIG_BASE/ddev/bin/mutagen`. You can use all the features of Mutagen with `ddev debug mutagen`. For example:
 
         ```bash
-        debug mutagen sync list --template "{{ json (index . 0) }}" | jq -r
+        ddev debug mutagen sync list --template "{{ json (index . 0) }}" | docker run -i --rm ddev/ddev-utilities jq -r
         ddev debug mutagen sync monitor <projectname> -l
         ```
     * You can run the [diagnose_mutagen.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/diagnose_mutagen.sh) script to gather information about Mutagen’s setup. Please share output from it when creating an issue or seeking support.


### PR DESCRIPTION
## The Issue

The example command is missing `ddev` at the start, `jq` may not be available.

## How This PR Solves The Issue

Fixes it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

