### PR TITLE
test: stop running nightly tests [skip ci]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches: [ master, main ]
 
-  schedule:
-    - cron: '01 00 * * *'
+#  schedule:
+#    - cron: '01 00 * * *'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION

## The Issue

The nightly tests often interrupt in-progress builds because of our concurrency controls. That happens about 1am UTC, so probably @stasadev doesn't see it often and I do. 

## How This PR Solves The Issue

Stop doing the nightly builds. We ignore then anyway, and we do enough builds all the time that we see shifts when they happen.

