### PR TITLE
docs: add link for config arguments as environment variables

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -30,6 +30,13 @@ You can hand-edit the YAML files DDEV creates for you after running [`ddev confi
     ```
 
     Run `ddev help config` to see all the available config arguments.
+=== "Environment variable"
+
+    ```shell
+    ddev exec 'echo $DDEV_PHP_VERSION'
+    ```
+
+    Some config arguments are available as readable environment variables. See [environment variables provided to custom commands](../extend/custom-commands.md#environment-variables-provided).
 
 ### Environmental Overrides
 


### PR DESCRIPTION
## The Issue

From Slack https://drupal.slack.com/archives/C5TQRQZRR/p1719307140534229

It would be really useful if https://ddev.readthedocs.io/en/stable/users/configuration/config said when a config value gets exposed as an env var.

## How This PR Solves The Issue

Adds a mention that some config arguments are exposed as env variables.
I haven't added the equivalent of an env variable for each config, as I find it hard to maintain and better to have it in one place.

## Manual Testing Instructions

See https://ddev--6349.org.readthedocs.build/en/6349/users/configuration/config/#setting-options

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
