### PR TITLE
docs: stop checking aur.archlinux.org link [skip ci]

### DIFF
--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -56,6 +56,9 @@
     },
     {
       "pattern": "^https://community.chocolatey.org"
+    },
+    {
+      "pattern": "^https://aur.archlinux.org"
     }
   ],
   "httpHeaders": [


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/actions/runs/9847531874/job/27190957328#step:11:348

```
ERROR: 1 dead links found!
[✖] https://aur.archlinux.org/packages/ddev-bin/ → Status: 0
```

## How This PR Solves The Issue

This is not the first time we see an error for this link, time to ignore it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
