### PR TITLE
fix: make self-upgrade command respect spaces, fixes #6274

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -9,7 +9,7 @@
 
 # split the loop output below by newlines
 IFS=$'\n'
-for ddev_path in $(which -a ddev); do
+for ddev_path in $(which -a ddev | uniq); do
   case $ddev_path in
     "/usr/bin/ddev")
       if [[ ${OSTYPE} = "linux-gnu"* ]]; then

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -7,6 +7,8 @@
 ## Example: "ddev self-upgrade"
 ## CanRunGlobally: true
 
+# split the loop output below by newlines
+IFS=$'\n'
 for ddev_path in $(which -a ddev); do
   case $ddev_path in
     "/usr/bin/ddev")


### PR DESCRIPTION
## The Issue

- #6274

The issue is caused by the fact that for loop items in bash were split by spaces.

## How This PR Solves The Issue

Adds split by newlines only.

## Manual Testing Instructions

Can be tested without Windows:

```
mkdir -p "$HOME/folder space"
cp $(which ddev) "$HOME/folder space"
export PATH="$HOME/folder space":$PATH
ddev self-upgrade
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
