### PR TITLE
feat: add two timestamp settings to settings.ddev.php for drupal 10 and 11 

### DIFF
--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -48,3 +48,8 @@ $config['symfony_mailer.mailer_transport.sendmail']['configuration']['port'] = '
 // Enable verbose logging for errors.
 // https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode
 $config['system.logging']['error_level'] = 'verbose';
+
+// Execute the timestamp field update hook fixing the Y2K38 bug with no timeout
+//https://www.drupal.org/node/3397596
+$settings['timestamp_field_update_y2038'] = TRUE;
+$settings['timestamp_field_update_y2038_timeout'] = 0;

--- a/pkg/ddevapp/drupal/drupal11/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal11/settings.ddev.php
@@ -45,3 +45,8 @@ $config['symfony_mailer.mailer_transport.sendmail']['configuration']['port'] = '
 // Enable verbose logging for errors.
 // https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode
 $config['system.logging']['error_level'] = 'verbose';
+
+// Execute the timestamp field update hook fixing the Y2K38 bug with no timeout
+//https://www.drupal.org/node/3397596
+$settings['timestamp_field_update_y2038'] = TRUE;
+$settings['timestamp_field_update_y2038_timeout'] = 0;


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

https://www.drupal.org/project/drupal/issues/2885413 introduced a fix for the Y2K38 bug. I've stumbled across the error cuz i'Ve noticed a mismatch of entity/field definitions on the status reports page. 

![Screenshot 2024-08-25 at 22 26 38](https://github.com/user-attachments/assets/50f6f44d-e426-4332-86bf-8551d33b5167)

all mismatches were around meta data fields (and as it turned out all around datetime). i already ran update db but the error persisted. but in todays lean coffee table we dug up the linked issue as well as the corresponding change record https://www.drupal.org/node/3397596 . adding those two lines to my settings.php 

```
$settings['timestamp_field_update_y2038'] = TRUE;
$settings['timestamp_field_update_y2038_timeout'] = 0;
```
setting back the keyvalue for the system to 11000 and then running `drush updatedb`again made the updatehook the linked patch provided run, the fields got updated, and the errors are gone now. the two lines being added by the commit to default.settings.php has had no effect. I had to manually add the two lines to my settings.php. 

## How This PR Solves The Issue

The PR adds the two lines to the settings.ddev.php for drupal 10 (the patch will be backported for 10.4 according to the issue) and drupal 11. that way both drupal 10 and drupal 11 would be ready right away. and by setting the second line to 0 there is no timeout. 

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
