### PR TITLE
fix: flush mutagen after deletion of .downloads directory

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -73,7 +73,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 	}
 
 	for _, commandSet := range []string{projectCommandPath, globalCommandPath} {
-		commandDirs, err := fileutil.ListFilesInDirFullPath(commandSet)
+		commandDirs, err := fileutil.ListFilesInDirFullPath(commandSet, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -271,7 +271,7 @@ func GatherAllManifests(app *DdevApp) (map[string]AddonManifest, error) {
 		return nil, err
 	}
 
-	dirs, err := fileutil.ListFilesInDirFullPath(metadataDir)
+	dirs, err := fileutil.ListFilesInDirFullPath(metadataDir, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddevapp/envfile_test.go
+++ b/pkg/ddevapp/envfile_test.go
@@ -1,14 +1,15 @@
 package ddevapp_test
 
 import (
-	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/fileutil"
-	asrt "github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/fileutil"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteProjectEnvFile(t *testing.T) {
@@ -24,7 +25,7 @@ func TestWriteProjectEnvFile(t *testing.T) {
 		_ = os.RemoveAll(app.GetConfigPath(".env"))
 	})
 
-	testEnvFiles, err := fileutil.ListFilesInDirFullPath(filepath.Join(origDir, "testdata", t.Name()))
+	testEnvFiles, err := fileutil.ListFilesInDirFullPath(filepath.Join(origDir, "testdata", t.Name()), false)
 	require.NoError(t, err)
 	appEnvFile := filepath.Join(app.AppRoot, ".env")
 	for _, envFileName := range testEnvFiles {

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -360,7 +360,7 @@ func (p *Provider) getDatabaseBackups() (filename []string, error error) {
 		return nil, err
 	}
 
-	sqlTarballs, err := fileutil.ListFilesInDirNoSubdirsFullPath(p.getDownloadDir())
+	sqlTarballs, err := fileutil.ListFilesInDirFullPath(p.getDownloadDir(), true)
 	if err != nil || sqlTarballs == nil {
 		return nil, fmt.Errorf("failed to find downloaded files in %s: %v", p.getDownloadDir(), err)
 	}

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -329,6 +329,11 @@ func (p *Provider) getDatabaseBackups() (filename []string, error error) {
 	if err != nil {
 		return nil, err
 	}
+	// Make sure the deletion is synced before we recreate
+	err = p.app.MutagenSyncFlush()
+	if err != nil {
+		return nil, err
+	}
 	err = os.Mkdir(p.getDownloadDir(), 0755)
 	if err != nil {
 		return nil, err

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -360,7 +360,7 @@ func (p *Provider) getDatabaseBackups() (filename []string, error error) {
 		return nil, err
 	}
 
-	sqlTarballs, err := fileutil.ListFilesInDirFullPath(p.getDownloadDir())
+	sqlTarballs, err := fileutil.ListFilesInDirNoSubdirsFullPath(p.getDownloadDir())
 	if err != nil || sqlTarballs == nil {
 		return nil, fmt.Errorf("failed to find downloaded files in %s: %v", p.getDownloadDir(), err)
 	}

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -227,6 +227,23 @@ func ListFilesInDirFullPath(path string) ([]string, error) {
 	return fileList, nil
 }
 
+// ListFilesInDirNoSubdirsFullPath returns an array of full path of files found in a directory, but not subdirectories
+func ListFilesInDirNoSubdirsFullPath(path string) ([]string, error) {
+	var fileList []string
+	dirEntrySlice, err := os.ReadDir(path)
+	if err != nil {
+		return fileList, err
+	}
+
+	for _, de := range dirEntrySlice {
+		if de.IsDir() {
+			continue
+		}
+		fileList = append(fileList, filepath.Join(path, de.Name()))
+	}
+	return fileList, nil
+}
+
 // RandomFilenameBase generates a temporary filename for use in testing or whatever.
 // From https://stackoverflow.com/a/28005931/215713
 func RandomFilenameBase() string {

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -213,8 +213,8 @@ func ListFilesInDir(path string) ([]string, error) {
 	return fileList, nil
 }
 
-// ListFilesInDirFullPath returns an array of full path of files found in a directory
-func ListFilesInDirFullPath(path string) ([]string, error) {
+// ListFilesInDirFullPath returns an array of full path of files found in a directory. If excludeDirectories is set, it skips subdirectories.
+func ListFilesInDirFullPath(path string, excludeDirectories bool) ([]string, error) {
 	var fileList []string
 	dirEntrySlice, err := os.ReadDir(path)
 	if err != nil {
@@ -222,21 +222,7 @@ func ListFilesInDirFullPath(path string) ([]string, error) {
 	}
 
 	for _, de := range dirEntrySlice {
-		fileList = append(fileList, filepath.Join(path, de.Name()))
-	}
-	return fileList, nil
-}
-
-// ListFilesInDirNoSubdirsFullPath returns an array of full path of files found in a directory, but not subdirectories
-func ListFilesInDirNoSubdirsFullPath(path string) ([]string, error) {
-	var fileList []string
-	dirEntrySlice, err := os.ReadDir(path)
-	if err != nil {
-		return fileList, err
-	}
-
-	for _, de := range dirEntrySlice {
-		if de.IsDir() {
+		if excludeDirectories && de.IsDir() {
 			continue
 		}
 		fileList = append(fileList, filepath.Join(path, de.Name()))

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -134,6 +134,15 @@ func TestListFilesInDir(t *testing.T) {
 	assert.Contains(fileList[1], "two.txt")
 }
 
+// TestListFilesInDirNoSubdirsFullPath tests ListFilesInDirNoSubdirsFullPath()
+func TestListFilesInDirNoSubdirsFullPath(t *testing.T) {
+	fileList, err := fileutil.ListFilesInDirNoSubdirsFullPath(filepath.Join("testdata", t.Name()))
+	require.NoError(t, err)
+	require.Len(t, fileList, 2)
+	require.Contains(t, fileList[0], "one.txt")
+	require.Contains(t, fileList[1], "two.txt")
+}
+
 // TestReplaceStringInFile tests the ReplaceStringInFile utility function.
 func TestReplaceStringInFile(t *testing.T) {
 	assert := asrt.New(t)

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -136,7 +136,7 @@ func TestListFilesInDir(t *testing.T) {
 
 // TestListFilesInDirNoSubdirsFullPath tests ListFilesInDirNoSubdirsFullPath()
 func TestListFilesInDirNoSubdirsFullPath(t *testing.T) {
-	fileList, err := fileutil.ListFilesInDirNoSubdirsFullPath(filepath.Join("testdata", t.Name()))
+	fileList, err := fileutil.ListFilesInDirFullPath(filepath.Join("testdata", t.Name()), true)
 	require.NoError(t, err)
 	require.Len(t, fileList, 2)
 	require.Contains(t, fileList[0], "one.txt")

--- a/pkg/fileutil/testdata/TestListFilesInDirNoSubdirsFullPath/one.txt
+++ b/pkg/fileutil/testdata/TestListFilesInDirNoSubdirsFullPath/one.txt
@@ -1,0 +1,1 @@
+.gitmanaged

--- a/pkg/fileutil/testdata/TestListFilesInDirNoSubdirsFullPath/subdir/subdir-three.txt
+++ b/pkg/fileutil/testdata/TestListFilesInDirNoSubdirsFullPath/subdir/subdir-three.txt
@@ -1,0 +1,1 @@
+.gitmanaged

--- a/pkg/fileutil/testdata/TestListFilesInDirNoSubdirsFullPath/subdir/subdir2/subdir-four.txt
+++ b/pkg/fileutil/testdata/TestListFilesInDirNoSubdirsFullPath/subdir/subdir2/subdir-four.txt
@@ -1,0 +1,1 @@
+.gitmanaged

--- a/pkg/fileutil/testdata/TestListFilesInDirNoSubdirsFullPath/two.txt
+++ b/pkg/fileutil/testdata/TestListFilesInDirNoSubdirsFullPath/two.txt
@@ -1,0 +1,1 @@
+.gitmanaged


### PR DESCRIPTION
## The Issue

Twice people have reported having trouble with `ddev pull pantheon --skip-files` where it tried to import files for some reason, or tried to import things that weren't there. 
* https://discord.com/channels/664580571770388500/1274137556858175642
* https://discord.com/channels/664580571770388500/1232668554550186024

## How This PR Solves The Issue

We delete the .downloads directory before downloading, but we don't do a mutagen sync, so this all may happen too fast, and sync may be incomplete, leading to files being in the .downloads/files directory, messing up the import. 

This does a sync before recreating the .downloads directory

In addition, we should never be trying to import directories during a database import process, so it's an error to try to traverse directories as was shown in the Discord OP.

In https://discord.com/channels/664580571770388500/1274137556858175642/1274137556858175642, @travisbutterfield reported the below. Clearly we shouldn't have been trying to import the subdirectory `files` even though it existed.

```
ddev pull pantheon --skip-files -y
Authenticating...
 [notice] Logging in via machine token.
 [notice] Found a machine token for ************@***.***.
 [notice] Logged in via machine token.
Obtaining databases...
+ set -eu -o pipefail
+ ls /var/www/html/.ddev
+ pushd /var/www/html/.ddev/.downloads
+ terminus backup:get asu-isearch.live --element=db --to=db.sql.gz
 [notice] Downloading asu-isearch_live_2024-08-16T20-00-00_UTC_database.sql.gz to db.sql.gz
Importing databases [/Users/tbutterf/web/asu-isearch/.ddev/.downloads/db.sql.gz /Users/tbutterf/web/asu-isearch/.ddev/.downloads/files]

1.12GiB 0:01:11 [16.1MiB/s] [====================================================>] 100%
Pull failed: unable to validate import asset /Users/tbutterf/web/asu-isearch/.ddev/.downloads/files: invalid asset: provided path is not a .sql file or archive
```

## Manual Testing Instructions

We're hoping that @travisbutterfield will be able to recreate the problem and we can test against it.

Otherwise, put some files in .ddev/.downloads/files/... and see if it can make the problem happen (without this fix)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
