### PR TITLE
build: Bump mysql to 8.0.36, fixes #6250

### DIFF
--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -10,7 +10,7 @@ CURRENT_ARCH=$(shell ../get_arch.sh)
 # So has to explicitly declare anything it might need from there (like SHELL)
 SHELL = /bin/bash
 
-BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_both mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mariadb_10.7_both mariadb_10.8_both mariadb_10.11_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.33
+BUILD_TARGETS=mariadb_5.5_amd64 mariadb_10.0_amd64 mariadb_10.1_both mariadb_10.2_both mariadb_10.3_both mariadb_10.4_both mariadb_10.5_both mariadb_10.6_both mariadb_10.7_both mariadb_10.8_both mariadb_10.11_both mysql_5.5_amd64 mysql_5.6_amd64 mysql_5.7_both mysql_8.0_both_8.0.36
 TEST_TARGETS=$(shell if [ "$(CURRENT_ARCH)" = "amd64" ] ; then \
 	echo "mariadb_5.5_test mariadb_10.0_test mariadb_10.1_test mariadb_10.2_test mariadb_10.3_test mariadb_10.4_test mariadb_10.5_test mariadb_10.6_test mariadb_10.7_test mariadb_10.8_test mariadb_10.11_test mysql_5.5_test mysql_5.6_test mysql_5.7_test mysql_8.0_test"; \
 	else \
@@ -38,13 +38,13 @@ mysql_5.7: mysql_5.7_both
 
 # Mysql 8.0 often must be pinned because xtrabackup is not ready for latest 8.0
 # So check whether xtrabackup is available for latest 8.0 before changing pin
-mysql_8.0: mysql_8.0_both_8.0.33
+mysql_8.0: mysql_8.0_both_8.0.36
 
 
 # Examples:
 # make <dbtype>_<dbmajor>_[both|amd64]_<pin>  # pin is optional, often needed for mysql 8.0
 # make mariadb_10.3_both VERSION=someversion PUSH=true
-# make mysql_8.0_amd64_8.0.33 VERSION=someversion
+# make mysql_8.0_amd64_8.0.36 VERSION=someversion
 $(BUILD_TARGETS):
 	@echo "building $@";
 	export DB_TYPE=$(word 1, $(subst _, ,$@)) && \

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "20240523_stasadev_apt_get_update_or_true" // Note that this can be
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.23.1"
+var BaseDBTag = "20240608_rfay_bump_mysql_8.0.36"
 
 const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.23.1"
 const TraefikRouterImage = "ddev/ddev-traefik-router:v1.23.1"


### PR DESCRIPTION

## The Issue

- #6250
- https://github.com/ddev/mysql-arm64-images/pull/8
- https://github.com/ddev/mysql-arm64-images/pull/9
- https://github.com/ddev/xtrabackup-build/releases/tag/8.0.35-30
- https://perconadev.atlassian.net/browse/PXB-3304

It looks like we can bump to mysql 8.0.36 now, with xtrabackup 8.0.35. 


## How This PR Solves The Issue

Update

Note that this updates the mysql:8.0 image to Ubuntu 22.04

## Manual Testing Instructions

Use mysql:8.0 and do snapshots and snapshot restores. 

## Automated Testing Overview

Existing tests may be adequate.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
