### PR TITLE
build: bump goreleaser to v2, update its action to v6

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -236,7 +236,7 @@ jobs:
 
       # Goreleaser does GitHub release artifacts, homebrew, AUR, deb/rpm
       - name: goreleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         if: startsWith( github.ref, 'refs/tags/v1')
         with:
           distribution: goreleaser-pro

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 ##### BUILDS ######
 builds:
 - id: ddev


### PR DESCRIPTION
## The Issue

https://goreleaser.com/blog/goreleaser-v2/#upgrading

## How This PR Solves The Issue

Bumps it.
I ran `goreleaser check` - all good.

## Manual Testing Instructions

## Automated Testing Overview

## Related Issue Link(s)

## Release/Deployment Notes

I created a test release here https://github.com/ddev-test/ddev/releases/tag/v1.22.11-goreleaser