### PR TITLE
test: stop testing use_docker_compose_from_path, update related docs

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -588,7 +588,7 @@ Whether to use the system-installed docker-compose. You can otherwise use [`requ
 When `true`, DDEV will use the docker-compose found in on your system’s path instead of using its private, known-good, docker-compose version.
 
 !!!warning "Troubleshooting Only!"
-    This should only be used in specific cases like troubleshooting. Best avoided otherwise.
+    This should only be used in specific cases like troubleshooting. (It is used in the Docker Compose automated tests.)
 
 ## `use_hardened_images`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -465,7 +465,7 @@ Specific docker-compose version for download.
 If set to `v2.8.0`, for example, it will download and use that version instead of the expected version for docker-compose.
 
 !!!warning "Troubleshooting Only!"
-    This should only be used in specific cases like troubleshooting. Best avoided otherwise.
+    This should only be used in specific cases like troubleshooting. Please don't experiment with it unless directed to do so.
 
 ## `router`
 

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -5,7 +5,7 @@ search:
 
 # Additional Service Configurations & Add-ons
 
-DDEV projects can be extended to provide additional add-ons, including services. You can define these add-ons using docker-compose files in the project’s `.ddev` directory.
+DDEV projects can be extended to provide additional add-ons, including services. You can define these add-ons using `docker-compose.*.yaml` files in the project’s `.ddev` directory.
 
 Anyone can create their own services with a `.ddev/docker-compose.*.yaml` file, and a growing number of popular services are supported and tested, and can be installed using the [`ddev get`](../usage/commands.md#get) command.
 

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -67,11 +67,6 @@ func TestDockerComposeDownload(t *testing.T) {
 		assert.Equal(globalconfig.GetRequiredDockerComposeVersion(), activeVersion)
 	}
 
-	// Test using docker-compose from path.
-	// Make sure our Required/Expected DockerComposeVersion is not something we'd find on the machine
-	globalconfig.DockerComposeVersion = ""
-	globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = "v2.5.1"
-	globalconfig.DdevGlobalConfig.UseDockerComposeFromPath = true
 	activeVersion, err := dockerutil.GetLiveDockerComposeVersion()
 	assert.NoError(err)
 	path, err := exec.LookPath("docker-compose")

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -2,12 +2,9 @@ package dockerutil_test
 
 import (
 	"os"
-	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
-	exec2 "github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
@@ -67,16 +64,4 @@ func TestDockerComposeDownload(t *testing.T) {
 		assert.Equal(globalconfig.GetRequiredDockerComposeVersion(), activeVersion)
 	}
 
-	activeVersion, err := dockerutil.GetLiveDockerComposeVersion()
-	assert.NoError(err)
-	path, err := exec.LookPath("docker-compose")
-	assert.NoError(err)
-	out, err := exec2.RunHostCommand(path, "version", "--short")
-	assert.NoError(err)
-	parsedFoundVersion := strings.Trim(string(out), "\r\n")
-	if !strings.HasPrefix(parsedFoundVersion, "v") {
-		parsedFoundVersion = "v" + parsedFoundVersion
-	}
-	assert.Equal(parsedFoundVersion, activeVersion)
-	t.Logf("parsedFoundVersion=%s activeVersion=%s", parsedFoundVersion, activeVersion)
 }

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -68,13 +68,14 @@ type GlobalConfig struct {
 	SimpleFormatting                 bool                        `yaml:"simple_formatting"`
 	TableStyle                       string                      `yaml:"table_style"`
 	TraefikMonitorPort               string                      `yaml:"traefik_monitor_port,omitempty"`
-	UseDockerComposeFromPath         bool                        `yaml:"use_docker_compose_from_path,omitempty"`
-	UseHardenedImages                bool                        `yaml:"use_hardened_images"`
-	UseLetsEncrypt                   bool                        `yaml:"use_letsencrypt"`
-	WSL2NoWindowsHostsMgt            bool                        `yaml:"wsl2_no_windows_hosts_mgt"`
-	WebEnvironment                   []string                    `yaml:"web_environment"`
-	XdebugIDELocation                string                      `yaml:"xdebug_ide_location"`
-	ProjectList                      map[string]*ProjectInfo     `yaml:"project_info,omitempty"`
+	// This may still be used in Docker Compose automated tests
+	UseDockerComposeFromPath bool                    `yaml:"use_docker_compose_from_path,omitempty"`
+	UseHardenedImages        bool                    `yaml:"use_hardened_images"`
+	UseLetsEncrypt           bool                    `yaml:"use_letsencrypt"`
+	WSL2NoWindowsHostsMgt    bool                    `yaml:"wsl2_no_windows_hosts_mgt"`
+	WebEnvironment           []string                `yaml:"web_environment"`
+	XdebugIDELocation        string                  `yaml:"xdebug_ide_location"`
+	ProjectList              map[string]*ProjectInfo `yaml:"project_info,omitempty"`
 }
 
 // New returns a default GlobalConfig
@@ -454,12 +455,6 @@ func WriteGlobalConfig(config GlobalConfig) error {
 # required_docker_compose_version: ""
 # This can be used to override the default required docker-compose version
 # It should normally be left alone, but can be set to, for example, "v2.1.1"
-
-# use_docker_compose_from_path: false
-# This can be set to true to allow DDEV to use whatever docker-compose is
-# found in the $PATH instead of using the private docker-compose downloaded
-# to ~/.ddev/bin/docker-compose.
-# Please don't use this unless directed to do so
 
 # messages:
 #   ticker_interval: 20 // Interval in hours to show ticker messages, -1 disables the ticker


### PR DESCRIPTION

## The Issue

* We support using an external docker-compose (from path) but would never hope for it to be used. 
* However, it was implemented so that `docker-compose` folks could implement DDEV in their automated tests, so doesn't make sense to remove
* Sometimes Docker Desktop moves things around (as they did in macOS DD v4.32.0) and they lose the external `docker-compose`, perhaps on purpose, because they want `compose` to be used as a docker plugin.

## How This PR Solves The Issue

* Stop testing that requires external docker-compose
* Update docs to be more specific about this feature not being used

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
