### PR TITLE
docs: improve placement of .env for environment variables

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -612,7 +612,7 @@ May also be set via `ddev config global --use-letsencrypt` or `ddev config globa
 
 ## `web_environment`
 
-Additional [custom environment variables](../extend/customization-extendibility.md#providing-custom-environment-variables-to-a-container) for a project’s web container. (Or for all projects if used globally.)
+Additional [custom environment variables](../extend/customization-extendibility.md#environment-variables-for-containers-and-services) for a project’s web container. (Or for all projects if used globally.)
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -41,13 +41,13 @@ If you’d rather use the CLI to set the project or global `web_environment` val
 ddev config --web-environment-add="MY_ENV_VAR=someval"
 
 # Set MY_ENV_VAR globally
-ddev config global --web-environment-add="MY_ENV_VAR=someval
+ddev config global --web-environment-add="MY_ENV_VAR=someval"
 ```
 
 You can use the `--web-environment` flag to overwrite existing values rather than adding them.
 
 !!!warning "Don’t check in sensitive values!"
-Sensitive variables like API keys should not be checked in with your project. Typically you might use an `.env` file and _not_ check that in, but offer `.env.example` with expected keys that don’t have values. Some use global configuration for sensitive values, as that’s not normally checked in either.
+	Sensitive variables like API keys should not be checked in with your project. Typically you might use an `.env` file and _not_ check that in, but offer `.env.example` with expected keys that don’t have values. Some use global configuration for sensitive values, as that’s not normally checked in either.
 
 ### Altering the In-Container `$PATH`
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -47,7 +47,7 @@ ddev config global --web-environment-add="MY_ENV_VAR=someval"
 You can use the `--web-environment` flag to overwrite existing values rather than adding them.
 
 !!!warning "Don’t check in sensitive values!"
-	Sensitive variables like API keys should not be checked in with your project. Typically you might use an `.env` file and _not_ check that in, but offer `.env.example` with expected keys that don’t have values. Some use global configuration for sensitive values, as that’s not normally checked in either.
+    Sensitive variables like API keys should not be checked in with your project. You might use an `.env` file and _not_ check that in, but offer a `.env.example` with expected keys that don’t have values. Some use global configuration for sensitive values, as that’s not normally checked in either. (If you provide a `.env.example` it can be checked in, overriding the `.ddev/.gitignore`, with `git add -f .ddev/.env.example`.)
 
 ### Altering the In-Container `$PATH`
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -126,7 +126,7 @@ Environment variables will be automatically added to your `.env` file to simplif
 
 In order for `ddev craft` to work when Craft is installed in a subdirectory, you will need to change the location of the `craft` executable by providing the `CRAFT_CMD_ROOT` environment variable to the web container. For example, if the installation lives in `my-craft-site/app`, you would run `ddev config --web-environment-add=CRAFT_CMD_ROOT=./app`. `CRAFT_CMD_ROOT` defaults to `./`, the project root directory. Run `ddev restart` to apply the change.
 
-Read more about customizing the environment and persisting configuration in [Providing Custom Environment Variables to a Container](./extend/customization-extendibility.md#providing-custom-environment-variables-to-a-container).
+Read more about customizing the environment and persisting configuration in [Providing Custom Environment Variables to a Container](./extend/customization-extendibility.md#environment-variables-for-containers-and-services).
 
 !!!tip "Installing Craft"
     Read more about installing Craft in the [official documentation](https://craftcms.com/docs).


### PR DESCRIPTION
## The Issue

Probably the best way these days to provide environment variables to containers/services is to use the `.ddev/.env` file.

## How This PR Solves The Issue

* Move the Environment variable section to the front page the page it's on
* Put the `.env` discussion first
* Push up the search preference value

I still don't get a good hit in search except with "variables", "environment variables" doesn't do much.

## Manual Testing Instructions

Rendered version is at https://ddev--6439.org.readthedocs.build/en/6439/users/extend/customization-extendibility/#environment-variables-for-containers-and-services

