### PR TITLE
test: make sure that volumes in buildkite are deleted at test start

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -162,9 +162,6 @@ fi
 
 set -x
 
-# We don't want any docker volumes to be existing and changing behavior
-docker volume prune -a -f >/dev/null 2>&1 || true
-
 # Run any testbot maintenance that may need to be done
 echo "--- running testbot_maintenance.sh"
 bash "$(dirname $0)/testbot_maintenance.sh" || true
@@ -175,7 +172,8 @@ ddev poweroff || true
 if [ "$(docker ps -aq | wc -l )" -gt 0 ] ; then
 	docker rm -f $(docker ps -aq) >/dev/null 2>&1 || true
 fi
-docker system prune --volumes --force >/dev/null || true
+docker system prune --volumes --force || true
+docker volume prune -a -f || true
 
 # Our testbot should be sane, run the testbot checker to make sure.
 echo "--- running sanetestbot.sh"


### PR DESCRIPTION

## The Issue

There were [quite](https://buildkite.com/ddev/macos-colima/builds/396#0190acea-35ee-4f1b-817b-e36e04d286e8) [a](https://buildkite.com/ddev/macos-colima-vz/builds/1292#0190b7e9-91cd-4a55-a719-17b5731a413a) [lot](https://buildkite.com/ddev/macos-colima-vz/builds/1308#0190c165-cc86-4048-8713-31d281a48c3c) of suspicious TestSSHAuth failures on colima-vz on tb-macos-arm64-6, so I finally thought I'd take a look. 

I found a lot of volumes, especially the SSH volumes, stuck there. 

It looks to me like we haven't been successful deleting volumes at test startup.

## How This PR Solves The Issue

* Make sure to delete volumes after all containers are stopped
* Double-delete
* Stop ignoring the output.

