### PR TITLE
feat: output snapshot list as a table, fixes #6116

### DIFF
--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -31,7 +31,7 @@ Example: "ddev snapshot restore d8git_20180717203845"`,
 			}
 		} else {
 			if len(args) != 1 { // If the name of the snapshot isn't provided, do prompted restore
-				snapshots, err := app.ListSnapshots()
+				snapshots, err := app.ListSnapshotNames()
 				if err != nil {
 					util.Failed("Cannot list snapshots of project %s: %v", app.GetName(), err)
 				}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2388,7 +2388,7 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 
 	snapshotFile := snapshotName + "-" + app.Database.Type + "_" + app.Database.Version + ".gz"
 
-	existingSnapshots, err := app.ListSnapshots()
+	existingSnapshots, err := app.ListSnapshotNames()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6116

`ddev snapshot --list` output is difficult to visually parse.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Output from `ddev snapshot --list` is now a table, which gives the name of the project, the name of the snapshot, and when the snapshot was created.

If no snapshots are available, the output is still in table format but clearly indicates there's no snapshots.

### Screenshots

![list of snapshots for a single project](https://github.com/user-attachments/assets/647482b7-3f77-4e4c-9a3c-e7e64de44ae2)
![no snapshots for that project](https://github.com/user-attachments/assets/d881fa86-9b7c-41ff-b925-e96ff960300a)
![no snapshots for any project](https://github.com/user-attachments/assets/d8f441f1-d1f8-41a5-9853-edc7325ae325)

## Manual Testing Instructions

Make sure the various table formats display as expected (both `simple_formatting` and `table_style` in https://ddev.readthedocs.io/en/stable/users/configuration/config/#simple_formatting)

Make sure json output works as expected

Make sure it gives appropriate output with the various flags, and with a combination of projects with-and-without snapshots

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

There seem to be no existing tests for `ddev shapshot --list` and I haven't added any.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

The json output of `ddev snapshot --list --json-output` will change, so scripts relying on that will need to be updated.
Given the output used to be several JSON objects that were unrelated to each other, this is a clear upgrade.
