### PR TITLE
fix: make composer subcommands ignore invalid flags on any errors, fixes #6380

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -34,42 +34,15 @@ ddev composer create --repository=https://repo.magento.com/ magento/project-comm
 ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 `,
 	ValidArgsFunction: getComposerCompletionFunc(true),
-	Run: func(cmd *cobra.Command, _ []string) {
-		// We only want to pass all flags and args to Composer
-		// cobra does not seem to allow direct access to everything predictably
-		var osargs []string
-		if len(os.Args) > 3 {
-			osargs = os.Args[3:]
-			var expandedOsargs []string
-			for _, osarg := range osargs {
-				// If this is a combined short option like "-test", split it into "-t -e -s -t"
-				// This is necessary, because each of these options will be checked for validity
-				if strings.HasPrefix(osarg, "-") && !strings.HasPrefix(osarg, "--") && len(osarg) > 2 {
-					// -vvv and -vv are exceptions, that should not be split
-					if strings.HasPrefix(osarg, "-vvv") {
-						expandedOsargs = append(expandedOsargs, "-vvv")
-						continue
-					}
-					if strings.HasPrefix(osarg, "-vv") {
-						expandedOsargs = append(expandedOsargs, "-vv")
-						continue
-					}
-					for _, char := range osarg[1:] {
-						expandedOsargs = append(expandedOsargs, "-"+string(char))
-					}
-				} else {
-					expandedOsargs = append(expandedOsargs, osarg)
-				}
-			}
-			osargs = expandedOsargs
-		} else {
-			_ = cmd.Help()
-			return
-		}
-
+	Run: func(cmd *cobra.Command, args []string) {
 		app, err := ddevapp.GetActiveApp("")
 		if err != nil {
 			util.Failed(err.Error())
+		}
+
+		if len(args) < 1 {
+			_ = cmd.Help()
+			return
 		}
 
 		// Ensure project is running
@@ -121,23 +94,33 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 
 		// Function to check if a Composer option is valid for a given command
 		isValidComposerOption := func(command, option string) bool {
-			// We have to pass arguments and options to "create-project",
-			// but only options for other composer commands,
-			// excluding options with "=", like "--repository=url".
-			if command != "create-project" && (!strings.HasPrefix(option, "-") || strings.Contains(option, "=")) {
-				return false
+			// All arguments are valid for "create-project" and not valid for other commands.
+			if !strings.HasPrefix(option, "-") {
+				return command == "create-project"
 			}
 			// Try each option with --dry-run to see if it is valid.
 			validateCmd := []string{"composer", command, option, "--dry-run"}
 			userOutFunc := util.CaptureUserOut()
-			_, _, _ = app.Exec(&ddevapp.ExecOpts{
+			_, _, err = app.Exec(&ddevapp.ExecOpts{
 				Service: "web",
 				Dir:     app.GetComposerRoot(true, false),
 				RawCmd:  validateCmd,
 			})
 			out := userOutFunc()
-			// If there is an error from symfony/console, it is an invalid option
-			return !strings.Contains(out, fmt.Sprintf(`"%s" option does not exist`, option))
+			if err == nil {
+				return true
+			}
+			// If it's an error for the "--dry-run" we use in validateCmd, then the option is valid.
+			if option != "--dry-run" && strings.Contains(out, `"--dry-run" option does not exist`) {
+				return true
+			}
+			// We only care about the "option does not exist" error for "create-project",
+			// and if there are other errors, the user should see them.
+			if command == "create-project" {
+				return !strings.Contains(out, fmt.Sprintf(`"%s" option does not exist`, option))
+			}
+			// The option is not valid for other commands on any error.
+			return false
 		}
 
 		// Add some args to avoid troubles while cloning the project.
@@ -145,9 +128,9 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 		// These options make the difference between "composer create-project" and "ddev composer create".
 		var createArgs []string
 
-		for _, osarg := range osargs {
-			if isValidComposerOption("create-project", osarg) {
-				createArgs = append(createArgs, osarg)
+		for _, arg := range args {
+			if isValidComposerOption("create-project", arg) {
+				createArgs = append(createArgs, arg)
 			}
 		}
 

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -122,8 +122,9 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 		// Function to check if a Composer option is valid for a given command
 		isValidComposerOption := func(command, option string) bool {
 			// We have to pass arguments and options to "create-project",
-			// but only options for other composer commands.
-			if command != "create-project" && !strings.HasPrefix(option, "-") {
+			// but only options for other composer commands,
+			// excluding options with "=", like "--repository=url".
+			if command != "create-project" && (!strings.HasPrefix(option, "-") || strings.Contains(option, "=")) {
 				return false
 			}
 			// Try each option with --dry-run to see if it is valid.

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -106,7 +106,7 @@ func TestComposerCreateCmd(t *testing.T) {
 			if docRoot == "" {
 				composerCommandTypeCheck = "installation with --no-plugins --no-scripts"
 				if projectType == nodeps.AppTypePHP {
-					composerCommandTypeCheck = "installation with --vvv --fake-flag"
+					composerCommandTypeCheck = "installation with -vvv --fake-flag"
 				}
 			} else {
 				composerCommandTypeCheck = "installation with --no-install"
@@ -121,7 +121,7 @@ func TestComposerCreateCmd(t *testing.T) {
 			}
 
 			// ddev composer create --repository='{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' -vvv --fake-flag test/ddev-composer-create
-			if composerCommandTypeCheck == "installation with --vvv --fake-flag" {
+			if composerCommandTypeCheck == "installation with -vvv --fake-flag" {
 				args = []string{"composer", "create", fmt.Sprintf("--repository=%s", repository), "-vvv", "--fake-flag", "test/ddev-composer-create"}
 			}
 
@@ -166,7 +166,7 @@ func TestComposerCreateCmd(t *testing.T) {
 			}
 
 			// ddev composer create --repository='{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' -vvv --fake-flag test/ddev-composer-create
-			if composerCommandTypeCheck == "installation with --vvv --fake-flag" {
+			if composerCommandTypeCheck == "installation with -vvv --fake-flag" {
 				// Check what was executed or not
 				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository=%s -vvv test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
 				assert.Contains(out, "Executing Composer command: [composer run-script post-root-package-install -vvv]")
@@ -211,6 +211,9 @@ func TestComposerCreateCmd(t *testing.T) {
 				assert.FileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require", "composer.json"))
 				assert.NoFileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
 			}
+
+			assert.Contains(out, "Moving install to Composer root")
+			assert.Contains(out, "ddev composer create was successful")
 
 			// Check that resulting composer.json (copied from testdata) has post-root-package-install and post-create-project-cmd scripts
 			composerManifest, err := composer.NewManifest(filepath.Join(composerRoot, "composer.json"))

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -120,9 +120,9 @@ func TestComposerCreateCmd(t *testing.T) {
 				args = []string{"composer", "create", "--repository", repository, "--no-plugins", "--no-scripts", "test/ddev-composer-create"}
 			}
 
-			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' -vvv --fake-flag test/ddev-composer-create
+			// ddev composer create --repository='{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' -vvv --fake-flag test/ddev-composer-create
 			if composerCommandTypeCheck == "installation with --vvv --fake-flag" {
-				args = []string{"composer", "create", "--repository", repository, "-vvv", "--fake-flag", "test/ddev-composer-create"}
+				args = []string{"composer", "create", fmt.Sprintf("--repository=%s", repository), "-vvv", "--fake-flag", "test/ddev-composer-create"}
 			}
 
 			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-install test/ddev-composer-create
@@ -130,9 +130,9 @@ func TestComposerCreateCmd(t *testing.T) {
 				args = []string{"composer", "create", "--repository", repository, "--no-install", "test/ddev-composer-create"}
 			}
 
-			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-dev test/ddev-composer-create
+			// ddev composer create --repository='{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-dev test/ddev-composer-create
 			if composerCommandTypeCheck == "installation with --no-dev" {
-				args = []string{"composer", "create", "--repository", repository, "--no-dev", "test/ddev-composer-create"}
+				args = []string{"composer", "create", fmt.Sprintf("--repository=%s", repository), "--no-dev", "test/ddev-composer-create"}
 			}
 
 			// Test failure
@@ -165,10 +165,10 @@ func TestComposerCreateCmd(t *testing.T) {
 				assert.FileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
 			}
 
-			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' -vvv --fake-flag test/ddev-composer-create
+			// ddev composer create --repository='{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' -vvv --fake-flag test/ddev-composer-create
 			if composerCommandTypeCheck == "installation with --vvv --fake-flag" {
 				// Check what was executed or not
-				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s -vvv test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
+				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository=%s -vvv test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
 				assert.Contains(out, "Executing Composer command: [composer run-script post-root-package-install -vvv]")
 				assert.Contains(out, "Executing Composer command: [composer install -vvv]")
 				assert.Contains(out, "Executing Composer command: [composer run-script post-create-project-cmd -vvv]")
@@ -196,10 +196,10 @@ func TestComposerCreateCmd(t *testing.T) {
 				assert.NoDirExists(filepath.Join(composerRoot, "vendor"))
 			}
 
-			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-dev test/ddev-composer-create
+			// ddev composer create --repository='{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-dev test/ddev-composer-create
 			if composerCommandTypeCheck == "installation with --no-dev" {
 				// Check what was executed or not
-				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s --no-dev test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
+				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository=%s --no-dev test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
 				assert.Contains(out, "Executing Composer command: [composer run-script post-root-package-install --no-dev]")
 				assert.Contains(out, "Executing Composer command: [composer install --no-dev]")
 				assert.Contains(out, "Executing Composer command: [composer run-script post-create-project-cmd --no-dev]")


### PR DESCRIPTION
## The Issue

- #6380

```
The "--repository" option does not exist.
```

## How This PR Solves The Issue

Ignores flags with `=` for `composer install` and `composer run-script`.

## Manual Testing Instructions

Try Magento 2 quickstart https://ddev.readthedocs.io/en/stable/users/quickstart/#magento

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
