### PR TITLE
fix: Don't warn about Docker Desktop on WSL2, fixes #6339 [skip ci]

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -119,7 +119,7 @@ which -a docker
 echo
 
 printf "Docker provider: ${docker_platform}\n"
-if [ "${OSTYPE%-*}" = "linux" ] && [ "$docker_platform" = "docker-desktop" ]; then
+if [ "${WSL_DISTRO_NAME}" = "" ] && [ "${OSTYPE%-*}" = "linux" ] && [ "$docker_platform" = "docker-desktop" ]; then
   printf "ERROR: Using Docker Desktop on Linux is not supported.\n"
 fi
 


### PR DESCRIPTION

## The Issue

* #6339 

## How This PR Solves The Issue

Don't emit warning on WSL2

## Manual Testing Instructions

Do `ddev debug test` on WSL2 with Docker Desktop. No warning should show.

For extreme extra credit, do `ddev debug test` on Linux with Docker Desktop for Linux. Warning should show.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
