### PR TITLE
docs: clearer statement about `ddev start` before offline, for #6499

### DIFF
--- a/docs/content/users/usage/offline.md
+++ b/docs/content/users/usage/offline.md
@@ -1,31 +1,24 @@
 # Using DDEV Offline
 
-DDEV attempts to work smoothly offline, and you shouldn’t have to do anything to make it work:
+!!!warning "Make sure to do a `ddev start` on every project you want to use before doing offline"
 
-* It doesn’t attempt instrumentation or update reporting if offline
-* It falls back to using `/etc/hosts` entries if DNS resolution fails
+    To work offline, you have to already have any needed Docker images pulled. That means you should do a `ddev start` on all of the projects before going offline. 
 
-However, it does not (yet) attempt to prevent Docker pulls if a new Docker image is required, so you’ll want to make sure that you try a [`ddev start`](../usage/commands.md#start) before going offline to make sure everything has been pulled.
+DDEV attempts to work smoothly offline, and you shouldn’t have to do anything to make it work.
 
-If you have a project running when you’re online (using DNS for name resolution) and you then go offline, you’ll want to do a [`ddev restart`](../usage/commands.md#restart) to get the hostname added into `/etc/hosts` for name resolution.
+However, it cannot pull needed Docker images when offline if a new Docker image is required, so you’ll want to make sure that you try a [`ddev start`](../usage/commands.md#start) before going offline to make sure everything has been pulled.
 
-You have general options as well:
+If you have a project running when you’re online (using DNS for name resolution) and you then go offline, do a [`ddev restart`](../usage/commands.md#restart) to get the hostname added into `/etc/hosts` for name resolution.
+
+You have some general options as well:
 
 In `.ddev/config.yaml`, [`use_dns_when_possible: false`](../configuration/config.md#use_dns_when_possible) will make DDEV never try to use DNS for resolution, instead adding hostnames to `/etc/hosts`. You can also use `ddev config --use-dns-when-possible=false` to set this configuration option.
 
-In `.ddev/config.yaml`, you can use `project_tld: example.com` to have DDEV use a project TLD that won’t be looked up via DNS. You can do the equivalent with `ddev config --project-tld=example.com`. This also works as a global option in `~/.ddev/global_config.yaml` or running `ddev config global --project-tld=example.com`.
-
 You can also set up a local DNS server like [dnsmasq](https://dnsmasq.org) (Linux and macOS, `brew install dnsmasq`) or ([unbound](https://github.com/NLnetLabs/unbound) or many others on Windows) in your own host environment that serves the project_tld that you choose, and DNS resolution will work fine. You’ll likely want a wildcard A record pointing to 127.0.0.1 on most DDEV installations. If you use dnsmasq, you must configure it to allow DNS rebinding.
-
-If you’re using a browser on Windows and accessing a DDEV project in WSL2, Windows will attempt to resolve the site name via DNS. This will fail if you don’t have an internet connection. To resolve this, update your `C:\Windows\System32\drivers\etc\hosts` file manually:
-
-```
-127.0.0.1 example.ddev.site
-```
 
 !!!note "Administrative Privileges Required"
 
-    You must have administrative privileges to save the hosts file on any OS.
+    If you `ddev start` when offline, DDEV will try to add `<projectname>.ddev.site` to your `/etc/hosts` file. You must have administrative privileges to edit the hosts file on any operating system.
 
 !!!note "Oddities of using `buildx` `docker-container` driver"
 

--- a/docs/content/users/usage/offline.md
+++ b/docs/content/users/usage/offline.md
@@ -1,6 +1,6 @@
 # Using DDEV Offline
 
-!!!warning "Make sure to do a `ddev start` on every project you want to use before doing offline"
+!!!warning "Make sure to do a `ddev start` on every project you want to use before going offline"
 
     To work offline, you have to already have any needed Docker images pulled. That means you should do a `ddev start` on all of the projects before going offline. 
 
@@ -14,7 +14,7 @@ You have some general options as well:
 
 In `.ddev/config.yaml`, [`use_dns_when_possible: false`](../configuration/config.md#use_dns_when_possible) will make DDEV never try to use DNS for resolution, instead adding hostnames to `/etc/hosts`. You can also use `ddev config --use-dns-when-possible=false` to set this configuration option.
 
-You can also set up a local DNS server like [dnsmasq](https://dnsmasq.org) (Linux and macOS, `brew install dnsmasq`) or ([unbound](https://github.com/NLnetLabs/unbound) or many others on Windows) in your own host environment that serves the project_tld that you choose, and DNS resolution will work fine. You’ll likely want a wildcard A record pointing to 127.0.0.1 on most DDEV installations. If you use dnsmasq, you must configure it to allow DNS rebinding.
+You can also set up a local DNS server like [dnsmasq](https://dnsmasq.org) (Linux and macOS, `brew install dnsmasq`) or ([unbound](https://github.com/NLnetLabs/unbound) or many others on Windows) in your own host environment that serves the `project_tld` that you choose, and DNS resolution will work fine. You’ll likely want a wildcard A record pointing to `127.0.0.1` on most DDEV installations. If you use dnsmasq, you must configure it to allow DNS rebinding.
 
 !!!note "Administrative Privileges Required"
 


### PR DESCRIPTION
## The Issue

* #6499 

The docs on offline usage need to be stronger about `ddev start` on each project before going offline.

Review new page at https://ddev--6502.org.readthedocs.build/en/6502/users/usage/offline/
