### PR TITLE
feat: add `ddev_version_constraint` for add-ons, remove `#ddev-nodisplay`, fixes #5969

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -267,6 +267,14 @@ ddev get --remove ddev-someaddonname
 				}
 			}
 		}
+
+		if s.DdevVersionConstraint != "" {
+			err := ddevapp.CheckDdevVersionConstraint(s.DdevVersionConstraint, fmt.Sprintf("Unable to install the '%s' add-on", s.Name), "")
+			if err != nil {
+				util.Failed(err.Error())
+			}
+		}
+
 		if len(s.PreInstallActions) > 0 {
 			util.Success("\nExecuting pre-install actions:")
 		}

--- a/cmd/ddev/cmd/testdata/TestCmdGetComplex/recipe/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdGetComplex/recipe/install.yaml
@@ -2,9 +2,6 @@ name: sample_get
 
 pre_install_actions:
 - |
-  #ddev-nodisplay
-  echo "This action should not have any output"
-- |
   {{ $ddev := (env "DDEV_BINARY_FULLPATH") }}
   {{ if not $ddev }} {{ $ddev = `ddev` }} {{end}}
   if ! ( which {{ $ddev }} && {{ $ddev }} debug capabilities 2>/dev/null | grep ddev-get-yaml-interpolation >/dev/null 2>&1 ) ; then

--- a/cmd/ddev/cmd/testdata/TestCmdGetDdevVersionConstraint/invalid_constraint_recipe/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdGetDdevVersionConstraint/invalid_constraint_recipe/install.yaml
@@ -1,0 +1,3 @@
+name: invalid_constraint_recipe
+
+ddev_version_constraint: ">= 1.twentythree"

--- a/cmd/ddev/cmd/testdata/TestCmdGetDdevVersionConstraint/valid_constraint_recipe/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdGetDdevVersionConstraint/valid_constraint_recipe/install.yaml
@@ -1,0 +1,3 @@
+name: valid_constraint_recipe
+
+ddev_version_constraint: "!= v0.0.0-overridden-by-make"

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -127,7 +127,7 @@ Example: `dbimage_extra_packages: ["less"]` will add the `less` package when the
 You can configure a [version constraint](https://github.com/Masterminds/semver#checking-version-constraints) for DDEV that will be validated against the running DDEV executable and prevent `ddev start` from running if it doesn't validate. For example:
 
 ```yaml
-ddev_version_constraint: '>=v1.23.0-alpha1'
+ddev_version_constraint: '>= v1.23.0-alpha1'
 ```
 
 This is only supported with DDEV versions above v1.22.4; older DDEV versions will ignore this setting.

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -133,7 +133,7 @@ Anyone can create an add-on for `ddev get`. See [this screencast](https://www.yo
 
 The `install.yaml` is a simple YAML file with a few main sections:
 
-* `name`: The add-on name. This will be used in `ddev get --remove` and similar commands. If the repository name is `ddev-solr`, for example, a good `name` will be `solr`. 
+* `name`: The add-on name. This will be used in `ddev get --remove` and similar commands. If the repository name is `ddev-solr`, for example, a good `name` will be `solr`.
 * `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s root directory.
 * `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
 * `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -138,9 +138,11 @@ The `install.yaml` is a simple YAML file with a few main sections:
 * `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
 * `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
 * `ddev_version_constraint` (available with DDEV v1.23.4+): a [version constraint](https://github.com/Masterminds/semver#checking-version-constraints) for DDEV that will be validated against the running DDEV executable and prevent add-on from being installed if it doesn't validate. For example:
+
     ```yaml
     ddev_version_constraint: '>= v1.23.4'
     ```
+
 * `dependencies`: an array of add-ons that this add-on depends on.
 * `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s root directory.
 * `removal_actions`: an array of Bash statements or scripts to be executed when the add-on is being removed with `ddev get --remove`.

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -133,7 +133,7 @@ Anyone can create an add-on for `ddev get`. See [this screencast](https://www.yo
 
 The `install.yaml` is a simple YAML file with a few main sections:
 
-* `name`: an add-on name.
+* `name`: The add-on name. This will be used in `ddev get --remove` and similar commands. If the repository name is `ddev-solr`, for example, a good `name` will be `solr`. 
 * `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s root directory.
 * `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
 * `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -133,9 +133,14 @@ Anyone can create an add-on for `ddev get`. See [this screencast](https://www.yo
 
 The `install.yaml` is a simple YAML file with a few main sections:
 
+* `name`: an add-on name.
 * `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s root directory.
 * `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
 * `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
+* `ddev_version_constraint` (available with DDEV v1.23.4+): a [version constraint](https://github.com/Masterminds/semver#checking-version-constraints) for DDEV that will be validated against the running DDEV executable and prevent add-on from being installed if it doesn't validate. For example:
+    ```yaml
+    ddev_version_constraint: '>= v1.23.4'
+    ```
 * `dependencies`: an array of add-ons that this add-on depends on.
 * `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s root directory.
 * `removal_actions`: an array of Bash statements or scripts to be executed when the add-on is being removed with `ddev get --remove`.

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -150,7 +150,6 @@ The `install.yaml` is a simple YAML file with a few main sections:
 
 In any stanza of `pre_install_actions` and `post_install_actions` you can:
 
-* Use `#ddev-nodisplay` on a line to suppress any output.
 * Use `#ddev-description:<some description of what stanza is doing>` to instruct DDEV to output a description of the action it's taking.
 
 You can see a simple `install.yaml` in [`ddev-addon-template`’s `install.yaml`](https://github.com/ddev/ddev-addon-template/blob/main/install.yaml).

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -24,14 +24,15 @@ const AddonMetadataDir = "addon-metadata"
 // Format of install.yaml
 type InstallDesc struct {
 	// Name must be unique in a project; it will overwrite any existing add-on with the same name.
-	Name               string            `yaml:"name"`
-	ProjectFiles       []string          `yaml:"project_files"`
-	GlobalFiles        []string          `yaml:"global_files,omitempty"`
-	Dependencies       []string          `yaml:"dependencies,omitempty"`
-	PreInstallActions  []string          `yaml:"pre_install_actions,omitempty"`
-	PostInstallActions []string          `yaml:"post_install_actions,omitempty"`
-	RemovalActions     []string          `yaml:"removal_actions,omitempty"`
-	YamlReadFiles      map[string]string `yaml:"yaml_read_files"`
+	Name                  string            `yaml:"name"`
+	ProjectFiles          []string          `yaml:"project_files"`
+	GlobalFiles           []string          `yaml:"global_files,omitempty"`
+	DdevVersionConstraint string            `yaml:"ddev_version_constraint,omitempty"`
+	Dependencies          []string          `yaml:"dependencies,omitempty"`
+	PreInstallActions     []string          `yaml:"pre_install_actions,omitempty"`
+	PostInstallActions    []string          `yaml:"post_install_actions,omitempty"`
+	RemovalActions        []string          `yaml:"removal_actions,omitempty"`
+	YamlReadFiles         map[string]string `yaml:"yaml_read_files"`
 }
 
 // format of the add-on manifest file

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -13,7 +13,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
@@ -453,24 +452,9 @@ func (app *DdevApp) ValidateConfig() error {
 
 	// Validate ddev version constraint, if any
 	if app.DdevVersionConstraint != "" {
-		constraint := app.DdevVersionConstraint
-		if !strings.Contains(constraint, "-") {
-			// Allow pre-releases to be included in the constraint validation
-			// @see https://github.com/Masterminds/semver#working-with-prerelease-versions
-			constraint += "-0"
-		}
-		c, err := semver.NewConstraint(constraint)
+		err := CheckDdevVersionConstraint(app.DdevVersionConstraint, fmt.Sprintf("unable to start the '%s' project", app.Name), "or update the `ddev_version_constraint` in your .ddev/config.yaml file")
 		if err != nil {
-			return fmt.Errorf("the %s project has '%s' constraint that is not valid. See https://github.com/Masterminds/semver#checking-version-constraints for valid constraints format", app.Name, app.DdevVersionConstraint).(invalidConstraint)
-		}
-
-		// Make sure we do this check with valid released versions
-		v, err := semver.NewVersion(versionconstants.DdevVersion)
-		if err == nil {
-			if !c.Check(v) {
-				return fmt.Errorf("the %s project has a DDEV version constraint of '%s' and the version of DDEV you are using ('%s') does not meet the constraint. Please update the `ddev_version_constraint` in your .ddev/config.yaml or use a version of DDEV that meets the constraint",
-					app.Name, app.DdevVersionConstraint, versionconstants.DdevVersion)
-			}
+			return err
 		}
 	}
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -551,6 +551,7 @@ func TestConfigValidate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			assert := asrt.New(t)
 			versionconstants.DdevVersion = tc.ddevVersion
 			app.DdevVersionConstraint = tc.versionConstraint
 			err = app.ValidateConfig()

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -534,14 +534,14 @@ func TestConfigValidate(t *testing.T) {
 	app.DdevVersionConstraint = ">= 1.twentythree"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "constraint that is not valid")
+	assert.Contains(err.Error(), "constraint is not valid")
 	app.DdevVersionConstraint = ""
 
 	versionconstants.DdevVersion = "v1.22.0"
 	app.DdevVersionConstraint = ">= 1.23"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "project has a DDEV version constraint of '>= 1.23' and the version of DDEV you are using ('v1.22.0') does not meet the constraint")
+	assert.Contains(err.Error(), "your DDEV version 'v1.22.0' doesn't meet the constraint '>= 1.23'")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
@@ -564,7 +564,7 @@ func TestConfigValidate(t *testing.T) {
 	app.DdevVersionConstraint = ">= 1.23"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "project has a DDEV version constraint of '>= 1.23' and the version of DDEV you are using ('v1.22.3-11-g8baef014e') does not meet the constraint")
+	assert.Contains(err.Error(), "your DDEV version 'v1.22.3-11-g8baef014e' doesn't meet the constraint '>= 1.23'")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
@@ -579,7 +579,7 @@ func TestConfigValidate(t *testing.T) {
 	app.DdevVersionConstraint = ">= 1.23.0-0"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "project has a DDEV version constraint of '>= 1.23.0-0' and the version of DDEV you are using ('v1.22.3-11-g8baef014e') does not meet the constraint")
+	assert.Contains(err.Error(), "your DDEV version 'v1.22.3-11-g8baef014e' doesn't meet the constraint '>= 1.23.0-0'")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 
@@ -587,7 +587,7 @@ func TestConfigValidate(t *testing.T) {
 	app.DdevVersionConstraint = ">= v1.22.3-alpha3"
 	err = app.ValidateConfig()
 	assert.Error(err)
-	assert.Contains(err.Error(), "project has a DDEV version constraint of '>= v1.22.3-alpha3' and the version of DDEV you are using ('v1.22.3-alpha2') does not meet the constraint")
+	assert.Contains(err.Error(), "your DDEV version 'v1.22.3-alpha2' doesn't meet the constraint '>= v1.22.3-alpha3'")
 	app.DdevVersionConstraint = ""
 	versionconstants.DdevVersion = ddevVersion
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -531,79 +531,39 @@ func TestConfigValidate(t *testing.T) {
 		t.Fatalf("Failed to app.ValidateConfig(), err=%v", err)
 	}
 
-	app.DdevVersionConstraint = ">= 1.twentythree"
-	err = app.ValidateConfig()
-	assert.Error(err)
-	assert.Contains(err.Error(), "constraint is not valid")
-	app.DdevVersionConstraint = ""
+	testCases := []struct {
+		description       string
+		ddevVersion       string
+		versionConstraint string
+		error             string
+	}{
+		{"Invalid constraint", ddevVersion, ">= 1.twentythree", "constraint is not valid"},
+		{"Lower version", "v1.22.0", ">= 1.23", "your DDEV version 'v1.22.0' doesn't meet the constraint '>= 1.23'"},
+		{"Equal version", "v1.23.0", ">= 1.23", ""},
+		{"Not semver version", "2134asdf-dirty", ">= 1.23", ""},
+		{"Lower semver version with suffix", "v1.22.3-11-g8baef014e", ">= 1.23", "your DDEV version 'v1.22.3-11-g8baef014e' doesn't meet the constraint '>= 1.23'"},
+		{"Equal semver version with suffix", "v1.22.3-11-g8baef014e", ">= 1.22", ""},
+		{"Constraint with suffix", "v1.22.3-11-g8baef014e", ">= 1.23.0-0", "your DDEV version 'v1.22.3-11-g8baef014e' doesn't meet the constraint '>= 1.23.0-0'"},
+		{"Lower prerelease version", "v1.22.3-alpha2", ">= v1.22.3-alpha3", "your DDEV version 'v1.22.3-alpha2' doesn't meet the constraint '>= v1.22.3-alpha3'"},
+		{"Greater prerelease version", "v1.22.3-beta1", ">= v1.22.3-alpha3", ""},
+		{"Compare with suffixes", "v1.22.3-11-g8baef014e", ">= 1.22.0-0", ""},
+	}
 
-	versionconstants.DdevVersion = "v1.22.0"
-	app.DdevVersionConstraint = ">= 1.23"
-	err = app.ValidateConfig()
-	assert.Error(err)
-	assert.Contains(err.Error(), "your DDEV version 'v1.22.0' doesn't meet the constraint '>= 1.23'")
-	app.DdevVersionConstraint = ""
-	versionconstants.DdevVersion = ddevVersion
-
-	versionconstants.DdevVersion = "v1.23.0"
-	app.DdevVersionConstraint = ">= 1.23"
-	err = app.ValidateConfig()
-	assert.NoError(err)
-	app.DdevVersionConstraint = ""
-	versionconstants.DdevVersion = ddevVersion
-
-	versionconstants.DdevVersion = "2134asdf-dirty"
-	app.DdevVersionConstraint = ">= 1.23"
-	err = app.ValidateConfig()
-	assert.NoError(err)
-	app.DdevVersionConstraint = ""
-	versionconstants.DdevVersion = ddevVersion
-
-	// Testing out pre-releases and built PRs versions
-	versionconstants.DdevVersion = "v1.22.3-11-g8baef014e"
-	app.DdevVersionConstraint = ">= 1.23"
-	err = app.ValidateConfig()
-	assert.Error(err)
-	assert.Contains(err.Error(), "your DDEV version 'v1.22.3-11-g8baef014e' doesn't meet the constraint '>= 1.23'")
-	app.DdevVersionConstraint = ""
-	versionconstants.DdevVersion = ddevVersion
-
-	versionconstants.DdevVersion = "v1.22.3-11-g8baef014e"
-	app.DdevVersionConstraint = ">= 1.22"
-	err = app.ValidateConfig()
-	assert.NoError(err)
-	app.DdevVersionConstraint = ""
-	versionconstants.DdevVersion = ddevVersion
-
-	versionconstants.DdevVersion = "v1.22.3-11-g8baef014e"
-	app.DdevVersionConstraint = ">= 1.23.0-0"
-	err = app.ValidateConfig()
-	assert.Error(err)
-	assert.Contains(err.Error(), "your DDEV version 'v1.22.3-11-g8baef014e' doesn't meet the constraint '>= 1.23.0-0'")
-	app.DdevVersionConstraint = ""
-	versionconstants.DdevVersion = ddevVersion
-
-	versionconstants.DdevVersion = "v1.22.3-alpha2"
-	app.DdevVersionConstraint = ">= v1.22.3-alpha3"
-	err = app.ValidateConfig()
-	assert.Error(err)
-	assert.Contains(err.Error(), "your DDEV version 'v1.22.3-alpha2' doesn't meet the constraint '>= v1.22.3-alpha3'")
-	app.DdevVersionConstraint = ""
-	versionconstants.DdevVersion = ddevVersion
-
-	versionconstants.DdevVersion = "v1.22.3-beta1"
-	app.DdevVersionConstraint = ">= v1.22.3-alpha3"
-	err = app.ValidateConfig()
-	assert.NoError(err)
-	app.DdevVersionConstraint = ""
-	versionconstants.DdevVersion = ddevVersion
-
-	versionconstants.DdevVersion = "v1.22.3-11-g8baef014e"
-	app.DdevVersionConstraint = ">= 1.22.0-0"
-	err = app.ValidateConfig()
-	assert.NoError(err)
-	app.DdevVersionConstraint = ""
-	versionconstants.DdevVersion = ddevVersion
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			versionconstants.DdevVersion = tc.ddevVersion
+			app.DdevVersionConstraint = tc.versionConstraint
+			err = app.ValidateConfig()
+			if tc.error == "" {
+				assert.NoError(err)
+			} else {
+				assert.Error(err)
+				assert.Contains(err.Error(), tc.error)
+			}
+			app.DdevVersionConstraint = ""
+			versionconstants.DdevVersion = ddevVersion
+		})
+	}
 
 	app.Name = "Invalid!"
 	err = app.ValidateConfig()


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev-xhgui/pull/31
- #5969

The current approach when you need to add a version constraint to an add-on involves using `ddev debug capabilities`, which is not obvious.

This isn't good because capabilities aren't added for each DDEV release and you can't add a version constraint for some minor release.

## How This PR Solves The Issue

Adds `ddev_version_constraint` to `install.yaml` for add-ons that allows you to check the semver constraint.

TODO:
- [x] update https://github.com/ddev/ddev-addon-template/blob/8d7dac3113074fbf6e6b37696a24d837fa323056/install.yaml#L24-L26.
- https://github.com/ddev/ddev-addon-template/pull/55
- [x] update https://ddev.com/blog/advanced-add-on-contributor-training/
- https://github.com/ddev/ddev.com/pull/235

## Manual Testing Instructions

```
git clone https://github.com/ddev/ddev-phpmyadmin
echo "ddev_version_constraint: '>= v1.23.4'" >> ddev-phpmyadmin/install.yaml
ddev get ddev-phpmyadmin # should show error
sed -i 's/v1.23.4/v1.23.3/' ddev-phpmyadmin/install.yaml # lower the constraint
ddev get ddev-phpmyadmin # should be installed
```
