### PR TITLE
docs: add instructions to access DDEV sites on iOS simulator

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -167,6 +167,7 @@ WSL
 WSL2
 WantedBy
 Webhosting
+Xcode
 XDebug
 XDG
 Xhprof

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -150,6 +150,21 @@ Probably! You’ll need to install an older, unsupported version of Docker Deskt
 
 Check out [this Stack Overflow answer](https://stackoverflow.com/a/69964995/897279) for a walk through the process.
 
+### How to access DDEV sites HTTPS URLs on iOS Simulator?
+
+When using the iOS Simulator (provided with Xcode), you may encounter issues accessing DDEV sites that use SSL.
+
+This is because the iOS Simulator does not trust the self-signed SSL certificates that DDEV uses by default.
+
+To resolve this issue, you need to install the DDEV root certificate on the iOS Simulator.
+
+Here’s how to do it:
+
+1. Open iOS Simulator and keep it on the home screen.
+2. On your Mac, open Finder and navigate to `~/Library/Application Support/mkcert/`.
+3. Drag the `rootCA.pem` file into the iOS Simulator window.
+4. Still on iOS Simulator, let's confirm the certificate was installed and will work properly.  Go to `Settings` > `General` > `About` > `Certificate Trust Settings` and confirm that the DDEV root certificate is listed and enabled on the `Enable full trust for root certificates` section.
+
 ## Performance & Troubleshooting
 
 ### How can I get the best performance?


### PR DESCRIPTION
## The Issue

Self signed certificates from host machine are not available automatically on iOS simulator.
Given that, when trying to open a site served by DDEV, the user will see an error:

![ssl-issue](https://github.com/user-attachments/assets/c818418f-dfc2-422e-84e2-ecc89afddacb)

## How This PR Solves The Issue

This PR update docs and include a new item on FAQ with instructions to install the self signed certificate on the iOS simulator to be able to open the site properly.

## Manual Testing Instructions

https://ddev--6488.org.readthedocs.build/en/6488/users/usage/faq/#how-to-access-ddev-sites-https-urls-on-ios-simulator

## Automated Testing Overview

documentation updates only, no test updates needed

## Release/Deployment Notes

documentation updates only, no release notes needed