### PR TITLE
test: Fix TestAcquiaPush and TestLagoonPush, add mariadb-old clients, fixes #6295

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -50,7 +50,7 @@ RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer
 RUN cd /tmp && curl -L -s --fail -O https://dlm.mariadb.com/3607865/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client_10.11.6+maria~deb12_$(dpkg --print-architecture).deb
 RUN cd /tmp && curl -L -s --fail -O https://dlm.mariadb.com/3607494/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client-core_10.11.6+maria~deb12_$(dpkg --print-architecture).deb
 RUN set -x && cd /tmp && for item in *.deb; do dpkg-deb -x ${item} extracted; done
-RUN mkdir -p /usr/local/mariadb-old/bin && cp /tmp/extracted/usr/bin/{mariadb,mariadb-dump,mysql,mysqldump} /usr/local/mariadb-old/bin
+RUN mkdir -p /usr/local/mariadb-old/bin && cp -ap /tmp/extracted/usr/bin/{mariadb,mariadb-dump,mysql,mysqldump} /usr/local/mariadb-old/bin
 
 # END ddev-webserver-base
 

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -25,7 +25,7 @@ RUN /sbin/mkhomedir_helper www-data
 RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | bash
 
 RUN apt-get -qq update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y libcap2-bin locales-all pv supervisor symfony-cli
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y libcap2-bin locales-all pv supervisor symfony-cli xz-utils
 
 # Arbitrary user needs to be able to bind to privileged ports (for nginx and apache2)
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/nginx
@@ -44,6 +44,14 @@ ADD ddev-webserver-base-scripts /
 
 # /usr/local/bin may need to be updated by start.sh, etc
 RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer
+
+# Install older mariadb client and mariadb-dump into /usr/local/mariadb-old/bin
+# to solve variety of problems with newer mariadb-dump.
+RUN cd /tmp && curl -L -s --fail -O https://dlm.mariadb.com/3607865/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client_10.11.6+maria~deb12_$(dpkg --print-architecture).deb
+RUN cd /tmp && curl -L -s --fail -O https://dlm.mariadb.com/3607494/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client-core_10.11.6+maria~deb12_$(dpkg --print-architecture).deb
+RUN set -x && cd /tmp && for item in *.deb; do dpkg-deb -x ${item} extracted; done
+RUN mkdir -p /usr/local/mariadb-old/bin && cp /tmp/extracted/usr/bin/{mariadb,mariadb-dump,mysql,mysqldump} /usr/local/mariadb-old/bin
+
 # END ddev-webserver-base
 
 

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -47,8 +47,8 @@ RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer
 
 # Install older mariadb client and mariadb-dump into /usr/local/mariadb-old/bin
 # to solve variety of problems with newer mariadb-dump.
-RUN cd /tmp && curl -L -s --fail -O https://dlm.mariadb.com/3607865/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client_10.11.6+maria~deb12_$(dpkg --print-architecture).deb
-RUN cd /tmp && curl -L -s --fail -O https://dlm.mariadb.com/3607494/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client-core_10.11.6+maria~deb12_$(dpkg --print-architecture).deb
+RUN cd /tmp && curl -L -s --fail -O "https://dlm.mariadb.com/3607865/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client_10.11.6+maria~deb12_$(dpkg --print-architecture).deb"
+RUN cd /tmp && curl -L -s --fail -O "https://dlm.mariadb.com/3607494/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client-core_10.11.6+maria~deb12_$(dpkg --print-architecture).deb"
 RUN set -x && cd /tmp && for item in *.deb; do dpkg-deb -x ${item} extracted; done
 RUN mkdir -p /usr/local/mariadb-old/bin && cp -ap /tmp/extracted/usr/bin/{mariadb,mariadb-dump,mysql,mysqldump} /usr/local/mariadb-old/bin
 

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -47,8 +47,8 @@ RUN chmod -f ugo+rwx /usr/local/bin /usr/local/bin/composer
 
 # Install older mariadb client and mariadb-dump into /usr/local/mariadb-old/bin
 # to solve variety of problems with newer mariadb-dump.
-RUN cd /tmp && curl -L -s --fail -O "https://dlm.mariadb.com/3607865/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client_10.11.6+maria~deb12_$(dpkg --print-architecture).deb"
-RUN cd /tmp && curl -L -s --fail -O "https://dlm.mariadb.com/3607494/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client-core_10.11.6+maria~deb12_$(dpkg --print-architecture).deb"
+RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then cd /tmp && curl -L -s --fail -O "https://dlm.mariadb.com/3607865/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client_10.11.6+maria~deb12_arm64.deb" -O "https://dlm.mariadb.com/3607494/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client-core_10.11.6+maria~deb12_arm64.deb"; fi
+RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then cd /tmp && curl -L -s --fail -O "https://dlm.mariadb.com/3607675/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client_10.11.6+maria~deb12_amd64.deb" -O "https://dlm.mariadb.com/3607123/MariaDB/mariadb-10.11.6/repo/debian/pool/main/m/mariadb/mariadb-client-core_10.11.6+maria~deb12_amd64.deb"; fi
 RUN set -x && cd /tmp && for item in *.deb; do dpkg-deb -x ${item} extracted; done
 RUN mkdir -p /usr/local/mariadb-old/bin && cp -ap /tmp/extracted/usr/bin/{mariadb,mariadb-dump,mysql,mysqldump} /usr/local/mariadb-old/bin
 

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
@@ -3,6 +3,7 @@
 # This script is used to install a matching `mysql` client (with `mysqldump`)
 # in ddev-webserver
 # It should be called with the appropriate mysql version as an argument
+# This script is intended to be run with root privileges (normally in a docker build phase)
 
 set -eu -o pipefail
 
@@ -18,8 +19,8 @@ TARBALL_URL=https://github.com/ddev/mysql-client-build/releases/download/${TARBA
 # Install the related mysql client if available
 set -x
 cd /tmp && curl -L -o /tmp/mysql.tgz --fail -s ${TARBALL_URL}
-sudo tar -zxf /tmp/mysql.tgz -C /usr/local/bin
+tar -zxf /tmp/mysql.tgz -C /usr/local/bin && rm -f /tmp/mysql.tgz
 
 # Remove any existing mariadb installs
-sudo apt remove -y mariadb-client-core mariadb-client || true
-sudo apt autoremove -y || true
+apt remove -y mariadb-client-core mariadb-client || true
+apt autoremove -y || true

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -120,9 +120,9 @@ func TestAcquiaPull(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "chocolate-brownie-umami.jpg"))
-	out, err := exec.RunCommand("bash", []string{"-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="randy@example.com";' | %s mysql -N`, DdevBin)})
+	out, err := exec.RunCommand("bash", []string{"-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="randy@example.com";' | %s mysql -B --skip-column-names `, DdevBin)})
 	assert.NoError(err)
-	assert.True(strings.HasPrefix(out, "1\n"))
+	assert.True(strings.HasSuffix(out, "\n1\n"), "out is unexpected '%s'", out)
 }
 
 // TestAcquiaPush ensures we can push to acquia for a configured environment.

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -75,6 +75,10 @@ func TestAcquiaPull(t *testing.T) {
 	require.NoError(t, err)
 	// acli really wants the project to look like the target project
 	app.Docroot = "docroot"
+	app.Database = ddevapp.DatabaseDesc{
+		Type:    nodeps.MySQL,
+		Version: nodeps.MySQL57,
+	}
 
 	err = setupSSHKey(t, sshkey, filepath.Join(origDir, "testdata", t.Name()))
 	require.NoError(t, err)
@@ -164,6 +168,10 @@ func TestAcquiaPush(t *testing.T) {
 	require.NoError(t, err)
 	// acli really wants the project to look like the target project
 	app.Docroot = "docroot"
+	app.Database = ddevapp.DatabaseDesc{
+		Type:    nodeps.MySQL,
+		Version: nodeps.MySQL57,
+	}
 
 	err = setupSSHKey(t, sshkey, filepath.Join(origDir, "testdata", t.Name()))
 	require.NoError(t, err)

--- a/pkg/ddevapp/providerLagoon_test.go
+++ b/pkg/ddevapp/providerLagoon_test.go
@@ -84,6 +84,11 @@ func TestLagoonPull(t *testing.T) {
 	require.NoError(t, err)
 
 	app.Docroot = "web"
+	app.Database = ddevapp.DatabaseDesc{
+		Type:    nodeps.MySQL,
+		Version: nodeps.MySQL57,
+	}
+
 	err = app.WriteConfig()
 	require.NoError(t, err)
 
@@ -106,7 +111,7 @@ func TestLagoonPull(t *testing.T) {
 	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "victoria-sponge-umami.jpg"))
 	out, err := exec.RunHostCommand("bash", "-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="margaret.hopper@example.com";' | %s mysql -N`, DdevBin))
 	assert.NoError(err)
-	assert.True(strings.HasPrefix(out, "1\n"))
+	assert.True(strings.HasSuffix(out, "\n1\n"))
 }
 
 // TestLagoonPush ensures we can push to lagoon for a configured environment.
@@ -141,6 +146,10 @@ func TestLagoonPush(t *testing.T) {
 	_ = app.Stop(true, false)
 
 	app.Docroot = "web"
+	app.Database = ddevapp.DatabaseDesc{
+		Type:    nodeps.MySQL,
+		Version: nodeps.MySQL57,
+	}
 
 	err = app.WriteConfig()
 	require.NoError(t, err)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240610_mysql_clients" // Note that this can be overridden by make
+var WebTag = "20240612_fix_testAcquiaPush" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

* #6295
* TestLagoonPush broke for the same reason
* We want to put a `neutral` mysql/mysqldump in there for people in this situation, so it's now in /usr/local/mariadb-old/bin

Acquia uses MySQL 5.7. We were using the default MariaDB:10.11 for the TestAcquiaPush test, and of course it has the mariadb-client 10.11.8, which has the broken directive in it.

This changes the tests to use MySQL 5.7, which now gets the MySQL 5.7 client in it, which should work OK.

