### PR TITLE
build: Bump gitpod image for DDEV v1.23.3 [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ddev/ddev-gitpod-base:20240614
+image: ddev/ddev-gitpod-base:20240702
 tasks:
   - name: build-run
     init: |


### PR DESCRIPTION

## The Issue

After release we have to bump the gitpod image for use with v1.23.3. This does it.

