### PR TITLE
docs: update instructions for cleaning up old `ddev` binaries

### DIFF
--- a/docs/content/users/install/ddev-upgrade.md
+++ b/docs/content/users/install/ddev-upgrade.md
@@ -2,6 +2,9 @@
 
 Installing and upgrading DDEV are nearly the same thing, because you're upgrading the `ddev` binary that talks with Docker. You can update this file like other software on your system, whether it’s with a package manager or traditional installer.
 
+!!!tip "`ddev --version` shows an old version"
+    If you have installed or upgraded DDEV to the latest version, but when you check the actual version with `ddev --version`, it shows an older version, please refer to [Why do I have an old DDEV?](../usage/faq.md#why-do-i-have-an-old-ddev)
+
 === "macOS"
 
     ## macOS

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -250,7 +250,7 @@ You may have installed DDEV several times using different techniques. Use `which
 $ which -a ddev
 /home/linuxbrew/.linuxbrew/bin/ddev # installed with Homebrew
 /usr/local/bin/ddev # installed manually with install_ddev.sh script
-/usr/bin/ddev # installed with apt/yum
+/usr/bin/ddev # installed with apt or yum/rpm
 /bin/ddev # don't touch it, it's a link to /usr/bin/ddev
 ```
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -244,15 +244,21 @@ If you’re using Homebrew, first run `brew unlink ddev` to get rid of the versi
 
 ### Why do I have an old DDEV?
 
-You may have installed DDEV several times using different techniques. Use `which -a ddev` to find all installed binaries. For example, you could install a DDEV in WSL2 with Homebrew, forget about it for a while, and then install it again with `apt`:
+You may have installed DDEV several times using different techniques. Use `which -a ddev` to find all installed binaries. For example, you could install a DDEV in WSL2 with Homebrew, forget about it for a while, install it manually, and then install it again with `apt`:
 
 ```bash
 $ which -a ddev
-/home/linuxbrew/.linuxbrew/bin/ddev
-/usr/bin/ddev
+/home/linuxbrew/.linuxbrew/bin/ddev # installed with Homebrew
+/usr/local/bin/ddev # installed manually with install_ddev.sh script
+/usr/bin/ddev # installed with apt/yum
+/bin/ddev # don't touch it, it's a link to /usr/bin/ddev
 ```
 
-You can check each binary version by its full path (`/usr/bin/ddev --version`) to find old versions. Remove them preferably in the same way you installed them, i.e. `/home/linuxbrew/.linuxbrew/bin/ddev` should be removed with Homebrew: `brew uninstall ddev`.
+You can check each binary version by its full path (`/usr/bin/ddev --version`) to find old versions. Remove them preferably in the same way you installed them, i.e. `/home/linuxbrew/.linuxbrew/bin/ddev` should be removed with Homebrew: `brew uninstall ddev`. A manually installed DDEV can be removed by deleting the `ddev` binary.
+
+Restart the terminal (or run `hash -r`) after uninstalling other versions of DDEV for the changes to take effect.
+
+If you see duplicates in the `which -a ddev` output, it means that some directories are added to your `$PATH` more than once. You can either ignore this or remove the extra directory from your `$PATH`.
 
 ### How can I back up or restore all project databases?
 

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -252,7 +252,7 @@ You should then be able to start your DDEV machine.
 
 ## `ddev --version` shows an old version
 
-If you have installed the latest version of DDEV, but when you check the actual version with `ddev --version`, it shows an older version, please refer to [Why do I have an old DDEV?](./faq.md#why-do-i-have-an-old-ddev)
+If you have installed or upgraded DDEV to the latest version, but when you check the actual version with `ddev --version`, it shows an older version, please refer to [Why do I have an old DDEV?](./faq.md#why-do-i-have-an-old-ddev)
 
 ## Trouble Building Dockerfiles
 


### PR DESCRIPTION

## The Issue

From Discord:
ddev version different when trying to upgrade
https://discord.com/channels/664580571770388500/1250826678096236554/1250826678096236554

## How This PR Solves The Issue

Updates instructions to include more use cases.
Adds a tip to the "Upgrading DDEV" page.

## Manual Testing Instructions

Rendered version is at https://ddev--6310.org.readthedocs.build/en/6310/users/install/ddev-upgrade/

