### PR TITLE
feat: add `--project` flag to `ddev add-on` commands, fixes #6513

### DIFF
--- a/cmd/ddev/cmd/addon-remove.go
+++ b/cmd/ddev/cmd/addon-remove.go
@@ -15,12 +15,13 @@ var AddonRemoveCmd = &cobra.Command{
 	Short: "Remove a DDEV add-on which was previously installed in this project",
 	Example: `ddev add-on remove someaddonname,
 ddev add-on remove someowner/ddev-someaddonname,
-ddev add-on remove ddev-someaddonname
+ddev add-on remove ddev-someaddonname,
+ddev add-on remove ddev-someaddonname --project my-project
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := ddevapp.GetActiveApp("")
+		app, err := ddevapp.GetActiveApp(cmd.Flag("project").Value.String())
 		if err != nil {
-			util.Failed("Unable to find active project: %v", err)
+			util.Failed("Unable to get project %v: %v", cmd.Flag("project").Value.String(), err)
 		}
 
 		origDir, _ := os.Getwd()
@@ -48,5 +49,7 @@ ddev add-on remove ddev-someaddonname
 
 func init() {
 	AddonRemoveCmd.Flags().BoolP("verbose", "v", false, "Extended/verbose output")
+	AddonRemoveCmd.Flags().String("project", "", "Name of the project to remove the add-on from")
+	_ = AddonRemoveCmd.RegisterFlagCompletionFunc("project", ddevapp.GetProjectNamesFunc("all", 0))
 	AddonCmd.AddCommand(AddonRemoveCmd)
 }

--- a/cmd/ddev/cmd/get.go
+++ b/cmd/ddev/cmd/get.go
@@ -66,8 +66,21 @@ ddev get --remove ddev-someaddonname
 		if len(args) < 1 {
 			util.Failed("You must specify an add-on to download")
 		}
+		if len(args) > 1 {
+			// Update --project flag if projects were passed as args.
+			apps, err := getRequestedProjects(args[1:], false)
+			if err != nil {
+				util.Failed("Unable to get project(s) %v: %v", args, err)
+			}
+			if len(apps) > 0 {
+				err = cmd.Flag("project").Value.Set(apps[0].GetName())
+				if err != nil {
+					util.Failed("Unable to set --project flag %v: %v", apps[0].GetName(), err)
+				}
+			}
+		}
 		// Hand off execution for ddev get <add-on>
-		AddonGetCmd.Run(cmd, args)
+		AddonGetCmd.Run(cmd, []string{args[0]})
 	},
 }
 
@@ -78,5 +91,6 @@ func init() {
 	Get.Flags().String("remove", "", `Remove a ddev-get add-on`)
 	Get.Flags().String("version", "", `Specify a particular version of add-on to install`)
 	Get.Flags().BoolP("verbose", "v", false, "Extended/verbose output for ddev get")
+	Get.Flags().String("project", "", "Name of the project to install the add-on in")
 	RootCmd.AddCommand(Get)
 }

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -633,6 +633,7 @@ Download an add-on (service, provider, etc.).
 
 Flags:
 
+* `--project <projectName>`: Specify a project to install the add-on into. Defaults to checking for a project in the current directory.
 * `--version <version>`: Specify a version to download
 * `--verbose`, `-v`: Output verbose error information with Bash `set -x` (default `false`)
 
@@ -656,6 +657,9 @@ ddev add-on get /path/to/package
 
 # Copy an add-on from a tarball in another directory
 ddev add-on get /path/to/tarball.tar.gz
+
+# Download the official Redis add-on and install it into a project named "my-project"
+ddev add-on get ddev/ddev-redis --project my-project
 ```
 
 In general, you can run `ddev add-on get` multiple times without doing any damage. Updating an add-on can be done by running `ddev add-on get <add-on-name>`. If you have changed an add-on file and removed the `#ddev-generated` marker in the file, that file will not be touched and DDEV will let you know about it.
@@ -666,6 +670,7 @@ Remove an installed add-on. Accepts the full add-on name, the short name of the 
 
 Flags:
 
+* `--project <projectName>`: Specify a project to remove the add-on from. Defaults to checking for a project in the current directory.
 * `--verbose`, `-v`: Output verbose error information with Bash `set -x` (default `false`)
 
 Example:
@@ -674,6 +679,7 @@ Example:
 ddev add-on remove redis
 ddev add-on remove ddev-redis
 ddev add-on remove ddev/ddev-redis
+ddev add-on remove ddev/ddev-redis --project my-project
 ```
 
 ### `add-on list`
@@ -684,6 +690,7 @@ Flags:
 
 * `--all`: List unofficial *and* official add-ons. (default `true`)
 * `--installed`: List installed add-ons
+* `--project <projectName>`: Specify a project to remove the add-on from. Can only be used with the `--installed` flag. Defaults to checking for a project in the current directory.
 
 Example:
 
@@ -696,6 +703,9 @@ ddev add-on list --all
 
 # List installed add-ons
 ddev add-on list --installed
+
+# List installed add-ons for a specific project
+ddev add-on list --installed --project my-project
 ```
 
 ## `heidisql`


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6513

<!-- Provide a brief description of the issue. -->
There's currently no way to remove add-ons for a given project (other than the current working dir), and the use of the second argument in `ddev add-on get` for a project name blocks the opportunity to install multiple add-ons at once in the future.

## How This PR Solves The Issue

1. Remove the second argument from `ddev add-on get` which is currently for a project name.
1. Add a `--project` flag to `ddev add-on get`, `ddev add-on remove`, and `ddev add-on list --installed`
1. In `ddev get`, make sure the second (and subsequent) argument is converted to a flag before proxying to the `add-on get` command.

Note that adding the flag to `ddev add-on list` wasn't originally mentioned in the issue, but I noticed while testing that it didn't make sense to _not_ have it.
I've added validation so that if the `--project` flag is used with `ddev add-on` without `--installed`, it throws an error. This is because it doesn't _mean_ anything without `--installed.
e.g. `ddev add-on list --installed --project my-project` is fine, but `ddev add-on list --project my-project` will throw an error.

## Manual Testing Instructions

Try the following, which should all work:

1. `ddev add-on get <add-on>`
1. `ddev add-on get <add-on> --project <project-name>`
1. `ddev add-on remove <add-on>`
1. `ddev add-on remove <add-on> --project <project-name>`
1. `ddev add-on list --installed`
1. `ddev add-on list --installed --project <project-name>`
1. `ddev get <add-on>`
1. `ddev get <add-on> <project-name>`
1. `ddev get <add-on> --project <project-name>` (I had to add this in order to set the flag for the proxy)

Try the following, which should all fail:

1. `ddev add-on get <add-on> --project <non-existent-project>`
1. `ddev add-on remove <add-on> --project <non-existent-project>`
1. `ddev add-on list --installed --project <non-existent-project>`
1. `ddev add-on list --project <project-name>`
1. `ddev add-on list --all --project <project-name>`

Also check out the tab completion of the `--project` flag values. You should be able to `ddev add-on get --project <tab>` for example, and it'll give you all projects as suggestions.

Try anything I haven't thought of ;p

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
I've added a test that installs an add-on, checks it's installed, and removes it - all using the new `--project` flag.

I have not added test coverage for the deprecated `ddev get`.

## Release/Deployment Notes

`ddev add-on` hasn't been included in a stable release yet, so this won't affect anyone other than giving some more flexibility.