### PR TITLE
fix: Use mariadb repositories for mariadb-client, for #6083

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -82,6 +82,9 @@ RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
 RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
 http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
 
+# Install mariadb_repo_setup to get mariadb-client from them directly
+RUN curl -LsSf https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version="mariadb-10.11"
+
 RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && rm -f /tmp/debsuryorg-archive-keyring.deb && \
     echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && apt-get update

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:v1.23.1 as ddev-webserver-base
+FROM ddev/ddev-php-base:20240607_rfay_mariadb_10.11_client as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240523_stasadev_apt_get_update_or_true" // Note that this can be overridden by make
+var WebTag = "20240607_rfay_mariadb_10.11_client" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #6083

mysql and mysqldump in the `ddev-webserver` don't handle mysql's new sandbox directive. 

## How This PR Solves The Issue

This installs the 10.11.8-MariaDB of the mariadb client (mysql) and the related mysqldump in the ddev-webserver

We already have matching versions in the ddev-dbserver, but some tools like drush and craft cms's backup tools use local tools in the ddev-webserver.

## Manual Testing Instructions

Try creating database dumps on ddev-webserver and importing them various places

You'll note `ddev exec 'mysqldump db >/tmp/db.sql'` will create a db.sql that has the dreaded `/*!999999\- enable the sandbox mode */`

`ddev import-db` and `ddev export-db` now strip this, but if processing is done by application-level things like drush, your mileage may vary. The sql dump that you create may not be import-able by a different version of mariadb or mysql.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
