### PR TITLE
fix: update regex for traefik v3 usage

### DIFF
--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -370,11 +370,11 @@ func configureTraefikForApp(app *DdevApp) error {
 		UseLetsEncrypt:  globalconfig.DdevGlobalConfig.UseLetsEncrypt,
 	}
 
-	// Convert externalHostnames wildcards like `*.<anything>` to `{subdomain:.+}.wild.ddev.site`
+	// Convert externalHostnames wildcards like `*.<anything>` to `[a-zA-Z0-9-]+.wild.ddev.site`
 	for i, v := range routingTable {
 		for j, h := range v.ExternalHostnames {
 			if strings.HasPrefix(h, `*.`) {
-				h = `{subdomain:.+}` + strings.TrimPrefix(h, `*`)
+				h = `[a-zA-Z0-9-]+` + strings.TrimPrefix(h, `*`)
 				routingTable[i].ExternalHostnames[j] = h
 			}
 		}

--- a/pkg/ddevapp/traefik_config_template.yaml
+++ b/pkg/ddevapp/traefik_config_template.yaml
@@ -11,11 +11,12 @@ http:
       entrypoints:
         - http-{{$s.ExternalPort}}
       {{- if not $.UseLetsEncrypt -}}{{/* Let's Encrypt only works with Host(), but we need HostRegexp() for wildcards*/}}
-      rule: HostRegexp({{ range $i, $h := $s.ExternalHostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
+      rule: {{ range $i, $h := $s.ExternalHostnames }}{{if $i}}|| {{end}}HostRegexp(`^{{$h | replace "." "\\."}}$`){{end}}
       {{ else }}
-      rule: Host({{ range $i, $h := $s.ExternalHostnames }}{{if $i}}, {{end}}`{{$h}}`{{end}})
+      rule: Host({{ range $i, $h := $s.ExternalHostnames }}{{if $i}}, {{end}}`^{{$h | replace "." "\\."}}$`{{end}})
       {{ end }}
       service: "{{$appname}}-{{$s.Service.InternalServiceName}}-{{$s.Service.InternalServicePort}}"
+      ruleSyntax: v3
       tls: false
       # middlewares:
       #   - "{{ $.App.Name }}-redirectHttps"
@@ -26,11 +27,12 @@ http:
       entrypoints:
         - http-{{$s.ExternalPort}}
       {{- if not $.UseLetsEncrypt -}}{{/* Let's Encrypt only works with Host(), but we need HostRegexp() for wildcards*/}}
-      rule: HostRegexp({{ range $i, $h := $s.ExternalHostnames }}{{ if $i }}, {{ end }}`{{$h}}`{{ end }})
+      rule: {{ range $i, $h := $s.ExternalHostnames }}{{ if $i }} || {{ end }}HostRegexp(`^{{$h | replace "." "\\."}}$`){{ end }}
       {{ else }}
-      rule: Host({{ range $i, $h := $s.ExternalHostnames }}{{- if $i -}}, {{- end -}}`{{$h}}`{{end}})
+      rule: Host({{ range $i, $h := $s.ExternalHostnames }}{{- if $i -}}, {{- end -}}`^{{$h | replace "." "\\."}}$`{{end}})
       {{ end }}
       service: "{{$appname}}-{{$s.Service.InternalServiceName}}-{{$s.Service.InternalServicePort}}"
+      ruleSyntax: v3
       {{ if not $.UseLetsEncrypt }}
       tls: true
       {{ else }}


### PR DESCRIPTION

## The Issue

* https://github.com/ddev/ddev/pull/6317 was supposed to convert to Traefik v3, but it wasn't quite successful. The rules were thinking they were using HostRegexp() but they weren't really successful.

## How This PR Solves The Issue

* Use `ruleSyntax: v3` in our generated rules
* Use HostRegexp() in the v3 way - `HostRegexp() || HostRegexp()` etc

## Manual Testing Instructions

Try a wildcard like `ddev config --additional-hostnames="*.wild"`

## Automated Testing Overview

I think existing tests do it right.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
