### PR TITLE
fix: Support MySQL 5.5 and 5.6 on ddev-webserver by using MySQL 5.7 clients

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
@@ -13,6 +13,11 @@ if [ "${DDEV_DATABASE_FAMILY}" != "mysql" ]; then
 fi
 ARCH=$(dpkg --print-architecture)
 MYSQL_VERSION=${DDEV_DATABASE#*:}
+# For MySQL 5.6 and 5.5 we can't build the client, but the 5.7 client is probably as good as it gets
+if [ "${MYSQL_VERSION}" = "5.6" ] || [ "${MYSQL_VERSION}" = "5.5" ]; then
+  MYSQL_VERSION="5.7"
+fi
+
 TARBALL_VERSION=v0.2.2
 TARBALL_URL=https://github.com/ddev/mysql-client-build/releases/download/${TARBALL_VERSION}/mysql-${MYSQL_VERSION}-${ARCH}.tar.gz
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1015,8 +1014,8 @@ redirect_stderr=true
 		}
 		extraWebContent = extraWebContent + "\nADD webextradaemons.conf /etc/supervisor/conf.d\nRUN chmod 644 /etc/supervisor/conf.d/webextradaemons.conf\n"
 	}
-	// For MySQL 5.7+ we'll install the matching mysql client (and mysqldump) in the ddev-webserver
-	if app.Database.Type == "mysql" && slices.Contains([]string{nodeps.MySQL57, nodeps.MySQL80, nodeps.MySQL84}, app.Database.Version) {
+	// For MySQL 5.5+ we'll install the matching mysql client (and mysqldump) in the ddev-webserver
+	if app.Database.Type == "mysql" {
 		extraWebContent = extraWebContent + "\nRUN mysql-client-install.sh || true\n"
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1016,7 +1016,7 @@ redirect_stderr=true
 	}
 	// For MySQL 5.5+ we'll install the matching mysql client (and mysqldump) in the ddev-webserver
 	if app.Database.Type == "mysql" {
-		extraWebContent = extraWebContent + "\nRUN mysql-client-install.sh || true\n"
+		extraWebContent = extraWebContent + "\nRUN timeout 30 mysql-client-install.sh || true\n"
 	}
 
 	err = WriteBuildDockerfile(app.GetConfigPath(".webimageBuild/Dockerfile"), app.GetConfigPath("web-build"), app.WebImageExtraPackages, app.ComposerVersion, extraWebContent)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240612_fix_testAcquiaPush" // Note that this can be overridden by make
+var WebTag = "20240613_rfay_mysql_5.5_5.6" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

* https://github.com/ddev/ddev/issues/6083#issuecomment-2165714455

It seems that people still do use MySQL 5.6 and maybe somebody out there still uses 5.5

We can't build the clients for those long-obsolete versions for Debian 12 Bookworm, but they should work fine with the MySQL 5.7 client. 

## How This PR Solves The Issue

If MySQL 5.5 or 5.6, use the mysql 5.7 client in the ddev-webserver.

## Manual Testing Instructions

Try using mysql 5.6. `ddev exec mysql --version` should show the 5.7 client.

I tested this on Gitpod with mysql 5.5 and 5.6 and it seems to be fine.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
