### PR TITLE
feat: add warnings for global commands when they are "unknown", for #5523, for #6275

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -132,6 +132,9 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 		// Skip host commands that need a project if we aren't in a project directory.
 		if service == "host" && app == nil {
 			if val, ok := directives["CanRunGlobally"]; !ok || val != "true" {
+				if isCustomCommandInArgs(commandName) {
+					util.Warning("Command '%s' cannot be used outside the project directory.", commandName)
+				}
 				continue
 			}
 		}
@@ -184,6 +187,14 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 
 		// If ProjectTypes is specified and we aren't of that type, skip
 		if projectTypes != "" && (app == nil || !strings.Contains(projectTypes, app.Type)) {
+			if app != nil && isCustomCommandInArgs(commandName) {
+				suggestedCommands := strings.Split(projectTypes, ",")
+				for i, projectType := range suggestedCommands {
+					suggestedCommands[i] = fmt.Sprintf("ddev config --project-type=%s", projectType)
+				}
+				suggestedCommand, _ := util.ArrayToReadableOutput(suggestedCommands)
+				util.Warning("Command '%s' is not available for the '%s' project type.\nIf you intend to use '%s', change the project type to one of the supported types %s", commandName, app.Type, commandName, suggestedCommand)
+			}
 			continue
 		}
 
@@ -195,6 +206,9 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 		// If OSTypes is specified and we aren't on one of the specified OSes, skip
 		if osTypes != "" {
 			if !strings.Contains(osTypes, runtime.GOOS) && !(strings.Contains(osTypes, "wsl2") && nodeps.IsWSL2()) {
+				if isCustomCommandInArgs(commandName) {
+					util.Warning("Command '%s' cannot be used with your OS.", commandName)
+				}
 				continue
 			}
 		}
@@ -215,6 +229,10 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 				}
 			}
 			if !binExists {
+				if isCustomCommandInArgs(commandName) {
+					suggestedBinaries, _ := util.ArrayToReadableOutput(bins)
+					util.Warning("Command '%s' cannot be used, because the binary is not found at %s", commandName, suggestedBinaries)
+				}
 				continue
 			}
 		}
@@ -227,6 +245,9 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 		// If DBTypes is specified and we aren't using that DBTypes
 		if dbTypes != "" && app != nil {
 			if !strings.Contains(dbTypes, app.Database.Type) {
+				if isCustomCommandInArgs(commandName) {
+					util.Warning("Command '%s' is not available for the '%s' database type.", commandName, app.Database.Type)
+				}
 				continue
 			}
 		}
@@ -329,6 +350,11 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 		commandsAdded[commandName] = 1
 	}
 	return nil
+}
+
+// isCustomCommandInArgs checks if the command is the first arg passed to the "ddev" command.
+func isCustomCommandInArgs(commandName string) bool {
+	return len(os.Args) > 1 && os.Args[1] == commandName
 }
 
 func makeHostCompletionFunc(autocompletePathOnHost string, commandToAdd *cobra.Command) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/drush
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/drush
@@ -4,7 +4,7 @@
 ## Description: Run drush CLI inside the web container
 ## Usage: drush [flags] [args]
 ## Example: "ddev drush uli" or "ddev drush sql-cli" or "ddev drush --version"
-## ProjectTypes: drupal7,drupal8,drupal9,drupal10,drupal,backdrop
+## ProjectTypes: drupal,drupal10,drupal9,drupal8,drupal7,backdrop
 ## ExecRaw: true
 
 if ! command -v drush >/dev/null; then

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
@@ -4,7 +4,7 @@
 ## Description: Enable or disable xdebug
 ## Usage: xdebug on|off|enable|disable|true|false|toggle|status
 ## Example: "ddev xdebug" (default is "on"), "ddev xdebug off", "ddev xdebug on", "ddev xdebug toggle", "ddev xdebug status"
-## Execraw: false
+## ExecRaw: false
 ## Flags: []
 ## AutocompleteTerms: ["on","off","enable","disable","toggle","status"]
 
@@ -32,7 +32,7 @@ get_xdebug_status() {
       echo "0"
       ;;
     esac
-} 
+}
 
 case $1 in
   on|true|enable)


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #5523
- #6275

DDEV users may run some legitimate bash commands built into DDEV and see errors like this:

```
$ ddev drush
Error: unknown command "drush" for "ddev"

Did you mean this?
        push

Run 'ddev --help' for usage.
```

For our users, this is confusing, they don't know what to do and how to fix it. I myself have been hit by an "unknown command" several times.

We need to provide better output to indicate why the specified command does not work.

## How This PR Solves The Issue

Adds a warning before "unknown command" error for custom bash commands, explaining why they don't work.

## Manual Testing Instructions

```
$ cd ~ && ddev mailpit
Command 'mailpit' cannot be used outside the project directory.

$ cd ~/workspace && mkdir command-warnings && cd command-warnings && ddev config --auto --database="postgres:16"

$ ddev drush
Command 'drush' is not available for the 'php' project type.
If you intend to use 'drush', change the project type to one of the supported types [
        ddev config --project-type=drupal
        ddev config --project-type=drupal10
        ddev config --project-type=drupal9
        ddev config --project-type=drupal8
        ddev config --project-type=drupal7
        ddev config --project-type=backdrop
]

$ ddev heidisql # using macOS or Linux
Command 'heidisql' cannot be used with your OS.

$ ddev sequelpro # using macOS without Sequel Pro
Command 'sequelpro' cannot be used, because the binary is not found at [
        /Applications/Sequel Pro.app
]

$ ddev sequelpro # using macOS with Sequel Pro
Command 'sequelpro' is not available for the 'postgres' database type.
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
