### PR TITLE
build: bump images to v1.23.3

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20240620_stasadev_ipv4 as ddev-webserver-base
+FROM ddev/ddev-php-base:v1.23.3 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,22 +11,22 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240629_rfay_mysqladmin_in_web" // Note that this can be overridden by make
+var WebTag = "v1.23.3" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20240617_hussainweb_mariadb_11_4"
+var BaseDBTag = "v1.23.3"
 
-const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.23.2"
-const TraefikRouterImage = "ddev/ddev-traefik-router:v1.23.2"
+const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.23.3"
+const TraefikRouterImage = "ddev/ddev-traefik-router:v1.23.3"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.23.2"
+var SSHAuthTag = "v1.23.3"
 
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION

## The Issue

It's time for v1.23.3, mostly because we had trouble with permission on /var/log as described in
* https://github.com/ddev/ddev/pull/6363

This bumps the images to current as well as pulling in all of Debian 12.6, which is what caused the pain.