### PR TITLE
docs: Update 'ddev get' example

### DIFF
--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -34,9 +34,15 @@ For example,
 ├──────────────────────────────────────┼────────────────────────────────────────────────────┤
 │ ddev/ddev-elasticsearch              │ Elasticsearch add-on for DDEV*                     │
 ├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-ioncube                    │ IonCube loaders for DDEV*                          │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
 │ ddev/ddev-memcached                  │ Install Memcached as an extra service in DDEV*     │
 ├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-minio                      │ MinIO addon for DDEV*                              │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
 │ ddev/ddev-mongo                      │ MongoDB add-on for DDEV*                           │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-opensearch                 │ OpenSearch add-on for DDEV*                        │
 ├──────────────────────────────────────┼────────────────────────────────────────────────────┤
 │ ddev/ddev-pdfreactor                 │ PDFreactor service for DDEV*                       │
 ├──────────────────────────────────────┼────────────────────────────────────────────────────┤
@@ -58,9 +64,14 @@ For example,
 ├──────────────────────────────────────┼────────────────────────────────────────────────────┤
 │ ddev/ddev-sqlsrv                     │ MS SQL server add-on for DDEV*                     │
 ├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-typo3-solr                 │ Use Apache Solr (standalone) in your DDEV project  │
+│                                      │ *                                                  │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
 │ ddev/ddev-varnish                    │ Varnish reverse proxy add-on for DDEV*             │
+├──────────────────────────────────────┼────────────────────────────────────────────────────┤
+│ ddev/ddev-xhgui                      │ XHGui service for a DDEV project*                  │
 └──────────────────────────────────────┴────────────────────────────────────────────────────┘
-20 repositories found. Add-ons marked with '*' are officially maintained DDEV add-ons.
+25 repositories found. Add-ons marked with '*' are officially maintained DDEV add-ons.
 ```
 
 !!!tip


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

Searching the docs for "opensearch" will give no results. This might lead some to believe that it is not officially supported.

## How This PR Solves The Issue

Update the `ddev get --list` example output in the docs to include a mention of all supported additional services.

## Manual Testing Instructions

-

## Automated Testing Overview

Changes are limited to docs, no testing needed.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
