### PR TITLE
fix: Don't terminate mutagen sessions on upgrade/version change

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -175,8 +175,6 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 			if okPoweroff {
 				ddevapp.PowerOff()
 			}
-			util.Debug("Terminating all Mutagen sync sessions")
-			ddevapp.TerminateAllMutagenSync()
 		}
 
 		// If they have a new version write the new version into last-started


### PR DESCRIPTION

## The Issue

This has apparently been an issue for quite some time, but if you change DDEV versions (upgrade, test a new one, whatever - or just change the `last_started_version` in ~/.ddev/global_config.yaml, it prompts you to poweroff. I guess I always did this... until recently. I didn't want to wait for it.

But then I would see that all of my other projects (the ones I didn't want to impact with a poweroff) were broken because their mutagen session was gone.

<img width="1100" alt="image" src="https://github.com/ddev/ddev/assets/112444/ac9d1d27-7d63-4733-9d5d-35915da9fa8f">


## How This PR Solves The Issue

If people do not agree to a poweroff, do not delete their mutagen sessions.

## Manual Testing Instructions

Change the last_started_version in global config and `ddev start` a project.  Do not accept poweroff.The other projects should not be broken.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
