### PR TITLE
docs: show actual running context in `install.yaml` for add-ons

### DIFF
--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -267,6 +267,21 @@ ddev get --remove ddev-someaddonname
 				}
 			}
 		}
+
+		origDir, _ := os.Getwd()
+
+		defer func() {
+			err = os.Chdir(origDir)
+			if err != nil {
+				util.Failed("Unable to chdir to %v: %v", origDir, err)
+			}
+		}()
+
+		err = os.Chdir(app.GetConfigPath(""))
+		if err != nil {
+			util.Failed("Unable to chdir to %v: %v", app.GetConfigPath(""), err)
+		}
+
 		if len(s.PreInstallActions) > 0 {
 			util.Success("\nExecuting pre-install actions:")
 		}
@@ -328,19 +343,6 @@ ddev get --remove ddev-someaddonname
 			} else {
 				util.Warning("NOT overwriting %s. The #ddev-generated signature was not found in the file, so it will not be overwritten. You can remove the file and use DDEV get again if you want it to be replaced: %v", dest, err)
 			}
-		}
-		origDir, _ := os.Getwd()
-
-		defer func() {
-			err = os.Chdir(origDir)
-			if err != nil {
-				util.Failed("Unable to chdir to %v: %v", origDir, err)
-			}
-		}()
-
-		err = os.Chdir(app.GetConfigPath(""))
-		if err != nil {
-			util.Failed("Unable to chdir to %v: %v", app.GetConfigPath(""), err)
 		}
 
 		if len(s.PostInstallActions) > 0 {

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -267,21 +267,6 @@ ddev get --remove ddev-someaddonname
 				}
 			}
 		}
-
-		origDir, _ := os.Getwd()
-
-		defer func() {
-			err = os.Chdir(origDir)
-			if err != nil {
-				util.Failed("Unable to chdir to %v: %v", origDir, err)
-			}
-		}()
-
-		err = os.Chdir(app.GetConfigPath(""))
-		if err != nil {
-			util.Failed("Unable to chdir to %v: %v", app.GetConfigPath(""), err)
-		}
-
 		if len(s.PreInstallActions) > 0 {
 			util.Success("\nExecuting pre-install actions:")
 		}
@@ -343,6 +328,19 @@ ddev get --remove ddev-someaddonname
 			} else {
 				util.Warning("NOT overwriting %s. The #ddev-generated signature was not found in the file, so it will not be overwritten. You can remove the file and use DDEV get again if you want it to be replaced: %v", dest, err)
 			}
+		}
+		origDir, _ := os.Getwd()
+
+		defer func() {
+			err = os.Chdir(origDir)
+			if err != nil {
+				util.Failed("Unable to chdir to %v: %v", origDir, err)
+			}
+		}()
+
+		err = os.Chdir(app.GetConfigPath(""))
+		if err != nil {
+			util.Failed("Unable to chdir to %v: %v", app.GetConfigPath(""), err)
 		}
 
 		if len(s.PostInstallActions) > 0 {

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -133,12 +133,12 @@ Anyone can create an add-on for `ddev get`. See [this screencast](https://www.yo
 
 The `install.yaml` is a simple YAML file with a few main sections:
 
-* `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s root directory.
+* `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s `.ddev` directory.
 * `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
 * `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
 * `dependencies`: an array of add-ons that this add-on depends on.
-* `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s root directory.
-* `removal_actions`: an array of Bash statements or scripts to be executed when the add-on is being removed with `ddev get --remove`.
+* `post_install_actions`: an array of Bash statements or scripts to be executed after `project_files` and `global_files` are installed. The actions are executed in the context of the target project’s `.ddev` directory.
+* `removal_actions`: an array of Bash statements or scripts to be executed when the add-on is being removed with `ddev get --remove`. The actions are executed in the context of the target project’s `.ddev` directory.
 * `yaml_read_files`: a map of `name: file` of YAML files to be read from the target project’s root directory. The contents of these YAML files may be used as templated actions within `pre_install_actions` and `post_install_actions`.
 
 In any stanza of `pre_install_actions` and `post_install_actions` you can:

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -133,7 +133,7 @@ Anyone can create an add-on for `ddev get`. See [this screencast](https://www.yo
 
 The `install.yaml` is a simple YAML file with a few main sections:
 
-* `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s `.ddev` directory.
+* `pre_install_actions`: an array of Bash statements or scripts to be executed before `project_files` are installed. The actions are executed in the context of the target project’s root directory.
 * `project_files`: an array of files or directories to be copied from the add-on into the target project’s `.ddev` directory.
 * `global_files`: is an array of files or directories to be copied from the add-on into the target system’s global `.ddev` directory (`~/.ddev/`).
 * `dependencies`: an array of add-ons that this add-on depends on.


### PR DESCRIPTION
## The Issue

While working on

- https://github.com/ddev/ddev-varnish/pull/28

I noticed that different add-on actions are performed in different contexts, which is confusing.

- `pre_install_actions` in `$DDEV_APPROOT`
- `post_install_actions` in `$DDEV_APPROOT/.ddev`
- `removal_actions` in `$DDEV_APPROOT/.ddev`

Related change:

- https://github.com/ddev/ddev-addon-template/pull/54

## How This PR Solves The Issue

Fixes documentation.

## Manual Testing Instructions

```
mkdir miniaddon && echo "name: miniaddon\npre_install_actions:\n- pwd\npost_install_actions:\n- pwd\nremoval_actions:\n- pwd" > miniaddon/install.yaml
# the output should show project root for pre_install_actions and .ddev for post_install_actions
ddev get miniaddon
# the output should show  .ddev for removal_actions
ddev get --remove miniaddon
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes
