### PR TITLE
build: use IPv4 inside a container, mariadb-client 11.4 for the webserver

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -394,6 +394,7 @@ dockerhub:
       - '{{ .Env.DOCKER_ORG }}/ddev-dbserver-mariadb-10.7'
       - '{{ .Env.DOCKER_ORG }}/ddev-dbserver-mariadb-10.8'
       - '{{ .Env.DOCKER_ORG }}/ddev-dbserver-mariadb-10.11'
+      - '{{ .Env.DOCKER_ORG }}/ddev-dbserver-mariadb-11.4'
       - '{{ .Env.DOCKER_ORG }}/ddev-dbserver-mysql-5.5'
       - '{{ .Env.DOCKER_ORG }}/ddev-dbserver-mysql-5.6'
       - '{{ .Env.DOCKER_ORG }}/ddev-dbserver-mysql-5.7'

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -646,7 +646,7 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 		}
 		parts := strings.Split(raw, ":")
 		if len(parts) != 2 {
-			util.Failed("Incorrect database value: %s - use something like 'mariadb:10.3 or mysql:8.0. Options are %v", raw, nodeps.GetValidDatabaseVersions())
+			util.Failed("Incorrect database value: %s - use something like 'mariadb:10.11' or 'mysql:8.0'. Options are %v", raw, nodeps.GetValidDatabaseVersions())
 		}
 		app.Database.Type = parts[0]
 		app.Database.Version = parts[1]

--- a/cmd/ddev/cmd/debug-migrate-database.go
+++ b/cmd/ddev/cmd/debug-migrate-database.go
@@ -16,7 +16,7 @@ var DebugMigrateDatabase = &cobra.Command{
 	Use:   "migrate-database",
 	Short: "Migrate a MySQL or MariaDB database to a different dbtype:dbversion; works only with MySQL and MariaDB, not with PostgreSQL",
 	Example: `ddev debug migrate-database mysql:8.0
-ddev debug migrate-database mariadb:10.7`,
+ddev debug migrate-database mariadb:11.4`,
 	Args: cobra.ExactArgs(1),
 	Run: func(_ *cobra.Command, args []string) {
 		app, err := ddevapp.GetActiveApp("")

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -81,10 +81,6 @@ RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
 RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
 http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
 
-# Prefer IPv4 over IPv6 for commands like "ping" inside a container.
-# https://wiki.archlinux.org/title/IPv6#Prefer_IPv4_over_IPv6
-RUN sed -i '/^#\s*precedence\s*::ffff:0:0\/96\s*100$/s/^#//' /etc/gai.conf
-
 # Install mariadb_repo_setup to get mariadb-client from them directly
 RUN curl -LsSf https://r.mariadb.com/downloads/mariadb_repo_setup -o /usr/local/bin/mariadb_repo_setup && chmod +x /usr/local/bin/mariadb_repo_setup
 # Don't forget to update mariadb-client-install.sh when changing MariaDB version here

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -81,8 +81,13 @@ RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
 RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
 http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
 
+# Prefer IPv4 over IPv6 for commands like "ping" inside a container.
+# https://wiki.archlinux.org/title/IPv6#Prefer_IPv4_over_IPv6
+RUN sed -i '/^#\s*precedence\s*::ffff:0:0\/96\s*100$/s/^#//' /etc/gai.conf
+
 # Install mariadb_repo_setup to get mariadb-client from them directly
-RUN curl -LsSf https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version="mariadb-10.11"
+RUN curl -LsSf https://r.mariadb.com/downloads/mariadb_repo_setup -o /usr/local/bin/mariadb_repo_setup && chmod +x /usr/local/bin/mariadb_repo_setup
+RUN /usr/local/bin/mariadb_repo_setup --mariadb-server-version="mariadb-10.11"
 
 RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && rm -f /tmp/debsuryorg-archive-keyring.deb && \

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -87,6 +87,7 @@ RUN sed -i '/^#\s*precedence\s*::ffff:0:0\/96\s*100$/s/^#//' /etc/gai.conf
 
 # Install mariadb_repo_setup to get mariadb-client from them directly
 RUN curl -LsSf https://r.mariadb.com/downloads/mariadb_repo_setup -o /usr/local/bin/mariadb_repo_setup && chmod +x /usr/local/bin/mariadb_repo_setup
+# Don't forget to update mariadb-client-install.sh when changing MariaDB version here
 RUN /usr/local/bin/mariadb_repo_setup --mariadb-server-version="mariadb-10.11"
 
 RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -83,7 +83,7 @@ http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.lis
 
 # Install mariadb_repo_setup to get mariadb-client from them directly
 RUN curl -LsSf https://r.mariadb.com/downloads/mariadb_repo_setup -o /usr/local/bin/mariadb_repo_setup && chmod +x /usr/local/bin/mariadb_repo_setup
-# Don't forget to update mariadb-client-install.sh when changing MariaDB version here
+# Search for CHANGE_MARIADB_CLIENT to update related code.
 RUN /usr/local/bin/mariadb_repo_setup --mariadb-server-version="mariadb-10.11"
 
 RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:v1.23.2 as ddev-webserver-base
+FROM ddev/ddev-php-base:20240620_stasadev_ipv4 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/gai.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/gai.conf
@@ -1,0 +1,69 @@
+# This is the typical /etc/gai.conf from Debian Bookworm with this option enabled:
+# Prefer IPv4 over IPv6 for commands like "ping" inside a container.
+# https://wiki.archlinux.org/title/IPv6#Prefer_IPv4_over_IPv6
+
+# Configuration for getaddrinfo(3).
+#
+# So far only configuration for the destination address sorting is needed.
+# RFC 3484 governs the sorting.  But the RFC also says that system
+# administrators should be able to overwrite the defaults.  This can be
+# achieved here.
+#
+# All lines have an initial identifier specifying the option followed by
+# up to two values.  Information specified in this file replaces the
+# default information.  Complete absence of data of one kind causes the
+# appropriate default information to be used.  The supported commands include:
+#
+# reload  <yes|no>
+#    If set to yes, each getaddrinfo(3) call will check whether this file
+#    changed and if necessary reload.  This option should not really be
+#    used.  There are possible runtime problems.  The default is no.
+#
+# label   <mask>   <value>
+#    Add another rule to the RFC 3484 label table.  See section 2.1 in
+#    RFC 3484.  The default is:
+#
+#label ::1/128       0
+#label ::/0          1
+#label 2002::/16     2
+#label ::/96         3
+#label ::ffff:0:0/96 4
+#label fec0::/10     5
+#label fc00::/7      6
+#label 2001:0::/32   7
+#
+#    This default differs from the tables given in RFC 3484 by handling
+#    (now obsolete) site-local IPv6 addresses and Unique Local Addresses.
+#    The reason for this difference is that these addresses are never
+#    NATed while IPv4 site-local addresses most probably are.  Given
+#    the precedence of IPv6 over IPv4 (see below) on machines having only
+#    site-local IPv4 and IPv6 addresses a lookup for a global address would
+#    see the IPv6 be preferred.  The result is a long delay because the
+#    site-local IPv6 addresses cannot be used while the IPv4 address is
+#    (at least for the foreseeable future) NATed.  We also treat Teredo
+#    tunnels special.
+#
+# precedence  <mask>   <value>
+#    Add another rule to the RFC 3484 precedence table.  See section 2.1
+#    and 10.3 in RFC 3484.  The default is:
+#
+#precedence  ::1/128       50
+#precedence  ::/0          40
+#precedence  2002::/16     30
+#precedence ::/96          20
+#precedence ::ffff:0:0/96  10
+#
+#    For sites which prefer IPv4 connections change the last line to
+#
+precedence ::ffff:0:0/96  100
+
+#
+# scopev4  <mask>  <value>
+#    Add another rule to the RFC 6724 scope table for IPv4 addresses.
+#    By default the scope IDs described in section 3.2 in RFC 6724 are
+#    used.  Changing these defaults should hardly ever be necessary.
+#    The defaults are equivalent to:
+#
+#scopev4 ::ffff:169.254.0.0/112  2
+#scopev4 ::ffff:127.0.0.0/104    2
+#scopev4 ::ffff:0.0.0.0/96       14

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/gai.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/gai.conf
@@ -55,6 +55,8 @@
 #
 #    For sites which prefer IPv4 connections change the last line to
 #
+# Prefer IPv4 over IPv6 for commands like "ping" inside a container.
+# https://wiki.archlinux.org/title/IPv6#Prefer_IPv4_over_IPv6
 precedence ::ffff:0:0/96  100
 
 #

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
@@ -12,16 +12,18 @@ if [ "${DDEV_DATABASE_FAMILY}" != "mariadb" ]; then
   echo "This script is to be used only with a project using mariadb" && exit 1
 fi
 MARIADB_VERSION=${DDEV_DATABASE#*:}
-# Add all required MariaDB versions here
-if [ "${MARIADB_VERSION}" != "11.4" ]; then
-  echo "This script is not intended to run with mariadb:${MARIADB_VERSION}" && exit 0
+
+# Search for CHANGE_MARIADB_CLIENT to update related code.
+# Add MariaDB versions that can have their own client here:
+if [ "${MARIADB_VERSION}" = "11.4" ]; then
+  # Configure the correct repository for mariadb
+  set -x
+  timeout 30 mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}"
+  rm -f /etc/apt/sources.list.d/mariadb.list.old_*
+
+  # Install the mariadb-client and mysql symlinks
+  # MariaDB 11.x moved MySQL symlinks into separate packages
+  apt-get install -y mariadb-client mariadb-client-compat
+else
+  echo "This script is not intended to run with mariadb:${MARIADB_VERSION}" && exit 1
 fi
-
-# Configure the correct repository for mariadb
-set -x
-timeout 30 mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}"
-rm -f /etc/apt/sources.list.d/mariadb.list.old_*
-
-# Install the mariadb-client and mysql symlinks
-# MariaDB 11.x moved MySQL symlinks into separate packages
-apt-get install -y mariadb-client mariadb-client-compat

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script is used to install a matching mariadb-client
+# in ddev-webserver
+# It should be called with the appropriate mariadb version as an argument
+# This script is intended to be run with root privileges (normally in a docker build phase)
+
+set -eu -o pipefail
+
+DDEV_DATABASE_FAMILY=${DDEV_DATABASE%:*}
+if [ "${DDEV_DATABASE_FAMILY}" != "mariadb" ]; then
+  echo "This script is to be used only with a project using mariadb" && exit 1
+fi
+MARIADB_VERSION=${DDEV_DATABASE#*:}
+# Add all required MariaDB versions here
+if [ "${MARIADB_VERSION}" != "11.4" ]; then
+  echo "This script is not intended to run with mariadb:${MARIADB_VERSION}" && exit 0
+fi
+
+# Configure the correct repository for mariadb
+set -x
+timeout 30 mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}"
+rm -f /etc/apt/sources.list.d/mariadb.list.old_*
+
+# Install the mariadb-client and mysql symlinks
+# MariaDB 11.x moved MySQL symlinks into separate packages
+apt-get install -y mariadb-client mariadb-client-compat

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
@@ -23,9 +23,9 @@ TARBALL_URL=https://github.com/ddev/mysql-client-build/releases/download/${TARBA
 
 # Install the related mysql client if available
 set -x
-cd /tmp && curl -L -o /tmp/mysql.tgz --fail -s ${TARBALL_URL}
+cd /tmp && timeout 30 curl -L -o /tmp/mysql.tgz --fail -s ${TARBALL_URL}
 tar -zxf /tmp/mysql.tgz -C /usr/local/bin && rm -f /tmp/mysql.tgz
 
 # Remove any existing mariadb installs
-apt remove -y mariadb-client-core mariadb-client || true
-apt autoremove -y || true
+apt-get remove -y mariadb-client-core mariadb-client || true
+apt-get autoremove -y || true

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1015,8 +1015,12 @@ redirect_stderr=true
 		extraWebContent = extraWebContent + "\nADD webextradaemons.conf /etc/supervisor/conf.d\nRUN chmod 644 /etc/supervisor/conf.d/webextradaemons.conf\n"
 	}
 	// For MySQL 5.5+ we'll install the matching mysql client (and mysqldump) in the ddev-webserver
-	if app.Database.Type == "mysql" {
-		extraWebContent = extraWebContent + "\nRUN timeout 30 mysql-client-install.sh || true\n"
+	if app.Database.Type == nodeps.MySQL {
+		extraWebContent = extraWebContent + "\nRUN mysql-client-install.sh || true\n"
+	}
+	// For MariaDb 11.4 we'll install the matching mariadb-client in the ddev-webserver
+	if app.Database.Type == nodeps.MariaDB {
+		extraWebContent = extraWebContent + "\nRUN mariadb-client-install.sh || true\n"
 	}
 
 	err = WriteBuildDockerfile(app.GetConfigPath(".webimageBuild/Dockerfile"), app.GetConfigPath("web-build"), app.WebImageExtraPackages, app.ComposerVersion, extraWebContent)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1018,7 +1018,7 @@ redirect_stderr=true
 	if app.Database.Type == nodeps.MySQL {
 		extraWebContent = extraWebContent + "\nRUN mysql-client-install.sh || true\n"
 	}
-	// For MariaDb 11.4 we'll install the matching mariadb-client in the ddev-webserver
+	// Some MariaDB versions may have their own client in the ddev-webserver
 	if app.Database.Type == nodeps.MariaDB {
 		extraWebContent = extraWebContent + "\nRUN mariadb-client-install.sh || true\n"
 	}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2138,7 +2138,7 @@ func TestWebserverDBClient(t *testing.T) {
 
 			// Search for CHANGE_MARIADB_CLIENT to update related code.
 			if dbType == nodeps.MariaDB {
-				// For MariaDB, we have installed the 10.11 client.
+				// For MariaDB, we have installed the 10.11 client by default.
 				expectedClientVersion = "10.11"
 				// Add MariaDB versions that can have their own client here:
 				if dbVersion == nodeps.MariaDB114 {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2071,8 +2071,7 @@ func TestWebserverDBClient(t *testing.T) {
 	assert := asrt.New(t)
 
 	// TODO: Add MySQL84 when it gets added to DDEV
-	// TODO: Add mariadb:11.4 when it gets added
-	serverVersions := []string{"mysql:5.7", "mysql:8.0", "mariadb:10.11", "mariadb:10.6", "mariadb:10.4"}
+	serverVersions := []string{"mysql:5.7", "mysql:8.0", "mariadb:10.11", "mariadb:10.6", "mariadb:10.4", "mariadb:11.4"}
 
 	app := &ddevapp.DdevApp{}
 	origDir, _ := os.Getwd()
@@ -2140,6 +2139,10 @@ func TestWebserverDBClient(t *testing.T) {
 			// For mariadb we have installed the 10.11 client
 			if dbType == nodeps.MariaDB {
 				expectedClientVersion = "10.11"
+				// Use MariaDB 11.4 client
+				if dbVersion == nodeps.MariaDB114 {
+					expectedClientVersion = "11.4"
+				}
 			}
 			// Output might be "mysql  Ver 8.0.36 for Linux on aarch64 (Source distribution)"
 			// Or "mysql  Ver 14.14 Distrib 5.7.44, for Linux (aarch64) using  EditLine wrapper"

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2136,10 +2136,11 @@ func TestWebserverDBClient(t *testing.T) {
 			require.True(t, len(parts) > 5)
 			expectedClientVersion := dbVersion
 
-			// For mariadb we have installed the 10.11 client
+			// Search for CHANGE_MARIADB_CLIENT to update related code.
 			if dbType == nodeps.MariaDB {
+				// For MariaDB, we have installed the 10.11 client.
 				expectedClientVersion = "10.11"
-				// Use MariaDB 11.4 client
+				// Add MariaDB versions that can have their own client here:
 				if dbVersion == nodeps.MariaDB114 {
 					expectedClientVersion = "11.4"
 				}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -26,7 +26,7 @@ const ConfigInstructions = `
 #   type: <dbtype> # mysql, mariadb, postgres
 #   version: <version> # database version, like "10.11" or "8.0"
 #   MariaDB versions can be 5.5-10.8, 10.11, and 11.4.
-#   MySQL versions can be 5.5-8.0
+#   MySQL versions can be 5.5-8.0.
 #   PostgreSQL versions can be 9-16.
 
 # router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240620_stasadev_corepack_yarn" // Note that this can be overridden by make
+var WebTag = "20240620_stasadev_ipv4" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

From Discord https://discord.com/channels/664580571770388500/1252792407775514686

Something changed in Debian Bookworm, which results in ping being using IPv6 inside a container:

```
$ ddev exec ping -c 1 localhost
PING localhost(localhost (::1)) 56 data bytes
64 bytes from localhost (::1): icmp_seq=1 ttl=64 time=0.026 ms

--- localhost ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.026/0.026/0.026/0.000 ms
```

I don't have a pattern here, but I remember a time when it always used IPv4. We can make it more predictable to always prefer IPv4 over IPv6.

## How This PR Solves The Issue

1. There is a commented section in `/etc/gai.conf`, that we can uncomment:

- https://wiki.archlinux.org/title/IPv6#Prefer_IPv4_over_IPv6

```
#
#    For sites which prefer IPv4 connections change the last line to
#
precedence ::ffff:0:0/96  100
```

2. After MariaDB 11.4 goes in, we can use `mariadb_repo_setup` to install newer `mariadb-client`, there is no need to pull this script every time (because the connection might fail and we don't want that):

- #6243

## Manual Testing Instructions

1. `ddev exec ping -c 1 localhost` should ping `127.0.0.1`
2. `ddev debug migrate-database mariadb:11.4 && ddev exec mysql -V` should show `11.4`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
