### PR TITLE
docs: add readable tab anchors

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,10 @@ markdown_extensions:
 - pymdownx.superfences:
 - pymdownx.tabbed:
     alternate_style: true
+    combine_header_slug: true
+    slugify: !!python/object/apply:pymdownx.slugs.slugify
+      kwds:
+        case: lower
 - pymdownx.tasklist:
     custom_checkbox: true
 - pymdownx.tilde


### PR DESCRIPTION
## The Issue

Tab anchors are unreadable.

For example, Drupal 11

![image](https://github.com/user-attachments/assets/45885545-b4e0-40c5-89ce-83b67f899813)

## How This PR Solves The Issue

Uses the latest available features from Tabbed https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#tabbed

![image](https://github.com/user-attachments/assets/4bbdbe55-f260-477c-bcc4-74e7a8dea783)

## Manual Testing Instructions

https://ddev--6464.org.readthedocs.build/en/6464/users/quickstart/#drupal-drupal-11

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
