### PR TITLE
fix: show containers we're waiting for and better error message on timeout/unhealthy

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1491,7 +1491,14 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	output.UserOut.Printf("Waiting for additional project containers to become ready...")
-	err = app.WaitByLabels(map[string]string{"com.ddev.site-name": app.GetName()})
+	waitLabels := map[string]string{"com.ddev.site-name": app.GetName()}
+	containersAwaited, err := dockerutil.FindContainersByLabels(waitLabels)
+	if err != nil {
+		return err
+	}
+	containerNames := dockerutil.GetContainerNames(containersAwaited)
+	output.UserOut.Printf("Waiting %ds for additional project containers %v to become ready...", 600, containerNames)
+	err = app.WaitByLabels(waitLabels)
 	if err != nil {
 		return err
 	}
@@ -2318,7 +2325,7 @@ func (app *DdevApp) WaitByLabels(labels map[string]string) error {
 	waitTime := app.GetMaxContainerWaitTime()
 	err := dockerutil.ContainersWait(waitTime, labels)
 	if err != nil {
-		return fmt.Errorf("container(s) failed to become healthy before their configured timeout or in %d seconds. This might be a problem with the healthcheck and not a functional problem. (%v)", waitTime, err)
+		return fmt.Errorf("container(s) failed to become healthy before their configured timeout or in %d seconds.\nThis might be a problem with the healthcheck and not a functional problem.\nThe error was '%v'", waitTime, err.Error())
 	}
 	return nil
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1497,7 +1497,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		return err
 	}
 	containerNames := dockerutil.GetContainerNames(containersAwaited)
-	output.UserOut.Printf("Waiting %ds for additional project containers %v to become ready...", 600, containerNames)
+	output.UserOut.Printf("Waiting %ds for additional project containers %v to become ready...", app.GetMaxContainerWaitTime(), containerNames)
 	err = app.WaitByLabels(waitLabels)
 	if err != nil {
 		return err

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -417,7 +417,7 @@ func ContainerWait(waittime int, labels map[string]string) (string, error) {
 				return logOutput, nil
 			case "unhealthy":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-				return logOutput, fmt.Errorf("%s container is unhealthy: %s, Troubleshot with: \n%s", name, logOutput, suggestedCommand)
+				return logOutput, fmt.Errorf("%s container is unhealthy, log=%s\nTroubleshoot this with these commands: \n%s", name, logOutput, suggestedCommand)
 			case "exited":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
 				return logOutput, fmt.Errorf("%s container exited,\nTroubleshoot this with these commands:\n%s", name, suggestedCommand)
@@ -471,7 +471,7 @@ func ContainersWait(waittime int, labels map[string]string) error {
 					continue
 				case "unhealthy":
 					name, suggestedCommand := getSuggestedCommandForContainerLog(&container)
-					return fmt.Errorf("%s container is unhealthy: %s\nTroubleshoot this with these commands:\n%s", name, logOutput, suggestedCommand)
+					return fmt.Errorf("%s container is unhealthy, log=%s\nTroubleshoot this with these commands:\n%s", name, logOutput, suggestedCommand)
 				case "exited":
 					name, suggestedCommand := getSuggestedCommandForContainerLog(&container)
 					return fmt.Errorf("%s container exited.\nTroubleshoot this with these commands:\n%s", name, suggestedCommand)
@@ -529,7 +529,7 @@ func ContainerWaitLog(waittime int, labels map[string]string, expectedLog string
 				return logOutput, nil
 			case status == "unhealthy":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-				return logOutput, fmt.Errorf("%s container is unhealthy: %s\nTroubleshoot this with these commands:\n%s", name, logOutput, suggestedCommand)
+				return logOutput, fmt.Errorf("%s container is unhealthy, log=%s\nTroubleshoot this with these commands:\n%s", name, logOutput, suggestedCommand)
 			case status == "exited":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
 				return logOutput, fmt.Errorf("%s container exited\nTroubleshoot this with these commands:\n%s", name, suggestedCommand)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -400,7 +400,7 @@ func ContainerWait(waittime int, labels map[string]string) (string, error) {
 				health, _ := GetContainerHealth(container)
 				if health != "healthy" {
 					name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-					desc = desc + fmt.Sprintf(" %s:%s - more info with %s", name, health, suggestedCommand)
+					desc = desc + fmt.Sprintf(" %s:%s\nTroubleshoot this with these commands:\n%s", name, health, suggestedCommand)
 				}
 			}
 			return "", fmt.Errorf("health check timed out after %v: labels %v timed out without becoming healthy, status=%v, detail=%s ", durationWait, labels, status, desc)
@@ -417,10 +417,10 @@ func ContainerWait(waittime int, labels map[string]string) (string, error) {
 				return logOutput, nil
 			case "unhealthy":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-				return logOutput, fmt.Errorf("%s container is unhealthy: %s, more info with %s", name, logOutput, suggestedCommand)
+				return logOutput, fmt.Errorf("%s container is unhealthy: %s, Troubleshot with: \n%s", name, logOutput, suggestedCommand)
 			case "exited":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-				return logOutput, fmt.Errorf("%s container exited, more info with %s", name, suggestedCommand)
+				return logOutput, fmt.Errorf("%s container exited,\nTroubleshoot this with these commands:\n%s", name, suggestedCommand)
 			}
 		}
 	}
@@ -451,7 +451,7 @@ func ContainersWait(waittime int, labels map[string]string) error {
 					health, _ := GetContainerHealth(&container)
 					if health != "healthy" {
 						name, suggestedCommand := getSuggestedCommandForContainerLog(&container)
-						desc = desc + fmt.Sprintf(" %s:%s - more info with %s", name, health, suggestedCommand)
+						desc = desc + fmt.Sprintf(" %s:%s\nTroubleshoot this with these commands:\n%s", name, health, suggestedCommand)
 					}
 				}
 			}
@@ -471,10 +471,10 @@ func ContainersWait(waittime int, labels map[string]string) error {
 					continue
 				case "unhealthy":
 					name, suggestedCommand := getSuggestedCommandForContainerLog(&container)
-					return fmt.Errorf("%s container is unhealthy: %s, more info with %s", name, logOutput, suggestedCommand)
+					return fmt.Errorf("%s container is unhealthy: %s\nTroubleshoot this with these commands:\n%s", name, logOutput, suggestedCommand)
 				case "exited":
 					name, suggestedCommand := getSuggestedCommandForContainerLog(&container)
-					return fmt.Errorf("%s container exited, more info with %s", name, suggestedCommand)
+					return fmt.Errorf("%s container exited.\nTroubleshoot this with these commands:\n%s", name, suggestedCommand)
 				default:
 					allHealthy = false
 				}
@@ -512,7 +512,7 @@ func ContainerWaitLog(waittime int, labels map[string]string, expectedLog string
 				health, _ := GetContainerHealth(container)
 				if health != "healthy" {
 					name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-					desc = desc + fmt.Sprintf(" %s:%s - more info with %s", name, health, suggestedCommand)
+					desc = desc + fmt.Sprintf(" %s:%s\nTroubleshoot this with these commands:\n%s", name, health, suggestedCommand)
 				}
 			}
 			return "", fmt.Errorf("health check timed out: labels %v timed out without becoming healthy, status=%v, detail=%s ", labels, status, desc)
@@ -529,10 +529,10 @@ func ContainerWaitLog(waittime int, labels map[string]string, expectedLog string
 				return logOutput, nil
 			case status == "unhealthy":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-				return logOutput, fmt.Errorf("%s container is unhealthy: %s, more info with %s", name, logOutput, suggestedCommand)
+				return logOutput, fmt.Errorf("%s container is unhealthy: %s\nTroubleshoot this with these commands:\n%s", name, logOutput, suggestedCommand)
 			case status == "exited":
 				name, suggestedCommand := getSuggestedCommandForContainerLog(container)
-				return logOutput, fmt.Errorf("%s container exited, more info with %s", name, suggestedCommand)
+				return logOutput, fmt.Errorf("%s container exited\nTroubleshoot this with these commands:\n%s", name, suggestedCommand)
 			}
 		}
 	}
@@ -1869,6 +1869,19 @@ func GetLiveDockerComposeVersion() (string, error) {
 
 	globalconfig.DockerComposeVersion = v
 	return globalconfig.DockerComposeVersion, nil
+}
+
+// GetContainerNames takes an array of Container
+// and returns an array of strings with container names
+func GetContainerNames(containers []dockerTypes.Container) []string {
+	var names []string
+	for _, container := range containers {
+		if len(container.Names) > 0 {
+			name := container.Names[0][1:] // Trimming the leading '/' from the container name
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 // IsErrNotFound returns true if the error is a NotFound error, which is returned

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -598,7 +598,7 @@ func GetContainerHealth(container *dockerTypes.Container) (string, string) {
 	if status != "" {
 		numLogs := len(inspect.State.Health.Log)
 		if numLogs > 0 {
-			logOutput = fmt.Sprintf("%v", inspect.State.Health.Log[numLogs-1])
+			logOutput = fmt.Sprintf("%v", inspect.State.Health.Log[numLogs-1].Output)
 		}
 	} else {
 		// Some containers may not have a healthcheck. In that case
@@ -611,7 +611,7 @@ func GetContainerHealth(container *dockerTypes.Container) (string, string) {
 		}
 	}
 
-	return status, logOutput
+	return status, strings.TrimSpace(logOutput)
 }
 
 // ComposeWithStreams executes a docker-compose command but allows the caller to specify

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -149,7 +149,7 @@ func TestGetContainerHealth(t *testing.T) {
 		assert.NotNil(container)
 
 		status, healthDetail := dockerutil.GetContainerHealth(container)
-		assert.Contains(healthDetail, "/var/www/html:OK mailpit:OK phpstatus:OK ")
+		assert.Contains(healthDetail, "/var/www/html:OK mailpit:OK phpstatus:OK")
 		assert.Equal("healthy", status)
 	})
 


### PR DESCRIPTION
## The Issue

* In a complex project, there may be many containers we're waiting for. Show what we're waiting for when waiting for them
* Although we try hard with our error message, people seem not to read or understand it. Try to improve readability

## How This PR Solves The Issue

* Show containers we're waiting for
* Improve error message

![image](https://github.com/user-attachments/assets/f8fa9181-86ae-45bc-9df6-573743be4ef5)


## Manual Testing Instructions

You can add a trivial failing extra service with `.ddev/docker-compose.longtimeout.yaml` with contents
```yaml
services:
  longtimeout:
    container_name: "ddev-${DDEV_SITENAME}-longtimeout"
    image: debian:12
    command: sleep infinity
    labels:
      com.ddev.site-name: ${DDEV_SITENAME}
      com.ddev.approot: ${DDEV_APPROOT}
    healthcheck:
      start_period: "10s"
      interval: "11s"
      start_interval: "11s"
      retries: 2
      timeout: "15s"
      test: "sleep 9 && false"
```

Or adjust as you like.

## Automated Testing Overview

Nothing new.

## Release/Deployment Notes

