### PR TITLE
fix: Use turn off innodb_doublewrite to improve import-db performance, fixes #6244

### DIFF
--- a/containers/ddev-dbserver/files/etc/my.cnf
+++ b/containers/ddev-dbserver/files/etc/my.cnf
@@ -79,6 +79,7 @@ innodb-buffer-pool-size        = 1024M
 ;innodb_large_prefix=true
 ;innodb_file_format=barracuda
 innodb_file_per_table=true
+innodb_doublewrite=0
 
 # LOGGING #
 log-error                      = /var/log/mysqld.err

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "20240708_rfay_postgresql_client_version" // Note that this can be 
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20240703_fix_xtrabackup"
+var BaseDBTag = "20240719_rfay_innodb_doublewrite"
 
 const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.23.3"
 const TraefikRouterImage = "ddev/ddev-traefik-router:20240616_traefik_3"


### PR DESCRIPTION

## The Issue

* #6244

## How This PR Solves The Issue

Turn off innodb_doublewrite to improve import-db performance

## Manual Testing Instructions

Try `ddev import-db` with huge databases

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
