### PR TITLE
test: check if `ddev composer create` runs its scripts, for #6281

### DIFF
--- a/cmd/ddev/cmd/testdata/TestComposerCreateRunScript/.ddev/test-composer-create-run-script/composer.json
+++ b/cmd/ddev/cmd/testdata/TestComposerCreateRunScript/.ddev/test-composer-create-run-script/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "test/composer-create-run-script",
+    "type": "project",
+    "version": "1.0.0",
+    "scripts": {
+        "post-root-package-install": [
+            "@php -r \"touch('created-by-post-root-package-install');\""
+        ],
+        "post-create-project-cmd": [
+            "@php -r \"touch('created-by-post-create-project-cmd');\""
+        ]
+    }
+}


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/6281#pullrequestreview-2110962930

We can test if DDEV runs composer scripts on`ddev composer create`.

## How This PR Solves The Issue

Adds a test.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
