### PR TITLE
docs: Remove stray info about packages from hooks docs

### DIFF
--- a/docs/content/users/configuration/hooks.md
+++ b/docs/content/users/configuration/hooks.md
@@ -176,10 +176,3 @@ hooks:
     post-start:
       - composer: install
 ```
-
-## Adding Additional Debian Packages (PHP Modules) Example
-
-```yaml
-webimage_extra_packages: ["php-bcmath", "php7.4-tidy"]
-dbimage_extra_packages: ["vim"]
-```


### PR DESCRIPTION

## The Issue

This removes a stray recommendation about adding php packages that somehow lived in the hooks page.

