### PR TITLE
feat: add `debug version-constraint` command

### DIFF
--- a/cmd/ddev/cmd/debug-capabilities_test.go
+++ b/cmd/ddev/cmd/debug-capabilities_test.go
@@ -2,12 +2,12 @@ package cmd
 
 import (
 	"encoding/json"
-	"github.com/ddev/ddev/pkg/nodeps"
-	asrt "github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/nodeps"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestDebugCapabilitiesCmd tests that ddev debug capabilities works
@@ -23,7 +23,7 @@ func TestDebugCapabilitiesCmd(t *testing.T) {
 
 	jsonCapabilities := make(map[string]interface{})
 	err = json.Unmarshal([]byte(out), &jsonCapabilities)
-	require.NoError(t, err, "failed to unmarshal json capabilities '%v', out")
+	require.NoError(t, err, "failed to unmarshal json capabilities '%v'", out)
 	caps, ok := jsonCapabilities["raw"]
 	require.True(t, ok, "raw section wasn't found in jsonCapabilities: %v", out)
 	sArr := []string{}

--- a/cmd/ddev/cmd/debug-version-constraint.go
+++ b/cmd/ddev/cmd/debug-version-constraint.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/ddev/ddev/pkg/versionconstants"
+	"github.com/spf13/cobra"
+)
+
+// DebugVersionConstraintCmd implements the ddev debug version-constraint command
+var DebugVersionConstraintCmd = &cobra.Command{
+	Use:   "version-constraint [constraint]",
+	Short: "Checks if the current version of DDEV meets the given constraint",
+	Example: `ddev debug version-constraint ">=v1.23.0-alpha1"
+
+if [ "$(ddev debug version-constraint ">=v1.23.3" 2>/dev/null)" != "true" ]; then
+    echo "This add-on requires DDEV v1.23.3 or higher, please upgrade." && exit 2
+fi`,
+	Run: func(_ *cobra.Command, args []string) {
+
+		if len(args) == 0 || len(args) > 1 {
+			util.Failed("This command only takes one optional argument: [constraint]")
+		}
+
+		constraint := args[0]
+		if !strings.Contains(constraint, "-") {
+			// Allow pre-releases to be included in the constraint validation
+			// @see https://github.com/Masterminds/semver#working-with-prerelease-versions
+			constraint += "-0"
+		}
+		c, err := semver.NewConstraint(constraint)
+		if err != nil {
+			util.Failed("'%s' constraint is invalid. See https://github.com/Masterminds/semver#checking-version-constraints for valid constraints format.", constraint)
+		}
+
+		// Make sure we do this check with valid released versions
+		v, err := semver.NewVersion(versionconstants.DdevVersion)
+		if err == nil {
+			if !c.Check(v) {
+				util.Failed("Your DDEV version '%s' doesn't meet the constraint '%s'.", versionconstants.DdevVersion, constraint)
+			}
+		}
+
+		output.UserOut.WithField("raw", "true").Print("true")
+	},
+}
+
+func init() {
+	DebugCmd.AddCommand(DebugVersionConstraintCmd)
+}

--- a/cmd/ddev/cmd/debug-version-constraint_test.go
+++ b/cmd/ddev/cmd/debug-version-constraint_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/versionconstants"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDebugVersionConstraintCmd tests that ddev debug version-constraint works
+func TestDebugVersionConstraintCmd(t *testing.T) {
+	assert := asrt.New(t)
+
+	versionConstraint := ">= 1.twentythree"
+	out, err := exec.RunHostCommand(DdevBin, "debug", "version-constraint", versionConstraint)
+	assert.Error(err)
+	assert.Contains(out, "constraint is invalid")
+
+	out, err = exec.RunHostCommand(DdevBin, "debug", "version-constraint")
+	assert.Error(err)
+	assert.Contains(out, "This command only takes one optional argument")
+
+	versionConstraint = "< " + versionconstants.DdevVersion
+	out, err = exec.RunHostCommand(DdevBin, "debug", "version-constraint", versionConstraint)
+	assert.Error(err)
+	assert.Contains(out, "doesn't meet the constraint")
+
+	versionConstraint = ">= " + versionconstants.DdevVersion
+	out, err = exec.RunHostCommand(DdevBin, "debug", "version-constraint", versionConstraint)
+	assert.NoError(err)
+	assert.Equal(out, "true\n")
+
+	versionConstraint = ">= " + versionconstants.DdevVersion
+	out, err = exec.RunHostCommand(DdevBin, "debug", "-j", "version-constraint", versionConstraint)
+	assert.NoError(err)
+	jsonResult := make(map[string]interface{})
+	err = json.Unmarshal([]byte(out), &jsonResult)
+	require.NoError(t, err, "failed to unmarshal version-constraint '%v'", out)
+	rawResult, ok := jsonResult["raw"]
+	require.True(t, ok, "raw section wasn't found in version-constraint: %v", out)
+	require.Equal(t, "true", rawResult.(string))
+}

--- a/cmd/ddev/cmd/debug-version-constraint_test.go
+++ b/cmd/ddev/cmd/debug-version-constraint_test.go
@@ -2,40 +2,43 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/versionconstants"
-	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestDebugVersionConstraintCmd tests that ddev debug version-constraint works
 func TestDebugVersionConstraintCmd(t *testing.T) {
-	assert := asrt.New(t)
-
 	versionConstraint := ">= 1.twentythree"
 	out, err := exec.RunHostCommand(DdevBin, "debug", "version-constraint", versionConstraint)
-	assert.Error(err)
-	assert.Contains(out, "constraint is invalid")
+	require.Error(t, err)
+	require.Contains(t, out, "constraint is invalid")
 
 	out, err = exec.RunHostCommand(DdevBin, "debug", "version-constraint")
-	assert.Error(err)
-	assert.Contains(out, "This command only takes one optional argument")
+	require.Error(t, err)
+	require.Contains(t, out, "This command only takes one optional argument")
+
+	if !strings.HasPrefix(versionconstants.DdevVersion, "v1.") {
+		t.Skip(fmt.Sprintf("Skipping because ddev version doesn't start with 'v1.', it's '%v'", versionconstants.DdevVersion))
+	}
 
 	versionConstraint = "< " + versionconstants.DdevVersion
 	out, err = exec.RunHostCommand(DdevBin, "debug", "version-constraint", versionConstraint)
-	assert.Error(err)
-	assert.Contains(out, "doesn't meet the constraint")
+	require.Error(t, err)
+	require.Contains(t, out, "doesn't meet the constraint")
 
 	versionConstraint = ">= " + versionconstants.DdevVersion
 	out, err = exec.RunHostCommand(DdevBin, "debug", "version-constraint", versionConstraint)
-	assert.NoError(err)
-	assert.Equal(out, "true\n")
+	require.NoError(t, err)
+	require.Equal(t, out, "true\n")
 
 	versionConstraint = ">= " + versionconstants.DdevVersion
 	out, err = exec.RunHostCommand(DdevBin, "debug", "-j", "version-constraint", versionConstraint)
-	assert.NoError(err)
+	require.NoError(t, err)
 	jsonResult := make(map[string]interface{})
 	err = json.Unmarshal([]byte(out), &jsonResult)
 	require.NoError(t, err, "failed to unmarshal version-constraint '%v'", out)

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -477,6 +477,22 @@ Example:
 ddev debug testcleanup
 ```
 
+### `debug version-constraint`
+
+Checks if the current version of DDEV meets the given [version constraint](https://github.com/Masterminds/semver#checking-version-constraints).
+
+Example:
+
+```shell
+# Check the semver constraint
+ddev debug version-constraint ">=v1.23.0-alpha1"
+
+# It's useful in add-ons
+if [ "$(ddev debug version-constraint ">=v1.23.3" 2>/dev/null)" != "true" ]; then
+    echo "This add-on requires DDEV v1.23.3 or higher, please upgrade." && exit 2
+fi
+```
+
 ## `delete`
 
 Remove all information, including the database, for an existing project.


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev-xhgui/pull/31

The current approach when you need to add a version constraint to an add-on involves using `ddev debug capabilities`, which is not obvious.

This isn't good because capabilities aren't added for each DDEV release and you can't add a version constraint for some minor release.

## How This PR Solves The Issue

Adds `debug version-constraint` command that allows you to check the semver constraint.

## Manual Testing Instructions

Try `ddev debug version-constraint ">=v1.23.0"`.

And a nice bonus is that the following bash command will also work with older versions of DDEV:

```bash
if [ "$(ddev debug version-constraint ">=v1.23.3" 2>/dev/null)" != "true" ]; then
    echo "This add-on requires DDEV v1.23.3 or higher, please upgrade." && exit 2
fi
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

Need to update https://github.com/ddev/ddev-addon-template/blob/8d7dac3113074fbf6e6b37696a24d837fa323056/install.yaml#L24-L26 after v1.23.3 release.

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
