### PR TITLE
ci: add new check from golangci-lint

### DIFF
--- a/cmd/ddev/cmd/debug-mutagen.go
+++ b/cmd/ddev/cmd/debug-mutagen.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // DebugMutagenCmd implements the ddev debug mutagen command
@@ -31,7 +32,7 @@ ddev d mutagen sync list
 			return
 		}
 		out, err := exec.RunHostCommand(mutagenPath, os.Args[3:]...)
-		output.UserOut.Printf(out)
+		output.UserOut.Printf("%s", out)
 		if err != nil {
 			util.Failed("Error running '%s %v': %v", globalconfig.GetMutagenPath(), args, err)
 		}

--- a/cmd/ddev/cmd/debug-nfsmount.go
+++ b/cmd/ddev/cmd/debug-nfsmount.go
@@ -67,7 +67,7 @@ var DebugNFSMountCmd = &cobra.Command{
 			util.Warning("NFS does not seem to be set up yet, see debugging instructions at https://ddev.readthedocs.io/en/stable/users/install/performance/#nfs")
 			util.Failed("Details: error=%v\noutput=%v", err, out)
 		}
-		output.UserOut.Printf(strings.TrimSpace(out))
+		output.UserOut.Printf("%s", strings.TrimSpace(out))
 		util.Success("")
 		util.Success("Successfully accessed NFS mount of %s", app.AppRoot)
 		switch {

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -174,7 +174,7 @@ func ListAvailableAddons(officialOnly bool) ([]*github.Repository, error) {
 			if resp != nil {
 				msg = msg + fmt.Sprintf(" rateinfo=%v", resp.Rate)
 			}
-			return nil, fmt.Errorf(msg)
+			return nil, fmt.Errorf("%s", msg)
 		}
 		allRepos = append(allRepos, repos.Repositories...)
 		if resp.NextPage == 0 {

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -88,7 +88,7 @@ func TestConfigOverrideAction(t *testing.T) {
 		})
 
 		// Prompt for apptype as a way to get it into the config.
-		input := fmt.Sprintf(appType + "\n")
+		input := fmt.Sprintf("%s\n", appType)
 		scanner := bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 		err = app.AppTypePrompt()
@@ -143,7 +143,7 @@ func TestConfigOverrideActionOnExistingConfig(t *testing.T) {
 		})
 
 		// Prompt for apptype as a way to get it into the config.
-		input := fmt.Sprintf(appType + "\n")
+		input := fmt.Sprintf("%s\n", appType)
 		scanner := bufio.NewScanner(strings.NewReader(input))
 		util.SetInputScanner(scanner)
 		err = app.AppTypePrompt()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -841,7 +841,7 @@ func (app *DdevApp) ExportDB(dumpFile string, compressionType string, targetDB s
 		confMsg = fmt.Sprintf("%s in %s format", confMsg, compressionType)
 	}
 
-	_, err = fmt.Fprintf(os.Stderr, confMsg+".\n")
+	_, err = fmt.Fprintf(os.Stderr, "%s.\n", confMsg)
 
 	return err
 }

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -795,7 +795,7 @@ func CheckDockerVersion(versionConstraint string) error {
 		for _, err := range errs {
 			msgs = fmt.Sprint(msgs, err, "\n")
 		}
-		return fmt.Errorf(msgs)
+		return fmt.Errorf("%s", msgs)
 	}
 	return nil
 }
@@ -835,7 +835,7 @@ func CheckDockerCompose() error {
 		for _, err := range errs {
 			msgs = fmt.Sprint(msgs, err, "\n")
 		}
-		return fmt.Errorf(msgs)
+		return fmt.Errorf("%s", msgs)
 	}
 
 	return nil

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -111,7 +111,7 @@ func RunInteractiveCommandWithOutput(command string, args []string, output io.Wr
 // combined stdout/stderr results and error
 func RunHostCommand(command string, args ...string) (string, error) {
 	if globalconfig.DdevVerbose {
-		output.UserOut.Printf("RunHostCommand: " + command + " " + strings.Join(args, " "))
+		output.UserOut.Printf("RunHostCommand: %s %v", command, strings.Join(args, " "))
 	}
 	c := HostCommand(command, args...)
 	c.Stdin = os.Stdin
@@ -148,7 +148,7 @@ func RunHostCommandWithEnv(command string, env []string, args ...string) (string
 // stdout and error
 func RunHostCommandSeparateStreams(command string, args ...string) (string, error) {
 	if globalconfig.DdevVerbose {
-		output.UserOut.Printf("RunHostCommandSeparateStreams: " + command + " " + strings.Join(args, " "))
+		output.UserOut.Printf("RunHostCommandSeparateStreams: %s %v", command, strings.Join(args, " "))
 	}
 	c := HostCommand(command, args...)
 	c.Stdin = os.Stdin

--- a/pkg/util/debug.go
+++ b/pkg/util/debug.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"bytes"
-	"github.com/ddev/ddev/pkg/output"
 	"os"
 	"runtime"
 	"runtime/pprof"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/sirupsen/logrus"
 )
 
@@ -94,7 +94,7 @@ func CheckGoroutines() {
 			p := pprof.Lookup("goroutine")
 			// Write it to stderr
 			_ = p.WriteTo(buf, 2)
-			Verbose(buf.String())
+			Verbose("%s", buf.String())
 		}
 		output.UserOut.Printf("goroutines=%d at exit of main()", globalconfig.GoroutineCount)
 	}


### PR DESCRIPTION
## The Issue

- https://github.com/golang/go/issues/60529

```
golangci-lint: 
pkg/exec/exec.go:114:25: printf: non-constant format string in call to (*github.com/sirupsen/logrus.Logger).Printf (govet)
                output.UserOut.Printf("RunHostCommand: " + command + " " + strings.Join(args, " "))
...
```

## How This PR Solves The Issue

Pacifies golangci-lint.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
