### PR TITLE
fix: add chmod for /var/log, for #5898

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1220,14 +1220,14 @@ RUN export XDEBUG_MODE=off; composer self-update --stable || composer self-updat
 		}
 	}
 
-	// Some installed php packages (php-gmp, php-dev) can change the permissions of /run/php, which leads to errors like:
-	// Unable to create the PID file (/run/php/php-fpm.pid).: Permission denied (13)
-	// See https://github.com/ddev/ddev/issues/5898
-	// Place this at the very end of the Dockerfile
+	// Some packages have default folder/file permissions described in /usr/lib/tmpfiles.d/*.conf files.
+	// For example, when you upgrade systemd, it sets 755 for /var/log.
+	// This may cause problems with previously set permissions when installing/upgrading packages.
+	// Place this at the very end of the Dockerfile.
 	if strings.Contains(fullpath, "webimageBuild") {
 		contents = contents + fmt.Sprintf(`
-### DDEV-injected php folder permission fix
-RUN chmod 777 /run/php
+### DDEV-injected folders permission fix
+RUN chmod 777 /run/php /var/log
 `)
 	}
 


### PR DESCRIPTION
## The Issue

From Discord https://discord.com/channels/664580571770388500/1257256256989696021

```
$ ddev config --webimage-extra-packages software-properties-common && ddev restart
$ ddev logs -s web
...
+ exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord-nginx-fpm.conf
...
PermissionError: [Errno 13] Permission denied: '/var/log/supervisord.log'
+ trap - SIGTERM
+ kill -- -1
```

Related issue with the same problem:

- #5898

## How This PR Solves The Issue

Adds `chmod 777 /var/log`.

Some packages have default folder/file permissions described in `/usr/lib/tmpfiles.d/*.conf` files.
This may cause problems with previously set permissions when installing/upgrading packages.

```
$ cat /usr/lib/tmpfiles.d/var.conf | grep /var/log
d /var/log 0755 - - -
f /var/log/wtmp 0664 root utmp -
f /var/log/btmp 0660 root utmp -
f /var/log/lastlog 0664 root utmp -

$ dpkg -S /usr/lib/tmpfiles.d/var.conf
systemd: /usr/lib/tmpfiles.d/var.conf

$ cat /usr/lib/tmpfiles.d/php8.3-fpm.conf
#Type Path                  Mode UID      GID      Age Argument
    d /run/php              0755 www-data www-data -   -

$ dpkg -S /usr/lib/tmpfiles.d/php8.3-fpm.conf
php8.3-fpm: /usr/lib/tmpfiles.d/php8.3-fpm.conf
```

For example, when you install `software-properties-common`, it has some dependency for `systemd`, and if there is an update for `systemd` (which is quite rare), it sets `755` for `/var/log`.

And I reviewed all files in `ls /usr/lib/tmpfiles.d/*.conf` to see if we need to add more permission overrides.

## Manual Testing Instructions

Try `ddev config --webimage-extra-packages software-properties-common && ddev restart`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
