### PR TITLE
fix: drupal class_loader_auto_detect no longer needed

### DIFF
--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -32,10 +32,6 @@ $settings['skip_permissions_hardening'] = TRUE;
 // names. Additional host patterns can be added for custom configurations.
 $settings['trusted_host_patterns'] = ['.*'];
 
-// Don't use Symfony's APCLoader. ddev includes APCu; Composer's APCu loader has
-// better performance.
-$settings['class_loader_auto_detect'] = FALSE;
-
 // Set $settings['config_sync_directory'] if not set in settings.php.
 if (empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = 'sites/default/files/sync';

--- a/pkg/ddevapp/drupal/drupal11/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal11/settings.ddev.php
@@ -29,10 +29,6 @@ $settings['skip_permissions_hardening'] = TRUE;
 // names. Additional host patterns can be added for custom configurations.
 $settings['trusted_host_patterns'] = ['.*'];
 
-// Don't use Symfony's APCLoader. ddev includes APCu; Composer's APCu loader has
-// better performance.
-$settings['class_loader_auto_detect'] = FALSE;
-
 // Set $settings['config_sync_directory'] if not set in settings.php.
 if (empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = 'sites/default/files/sync';

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -29,10 +29,6 @@ $settings['skip_permissions_hardening'] = TRUE;
 // names. Additional host patterns can be added for custom configurations.
 $settings['trusted_host_patterns'] = ['.*'];
 
-// Don't use Symfony's APCLoader. ddev includes APCu; Composer's APCu loader has
-// better performance.
-$settings['class_loader_auto_detect'] = FALSE;
-
 // Set $settings['config_sync_directory'] if not set in settings.php.
 if (empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = 'sites/default/files/sync';


### PR DESCRIPTION
## The Issue

Drupal #ddev slack https://drupal.slack.com/archives/C5TQRQZRR/p1723338555563719 points out that settings.ddev.php has

```
// Don't use Symfony's APCLoader. ddev includes APCu; Composer's APCu loader has
// better performance.
$settings['class_loader_auto_detect'] = FALSE;
```

but that comes from long ago. Apparently it's not needed in Drupal 9+, so can be removed. 

It was probably introduced in https://github.com/ddev/ddev/pull/1368 (https://github.com/ddev/ddev/pull/1368/commits/dd3b86188e13e14adce26c15ee35d82502fdcb81#diff-0196cec3f796f7d78f6e01b3d20405d825d0d874dd0aa9aff53930171d394217R161-R162) 

However, the need for it seems to have been removed in https://www.drupal.org/project/drupal/issues/3020296 (Drupal 9+)

* [Change record: Only Composer's classloader is used](https://www.drupal.org/node/3116384)
* 
## How This PR Solves The Issue

Remove `$settings['class_loader_auto_detect'] = FALSE;` from settings.ddev.php in drupal9+

## Manual Testing Instructions

Try it out in Drupal project

