### PR TITLE
fix: omit ddev-router for Gitpod (for DDEV PRs) [skip ci]

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,7 @@ tasks:
     init: |
       # Compile ddev
       make
+      ddev config global --omit-containers=ddev-router
       ddev debug download-images
       mkcert -install
     command: |


### PR DESCRIPTION
## The Issue

`omit_containers: [ddev-router]` is not written to global DDEV config after:

- #6315

It led to problems with add-ons:

- https://github.com/ddev/ddev-phpmyadmin/issues/15


This is caused by the fact that `/workspace` appears to be a special folder that is overridden by Gitpod. It doesn't pick up any content from the pre-built Docker image.

## How This PR Solves The Issue

Omits the `ddev-router` on the project init.

## Manual Testing Instructions

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ddev/ddev/pull/6390)

Confirm that `ddev config global | grep omit` contains `ddev-router`.
Stop the Gitpod workspace, start it again and confirm the same.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
