### PR TITLE
docs: ddev debug test should suggest current stable [skip ci]

### DIFF
--- a/cmd/ddev/cmd/debug-test.go
+++ b/cmd/ddev/cmd/debug-test.go
@@ -44,7 +44,7 @@ var DebugTestCmdCmd = &cobra.Command{
 
 		util.Success("Please make sure you have already looked at troubleshooting guide:")
 		util.Success("https://ddev.readthedocs.io/en/stable/users/usage/troubleshooting/")
-		util.Success("Simple things to check:\n* ddev poweroff\n* Restart Docker Provider\n* Reboot computer\n* Temporarily disable VPN and firewall\n* Remove customizations like 'docker-compose.*.yaml' and PHP/Apache/Nginx config while debugging.")
+		util.Success("Simple things to check:\n* Use latest stable DDEV version\n* ddev poweroff\n* Restart Docker Provider\n* Reboot computer\n* Temporarily disable VPN and firewall\n* Remove customizations like 'docker-compose.*.yaml' and PHP/Apache/Nginx config while debugging.")
 
 		output.UserOut.Printf("Resulting output will be written to:\n%s\nfile://%s\nPlease provide the file for support in Discord or the issue queue.", outputFilename, outputFilename)
 


### PR DESCRIPTION

## The Issue

After a support issue I was looking to make sure we bring up the "latest current version" thing.

This adds it to the front of `ddev debug test`, not sure that will help.

I'm going to leave this in draft for some time, if https://github.com/ddev/ddev/pull/6414 goes in there may be some adjusting to do here. 

