### PR TITLE
fix: Use port 80 to get better headers for Codespaces, fixes #6102

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2061,6 +2061,12 @@ func (app *DdevApp) DockerEnv() {
 	// * provide default host-side port bindings, assuming only one project running,
 	//   as is usual on Gitpod, but if more than one project, can override with normal
 	//   config.yaml settings.
+	// Codespaces stumbles if not on a "standard" port like port 80
+	if nodeps.IsGitpod() || nodeps.IsCodespaces() {
+		if app.HostWebserverPort == "" {
+			app.HostWebserverPort = "80"
+		}
+	}
 	if nodeps.IsGitpod() || nodeps.IsCodespaces() {
 		if app.HostWebserverPort == "" {
 			app.HostWebserverPort = "8080"
@@ -2076,6 +2082,7 @@ func (app *DdevApp) DockerEnv() {
 		}
 		app.BindAllInterfaces = true
 	}
+
 	isWSL2 := "false"
 	if nodeps.IsWSL2() {
 		isWSL2 = "true"

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2062,7 +2062,7 @@ func (app *DdevApp) DockerEnv() {
 	//   as is usual on Gitpod, but if more than one project, can override with normal
 	//   config.yaml settings.
 	// Codespaces stumbles if not on a "standard" port like port 80
-	if nodeps.IsGitpod() || nodeps.IsCodespaces() {
+	if nodeps.IsCodespaces() {
 		if app.HostWebserverPort == "" {
 			app.HostWebserverPort = "80"
 		}


### PR DESCRIPTION

## The Issue

* #6102 

Handling ports in HTTP is always a little complex, port 80 is default for http, port 443 for https. Codespaces seems to handle the Host header and X-Forwarded-Host incorrectly when it's forwarding a nonstandard (not port 80) port.

## How This PR Solves The Issue

Use port 80 by default in codespaces. This seems to do no harm. It affects only Codespaces.

## Manual Testing Instructions

* Run this PR in Codespaces
* Start a project
* Install Drupal 10
* Log in. If it works, it's fixed

