### PR TITLE
fix: create mutagen-agents tarball if it doesn't exist, fixes #6421 

### DIFF
--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -582,16 +582,9 @@ func DownloadMutagenIfNeeded() error {
 	if err != nil {
 		return err
 	}
-	curVersion, err := version.GetLiveMutagenVersion()
-	if err != nil || curVersion != versionconstants.RequiredMutagenVersion {
-		err = DownloadMutagen()
-		if err != nil {
-			return err
-		}
-	}
-	// Also make sure the mutagen-agents.tar.gz is in place
 	agentsFile := filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz")
-	if !fileutil.FileExists(agentsFile) {
+	curVersion, err := version.GetLiveMutagenVersion()
+	if err != nil || curVersion != versionconstants.RequiredMutagenVersion || !fileutil.FileExists(agentsFile) {
 		err = DownloadMutagen()
 		if err != nil {
 			return err

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -589,6 +589,14 @@ func DownloadMutagenIfNeeded() error {
 			return err
 		}
 	}
+	// Also make sure the mutagen-agents.tar.gz is in place
+	agentsFile := filepath.Join(globalconfig.GetGlobalDdevDirLocation(), "mutagen-agents.tar.gz")
+	if !fileutil.FileExists(agentsFile) {
+		err = DownloadMutagen()
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -590,7 +590,7 @@ func DownloadMutagenIfNeeded() error {
 		}
 	}
 	// Also make sure the mutagen-agents.tar.gz is in place
-	agentsFile := filepath.Join(globalconfig.GetGlobalDdevDirLocation(), "mutagen-agents.tar.gz")
+	agentsFile := filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz")
 	if !fileutil.FileExists(agentsFile) {
 		err = DownloadMutagen()
 		if err != nil {

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -250,3 +250,48 @@ func TestMutagenConfigChange(t *testing.T) {
 
 	util.Debug("origSyncID=%s afterRestartSyncID=%s afterChangeSyncID=%s", origSyncID, afterRestartSyncID, afterChangeSyncID)
 }
+
+// Test app starts despite a missing mutagen-agents.tar.gz file
+func TestDownloadMutagen(t *testing.T) {
+	// Keep the same setup as TestMutagenSimple but remove the mutagen-agents.tar.gz file
+	assert := asrt.New(t)
+	_, _ = exec.RunHostCommand("pkill", "mutagen")
+	origDir, _ := os.Getwd()
+	site := FullTestSites[8]
+	app := &ddevapp.DdevApp{Name: site.Name}
+	_ = app.Stop(true, false)
+	_ = globalconfig.RemoveProjectInfo(site.Name)
+	err := site.Prepare()
+	require.NoError(t, err)
+	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
+	err = app.Init(site.Dir)
+	assert.NoError(err)
+	app.SetPerformanceMode(types.PerformanceModeMutagen)
+	err = app.WriteConfig()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		runTime()
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		assert.False(dockerutil.VolumeExists(ddevapp.GetMutagenVolumeName(app)))
+	})
+
+	// Remove the mutagen-agents.tar.gz file if it exists and start the app
+	if fileutil.FileExists(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz")) {
+		err = os.Remove(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
+		require.NoError(t, err)
+	}
+	err = app.Start()
+	require.NoError(t, err)
+	// Verify that the mutagen-agents.tar.gz file was downloaded
+	assert.FileExists(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
+	// Remove the mutagen-agents.tar.gz file again and restart the app
+	err = os.Remove(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
+	require.NoError(t, err)
+	err = app.Restart()
+	require.NoError(t, err)
+	// Verify again that the mutagen-agents.tar.gz file was downloaded
+	assert.FileExists(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
+}

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -150,6 +150,26 @@ func TestMutagenSimple(t *testing.T) {
 	assert.NoError(err, "Could not run Mutagen sync list: status=%s short=%s, long=%s, err=%v", status, short, long, err)
 	assert.Equal("ok", status, "wrong status: status=%s short=%s, long=%s", status, short, long)
 
+	err = app.Stop(false, false)
+	require.NoError(t, err)
+
+	// Remove the mutagen-agents.tar.gz file if it exists and start the app
+	if fileutil.FileExists(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz")) {
+		err = os.Remove(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
+		require.NoError(t, err)
+	}
+	err = app.Start()
+	require.NoError(t, err)
+	// Verify that the mutagen-agents.tar.gz file was downloaded
+	assert.FileExists(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
+	// Remove the mutagen-agents.tar.gz file again and restart the app
+	err = os.Remove(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
+	require.NoError(t, err)
+	err = app.Restart()
+	require.NoError(t, err)
+	// Verify again that the mutagen-agents.tar.gz file was downloaded
+	assert.FileExists(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
+
 	// Make sure Mutagen daemon gets stopped on poweoff
 	ddevapp.PowerOff()
 	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
@@ -249,49 +269,4 @@ func TestMutagenConfigChange(t *testing.T) {
 	require.NotEqual(t, firstStartHash, thirdStartHash)
 
 	util.Debug("origSyncID=%s afterRestartSyncID=%s afterChangeSyncID=%s", origSyncID, afterRestartSyncID, afterChangeSyncID)
-}
-
-// Test app starts despite a missing mutagen-agents.tar.gz file
-func TestDownloadMutagen(t *testing.T) {
-	// Keep the same setup as TestMutagenSimple but remove the mutagen-agents.tar.gz file
-	assert := asrt.New(t)
-	_, _ = exec.RunHostCommand("pkill", "mutagen")
-	origDir, _ := os.Getwd()
-	site := FullTestSites[8]
-	app := &ddevapp.DdevApp{Name: site.Name}
-	_ = app.Stop(true, false)
-	_ = globalconfig.RemoveProjectInfo(site.Name)
-	err := site.Prepare()
-	require.NoError(t, err)
-	runTime := util.TimeTrackC(fmt.Sprintf("%s %s", site.Name, t.Name()))
-	err = app.Init(site.Dir)
-	assert.NoError(err)
-	app.SetPerformanceMode(types.PerformanceModeMutagen)
-	err = app.WriteConfig()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		runTime()
-		err = os.Chdir(origDir)
-		assert.NoError(err)
-		err = app.Stop(true, false)
-		assert.NoError(err)
-		assert.False(dockerutil.VolumeExists(ddevapp.GetMutagenVolumeName(app)))
-	})
-
-	// Remove the mutagen-agents.tar.gz file if it exists and start the app
-	if fileutil.FileExists(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz")) {
-		err = os.Remove(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
-		require.NoError(t, err)
-	}
-	err = app.Start()
-	require.NoError(t, err)
-	// Verify that the mutagen-agents.tar.gz file was downloaded
-	assert.FileExists(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
-	// Remove the mutagen-agents.tar.gz file again and restart the app
-	err = os.Remove(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
-	require.NoError(t, err)
-	err = app.Restart()
-	require.NoError(t, err)
-	// Verify again that the mutagen-agents.tar.gz file was downloaded
-	assert.FileExists(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen-agents.tar.gz"))
 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6421 

The app is unable to start without a mutagen-agents.tar.gz file in the global bin directory.

## How This PR Solves The Issue
This PR adds a check to make sure the tarbell exists in the DownloadMutagenIfNeeded function, and if it does not, downloads mutagen. It also adds a test to test this functionality works.

## Manual Testing Instructions
Remove the tarbell file in the global bin directory e.g. rm ~/.ddev/bin/mutagen-agents.tar.gz and restart the app e.g. ddev restart

## Automated Testing Overview
Adds the TestDownloadMutagen test which has the same setup as TestMutagenSimple but removes the tarbell if it exists, then starts the app. Then it verifies that the tarbell has been downloaded. Then it removes it again and restarts the app, and finally verifies that the tarbell has been downloaded again.

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
