### PR TITLE
test: minor updates to avoid use of literals 80 and 443

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -358,11 +358,13 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 					continue
 				}
 
+				// If the HTTP port is 80 (default), it doesn't get included in URL
 				portDefault := "80"
 				attributeName := "http_url"
 				protocol := "http://"
 
 				if name == "HTTPS_EXPOSE" {
+					// If the HTTPS port is 443 (default), it doesn't get included in URL
 					portDefault = "443"
 					attributeName = "https_url"
 					protocol = "https://"
@@ -2692,6 +2694,7 @@ func (app *DdevApp) GetHTTPURL() string {
 	url := ""
 	if !IsRouterDisabled(app) {
 		url = "http://" + app.GetHostname()
+		// If the HTTP port is the default "80", it's not included in the URL
 		if app.GetRouterHTTPPort() != "80" {
 			url = url + ":" + app.GetRouterHTTPPort()
 		}
@@ -2707,6 +2710,7 @@ func (app *DdevApp) GetHTTPSURL() string {
 	if !IsRouterDisabled(app) {
 		url = "https://" + app.GetHostname()
 		p := app.GetRouterHTTPSPort()
+		// If the HTTPS port is 443 (default), it doesn't get included in URL
 		if p != "443" {
 			url = url + ":" + p
 		}
@@ -2741,6 +2745,7 @@ func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs
 		if app.GetRouterHTTPPort() != "80" {
 			httpPort = ":" + app.GetRouterHTTPPort()
 		}
+		// If the HTTPS port is 443 (default), it doesn't get included in URL
 		if app.GetRouterHTTPSPort() != "443" {
 			httpsPort = ":" + app.GetRouterHTTPSPort()
 		}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3250,8 +3250,8 @@ func TestRouterPortsCheck(t *testing.T) {
 	// of the port by the time it comes up.
 	portBinding := map[nat.Port][]nat.PortBinding{
 		"80/tcp": {
-			{HostPort: "80"},
-			{HostPort: "443"},
+			{HostPort: app.GetRouterHTTPPort()},
+			{HostPort: app.GetRouterHTTPSPort()},
 		},
 	}
 

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -146,8 +146,8 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 		err = app.Stop(true, false)
 		assert.NoError(err)
 
-		app.RouterHTTPSPort = "443"
-		app.RouterHTTPPort = "80"
+		app.RouterHTTPSPort = ""
+		app.RouterHTTPPort = ""
 		err = app.WriteConfig()
 		assert.NoError(err)
 


### PR DESCRIPTION

## The Issue

Minor cleanup noted in 
* https://github.com/ddev/ddev/pull/6414

## How This PR Solves The Issue

Try not to use literals for default ports "80" and "443". Instead used configured values

## Manual Testing Instructions

I don't think this will change anything, but it does make one test a bit better.

