### PR TITLE
fix: default_container_timeout should work right, fixes #5133 again

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -84,7 +84,7 @@ services:
       {{ if templateCanUse "healthcheck.start_interval" }}
       start_interval: 1s
       {{ end }}
-      timeout: "{{ if lt (atoi .DefaultContainerTimeout) 70 }}{{ .DefaultContainerTimeout }}s{{ else }}70s{{ end }}"
+      timeout: "70s"
   {{ end }} {{/* end if not .OmitDB */}}
 
   web:
@@ -251,7 +251,7 @@ services:
       {{ if templateCanUse "healthcheck.start_interval" }}
       start_interval: 1s
       {{ end }}
-      timeout: {{ if lt (atoi .DefaultContainerTimeout) 70 }}{{ .DefaultContainerTimeout}}s{{ else }}70s{{ end }}
+      timeout: "70s"
 
 networks:
   ddev_default:

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -78,11 +78,11 @@ services:
       {{ if eq .DBType "postgres" }}
       test: ["CMD-SHELL", "/postgres_healthcheck.sh"]
       {{ end }}
-      interval: 1s
+      interval: "1s"
       retries: 120
       start_period: "{{ .DefaultContainerTimeout }}s"
       {{ if templateCanUse "healthcheck.start_interval" }}
-      start_interval: 1s
+      start_interval: "1s"
       {{ end }}
       timeout: "70s"
   {{ end }} {{/* end if not .OmitDB */}}
@@ -245,11 +245,11 @@ services:
       {{ end }}
       {{ end }}
     healthcheck:
-      interval: 1s
+      interval: "1s"
       retries: 120
       start_period: "{{ .DefaultContainerTimeout }}s"
       {{ if templateCanUse "healthcheck.start_interval" }}
-      start_interval: 1s
+      start_interval: "1s"
       {{ end }}
       timeout: "70s"
 

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -79,7 +79,7 @@ services:
       test: ["CMD-SHELL", "/postgres_healthcheck.sh"]
       {{ end }}
       interval: "1s"
-      retries: 120
+      retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
       {{ if templateCanUse "healthcheck.start_interval" }}
       start_interval: "1s"
@@ -246,7 +246,7 @@ services:
       {{ end }}
     healthcheck:
       interval: "1s"
-      retries: 120
+      retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
       {{ if templateCanUse "healthcheck.start_interval" }}
       start_interval: "1s"

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -75,7 +75,7 @@ services:
       - USER={{ .Username }}
     command: ${DDEV_DB_CONTAINER_COMMAND}
     healthcheck:
-      {{- if eq .DBType "postgres" -}}
+      {{- if eq .DBType "postgres" }}
       test: ["CMD-SHELL", "/postgres_healthcheck.sh"]
       {{- end }}
       interval: "1s"

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -75,15 +75,15 @@ services:
       - USER={{ .Username }}
     command: ${DDEV_DB_CONTAINER_COMMAND}
     healthcheck:
-      {{ if eq .DBType "postgres" }}
+      {{- if eq .DBType "postgres" -}}
       test: ["CMD-SHELL", "/postgres_healthcheck.sh"]
-      {{ end }}
+      {{- end }}
       interval: "1s"
       retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
-      {{ if templateCanUse "healthcheck.start_interval" }}
+      {{ if templateCanUse "healthcheck.start_interval" -}}
       start_interval: "1s"
-      {{ end }}
+      {{- end }}
       timeout: "70s"
   {{ end }} {{/* end if not .OmitDB */}}
 
@@ -248,9 +248,9 @@ services:
       interval: "1s"
       retries: 70
       start_period: "{{ .DefaultContainerTimeout }}s"
-      {{ if templateCanUse "healthcheck.start_interval" }}
+      {{- if templateCanUse "healthcheck.start_interval" }}
       start_interval: "1s"
-      {{ end }}
+      {{- end }}
       timeout: "70s"
 
 networks:

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -84,7 +84,7 @@ services:
       {{ if templateCanUse "healthcheck.start_interval" }}
       start_interval: 1s
       {{ end }}
-      timeout: 70s
+      timeout: {{ if lt .DefaultContainerTimeout 70 }}{{ .DefaultContainerTimeout}}{{ else }}70{{ end }}
   {{ end }} {{/* end if not .OmitDB */}}
 
   web:
@@ -251,7 +251,7 @@ services:
       {{ if templateCanUse "healthcheck.start_interval" }}
       start_interval: 1s
       {{ end }}
-      timeout: 70s
+      timeout: {{ if lt .DefaultContainerTimeout 70 }}{{ .DefaultContainerTimeout}}{{ else }}70{{ end }}
 
 networks:
   ddev_default:

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -84,7 +84,7 @@ services:
       {{ if templateCanUse "healthcheck.start_interval" }}
       start_interval: 1s
       {{ end }}
-      timeout: {{ if lt .DefaultContainerTimeout 70 }}{{ .DefaultContainerTimeout}}{{ else }}70{{ end }}
+      timeout: "{{ if lt (atoi .DefaultContainerTimeout) 70 }}{{ .DefaultContainerTimeout }}s{{ else }}70s{{ end }}"
   {{ end }} {{/* end if not .OmitDB */}}
 
   web:
@@ -251,7 +251,7 @@ services:
       {{ if templateCanUse "healthcheck.start_interval" }}
       start_interval: 1s
       {{ end }}
-      timeout: {{ if lt .DefaultContainerTimeout 70 }}{{ .DefaultContainerTimeout}}{{ else }}70{{ end }}
+      timeout: {{ if lt (atoi .DefaultContainerTimeout) 70 }}{{ .DefaultContainerTimeout}}s{{ else }}70s{{ end }}
 
 networks:
   ddev_default:

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1551,7 +1551,7 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 			app.DockerEnv()
 			err = app.WriteDockerComposeYAML()
 			require.NoError(t, err)
-			maxTimeout := app.FindMaxTimeout()
+			maxTimeout := app.GetMaxContainerWaitTime()
 			require.Equal(t, tc.expectation, maxTimeout, "for tc=%v expected maxTimeout to be %v but it was %v", tc, tc.expectation, maxTimeout)
 		})
 	}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1605,8 +1605,8 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 		c, err = dockerutil.InspectContainer(ddevapp.GetContainerName(app, "db"))
 		require.NoError(t, err)
 		require.NotEqual(t, dockerTypes.ContainerJSON{}, c)
-		expectedWaitTime = 600
-		// If the maxWaitTime was set to greater than the expected 600
+		expectedWaitTime = ddevapp.SnapshotRestoreDefaultWaitTime
+		// If the maxWaitTime was set to greater than the expected 600/SnapshotRestoreDefaultWaitTime
 		// (which is set in the snapshot restore code) then use the maxWaitTime value
 		if maxWaitTimeInt, _ := strconv.Atoi(maxWaitTime); maxWaitTimeInt > expectedWaitTime {
 			expectedWaitTime = maxWaitTimeInt

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1547,27 +1547,29 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 		maxWaitTime int
 		expectation int
 	}{
-		{"nospec", defaultTimeoutInt, defaultTimeoutInt},
-		{"nospec", 30, 30},
-		{"nohealthcheck", defaultTimeoutInt, defaultTimeoutInt},
-		{"nohealthcheck", 1200, 1200},
-		{"longtimeout", defaultTimeoutInt, defaultTimeoutInt},
-		{"longtimeout", 1200, 1200},
-		{"withshortstartperiod", defaultTimeoutInt, defaultTimeoutInt},
-		{"withshortstartperiod", 1200, 1200},
-		{"withlongstartperiod", defaultTimeoutInt, 1350},
-		{"withlongstartperiod", 1200, 1350},
-		{"intervalset", defaultTimeoutInt, 135},
-		{"intervalset", 1200, 1200},
-		{"intervalandretriesset", defaultTimeoutInt, 660},
-		{"intervalandretriesset", 1200, 1200},
+		{"nospec-default", defaultTimeoutInt, defaultTimeoutInt},
+		{"nospec-30", 30, 30},
+		{"nohealthcheck-default", defaultTimeoutInt, defaultTimeoutInt},
+		{"nohealthcheck-1200", 1200, 1200},
+		{"longtimeout-default", defaultTimeoutInt, defaultTimeoutInt},
+		{"longtimeout-1200", 1200, 1200},
+		{"withshortstartperiod-default", defaultTimeoutInt, defaultTimeoutInt},
+		{"withshortstartperiod-1200", 1200, 1200},
+		{"withlongstartperiod-default", defaultTimeoutInt, 1350},
+		{"withlongstartperiod-1200", 1200, 1350},
+		{"intervalset-default", defaultTimeoutInt, 135},
+		{"intervalset-1200", 1200, 1200},
+		{"intervalandretriesset-default", defaultTimeoutInt, 660},
+		{"intervalandretriesset-1200", 1200, 1200},
 	}
 
 	for _, tc := range simpleWaitTimeMatrix {
 		t.Run(tc.description, func(t *testing.T) {
+			parts := strings.Split(tc.description, "-")
+			tcDesc := parts[0]
 			app.DefaultContainerTimeout = strconv.Itoa(tc.maxWaitTime)
 			app.DockerEnv()
-			dockerComposeSource := filepath.Join(origDir, "testdata", tName, fmt.Sprintf("docker-compose.%s.yaml", tc.description))
+			dockerComposeSource := filepath.Join(origDir, "testdata", tName, fmt.Sprintf("docker-compose.%s.yaml", tcDesc))
 			dockerComposeTarget := app.GetConfigPath("docker-compose." + tName + ".yaml")
 			_ = os.RemoveAll(dockerComposeTarget)
 			err = copy2.Copy(dockerComposeSource, dockerComposeTarget, copy2.Options{})
@@ -1575,6 +1577,9 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 			err = app.WriteDockerComposeYAML()
 			require.NoError(t, err)
 			maxWaitTime := app.GetMaxContainerWaitTime()
+			if tc.expectation != maxWaitTime {
+				t.Logf("oops - not equal")
+			}
 			require.Equal(t, tc.expectation, maxWaitTime, "for tc=%v expected maxWaitTime to be %v but it was %v", tc, tc.expectation, maxWaitTime)
 		})
 	}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1547,39 +1547,33 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 		maxWaitTime int
 		expectation int
 	}{
-		{"nospec-default", defaultTimeoutInt, defaultTimeoutInt},
-		{"nospec-30", 30, 30},
-		{"nohealthcheck-default", defaultTimeoutInt, defaultTimeoutInt},
-		{"nohealthcheck-1200", 1200, 1200},
-		{"longtimeout-default", defaultTimeoutInt, defaultTimeoutInt},
-		{"longtimeout-1200", 1200, 1200},
-		{"withshortstartperiod-default", defaultTimeoutInt, defaultTimeoutInt},
-		{"withshortstartperiod-1200", 1200, 1200},
-		{"withlongstartperiod-default", defaultTimeoutInt, 1350},
-		{"withlongstartperiod-1200", 1200, 1350},
-		{"intervalset-default", defaultTimeoutInt, 135},
-		{"intervalset-1200", 1200, 1200},
-		{"intervalandretriesset-default", defaultTimeoutInt, 660},
-		{"intervalandretriesset-1200", 1200, 1200},
+		{"nospec", defaultTimeoutInt, defaultTimeoutInt},
+		{"nospec", 30, 30},
+		{"nohealthcheck", defaultTimeoutInt, defaultTimeoutInt},
+		{"nohealthcheck", 1200, 1200},
+		{"longtimeout", defaultTimeoutInt, defaultTimeoutInt},
+		{"longtimeout", 1200, 1200},
+		{"withshortstartperiod", defaultTimeoutInt, defaultTimeoutInt},
+		{"withshortstartperiod", 1200, 1200},
+		{"withlongstartperiod", defaultTimeoutInt, 1350},
+		{"withlongstartperiod", 1200, 1350},
+		{"intervalset", defaultTimeoutInt, 135},
+		{"intervalset", 1200, 1200},
+		{"intervalandretriesset", defaultTimeoutInt, 660},
+		{"intervalandretriesset", 1200, 1200},
 	}
 
 	for _, tc := range simpleWaitTimeMatrix {
 		t.Run(tc.description, func(t *testing.T) {
-			parts := strings.Split(tc.description, "-")
-			tcDesc := parts[0]
 			app.DefaultContainerTimeout = strconv.Itoa(tc.maxWaitTime)
 			app.DockerEnv()
-			dockerComposeSource := filepath.Join(origDir, "testdata", tName, fmt.Sprintf("docker-compose.%s.yaml", tcDesc))
+			dockerComposeSource := filepath.Join(origDir, "testdata", tName, fmt.Sprintf("docker-compose.%s.yaml", tc.description))
 			dockerComposeTarget := app.GetConfigPath("docker-compose." + tName + ".yaml")
-			_ = os.RemoveAll(dockerComposeTarget)
 			err = copy2.Copy(dockerComposeSource, dockerComposeTarget, copy2.Options{})
 			require.NoError(t, err)
 			err = app.WriteDockerComposeYAML()
 			require.NoError(t, err)
 			maxWaitTime := app.GetMaxContainerWaitTime()
-			if tc.expectation != maxWaitTime {
-				t.Logf("oops - not equal")
-			}
 			require.Equal(t, tc.expectation, maxWaitTime, "for tc=%v expected maxWaitTime to be %v but it was %v", tc, tc.expectation, maxWaitTime)
 		})
 	}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1567,8 +1567,10 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			app.DefaultContainerTimeout = strconv.Itoa(tc.maxWaitTime)
 			app.DockerEnv()
-			dockerComposeFile := filepath.Join(origDir, "testdata", tName, fmt.Sprintf("docker-compose.%s.yaml", tc.description))
-			err = copy2.Copy(dockerComposeFile, app.GetConfigPath("docker-compose."+tName+".yaml"))
+			dockerComposeSource := filepath.Join(origDir, "testdata", tName, fmt.Sprintf("docker-compose.%s.yaml", tc.description))
+			dockerComposeTarget := app.GetConfigPath("docker-compose." + tName + ".yaml")
+			_ = os.RemoveAll(dockerComposeTarget)
+			err = copy2.Copy(dockerComposeSource, dockerComposeTarget, copy2.Options{})
 			require.NoError(t, err)
 			err = app.WriteDockerComposeYAML()
 			require.NoError(t, err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1595,9 +1595,9 @@ func FindNotOmittedImages(app *DdevApp) []string {
 }
 
 // FindMaxTimeout looks through all services and returns the max timeout found
-// Defaults to 120
+// Defaults to DefaultContainerTimeout (usually 120 unless configured)
 func (app *DdevApp) FindMaxTimeout() int {
-	const defaultContainerTimeout = 120
+	defaultContainerTimeout, _ := strconv.Atoi(app.DefaultContainerTimeout)
 	maxTimeout := defaultContainerTimeout
 	if app.ComposeYaml == nil {
 		return defaultContainerTimeout

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1628,7 +1628,11 @@ func (app *DdevApp) GetMaxContainerWaitTime() int {
 					if retriesSpecified, ok := i.(map[string]interface{})["retries"]; ok {
 						retries = retriesSpecified.(int)
 					}
-					maxWaitTime = retries * interval
+					// If the guessed maxWaitTime is greater than what we've found before
+					// then use it. This will be unusual.
+					if retries*interval > maxWaitTime {
+						maxWaitTime = retries * interval
+					}
 				}
 			}
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1600,6 +1600,7 @@ func FindNotOmittedImages(app *DdevApp) []string {
 func (app *DdevApp) GetMaxContainerWaitTime() int {
 	defaultContainerTimeout, _ := strconv.Atoi(app.DefaultContainerTimeout)
 	maxWaitTime := defaultContainerTimeout
+
 	if app.ComposeYaml == nil {
 		return defaultContainerTimeout
 	}
@@ -1618,7 +1619,8 @@ func (app *DdevApp) GetMaxContainerWaitTime() int {
 				} else { /* In this case we didn't have a specified start_period, so guess at one */
 					interval := 1
 					retries := 3
-					startPeriod = 15 /* Use a generic default for start_period based on 3*5 */
+					maxWaitTime = 15 /* Use a generic default for start_period/maxWaitTime based on 3*5 */
+
 					if intervalStr, ok := i.(map[string]interface{})["interval"]; ok {
 						intervalInt, err := time.ParseDuration(intervalStr.(string))
 						if err == nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1619,7 +1619,9 @@ func (app *DdevApp) GetMaxContainerWaitTime() int {
 				} else { /* In this case we didn't have a specified start_period, so guess at one */
 					interval := 1
 					retries := 3
-					maxWaitTime = 15 /* Use a generic default for start_period/maxWaitTime based on 3*5 */
+					// Use a generic default for start_period/maxWaitTime based on
+					// `retries` (3) * default `interval` (5)
+					maxWaitTime = 15
 
 					if intervalStr, ok := i.(map[string]interface{})["interval"]; ok {
 						intervalInt, err := time.ParseDuration(intervalStr.(string))

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1615,6 +1615,20 @@ func (app *DdevApp) GetMaxContainerWaitTime() int {
 					if t > maxWaitTime {
 						maxWaitTime = t
 					}
+				} else { /* In this case we didn't have a specified start_period, so guess at one */
+					interval := 1
+					retries := 3
+					startPeriod = 15 /* Use a generic default for start_period based on 3*5 */
+					if intervalStr, ok := i.(map[string]interface{})["interval"]; ok {
+						intervalInt, err := time.ParseDuration(intervalStr.(string))
+						if err == nil {
+							interval = int(intervalInt.Seconds())
+						}
+					}
+					if retriesSpecified, ok := i.(map[string]interface{})["retries"]; ok {
+						retries = retriesSpecified.(int)
+					}
+					maxWaitTime = retries * interval
 				}
 			}
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1620,7 +1620,8 @@ func (app *DdevApp) GetMaxContainerWaitTime() int {
 					interval := 1
 					retries := 3
 					// Use a generic default for start_period/maxWaitTime based on
-					// `retries` (3) * default `interval` (5)
+					// https://docs.docker.com/reference/dockerfile/#healthcheck
+					// `retries` (3) * default `start_interval` (5)
 					maxWaitTime = 15
 
 					if intervalStr, ok := i.(map[string]interface{})["interval"]; ok {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1617,12 +1617,10 @@ func (app *DdevApp) GetMaxContainerWaitTime() int {
 						maxWaitTime = t
 					}
 				} else { /* In this case we didn't have a specified start_period, so guess at one */
-					interval := 1
-					retries := 3
-					// Use a generic default for start_period/maxWaitTime based on
+					// Use defaults for interval and retries
 					// https://docs.docker.com/reference/dockerfile/#healthcheck
-					// `retries` (3) * default `start_interval` (5)
-					maxWaitTime = 15
+					interval := 5
+					retries := 3
 
 					if intervalStr, ok := i.(map[string]interface{})["interval"]; ok {
 						intervalInt, err := time.ParseDuration(intervalStr.(string))
@@ -1633,7 +1631,7 @@ func (app *DdevApp) GetMaxContainerWaitTime() int {
 					if retriesSpecified, ok := i.(map[string]interface{})["retries"]; ok {
 						retries = retriesSpecified.(int)
 					}
-					// If the guessed maxWaitTime is greater than what we've found before
+					// If the retries*interval is greater than what we've found before
 					// then use it. This will be unusual.
 					if retries*interval > maxWaitTime {
 						maxWaitTime = retries * interval

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -2,12 +2,6 @@ package ddevapp
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/dockerutil"
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/output"
-	"github.com/ddev/ddev/pkg/util"
 	"io/fs"
 	"os"
 	"path"
@@ -17,6 +11,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
 )
 
 // DeleteSnapshot removes the snapshot tarball or directory inside a project
@@ -175,7 +176,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	// For mariadb/mysql restart container and wait for restore
 	if status == SiteRunning || status == SitePaused {
 		util.Success("Stopping db container for snapshot restore of '%s'...", snapshotFile)
-		util.Success("With large snapshots this may take a long time.\nThis will normally time out after %d seconds (max of all container timeouts)\nbut you can increase it by changing default_container_timeout.", app.FindMaxTimeout())
+		util.Success("With large snapshots this may take a long time.\nThis may time out after %d seconds (max of all container timeouts)\nbut you can increase it by changing default_container_timeout.", app.FindMaxTimeout())
 		dbContainer, err := GetContainer(app, "db")
 		if err != nil || dbContainer == nil {
 			return fmt.Errorf("no container found for db; err=%v", err)

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -176,7 +176,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	// For mariadb/mysql restart container and wait for restore
 	if status == SiteRunning || status == SitePaused {
 		util.Success("Stopping db container for snapshot restore of '%s'...", snapshotFile)
-		util.Success("With large snapshots this may take a long time.\nThis may time out after %d seconds (max of all container timeouts)\nbut you can increase it by changing default_container_timeout.", app.FindMaxTimeout())
+		util.Success("With large snapshots this may take a long time.\nThis may time out after %d seconds (max of all container timeouts)\nbut you can increase it by changing default_container_timeout.", app.GetMaxContainerWaitTime())
 		dbContainer, err := GetContainer(app, "db")
 		if err != nil || dbContainer == nil {
 			return fmt.Errorf("no container found for db; err=%v", err)

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.intervalandretriesset.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.intervalandretriesset.yaml
@@ -1,0 +1,11 @@
+services:
+  longtimeout:
+    container_name: "ddev-${DDEV_SITENAME}-longtimeout"
+    image: debian:12
+    command: sleep infinity
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    healthcheck:
+      interval: "60s"
+      retries: 11

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.intervalset.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.intervalset.yaml
@@ -1,0 +1,10 @@
+services:
+  longtimeout:
+    container_name: "ddev-${DDEV_SITENAME}-longtimeout"
+    image: debian:12
+    command: sleep infinity
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    healthcheck:
+      interval: "45s"

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.longtimeout.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.longtimeout.yaml
@@ -1,0 +1,10 @@
+services:
+  longtimeout:
+    container_name: "ddev-${DDEV_SITENAME}-longtimeout"
+    image: debian:12
+    command: sleep infinity
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    healthcheck:
+      timeout: "1000s"

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.nohealthcheck.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.nohealthcheck.yaml
@@ -1,0 +1,8 @@
+services:
+  longtimeout:
+    container_name: "ddev-${DDEV_SITENAME}-longtimeout"
+    image: debian:12
+    command: sleep infinity
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.withlongstartperiod.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.withlongstartperiod.yaml
@@ -1,0 +1,10 @@
+services:
+  longtimeout:
+    container_name: "ddev-${DDEV_SITENAME}-longtimeout"
+    image: debian:12
+    command: sleep infinity
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    healthcheck:
+      start_period: "1350s"

--- a/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.withshortstartperiod.yaml
+++ b/pkg/ddevapp/testdata/TestConfigDefaultContainerTimeout/docker-compose.withshortstartperiod.yaml
@@ -1,0 +1,10 @@
+services:
+  longtimeout:
+    container_name: "ddev-${DDEV_SITENAME}-longtimeout"
+    image: debian:12
+    command: sleep infinity
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    healthcheck:
+      start_period: "10s"


### PR DESCRIPTION
## The Issue

* #5133 - over and over again

`default_container_timeout` hasn't had the behavior we expect, even though we've changed that behavior lots of times.

## TODO

- [x] app.GetMaxContainerWaitTime() needs to estimate a start_period if none is specified
- [x] Make TestConfigDefaultContainerTimeout more comprehensive (include 3rd party services)

## How This PR Solves The Issue

Resolve the differences between the docker-compose `timeout` and what we need, `start_period` or defaults for `start_period`

## Manual Testing Instructions

* Read [blog on this](https://ddev.com/blog/ddev-and-docker-healthchecks-technote)
* Try `ddev snapshot restore` with a larger snapshot
* Try it with different `default_container_timeout` - larger ones should result in more time for the snapshot restore
* Try `docker-compose.*.yaml` with a variety of healthcheck values, especially `start_period` There are a number of these for examples in the TestConfigDefaultContainerTimeout directory.

## Automated Testing Overview

New `TestConfigDefaultContainerTimeout`, maybe it can get me out of hell eventually. This has a ways to go yet.

