### PR TITLE
feat: add `log-stderr.sh` command, for #6451, for #6420

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -7,6 +7,7 @@ export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
 
 # GOTEST_SHORT=12 means drupal10
 export GOTEST_SHORT=12
+export DDEV_SKIP_NODEJS_TEST=true
 
 export DOCKER_SCAN_SUGGEST=false
 export DOCKER_SCOUT_SUGGEST=false

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -98,12 +98,9 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     nginx \
     sqlite3
 
-# Install n to manage nodejs_version, make a symlink for nodejs
-RUN curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s "${NODE_VERSION}" && \
-    npm install -g n && \
-    n rm "${NODE_VERSION}" && \
-    ln -sf "$(which node)" "$(which node)js"
-
+RUN curl -L --fail -o /usr/local/bin/n -sSL https://raw.githubusercontent.com/tj/n/master/bin/n && chmod ugo+wx /usr/local/bin/n
+# Install node, remove it from cache, make a symlink for nodejs
+RUN n install "${NODE_VERSION}" && n rm "${NODE_VERSION}" && ln -sf "$(which node)" "$(which node)js"
 RUN npm install --unsafe-perm=true --global gulp-cli yarn
 # Normal user needs to be able to write to php sessions
 RUN set -eu -o pipefail && LATEST=$(curl -L --fail --silent "https://api.github.com/repos/nvm-sh/nvm/releases/latest" | jq -r .tag_name) && curl --fail -sL https://raw.githubusercontent.com/nvm-sh/nvm/${LATEST}/install.sh -o /usr/local/bin/install_nvm.sh && chmod +x /usr/local/bin/install_nvm.sh

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20240723_stasadev_n_install_auto as ddev-webserver-base
+FROM ddev/ddev-php-base:v1.23.4 as ddev-webserver-base
 
 ENV BACKDROP_DRUSH_VERSION=1.4.0
 ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# This script is used to run a command with optional timeout
+# and save stderr to /tmp/ddev-log-stderr-${whoami}.txt
+set +eu
+
+# Function to display usage information
+usage() {
+  echo "Usage: $(basename "$0") [-t timeout] command"
+  echo "  -t, --timeout: Timeout in seconds (default: no timeout)"
+  exit 1
+}
+
+# Default timeout value
+timeout=0
+
+if whoami &>/dev/null; then
+  whoami=$(whoami)
+else
+  whoami=$(id -u)
+fi
+
+# Parse command line options
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -t|--timeout)
+      timeout="$2"
+      shift 2
+      ;;
+    -*)
+      usage
+      ;;
+    *)
+      command=("$@")
+      break
+      ;;
+  esac
+done
+
+# If no command is provided, show usage
+if [ -z "${command[*]}" ]; then
+  usage
+fi
+
+tmp_error_file="/tmp/tmp-ddev-log-stderr-${whoami}-$(echo -n "${command[*]} $(date +%s)" | md5sum | awk '{print $1}').txt"
+
+# Run the command with timeout if specified
+if [ "${timeout}" -gt 0 ]; then
+  timeout "${timeout}" "${command[@]}" 2> >(tee -a "${tmp_error_file}" >&2)
+  exit_code=$?
+else
+  "${command[@]}" 2> >(tee -a "${tmp_error_file}" >&2)
+  exit_code=$?
+fi
+
+# Exit on success
+if [ "${exit_code}" -eq 0 ]; then
+  rm -f "${tmp_error_file}"
+  exit "${exit_code}"
+fi
+
+# If it is a timeout error (see 'timeout --help')
+if [ "${timeout}" -gt 0 ] && [ "${exit_code}" -eq 124 ]; then
+  echo "Warning: '${command[*]}' timed out after ${timeout} seconds" | tee -a "${tmp_error_file}" >&2
+fi
+
+# Remove blank lines from begin and end of a file
+sed -i -e '/./,$!d' -e :a -e '/^\n*$/{$d;N;ba' -e '}' "${tmp_error_file}"
+
+# If stderr is empty
+if [ ! -s "${tmp_error_file}" ]; then
+  echo "Warning: '${command[*]}' didn't return stderr output" | tee -a "${tmp_error_file}" >&2
+fi
+
+# Write to the log
+{ printf "Warning: Command '%s' run as '%s' failed with exit code %s:\n" "${command[*]}" "${whoami}" "${exit_code}"; cat "${tmp_error_file}"; } >> "/tmp/ddev-log-stderr-${whoami}.txt"
+rm -f "${tmp_error_file}"
+
+exit "${exit_code}"

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
@@ -1,28 +1,39 @@
 #!/bin/bash
 
 # This script is used to run a command with optional timeout
-# and save stderr to /tmp/ddev-log-stderr-${whoami}.txt
-set +eu
+# and save stderr to /tmp/ddev-log-stderr-{whoami}-{command-md5sum}.txt
 
 # Function to display usage information
 usage() {
-  echo "Usage: $(basename "$0") [-t timeout] command"
-  echo "  -t, --timeout: Timeout in seconds (default: no timeout)"
+  echo "Usage: $(basename "$0") [-t timeout] [-r] [-s] command"
+  echo "  -d, --debug          Enables debug mode"
+  echo "  -s, --show           Shows stderr log (no command required)"
+  echo "  -t, --timeout <int>  Timeout in seconds (default: no timeout)"
+  echo "  -r, --remove         Removes stderr log for specified command"
   exit 1
 }
 
-# Default timeout value
+# Defaults
+debug=false
+show=false
+remove=false
 timeout=0
-
-if whoami &>/dev/null; then
-  whoami=$(whoami)
-else
-  whoami=$(id -u)
-fi
 
 # Parse command line options
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
+    -d|--debug)
+      debug=true
+      shift
+      ;;
+    -r|--remove)
+      remove=true
+      shift
+      ;;
+    -s|--show)
+      show=true
+      shift
+      ;;
     -t|--timeout)
       timeout="$2"
       shift 2
@@ -37,43 +48,69 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
+[ "${debug}" = "true" ] && set -x
+
+# show stderr output
+if [ "${show}" = "true" ]; then
+  # find /tmp -maxdepth 1 -name 'ddev-log-stderr-*.txt': Searches for files matching the pattern.
+  # -printf "%C@ %p\n": Outputs the creation time (%C@) in seconds since the epoch followed by the file path (%p).
+  # sort -n: Sorts the output numerically (-n).
+  # awk '{print $2}': Extracts the file paths from the sorted output.
+  # xargs cat --squeeze-blank: Concatenates content by collapsing multiple blank lines into a single blank line.
+  find /tmp -maxdepth 1 -name 'ddev-log-stderr-*.txt' -printf "%C@ %p\n" | sort -n | awk '{print $2}' | xargs --no-run-if-empty cat --squeeze-blank
+  exit $?
+fi
+
 # If no command is provided, show usage
 if [ -z "${command[*]}" ]; then
   usage
 fi
 
-tmp_error_file="/tmp/tmp-ddev-log-stderr-${whoami}-$(echo -n "${command[*]} $(date +%s)" | md5sum | awk '{print $1}').txt"
+if whoami &>/dev/null; then
+  whoami=$(whoami)
+else
+  whoami=$(id -u)
+fi
+
+# get a unique identifier for a filename
+identifier="$(echo -n "${whoami}-${command[*]}" | md5sum | awk '{print $1}')"
+
+error_file="/tmp/ddev-log-stderr-${identifier}.txt"
+
+if [ "${remove}" = "true" ]; then
+  rm -f "${error_file}"
+  exit $?
+fi
+
+tmp_error_file="/tmp/tmp-ddev-log-stderr-${identifier}-$(date +%s).txt"
 
 # Run the command with timeout if specified
 if [ "${timeout}" -gt 0 ]; then
   timeout "${timeout}" "${command[@]}" 2> >(tee -a "${tmp_error_file}" >&2)
-  exit_code=$?
 else
   "${command[@]}" 2> >(tee -a "${tmp_error_file}" >&2)
-  exit_code=$?
 fi
+
+exit_code=$?
 
 # Exit on success
 if [ "${exit_code}" -eq 0 ]; then
-  rm -f "${tmp_error_file}"
+  rm -f "${tmp_error_file}" "${error_file}"
   exit "${exit_code}"
 fi
 
 # If it is a timeout error (see 'timeout --help')
 if [ "${timeout}" -gt 0 ] && [ "${exit_code}" -eq 124 ]; then
-  echo "Warning: '${command[*]}' timed out after ${timeout} seconds" | tee -a "${tmp_error_file}" >&2
+  echo "Command '${command[*]}' timed out after ${timeout} seconds" | tee -a "${tmp_error_file}" >&2
 fi
-
-# Remove blank lines from begin and end of a file
-sed -i -e '/./,$!d' -e :a -e '/^\n*$/{$d;N;ba' -e '}' "${tmp_error_file}"
 
 # If stderr is empty
 if [ ! -s "${tmp_error_file}" ]; then
-  echo "Warning: '${command[*]}' didn't return stderr output" | tee -a "${tmp_error_file}" >&2
+  echo "Command '${command[*]}' didn't return stderr output" | tee -a "${tmp_error_file}" >&2
 fi
 
 # Write to the log
-{ printf "Warning: Command '%s' run as '%s' failed with exit code %s:\n" "${command[*]}" "${whoami}" "${exit_code}"; cat "${tmp_error_file}"; } >> "/tmp/ddev-log-stderr-${whoami}.txt"
+{ printf "Warning: command '%s' run as '%s' failed with exit code %s:\n" "${command[*]}" "${whoami}" "${exit_code}"; cat "${tmp_error_file}" --squeeze-blank; echo; } >> "${error_file}"
 rm -f "${tmp_error_file}"
 
 exit "${exit_code}"

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/n-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/n-install.sh
@@ -33,11 +33,13 @@ ln -sf "/mnt/ddev-global-cache/n_prefix/${HOSTNAME}" "${N_PREFIX}"
 
 # try online install that also uses cache
 n_install_result=true
-log-stderr.sh -t 30 n install "${N_INSTALL_VERSION}" || n_install_result=false
+log-stderr.sh --timeout 30 n install "${N_INSTALL_VERSION}" || n_install_result=false
 
 # try offline install on fail
-if [ "${n_install_result}" = "false" ]; then
-  timeout 30 n install "${N_INSTALL_VERSION}" --offline && n_install_result=true
+if [ "${n_install_result}" = "false" ] && timeout 30 n install "${N_INSTALL_VERSION}" --offline; then
+  n_install_result=true
+  # remove stderr log from the previous command
+  log-stderr.sh --remove n install "${N_INSTALL_VERSION}" || true
 fi
 
 # remove the symlink on error so that the system Node.js can be used

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/n-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/n-install.sh
@@ -31,28 +31,27 @@ fi
 
 ln -sf "/mnt/ddev-global-cache/n_prefix/${HOSTNAME}" "${N_PREFIX}"
 
-# try normal install that also uses cache
+# try online install that also uses cache
 n_install_result=true
-timeout 30 n install "${N_INSTALL_VERSION}" 2> >(tee /tmp/n-install-stderr.txt >&2) || n_install_result=false
+log-stderr.sh -t 30 n install "${N_INSTALL_VERSION}" || n_install_result=false
 
-# try offline install on fail, but only if there is no error for invalid ${N_INSTALL_VERSION}
-if [ "${n_install_result}" = "false" ] && ! grep -q "invalid version" /tmp/n-install-stderr.txt; then
-  timeout 30 n install "${N_INSTALL_VERSION}" --offline 2> >(tee -a /tmp/n-install-stderr.txt >&2) && n_install_result=true
+# try offline install on fail
+if [ "${n_install_result}" = "false" ]; then
+  timeout 30 n install "${N_INSTALL_VERSION}" --offline && n_install_result=true
 fi
 
-if [ "${n_install_result}" = "true" ]; then
-  # create symlinks on success
-  for node_binary in "${N_PREFIX}/bin/"*; do
-    if [ -f "${node_binary}" ]; then
-      ln -sf "${node_binary}" "${system_node_dir}"
-    fi
-  done
-  ln -sf "${system_node_dir}/node" "${system_node_dir}/nodejs"
-  # we don't need this file if everything is fine
-  rm -f /tmp/n-install-stderr.txt
-else
-  # remove the symlink on error so that the system Node.js can be used
-  rm -f "${N_PREFIX}"
+# remove the symlink on error so that the system Node.js can be used
+if [ "${n_install_result}" = "false" ]; then
+  rm -f "${N_PREFIX}" && exit 6
 fi
+
+# create symlinks on success
+for node_binary in "${N_PREFIX}/bin/"*; do
+  if [ -f "${node_binary}" ]; then
+    ln -sf "${node_binary}" "${system_node_dir}"
+  fi
+done
+
+ln -sf "${system_node_dir}/node" "${system_node_dir}/nodejs"
 
 hash -r

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1477,6 +1477,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	stderrOut, _, _ := app.Exec(&ExecOpts{
 		Cmd: "(ls -r /tmp/ddev-log-stderr-*.txt | xargs cat) 2>/dev/null || true",
 	})
+	stderrOut = strings.TrimSpace(stderrOut)
 	if stderrOut != "" {
 		util.Warning(stderrOut)
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1473,14 +1473,12 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		util.Warning("Something is wrong with your Docker provider and /mnt/ddev_config is not mounted from the project .ddev folder. Your project cannot normally function successfully with this situation. Is your project in your home directory?")
 	}
 
-	if app.NodeJSVersion != nodeps.NodeJSDefault {
-		util.Debug(`checking nodejs_version: "%s" install for errors`, app.NodeJSVersion)
-		nInstallStderr, _, _ := app.Exec(&ExecOpts{
-			Cmd: "cat /tmp/n-install-stderr.txt 2>/dev/null || true",
-		})
-		if nInstallStderr != "" {
-			util.Warning("Unable to install nodejs_version: \"%s\".\nError output from `n install %s`:\n%s", app.NodeJSVersion, app.NodeJSVersion, nInstallStderr)
-		}
+	util.Debug("checking /tmp/ddev-log-stderr-*.txt")
+	stderrOut, _, _ := app.Exec(&ExecOpts{
+		Cmd: "(ls -r /tmp/ddev-log-stderr-*.txt | xargs cat) 2>/dev/null || true",
+	})
+	if stderrOut != "" {
+		util.Warning(stderrOut)
 	}
 
 	if !IsRouterDisabled(app) {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1473,13 +1473,13 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		util.Warning("Something is wrong with your Docker provider and /mnt/ddev_config is not mounted from the project .ddev folder. Your project cannot normally function successfully with this situation. Is your project in your home directory?")
 	}
 
-	util.Debug("checking /tmp/ddev-log-stderr-*.txt")
-	stderrOut, _, _ := app.Exec(&ExecOpts{
-		Cmd: "(ls -r /tmp/ddev-log-stderr-*.txt | xargs cat) 2>/dev/null || true",
+	util.Debug("Getting stderr output from 'log-stderr.sh --show'")
+	logStderr, _, _ := app.Exec(&ExecOpts{
+		Cmd: "log-stderr.sh --show 2>/dev/null || true",
 	})
-	stderrOut = strings.TrimSpace(stderrOut)
-	if stderrOut != "" {
-		util.Warning(stderrOut)
+	logStderr = strings.TrimSpace(logStderr)
+	if logStderr != "" {
+		util.Warning(logStderr)
 	}
 
 	if !IsRouterDisabled(app) {

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240723_stasadev_n_install_auto" // Note that this can be overridden by make
+var WebTag = "20240802_stasadev_log_stderr_for_n" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #6451
- #6420

## How This PR Solves The Issue

- Adds a new bash command `log-stderr.sh` that stores `stderr` output. (I've only used it for `n install` so far, I will add it to other commands later, after some testing and probably after the next DDEV release.)
- Adds `export DDEV_SKIP_NODEJS_TEST=true` for Buildkite tests.
- Changes `n` installation technique according to upstream recommendations.
- Optimizes error output for `n install` (removes `--offline` logging).

## Manual Testing Instructions

Look at the newer error output for:

```
$ ddev config --nodejs-version auto # when you don't have .nvmrc file or another file
...
Warning: Command 'n install auto' run as 'stas' failed with exit code 2:
  Error: no file found for auto version (.n-node-version, .node-version, .nvmrc, or package.json)

$ ddev config --nodejs-version foobar # invalid version
...
Warning: Command 'n install foobar' run as 'stas' failed with exit code 2:
  Error: invalid version 'foobar'

$ ddev config --nodejs-version 6 # without internet
...
Warning: Command 'n install 6' run as 'stas' failed with exit code 2:
curl: (6) Could not resolve host: nodejs.org

  Error: failed to download version index (https://nodejs.org/dist/index.tab)
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
