### PR TITLE
docs: remove bad link to deb.sury.org, confusing extra verbiage

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -77,16 +77,6 @@ RUN chmod 666 /etc/php/${DDEV_PHP_VERSION}/mods-available/xdebug.ini
 #RUN phpenmod ${extension}
 ```
 
-## Determining What Packages You Need
-
-The `web` container is a Debian image, and its PHP distributions are packaged (thank you!) by [`deb.sury.org`](https://deb.sury.org/).
-
-Most PHP extensions are built within the `deb.sury.org` distribution. You can Google the extension you want, or download and search the [Packages](https://packages.sury.org/php/dists/buster/main/binary-amd64/Packages) list from the `sury` distribution. For example, the `bcmath` PHP extension is provided by `php-bcmath`. Many packages have version-specific names, like `php7.3-tidy`.
-
-If you need a package that is *not* a PHP package, you can view and search standard Debian packages at [packages.debian.org/stable](https://packages.debian.org/stable/), or use Google.
-
-To test that a package will do what you want, you can [`ddev ssh`](../usage/commands.md#ssh) and `(sudo apt-get update || true) && sudo apt-get install <package>` to verify that you can install it and you get what you need. A PHP extension may require `killall -USR2 php-fpm` to take effect. After you’ve tried that, you can add the package to [`webimage_extra_packages`](../configuration/config.md#webimage_extra_packages).
-
 ## Adding Extra Dockerfiles for `webimage` and `dbimage`
 
 For more complex requirements, you can add:


### PR DESCRIPTION
## The Issue

deb.sury.org removed support for buster packages today.

We had a reference to the buster packages, so docs link broke.

However, the reference was in a confusing repetitive section where better instructions had already been given above, so I ended up removing the paragraph where it was contained.

