### PR TITLE
docs: store magento2 credentials in the global config, for #5932, for #6380

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -418,13 +418,13 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     Normal details of a Composer build for Magento 2 are on the [Magento 2 site](https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/composer.html). You must have a public and private key to install from Magento’s repository. When prompted for “username” and “password” in `composer create`, it’s asking for your public key as "username" and private key as "password".
 
     !!!tip "Store Adobe/Magento Composer credentials in the global DDEV config"
-        If you already have Composer installed on you system you can reuse the `auth.json` by making a symlink. See [In-Container Home Directory and Shell Configuration](extend/in-container-configuration.md):
+        If you have Composer installed on your workstation and have an `auth.json` you can reuse the `auth.json` by making a symlink. See [In-Container Home Directory and Shell Configuration](extend/in-container-configuration.md):
 
         ```
         mkdir -p ~/.ddev/homeadditions/.composer && ln -s ~/.composer/auth.json ~/.ddev/homeadditions/.composer/auth.json
         ```
 
-        Alternatively, you can install the Adobe/Magento Composer credentials in your global `~/.ddev/homeadditions/.composer/auth.json` and never have to find them again (see below):
+        Alternately, you can install the Adobe/Magento Composer credentials in your global `~/.ddev/homeadditions/.composer/auth.json` and never have to enter them again (see below):
     
         ??? "Script to store Adobe/Magento Composer credentials (click me)"
             ```bash

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -421,20 +421,14 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
     ```bash
     mkdir my-magento2-site && cd my-magento2-site
-    ddev config --project-type=magento2 --docroot=pub --disable-settings-management \
-    --upload-dirs=media
+    ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
+
+    # a one-time action to save your Magento credentials in the global DDEV config
+    # enter your username/password and agree to store your credentials
+    ddev_dir="$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r ".raw.\"global-ddev-dir\" | select (.!=null) // \"$HOME/.ddev\"" 2>/dev/null)" && mkdir -p $ddev_dir/homeadditions/.composer && docker run -it --rm -v "$ddev_dir/homeadditions/.composer:/composer" --workdir=/composer -e COMPOSER_HOME=/composer --user $(id -u):$(id -g) $(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r ".raw.web | select (.!=null)" 2>/dev/null) bash -c "cd /tmp && composer create --repository https://repo.magento.com/ magento/project-community-edition --no-install"
 
     ddev get ddev/ddev-elasticsearch
     ddev start
-
-    # if the Magento auth is not found in the Composer global config, save it at the project level
-    if ! ddev exec "composer config --list --global 2>/dev/null | grep -q repo.magento.com" 2>/dev/null; then
-        ddev config --web-environment-add=COMPOSER_HOME="/var/www/html/.ddev/homeadditions/.composer"
-        mkdir -p .ddev/homeadditions/.composer
-        echo "*\n\!.gitignore" >.ddev/homeadditions/.composer/.gitignore
-        ddev restart
-    fi
-
     ddev composer create --repository https://repo.magento.com/ magento/project-community-edition
     rm -f app/etc/env.php
 
@@ -448,7 +442,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ddev magento deploy:mode:set developer
     ddev magento module:disable Magento_TwoFactorAuth Magento_AdminAdobeImsTwoFactorAuth
     ddev config --disable-settings-management=false
-    ddev php bin/magento info:adminuri
+    ddev magento info:adminuri
     # Append the URI returned by the previous command either to ddev launch, like for example ddev launch /admin_XXXXXXX, or just run ddev launch and append the URI to the path in the browser
     ddev launch
     ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -427,8 +427,8 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ddev get ddev/ddev-elasticsearch
     ddev start
 
-    # if the Magento auth is not found in the Composer config, save it at the project level
-    if ! ddev exec "composer config --list 2>/dev/null | grep -q repo.magento.com || composer config --list --global 2>/dev/null | grep -q repo.magento.com" 2>/dev/null; then
+    # if the Magento auth is not found in the Composer global config, save it at the project level
+    if ! ddev exec "composer config --list --global 2>/dev/null | grep -q repo.magento.com" 2>/dev/null; then
         ddev config --web-environment-add=COMPOSER_HOME="/var/www/html/.ddev/homeadditions/.composer"
         mkdir -p .ddev/homeadditions/.composer
         echo "*\n\!.gitignore" >.ddev/homeadditions/.composer/.gitignore

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -417,32 +417,32 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
     Normal details of a Composer build for Magento 2 are on the [Magento 2 site](https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/composer.html). You must have a public and private key to install from Magento’s repository. When prompted for “username” and “password” in `composer create`, it’s asking for your public key as "username" and private key as "password".
 
-    !!!tip "Reuse the existing `auth.json` from the Composer installed on the host side"
+    !!!tip "Store Adobe/Magento Composer credentials in the global DDEV config"
         If you already have Composer installed on you system you can reuse the `auth.json` by making a symlink. See [In-Container Home Directory and Shell Configuration](extend/in-container-configuration.md):
 
         ```
         mkdir -p ~/.ddev/homeadditions/.composer && ln -s ~/.composer/auth.json ~/.ddev/homeadditions/.composer/auth.json
         ```
 
-    !!!tip "Store Adobe/Magento Composer credentials in the global DDEV config" 
-        You can install the Adobe/Magento Composer credentials in your global `~/.ddev/homeadditions/.composer/auth.json` and never have to find them again:
-
-        ```bash
-        # enter your username/password and agree to store your credentials
-        ddev_dir="$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r ".raw.\"global-ddev-dir\" | select (.!=null) // \"$HOME/.ddev\"" 2>/dev/null)"
-        mkdir -p $ddev_dir/homeadditions/.composer
-        docker_command=("docker" "run" "-it" "--rm" "-v" "$ddev_dir/homeadditions/.composer:/composer" "--workdir=/tmp" "-e" "COMPOSER_HOME=/composer" "--user" "$(id -u):$(id -g)")
-        auth_json_path="$ddev_dir/homeadditions/.composer/auth.json"
-        if [ -L "$auth_json_path" ]; then
-            # If auth.json is a symlink, add the optional mount
-            auth_json_dir=$(dirname "$(readlink -f "$auth_json_path")")
-            docker_command+=("-v" "$auth_json_dir:$auth_json_dir")
-        fi
-        image="$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r ".raw.web | select (.!=null)" 2>/dev/null)"
-        docker_command+=("$image" "bash" "-c" "composer create --repository https://repo.magento.com/ magento/project-community-edition --no-install")
-        # Execute the command to store credentials
-        "${docker_command[@]}"
-        ```
+        Alternatively, you can install the Adobe/Magento Composer credentials in your global `~/.ddev/homeadditions/.composer/auth.json` and never have to find them again (see below):
+    
+        ??? "Script to store Adobe/Magento Composer credentials (click me)"
+            ```bash
+            # Enter your username/password and agree to store your credentials
+            ddev_dir="$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r ".raw.\"global-ddev-dir\" | select (.!=null) // \"$HOME/.ddev\"" 2>/dev/null)"
+            mkdir -p $ddev_dir/homeadditions/.composer
+            docker_command=("docker" "run" "-it" "--rm" "-v" "$ddev_dir/homeadditions/.composer:/composer" "--workdir=/tmp" "-e" "COMPOSER_HOME=/composer" "--user" "$(id -u):$(id -g)")
+            auth_json_path="$ddev_dir/homeadditions/.composer/auth.json"
+            if [ -L "$auth_json_path" ]; then
+                # If auth.json is a symlink, add the optional mount
+                auth_json_dir=$(dirname "$(readlink -f "$auth_json_path")")
+                docker_command+=("-v" "$auth_json_dir:$auth_json_dir")
+            fi
+            image="$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r ".raw.web | select (.!=null)" 2>/dev/null)"
+            docker_command+=("$image" "bash" "-c" "composer create --repository https://repo.magento.com/ magento/project-community-edition --no-install")
+            # Execute the command to store credentials
+            "${docker_command[@]}"
+            ```
 
     ```bash
     mkdir my-magento2-site && cd my-magento2-site

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -422,13 +422,21 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ```bash
     mkdir my-magento2-site && cd my-magento2-site
     ddev config --project-type=magento2 --docroot=pub --disable-settings-management \
-    --upload-dirs=media --web-environment-add=COMPOSER_HOME="/var/www/html/.ddev/homeadditions/.composer"
+    --upload-dirs=media
 
     ddev get ddev/ddev-elasticsearch
     ddev start
-    ddev composer create --repository=https://repo.magento.com/ magento/project-community-edition
+
+    # if the Magento auth is not found in the Composer global config, save it at the project level
+    if ! ddev exec "composer config --list --global 2>/dev/null | grep -q repo.magento.com" 2>/dev/null; then
+        ddev config --web-environment-add=COMPOSER_HOME="/var/www/html/.ddev/homeadditions/.composer"
+        mkdir -p .ddev/homeadditions/.composer
+        echo "*\n\!.gitignore" >.ddev/homeadditions/.composer/.gitignore
+        ddev restart
+    fi
+
+    ddev composer create --repository https://repo.magento.com/ magento/project-community-edition
     rm -f app/etc/env.php
-    echo "/auth.json" >.ddev/homeadditions/.composer/.gitignore
 
     # Change the base-url below to your project's URL
     ddev magento setup:install --base-url="https://my-magento2-site.ddev.site/" \

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -427,8 +427,8 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ddev get ddev/ddev-elasticsearch
     ddev start
 
-    # if the Magento auth is not found in the Composer global config, save it at the project level
-    if ! ddev exec "composer config --list --global 2>/dev/null | grep -q repo.magento.com" 2>/dev/null; then
+    # if the Magento auth is not found in the Composer config, save it at the project level
+    if ! ddev exec "composer config --list 2>/dev/null | grep -q repo.magento.com || composer config --list --global 2>/dev/null | grep -q repo.magento.com" 2>/dev/null; then
         ddev config --web-environment-add=COMPOSER_HOME="/var/www/html/.ddev/homeadditions/.composer"
         mkdir -p .ddev/homeadditions/.composer
         echo "*\n\!.gitignore" >.ddev/homeadditions/.composer/.gitignore

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -417,16 +417,36 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
     Normal details of a Composer build for Magento 2 are on the [Magento 2 site](https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/composer.html). You must have a public and private key to install from Magento’s repository. When prompted for “username” and “password” in `composer create`, it’s asking for your public key as "username" and private key as "password".
 
-    Note that you can install the Adobe/Magento composer credentials in your global `~/.ddev/homeadditions/.composer/auth.json` and never have to find them again. See [In-Container Home Directory and Shell Configuration](extend/in-container-configuration.md).
+    !!!tip "Reuse the existing `auth.json` from the Composer installed on the host side"
+        If you already have Composer installed on you system you can reuse the `auth.json` by making a symlink. See [In-Container Home Directory and Shell Configuration](extend/in-container-configuration.md):
+
+        ```
+        mkdir -p ~/.ddev/homeadditions/.composer && ln -s ~/.composer/auth.json ~/.ddev/homeadditions/.composer/auth.json
+        ```
+
+    !!!tip "Store Adobe/Magento Composer credentials in the global DDEV config" 
+        You can install the Adobe/Magento Composer credentials in your global `~/.ddev/homeadditions/.composer/auth.json` and never have to find them again:
+
+        ```bash
+        # enter your username/password and agree to store your credentials
+        ddev_dir="$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r ".raw.\"global-ddev-dir\" | select (.!=null) // \"$HOME/.ddev\"" 2>/dev/null)"
+        mkdir -p $ddev_dir/homeadditions/.composer
+        docker_command=("docker" "run" "-it" "--rm" "-v" "$ddev_dir/homeadditions/.composer:/composer" "--workdir=/tmp" "-e" "COMPOSER_HOME=/composer" "--user" "$(id -u):$(id -g)")
+        auth_json_path="$ddev_dir/homeadditions/.composer/auth.json"
+        if [ -L "$auth_json_path" ]; then
+            # If auth.json is a symlink, add the optional mount
+            auth_json_dir=$(dirname "$(readlink -f "$auth_json_path")")
+            docker_command+=("-v" "$auth_json_dir:$auth_json_dir")
+        fi
+        image="$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r ".raw.web | select (.!=null)" 2>/dev/null)"
+        docker_command+=("$image" "bash" "-c" "composer create --repository https://repo.magento.com/ magento/project-community-edition --no-install")
+        # Execute the command to store credentials
+        "${docker_command[@]}"
+        ```
 
     ```bash
     mkdir my-magento2-site && cd my-magento2-site
     ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
-
-    # a one-time action to save your Magento credentials in the global DDEV config
-    # enter your username/password and agree to store your credentials
-    ddev_dir="$(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r ".raw.\"global-ddev-dir\" | select (.!=null) // \"$HOME/.ddev\"" 2>/dev/null)" && mkdir -p $ddev_dir/homeadditions/.composer && docker run -it --rm -v "$ddev_dir/homeadditions/.composer:/composer" --workdir=/composer -e COMPOSER_HOME=/composer --user $(id -u):$(id -g) $(ddev version -j | docker run -i --rm ddev/ddev-utilities jq -r ".raw.web | select (.!=null)" 2>/dev/null) bash -c "cd /tmp && composer create --repository https://repo.magento.com/ magento/project-community-edition --no-install"
-
     ddev get ddev/ddev-elasticsearch
     ddev start
     ddev composer create --repository https://repo.magento.com/ magento/project-community-edition


### PR DESCRIPTION
## The Issue

- #5932

The documentation says https://ddev.readthedocs.io/en/stable/users/quickstart/#magento

> Note that you can install the Adobe/Magento composer credentials in your global `~/.ddev/homeadditions/.composer/auth.json` and never have to find them again.

But the current quickstart doesn't check composer's global configuration for this auth, resulting in a situation where you have to add these credentials each time for each project.

## How This PR Solves The Issue

Stores magento2 credentials in the global config `~/.ddev/homeadditions/.composer/auth.json` (and respects `$XDG_CONFIG_HOME`)

This is one-time action. If you run it again, it will simply check if your credentials are correct.

## Manual Testing Instructions

Review at https://ddev--6442.org.readthedocs.build/en/6442/users/quickstart/#magento

Try it out.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
