### PR TITLE
refactor: set default drupal config to php 8.3 for drupal 11 compatibility, fixes #6306

### DIFF
--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -65,7 +65,7 @@ func TestConfigOverrideAction(t *testing.T) {
 		nodeps.AppTypeCraftCms:     nodeps.PHPDefault,
 		nodeps.AppTypeDrupal6:      nodeps.PHP56,
 		nodeps.AppTypeDrupal7:      nodeps.PHP82,
-		nodeps.AppTypeDrupal:       nodeps.PHPDefault,
+		nodeps.AppTypeDrupal:       nodeps.PHP83,
 		nodeps.AppTypeLaravel:      nodeps.PHP82,
 		nodeps.AppTypeMagento:      nodeps.PHPDefault,
 		nodeps.AppTypeMagento2:     nodeps.PHP82,

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -230,7 +230,7 @@ func TestConfigCommand(t *testing.T) {
 	testMatrix := map[string][]string{
 		"magentophpversion": {nodeps.AppTypeMagento, nodeps.PHPDefault},
 		"drupal7phpversion": {nodeps.AppTypeDrupal7, nodeps.PHP82},
-		"drupalphpversion":  {nodeps.AppTypeDrupal, nodeps.PHPDefault},
+		"drupalphpversion":  {nodeps.AppTypeDrupal, nodeps.PHP83},
 	}
 
 	for testName, testValues := range testMatrix {

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -357,6 +357,7 @@ func drupal7ConfigOverrideAction(app *DdevApp) error {
 
 // drupalConfigOverrideAction selects proper versions for
 func drupalConfigOverrideAction(app *DdevApp) error {
+	app.PHPVersion = nodeps.PHP83
 	v, err := GetDrupalVersion(app)
 	if err != nil || v == "" {
 		util.Warning("Unable to detect Drupal version, continuing")


### PR DESCRIPTION
## The Issue

- Fixes #6306

Make default `drupal` config Drupal 11 compatible. 

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
