### PR TITLE
feat: add ddev/ddev-utilities to the pulled images

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1535,9 +1535,9 @@ func (app *DdevApp) PullContainerImages() error {
 }
 
 // PullBaseContainerImages pulls only the fundamentally needed images so they can be available early.
-// We always need web image and busybox for housekeeping.
+// We always need web image, busybox, and ddev-utilities for housekeeping.
 func PullBaseContainerImages() error {
-	images := []string{ddevImages.GetWebImage(), versionconstants.BusyboxImage}
+	images := []string{ddevImages.GetWebImage(), versionconstants.BusyboxImage, versionconstants.UtilitiesImage}
 	images = append(images, FindNotOmittedImages(nil)...)
 
 	for _, i := range images {

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -31,6 +31,9 @@ var SSHAuthTag = "v1.23.3"
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"
 
+// UtilitiesImage is used in bash scripts
+var UtilitiesImage = "ddev/ddev-utilities"
+
 // BUILDINFO is information with date and context, supplied by make
 var BUILDINFO = "BUILDINFO should have new info"
 


### PR DESCRIPTION
## The Issue

https://hub.docker.com/r/ddev/ddev-utilities is used in:

- `ddev debug test`
- `ddev launch`
- the docs

But we don't pull it.

## How This PR Solves The Issue

Let's pull it to avoid a couple of seconds of waiting.

## Manual Testing Instructions

```
docker rmi ddev/ddev-utilities
DDEV_DEBUG=true ddev debug download-images
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
