### PR TITLE
docs: Improve ddev debug test by offering suggestions early [skip ci]

### DIFF
--- a/cmd/ddev/cmd/debug-test.go
+++ b/cmd/ddev/cmd/debug-test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -32,7 +33,7 @@ var DebugTestCmdCmd = &cobra.Command{
 		}
 		p := util.WindowsPathToCygwinPath(tmpDir)
 		c := []string{"-c", path.Join(p, "test_ddev.sh") + " " + outputFilename}
-		util.Success("Running %s %v", bashPath, c)
+		util.Debug("Running %s %v", bashPath, c)
 
 		// Create a new file to capture output
 		f, err := os.Create(outputFilename)
@@ -41,11 +42,15 @@ var DebugTestCmdCmd = &cobra.Command{
 		}
 		defer f.Close()
 
-		util.Success("Resulting output will be written to:\n%s\nfile://%s\nPlease provide the file for support in Discord or the issue queue.", outputFilename, outputFilename)
+		util.Success("Please make sure you have already looked at troubleshooting guide:")
+		util.Success("https://ddev.readthedocs.io/en/stable/users/usage/troubleshooting/")
+		util.Success("Simple things to check:\n* ddev poweroff\n* Restart Docker Provider\n* Reboot computer\n* Temporarily disable VPN and firewall\n* Remove customizations like 'docker-compose.*.yaml' and PHP/Apache/Nginx config while debugging.")
+
+		output.UserOut.Printf("Resulting output will be written to:\n%s\nfile://%s\nPlease provide the file for support in Discord or the issue queue.", outputFilename, outputFilename)
 
 		activeApps := ddevapp.GetActiveProjects()
 		if len(activeApps) > 0 {
-			y := util.Confirm("OK to stop running projects? This does no harm, and they will be restarted")
+			y := util.Confirm("OK to stop running projects? This does no harm, they will be restarted")
 			if !y {
 				util.Warning("Exiting, no permission given to poweroff")
 				os.Exit(3)

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -30,12 +30,10 @@ function docker_desktop_version {
   fi
 }
 
-header "Please make sure that you have already looked at troubleshooting guide"
 
-printf "Troubleshooting guide: https://ddev.readthedocs.io/en/stable/users/usage/troubleshooting/ \n"
-printf "Simple things to check:\n* ddev poweroff\n* Restart Docker Provider\n* Reboot computer\n* Temporarily disable VPN and firewall\n"
-printf "Press any key to continue:\n"
-[[ "${DDEV_NONINTERACTIVE:-}" == "true" ]] || read x
+if [[ ${PWD} != ${HOME}* ]]; then
+  printf "\n\nWARNING: Project should usually be in a subdirectory of the user's home directory.\nInstead it's in ${PWD}\n\n"
+fi
 
 header "Output file will be in $1"
 if ! ddev describe >/dev/null 2>&1; then printf "Please try running this in an existing DDEV project directory, preferably the problem project.\nIt doesn't work in other directories.\n"; exit 2; fi
@@ -46,10 +44,6 @@ header "Existing project config"
 echo "ddev installation alternate locations:"
 which -a ddev
 echo
-
-if [[ ${PWD} != ${HOME}* ]]; then
-  printf "\n\nWARNING: Project should most often be in a subdirectory of the user's home directory.\nInstead it's in ${PWD}\n\n"
-fi
 
 ddev debug configyaml | grep -v web_environment
 


### PR DESCRIPTION

## The Issue

`ddev debug test` can do a better job coaching people about debugging. This tries to focus them more on that at the beginning.

Eventually we should actually have a clearer diagnosis script maybe.

## How This PR Solves The Issue

<img width="947" alt="image" src="https://github.com/ddev/ddev/assets/112444/0c7d648e-bac3-47b7-a13c-a705aa01ec66">


