### PR TITLE
fix: Lets Encrypt traefik formatting was broken, fixes #6486

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -304,7 +304,7 @@ Email associated with Let’s Encrypt feature. (Works in conjunction with [`use_
 | -- | -- | --
 | :octicons-globe-16: global | `` | &zwnj;
 
-Set with `ddev config global --letsencrypt-email=me@example.com`. Used with the [casual hosting](../topics/hosting.md) feature.
+Set with `ddev config global --letsencrypt-email=me@example.com`. Used with the [non-traditional hosting](../topics/hosting.md) feature.
 
 ## `mailpit_http_port`
 
@@ -626,7 +626,7 @@ Whether to use hardened images for internet deployment.
 | -- | -- | --
 | :octicons-globe-16: global | `false` | Can `true` or `false`.
 
-When `true`, more secure hardened images are used for an internet deployment. These do not include sudo in the web container, and the container is run without elevated privileges. Generally used with the [casual hosting](../topics/hosting.md) feature.
+When `true`, more secure hardened images are used for an internet deployment. These do not include sudo in the web container, and the container is run without elevated privileges. Generally used with the [non-traditional hosting](../topics/hosting.md) feature.
 
 ## `use_letsencrypt`
 
@@ -636,7 +636,7 @@ Whether to enable Let’s Encrypt integration. (Works in conjunction with [`lets
 | -- | -- | --
 | :octicons-globe-16: global | `false` | Can `true` or `false`.
 
-May also be set via `ddev config global --use-letsencrypt` or `ddev config global --use-letsencrypt=false`. When `true`, `letsencrypt_email` must also be set and the system must be available on the internet. Used with the [casual hosting](../topics/hosting.md) feature.
+May also be set via `ddev config global --use-letsencrypt` or `ddev config global --use-letsencrypt=false`. When `true`, `letsencrypt_email` must also be set and the system must be available on the internet. Used with the [non-traditional hosting](../topics/hosting.md) feature.
 
 ## `web_environment`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -304,7 +304,7 @@ Email associated with Let’s Encrypt feature. (Works in conjunction with [`use_
 | -- | -- | --
 | :octicons-globe-16: global | `` | &zwnj;
 
-Set with `ddev config global --letsencrypt-email=me@example.com`. Used with the [non-traditional hosting](../topics/hosting.md) feature.
+Set with `ddev config global --letsencrypt-email=me@example.com`. Used with the [hosting](../topics/hosting.md) feature.
 
 ## `mailpit_http_port`
 
@@ -626,7 +626,7 @@ Whether to use hardened images for internet deployment.
 | -- | -- | --
 | :octicons-globe-16: global | `false` | Can `true` or `false`.
 
-When `true`, more secure hardened images are used for an internet deployment. These do not include sudo in the web container, and the container is run without elevated privileges. Generally used with the [non-traditional hosting](../topics/hosting.md) feature.
+When `true`, more secure hardened images are used for an internet deployment. These do not include sudo in the web container, and the container is run without elevated privileges. Generally used with the [hosting](../topics/hosting.md) feature.
 
 ## `use_letsencrypt`
 
@@ -636,7 +636,7 @@ Whether to enable Let’s Encrypt integration. (Works in conjunction with [`lets
 | -- | -- | --
 | :octicons-globe-16: global | `false` | Can `true` or `false`.
 
-May also be set via `ddev config global --use-letsencrypt` or `ddev config global --use-letsencrypt=false`. When `true`, `letsencrypt_email` must also be set and the system must be available on the internet. Used with the [non-traditional hosting](../topics/hosting.md) feature.
+May also be set via `ddev config global --use-letsencrypt` or `ddev config global --use-letsencrypt=false`. When `true`, `letsencrypt_email` must also be set and the system must be available on the internet. Used with the [hosting](../topics/hosting.md) feature.
 
 ## `web_environment`
 

--- a/docs/content/users/topics/hosting.md
+++ b/docs/content/users/topics/hosting.md
@@ -1,11 +1,13 @@
-# Casual Hosting
+# Non-traditional Hosting (Formerly "Casual Hosting")
 
 !!!warning "Experimental Feature!"
-    This is not a replacement for scalable, managed hosting. It’s unknown how much traffic it can handle in a given environment.
+    This is not a replacement for scalable, managed hosting. It’s unknown how much traffic it can handle in a given environment. Lots of people really like it for a number of uses though.
 
-One of DDEV’s experimental features is lightweight hosting with Let’s Encrypt for HTTPS support. You can run DDEV on a public web server, point DNS to it, and use it as a limited hosting environment.
+One of DDEV’s features is lightweight hosting with Let’s Encrypt for HTTPS support. You can run DDEV on a public web server, point DNS to it, and use it as a hosting environment.
 
-This may be appropriate for small or abandoned sites that have special requirements like old versions of PHP that aren’t supported elsewhere.
+This can be appropriate for many sites with limited traffic expectations, and works great for sites with special requirements like old versions of PHP that aren’t supported elsewhere. Many teams use it for continuous integration (CI) and for staging and demonstration sites.
+
+There is no security team behind this approach, although efforts have been made to secure the approach with hardened Docker images and removal of tools like `sudo`.
 
 Here’s how to try it for yourself:
 
@@ -16,16 +18,39 @@ Here’s how to try it for yourself:
 4. Before proceeding, your system and your project must be accessible on the internet on port 80 and your project DNS name (`myproject.example.com`) must resolve to the appropriate server.
 5. Configure your project with [`ddev config`](../usage/commands.md#config).
 6. Import your database and files using [`ddev import-db`](../usage/commands.md#import-db) and [`ddev import-files`](../usage/commands.md#import-files).
-7. Tell DDEV to listen on all network interfaces, omit the SSH agent, use hardened images, and enable Let’s Encrypt:
+7. Save all databases with `ddev snapshot --all` before beginning, so you can restore your database if you have to change the name of the project.
+8. Tell DDEV to listen on all network interfaces, omit the SSH agent, use hardened images, and enable Let’s Encrypt:
 
     ```
     ddev config global --router-bind-all-interfaces --omit-containers=ddev-ssh-agent --use-hardened-images --performance-mode=none --use-letsencrypt --letsencrypt-email=you@example.com
     ```
 
-8. Create your DDEV project as you normally would, but `ddev config --project-name=<yourproject> --project-tld=<your-top-level-domain>`. If your website responds to multiple hostnames (e.g., with and without `www`), you’ll need to add `additional_hostnames`.
-9. Redirect HTTP to HTTPS. Edit the `.ddev/traefik/config/<projectname>.yaml` to remove the `#ddev-generated` and uncomment the `middlewares:` and `- "redirectHttps"` lines in the HTTP router section.
-10. Run [`ddev start`](../usage/commands.md#start) and visit your site. With some CMSes, you may also need to clear your cache.
-11. If you see trouble with Let's Encrypt `ACME` failures, you can temporarily switch to the `ACME` staging server, and avoid getting rate-limited while you are experimenting. The certificates it serves will not be valid, but you'll see that they're coming from Let's Encrypt anyway. Add a `~/.ddev/traefik/static_config.staging.yaml` with the contents:
+9. Create your DDEV project, but `ddev config --project-name=<yourproject> --project-tld=<your-top-level-domain>`. If your website responds to multiple hostnames (e.g., with and without `www`), you’ll need to add `additional_hostnames`. For example, if you're serving a site at `something.example.com`, set `project_tld: example.com` and `additional_hostnames: ["something"]`.
+
+    !!!warning "Complex configuration with apex domains"
+
+        Unfortunately, the `traefik` integration with Let's Encrypt does not work if you have hostnames specified that are not resolvable, so all hostnames referenced must be resolvable in DNS. (You can use `additional_fqdns` as well as `additional_hostnames`, but all combinations must be resolvable in DNS.) Some examples:
+
+        **Project name = example, URL = `example.com`, also serving `www.example.com` and `mysite.com`**
+        ```yaml
+        project_tld: com
+        name: example
+        additional_hostnames:
+        - www.example
+        additional_fqdns:
+        - mysite.com
+        ```
+
+        **Project name = `stories`, URL = `stories.example.org`**
+
+        ```yaml
+        name: stories
+        project_tld: example.org
+        ```
+
+10. If you want to redirect HTTP to HTTPS, edit the `.ddev/traefik/config/<projectname>.yaml` to remove the `#ddev-generated` and uncomment the `middlewares:` and `- "redirectHttps"` lines in the HTTP router section.
+11. Run [`ddev start`](../usage/commands.md#start) and visit your site. With some CMSes, you may also need to clear your cache.
+12. If you see trouble with Let's Encrypt `ACME` failures, you can temporarily switch to the `ACME` staging server, and avoid getting rate-limited while you are experimenting. The certificates it serves will not be valid, but you'll see that they're coming from Let's Encrypt anyway. Add a `~/.ddev/traefik/static_config.staging.yaml` with the contents:
 
     ```yaml
     certificatesResolvers:

--- a/docs/content/users/topics/hosting.md
+++ b/docs/content/users/topics/hosting.md
@@ -1,11 +1,11 @@
-# Non-traditional Hosting (Formerly "Casual Hosting")
+# Hosting with DDEV
 
 !!!warning "Experimental Feature!"
-    This is not a replacement for scalable, managed hosting. It’s unknown how much traffic it can handle in a given environment. Lots of people really like it for a number of uses though.
+    Hosting with DDEV is not a replacement for scalable, managed hosting. It is not known how much traffic can be handled this way. Lots of people really like it for a number of uses though.
 
-One of DDEV’s features is lightweight hosting with Let’s Encrypt for HTTPS support. You can run DDEV on a public web server, point DNS to it, and use it as a hosting environment.
+Lightweight hosting with Let’s Encrypt for HTTPS support is a popular DDEV feature. You can run DDEV on a public web server, point DNS to it, and use it as a hosting environment.
 
-This can be appropriate for many sites with limited traffic expectations, and works great for sites with special requirements like old versions of PHP that aren’t supported elsewhere. Many teams use it for continuous integration (CI) and for staging and demonstration sites.
+This can be appropriate for many sites with modest traffic expectations, and works great for sites with special requirements (old versions of PHP, old database servers, etc.) A number of teams use it for continuous integration (CI) and for staging and demonstration sites.
 
 There is no security team behind this approach, although efforts have been made to secure the approach with hardened Docker images and removal of tools like `sudo`.
 

--- a/docs/content/users/topics/index.md
+++ b/docs/content/users/topics/index.md
@@ -3,6 +3,6 @@
 DDEV does not provide capabilities for deploying your code, as it's focused on being a **local development** solution. Teams almost universally use Git to manage their code and some Git provider like GitHub or GitLab to store it. They use many different types of deployment tools to actually get the code to their upstream servers or integration environments. For local development, DDEV provides capabilities to pull upstream databases and user-generated files as well as push those in some circumstances.
 
 * [Sharing your project](sharing.md)
-* [Non-traditional hosting with DDEV](hosting.md)
+* [Hosting with DDEV](hosting.md)
 * [Remote Docker environments](remote-docker.md)
 * [Hosting integrations](../providers/index.md) including Acquia, Lagoon, Pantheon, Platform.sh, Upsun, rsync-based solutions, Git-based solutions, local files (like Dropbox), etc.

--- a/docs/content/users/topics/index.md
+++ b/docs/content/users/topics/index.md
@@ -3,6 +3,6 @@
 DDEV does not provide capabilities for deploying your code, as it's focused on being a **local development** solution. Teams almost universally use Git to manage their code and some Git provider like GitHub or GitLab to store it. They use many different types of deployment tools to actually get the code to their upstream servers or integration environments. For local development, DDEV provides capabilities to pull upstream databases and user-generated files as well as push those in some circumstances.
 
 * [Sharing your project](sharing.md)
-* [Casual hosting with DDEV](hosting.md)
+* [Non-traditional hosting with DDEV](hosting.md)
 * [Remote Docker environments](remote-docker.md)
 * [Hosting integrations](../providers/index.md) including Acquia, Lagoon, Pantheon, Platform.sh, Upsun, rsync-based solutions, Git-based solutions, local files (like Dropbox), etc.

--- a/docs/content/users/topics/remote-docker.md
+++ b/docs/content/users/topics/remote-docker.md
@@ -13,7 +13,7 @@ You can use remote Docker instances, whether on the internet, inside your networ
 * Make sure you can access the remote machine using `docker ps`.
 * Bind mounts cannot work on a remote Docker setup, so you must use `ddev config global --no-bind-mounts`. This will cause DDEV to push needed information to and from the remote Docker instance when needed. This also automatically turns on Mutagen caching.
 * You may want to use a FQDN other than `*.ddev.site` because the DDEV site will *not* be at `127.0.0.1`. For example, `ddev config --fqdns=debian-11` and then use `https://debian-11` to access the site.
-* If the Docker host is reachable on the internet, you can actually enable real HTTPS for it using Let’s Encrypt as described in [Non-traditional Webhosting](../topics/hosting.md). Make sure port 2375 is not available on the internet.
+* If the Docker host is reachable on the internet, you can actually enable real HTTPS for it using Let’s Encrypt as described in [Hosting with DDEV](../topics/hosting.md). Make sure port 2375 is not available on the internet.
 
 ## Continuous Integration (CI)
 

--- a/docs/content/users/topics/remote-docker.md
+++ b/docs/content/users/topics/remote-docker.md
@@ -13,7 +13,7 @@ You can use remote Docker instances, whether on the internet, inside your networ
 * Make sure you can access the remote machine using `docker ps`.
 * Bind mounts cannot work on a remote Docker setup, so you must use `ddev config global --no-bind-mounts`. This will cause DDEV to push needed information to and from the remote Docker instance when needed. This also automatically turns on Mutagen caching.
 * You may want to use a FQDN other than `*.ddev.site` because the DDEV site will *not* be at `127.0.0.1`. For example, `ddev config --fqdns=debian-11` and then use `https://debian-11` to access the site.
-* If the Docker host is reachable on the internet, you can actually enable real HTTPS for it using Let’s Encrypt as described in [Casual Webhosting](../topics/hosting.md). Make sure port 2375 is not available on the internet.
+* If the Docker host is reachable on the internet, you can actually enable real HTTPS for it using Let’s Encrypt as described in [Non-traditional Webhosting](../topics/hosting.md). Make sure port 2375 is not available on the internet.
 
 ## Continuous Integration (CI)
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -629,7 +629,7 @@ Flags:
 
 Environment variables:
 
-* `DDEV_GITHUB_TOKEN`: A [GitHub token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) may be used for `ddev get` requests (which result in GitHub API queries). It's unusual for casual users to need this, but if you're doing lots of `ddev get` requests you may run into rate limiting. The token you use requires no privileges at all. Example:
+* `DDEV_GITHUB_TOKEN`: A [GitHub token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) may be used for `ddev get` requests (which result in GitHub API queries). It's unusual for users to need this, but if you're doing lots of `ddev get` requests you may run into rate limiting. The token you use requires no privileges at all. Example:
 
 ```bash
 export DDEV_GITHUB_TOKEN=<your github token>

--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -84,7 +84,7 @@ func processHTTPExpose(serviceName string, httpExpose string, isHTTPS bool, exte
 			ports = append(ports, ports[0])
 		}
 		if ports[1] == "8025" && (globalconfig.DdevGlobalConfig.UseHardenedImages || globalconfig.DdevGlobalConfig.UseLetsEncrypt) {
-			util.Debug("skipping port 8025 (mailpit) because not appropriate in casual hosting environment")
+			util.Debug("skipping port 8025 (mailpit) because not appropriate in non-traditional hosting environment")
 			continue
 		}
 		routingTable = append(routingTable, TraefikRouting{ExternalHostnames: externalHostnames, ExternalPort: ports[0],

--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -84,7 +84,7 @@ func processHTTPExpose(serviceName string, httpExpose string, isHTTPS bool, exte
 			ports = append(ports, ports[0])
 		}
 		if ports[1] == "8025" && (globalconfig.DdevGlobalConfig.UseHardenedImages || globalconfig.DdevGlobalConfig.UseLetsEncrypt) {
-			util.Debug("skipping port 8025 (mailpit) because not appropriate in non-traditional hosting environment")
+			util.Debug("skipping port 8025 (mailpit) because not appropriate in hosting environment")
 			continue
 		}
 		routingTable = append(routingTable, TraefikRouting{ExternalHostnames: externalHostnames, ExternalPort: ports[0],

--- a/pkg/ddevapp/traefik_config_template.yaml
+++ b/pkg/ddevapp/traefik_config_template.yaml
@@ -13,7 +13,7 @@ http:
       {{- if not $.UseLetsEncrypt -}}{{/* Let's Encrypt only works with Host(), but we need HostRegexp() for wildcards*/}}
       rule: {{ range $i, $h := $s.ExternalHostnames }}{{if $i}}|| {{end}}HostRegexp(`^{{$h | replace "." "\\."}}$`){{end}}
       {{ else }}
-      rule: Host({{ range $i, $h := $s.ExternalHostnames }}{{if $i}}, {{end}}`^{{$h | replace "." "\\."}}$`{{end}})
+      rule: {{ $length := len $s.ExternalHostnames }}{{ range $i, $h := $s.ExternalHostnames }}Host(`{{$h}}`){{if lt $i (sub $length 1)}} || {{end}}{{end}}
       {{ end }}
       service: "{{$appname}}-{{$s.Service.InternalServiceName}}-{{$s.Service.InternalServicePort}}"
       ruleSyntax: v3
@@ -29,7 +29,7 @@ http:
       {{- if not $.UseLetsEncrypt -}}{{/* Let's Encrypt only works with Host(), but we need HostRegexp() for wildcards*/}}
       rule: {{ range $i, $h := $s.ExternalHostnames }}{{ if $i }} || {{ end }}HostRegexp(`^{{$h | replace "." "\\."}}$`){{ end }}
       {{ else }}
-      rule: Host({{ range $i, $h := $s.ExternalHostnames }}{{- if $i -}}, {{- end -}}`^{{$h | replace "." "\\."}}$`{{end}})
+      rule: {{ $length := len $s.ExternalHostnames }}{{ range $i, $h := $s.ExternalHostnames }}Host(`{{$h}}`){{if lt $i (sub $length 1)}} || {{end}}{{end}}
       {{ end }}
       service: "{{$appname}}-{{$s.Service.InternalServiceName}}-{{$s.Service.InternalServicePort}}"
       ruleSyntax: v3


### PR DESCRIPTION
## The Issue

* #6486 

* Regular expressions were being used for hostnames in Host() statements for Let's Encrypt, but those are wrong
* We had `Host(hostname1, hostname2, hostname3)` when it should be `Host(hostname1) || Host(hostname2) || Host(hostname3)`

## How This PR Solves The Issue

Previous incorrect formatting:
```
http:
  routers:
    d10-web-80-http:
      entrypoints:
        - http-80
      rule: Host(`^d10\.traefik\.thefays\.us$`)
```

and 

```
  routers:
    d10-web-80-http:
      entrypoints:
        - http-80
      rule: Host(`^d10\.traefik\.thefays\.us$`, `^one\.traefik\.thefays\.us$`, `^two\.traefik\.thefays\.us$`)
```

New formatting:

```
  routers:
    d10-web-80-http:
      entrypoints:
        - http-80
      rule: Host(`d10.ddev.site`)
```

and

```
  routers:
    d10-web-80-http:
      entrypoints:
        - http-80
      rule: Host(`d10.ddev.site`) || Host(`one.ddev.site`) || Host(`three.ddev.site`) || Host(`two.ddev.site`)
```


## Manual Testing Instructions

- [x] Review docs: https://ddev--6494.org.readthedocs.build/en/6494/users/topics/hosting/
- [x] Set up Let's Encrypt on a project and get it to work
- [x] Make it work with additional_hostnames
- [x] Make it work with additional_fqdns

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
