### PR TITLE
docs: windows-wsl2-dd needs apt install for ngrok

### DIFF
--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -41,7 +41,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 1. The Ubuntu distro should be set up with the user `buildkite-agent`
 2. `sudo apt update && sudo apt install -y apt-transport-https autojump build-essential ca-certificates curl dirmngr etckeeper expect git gnupg icinga2 jq libcurl4-gnutls-dev libnss3-tools lsb-release mariadb-client nagios-plugins postgresql-client unzip vim zip`
 3. `sudo snap install --classic go`
-4. `sudo snap install ngrok`
+4. Install `ngrok` with the [`linux apt` technique](https://ngrok.com/download).
 5. `curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg`
 6. `echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list`
 7. `sudo apt-get update && sudo apt-get install -y buildkite-agent`


### PR DESCRIPTION

## The Issue

Minor docs update for Buildkite setup for wsl-dd. The ngrok install was wrong; you can't use snap ngrok outside /home.

