### PR TITLE
docs: suggestion ddev --version, move mkcert -install to later

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -20,7 +20,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### Install Script
 
-    The [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) is another option. It downloads, verifies, and sets up the `ddev` binary:
+    The [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) is another option. It downloads, verifies, and sets up the `ddev` executable:
 
     ```bash
     # Download and run the install script
@@ -28,7 +28,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ```
 
     ??? "Do you still have an old version after installing or upgrading?"
-        If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` binary must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
+        If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` executable must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
     ??? "Need a specific version?"
         Use the `-s` argument to specify a specific stable or prerelease version:
 
@@ -65,7 +65,10 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     mkcert -install
     ```
 
-    (Some versions of Firefox (Developer Edition, Flatpak) may need some [extra work](https://github.com/FiloSottile/mkcert/issues/370#issuecomment-1280377305), see also [this issue](https://github.com/ddev/ddev/issues/5415).)
+    (Some versions of Firefox (Developer Edition, Flatpak) may need some [extra work](https://github.com/FiloSottile/mkcert/issues/370#issuecomment-1280377305) with `mkcert`, see also [this issue](https://github.com/ddev/ddev/issues/5415).)
+
+    ??? "Do you still have an old version after installing or upgrading?"
+        If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` executable must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
 
     ??? "Need to remove a previously-installed variant?"
         If you previously used DDEV’s [install script](#install-script), you can remove that version:
@@ -104,9 +107,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ```bash
     # Install DDEV
     yay -S ddev-bin
-    ```
 
-    ```bash
     # One-time initialization of mkcert
     mkcert -install
     ```
@@ -124,7 +125,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     <!-- we’re using HTML here to customize the #install-script-linux anchor -->
     <h3 id="install-script-linux">Install Script<a class="headerlink" href="#install-script-linux" title="Permanent link">¶</a></h3>
 
-    The [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) is another option. It downloads, verifies, and sets up the `ddev` binary:
+    The [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) is another option. It downloads, verifies, and sets up the `ddev` executable:
 
     ```bash
     # Download and run the install script
@@ -140,7 +141,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         ```
 
     ??? "Do you still have an old version after installing or upgrading?"
-        If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` binary must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
+        If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` executable must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
 
 === "Windows"
 
@@ -498,7 +499,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ## Manual
 
-    DDEV is a single executable, so installation on any OS is a matter of copying the `ddev` binary for your architecture into the appropriate system path on your machine.
+    DDEV is a single executable, so installation on any OS is a matter of copying the `ddev` executable for your architecture into the appropriate system path on your machine.
 
     * Download and extract the latest [DDEV release](https://github.com/ddev/ddev/releases) for your architecture.
     * Move `ddev` to `/usr/local/bin` with `mv ddev /usr/local/bin/` (may require `sudo`), or another directory in your `$PATH` as preferred.

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -8,13 +8,13 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### Homebrew
 
-    [Homebrew](https://brew.sh/) is the easiest and most reliable way to install and upgrade DDEV:
+    [Homebrew](https://brew.sh/) is the easiest and most reliable way to install and [upgrade](./ddev-upgrade.md) DDEV:
 
     ```bash
     # Install DDEV
     brew install ddev/ddev/ddev
 
-    # Initialize mkcert
+    # One-time initialization of mkcert
     mkcert -install
     ```
 
@@ -27,6 +27,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     curl -fsSL https://ddev.com/install.sh | bash
     ```
 
+    ??? "Do you still have an old version after installing or upgrading?"
+        If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` binary must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
     ??? "Need a specific version?"
         Use the `-s` argument to specify a specific stable or prerelease version:
 
@@ -38,17 +40,6 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 === "Linux"
 
     ## Linux
-
-    ### Locally-trusted certificate with mkcert
-
-    Modern browsers require valid certificates, which mkcert can create. [Install mkcert](https://github.com/FiloSottile/mkcert#installation), and then run this:
-
-    ```bash
-    # Initialize mkcert
-    mkcert -install
-    ```
-
-    Some versions of Firefox (Developer Edition, Flatpak) may need some [extra work](https://github.com/FiloSottile/mkcert/issues/370#issuecomment-1280377305), see also [this issue](https://github.com/ddev/ddev/issues/5415).
 
     ### Debian/Ubuntu
 
@@ -69,7 +60,12 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     # Update package information and install DDEV
     sudo sh -c 'echo ""'
     sudo apt-get update && sudo apt-get install -y ddev
+
+    # One-time initialization of mkcert
+    mkcert -install
     ```
+
+    (Some versions of Firefox (Developer Edition, Flatpak) may need some [extra work](https://github.com/FiloSottile/mkcert/issues/370#issuecomment-1280377305), see also [this issue](https://github.com/ddev/ddev/issues/5415).)
 
     ??? "Need to remove a previously-installed variant?"
         If you previously used DDEV’s [install script](#install-script), you can remove that version:
@@ -94,7 +90,9 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     # Install DDEV
     sudo sh -c 'echo ""'
     sudo dnf install --refresh ddev
-    ```
+
+    # One-time initialization of mkcert
+    mkcert -install
 
     Signed yum repository support will be added in the future.
 
@@ -107,11 +105,19 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     yay -S ddev-bin
     ```
 
+    ```bash
+    # One-time initialization of mkcert
+    mkcert -install
+    ```
+
     ### Homebrew (AMD64 only)
 
     ```bash
     # Install DDEV using Homebrew
     brew install ddev/ddev/ddev
+    # One-time initialization of mkcert
+    mkcert -install
+
     ```
 
     <!-- we’re using HTML here to customize the #install-script-linux anchor -->
@@ -131,6 +137,9 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         # Download and run the script to install DDEV v1.21.4
         curl -fsSL https://ddev.com/install.sh | bash -s v1.21.4
         ```
+
+    ??? "Do you still have an old version after installing or upgrading?"
+        If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` binary must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
 
 === "Windows"
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -93,6 +93,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     # One-time initialization of mkcert
     mkcert -install
+    ```
 
     Signed yum repository support will be added in the future.
 
@@ -115,9 +116,9 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ```bash
     # Install DDEV using Homebrew
     brew install ddev/ddev/ddev
+
     # One-time initialization of mkcert
     mkcert -install
-
     ```
 
     <!-- we’re using HTML here to customize the #install-script-linux anchor -->

--- a/docs/content/users/install/ddev-upgrade.md
+++ b/docs/content/users/install/ddev-upgrade.md
@@ -23,6 +23,10 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     curl -fsSL https://ddev.com/install.sh | bash
     ```
 
+    ### Verify New Version
+
+    Use `ddev --version` to find out the version of the `ddev` binary in your `$PATH`. If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` binary must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
+
     ??? "Need a specific version?"
         Use the `-s` argument to specify a specific stable or prerelease version:
 
@@ -56,6 +60,10 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     yay -Syu ddev-bin
     ```
 
+    ### Verify New Version
+
+    Use `ddev --version` to find out the version of the `ddev` binary in your `$PATH`. If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` binary must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
+
 === "Windows"
 
     ## Windows
@@ -70,6 +78,10 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
     # Upgrade the DDEV package
     sudo apt-get update && sudo apt-get upgrade -y
     ```
+
+    ### Verify New Version
+
+    Use `ddev --version` to find out the version of the `ddev` binary in your `$PATH`. If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` binary must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
 
     ### Traditional Windows
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -45,5 +45,5 @@ for ddev_path in $(which -a ddev | uniq); do
   esac
 done
 printf "\n'ddev --version' will show you the version you currently have installed.\n"
-printf "'which ddev' will show you where that executable is on your filesystem\n"
+printf "'which ddev' will show you where that executable is on your filesystem.\n"
 printf "See docs for more info: \nhttps://ddev.readthedocs.io/en/stable/users/install/ddev-installation/\n"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -44,3 +44,6 @@ for ddev_path in $(which -a ddev | uniq); do
 
   esac
 done
+printf "\n'ddev --version' will show you the version you currently have installed.\n"
+printf "'which ddev' will show you where that executable is on your filesystem\n"
+printf "See docs for more info: \nhttps://ddev.readthedocs.io/en/stable/users/install/ddev-installation/\n"


### PR DESCRIPTION

## The Issue

* A fairly common question is "I upgraded DDEV but `ddev --version` still shows the old version.
* `mkcert` is installed as a dependency most places, so a separate mention of the download etc is not needed.


## How This PR Solves The Issue

Update docs

