### PR TITLE
test: stop testing deprecated nginx-proxy [skip ci]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,8 +54,8 @@ jobs:
             mutagen: true
 #          - name: "no-bind-mounts"
 #            no-bind-mounts: "true"
-          - name: "nginx-proxy"
-            router: "nginx-proxy"
+#          - name: "nginx-proxy"
+#            router: "nginx-proxy"
           - name: "pull-push-test-platforms"
             pull-push-test-platforms: true
           - name: "race-detection"


### PR DESCRIPTION

## The Issue

The nginx-proxy router is deprecated, and we've never seen problems with it. 

Stop running github tests for it.

