### PR TITLE
fix: Make sure that we actually wait for bound ports to be released

### DIFF
--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -274,11 +274,12 @@ func FindDdevRouter() (*dockerTypes.Container, error) {
 }
 
 // GetRouterBoundPorts() returns the currently bound ports on ddev-router
+// or an empty array if router not running
 func GetRouterBoundPorts() ([]uint16, error) {
 	boundPorts := []uint16{}
 	r, err := FindDdevRouter()
 	if err != nil {
-		return nil, err
+		return []uint16{}, nil
 	}
 
 	for _, p := range r.Ports {


### PR DESCRIPTION

## The Issue

* https://github.com/ddev/ddev/pull/6414

In there, trying to solve the problems with failed URLs on Lima/Colima/Rancher I inserted a wait for ports to be freed. But the logic there was wrong, and no ports were waited for. It was just wrong.

## How This PR Solves The Issue

Get the ports that we need to wait for from the ddev-router itself by inspecting it.

## Manual Testing Instructions

Block ports 80 and 443, `nc -k -l 80` and `nc -k -l 443` to make it start new items all the time.

With DDEV_DEBUG=true you should see notification of all the related ports being checked.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
