### PR TITLE
test: Improve several tests, make sure containers get removed

### DIFF
--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -67,11 +67,11 @@ func TestArchiveTar(t *testing.T) {
 	origDir, _ := os.Getwd()
 
 	tarballFile, err := os.CreateTemp("", t.Name()+"_*.tar.gz")
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	tarSrc := filepath.Join(origDir, "testdata", t.Name())
 	err = os.Chdir(tarSrc)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	expectations := map[string]fs.FileMode{}
 	for _, f := range []string{".test.sh", "root.txt", filepath.Join("subdir1", "subdir1.txt")} {
@@ -81,36 +81,34 @@ func TestArchiveTar(t *testing.T) {
 	}
 
 	err = archive.Tar(tarSrc, tarballFile.Name(), filepath.Join("subdir1", "subdir2"))
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	tmpDir := testcommon.CreateTmpDir(t.Name())
 
-	err = os.Chdir(tmpDir)
-	assert.NoError(err)
 	t.Cleanup(
 		func() {
 			err := os.Chdir(origDir)
 			assert.NoError(err)
 
-			// Could not figure out what causes this not to be removable
-			//err = os.Remove(tarballFile.Name())
-			//assert.NoError(err)
+			_ = os.Remove(tarballFile.Name())
 			_ = os.RemoveAll(tmpDir)
 		})
+
+	_ = os.Chdir(tmpDir)
 	err = archive.Untar(tarballFile.Name(), tmpDir, "")
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	for fileName, mode := range expectations {
 		testedFileName, err := filepath.Abs(fileName)
-		assert.NoError(err, "fileName err: %v %v", testedFileName, err)
+		require.NoError(t, err, "fileName err: %v %v", testedFileName, err)
 		fi, err := os.Stat(fileName)
-		assert.NoError(err)
+		require.NoError(t, err)
 		require.NotNil(t, fi)
 		//desc := fmt.Sprintf("%s: Orig mode=%o, found mode=%o", fileName, mode, fi.Mode())
 		//t.Log(desc)
-		assert.Equal(mode, fi.Mode(), "expected mode for %s was %o but got %o", fileName, mode, fi.Mode())
+		require.Equal(t, fi.Mode(), mode, "expected mode for %s was %o but got %o", fileName, mode, fi.Mode())
 	}
-	assert.NoFileExists(filepath.Join(tmpDir, "subdir1", "subdir2", "s2.txt"))
+	require.NoFileExists(t, filepath.Join(tmpDir, "subdir1", "subdir2", "s2.txt"))
 }
 
 // TestArchiveTar tests creation of a simple tarball

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2599,10 +2599,10 @@ func TestDdevImportFilesDir(t *testing.T) {
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}
+	var err error
 
 	// Create a dummy directory to test non-archive imports
-	importDir, err := os.MkdirTemp("", t.Name())
-	assert.NoError(err)
+	importDir := testcommon.CreateTmpDir(t.Name())
 	fileNames := make([]string, 0)
 	for i := 0; i < 5; i++ {
 		fileName := uuid.New().String()

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
 	dockerContainer "github.com/docker/docker/api/types/container"
@@ -315,11 +316,10 @@ func TestComposeWithStreams(t *testing.T) {
 
 	// Use the current actual web container for this, so replace in base docker-compose file
 	composeBase := filepath.Join("testdata", "TestComposeWithStreams", "test-compose-with-streams.yaml")
-	tmp, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	realComposeFile := filepath.Join(tmp, "replaced-compose-with-streams.yaml")
+	tmpDir := testcommon.CreateTmpDir(t.Name())
+	realComposeFile := filepath.Join(tmpDir, "replaced-compose-with-streams.yaml")
 
-	err = fileutil.ReplaceStringInFile("TEST-COMPOSE-WITH-STREAMS-IMAGE", versionconstants.WebImg+":"+versionconstants.WebTag, composeBase, realComposeFile)
+	err := fileutil.ReplaceStringInFile("TEST-COMPOSE-WITH-STREAMS-IMAGE", versionconstants.WebImg+":"+versionconstants.WebTag, composeBase, realComposeFile)
 	assert.NoError(err)
 
 	composeFiles := []string{realComposeFile}
@@ -716,7 +716,7 @@ func TestCopyFromContainer(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cid)
 
-	targetDir, err := os.MkdirTemp("", t.Name())
+	targetDir := testcommon.CreateTmpDir(t.Name())
 	require.NoError(t, err)
 
 	err = dockerutil.CopyFromContainer(testContainerName, containerSourceDir, targetDir)

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -179,82 +179,94 @@ func TestContainerWait(t *testing.T) {
 		"com.ddev.site-name": testContainerName,
 	}
 
+	// We should have `testContainerName' already running, it was started by
+	// startTestContainer(). And we don't delete it.
+
 	// Try a zero-wait, should show timed-out
 	_, err := dockerutil.ContainerWait(0, labels)
-	assert.Error(err)
-	if err != nil {
-		assert.Contains(err.Error(), "health check timed out")
-	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "health check timed out")
 
 	// Try 30-second wait for "healthy", should show OK
 	healthDetail, err := dockerutil.ContainerWait(30, labels)
-	assert.NoError(err)
+	require.NoError(t, err)
 
-	assert.Contains(healthDetail, "phpstatus:OK")
+	require.Contains(t, healthDetail, "phpstatus:OK")
 
 	// Try a nonexistent container, should get error
 	labels = map[string]string{"com.ddev.site-name": "nothing-there"}
+	// Make sure none already exist
+	_ = dockerutil.RemoveContainersByLabels(labels)
+
 	_, err = dockerutil.ContainerWait(1, labels)
 	require.Error(t, err)
-	assert.Contains(err.Error(), "failed to query container")
+	require.Contains(t, err.Error(), "failed to query container")
 
 	// If we run a quick container and it immediately exits, ContainerWait should find it is not there
 	// and note that it exited.
 	labels = map[string]string{"test": "quickexit"}
+	// Make sure none already exist
 	_ = dockerutil.RemoveContainersByLabels(labels)
-	cID, _, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, t.Name()+util.RandString(5), []string{"ls"}, nil, nil, nil, "0", false, true, labels, nil, nil)
+	c1, _, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, t.Name()+"-quickexit-"+util.RandString(5), []string{"ls"}, nil, nil, nil, "0", false, true, labels, nil, nil)
 	t.Cleanup(func() {
-		_ = dockerutil.RemoveContainer(cID)
+		_ = dockerutil.RemoveContainer(c1)
+		assert.NoError(err, "failed to remove container %v (%s)", labels, c1)
+
 	})
 	require.NoError(t, err)
 	_, err = dockerutil.ContainerWait(5, labels)
-	assert.Error(err)
-	assert.Contains(err.Error(), "container exited")
-	_ = dockerutil.RemoveContainer(cID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "container exited")
 
 	// If we run a container that does not have a healthcheck
 	// it should be found as good immediately
 	labels = map[string]string{"test": "nohealthcheck"}
+	// Make sure none already exist
 	_ = dockerutil.RemoveContainersByLabels(labels)
-	cID, _, err = dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, t.Name()+util.RandString(5), []string{"sleep", "60"}, nil, nil, nil, "0", false, true, labels, nil, nil)
+
+	c2, _, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, t.Name()+"-nohealthcheck-busybox-sleep-60-"+util.RandString(5), []string{"sleep", "60"}, nil, nil, nil, "0", false, true, labels, nil, nil)
 	t.Cleanup(func() {
-		_ = dockerutil.RemoveContainer(cID)
+		err = dockerutil.RemoveContainer(c2)
+		assert.NoError(err, "failed to remove container (sleep 60) %v (%s)", labels, c2)
 	})
 	require.NoError(t, err)
 	_, err = dockerutil.ContainerWait(5, labels)
-	assert.NoError(err)
+	require.NoError(t, err)
 
-	ddevWebserver := versionconstants.WebImg + ":" + versionconstants.WebTag
+	ddevWebserver := ddevImages.GetWebImage()
 	// If we run a container that *does* have a healthcheck but it's unhealthy
 	// then ContainerWait shouldn't return until specified wait, and should fail
 	// Use ddev-webserver for this; it won't have good health on normal run
-	labels = map[string]string{"test": "hashealthcheckbutbad"}
+	labels = map[string]string{"test": "hashealthcheckbutunhealthy"}
+	// Make sure none already exist
 	_ = dockerutil.RemoveContainersByLabels(labels)
-	cID, _, err = dockerutil.RunSimpleContainer(ddevWebserver, t.Name()+util.RandString(5), []string{"sleep", "5"}, nil, []string{"DDEV_WEBSERVER_TYPE=nginx-fpm"}, nil, "0", false, true, labels, nil, nil)
+	c3, _, err := dockerutil.RunSimpleContainer(ddevWebserver, t.Name()+"-hashealthcheckbutunhealthy-"+util.RandString(5), []string{"sleep", "5"}, nil, []string{"DDEV_WEBSERVER_TYPE=nginx-fpm"}, nil, "0", false, true, labels, nil, nil)
 	t.Cleanup(func() {
-		_ = dockerutil.RemoveContainer(cID)
+		err = dockerutil.RemoveContainer(c3)
+		assert.NoError(err, "failed to remove container %v (%s)", labels, c3)
 	})
 	require.NoError(t, err)
 	_, err = dockerutil.ContainerWait(3, labels)
-	assert.Error(err)
-	assert.Contains(err.Error(), "timed out without becoming healthy")
-	_ = dockerutil.RemoveContainer(cID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out without becoming healthy")
 
 	// If we run a container that *does* have a healthcheck but it's not healthy for a while
 	// then ContainerWait should detect failure early, but should succeed later
 	labels = map[string]string{"test": "hashealthcheckbutbad"}
+	// Make sure none already exist
 	_ = dockerutil.RemoveContainersByLabels(labels)
-	cID, _, err = dockerutil.RunSimpleContainer(ddevWebserver, t.Name()+util.RandString(5), []string{"bash", "-c", "sleep 5 && /start.sh"}, nil, []string{"DDEV_WEBSERVER_TYPE=nginx-fpm"}, nil, "0", false, true, labels, nil, nil)
+	c4, _, err := dockerutil.RunSimpleContainer(ddevWebserver, t.Name()+"-hashealthcheckbutbad2-"+util.RandString(5), []string{"bash", "-c", "sleep 5 && /start.sh"}, nil, []string{"DDEV_WEBSERVER_TYPE=nginx-fpm"}, nil, "0", false, true, labels, nil, nil)
 	t.Cleanup(func() {
-		_ = dockerutil.RemoveContainer(cID)
+		err = dockerutil.RemoveContainer(c4)
+		assert.NoError(err, "failed to remove container %v (%s)", labels, c4)
 	})
 	require.NoError(t, err)
 	_, err = dockerutil.ContainerWait(3, labels)
-	assert.Error(err)
-	assert.Contains(err.Error(), "timed out without becoming healthy")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out without becoming healthy")
 	// Try it again, wait 60s for health; on macOS it usually takes about 2s for ddev-webserver to become healthy
 	out, err := dockerutil.ContainerWait(60, labels)
-	assert.NoError(err, "output=%s", out)
+	require.NoError(t, err, "output=%s", out)
 }
 
 // TestComposeCmd tests execution of docker-compose commands.

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -137,10 +137,9 @@ func TestListFilesInDir(t *testing.T) {
 // TestReplaceStringInFile tests the ReplaceStringInFile utility function.
 func TestReplaceStringInFile(t *testing.T) {
 	assert := asrt.New(t)
-	tmp, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	newFilePath := filepath.Join(tmp, "newfile.txt")
-	err = fileutil.ReplaceStringInFile("some needle we're looking for", "specialJUNKPattern", "testdata/fgrep_has_positive_contents.txt", newFilePath)
+	tmpDir := testcommon.CreateTmpDir(t.Name())
+	newFilePath := filepath.Join(tmpDir, "newfile.txt")
+	err := fileutil.ReplaceStringInFile("some needle we're looking for", "specialJUNKPattern", "testdata/fgrep_has_positive_contents.txt", newFilePath)
 	assert.NoError(err)
 	found, err := fileutil.FgrepStringInFile(newFilePath, "specialJUNKPattern")
 	assert.NoError(err)


### PR DESCRIPTION

## The Issue

* TestContainerWait was leaving dead containers behind. It turned out that the t.Cleanup() was re-using the last value of cID instead of the value at time of creation of the closure. This is a new problem to me.
* A number of tests were using os.MkdirTemp() where testcommon.CreateTmpDir() would be better. They had been noticed leaving things laying around on Windows, especially.
* TestArchiveTar and TestArchiveTarGz weren't deleting their tarballs. 

