### PR TITLE
fix: allow overrides for Docker networks, fixes #5706, fixes #6376

### DIFF
--- a/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.networks.yaml
+++ b/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.networks.yaml
@@ -1,0 +1,17 @@
+networks:
+  dummy:
+    name: dummy_name
+  ddev_default:
+    name: this_name_and_external_false_should_be_ignored_by_ddev
+    external: false
+  default:
+    name: this_name_and_external_true_should_be_ignored_by_ddev
+    external: true
+
+services:
+  web:
+    networks:
+      default:
+        priority: 1
+      dummy:
+        priority: 2


### PR DESCRIPTION
## The Issue

- #5706
- #6376

## How This PR Solves The Issue

Allows users to make modifications to the `ddev_default` and `default` networks, but with some limitations, that were allowed before, such as:
- it is now forbidden to change `ddev_default` and `default` networks name.
- it is now forbidden to change the `external` setting for `ddev_default` and `default` networks.

Allows users to add new networks to the Docker services.

Adds `com.ddev.platform` labels to all internal networks.

## Manual Testing Instructions

To test this, use the examples from the related issues description or create a new `.ddev/docker-compose.networks.yaml`:

```yaml
networks:
  dummy:
    name: dummy_name
  ddev_default:
    name: this_name_and_external_false_should_be_ignored_by_ddev
    external: false
  default:
    name: this_name_and_external_true_should_be_ignored_by_ddev
    external: true

services:
  web:
    networks:
      default:
        priority: 1
      dummy:
        priority: 2
```

Start the project and look into `.ddev/.ddev-docker-compose-full.yaml`:
1. It should add new `dummy` network to the `web` service, and change `priority` setting.
2. The `ddev_default` and `default` networks should have the original `name` and `external` settings.
3. The `dummy` and `default` networks must have the `com.ddev.platform` label set.

## Automated Testing Overview

I added tests to the existing `TestMultipleComposeFiles` test.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
