### PR TITLE
fix: improve installation method for mariadb-client

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -81,11 +81,6 @@ RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
 RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
 http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
 
-# Install mariadb_repo_setup to get mariadb-client from them directly
-RUN curl -LsSf https://r.mariadb.com/downloads/mariadb_repo_setup -o /usr/local/bin/mariadb_repo_setup && chmod +x /usr/local/bin/mariadb_repo_setup
-# Search for CHANGE_MARIADB_CLIENT to update related code.
-RUN /usr/local/bin/mariadb_repo_setup --mariadb-server-version="mariadb-10.11" --skip-maxscale --skip-tools
-
 RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && rm -f /tmp/debsuryorg-archive-keyring.deb && \
     echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && apt-get update
@@ -101,7 +96,6 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     gunicorn \
     graphicsmagick \
     jq \
-    mariadb-client \
     msmtp \
     nginx \
     nodejs \

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -84,7 +84,7 @@ http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.lis
 # Install mariadb_repo_setup to get mariadb-client from them directly
 RUN curl -LsSf https://r.mariadb.com/downloads/mariadb_repo_setup -o /usr/local/bin/mariadb_repo_setup && chmod +x /usr/local/bin/mariadb_repo_setup
 # Search for CHANGE_MARIADB_CLIENT to update related code.
-RUN /usr/local/bin/mariadb_repo_setup --mariadb-server-version="mariadb-10.11"
+RUN /usr/local/bin/mariadb_repo_setup --mariadb-server-version="mariadb-10.11" --skip-maxscale --skip-tools
 
 RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && rm -f /tmp/debsuryorg-archive-keyring.deb && \

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -24,8 +24,20 @@ RUN /sbin/mkhomedir_helper www-data
 # symfony cli
 RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | bash
 
+# Install mariadb_repo_setup to get mariadb-client from them directly
+RUN curl -LsSf https://r.mariadb.com/downloads/mariadb_repo_setup -o /usr/local/bin/mariadb_repo_setup && chmod +x /usr/local/bin/mariadb_repo_setup
+# Search for CHANGE_MARIADB_CLIENT to update related code.
+RUN mariadb_repo_setup --mariadb-server-version="mariadb-10.11" --skip-maxscale --skip-tools
+
 RUN apt-get -qq update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y libcap2-bin locales-all pv supervisor symfony-cli xz-utils
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
+    libcap2-bin \
+    locales-all \
+    mariadb-client \
+    pv \
+    supervisor \
+    symfony-cli \
+    xz-utils
 
 # Arbitrary user needs to be able to bind to privileged ports (for nginx and apache2)
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/nginx

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:v1.23.3 as ddev-webserver-base
+FROM ddev/ddev-php-base:20240704_stasadev_mariadb_11_4_client as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
@@ -16,16 +16,16 @@ MARIADB_VERSION=${DDEV_DATABASE#*:}
 # Search for CHANGE_MARIADB_CLIENT to update related code.
 # Add MariaDB versions that can have their own client here:
 if [ "${MARIADB_VERSION}" = "11.4" ]; then
-  set -x
   # Configure the correct repository for mariadb
-  DEFAULT_MARIADB_VERSION="10.11"
-  sed -i "s|${DEFAULT_MARIADB_VERSION}|${MARIADB_VERSION}|g" /etc/apt/sources.list.d/mariadb.list
-  # update only mariadb.list to make it faster
-  timeout 30 apt-get update -o Dir::Etc::sourcelist="sources.list.d/mariadb.list" \
-    -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || exit 2
-  # Install the mariadb-client and mysql symlinks
-  # MariaDB 11.x moved MySQL symlinks into separate packages
-  apt-get install -y mariadb-client mariadb-client-compat || exit 3
+  set -x
+  timeout 30 mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --skip-key-import || exit 2
+  rm -f /etc/apt/sources.list.d/mariadb.list.old_*
+  # --skip-key-import flag doesn't download the existing key again and omits "apt-get -qq update",
+  # so we can run "apt-get -qq update" manually only for mariadb repo to make it faster
+  apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/mariadb.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || exit 3
+  # Install the mariadb-client and MySQL symlinks
+  # MariaDB 11.x moved MySQL symlinks into a separate package
+  apt-get install -y mariadb-client mariadb-client-compat || exit 4
 else
-  echo "This script is not intended to run with mariadb:${MARIADB_VERSION}" && exit 4
+  echo "This script is not intended to run with mariadb:${MARIADB_VERSION}" && exit 5
 fi

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.23.3" // Note that this can be overridden by make
+var WebTag = "20240704_stasadev_mariadb_11_4_client" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

TestWebserverDBClient fails fairly regularly on MariaDB 11.4
- https://github.com/ddev/ddev/actions/runs/9788192607/job/27025855851
- https://buildkite.com/ddev/ddev-macos-arm64-mutagen/builds/8122#01907bda-1be5-4dc2-a1cd-d1887c6e38d5

It seems that mariadb-client for 11.4 is not always installed, the offending line is:
```
timeout 30 mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}"
```

## How This PR Solves The Issue

There are some problems with `mariadb_repo_setup`:
1. It adds three repos (server, tools, maxscale), but we only need the server:
	```
	$ ddev exec sudo apt update | grep mariadb
	Hit:4 https://downloads.mariadb.com/Tools/debian bookworm InRelease
	Hit:11 https://dlm.mariadb.com/repo/mariadb-server/10.11/repo/debian bookworm InRelease
	Hit:12 https://dlm.mariadb.com/repo/maxscale/latest/apt bookworm InRelease
	```
2. It runs `apt-get -qq update` (which can take a long time), but we really need to refresh only mariadb repo here.

This PR tries to make setup faster by skipping unnecessary options.

## Manual Testing Instructions

```
ddev config --database="mariadb:11.4"
ddev start
ddev exec mariadb -V
```

## Automated Testing Overview

The tests just have to work.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
