### PR TITLE
test: Skip TestSSHAuth on Colima

### DIFF
--- a/pkg/ddevapp/ssh_auth_test.go
+++ b/pkg/ddevapp/ssh_auth_test.go
@@ -20,6 +20,9 @@ import (
 
 // TestSSHAuth tests basic SSH authentication
 func TestSSHAuth(t *testing.T) {
+	if dockerutil.IsColima() {
+		t.Skip("Skipping on Colima")
+	}
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}


### PR DESCRIPTION

## The Issue

TestSSHAuth() has been [failing intermittently on Colima, tb-macos-arm64-6](https://buildkite.com/ddev/macos-colima-vz/builds/1347#0190e21d-6c10-4546-834d-fde7873a3182), and we really don't need to know what it's done. So disable on Colima.


