### PR TITLE
test: fix  TestExtraPortExpose with correct URL

### DIFF
--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -2,10 +2,12 @@ package ddevapp_test
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/dockerutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/ddev/ddev/pkg/dockerutil"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
@@ -63,9 +65,20 @@ func TestExtraPortExpose(t *testing.T) {
 	}
 
 	for i, p := range portsToTest {
-		url := fmt.Sprintf("%s:%s/testfile.html", app.GetPrimaryURL(), p)
+		baseURL := getBaseURL(app.GetPrimaryURL())
+		url := fmt.Sprintf("%s:%s/testfile.html", baseURL, p)
 		out, resp, err := testcommon.GetLocalHTTPResponse(t, url)
 		require.NoError(t, err, "failed to get hit url %s, out=%s, resp=%v err=%v", url, out, resp, err)
 		require.Contains(t, out, fmt.Sprintf("this is test%d", i+1))
 	}
+}
+
+// getBaseURL returns the base url (http://hostname.example.com) from a URL, without port
+func getBaseURL(fullURL string) string {
+	parsedURL, err := url.Parse(fullURL)
+	if err != nil {
+		return ""
+	}
+	baseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Hostname())
+	return baseURL
 }

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -2,12 +2,12 @@ package ddevapp_test
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/netutil"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
@@ -65,20 +65,10 @@ func TestExtraPortExpose(t *testing.T) {
 	}
 
 	for i, p := range portsToTest {
-		baseURL := getBaseURL(app.GetPrimaryURL())
+		baseURL := netutil.BaseURLFromFullURL(app.GetPrimaryURL())
 		url := fmt.Sprintf("%s:%s/testfile.html", baseURL, p)
 		out, resp, err := testcommon.GetLocalHTTPResponse(t, url)
 		require.NoError(t, err, "failed to get hit url %s, out=%s, resp=%v err=%v", url, out, resp, err)
 		require.Contains(t, out, fmt.Sprintf("this is test%d", i+1))
 	}
-}
-
-// getBaseURL returns the base url (http://hostname.example.com) from a URL, without port
-func getBaseURL(fullURL string) string {
-	parsedURL, err := url.Parse(fullURL)
-	if err != nil {
-		return ""
-	}
-	baseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Hostname())
-	return baseURL
 }

--- a/pkg/ddevapp/hooks_test.go
+++ b/pkg/ddevapp/hooks_test.go
@@ -68,7 +68,7 @@ func TestProcessHooks(t *testing.T) {
 		{"exec: ls /usr/local/bin", "acli\ncomposer", "Running task: Exec command 'ls /usr/local/bin'"},
 		{"exec-host: \"echo something\"", "something\n", "Running task: Exec command 'echo something' on the host"},
 		{"exec: echo MYSQL_PWD=${MYSQL_PWD:-}\n    service: db", "MYSQL_PWD=db\n", "Running task: Exec command 'echo MYSQL_PWD=${MYSQL_PWD:-}' in container/service 'db'"},
-		{"exec: \"echo TestProcessHooks > /var/www/html/TestProcessHooks${DDEV_ROUTER_HTTPS_PORT}.txt\"", "", "Running task: Exec command 'echo TestProcessHooks > /var/www/html/TestProcessHooks${DDEV_ROUTER_HTTPS_PORT}.txt'"},
+		{"exec: \"echo TestProcessHooks > /var/www/html/TestProcessHooks-php-version-${DDEV_PHP_VERSION}.txt\"", "", "Running task: Exec command 'echo TestProcessHooks > /var/www/html/TestProcessHooks-php-version-${DDEV_PHP_VERSION}.txt'"},
 		{"exec: \"touch /var/tmp/TestProcessHooks && touch /var/www/html/touch_works_after_and.txt\"", "", "Running task: Exec command 'touch /var/tmp/TestProcessHooks && touch /var/www/html/touch_works_after_and.txt'"},
 		{"exec:\n    exec_raw: [ls, /usr/local]", "bin\netc\ngames\n", "Exec command '[ls /usr/local] (raw)'"},
 	}
@@ -101,19 +101,19 @@ func TestProcessHooks(t *testing.T) {
 	err = app.Restart()
 	require.NoError(t, err)
 
-	require.FileExists(t, filepath.Join(app.AppRoot, fmt.Sprintf("%s%s.txt", t.Name(), app.GetRouterHTTPSPort())))
+	require.FileExists(t, filepath.Join(app.AppRoot, fmt.Sprintf("%s-php-version-%s.txt", t.Name(), app.PHPVersion)))
 	require.FileExists(t, filepath.Join(app.AppRoot, "touch_works_after_and.txt"))
 
 	// Make sure skip hooks work
 	ddevapp.SkipHooks = true
 	app.Hooks = map[string][]ddevapp.YAMLTask{
 		"hook-test-skip-hooks": {
-			{"exec": "\"echo TestProcessHooks > /var/www/html/TestProcessHooksSkipHooks${DDEV_ROUTER_HTTPS_PORT}.txt\""},
+			{"exec": "\"echo TestProcessHooks > /var/www/html/TestProcessHooksSkipHooks-php-version-${DDEV_PHP_VERSION}.txt\""},
 		},
 	}
 	err = app.ProcessHooks("hook-test")
 	require.NoError(t, err)
-	require.NoFileExists(t, filepath.Join(app.AppRoot, fmt.Sprintf("TestProcessHooksSkipHooks%s.txt", app.GetRouterHTTPSPort())))
+	require.NoFileExists(t, filepath.Join(app.AppRoot, fmt.Sprintf("TestProcessHooksSkipHooks-php-version-%s.txt", app.PHPVersion)))
 	ddevapp.SkipHooks = false
 
 	// Attempt processing hooks with a guaranteed failure

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -82,7 +82,7 @@ func StopRouterIfNoContainers() error {
 		// Colima and Lima don't release ports very fast after container is removed
 		// see https://github.com/lima-vm/lima/issues/2536 and
 		// https://github.com/abiosoft/colima/issues/644
-		if dockerutil.IsLima() || dockerutil.IsColima() {
+		if dockerutil.IsLima() || dockerutil.IsColima() || dockerutil.IsRancherDesktop() {
 			if globalconfig.DdevDebug {
 				out, err := exec.RunHostCommand("docker", "ps", "-a")
 				util.Debug("Lima/Colima stopping router, output of docker ps -a: '%v', err=%v", out, err)

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -1,7 +1,9 @@
 package netutil
 
 import (
+	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"slices"
 	"syscall"
@@ -91,4 +93,14 @@ func GetLocalIPs() ([]string, error) {
 	}
 
 	return localIPs, nil
+}
+
+// BaseURLFromFullURL returns the base url (http://hostname.example.com) from a URL, without port
+func BaseURLFromFullURL(fullURL string) string {
+	parsedURL, err := url.Parse(fullURL)
+	if err != nil {
+		return ""
+	}
+	baseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Hostname())
+	return baseURL
 }


### PR DESCRIPTION
## The Issue

In https://buildkite.com/ddev/macos-rancher-desktop/builds/957#01918e49-185d-4044-bcf0-8db01bb419df/10062-10136 I see that there is still some erroneous logic in tests when the primary URL may have a port.

> failed to get hit url https://testpkgdrupal10.ddev.site:33003:3000/testfile.html, out=, resp=<nil> err=Get "https://127.0.0.1:3000/testfile.html": dial tcp 127.0.0.1:3000: connect: connection refused

Note `https://testpkgdrupal10.ddev.site:33003:3000/testfile.html`

## How This PR Solves The Issue

Add BaseURLFromFullURL() to get the base URL from any URL, without the port. 


