### PR TITLE
test: apt key expiration management, fixes #5829 [skip buildkite]

### DIFF
--- a/.ci-scripts/linux_arm64_setup.sh
+++ b/.ci-scripts/linux_arm64_setup.sh
@@ -26,7 +26,7 @@ echo "capath=/etc/ssl/certs/" >>~/.curlrc
 
 curl -sSL https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz -o /tmp/go.tgz && sudo rm -rf /usr/local/go && sudo tar -zxf /tmp/go.tgz -C /usr/local
 
-git clone --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats-core && pushd /tmp/bats-core >/dev/null && sudo ./install.sh /usr/local
+git clone --branch v1.11.0 https://github.com/bats-core/bats-core.git /tmp/bats-core && pushd /tmp/bats-core >/dev/null && sudo ./install.sh /usr/local
 
 # Install mkcert
 sudo curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=linux/arm64" && sudo chmod +x /usr/local/bin/mkcert

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -35,7 +35,7 @@ done
 
 mkcert -install
 
-git clone --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats-core && pushd /tmp/bats-core >/dev/null && sudo ./install.sh /usr/local >/dev/null
+git clone --branch v1.11.0 https://github.com/bats-core/bats-core.git /tmp/bats-core && pushd /tmp/bats-core >/dev/null && sudo ./install.sh /usr/local >/dev/null
 
 primary_ip=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')
 

--- a/containers/check_key_expirations.sh
+++ b/containers/check_key_expirations.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Directories containing keyrings
+directories=("/etc/apt/trusted.gpg.d/" "/usr/share/keyrings/")
+# Today's date in Unix time
+today=$(date +%s)
+# Days ahead to check for expiration
+days_ahead=${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90}
+# Seconds ahead (60 days)
+seconds_ahead=$((days_ahead * 24 * 3600))
+
+# Process each directory
+for dir in "${directories[@]}"; do
+    echo "Checking directory: $dir"
+    cd "$dir"
+    for keyring in *.gpg *.asc; do
+        # Skip specific keyrings
+        if [[ "$keyring" == "debian-archive-removed-keys.gpg" ]]; then
+            continue
+        fi
+
+        # Prepare keyring path for GPG command
+        keyring_path="$dir$keyring"
+        # Determine if temporary keyring is needed (for .asc files)
+        if [[ "$keyring" == *.asc ]]; then
+            temp_keyring="/tmp/temp-${keyring%.asc}.gpg"
+            gpg --dearmor < "$keyring_path" > "$temp_keyring"
+            keyring_to_check="$temp_keyring"
+        else
+            keyring_to_check="$keyring_path"
+        fi
+
+        echo "Checking keyring: $keyring"
+        # List keys using GPG, parse with AWK
+        gpg --no-default-keyring --keyring "$keyring_to_check" --list-keys --with-colons --fixed-list-mode | \
+        awk -F: -v today="$today" -v seconds_ahead="$seconds_ahead" '
+            /^pub/ {keyid = $5; expiry_date = $7}
+            /^uid/ && keyid {
+                # Calculate the time until expiration
+                time_to_expire = expiry_date - today;
+                # Check if the key expires within 60 days
+                if (expiry_date != "" && expiry_date > 0 && time_to_expire <= seconds_ahead) {
+                    print "Key ID:", keyid, "Name:", $10, "Expires in:", int(time_to_expire / 86400), "days"
+                }
+                keyid = ""; expiry_date = "";
+            }
+        '
+        # Clean up temporary file if it was created
+        if [[ "$keyring" == *.asc ]]; then
+            rm "$temp_keyring"
+        fi
+    done
+done

--- a/containers/ddev-dbserver/test/functions.sh
+++ b/containers/ddev-dbserver/test/functions.sh
@@ -2,7 +2,7 @@
 
 function basic_setup {
     export CONTAINER_NAME="testserver"
-    export HOSTPORT=33000
+    export HOSTPORT=31000
     export MYTMPDIR="${HOME}/tmp/testserver-sh_${RANDOM}_$$"
     export outdir="${HOME}/tmp/mariadb_testserver/output_${RANDOM}_$$"
     export VOLUME="dbserver_test-${RANDOM}_$$"

--- a/containers/ddev-dbserver/test/image_general.bats
+++ b/containers/ddev-dbserver/test/image_general.bats
@@ -16,6 +16,10 @@ function setup {
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
+  if [ "${DB_TYPE:-}" = "mysql" ] && [[ ${DB_VERSION} =~ ^5.[56]$ ]]; then
+    skip "Skipping mysql:${DB_VERSION} as its keys are long since expired"
+  fi
+
   docker cp ${TEST_SCRIPT_DIR}/check_key_expirations.sh ${CONTAINER_NAME}:/tmp
   docker exec -u root -e "DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} /tmp/check_key_expirations.sh
 

--- a/containers/ddev-dbserver/test/image_general.bats
+++ b/containers/ddev-dbserver/test/image_general.bats
@@ -12,22 +12,13 @@ function setup {
   containercheck
 }
 
-@test "verify apt keys are not expiring" {
-  DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90}
+@test "verify apt keys are not expiring within ${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90} days" {
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
-  echo "# DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION='${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION}' DDEV_IGNORE_EXPIRING_KEYS='${DDEV_IGNORE_EXPIRING_KEYS}'" >&3
-  docker exec -e "max=${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION}" ${CONTAINER_NAME} bash -c '
-    dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
-    for item in ${dates}; do
-      today=$(date -I)
-      let diff=($(date +%s -d ${item})-$(date +%s -d ${today}))/86400
-      if [ ${diff} -le ${max} ]; then
-        exit 1
-      fi
-    done
-  '
+  docker cp ${TEST_SCRIPT_DIR}/check_key_expirations.sh ${CONTAINER_NAME}:/tmp
+  docker exec -u root -e "DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} /tmp/check_key_expirations.sh
+
 }
 
 @test "verify xtrabackup version equal to mysql-server version" {

--- a/containers/ddev-dbserver/test/image_general.bats
+++ b/containers/ddev-dbserver/test/image_general.bats
@@ -21,7 +21,7 @@ function setup {
   fi
 
   docker cp ${TEST_SCRIPT_DIR}/check_key_expirations.sh ${CONTAINER_NAME}:/tmp
-  docker exec -u root -e "DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} /tmp/check_key_expirations.sh
+  docker exec -u root -e "DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} /tmp/check_key_expirations.sh >&3
 
 }
 

--- a/containers/ddev-dbserver/test/test_dbserver.sh
+++ b/containers/ddev-dbserver/test/test_dbserver.sh
@@ -2,6 +2,7 @@
 
 # Find the directory of this script
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+export TEST_SCRIPT_DIR=${DIR}/../../testscripts
 
 set -o errexit
 set -o pipefail
@@ -20,5 +21,5 @@ export CURRENT_ARCH=$(../get_arch.sh)
 
 # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
 export PATH="/usr/local/bin:$PATH"
-bats test || (echo "bats tests failed for DB_TYPE ${DB_TYPE} DB_VERSION=${DB_VERSION} TAG=${TAG}" && exit 2)
+bats --show-output-of-passing-tests test || (echo "bats tests failed for DB_TYPE ${DB_TYPE} DB_VERSION=${DB_VERSION} TAG=${TAG}" && exit 2)
 printf "Test successful for DB_TYPE ${DB_TYPE} DB_VERSION=${DB_VERSION} TAG=${TAG}\n\n"

--- a/containers/ddev-dbserver/test/test_dbserver.sh
+++ b/containers/ddev-dbserver/test/test_dbserver.sh
@@ -21,5 +21,5 @@ export CURRENT_ARCH=$(../get_arch.sh)
 
 # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
 export PATH="/usr/local/bin:$PATH"
-bats --show-output-of-passing-tests test || (echo "bats tests failed for DB_TYPE ${DB_TYPE} DB_VERSION=${DB_VERSION} TAG=${TAG}" && exit 2)
+bats test || (echo "bats tests failed for DB_TYPE ${DB_TYPE} DB_VERSION=${DB_VERSION} TAG=${TAG}" && exit 2)
 printf "Test successful for DB_TYPE ${DB_TYPE} DB_VERSION=${DB_VERSION} TAG=${TAG}\n\n"

--- a/containers/ddev-ssh-agent/Dockerfile
+++ b/containers/ddev-ssh-agent/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-RUN apt-get update && apt-get install -y bash expect file openssh-client socat psmisc && apt-get autoclean
+RUN apt-get update && apt-get install -y bash expect file gpg openssh-client socat psmisc && apt-get autoclean
 
 # Copy container files
 COPY files /

--- a/containers/ddev-ssh-agent/test/functions.sh
+++ b/containers/ddev-ssh-agent/test/functions.sh
@@ -2,7 +2,7 @@
 
 function basic_setup {
     export CONTAINER_NAME="testserver"
-    export HOSTPORT=33000
+    export HOSTPORT=31000
     export MYTMPDIR="${HOME}/tmp/testserver-sh_${RANDOM}_$$"
     export outdir="${HOME}/tmp/mariadb_testserver/output_${RANDOM}_$$"
     export VOLUME="dbserver_test-${RANDOM}_$$"

--- a/containers/ddev-ssh-agent/test/image_general.bats
+++ b/containers/ddev-ssh-agent/test/image_general.bats
@@ -12,20 +12,11 @@ function setup {
   containercheck
 }
 
-@test "verify apt keys are not expiring" {
-    DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90}
+@test "verify apt keys are not expiring within ${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90} days" {
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
-  docker exec -e "max=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} bash -c '
-    dates=$(apt-key list 2>/dev/null | awk "/\[expires/ { gsub(/[\[\]]/, \"\"); print \$6;}")
-    for item in ${dates}; do
-      today=$(date -I)
-      let diff=($(date +%s -d ${item})-$(date +%s -d ${today}))/86400
-      if [ ${diff} -le ${max} ]; then
-        exit 1
-      fi
-    done
-  '
+  docker cp ${TEST_SCRIPT_DIR}/check_key_expirations.sh ${CONTAINER_NAME}:/tmp
+  docker exec -u root -e "DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} /tmp/check_key_expirations.sh
 
 }

--- a/containers/ddev-ssh-agent/test/image_general.bats
+++ b/containers/ddev-ssh-agent/test/image_general.bats
@@ -17,6 +17,6 @@ function setup {
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
   docker cp ${TEST_SCRIPT_DIR}/check_key_expirations.sh ${CONTAINER_NAME}:/tmp
-  docker exec -u root -e "DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} /tmp/check_key_expirations.sh
+  docker exec -u root -e "DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} /tmp/check_key_expirations.sh >&3
 
 }

--- a/containers/ddev-ssh-agent/test/test.sh
+++ b/containers/ddev-ssh-agent/test/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Find the directory of this script
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+export DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+export TEST_SCRIPT_DIR=${DIR}/../../testscripts
 
 set -o errexit
 set -o pipefail
@@ -17,5 +18,5 @@ export CURRENT_ARCH=$(../get_arch.sh)
 
 # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
 export PATH="/usr/local/bin:$PATH"
-bats test || (echo "bats tests failed for IMAGE=${IMAGE}" && exit 2)
+bats --verbose-run --show-output-of-passing-tests test || (echo "bats tests failed for IMAGE=${IMAGE}" && exit 2)
 printf "Test successful for IMAGE=${IMAGE}\n\n"

--- a/containers/ddev-ssh-agent/test/test.sh
+++ b/containers/ddev-ssh-agent/test/test.sh
@@ -18,5 +18,5 @@ export CURRENT_ARCH=$(../get_arch.sh)
 
 # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
 export PATH="/usr/local/bin:$PATH"
-bats --verbose-run --show-output-of-passing-tests test || (echo "bats tests failed for IMAGE=${IMAGE}" && exit 2)
+bats --show-output-of-passing-tests test || (echo "bats tests failed for IMAGE=${IMAGE}" && exit 2)
 printf "Test successful for IMAGE=${IMAGE}\n\n"

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -62,7 +62,7 @@
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
   fi
   docker cp ${TEST_SCRIPT_DIR}/check_key_expirations.sh ${CONTAINER_NAME}:/tmp
-  docker exec -u root -e "DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} /tmp/check_key_expirations.sh
+  docker exec -u root -e "DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} /tmp/check_key_expirations.sh >&3
 
 }
 

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -12,6 +12,10 @@ if [[ "${DOCKER_REPO}" == "*prod*" ]]; then
   IS_HARDENED=true
 fi
 
+# Find the directory of this script
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+export TEST_SCRIPT_DIR=${DIR}/../../../testscripts
+
 export HOST_HTTP_PORT="8080"
 export HOST_HTTPS_PORT="8443"
 export CONTAINER_HTTP_PORT="80"
@@ -71,7 +75,7 @@ if ! containerwait; then
     echo "=============== Failed containerwait after docker run with  DDEV_WEBSERVER_TYPE=${WEBSERVER_TYPE} DDEV_PHP_VERSION=$PHP_VERSION ==================="
     exit 100
 fi
-bats tests/ddev-webserver/general.bats
+bats --show-output-of-passing-tests tests/ddev-webserver/general.bats
 
 cleanup
 

--- a/containers/testscripts/check_key_expirations.sh
+++ b/containers/testscripts/check_key_expirations.sh
@@ -11,7 +11,7 @@ directories=("/etc/apt/trusted.gpg.d/" "/usr/share/keyrings/")
 today=$(date +%s)
 # Days ahead to check for expiration
 days_ahead=${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90}
-printf "Checking key expirations for ${days_ahead} days ahead"
+printf "Checking key expirations for ${days_ahead} days ahead\n"
 # Seconds ahead (DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION days)
 seconds_ahead=$((days_ahead * 24 * 3600))
 
@@ -26,7 +26,7 @@ for dir in "${directories[@]}"; do
     shopt -s nullglob
     for keyring in *.{gpg,asc}; do
         # Skip specific keyrings
-        if [[ "$keyring" == "debian-archive-removed-keys.gpg" ]]; then
+        if [[ "$keyring" =~ -removed-keys\.gpg$ ]]; then
             continue
         fi
 
@@ -42,20 +42,26 @@ for dir in "${directories[@]}"; do
         fi
 
         echo "Checking keyring: $keyring"
-        # List keys using GPG, parse with AWK
         gpg --no-default-keyring --keyring "$keyring_to_check" --list-keys --with-colons --fixed-list-mode | \
         awk -F: -v today="$today" -v seconds_ahead="$seconds_ahead" '
             /^pub/ {keyid = $5; expiry_date = $7}
             /^uid/ && keyid {
-                # Calculate the time until expiration
-                time_to_expire = expiry_date - today;
-                # print "Key ID:", keyid, "Name:", $10, "Expires in:", int(time_to_expire / 86400), "days"
-                # Check if the key expires within DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION days
-                if (expiry_date != "" && expiry_date > 0 && time_to_expire <= seconds_ahead) {
-                    print "Key ID:", keyid, "Name:", $10, "Expires in:", int(time_to_expire / 86400), "days";
-                    exit 1;
+                # Calculate the time until expiration only if the key has an expiration date
+                if (expiry_date == 0 || expiry_date == "") {
+                    print "Key ID:", keyid, "Name:", $10, "has no expiration date"
+                } else if (expiry_date > 0) {
+                    time_to_expire = expiry_date - today;
+                    print "Key ID:", keyid, "Name:", $10, "Expires in:", int(time_to_expire / 86400), "days"
+                    # Check if the key expires within DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION days
+                    if (expiry_date != "" && expiry_date > 0 && time_to_expire <= seconds_ahead) {
+                        print "Key ID:", keyid, "Name:", $10, "Expires in:", int(time_to_expire / 86400), "days";
+                        exit 1;
+                    }
+                    keyid = ""; expiry_date = "";
+                } else {
+                    print "Error: Key MESSUP negative:", keyid, "Expiry date:", expiry_date, "Name:", $10, "Expires in:", int(time_to_expire / 86400), "days"
+                    exit 2
                 }
-                keyid = ""; expiry_date = "";
             }
         '
     done


### PR DESCRIPTION
## The Issue

* #5829 

## How This PR Solves The Issue

Add a script that uses `gpg` to check expiration dates of both .gpg and .asc files

## Manual Testing Instructions

* Review the test output for the tests (Test Container) to see the keys and their expiration and/or
* In a supported project like ddev-dbserver, ddev-ssh-agent, ddev-webserver

To show success, with evaluation of all the keys:
```
export DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=200
make test
```

To show a failure
```
export DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=1000
make test
```

I didn't do `ddev-traefik-router` because it's apk based instead of debian
I didn't do `ddev-php-base` because everything in it is in `ddev-webserver`

It's ironic that I'm doing this now, when we're more than 500 days from any expiration, when we had TWO accidental expirations in the last several months. 

Right now, it shows all the keys. I think before pulling I'll change `bats --show-output-of-passing-tests` to remove that, so it doesn't show all the keys and their expiration dates.