### PR TITLE
build: use $XDG_CONFIG_HOME in Gitpod for v1.23.2 release, for #6228 [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ddev/ddev-gitpod-base:20240516
+image: ddev/ddev-gitpod-base:20240614
 tasks:
   - name: build-run
     init: |

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -25,7 +25,12 @@ RUN echo 'if [ -r "/home/linuxbrew/.linuxbrew/etc/profile.d/bash_completion.sh" 
 RUN echo 'export PATH=~/bin:$PATH' >>~/.bashrc && mkdir -p ~/bin
 RUN echo ". /usr/share/autojump/autojump.sh" >> ~/.bashrc
 RUN ln -sf /workspace/ddev/.gotmp/bin/linux_amd64/ddev ~/bin/ddev
-RUN mkdir -p ~/.ddev && echo "omit_containers: [ddev-router]" >> ~/.ddev/global_config.yaml
+# Use a non-volatile global config location
+ENV XDG_CONFIG_HOME=/workspace/.config
+RUN mkdir -p ${XDG_CONFIG_HOME}/ddev && echo "omit_containers: [ddev-router]" >> ${XDG_CONFIG_HOME}/ddev/global_config.yaml
+# Make a link to the previous global config location,
+# in case someone has hardcoded it in their projects somewhere, e.g. in hooks
+RUN ln -sf ${XDG_CONFIG_HOME}/ddev ~/.ddev
 RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
 # a gcc instance named gcc-5 is required for some vscode installations


### PR DESCRIPTION
## The Issue

- #6228

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Sets `XDG_CONFIG_HOME=/workspace/.config` inside the Gitpod container.
DDEV global configuration will be stored in a non-volatile location: `${XDG_CONFIG_HOME}/ddev`
I added a symlink from `~/.ddev` to `${XDG_CONFIG_HOME}/ddev`, so it won't break a custom user script (e.g. in hooks) that uses the `~/.ddev` location.

## Manual Testing Instructions

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ddev/ddev/pull/6315)

Click Open in Gitpod, change some global config setting, e.g.:
```
ddev config global --internet-detection-timeout-ms 4000
```
Stop the workspace in https://gitpod.io/workspaces, open it again, and confirm that setting is the same:
```
ddev config global | grep internet-detection-timeout-ms
internet-detection-timeout-ms=4000
```
Check that `~/.ddev` points to `${XDG_CONFIG_HOME}/ddev`
```
ls -la ~ | grep .ddev
lrwxrwxrwx 1 gitpod gitpod   23 Jun 14 11:00 .ddev -> /workspace/.config/ddev
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
