### PR TITLE
feat: automatic timezone detection from `$TZ` env or `/etc/localtime` symlink, fixes #6458

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -559,7 +559,7 @@ Timezone for container and PHP configuration.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | `UTC` | Can be any [valid timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), like `Europe/Dublin` or `MST7MDT`.
+| :octicons-file-directory-16: project | Automatic detection or `UTC` | Can be any [valid timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), like `Europe/Dublin` or `MST7MDT`.
 
 ## `traefik_monitor_port`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -561,7 +561,7 @@ Timezone for container and PHP configuration.
 | -- | -- | --
 | :octicons-file-directory-16: project | Automatic detection or `UTC` | Can be any [valid timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), like `Europe/Dublin` or `MST7MDT`.
 
-If `timezone` is unset, DDEV will attempt to derive it from the host system timezone.
+If `timezone` is unset, DDEV will attempt to derive it from the host system timezone using the `$TZ` environment variable or the `/etc/localtime` symlink.
 
 ## `traefik_monitor_port`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -561,6 +561,8 @@ Timezone for container and PHP configuration.
 | -- | -- | --
 | :octicons-file-directory-16: project | Automatic detection or `UTC` | Can be any [valid timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), like `Europe/Dublin` or `MST7MDT`.
 
+If `timezone` is unset, DDEV will attempt to derive it from the host system timezone.
+
 ## `traefik_monitor_port`
 
 Specify an alternate port for the Traefik (ddev-router) monitor port. This defaults to 10999 and rarely needs to be changed, but can be changed in cases of port conflicts.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -825,6 +825,16 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		return "", err
 	}
 
+	timezone := app.Timezone
+	if timezone == "" {
+		timezone, err = app.GetLocalTimezone()
+		if err != nil {
+			util.Debug("Unable to autodetect timezone: %v", err.Error())
+		} else {
+			util.Debug("Using automatically detected timezone: TZ=%s", timezone)
+		}
+	}
+
 	templateVars := composeYAMLVars{
 		Name:                      app.Name,
 		Plugin:                    "ddev",
@@ -852,7 +862,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		MountType:          "bind",
 		WebMount:           "../",
 		Hostnames:          app.GetHostnames(),
-		Timezone:           app.Timezone,
+		Timezone:           timezone,
 		ComposerVersion:    app.ComposerVersion,
 		Username:           username,
 		UID:                uid,

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1055,30 +1055,31 @@ func (app *DdevApp) GetDBImage() string {
 	return dbImage
 }
 
-// GetLocalTimezone tries to find local timezone from /etc/localtime symlink
+// GetLocalTimezone tries to find local timezone from $TZ or /etc/localtime symlink
 func (app *DdevApp) GetLocalTimezone() (string, error) {
-	// the code below doesn't work for Windows
-	if runtime.GOOS == "windows" {
-		return "", fmt.Errorf("unable to read /etc/localtime on Windows")
+	timezone := ""
+	if os.Getenv("TZ") != "" {
+		timezone = os.Getenv("TZ")
+	} else {
+		localtimeFile := filepath.Join("/etc", "localtime")
+		timezoneFile, err := filepath.EvalSymlinks(localtimeFile)
+		if err != nil {
+			return "", fmt.Errorf("unable to read timezone from %s file: %v", localtimeFile, err)
+		}
+		// /etc/localtime is a symlink to a file, for example:
+		// /usr/share/zoneinfo/Europe/London on Linux and WSL2
+		// /var/db/timezone/zoneinfo/Europe/London on macOS (the exact path to /zoneinfo/ may differ)
+		// We can search for anything after /zoneinfo/ in the file path
+		parts := strings.Split(strings.TrimSpace(timezoneFile), "/zoneinfo/")
+		if len(parts) != 2 {
+			return "", fmt.Errorf("unable to read timezone from %s file", timezoneFile)
+		}
+		timezone = parts[1]
+		if timezone == "" {
+			return "", fmt.Errorf("unable to read timezone from %s file", timezoneFile)
+		}
 	}
-	bash := util.FindBashPath()
-	timezone, err := exec.RunHostCommand(bash, "-c", "[ ! -e /etc/localtime ] || /usr/bin/readlink -f /etc/localtime 2>/dev/null || /bin/readlink -f /etc/localtime 2>/dev/null")
-	if err != nil {
-		return "", err
-	}
-	// /etc/localtime is a symlink to a file, for example:
-	// /usr/share/zoneinfo/Europe/London on Linux and WSL2
-	// /var/db/timezone/zoneinfo/Europe/London on macOS (the exact path to /zoneinfo/ may differ)
-	// We can search for anything after /zoneinfo/ in the file path
-	parts := strings.Split(strings.TrimSpace(timezone), "/zoneinfo/")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("unable to read /etc/localtime symlink")
-	}
-	timezone = parts[1]
-	if timezone == "" {
-		return "", fmt.Errorf("unable to read /etc/localtime timezone")
-	}
-	_, err = time.LoadLocation(timezone)
+	_, err := time.LoadLocation(timezone)
 	if err != nil {
 		return "", fmt.Errorf("failed to load timezone '%s': %v", timezone, err)
 	}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -45,6 +45,7 @@ const ConfigInstructions = `
 # webserver_type: nginx-fpm, apache-fpm, or nginx-gunicorn
 
 # timezone: Europe/Berlin
+# If this value is not set, the timezone is mapped from the host (with UTC fallback).
 # This is the timezone used in the containers and by PHP;
 # it can be set to any valid timezone,
 # see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -45,7 +45,8 @@ const ConfigInstructions = `
 # webserver_type: nginx-fpm, apache-fpm, or nginx-gunicorn
 
 # timezone: Europe/Berlin
-# If this value is not set, the timezone is mapped from the host (with UTC fallback).
+# If timezone is unset, DDEV will attempt to derive it from the host system timezone
+# using the $TZ environment variable or the /etc/localtime symlink.
 # This is the timezone used in the containers and by PHP;
 # it can be set to any valid timezone,
 # see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6458

## How This PR Solves The Issue

We can use the `$TZ` env and  the `/etc/localtime` symlink to get the timezone from the host.
`/etc/localtime` does not exist on traditional Windows, where users can set `$TZ` env.

## Manual Testing Instructions

Unset timezone if it is set:
```
ddev config --timezone=""
```

Run
```
DDEV_DEBUG=true ddev start
...
2024-08-07T12:41:13.739 Using automatically detected timezone: TZ=Europe/Kyiv
...
```
Check the timezone inside the container:
```
ddev exec 'echo $TZ'
ddev exec date
ddev php -r "var_dump(date_default_timezone_get());"
```

Retry `ddev start` after changing the time zone on the host to check for a different timezone.

Set `export TZ=Europe/Paris` and retry `ddev start`.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
