### PR TITLE
refactor: Update to new amplitude/analytics-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/amplitude/analytics-go v1.0.1
+	github.com/amplitude/analytics-go v1.0.2
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/cheggaaa/pb v1.0.29
 	github.com/denisbrodbeck/machineid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX7IL/m9Y5LO+KQYv+t1CQOiFe6+SV2J7bE=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
-github.com/amplitude/analytics-go v1.0.1 h1:rrdC5VBctlJigSk0kw7ktwSijob/wyH4bop2SqWduCU=
-github.com/amplitude/analytics-go v1.0.1/go.mod h1:kAQG8OQ6aPOxZrEZ3+/NFCfxdYSyjqXZhgkjWFD3/vo=
+github.com/amplitude/analytics-go v1.0.2 h1:GiKYxFwuuEcEgNpw8p4lPiIXHL6z9iEXa8QlkZDQpUk=
+github.com/amplitude/analytics-go v1.0.2/go.mod h1:kAQG8OQ6aPOxZrEZ3+/NFCfxdYSyjqXZhgkjWFD3/vo=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=

--- a/vendor/github.com/amplitude/analytics-go/amplitude/constants/constants.go
+++ b/vendor/github.com/amplitude/analytics-go/amplitude/constants/constants.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	SdkLibrary = "amplitude-go"
-	SdkVersion = "1.0.1"
+	SdkVersion = "1.0.2"
 
 	IdentifyEventType      = "$identify"
 	GroupIdentifyEventType = "$groupidentify"

--- a/vendor/github.com/amplitude/analytics-go/amplitude/plugins/destination/internal/amplitude_http_client.go
+++ b/vendor/github.com/amplitude/analytics-go/amplitude/plugins/destination/internal/amplitude_http_client.go
@@ -109,6 +109,9 @@ func (c *amplitudeHTTPClient) Send(payload AmplitudePayload) AmplitudeResponse {
 	var amplitudeResponse AmplitudeResponse
 	if json.Valid(body) {
 		_ = json.Unmarshal(body, &amplitudeResponse)
+	} else {
+		c.logger.Debugf("HTTP response body is not valid JSON: %s", string(body))
+		amplitudeResponse.Code = response.StatusCode
 	}
 
 	amplitudeResponse.Status = response.StatusCode

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -39,7 +39,7 @@ github.com/ProtonMail/go-crypto/openpgp/internal/ecc
 github.com/ProtonMail/go-crypto/openpgp/internal/encoding
 github.com/ProtonMail/go-crypto/openpgp/packet
 github.com/ProtonMail/go-crypto/openpgp/s2k
-# github.com/amplitude/analytics-go v1.0.1
+# github.com/amplitude/analytics-go v1.0.2
 ## explicit; go 1.17
 github.com/amplitude/analytics-go/amplitude
 github.com/amplitude/analytics-go/amplitude/constants


### PR DESCRIPTION

## The Issue

Amplitude did a [new 1.0.2 release](https://github.com/amplitude/analytics-go/releases/tag/v1.0.2) of their analytics-go, which we use.

It appeared to be a minor bug fix only, but this package gets very little maintenance, so I wanted to make sure we explicitly updated and tested it instead of getting it by accident someday in the future.

## How This PR Solves The Issue

Use the new version

## Manual Testing Instructions

Manual testing is the key here. 

Use https://ddev.readthedocs.io/en/stable/developers/building-contributing/#examining-data-on-amplitudecom

Verify that expected events are arriving.

