### PR TITLE
fix: Check to see if IP address is local to determine whether to add to hosts

### DIFF
--- a/pkg/ddevapp/hostname_mgt.go
+++ b/pkg/ddevapp/hostname_mgt.go
@@ -2,21 +2,23 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/asaskevich/govalidator"
-	"github.com/ddev/ddev/pkg/ddevhosts"
-	"github.com/ddev/ddev/pkg/dockerutil"
-	"github.com/ddev/ddev/pkg/exec"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/output"
-	"github.com/ddev/ddev/pkg/util"
-	goodhosts "github.com/goodhosts/hostsfile"
 	"net"
 	"os"
 	exec2 "os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/asaskevich/govalidator"
+	"github.com/ddev/ddev/pkg/ddevhosts"
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/netutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+	goodhosts "github.com/goodhosts/hostsfile"
 )
 
 // windowsDdevExeAvailable says if ddev.exe is available on Windows side
@@ -94,9 +96,9 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 			checkName := strings.TrimPrefix(name, "*.")
 			hostIPs, err := net.LookupHost(checkName)
 
-			// If we had successful lookup and dockerIP matches
-			// with adding to hosts file.
-			if err == nil && len(hostIPs) > 0 && hostIPs[0] == dockerIP {
+			// If we had successful lookup and the IP address looked up is local
+			// then we don't have to add it to the /etc/hosts.
+			if err == nil && len(hostIPs) > 0 && netutil.IsLocalIP(hostIPs[0]) {
 				continue
 			}
 		}

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -1,7 +1,6 @@
 package netutil
 
 import (
-	"fmt"
 	"net"
 	"os"
 	"slices"
@@ -47,16 +46,16 @@ func IsPortActive(port string) bool {
 // assigned to the local computer
 func IsLocalIP(ipAddress string) bool {
 	dockerIP, err := dockerutil.GetDockerIP()
-	
+
 	if err != nil {
 		util.Warning("Failed to get Docker IP address: %v", err)
 		return false
 	}
-	
+
 	if ipAddress == dockerIP {
 		return true
 	}
-	
+
 	localIPs, err := GetLocalIPs()
 
 	if err != nil {

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -46,9 +46,21 @@ func IsPortActive(port string) bool {
 // IsLocalIP returns true if the provided IP address is
 // assigned to the local computer
 func IsLocalIP(ipAddress string) bool {
-	localIPs, err := GetLocalIPs()
+	dockerIP, err := dockerutil.GetDockerIP()
+	
 	if err != nil {
-		fmt.Printf("Error fetching local IPs: %v\n", err)
+		util.Warning("Failed to get Docker IP address: %v", err)
+		return false
+	}
+	
+	if ipAddress == dockerIP {
+		return true
+	}
+	
+	localIPs, err := GetLocalIPs()
+
+	if err != nil {
+		util.Warning("Failed to get local IPs: %v", err)
 		return false
 	}
 


### PR DESCRIPTION

## The Issue

In testing Let's Encrypt/Casual Hosting in
* https://github.com/ddev/ddev/pull/6317

I noted that even when the IP address of the machine was a local (non-localhost) address, it was still adding 127.0.0.1 to the /etc/hosts on that machine. For example, if the hostname DDEV wanted to use was `test.something.thefays.us` and `test.something.thefays.us` properly resolved to the current machine, DDEV would still add `test.something.thefays.us` to /etc/hosts as 127.0.0.1

This was a result of the logic in AddHostsEntriesIfNeeded() that said
```go
// If we had successful lookup and dockerIP matches
// with adding to hosts file.
if err == nil && len(hostIPs) > 0 && hostIPs[0] == dockerIP {
	continue
}
```

Essentially, it was only allowing the looked-up value of 127.0.0.1 (typical dockerIP) as "local", but it could be other things.

## How This PR Solves The Issue

Instead of comparing with dockerIP, check to see if the IP address is assigned to this machine.

Note that the small overhead required by this is only incurred during `ddev start` and should be irrelevant.

## Manual Testing Instructions

* Create a DNS entry or wildcard that points to the local machine. For example, `*.something.ddev.com` might be an A record that contains `192.168.5.13`, the IP address of the local machine.
* `ddev config --project-name=xx`
* `ddev config --project-tld=something.ddev.com`
* `ddev start`

It should start up without trying to add `xx.something.ddev.com` to the /etc/hosts

## Automated Testing Overview

I wanted to add a test for IsLocalIP() but I couldn't figure out a useful test, since it would be dependent on the local configuration.

