### PR TITLE
test: mysql-client 9.0 in homebrew is broken, use 8.0

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -29,10 +29,12 @@ case $os in
 darwin)
     brew pin buildkite-agent
     brew upgrade
-    for item in ddev/ddev/ddev golang golangci-lint libpq mkcert mkdocs; do
+    brew uninstall -f mysql-client || true
+    for item in ddev/ddev/ddev golang golangci-lint libpq mkcert mkdocs mysql-client@8.0; do
         brew install $item || true
     done
     brew link --force libpq
+    brew link mysql-client@8.0
     ;;
 windows)
     (yes | choco upgrade -y golang nodejs markdownlint-cli mkcert mkdocs postgresql) || true

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -138,7 +138,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 10. `sudo mkdir -p /usr/local/bin && sudo chown -R testbot /usr/local/bin`
 11. Install [Homebrew](https://brew.sh/) `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
 12. After installing Homebrew follow the instructions it gives you at the end to add brew to your PATH.
-13. Install everything you’ll need with `brew install buildkite/buildkite/buildkite-agent bats-core composer ddev/ddev/ddev git golang jq mysql-client mkcert netcat p7zip  && brew install --cask docker iterm2 ngrok && brew link --force mysql-client`.
+13. Install everything you’ll need with `brew install buildkite/buildkite/buildkite-agent bats-core composer ddev/ddev/ddev git golang jq mysql-client@8.0 mkcert netcat p7zip  && brew install --cask docker iterm2 ngrok && brew link --force mysql-client`.
 14. Run `ngrok authtoken <token>` with token for free account from 1Password.
 15. Run `mkcert -install`.
 16. If Docker Desktop will be deployed, run Docker manually and go through its configuration routine.


### PR DESCRIPTION

## The Issue

Homebrew's mysql-client 9.0 just came out and is broken, https://buildkite.com/ddev/ddev-macos-arm64-mutagen/builds/8398#01911f62-d2cd-499c-897c-5ca0fd7a38ef/2586-2656

> ERROR 2059 (HY000): Authentication plugin 'mysql_native_password' cannot be loaded: dlopen(/opt/homebrew/Cellar/mysql-client/9.0.1/lib/plugin/mysql_native_password.so, 0x0002): tried: '/opt/homebrew/Cellar/mysql-client/9.0.1/lib/plugin/mysql_native_password.so' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/mysql-client/9.0.1/lib/plugin/mysql_native_password.so' (no such file), '/opt/homebrew/Cellar/mysql-client/9.0.1/lib/plugin/mysql_native_password.so' (no such file)
 
## How This PR Solves The Issue

Use mysql-client@8.0 instead

## Manual Testing Instructions

If the tests run it should be OK. However, machines that have mysql-client@9.0 will be sad.

