### PR TITLE
fix: optionally load bash completion for npm and nvm, fixes #6106

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/npm
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/npm
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 #ddev-generated
-# set env variables required for nvm's bash completion script
+# load bash completion for npm if it is not declared
+if ! declare -F _npm_completion >/dev/null; then
+  [ -n "$(type -t npm)" ] && eval "$(npm completion)"
+fi
+# set env variables required for npm's bash completion script
 COMP_WORDS=("$@")
 COMP_CWORD=$(($# - 1))
 # run the actual script

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/nvm
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/nvm
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 #ddev-generated
+# load bash completion for nvm if it is not declared
+if ! declare -F __nvm >/dev/null; then
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
+  [ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"
+fi
 # set env variables required for nvm's bash completion script
 COMP_WORDS=("$@")
 COMP_CWORD=$(($# - 1))


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6106

`ddev npm` completions don't work.

## How This PR Solves The Issue

Adds an optional check if the completion function is available, if not: load it again.
I did the same for `nvm` just in case.

## Manual Testing Instructions

`ddev npm <tab><tab>`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
