### PR TITLE
fix: autodownload yarn from corepack, and set cache-folder, fixes #6332

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -96,12 +96,14 @@ sudo mkdir -p ${TERMINUS_CACHE_DIR}
 sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry,corepack}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 # The following ensures a persistent and shared "global" cache for
-# yarn1 (classic) and yarn2 (berry). In the case of yarn2, the global cache
+# yarn classic (frozen v1) and yarn berry (active). In the case of berry, the global cache
 # will only be used if the project is configured to use it through it's own
 # enableGlobalCache configuration option. Assumes ~/.yarn/berry as the default
 # global folder.
-( (cd ~ || echo "unable to cd to home directory"; exit 22) && yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic || true)
-# ensure default yarn2 global folder is there to symlink cache afterwards
+(if cd ~ || (echo "unable to cd to home directory"; exit 22); then
+  yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic >/dev/null || true
+fi)
+# ensure default yarn berry global folder is there to symlink cache afterwards
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ~/.nvm

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -93,12 +93,14 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},nvm_dir/${HOSTNAME},npm,yarn/classic,yarn/berry,corepack}
 
 # The following ensures a persistent and shared "global" cache for
-# yarn1 (classic) and yarn2 (berry). In the case of yarn2, the global cache
+# yarn classic (frozen v1) and yarn berry (active). In the case of berry, the global cache
 # will only be used if the project is configured to use it through it's own
 # enableGlobalCache configuration option. Assumes ~/.yarn/berry as the default
 # global folder.
-( (cd ~ || echo "unable to cd to home directory"; exit 22) && yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic || true)
-# ensure default yarn2 global folder is there to symlink cache afterwards
+(if cd ~ || (echo "unable to cd to home directory"; exit 22); then
+  yarn config set cache-folder /mnt/ddev-global-cache/yarn/classic >/dev/null || true
+fi)
+# ensure default yarn berry global folder is there to symlink cache afterwards
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ~/.nvm

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -171,6 +171,7 @@ services:
     {{ end }}
     environment:
     - COLUMNS
+    - COREPACK_ENABLE_DOWNLOAD_PROMPT=0
     - COREPACK_HOME=/mnt/ddev-global-cache/corepack
     - DOCROOT=${DDEV_DOCROOT}
     - DDEV_COMPOSER_ROOT

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.23.2" // Note that this can be overridden by make
+var WebTag = "20240620_stasadev_corepack_yarn" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #6332

Yarn should not ask to download classic yarn with `corepack enable`.

## How This PR Solves The Issue

Adds `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` to disable download prompt for Yarn.
In addition, I found that `yarn set config cache-folder` was never called because of an incorrect condition.

## Manual Testing Instructions

1. `docker run --rm -it -v ddev-global-cache:/mnt/ddev-global-cache busybox sh -c "rm -rf /mnt/ddev-global-cache/corepack"` to remove cached yarn downloads
2. `ddev config --corepack-enable && ddev start && ddev yarn -v` should not ask for download
3. `ddev yarn config get cache-folder` should show `/mnt/ddev-global-cache/yarn/classic` (this command works only for yarn v1)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
