### PR TITLE
fix: Composer post-root-package-install didn't work with Mutagen enabled

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -164,6 +164,12 @@ ddev composer create --preserve-flags --no-interaction psr/log
 			util.Failed("failed to create project: %v", err)
 		}
 
+		// Make sure composer.json is here with Mutagen enabled
+		err = app.MutagenSyncFlush()
+		if err != nil {
+			util.Failed("Failed to flush Mutagen: %v", err)
+		}
+
 		composerManifest, _ := composer.NewManifest(path.Join(composerRoot, "composer.json"))
 
 		if !preserveFlags && composerManifest != nil && composerManifest.HasPostRootPackageInstallScript() {


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/6256#discussion_r1627427307

`.env.local` is not created in the Sulu project quickstart, but it should.
`ddev composer create` doesn't run `post-root-package-install` composer script because Mutagen doesn't perform a sync.

## How This PR Solves The Issue

Adds additional `app.MutagenSyncFlush()` right before checking for `composer.json`

## Manual Testing Instructions

```
ddev config global --performance-mode=mutagen

mkdir my-sulu-site && cd my-sulu-site
ddev config --project-type=php --docroot=public --upload-dirs=uploads
ddev composer create sulu/skeleton

# see this in the output:
Executing composer command: [composer run-script post-root-package-install]

# and check if the file exists, it should:
ls .env.local
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

