### PR TITLE
test: Update tests for Drupal11 to latest tarballs, fixes #6452

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -353,10 +353,10 @@ var (
 		// 19: drupal11
 		{
 			Name:                          "TestPkgDrupal11",
-			SourceURL:                     "https://github.com/ddev/test-drupal11/archive/refs/tags/11.0.0-beta1.tar.gz",
-			ArchiveInternalExtractionPath: "test-drupal11-11.0.0-beta1/",
-			FilesTarballURL:               "https://github.com/ddev/test-drupal11/releases/download/11.0.0-beta1/files.tgz",
-			DBTarURL:                      "https://github.com/ddev/test-drupal11/releases/download/11.0.0-beta1/db.sql.tar.gz",
+			SourceURL:                     "https://github.com/ddev/test-drupal11/archive/refs/tags/11.0.0.tar.gz",
+			ArchiveInternalExtractionPath: "test-drupal11-11.0.0/",
+			FilesTarballURL:               "https://github.com/ddev/test-drupal11/releases/download/11.0.0/files.tgz",
+			DBTarURL:                      "https://github.com/ddev/test-drupal11/releases/download/11.0.0/db.sql.tar.gz",
 			FullSiteTarballURL:            "",
 			Type:                          nodeps.AppTypeDrupal,
 			Docroot:                       "web",


### PR DESCRIPTION

## The Issue

* #6452 

Drupal 11 out, update test tarballs to match it. 

## Automated Testing Overview

Update drupal11 test, if it works, it should be OK.

