### PR TITLE
fix: fail gently if sqlite3 can't be downloaded for drupal11, fixes #6425, for #6419

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -988,11 +988,11 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 			extraWebContent = extraWebContent + "\n" + fmt.Sprintf(`
 ### Drupal 11+ requires a minimum sqlite3 version (3.45 currently)
 ARG SQLITE_VERSION=%s
-RUN mkdir -p /tmp/sqlite3 && \
+RUN ( mkdir -p /tmp/sqlite3 && \
 wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
 wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
 apt-get install -y /tmp/sqlite3/*.deb && \
-rm -rf /tmp/sqlite3
+rm -rf /tmp/sqlite3 ) || true
 			`, versionconstants.Drupal11RequiredSqlite3Version)
 		}
 	}


### PR DESCRIPTION

## The Issue

* #6425
* #6419

## How This PR Solves The Issue

If we can't download and install sqlite 3.45, just move on.

Most Drupal11 users don't need it anyway.

## Manual Testing Instructions

* Turn off internet
* Create new Drupal11 project
* `ddev start`
* ddev config --update
* `ddev restart`

`ddev exec dpkg -l sqlite3` should show older sqlite

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
