### PR TITLE
fix: always show `pv` output on `ddev import-db`

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -717,7 +717,7 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 		}
 
 		// Case for reading from file
-		inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && mysql -uroot -proot -e "%s" %s && pv %s/*.*sql |  perl -p -e 's/^(\/\*.*999999.*enable the sandbox mode *|CREATE DATABASE \/\*|USE %s)[^;]*(;|\*\/)//' | mysql %s %s`, preImportSQL, nodeps.MySQLRemoveDeprecatedMessage, insideContainerImportPath, "`", targetDB, nodeps.MySQLRemoveDeprecatedMessage)}
+		inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && mysql -uroot -proot -e "%s" %s && pv -f %s/*.*sql |  perl -p -e 's/^(\/\*.*999999.*enable the sandbox mode *|CREATE DATABASE \/\*|USE %s)[^;]*(;|\*\/)//' | mysql %s %s`, preImportSQL, nodeps.MySQLRemoveDeprecatedMessage, insideContainerImportPath, "`", targetDB, nodeps.MySQLRemoveDeprecatedMessage)}
 
 		// Alternate case where we are reading from stdin
 		if dumpFile == "" && extractPath == "" {
@@ -743,7 +743,7 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 		if dumpFile == "" && extractPath == "" {
 			inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && (echo '%s' | psql -d postgres) && psql -v ON_ERROR_STOP=1 -d %s`, preImportSQL, targetDB)}
 		} else { // otherwise getting it from mounted file
-			inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && (echo "%s" | psql -q -d postgres -v ON_ERROR_STOP=1) && pv %s/*.*sql | psql -q -v ON_ERROR_STOP=1 %s >/dev/null`, preImportSQL, insideContainerImportPath, targetDB)}
+			inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && (echo "%s" | psql -q -d postgres -v ON_ERROR_STOP=1) && pv -f %s/*.*sql | psql -q -v ON_ERROR_STOP=1 %s >/dev/null`, preImportSQL, insideContainerImportPath, targetDB)}
 		}
 	}
 	stdout, stderr, err := app.Exec(&ExecOpts{


### PR DESCRIPTION
## The Issue

- https://github.com/orgs/ddev/discussions/6483

Users cannot redirect `pv` output on `ddev import-db`

To reproduce:

```
ddev exec "pv /dev/zero | head -c 5M | while read -r line; do sleep 0.01; done" >stdout.txt 2>stderr.txt
```
And view inside `stderr.txt` - it is empty.

## How This PR Solves The Issue

Uses `pv -f` instead of `pv`

```
$ pv -h
Usage: pv [OPTION] [FILE]...
Concatenate FILE(s), or standard input, to standard output, with monitoring.
...
  -f, --force                    output even if standard error is not a terminal
...
```

## Manual Testing Instructions

```
ddev exec "pv -f /dev/zero | head -c 5M | while read -r line; do sleep 0.01; done" >stdout.txt 2>stderr.txt
```
And view inside `stderr.txt` - it should contain the output from `pv`.

Or
```
ddev import-db --file=db.sql.gz >stdout.txt 2>stderr.txt
```
And view inside `stderr.txt` - it should contain the output from `pv`.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
