### PR TITLE
docs: update magento1 and backdrop quickstarts, fixes #6448

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -13,7 +13,7 @@ To get started with [Backdrop](https://backdropcms.org), clone the project repos
     ```bash
     mkdir my-backdrop-site && cd my-backdrop-site
     curl -LJO https://github.com/backdrop/backdrop/releases/latest/download/backdrop.zip
-    unzip ./backdrop.zip && rm -f backdrop.zip && bash -c "mv -f ./backdrop/{.,}* ." && rm -rf backdrop
+    unzip ./backdrop.zip && rm -f backdrop.zip && mv -f ./backdrop/{.,}* . ; rm -rf backdrop
     ddev config --project-type=backdrop
     ddev start
     ddev launch

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -463,21 +463,11 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     tag=$(curl -L "https://api.github.com/repos/OpenMage/magento-lts/releases/latest" | docker run -i --rm ddev/ddev-utilities jq -r .tag_name) && curl -L "https://github.com/OpenMage/magento-lts/releases/download/$tag/openmage-$tag.zip" -o openmage.zip
     unzip ./openmage.zip && rm -f openmage.zip
     ddev config --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
-
-    # Install sample data. (See below.)
-
     ddev start
-    ddev launch
+    # Install sample data
+    ddev openmage-install
+    ddev launch /admin
     ```
-
-    You may want the [Magento 1 Sample Data](https://github.com/Vinai/compressed-magento-sample-data) for experimentation:
-
-    * Download Magento [1.9.2.4 Sample Data](https://github.com/Vinai/compressed-magento-sample-data/raw/master/compressed-magento-sample-data-1.9.2.4.tgz).
-    * Extract the download:
-        `tar -zxf ~/Downloads/compressed-magento-sample-data-1.9.2.4.tgz --strip-components=1`
-    * Import the example database `magento_sample_data_for_1.9.2.4.sql` with `ddev import-db --file=~/Downloads/magento_sample_data_for_1.9.2.4.sql` to database **before** running OpenMage install.
-
-    OpenMage is a huge codebase, and we recommend [using Mutagen for performance](install/performance.md#mutagen) on macOS and traditional Windows.
 
 ## Moodle
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -466,9 +466,11 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ddev start
     # Install openmage and optionally install sample data
     ddev openmage-install
-    
-    # Note that openmage itself provides the `openmage-install`, `openmage-admin`, `phpmd`, `rector`, `phpcbf`, `phpstan`, `vendor-patches`, and `php-cs-fixer` DDEV custom commands.
     ddev launch /admin
+
+    # Note that openmage itself provides several custom DDEV commands, including
+    # `openmage-install`, `openmage-admin`, `phpmd`, `rector`, `phpcbf`, `phpstan`, `vendor-patches`, 
+    # and `php-cs-fixer`.
     ```
 
 ## Moodle

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -13,7 +13,7 @@ To get started with [Backdrop](https://backdropcms.org), clone the project repos
     ```bash
     mkdir my-backdrop-site && cd my-backdrop-site
     curl -LJO https://github.com/backdrop/backdrop/releases/latest/download/backdrop.zip
-    unzip ./backdrop.zip && rm backdrop.zip && mv -f ./backdrop/{.,}* . && rm -r backdrop
+    unzip ./backdrop.zip && rm -f backdrop.zip && bash -c "mv -f ./backdrop/{.,}* ." && rm -rf backdrop
     ddev config --project-type=backdrop
     ddev start
     ddev launch
@@ -322,7 +322,7 @@ Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/insta
 ```bash
 mkdir my-joomla-site && cd my-joomla-site
 tag=$(curl -L "https://api.github.com/repos/joomla/joomla-cms/releases/latest" | docker run -i --rm ddev/ddev-utilities jq -r .tag_name) && curl -L "https://github.com/joomla/joomla-cms/releases/download/$tag/Joomla_$tag-Stable-Full_Package.zip" -o joomla.zip
-unzip ./joomla.zip && rm joomla.zip
+unzip ./joomla.zip && rm -f joomla.zip
 ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
 ddev start
 ddev php installation/joomla.php install --site-name="My Joomla Site" --admin-user="Administrator" --admin-username=admin --admin-password=AdminAdmin1! --admin-email=admin@example.com --db-type=mysql --db-encryption=0 --db-host=db --db-user=db --db-pass="db" --db-name=db --db-prefix=ddev_ --public-folder=""
@@ -458,19 +458,24 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
 === "OpenMage/Magento 1"
 
-    1. Download OpenMage from [release page](https://github.com/OpenMage/magento-lts/releases).
-    2. Make a directory for it, for example `mkdir ~/workspace/OpenMage` and change to the new directory `cd ~/workspace/OpenMage`.
-    3. Run [`ddev config`](../users/usage/commands.md#config) and accept the defaults.
-    4. Install sample data. (See below.)
-    5. Run [`ddev start`](../users/usage/commands.md#start).
-    6. Follow the URL to the base site.
+    ```bash
+    mkdir my-magento1-site && cd my-magento1-site
+    tag=$(curl -L "https://api.github.com/repos/OpenMage/magento-lts/releases/latest" | docker run -i --rm ddev/ddev-utilities jq -r .tag_name) && curl -L "https://github.com/OpenMage/magento-lts/releases/download/$tag/openmage-$tag.zip" -o openmage.zip
+    unzip ./openmage.zip && rm -f openmage.zip
+    ddev config --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
+
+    # Install sample data. (See below.)
+
+    ddev start
+    ddev launch
+    ```
 
     You may want the [Magento 1 Sample Data](https://github.com/Vinai/compressed-magento-sample-data) for experimentation:
 
     * Download Magento [1.9.2.4 Sample Data](https://github.com/Vinai/compressed-magento-sample-data/raw/master/compressed-magento-sample-data-1.9.2.4.tgz).
     * Extract the download:
         `tar -zxf ~/Downloads/compressed-magento-sample-data-1.9.2.4.tgz --strip-components=1`
-    * Import the example database `magento_sample_data_for_1.9.2.4.sql` with `ddev import-db --file=magento_sample_data_for_1.9.2.4.sql` to database **before** running OpenMage install.
+    * Import the example database `magento_sample_data_for_1.9.2.4.sql` with `ddev import-db --file=~/Downloads/magento_sample_data_for_1.9.2.4.sql` to database **before** running OpenMage install.
 
     OpenMage is a huge codebase, and we recommend [using Mutagen for performance](install/performance.md#mutagen) on macOS and traditional Windows.
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -462,10 +462,12 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     mkdir my-magento1-site && cd my-magento1-site
     tag=$(curl -L "https://api.github.com/repos/OpenMage/magento-lts/releases/latest" | docker run -i --rm ddev/ddev-utilities jq -r .tag_name) && curl -L "https://github.com/OpenMage/magento-lts/releases/download/$tag/openmage-$tag.zip" -o openmage.zip
     unzip ./openmage.zip && rm -f openmage.zip
-    ddev config --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
+    ddev config --project-type=magento --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
     ddev start
-    # Install sample data
+    # Install openmage and optionally install sample data
     ddev openmage-install
+    
+    # Note that openmage itself provides the `openmage-install`, `openmage-admin`, `phpmd`, `rector`, `phpcbf`, `phpstan`, `vendor-patches`, and `php-cs-fixer` DDEV custom commands.
     ddev launch /admin
     ```
 


### PR DESCRIPTION
## The Issue

- #6448

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

- Updated the Magento1 quickstart to use a terminal approach like other quickstarts.
- Adds `ddev config --web-environment-add=MAGE_IS_DEVELOPER_MODE=1` for the Magento1 quickstart as requested.
- Adds `-f` to `rm` where it was not added.

I tried other quickstarts, and I noticed a problem with backdrop when running it in `zsh`:

```
$ mv -f ./backdrop/{.,}* .
mv: cannot stat './backdrop/.editorconfig': No such file or directory
mv: cannot stat './backdrop/.gitignore': No such file or directory
mv: cannot stat './backdrop/.htaccess': No such file or directory
```

- It actually worked, but `&& rm -rf backdrop` was not executed, fixed it with `; rm -rf backdrop`

## Manual Testing Instructions

Try Magento1 quickstart.
https://ddev--6449.org.readthedocs.build/en/6449/users/quickstart/#__tabbed_9_2

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
