### PR TITLE
fix: add mysqladmin to web container for mysql, fixes #6355

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
@@ -18,7 +18,7 @@ if [ "${MYSQL_VERSION}" = "5.6" ] || [ "${MYSQL_VERSION}" = "5.5" ]; then
   MYSQL_VERSION="5.7"
 fi
 
-TARBALL_VERSION=v0.2.2
+TARBALL_VERSION=v0.2.3
 TARBALL_URL=https://github.com/ddev/mysql-client-build/releases/download/${TARBALL_VERSION}/mysql-${MYSQL_VERSION}-${ARCH}.tar.gz
 
 # Install the related mysql client if available

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -2,7 +2,7 @@
 
 @test "Verify required binaries are installed in normal image" {
     if [ "${IS_HARDENED}" == "true" ]; then skip "Skipping because IS_HARDENED==true"; fi
-    COMMANDS="composer drush8 git magerun magerun2 mkcert node npm platform sudo symfony terminus wp"
+    COMMANDS="composer drush8 git magerun magerun2 mkcert mysql mysqladmin mysqldump node npm platform sudo symfony terminus wp"
     for item in $COMMANDS; do
 #      echo "# looking for $item" >&3
       docker exec $CONTAINER_NAME bash -c "command -v $item >/dev/null"

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2126,7 +2126,7 @@ func TestWebserverDBClient(t *testing.T) {
 		startErr := app.Start()
 		require.NoError(t, startErr)
 
-		for _, tool := range []string{"mysql", "mysqldump"} {
+		for _, tool := range []string{"mysql", "mysqladmin", "mysqldump"} {
 			cmd := tool + " --version"
 			stdout, stderr, err := app.Exec(&ddevapp.ExecOpts{
 				Cmd: cmd,

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240620_stasadev_ipv4" // Note that this can be overridden by make
+var WebTag = "20240629_rfay_mysqladmin_in_web" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

* #6355

When installing custom-built mysql clients in ddev-webserver we only added `mysql` and `mysqldump`, but people also use `mysqladmin`

## How This PR Solves The Issue

Add `mysqladmin`

## Manual Testing Instructions

With a mysql:8.0 or mysql:5.7 project use `ddev ssh` and `mysqladmin` or `ddev exec mysqladmin`

## Automated Testing Overview

Added check to verify in both the container test and TestWebserverDBClient

