### PR TITLE
fix: pass all valid options to nested commands in `ddev composer create`, fixes #6300, fixes #6246, for #5058

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/composer"
@@ -43,6 +44,8 @@ ddev composer create --preserve-flags --no-interaction psr/log
 		osargs := []string{}
 		if len(os.Args) > 3 {
 			osargs = os.Args[3:]
+			// I don't know why, but cmd.Flags().GetBool("preserve-flags") is always false, so we can check it here
+			preserveFlags = slices.Contains(osargs, "--preserve-flags")
 			osargs = nodeps.RemoveItemFromSlice(osargs, "--preserve-flags")
 			expandedOsargs := []string{}
 			for _, osarg := range osargs {
@@ -91,10 +94,10 @@ ddev composer create --preserve-flags --no-interaction psr/log
 
 				checkPath := app.GetRelativeDirectory(walkPath)
 
-				if walkInfo.IsDir() && nodeps.ArrayContainsString(skipDirs, checkPath) {
+				if walkInfo.IsDir() && slices.Contains(skipDirs, checkPath) {
 					return filepath.SkipDir
 				}
-				if !nodeps.ArrayContainsString(composerCreateAllowedPaths, checkPath) {
+				if !slices.Contains(composerCreateAllowedPaths, checkPath) {
 					return fmt.Errorf("'%s' is not allowed to be present. composer create needs to be run on a clean/empty project with only the following paths: %v - please clean up the project before using 'ddev composer create'", filepath.Join(appRoot, checkPath), composerCreateAllowedPaths)
 				}
 				if err != nil {
@@ -141,16 +144,16 @@ ddev composer create --preserve-flags --no-interaction psr/log
 			}
 		}
 
-		if !preserveFlags && !nodeps.ArrayContainsString(createArgs, "--no-plugins") {
+		if !preserveFlags && !slices.Contains(createArgs, "--no-plugins") {
 			createArgs = append(createArgs, "--no-plugins")
 		}
 
-		if !preserveFlags && !nodeps.ArrayContainsString(createArgs, "--no-scripts") {
+		if !preserveFlags && !slices.Contains(createArgs, "--no-scripts") {
 			createArgs = append(createArgs, "--no-scripts")
 		}
 
 		// Remember if --no-install was provided by the user
-		noInstallPresent := nodeps.ArrayContainsString(createArgs, "--no-install")
+		noInstallPresent := slices.Contains(createArgs, "--no-install")
 		if !noInstallPresent {
 			// Add the --no-install option by default to avoid issues with
 			// rsyncing many files afterwards to the project root.

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -6,9 +6,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ddev/ddev/pkg/composer"
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
@@ -28,24 +30,22 @@ func TestComposerCreateCmd(t *testing.T) {
 	origDir, err := os.Getwd()
 	assert.NoError(err)
 
-	types := ddevapp.GetValidAppTypesWithoutAliases()
+	validAppTypes := ddevapp.GetValidAppTypesWithoutAliases()
 	if os.Getenv("GOTEST_SHORT") != "" {
-		types = []string{nodeps.AppTypePHP, nodeps.AppTypeDrupal}
+		validAppTypes = []string{nodeps.AppTypePHP, nodeps.AppTypeDrupal}
 	}
 
 	for _, docRoot := range []string{"", "doc-root"} {
-		for _, projectType := range types {
+		for _, projectType := range validAppTypes {
 			if projectType == nodeps.AppTypeDjango4 || projectType == nodeps.AppTypePython {
 				// Skip as an empty django4/python do not start nicely right away
 				// https://github.com/ddev/ddev/issues/5171
-				t.Logf("== SKIP TestComposerCreateCmd for project of type '%s' with docroot  '%s'\n", projectType, docRoot)
+				t.Logf("== SKIP TestComposerCreateCmd for project of type '%s' with docroot '%s'\n", projectType, docRoot)
 				t.Logf("== SKIP python projects are not starting up nicely and composer create is very unlikely to be used")
 				continue
 			}
 			if projectType == nodeps.AppTypeDrupal6 {
-				// Skip as an empty django4/python do not start nicely right away
-				// https://github.com/ddev/ddev/issues/5171
-				t.Logf("== SKIP TestComposerCreateCmd for project of type '%s' with docroot  '%s'\n", projectType, docRoot)
+				t.Logf("== SKIP TestComposerCreateCmd for project of type '%s' with docroot '%s'\n", projectType, docRoot)
 				t.Logf("== SKIP drupal6 projects uses a very old php version and composer create is very unlikely to be used")
 				continue
 			}
@@ -60,7 +60,7 @@ func TestComposerCreateCmd(t *testing.T) {
 			composerRoot := tmpDir
 			if docRoot != "" {
 				arguments = append(arguments, "--docroot", docRoot)
-				// For Drupal we test that the composer root is the same as the created root
+				// For Drupal, we test that the composer root is the same as the created root
 				if projectType == nodeps.AppTypeDrupal {
 					arguments = append(arguments, "--composer-root", docRoot)
 					composerRoot = filepath.Join(tmpDir, docRoot)
@@ -88,8 +88,45 @@ func TestComposerCreateCmd(t *testing.T) {
 
 			err = app.StartAndWait(5)
 			require.NoError(t, err)
-			// ddev composer create --prefer-dist --no-interaction --no-dev psr/log:1.1.0
-			args := []string{"composer", "create", "--prefer-dist", "--no-interaction", "--no-dev", "--no-install", "psr/log:1.1.0"}
+
+			// This is a local package that we can use to test composer create
+			repository := `{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}`
+			repositoryPath := filepath.Join(origDir, "testdata", t.Name(), ".ddev/test-ddev-composer-create")
+			err = fileutil.CopyDir(repositoryPath, filepath.Join(app.AppRoot, ".ddev/test-ddev-composer-create"))
+			require.NoError(t, err)
+			err = app.MutagenSyncFlush()
+			require.NoError(t, err)
+
+			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-interaction --no-dev -av --fake-flag test/ddev-composer-create
+			// Rules:
+			// combined short options will be split into single options, i.e. -av here will become -a -v
+			// all invalid options will be ignored without any error: --fake-flag
+			// composer commands will use only the flags they are supposed to use, i.e. -a (short form of --classmap-authoritative) will not be used by create-project
+			// Validation:
+			// valid options for create-project: --repository --no-interaction --no-dev -v
+			// valid options for run-script: --no-interaction --no-dev -v
+			// valid options for install: --no-interaction --no-dev -a -v
+			args := []string{"composer", "create", "--repository", repository, "--no-interaction", "--no-dev", "-av", "--fake-flag", "test/ddev-composer-create"}
+
+			// If --no-install is provided, the 'install' and 'run-script post-create-project-cmd' scripts will not run, but 'run-script post-root-package-install' will
+			if docRoot != "" {
+				// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-interaction --no-install test/ddev-composer-create
+				// Validation:
+				// valid options for create-project: --repository --no-interaction --no-install
+				// valid options for run-script: --no-interaction
+				// valid options for install: doesn't run
+				args = []string{"composer", "create", "--repository", repository, "--no-interaction", "--no-install", "test/ddev-composer-create"}
+			}
+
+			// If --preserve-flags is provided, the --no-plugins and --no-scripts flags will not be added
+			if docRoot != "" && projectType == nodeps.AppTypePHP {
+				// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --preserve-flags --no-interaction test/ddev-composer-create
+				// Validation:
+				// valid options for create-project: --repository --no-interaction --no-install
+				// valid options for run-script: none
+				// valid options for install: doesn't run
+				args = []string{"composer", "create", "--repository", repository, "--preserve-flags", "--no-interaction", "test/ddev-composer-create"}
+			}
 
 			// Test failure
 			file, err := os.Create(filepath.Join(composerRoot, "touch1.txt"))
@@ -97,13 +134,67 @@ func TestComposerCreateCmd(t *testing.T) {
 			assert.Error(err)
 			assert.Contains(out, "touch1.txt")
 			_ = file.Close()
-			os.Remove(filepath.Join(composerRoot, "touch1.txt"))
+			_ = os.Remove(filepath.Join(composerRoot, "touch1.txt"))
 
 			// Test success
 			out, err = exec.RunHostCommand(DdevBin, args...)
 			assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
 			assert.Contains(out, "Created project in ")
 			assert.FileExists(filepath.Join(composerRoot, "composer.json"))
+
+			// Check that all composer commands were run, these include the specified flags
+			if docRoot == "" {
+				// When there is no --preserve-flags, the --no-plugins and --no-scripts flags are appended
+				// --no-install is always added to 'composer create-project' to avoid problems with installation
+				assert.Contains(out, `Executing Composer command: [composer create-project --repository {"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}} --no-interaction --no-dev -v test/ddev-composer-create --no-plugins --no-scripts --no-install`)
+				assert.Contains(out, "Executing composer command: [composer run-script post-root-package-install --no-interaction --no-dev -v]")
+				// -av is expanded to -a -v
+				assert.Contains(out, "Executing Composer command: [composer install --no-interaction --no-dev -a -v]")
+				assert.Contains(out, "Executing composer command: [composer run-script post-create-project-cmd --no-interaction --no-dev -v]")
+
+				// Check if the files created by composer scripts from the test/composer-create-run-script package are here
+				assert.FileExists(filepath.Join(composerRoot, "created-by-post-root-package-install"))
+				assert.FileExists(filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
+				// Check if vendor/autoload.php is created
+				assert.FileExists(filepath.Join(composerRoot, "vendor", "autoload.php"))
+				// psr/log is installed by test/ddev-composer-create package
+				assert.DirExists(filepath.Join(composerRoot, "vendor", "psr", "log"))
+			} else {
+				// If --preserve-flags is provided, the --no-plugins and --no-scripts flags will not be added
+				if projectType == nodeps.AppTypePHP {
+					assert.Contains(out, `Executing Composer command: [composer create-project --repository {"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}} --no-interaction test/ddev-composer-create --no-install`)
+					assert.Contains(out, "Executing Composer command: [composer install --no-interaction]")
+					// With --preserve-flags scripts will run, but without DDEV help
+					assert.NotContains(out, "Executing composer command: [composer run-script post-root-package-install")
+					assert.NotContains(out, "Executing composer command: [composer run-script post-create-project-cmd")
+					// Check if the files created by composer scripts from the test/composer-create-run-script package are here
+					assert.FileExists(filepath.Join(composerRoot, "created-by-post-root-package-install"))
+					assert.FileExists(filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
+					// Check if vendor/autoload.php is created
+					assert.FileExists(filepath.Join(composerRoot, "vendor", "autoload.php"))
+					// psr/log is installed by test/ddev-composer-create package
+					assert.DirExists(filepath.Join(composerRoot, "vendor", "psr", "log"))
+				} else {
+					// If --no-install is provided, the 'install' and 'run-script post-create-project-cmd' flags will not run, but 'run-script post-root-package-install' will
+					assert.Contains(out, `Executing Composer command: [composer create-project --repository {"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}} --no-interaction --no-install test/ddev-composer-create --no-plugins --no-scripts`)
+					assert.Contains(out, "Executing composer command: [composer run-script post-root-package-install --no-interaction]")
+					assert.NotContains(out, "Executing Composer command: [composer install")
+					assert.NotContains(out, "Executing composer command: [composer run-script post-create-project-cmd")
+					// Check if the files created by composer scripts from the test/composer-create-run-script package are here
+					assert.FileExists(filepath.Join(composerRoot, "created-by-post-root-package-install"))
+					// The post-create-project-cmd script doesn't run, so there should be no file
+					assert.NoFileExists(filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
+					// If --no-install is provided, no vendor should be created
+					assert.NoDirExists(filepath.Join(composerRoot, "vendor"))
+				}
+			}
+
+			// Check that resulting composer.json (copied from testdata) has post-root-package-install and post-create-project-cmd scripts
+			composerManifest, err := composer.NewManifest(filepath.Join(composerRoot, "composer.json"))
+			assert.NoError(err)
+			assert.True(composerManifest != nil)
+			assert.True(composerManifest.HasPostRootPackageInstallScript())
+			assert.True(composerManifest.HasPostCreateProjectCmdScript())
 
 			err = app.Stop(true, false)
 			require.NoError(t, err)

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -104,25 +104,25 @@ func TestComposerCreateCmd(t *testing.T) {
 			// These are different conditions to test different composer flag combinations
 			// Conditions for docRoot and projectType are not important here, they are only needed to make the test act different each time
 			if docRoot == "" {
-				composerCommandTypeCheck = "installation with --no-dev --no-plugins --no-scripts"
+				composerCommandTypeCheck = "installation with --no-plugins --no-scripts"
 				if projectType == nodeps.AppTypePHP {
-					composerCommandTypeCheck = "installation with short flag expansion and non-existing flags"
+					composerCommandTypeCheck = "installation with --vvv --fake-flag"
 				}
 			} else {
 				composerCommandTypeCheck = "installation with --no-install"
 				if projectType == nodeps.AppTypePHP {
-					composerCommandTypeCheck = "installation with --preserve-flags"
+					composerCommandTypeCheck = "installation with --no-dev"
 				}
 			}
 
-			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-dev --no-plugins --no-scripts test/ddev-composer-create
-			if composerCommandTypeCheck == "installation with --no-dev --no-plugins --no-scripts" {
-				args = []string{"composer", "create", "--repository", repository, "--no-dev", "--no-plugins", "--no-scripts", "test/ddev-composer-create"}
+			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-plugins --no-scripts test/ddev-composer-create
+			if composerCommandTypeCheck == "installation with --no-plugins --no-scripts" {
+				args = []string{"composer", "create", "--repository", repository, "--no-plugins", "--no-scripts", "test/ddev-composer-create"}
 			}
 
-			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' -avv --fake-flag test/ddev-composer-create
-			if composerCommandTypeCheck == "installation with short flag expansion and non-existing flags" {
-				args = []string{"composer", "create", "--repository", repository, "-avv", "--fake-flag", "test/ddev-composer-create"}
+			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' -vvv --fake-flag test/ddev-composer-create
+			if composerCommandTypeCheck == "installation with --vvv --fake-flag" {
+				args = []string{"composer", "create", "--repository", repository, "-vvv", "--fake-flag", "test/ddev-composer-create"}
 			}
 
 			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-install test/ddev-composer-create
@@ -130,9 +130,9 @@ func TestComposerCreateCmd(t *testing.T) {
 				args = []string{"composer", "create", "--repository", repository, "--no-install", "test/ddev-composer-create"}
 			}
 
-			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --preserve-flags test/ddev-composer-create
-			if composerCommandTypeCheck == "installation with --preserve-flags" {
-				args = []string{"composer", "create", "--repository", repository, "--preserve-flags", "test/ddev-composer-create"}
+			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-dev test/ddev-composer-create
+			if composerCommandTypeCheck == "installation with --no-dev" {
+				args = []string{"composer", "create", "--repository", repository, "--no-dev", "test/ddev-composer-create"}
 			}
 
 			// Test failure
@@ -149,12 +149,12 @@ func TestComposerCreateCmd(t *testing.T) {
 			assert.Contains(out, "Created project in ")
 			assert.FileExists(filepath.Join(composerRoot, "composer.json"))
 
-			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-dev --no-plugins --no-scripts test/ddev-composer-create
-			if composerCommandTypeCheck == "installation with --no-dev --no-plugins --no-scripts" {
+			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-plugins --no-scripts test/ddev-composer-create
+			if composerCommandTypeCheck == "installation with --no-plugins --no-scripts" {
 				// Check what was executed or not
-				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s --no-dev --no-plugins --no-scripts test/ddev-composer-create --no-install`, repository))
+				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s --no-plugins --no-scripts test/ddev-composer-create --no-install`, repository))
 				assert.NotContains(out, "Executing Composer command: [composer run-script post-root-package-install")
-				assert.Contains(out, "Executing Composer command: [composer install --no-dev --no-plugins --no-scripts]")
+				assert.Contains(out, "Executing Composer command: [composer install --no-plugins --no-scripts]")
 				assert.NotContains(out, "Executing Composer command: [composer run-script post-create-project-cmd")
 				// Check the actual result of executing composer scripts
 				assert.NoFileExists(filepath.Join(composerRoot, "created-by-post-root-package-install"))
@@ -162,16 +162,17 @@ func TestComposerCreateCmd(t *testing.T) {
 				// Check vendor directory
 				assert.FileExists(filepath.Join(composerRoot, "vendor", "autoload.php"))
 				assert.FileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require", "composer.json"))
-				assert.NoFileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
+				assert.FileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
 			}
 
-			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' -avv --fake-flag test/ddev-composer-create
-			if composerCommandTypeCheck == "installation with short flag expansion and non-existing flags" {
+			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' -vvv --fake-flag test/ddev-composer-create
+			if composerCommandTypeCheck == "installation with --vvv --fake-flag" {
 				// Check what was executed or not
-				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s -v -v test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
-				assert.Contains(out, "Executing Composer command: [composer run-script post-root-package-install -v -v]")
-				assert.Contains(out, "Executing Composer command: [composer install -a -v -v]")
-				assert.Contains(out, "Executing Composer command: [composer run-script post-create-project-cmd -v -v]")
+				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s -vvv test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
+				assert.Contains(out, "Executing Composer command: [composer run-script post-root-package-install -vvv]")
+				assert.Contains(out, "Executing Composer command: [composer install -vvv]")
+				assert.Contains(out, "Executing Composer command: [composer run-script post-create-project-cmd -vvv]")
+				assert.NotContains(out, "--fake-flag")
 				// Check the actual result of executing composer scripts
 				assert.FileExists(filepath.Join(composerRoot, "created-by-post-root-package-install"))
 				assert.FileExists(filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
@@ -195,23 +196,20 @@ func TestComposerCreateCmd(t *testing.T) {
 				assert.NoDirExists(filepath.Join(composerRoot, "vendor"))
 			}
 
-			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --preserve-flags test/ddev-composer-create
-			if composerCommandTypeCheck == "installation with --preserve-flags" {
+			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-dev test/ddev-composer-create
+			if composerCommandTypeCheck == "installation with --no-dev" {
 				// Check what was executed or not
-				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s test/ddev-composer-create --no-scripts --no-install`, repository))
-				assert.Contains(out, "Executing Composer command: [composer run-script post-root-package-install]")
-				assert.Contains(out, "Executing Composer command: [composer install]")
-				assert.Contains(out, "Executing Composer command: [composer run-script post-create-project-cmd]")
-				// Preserve flags should not append --no-plugins
-				assert.NotContains(out, "--no-plugins")
+				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s --no-dev test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
+				assert.Contains(out, "Executing Composer command: [composer run-script post-root-package-install --no-dev]")
+				assert.Contains(out, "Executing Composer command: [composer install --no-dev]")
+				assert.Contains(out, "Executing Composer command: [composer run-script post-create-project-cmd --no-dev]")
 				// Check the actual result of executing composer scripts
-				// These files should exist because with --preserve-flags we do not append --no-scripts to the command
 				assert.FileExists(filepath.Join(composerRoot, "created-by-post-root-package-install"))
 				assert.FileExists(filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
 				// Check vendor directory
 				assert.FileExists(filepath.Join(composerRoot, "vendor", "autoload.php"))
 				assert.FileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require", "composer.json"))
-				assert.FileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
+				assert.NoFileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
 			}
 
 			// Check that resulting composer.json (copied from testdata) has post-root-package-install and post-create-project-cmd scripts

--- a/cmd/ddev/cmd/testdata/TestComposerCreateCmd/.ddev/test-ddev-composer-create/composer.json
+++ b/cmd/ddev/cmd/testdata/TestComposerCreateCmd/.ddev/test-ddev-composer-create/composer.json
@@ -1,10 +1,30 @@
 {
     "name": "test/ddev-composer-create",
+    "description": "This is a test project to check 'ddev composer create' behavior.",
     "type": "project",
     "version": "1.0.0",
     "require": {
-        "psr/log": "1.1.0"
+        "test/ddev-require": "1.0.0"
     },
+    "require-dev": {
+        "test/ddev-require-dev": "1.0.0"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "./test-ddev-require",
+            "options": {
+                "symlink": false
+            }
+        },
+        {
+            "type": "path",
+            "url": "./test-ddev-require-dev",
+            "options": {
+                "symlink": false
+            }
+        }
+    ],
     "scripts": {
         "post-root-package-install": [
             "@php -r \"touch('created-by-post-root-package-install');\""

--- a/cmd/ddev/cmd/testdata/TestComposerCreateCmd/.ddev/test-ddev-composer-create/composer.json
+++ b/cmd/ddev/cmd/testdata/TestComposerCreateCmd/.ddev/test-ddev-composer-create/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "test/ddev-composer-create",
+    "type": "project",
+    "version": "1.0.0",
+    "require": {
+        "psr/log": "1.1.0"
+    },
+    "scripts": {
+        "post-root-package-install": [
+            "@php -r \"touch('created-by-post-root-package-install');\""
+        ],
+        "post-create-project-cmd": [
+            "@php -r \"touch('created-by-post-create-project-cmd');\""
+        ]
+    }
+}

--- a/cmd/ddev/cmd/testdata/TestComposerCreateCmd/.ddev/test-ddev-composer-create/test-ddev-require-dev/composer.json
+++ b/cmd/ddev/cmd/testdata/TestComposerCreateCmd/.ddev/test-ddev-composer-create/test-ddev-require-dev/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "test/ddev-require-dev",
+    "description": "This is a test library to check if 'require-dev' section works.",
+    "type": "library",
+    "version": "1.0.0"
+}

--- a/cmd/ddev/cmd/testdata/TestComposerCreateCmd/.ddev/test-ddev-composer-create/test-ddev-require/composer.json
+++ b/cmd/ddev/cmd/testdata/TestComposerCreateCmd/.ddev/test-ddev-composer-create/test-ddev-require/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "test/ddev-require",
+    "description": "This is a test library to check if 'require' section works.",
+    "type": "library",
+    "version": "1.0.0"
+}

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -55,7 +55,6 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
     mkdir my-cakephp-site && cd my-cakephp-site
     ddev config --project-type=cakephp --docroot=webroot
     ddev composer create --prefer-dist --no-interaction cakephp/app:~5.0
-    ddev cake
     ddev launch
     ```
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -54,7 +54,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
     ```bash
     mkdir my-cakephp-site && cd my-cakephp-site
     ddev config --project-type=cakephp --docroot=webroot
-    ddev composer create --prefer-dist cakephp/app:~5.0
+    ddev composer create --prefer-dist --no-interaction cakephp/app:~5.0
     ddev cake
     ddev launch
     ```

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -40,12 +40,12 @@ For example:
 
 When using `ddev composer create` your project should be essentially empty or the command will refuse to run, to avoid loss of your files.
 
-Standard order of operations for `ddev composer create`:
+`ddev composer create` does these things in this order:
 
 1. `composer create-project --no-plugins --no-scripts --no-install` clones a bare Composer package without any additional actions.
-2. `composer run-script post-root-package-install` runs if `--no-scripts` is not provided manually.
-3. `composer install` runs if `--no-install` is not provided manually.
-4. `composer run-script post-create-project-cmd` runs if `--no-scripts` is not provided manually.
+2. `composer run-script post-root-package-install` runs if `--no-scripts` is not given as a flag to `ddev composer create`.
+3. `composer install` runs if `--no-install` is not given as a flag to `ddev composer create`.
+4. `composer run-script post-create-project-cmd` runs if `--no-scripts` is not given as a flag to `ddev composer create`.
 
 All flags that you provide to `ddev composer create` are checked for validity. All invalid flags will be ignored. If they are valid for `composer create-project`, they will be also passed to `composer run-script` and `composer install`, but only if these commands support these flags.
 

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -40,7 +40,7 @@ For example:
 
 When using `ddev composer create` your project should be essentially empty or the command will refuse to run, to avoid loss of your files.
 
-By default `--no-plugins` and `--no-scripts` options are used while cloning the project and `composer install` is executed afterwards as long as `--no-install` is not provided. When using `--preserve-flags` plugins and scripts are allowed during the cloning step.
+By default `--no-plugins` and `--no-scripts` options are used while cloning the project and `composer install` is executed afterwards as long as `--no-install` is not provided. When using `--preserve-flags` plugins are allowed during the cloning step.
 
 To execute a fully-featured `composer create-project` command, you can execute the command from within the container after executing [`ddev ssh`](../usage/commands.md#ssh), or pass the full command to [`ddev exec`](../usage/commands.md#exec), like so:
 

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -40,7 +40,14 @@ For example:
 
 When using `ddev composer create` your project should be essentially empty or the command will refuse to run, to avoid loss of your files.
 
-By default `--no-plugins` and `--no-scripts` options are used while cloning the project and `composer install` is executed afterwards as long as `--no-install` is not provided. When using `--preserve-flags` plugins are allowed during the cloning step.
+Standard order of operations for `ddev composer create`:
+
+1. `composer create-project --no-plugins --no-scripts --no-install` clones a bare Composer package without any additional actions.
+2. `composer run-script post-root-package-install` runs if `--no-scripts` is not provided manually.
+3. `composer install` runs if `--no-install` is not provided manually.
+4. `composer run-script post-create-project-cmd` runs if `--no-scripts` is not provided manually.
+
+All flags that you provide to `ddev composer create` are checked for validity. All invalid flags will be ignored. If they are valid for `composer create-project`, they will be also passed to `composer run-script` and `composer install`, but only if these commands support these flags.
 
 To execute a fully-featured `composer create-project` command, you can execute the command from within the container after executing [`ddev ssh`](../usage/commands.md#ssh), or pass the full command to [`ddev exec`](../usage/commands.md#exec), like so:
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6300
- #6246
- #5058

Composer options were not respected by `composer run-script`.

## How This PR Solves The Issue

Makes `ddev composer create` fully compatible with all possible composer options. I removed all the hard-coded options.
Adds composer options to `composer run-script`.
Adds `--no-interaction` to CakePHP quickstart.

---

`--preserve-flags` (which doesn't add `--no-plugins` and `--no-scripts`) didn't work as expected, I decided to remove it.

This is not a breaking change, because `--preserve-flags` didn't work before (it was always `false`).

---

I moved `composer run-script post-create-project-cmd` outside the condition for `composer install`, to make it work the same way as in `composer create-project`.

---

If you passed `--no-scripts`, DDEV tried to run `composer run-script`, which was wrong behavior, fixed it.

---

If `--help` or `--version` flags were provided, composer showed it's help page or it's version, and DDEV tried to continue creating the project, which was wrong behavior, fixed it.

---

I refactored the test logic to make it more clear and added more tests. I removed the testing for the `psr/log` package and replaced it with custom-made fake packages.

## Manual Testing Instructions

1. The order of commands executed for `ddev composer create` must be the same as for `composer create-project`.

To check this behavior, you can use a test repository (it is used for `testdata` here) which contains all the necessary situations to check:

```
cd ~/workspace && mkdir composer-create && cd composer-create
ddev config --auto
mkdir -p .ddev/test-ddev-composer-create/{test-ddev-require,test-ddev-require-dev}

curl -o .ddev/test-ddev-composer-create/composer.json https://raw.githubusercontent.com/stasadev/ddev/20240612_stasadev_composer_create/cmd/ddev/cmd/testdata/TestComposerCreateCmd/.ddev/test-ddev-composer-create/composer.json
curl -o .ddev/test-ddev-composer-create/test-ddev-require/composer.json https://raw.githubusercontent.com/stasadev/ddev/20240612_stasadev_composer_create/cmd/ddev/cmd/testdata/TestComposerCreateCmd/.ddev/test-ddev-composer-create/test-ddev-require/composer.json
curl -o .ddev/test-ddev-composer-create/test-ddev-require-dev/composer.json https://raw.githubusercontent.com/stasadev/ddev/20240612_stasadev_composer_create/cmd/ddev/cmd/testdata/TestComposerCreateCmd/.ddev/test-ddev-composer-create/test-ddev-require-dev/composer.json

export repo='{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}'

# see the result for:
composer create-project --repository $repo test/ddev-composer-create # add different flags here

# clear the directory
ls | grep -xv ".ddev" | xargs rm -rf

# see the result for:
ddev composer create --repository $repo test/ddev-composer-create # add different flags here

# clear the directory
ls | grep -xv ".ddev" | xargs rm -rf
````

`test/ddev-composer-create` package (`.ddev/test-ddev-composer-create/composer.json`) contains this:
- it requires `test/ddev-require` from `require` section:
  - `vendor/test/ddev-require` will be here, but only if there is no `--no-install` flag
- it requires `test/ddev-require-dev` from `require-dev` section:
  - `vendor/test/ddev-require-dev` will be here, but only if there is no `--no-dev`/`--no-install` flag
- it runs `post-root-package-install` script:
  - this script should run before `composer install`
  - it creates `created-by-post-root-package-install` file, but only if there is no `--no-scripts` flag
- it runs `post-create-project-cmd` script:
  - this script should run after `composer install`
  - it creates `created-by-post-create-project-cmd` file, but only if there is no `--no-scripts` flag

And use different flag combinations to see how it works for `composer create-project` and `ddev composer create`. It is important to check if the commands run in the same order.

Available flags for `composer create-project` https://getcomposer.org/doc/03-cli.md#create-project

Ignore the `test-ddev-require` and `test-ddev-require-dev` directories created in the project root (they are expected to be created every time as they are part of the composer package).

Every `ddev composer create` will have this output:
```
Executing composer command: [composer ...]
```
You can see what flags are used for each of these composer commands, and flags like `--no-interaction` will be also used for `composer run-script` and `composer install`.

For example:

This should not create `vendor` folder, and there should be no `created-by-*` files
```
# see the result for:
composer create-project --repository $repo test/ddev-composer-create --no-install --no-scripts

# clear the directory
ls | grep -xv ".ddev" | xargs rm -rf

# see the result for:
ddev composer create --repository $repo test/ddev-composer-create --no-install --no-scripts

# clear the directory
ls | grep -xv ".ddev" | xargs rm -rf
```

This should create `vendor/test/ddev-require` folder, (but not `vendor/test/ddev-require-dev`) and there should be no `created-by-*` files
```
# see the result for:
composer create-project --repository $repo test/ddev-composer-create --no-scripts --no-dev

# clear the directory
ls | grep -xv ".ddev" | xargs rm -rf

# see the result for:
ddev composer create --repository $repo test/ddev-composer-create --no-scripts --no-dev

# clear the directory
ls | grep -xv ".ddev" | xargs rm -rf
```

And so on.

---

2. Try CakePHP quickstart (without interaction), it should not ask for input:

```
mkdir my-cakephp-site && cd my-cakephp-site
ddev config --project-type=cakephp --docroot=webroot
ddev composer create --prefer-dist --no-interaction cakephp/app:~5.0
```

---

3. Try `Steps To Reproduce` example (it should not ask for input) from:

- #6246

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
