### PR TITLE
fix: generated gitignore is not working correctly

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1405,7 +1405,9 @@ func PrepDdevDirectory(app *DdevApp) error {
 		return err
 	}
 
-	err = CreateGitIgnore(dir, "**/*.example", ".dbimageBuild", ".dbimageExtra", ".ddev-docker-*.yaml", ".*downloads", ".homeadditions", ".importdb*", ".sshimageBuild", ".venv", ".webimageBuild", ".webimageExtra", "apache/apache-site.conf", "commands/.gitattributes", "commands/db/mysql", "commands/host/launch", "commands/web/xdebug", "commands/web/live", "config.local.y*ml", "db_snapshots", "import-db", "import.yaml", "mutagen/mutagen.yml", "mutagen/.start-synced", "nginx_full/nginx-site.conf", "postgres/postgresql.conf", "providers/acquia.yaml", "providers/lagoon.yaml", "providers/platform.yaml", "providers/upsun.yaml", "sequelpro.spf", "settings/settings.ddev.py", fmt.Sprintf("traefik/config/%s.yaml", app.Name), fmt.Sprintf("traefik/certs/%s.crt", app.Name), fmt.Sprintf("traefik/certs/%s.key", app.Name), "xhprof/xhprof_prepend.php", "**/README.*")
+	// Some of the listed items are wildcards or directories, and if they are, there's an error
+	// opening them and they innately get added to the .gitignore.
+	err = CreateGitIgnore(dir, "**/*.example", ".dbimageBuild", ".ddev-docker-*.yaml", ".*downloads", ".homeadditions", ".importdb*", ".sshimageBuild", ".venv", ".webimageBuild", "apache/apache-site.conf", "commands/.gitattributes", "config.local.y*ml", "db_snapshots", "mutagen/mutagen.yml", "mutagen/.start-synced", "nginx_full/nginx-site.conf", "postgres/postgresql.conf", "providers/acquia.yaml", "providers/lagoon.yaml", "providers/pantheon.yaml", "providers/platform.yaml", "providers/upsun.yaml", "sequelpro.spf", "settings/settings.ddev.py", fmt.Sprintf("traefik/config/%s.yaml", app.Name), fmt.Sprintf("traefik/certs/%s.crt", app.Name), fmt.Sprintf("traefik/certs/%s.key", app.Name), "xhprof/xhprof_prepend.php", "**/README.*")
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -251,7 +251,11 @@ func CreateGitIgnore(targetDir string, ignores ...string) error {
 
 	generatedIgnores := []string{}
 	for _, p := range ignores {
-		sigFound, err := fileutil.FgrepStringInFile(p, nodeps.DdevFileSignature)
+		pFullPath := filepath.Join(targetDir, p)
+		sigFound, err := fileutil.FgrepStringInFile(pFullPath, nodeps.DdevFileSignature)
+		//if err != nil {
+		//	util.Warning("file not found: %s: %v", p, err)
+		//}
 		if sigFound || err != nil {
 			generatedIgnores = append(generatedIgnores, p)
 		}


### PR DESCRIPTION

## The Issue

In studying 
* #6317

I found that the project .ddev/.gitignore was not being created correctly at all. Mostly it was failing.

It's intended to look for named files, check them for #ddev-generated, and add them to the .gitignore if that's found *or* if there's an error in opening the file.

However, due to a bug in the logic, it wasn't successfully opening *any* file, and as a result was not adding files to the .gitignore that should be added (like if they had the #ddev-generated removed).

This PR:
* Removes a number of obsolete items from the CreateGitignore() call. I didn't recognize several of them, and didn't find them in a search.
* Fixes so we actually grep the right file before adding it to the .gitignore

## Manual Testing Instructions

Remove the "#ddev-generated" from an important file, like in providers dir, or traekfik/config. `ddev start` and it should show in `git status`

## Automated Testing Overview

I thought TestConfigGitignore would have caught this, but it seems to have been created for slightly different reason.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
