### PR TITLE
feat: add SVG support for ImageMagick

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get install -y postgresql-common && yes | /usr/share/postgresql-common/p
 RUN apt-get -qq update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
     libcap2-bin \
-    librsvg2-bin \
+    librsvg2-bin libmagickcore-6.q16-6-extra \
     locales-all \
     mariadb-client \
     postgresql-client \

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get install -y postgresql-common && yes | /usr/share/postgresql-common/p
 RUN apt-get -qq update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
     libcap2-bin \
+    librsvg2-bin \
     locales-all \
     mariadb-client \
     postgresql-client \

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/ImageMagick-6/policy.xml
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/ImageMagick-6/policy.xml
@@ -94,4 +94,5 @@
   <!-- Enable processing of PDF files to ensure TYPO3 is able to create thumbnails and previews -->
   <!-- <policy domain="coder" rights="none" pattern="PDF" /> -->
   <policy domain="coder" rights="none" pattern="XPS" />
+  <policy domain="coder" rights="none" pattern="SVG" />
 </policymap>

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.23.4" // Note that this can be overridden by make
+var WebTag = "20240830_saitho_imagemagick_svg" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6518

SVG files are commonly used nowadays, yet the ImageMagick used in DDEV does not support converting SVG files.

## How This PR Solves The Issue

Installs the package providing SVG conversion and configures ImageMagick to use it.

## Manual Testing Instructions

```
ddev php -r "echo (new Imagick())->queryFormats('SVG') ? 'SVG supported' : 'SVG not supported';"
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
