### PR TITLE
feat: add global phpmyadmin install command, fixes #6342

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -182,7 +182,7 @@ func TestCustomCommands(t *testing.T) {
 	assert.NoError(err)
 
 	// Make sure that all the official ddev-provided custom commands are usable by checking help
-	for _, c := range []string{"launch", "xdebug"} {
+	for _, c := range []string{"launch", "phpmyadmin", "xdebug"} {
 		_, err = exec.RunHostCommand(DdevBin, c, "-h")
 		assert.NoError(err, "Failed to run ddev %s -h", c)
 	}

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -38,19 +38,3 @@ case "$answer" in
         echo "Nothing has been changed."
         ;;
 esac
-
-if [[ "$answer" == "yes" ]]; then
-    ddev get ddev/ddev-phpmyadmin
-    echo "phpMyAdmin has been installed and requires a restart."
-    read -p "Would you like me to restart now? (yes/no): " answerrestart
-    if [[ "answerrestart" == "yes" ]]; then
-      ddev restart
-      echo "Run ddev phpmyadmin again to use it."
-    else
-      echo "You must manually restart ddev to use phpMyAdmin ddev restart."
-    fi
-elif [[ "$answer" == "no" ]]; then
-    echo "Nothing has been changed."
-else
-    echo "Please enter yes or no."
-fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -30,7 +30,7 @@ case "$answer" in
                 echo "Run ddev phpmyadmin again to use it."
                 ;;
             *)
-                echo "You must manually restart ddev to use phpMyAdmin ddev restart."
+                echo "You must run 'ddev restart' to finish configuring the phpMyAdmin add-on."
                 ;;
         esac
         ;;

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -5,16 +5,9 @@
 ## Usage: phpmyadmin
 ## Example: "ddev phpmyadmin"
 
-if [ "${DDEV_PROJECT_STATUS-running}" != "running" ] && [ -z "$no_recursion" ]; then
-  echo "Project ${DDEV_PROJECT} is not running, starting it"
-  ddev start
-  start_exit_code=$?
-  if [ $start_exit_code -ne 0 ]; then
-    exit $start_exit_code
-  fi
-  # run this script again, as the environment is updated after "ddev start"
-  no_recursion=true ddev "$(basename "$0")" "$@"
-  exit $?
+if [ "${DDEV_NONINTERACTIVE:-}" != "" ]]; then
+  echo "Nothing has been changed."
+  exit 0
 fi
 
 read -p "phpMyAdmin is not installed would you like to install? (y/N): " answer

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+## #ddev-generated: If you want to edit and own this file, remove this line.
+## Description: Prompt downloading phpMyAdmin if it is not installed.
+## Usage: phpmyadmin
+## Example: "ddev phpmyadmin"
+
+if [ "${DDEV_PROJECT_STATUS-running}" != "running" ] && [ -z "$no_recursion" ]; then
+  echo "Project ${DDEV_PROJECT} is not running, starting it"
+  ddev start
+  start_exit_code=$?
+  if [ $start_exit_code -ne 0 ]; then
+    exit $start_exit_code
+  fi
+  # run this script again, as the environment is updated after "ddev start"
+  no_recursion=true ddev "$(basename "$0")" "$@"
+  exit $?
+fi
+
+read -p "phpMyAdmin is not installed would you like to install? (yes/no): " answer
+
+if [[ "$answer" == "yes" ]]; then
+    ddev get ddev/ddev-phpmyadmin
+    echo "phpMyAdmin has been installed. Run ddev phpmyadmin again to use it."
+elif [[ "$answer" == "no" ]]; then
+    echo "Nothing has been changed."
+else
+    echo "Please enter yes or no."
+fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -21,6 +21,7 @@ read -p "phpMyAdmin is not installed would you like to install? (yes/no): " answ
 
 if [[ "$answer" == "yes" ]]; then
     ddev get ddev/ddev-phpmyadmin
+    ddev restart
     echo "phpMyAdmin has been installed. Run ddev phpmyadmin again to use it."
 elif [[ "$answer" == "no" ]]; then
     echo "Nothing has been changed."

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -19,10 +19,36 @@ fi
 
 read -p "phpMyAdmin is not installed would you like to install? (yes/no): " answer
 
+case "$answer" in
+    [Yy] | [Yy][Ee][Ss])
+        ddev get ddev/ddev-phpmyadmin
+        echo "phpMyAdmin has been installed and requires a restart."
+        read -p "Would you like me to restart now? (yes/no): " answerrestart
+        case "$answerrestart" in
+            [Yy] | [Yy][Ee][Ss])
+                ddev restart
+                echo "Run ddev phpmyadmin again to use it."
+                ;;
+            *)
+                echo "You must manually restart ddev to use phpMyAdmin ddev restart."
+                ;;
+        esac
+        ;;
+    *)
+        echo "Nothing has been changed."
+        ;;
+esac
+
 if [[ "$answer" == "yes" ]]; then
     ddev get ddev/ddev-phpmyadmin
-    ddev restart
-    echo "phpMyAdmin has been installed. Run ddev phpmyadmin again to use it."
+    echo "phpMyAdmin has been installed and requires a restart."
+    read -p "Would you like me to restart now? (yes/no): " answerrestart
+    if [[ "answerrestart" == "yes" ]]; then
+      ddev restart
+      echo "Run ddev phpmyadmin again to use it."
+    else
+      echo "You must manually restart ddev to use phpMyAdmin ddev restart."
+    fi
 elif [[ "$answer" == "no" ]]; then
     echo "Nothing has been changed."
 else

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -17,7 +17,7 @@ if [ "${DDEV_PROJECT_STATUS-running}" != "running" ] && [ -z "$no_recursion" ]; 
   exit $?
 fi
 
-read -p "phpMyAdmin is not installed would you like to install? (yes/no): " answer
+read -p "phpMyAdmin is not installed would you like to install? (y/N): " answer
 
 case "$answer" in
     [Yy] | [Yy][Ee][Ss])

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -6,8 +6,8 @@
 ## Example: "ddev phpmyadmin"
 
 if [ "${DDEV_NONINTERACTIVE:-}" != "" ]; then
-  echo "Nothing has been changed."
-  exit 0
+    echo "Nothing has been changed."
+    exit 0
 fi
 
 read -p "The phpMyAdmin add-on is not installed. Would you like to install it? (Y/n): [Y]" answer

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -19,7 +19,7 @@ case "$answer" in
     [Yy] | [Yy][Ee][Ss])
         ddev get ddev/ddev-phpmyadmin
         echo "phpMyAdmin has been installed and requires a restart."
-        read -p "Would you like me to restart now? (Y/n): [Y]" answerrestart
+        read -p "Would you like to restart DDEV now? (Y/n): [Y]" answerrestart
         if [ -z "$answerrestart" ]; then
             answerrestart="Y"
         fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -10,13 +10,19 @@ if [ "${DDEV_NONINTERACTIVE:-}" != "" ]]; then
   exit 0
 fi
 
-read -p "phpMyAdmin is not installed would you like to install? (y/N): " answer
+read -p "phpMyAdmin is not installed would you like to install? (Y/n): [Y]" answer
+if [ -z "$answer" ]; then
+    answer="Y"
+fi
 
 case "$answer" in
     [Yy] | [Yy][Ee][Ss])
         ddev get ddev/ddev-phpmyadmin
         echo "phpMyAdmin has been installed and requires a restart."
-        read -p "Would you like me to restart now? (yes/no): " answerrestart
+        read -p "Would you like me to restart now? (Y/n): [Y]" answerrestart
+        if [ -z "$answerrestart" ]; then
+            answerrestart="Y"
+        fi
         case "$answerrestart" in
             [Yy] | [Yy][Ee][Ss])
                 ddev restart

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -10,7 +10,7 @@ if [ "${DDEV_NONINTERACTIVE:-}" != "" ]; then
   exit 0
 fi
 
-read -p "phpMyAdmin is not installed would you like to install? (Y/n): [Y]" answer
+read -p "The phpMyAdmin add-on is not installed. Would you like to install it? (Y/n): [Y]" answer
 if [ -z "$answer" ]; then
     answer="Y"
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -5,7 +5,7 @@
 ## Usage: phpmyadmin
 ## Example: "ddev phpmyadmin"
 
-if [ "${DDEV_NONINTERACTIVE:-}" != "" ]]; then
+if [ "${DDEV_NONINTERACTIVE:-}" != "" ]; then
   echo "Nothing has been changed."
   exit 0
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -27,7 +27,7 @@ case "$answer" in
         case "$answerrestart" in
             [Yy] | [Yy][Ee][Ss])
                 ddev restart
-                echo "Run ddev phpmyadmin again to use it."
+                echo "Run 'ddev phpmyadmin' again to use it."
                 ;;
             *)
                 echo "You must run 'ddev restart' to finish configuring the phpMyAdmin add-on."

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/phpmyadmin
@@ -10,7 +10,8 @@ if [ "${DDEV_NONINTERACTIVE:-}" != "" ]; then
     exit 0
 fi
 
-read -p "The phpMyAdmin add-on is not installed. Would you like to install it? (Y/n): [Y]" answer
+echo "The phpMyAdmin add-on is not installed."
+read -p "Would you like to install it? [Y/n] (yes): " answer
 if [ -z "$answer" ]; then
     answer="Y"
 fi
@@ -18,8 +19,8 @@ fi
 case "$answer" in
     [Yy] | [Yy][Ee][Ss])
         ddev get ddev/ddev-phpmyadmin
-        echo "phpMyAdmin has been installed and requires a restart."
-        read -p "Would you like to restart DDEV now? (Y/n): [Y]" answerrestart
+        echo "The phpMyAdmin add-on has been installed and requires a restart."
+        read -p "Would you like to restart DDEV now? [Y/n] (yes): " answerrestart
         if [ -z "$answerrestart" ]; then
             answerrestart="Y"
         fi


### PR DESCRIPTION
## The Issue

- #6342

<!-- Provide a brief description of the issue. -->
Adds a global phpmyadmin command that asks the user if they want to install the phpmyadmin addon.

## How This PR Solves The Issue
If the user answers yes then the ddev get ddev/ddev-phpmyadmin command is run.
Since this is global once the addon is installed it will override the phpmyadmin command.

## Manual Testing Instructions
Configure a new directory for ddev `ddev config`
Run `ddev phpmyadmin`
You should be asked if you want to install the addon
If you answer no running `ddev phpmyadmin` will ask if you want to install again
If you answer yes you should receive a success message and a subsequent `ddev phpmyadmin` will launch phpmyadmin

## Automated Testing Overview
No tests added

## Release/Deployment Notes
Adds global phpmyadmin command.
