### PR TITLE
fix: make `ddev launch` fully compatible with Gitpod and Codespaces, fixes #6389

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -24,11 +24,19 @@ IN_CLOUD=""
 if [[ -n "${GITPOD_INSTANCE_ID}" ]] || [[ "${CODESPACES}" == "true" ]]; then IN_CLOUD=true; fi
 
 get_fullurl_port() {
-  docker run -i --rm ddev/ddev-utilities sh -c "echo ${FULLURL} | grep -o ':[0-9]\+' | awk -F':' '{print \$2}' | head -1" 2>/dev/null
+  docker run -i --rm ddev/ddev-utilities sh -c "echo '${FULLURL}' | grep -o ':[0-9]\+' | awk -F':' '{print \$2}' | head -1" 2>/dev/null
 }
 replace_port_in_cloud() {
-  fullurl_without_port=$(docker run -i --rm ddev/ddev-utilities sh -c "echo ${FULLURL} | sed -E 's/:[0-9]+//'" 2>/dev/null)
-  docker run -i --rm ddev/ddev-utilities sh -c "echo ${fullurl_without_port} | sed -E 's/\b${DDEV_HOST_WEBSERVER_PORT}\b/${1}/'" 2>/dev/null
+  replace_port="${1}"
+  if [[ $(docker run -i --rm ddev/ddev-utilities sh -c "echo '${FULLURL}' | sed -E 's/:([0-9]+)//' | awk -F'/' '{print \$1\"//\"\$3}' | grep -E '\b${DDEV_HOST_WEBSERVER_PORT}\b'" 2>/dev/null) != "" ]]; then
+    # remove any port from ${FULLURL}
+    fullurl_without_port=$(docker run -i --rm ddev/ddev-utilities sh -c "echo '${FULLURL}' | sed -E 's/:[0-9]+//'" 2>/dev/null)
+    # and replace ${DDEV_HOST_WEBSERVER_PORT} with provided port.
+    docker run -i --rm ddev/ddev-utilities sh -c "echo '${fullurl_without_port}' | sed -E 's/\b${DDEV_HOST_WEBSERVER_PORT}\b/${replace_port}/'" 2>/dev/null
+  else
+    # if ${DDEV_HOST_WEBSERVER_PORT} is not found in ${FULLURL}, leave it as is.
+    echo "${FULLURL}"
+  fi
 }
 
 while :; do

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -20,37 +20,47 @@ fi
 FULLURL=${DDEV_PRIMARY_URL}
 HTTPS=""
 if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then HTTPS=true; fi
+IN_CLOUD=""
+if [[ -n "${GITPOD_INSTANCE_ID}" ]] || [[ "${CODESPACES}" == "true" ]]; then IN_CLOUD=true; fi
+
+get_fullurl_port() {
+  docker run -i --rm ddev/ddev-utilities sh -c "echo ${FULLURL} | grep -o ':[0-9]\+' | awk -F':' '{print \$2}' | head -1" 2>/dev/null
+}
+replace_port_in_cloud() {
+  fullurl_without_port=$(docker run -i --rm ddev/ddev-utilities sh -c "echo ${FULLURL} | sed -E 's/:[0-9]+//'" 2>/dev/null)
+  docker run -i --rm ddev/ddev-utilities sh -c "echo ${fullurl_without_port} | sed -E 's/\b${DDEV_HOST_WEBSERVER_PORT}\b/${1}/'" 2>/dev/null
+}
 
 while :; do
-     case ${1:-} in
-         -p|--phpmyadmin)
-            echo "phpMyAdmin is no longer built into DDEV, please 'ddev get ddev/ddev-phpmyadmin' and use 'ddev phpmyadmin' to launch phpMyAdmin" && exit 2
-            ;;
-         -m|--mailpit|--mailhog)
-            if [[ ! -z "${GITPOD_INSTANCE_ID}" ]] || [[ "${CODESPACES}" == "true" ]]; then
-                FULLURL="${FULLURL/-${DDEV_HOST_WEBSERVER_PORT}/-${DDEV_HOST_MAILPIT_PORT}}"
-            else
-                if [ "${HTTPS}" = "" ]; then
-                    FULLURL="${FULLURL%:[0-9]*}:${DDEV_MAILPIT_PORT}"
-                else
-                    FULLURL="${FULLURL%:[0-9]*}:${DDEV_MAILPIT_HTTPS_PORT}"
-                fi
-            fi
-             ;;
+  case ${1:-} in
+  -p | --phpmyadmin)
+    echo "phpMyAdmin is no longer built into DDEV, please 'ddev get ddev/ddev-phpmyadmin' and use 'ddev phpmyadmin' to launch phpMyAdmin" && exit 2
+    ;;
+  -m | --mailpit | --mailhog)
+    if [ "${IN_CLOUD}" != "" ]; then
+      FULLURL=$(replace_port_in_cloud "${DDEV_HOST_MAILPIT_PORT}")
+    else
+      if [ "${HTTPS}" = "" ]; then
+        FULLURL="${FULLURL%:[0-9]*}:${DDEV_MAILPIT_PORT}"
+      else
+        FULLURL="${FULLURL%:[0-9]*}:${DDEV_MAILPIT_HTTPS_PORT}"
+      fi
+    fi
+    ;;
 
-         --)              # End of all options.
-             shift
-             break
-             ;;
-         -?*)
-             printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
-             ;;
-         *)               # Default case: No more options, so break out of the loop.
-             break
-     esac
+  --) # End of all options.
+    shift
+    break
+    ;;
+  -?*)
+    printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
+    ;;
+  *) # Default case: No more options, so break out of the loop.
+    break ;;
+  esac
 
-     shift
- done
+  shift
+done
 
 if [ -n "${1:-}" ]; then
   if [[ $1 =~ ^https?:// ]]; then
@@ -59,16 +69,25 @@ if [ -n "${1:-}" ]; then
   elif [[ $1 =~ ^: ]]; then
     # specific port
     FULLURL="${FULLURL%:[0-9]*}${1}"
-    # check if the port is running on https or http
-    port=$(docker run -i --rm ddev/ddev-utilities sh -c "echo '${1}' | grep -o ':[0-9]\+' | awk -F':' '{print \$2}'" 2>/dev/null)
-    if [[ "${port}" != "" ]] && ddev describe -j | docker run -i --rm ddev/ddev-utilities sh -c "jq -r '.raw' | grep -w ${port} | grep -q https" 2>/dev/null; then
-      FULLURL="${FULLURL/http:/https:}"
-    elif [[ "${port}" != "" ]] && ddev describe -j | docker run -i --rm ddev/ddev-utilities sh -c "jq -r '.raw' | grep -w ${port} | grep -q http" 2>/dev/null; then
-      FULLURL="${FULLURL/https:/http:}"
+    if [[ "${IN_CLOUD}" == "" ]]; then
+      # check if the port is running on https or http
+      port="$(get_fullurl_port)"
+      if [[ "${port}" != "" ]] && ddev describe -j | docker run -i --rm ddev/ddev-utilities sh -c "jq -r '.raw' | grep -w ${port} | grep -q https" 2>/dev/null; then
+        FULLURL="${FULLURL/http:/https:}"
+      elif [[ "${port}" != "" ]] && ddev describe -j | docker run -i --rm ddev/ddev-utilities sh -c "jq -r '.raw' | grep -w ${port} | grep -q http" 2>/dev/null; then
+        FULLURL="${FULLURL/https:/http:}"
+      fi
     fi
   else
     # relative path
     FULLURL="${FULLURL%/}/${1#/}"
+  fi
+  # handle Gitpod and Codespaces
+  if [[ "${IN_CLOUD}" != "" ]]; then
+    port="$(get_fullurl_port)"
+    if [[ "${port}" != "" ]]; then
+      FULLURL=$(replace_port_in_cloud "${port}")
+    fi
   fi
 fi
 


### PR DESCRIPTION
## The Issue

- #6389

## How This PR Solves The Issue

Replaces the `${DDEV_HOST_WEBSERVER_PORT}` in the URL for all possible scenarios

## Manual Testing Instructions

Try in Gitpod and Codespaces:

1. `ddev mailpit` - it should open Mailpit
2. `ddev launch :8027` - it should replace `8080` with `8027`, don't add `:8027` to the URL
3. `ddev launch :8027/test` - the same and preserve `/test`
4. `ddev launch https://full-url-here:8027` - it should replace `8080` with `8027`, don't add `:8027` to the URL
5. `ddev launch https://full-url-here:8027/test` - the same and preserve `/test`
6. `ddev launch https://example.com:8080/test` - it should remain the same
7. `ddev launch :8080` - it should open the same URL as for `ddev launch`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
