### PR TITLE
fix: install extra content in Dockerfile earlier, for #4394

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1139,6 +1139,13 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 		}
 	}
 
+	if extraContent != "" {
+		contents = contents + fmt.Sprintf(`
+### DDEV-injected extra content
+%s
+`, extraContent)
+	}
+
 	if extraPackages != nil {
 		contents = contents + `
 ### DDEV-injected from webimage_extra_packages or dbimage_extra_packages
@@ -1173,13 +1180,6 @@ RUN (apt-get -qq update || true) && DEBIAN_FRONTEND=noninteractive apt-get -qq i
 ### DDEV-injected composer update
 RUN export XDEBUG_MODE=off; composer self-update --stable || composer self-update --stable || true; composer self-update %s || composer self-update %s || true
 `, composerSelfUpdateArg, composerSelfUpdateArg)
-	}
-
-	if extraContent != "" {
-		contents = contents + fmt.Sprintf(`
-### DDEV-injected extra content
-%s
-`, extraContent)
 	}
 
 	// If there are user dockerfiles, appends their contents


### PR DESCRIPTION
## The Issue

- #6362

I googled how people install PostGIS and found out that they have a really hard time with it because they don't know what packages they need to install to be able to use it.

I decided to provide complete installation instructions for each supported version of PostgreSQL in DDEV: https://stackoverflow.com/a/78691855/8097891

And I found that `dbimage_extra_packages` didn't work at all for PostgreSQL 9,10,11:

```
#13 [db  3/14] RUN (apt-get -qq update || true) && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests postgresql-11-postgis-2.5 postgresql-11-postgis-2.5-scripts postgis
#13 1.420 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
#13 1.420 W: The repository 'http://apt.postgresql.org/pub/repos/apt stretch-pgdg Release' does not have a Release file.
#13 1.420 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
#13 1.420 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
#13 1.420 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found
#13 1.420 E: Failed to fetch http://apt.postgresql.org/pub/repos/apt/dists/stretch-pgdg/main/binary-amd64/Packages  404  Not Found [IP: 217.196.149.55 80]
#13 1.420 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
#13 1.420 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
#13 1.420 E: Some index files failed to download. They have been ignored, or old ones used instead.
```

## How This PR Solves The Issue

This is because a fix for the stretch repository was added after installing `dbimage_extra_packages`:

- #4394

I've moved the extra content to the top before `DDEV-injected from webimage_extra_packages or dbimage_extra_packages` so it will be installed first.

## Manual Testing Instructions

From https://stackoverflow.com/a/78691855/8097891

```
ddev config --database="postgres:11" --dbimage-extra-packages=postgresql-11-postgis-2.5,postgresql-11-postgis-2.5-scripts,postgis
ddev start
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
