### PR TITLE
test: fix TestFileHash on Windows, fixes #6284

### DIFF
--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -69,7 +68,7 @@ var AuthSSHCommand = &cobra.Command{
 		if err != nil {
 			util.Failed("Failed to start ddev-ssh-agent container: %v", err)
 		}
-		sshKeyPath = dockerutil.MassageWindowsHostMountpoint(sshKeyPath)
+		sshKeyPath = nodeps.WindowsPathToCygwinPath(sshKeyPath)
 
 		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--entrypoint=", "--mount=type=bind,src=" + sshKeyPath + ",dst=/tmp/sshtmp", versionconstants.SSHAuthImage + ":" + versionconstants.SSHAuthTag + "-built", "bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && ssh-add $(file * | awk -F: "/private key/ { print \$1 }")`}
 

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -68,7 +68,7 @@ var AuthSSHCommand = &cobra.Command{
 		if err != nil {
 			util.Failed("Failed to start ddev-ssh-agent container: %v", err)
 		}
-		sshKeyPath = nodeps.WindowsPathToCygwinPath(sshKeyPath)
+		sshKeyPath = util.WindowsPathToCygwinPath(sshKeyPath)
 
 		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--entrypoint=", "--mount=type=bind,src=" + sshKeyPath + ",dst=/tmp/sshtmp", versionconstants.SSHAuthImage + ":" + versionconstants.SSHAuthTag + "-built", "bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && ssh-add $(file * | awk -F: "/private key/ { print \$1 }")`}
 

--- a/cmd/ddev/cmd/debug-test.go
+++ b/cmd/ddev/cmd/debug-test.go
@@ -2,12 +2,12 @@ package cmd
 
 import (
 	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 
-	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/util"
@@ -31,7 +31,7 @@ var DebugTestCmdCmd = &cobra.Command{
 		if err != nil {
 			util.Failed("Failed to copy test_ddev.sh to %s: %v", tmpDir, err)
 		}
-		p := dockerutil.MassageWindowsHostMountpoint(tmpDir)
+		p := nodeps.WindowsPathToCygwinPath(tmpDir)
 		c := []string{"-c", path.Join(p, "test_ddev.sh") + " " + outputFilename}
 		util.Success("Running %s %v", bashPath, c)
 

--- a/cmd/ddev/cmd/debug-test.go
+++ b/cmd/ddev/cmd/debug-test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"io"
 	"os"
 	"path"
@@ -31,7 +30,7 @@ var DebugTestCmdCmd = &cobra.Command{
 		if err != nil {
 			util.Failed("Failed to copy test_ddev.sh to %s: %v", tmpDir, err)
 		}
-		p := nodeps.WindowsPathToCygwinPath(tmpDir)
+		p := util.WindowsPathToCygwinPath(tmpDir)
 		c := []string{"-c", path.Join(p, "test_ddev.sh") + " " + outputFilename}
 		util.Success("Running %s %v", bashPath, c)
 

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -107,7 +107,7 @@ func TestCmdExec(t *testing.T) {
 	bashPath := util.FindBashPath()
 	// Make sure we can pipe things into ddev exec and have them work in stdin inside container
 	filename := t.Name() + "_junk.txt"
-	ddevBinForBash := dockerutil.MassageWindowsHostMountpoint(DdevBin)
+	ddevBinForBash := nodeps.WindowsPathToCygwinPath(DdevBin)
 	_, err = exec.RunHostCommand(bashPath, "-c", fmt.Sprintf(`printf "This file was piped into ddev exec" | %s exec "cat >/var/www/html/%s"`, ddevBinForBash, filename))
 	assert.NoError(err)
 	err = app.MutagenSyncFlush()
@@ -124,7 +124,7 @@ func TestCmdExec(t *testing.T) {
 	assert.NoError(err)
 	defer os.Remove(f.Name()) // nolint: errcheck
 
-	bashTempName := dockerutil.MassageWindowsHostMountpoint(f.Name())
+	bashTempName := nodeps.WindowsPathToCygwinPath(f.Name())
 	_, err = exec.RunHostCommand(bashPath, "-c", fmt.Sprintf("%s exec ls -l //usr/local/bin/composer >%s", ddevBinForBash, bashTempName))
 
 	out, err = fileutil.ReadFileIntoString(f.Name())

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -107,7 +106,7 @@ func TestCmdExec(t *testing.T) {
 	bashPath := util.FindBashPath()
 	// Make sure we can pipe things into ddev exec and have them work in stdin inside container
 	filename := t.Name() + "_junk.txt"
-	ddevBinForBash := nodeps.WindowsPathToCygwinPath(DdevBin)
+	ddevBinForBash := util.WindowsPathToCygwinPath(DdevBin)
 	_, err = exec.RunHostCommand(bashPath, "-c", fmt.Sprintf(`printf "This file was piped into ddev exec" | %s exec "cat >/var/www/html/%s"`, ddevBinForBash, filename))
 	assert.NoError(err)
 	err = app.MutagenSyncFlush()
@@ -124,7 +123,7 @@ func TestCmdExec(t *testing.T) {
 	assert.NoError(err)
 	defer os.Remove(f.Name()) // nolint: errcheck
 
-	bashTempName := nodeps.WindowsPathToCygwinPath(f.Name())
+	bashTempName := util.WindowsPathToCygwinPath(f.Name())
 	_, err = exec.RunHostCommand(bashPath, "-c", fmt.Sprintf("%s exec ls -l //usr/local/bin/composer >%s", ddevBinForBash, bashTempName))
 
 	out, err = fileutil.ReadFileIntoString(f.Name())

--- a/pkg/ddevapp/providerLocalfile_test.go
+++ b/pkg/ddevapp/providerLocalfile_test.go
@@ -1,6 +1,7 @@
 package ddevapp_test
 
 import (
+	"github.com/ddev/ddev/pkg/util"
 	"os"
 	"path"
 	"path/filepath"
@@ -60,8 +61,8 @@ func TestLocalfilePull(t *testing.T) {
 	// Build our localfile.yaml from the example file
 	s, err := os.ReadFile(app.GetConfigPath("providers/localfile.yaml.example"))
 	require.NoError(t, err)
-	x := strings.Replace(string(s), "~/Dropbox", path.Join(nodeps.WindowsPathToCygwinPath(origDir), "testdata", t.Name()), -1)
-	appRoot := nodeps.WindowsPathToCygwinPath(app.AppRoot)
+	x := strings.Replace(string(s), "~/Dropbox", path.Join(util.WindowsPathToCygwinPath(origDir), "testdata", t.Name()), -1)
+	appRoot := util.WindowsPathToCygwinPath(app.AppRoot)
 	x = strings.Replace(x, "/full/path/to/project/root", appRoot, -1)
 	err = os.WriteFile(app.GetConfigPath("providers/localfile.yaml"), []byte(x), 0666)
 	assert.NoError(err)

--- a/pkg/ddevapp/providerLocalfile_test.go
+++ b/pkg/ddevapp/providerLocalfile_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
@@ -61,8 +60,8 @@ func TestLocalfilePull(t *testing.T) {
 	// Build our localfile.yaml from the example file
 	s, err := os.ReadFile(app.GetConfigPath("providers/localfile.yaml.example"))
 	require.NoError(t, err)
-	x := strings.Replace(string(s), "~/Dropbox", path.Join(dockerutil.MassageWindowsHostMountpoint(origDir), "testdata", t.Name()), -1)
-	appRoot := dockerutil.MassageWindowsHostMountpoint(app.AppRoot)
+	x := strings.Replace(string(s), "~/Dropbox", path.Join(nodeps.WindowsPathToCygwinPath(origDir), "testdata", t.Name()), -1)
+	appRoot := nodeps.WindowsPathToCygwinPath(app.AppRoot)
 	x = strings.Replace(x, "/full/path/to/project/root", appRoot, -1)
 	err = os.WriteFile(app.GetConfigPath("providers/localfile.yaml"), []byte(x), 0666)
 	assert.NoError(err)

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -1,7 +1,6 @@
 package ddevapp_test
 
 import (
-	"github.com/ddev/ddev/pkg/nodeps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -89,7 +88,7 @@ func TestSSHAuth(t *testing.T) {
 	// ddev auth ssh command, and with an expect script to provide the passphrase.
 	uidStr, _, username := util.GetContainerUIDGid()
 	sshKeyPath := app.GetConfigPath(".ssh")
-	sshKeyPath = nodeps.WindowsPathToCygwinPath(sshKeyPath)
+	sshKeyPath = util.WindowsPathToCygwinPath(sshKeyPath)
 
 	err = exec.RunInteractiveCommand("docker", []string{"run", "-t", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "-v", sshKeyPath + ":/home/" + username + "/.ssh", "-u", uidStr, versionconstants.SSHAuthImage + ":" + versionconstants.SSHAuthTag + "-built", "//test.expect.passphrase"})
 	require.NoError(t, err)

--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -1,6 +1,7 @@
 package ddevapp_test
 
 import (
+	"github.com/ddev/ddev/pkg/nodeps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,7 +89,7 @@ func TestSSHAuth(t *testing.T) {
 	// ddev auth ssh command, and with an expect script to provide the passphrase.
 	uidStr, _, username := util.GetContainerUIDGid()
 	sshKeyPath := app.GetConfigPath(".ssh")
-	sshKeyPath = dockerutil.MassageWindowsHostMountpoint(sshKeyPath)
+	sshKeyPath = nodeps.WindowsPathToCygwinPath(sshKeyPath)
 
 	err = exec.RunInteractiveCommand("docker", []string{"run", "-t", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "-v", sshKeyPath + ":/home/" + username + "/.ssh", "-u", uidStr, versionconstants.SSHAuthImage + ":" + versionconstants.SSHAuthTag + "-built", "//test.expect.passphrase"})
 	require.NoError(t, err)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1116,18 +1116,6 @@ func GetExposedContainerPorts(containerID string) ([]string, error) {
 	return ports, nil
 }
 
-// MassageWindowsHostMountpoint changes C:/path/to/something to //c/path/to/something
-// This is required for Docker bind mounts on Docker toolbox.
-// Sadly, if we have a Windows drive name, it has to be converted from C:/ to //c for Win10Home/Docker toolbox
-func MassageWindowsHostMountpoint(mountPoint string) string {
-	if string(mountPoint[1]) == ":" {
-		pathPortion := strings.Replace(mountPoint[2:], `\`, "/", -1)
-		drive := strings.ToLower(string(mountPoint[0]))
-		mountPoint = "/" + drive + pathPortion
-	}
-	return mountPoint
-}
-
 // MassageWindowsNFSMount changes C:\Path\to\something to /c/Path/to/something
 func MassageWindowsNFSMount(mountPoint string) string {
 	if string(mountPoint[1]) == ":" {

--- a/pkg/fileutil/file_hash.go
+++ b/pkg/fileutil/file_hash.go
@@ -3,9 +3,10 @@ package fileutil
 import (
 	"crypto/sha1"
 	"fmt"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"io"
 	"os"
-	"path/filepath"
+	"runtime"
 
 	"github.com/ddev/ddev/pkg/util"
 )
@@ -31,7 +32,15 @@ func FileHash(filePath string, optionalExtraString string) (string, error) {
 	// Include file location in the hash, if in a different
 	// place it should not hash the same
 	// file.Name() is the full path of the file
-	if _, err := hash.Write([]byte(filepath.ToSlash(file.Name()))); err != nil {
+
+	canonicalFileName := file.Name()
+
+	// Use a canonical filename in unix-style format so that we don't
+	// get caught by differences in filename format on Windows.
+	if runtime.GOOS == "windows" {
+		canonicalFileName = nodeps.WindowsPathToCygwinPath(canonicalFileName)
+	}
+	if _, err := hash.Write([]byte(canonicalFileName)); err != nil {
 		return "", err
 	}
 

--- a/pkg/fileutil/file_hash.go
+++ b/pkg/fileutil/file_hash.go
@@ -3,7 +3,6 @@ package fileutil
 import (
 	"crypto/sha1"
 	"fmt"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"io"
 	"os"
 	"runtime"
@@ -38,7 +37,7 @@ func FileHash(filePath string, optionalExtraString string) (string, error) {
 	// Use a canonical filename in unix-style format so that we don't
 	// get caught by differences in filename format on Windows.
 	if runtime.GOOS == "windows" {
-		canonicalFileName = nodeps.WindowsPathToCygwinPath(canonicalFileName)
+		canonicalFileName = util.WindowsPathToCygwinPath(canonicalFileName)
 	}
 	if _, err := hash.Write([]byte(canonicalFileName)); err != nil {
 		return "", err

--- a/pkg/fileutil/file_hash.go
+++ b/pkg/fileutil/file_hash.go
@@ -3,9 +3,11 @@ package fileutil
 import (
 	"crypto/sha1"
 	"fmt"
-	"github.com/ddev/ddev/pkg/util"
 	"io"
 	"os"
+	"path/filepath"
+
+	"github.com/ddev/ddev/pkg/util"
 )
 
 // FileHash returns string of hash of filePath passed in
@@ -29,7 +31,7 @@ func FileHash(filePath string, optionalExtraString string) (string, error) {
 	// Include file location in the hash, if in a different
 	// place it should not hash the same
 	// file.Name() is the full path of the file
-	if _, err := hash.Write([]byte(file.Name())); err != nil {
+	if _, err := hash.Write([]byte(filepath.ToSlash(file.Name()))); err != nil {
 		return "", err
 	}
 

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -2,7 +2,6 @@ package fileutil_test
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"os"
 	"path"
 	"path/filepath"
@@ -49,7 +48,7 @@ func TestFileHash(t *testing.T) {
 			// we can use the externalComputeSha1Sum successfully
 			canonicalFileName := testFile
 			if runtime.GOOS == "windows" {
-				canonicalFileName = nodeps.WindowsPathToCygwinPath(testFile)
+				canonicalFileName = util.WindowsPathToCygwinPath(testFile)
 			}
 			f, err := os.OpenFile(testFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			require.NoError(t, err)
@@ -74,7 +73,7 @@ func externalComputeSha1Sum(filePath string) (string, error) {
 	// Use a canonical filename in unix-style format so that we don't
 	// get caught by differences in filename format on Windows.
 	if runtime.GOOS == "windows" {
-		filePath = nodeps.WindowsPathToCygwinPath(filePath)
+		filePath = util.WindowsPathToCygwinPath(filePath)
 	}
 	dir := path.Dir(filePath)
 	_, out, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"sha1sum", filePath}, nil, nil, []string{dir + ":" + dir}, "0", true, false, nil, nil, nil)

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
@@ -65,6 +67,14 @@ func TestFileHash(t *testing.T) {
 // externalComputeSha1Sum uses external tool (sha1sum for example) to compute shasum
 func externalComputeSha1Sum(filePath string) (string, error) {
 	filePath = filepath.ToSlash(filePath)
+	// Convert Windows path to POSIX path
+	if runtime.GOOS == "windows" {
+		out, err := exec.RunCommand("cygpath", []string{"-u", filePath})
+		if err != nil {
+			return "", err
+		}
+		filePath = out
+	}
 	dir := filepath.Dir(filePath)
 	_, out, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"sha1sum", filePath}, nil, nil, []string{dir + ":" + dir}, "0", true, false, nil, nil, nil)
 

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -2,16 +2,17 @@ package fileutil_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
 // TestFileHash is a unit test for FileHash()
@@ -63,6 +64,7 @@ func TestFileHash(t *testing.T) {
 
 // externalComputeSha1Sum uses external tool (sha1sum for example) to compute shasum
 func externalComputeSha1Sum(filePath string) (string, error) {
+	filePath = filepath.ToSlash(filePath)
 	dir := filepath.Dir(filePath)
 	_, out, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"sha1sum", filePath}, nil, nil, []string{dir + ":" + dir}, "0", true, false, nil, nil, nil)
 

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -2,14 +2,15 @@ package fileutil_test
 
 import (
 	"fmt"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
-	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
@@ -46,9 +47,13 @@ func TestFileHash(t *testing.T) {
 
 			// But we have to add the filepath to the testFile before
 			// we can use the externalComputeSha1Sum successfully
+			canonicalFileName := testFile
+			if runtime.GOOS == "windows" {
+				canonicalFileName = nodeps.WindowsPathToCygwinPath(testFile)
+			}
 			f, err := os.OpenFile(testFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			require.NoError(t, err)
-			_, err = f.WriteString(testFile)
+			_, err = f.WriteString(canonicalFileName)
 			require.NoError(t, err)
 			if tc.optionalExtra != "" {
 				_, err = f.WriteString(tc.optionalExtra)
@@ -66,16 +71,12 @@ func TestFileHash(t *testing.T) {
 
 // externalComputeSha1Sum uses external tool (sha1sum for example) to compute shasum
 func externalComputeSha1Sum(filePath string) (string, error) {
-	filePath = filepath.ToSlash(filePath)
-	// Convert Windows path to POSIX path
+	// Use a canonical filename in unix-style format so that we don't
+	// get caught by differences in filename format on Windows.
 	if runtime.GOOS == "windows" {
-		out, err := exec.RunCommand("cygpath", []string{"-u", filePath})
-		if err != nil {
-			return "", err
-		}
-		filePath = out
+		filePath = nodeps.WindowsPathToCygwinPath(filePath)
 	}
-	dir := filepath.Dir(filePath)
+	dir := path.Dir(filePath)
 	_, out, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"sha1sum", filePath}, nil, nil, []string{dir + ":" + dir}, "0", true, false, nil, nil, nil)
 
 	if err != nil {

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -4,7 +4,6 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -152,16 +151,4 @@ func PathWithSlashesToArray(path string) []string {
 		partial += "/"
 	}
 	return paths
-}
-
-// WindowsPathToCygwinPath changes C:/path/to/something to //c/path/to/something
-// This is required for Docker bind mounts on Docker toolbox.
-// Sadly, if we have a Windows drive name, it has to be converted from C:/ to //c for Win10Home/Docker toolbox
-func WindowsPathToCygwinPath(windowsPath string) string {
-	windowsPath = filepath.ToSlash(windowsPath)
-	if string(windowsPath[1]) == ":" {
-		drive := strings.ToLower(string(windowsPath[0]))
-		windowsPath = "/" + drive + windowsPath[2:]
-	}
-	return windowsPath
 }

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"net"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -151,4 +152,16 @@ func PathWithSlashesToArray(path string) []string {
 		partial += "/"
 	}
 	return paths
+}
+
+// WindowsPathToCygwinPath changes C:/path/to/something to //c/path/to/something
+// This is required for Docker bind mounts on Docker toolbox.
+// Sadly, if we have a Windows drive name, it has to be converted from C:/ to //c for Win10Home/Docker toolbox
+func WindowsPathToCygwinPath(windowsPath string) string {
+	windowsPath = filepath.ToSlash(windowsPath)
+	if string(windowsPath[1]) == ":" {
+		drive := strings.ToLower(string(windowsPath[0]))
+		windowsPath = "/" + drive + windowsPath[2:]
+	}
+	return windowsPath
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	osexec "os/exec"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -358,4 +359,16 @@ func ArrayToReadableOutput(slice []string) (response string, err error) {
 		return "", fmt.Errorf("empty slice")
 	}
 	return "[\n\t" + strings.Join(slice, "\n\t") + "\n]", nil
+}
+
+// WindowsPathToCygwinPath changes C:/path/to/something to //c/path/to/something
+// This is required for Docker bind mounts on Docker toolbox.
+// Sadly, if we have a Windows drive name, it has to be converted from C:/ to //c for Win10Home/Docker toolbox
+func WindowsPathToCygwinPath(windowsPath string) string {
+	windowsPath = filepath.ToSlash(windowsPath)
+	if string(windowsPath[1]) == ":" {
+		drive := strings.ToLower(string(windowsPath[0]))
+		windowsPath = "/" + drive + windowsPath[2:]
+	}
+	return windowsPath
 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6284

`TestFileHash` is broken on Windows due to different slashes in the filepath.

## How This PR Solves The Issue

Uses `filepath.ToSlash()` to normalize behavior for different OSs.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
