### PR TITLE
build: fix FromAsCasing warning from Dockerfile, for #6462 [skip ci]

### DIFF
--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-base:latest as workspace-base
+FROM gitpod/workspace-base:latest AS workspace-base
 SHELL ["/bin/bash", "-c"]
 
 USER root

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -81,9 +81,9 @@ RUN /sbin/mkhomedir_helper www-data
 # Have requested them to update this in https://bugs.mysql.com/bug.php?id=105632
 # But they haven't done it, and it will break things when it expires.
 RUN rm -f /etc/apt/sources.list.d/mysql.list && \
-  for item in "A4A9 4068 76FC BD3C 4567  70C8 8C71 8D3B 5072 E1F5" ; do \
-    apt-key remove "${item}" || true; \
-  done;
+    for item in "A4A9 4068 76FC BD3C 4567  70C8 8C71 8D3B 5072 E1F5" ; do \
+        apt-key remove "${item}" || true; \
+    done;
 
 # Normal upstream image doesn't actually have /home/mysql created
 # Make sure it's there in case user 999 (mysql) is using this image.

--- a/containers/ddev-nginx-proxy-router/Dockerfile
+++ b/containers/ddev-nginx-proxy-router/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get -qq update && \
         ca-certificates certbot curl iputils-ping less python3-certbot-nginx procps telnet vim wget && \
     apt-get autoremove -y && \
     apt-get clean -y && \
-	rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 # Download docker-gen
 RUN set -eu -o pipefail && \
@@ -42,7 +42,7 @@ RUN set -eu -o pipefail && \
 
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
- && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
+    && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
 
 # We don't want the default.conf provided by nginx package
 RUN rm -f /etc/nginx/conf.d/default.conf

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -1,17 +1,17 @@
 ### ---------------------------base--------------------------------------
 ### Build the base Debian image that will be used in every other image
-FROM debian:bookworm-slim as base
+FROM debian:bookworm-slim AS base
 
 RUN ls -l $(which dpkg-split) && ls -l $(which dpkg-deb)
 RUN for item in dpkg-split dpkg-deb; do \
-  if [ ! -f /usr/sbin/$item ]; then \
-    ln -sf /usr/bin/$item /usr/sbin/$item; \
-  fi; \
+    if [ ! -f /usr/sbin/$item ]; then \
+        ln -sf /usr/bin/$item /usr/sbin/$item; \
+    fi; \
 done
 RUN for item in tar rm; do \
-  if [ ! -f /usr/sbin/$item ]; then \
-    ln -sf /bin/$item /usr/sbin/$item; \
-  fi; \
+    if [ ! -f /usr/sbin/$item ]; then \
+        ln -sf /bin/$item /usr/sbin/$item; \
+    fi; \
 done
 
 RUN ls -l /usr/sbin/dpkg-split /usr/sbin/dpkg-deb /usr/sbin/tar /usr/sbin/rm
@@ -37,7 +37,7 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
 ### See https://github.com/ddev/ddev/issues/6159
 ### We don't need to recompile every Xdebug library https://xdebug.org/docs/compat (only PHP 8.0, 8.1, 8.2 can have Xdebug 3.2)
 ### PECL does not allow you to install multiple versions of Xdebug, so there is `rm -f xdebug.reg`
-FROM base as ddev-xdebug-build
+FROM base AS ddev-xdebug-build
 SHELL ["/bin/bash", "-c"]
 RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && rm -f /tmp/debsuryorg-archive-keyring.deb && \
@@ -77,7 +77,7 @@ ARG BUILDPLATFORM
 SHELL ["/bin/bash", "-c"]
 
 RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
-        | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+    | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
 RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
 http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
 

--- a/containers/ddev-traefik-router/Dockerfile
+++ b/containers/ddev-traefik-router/Dockerfile
@@ -6,4 +6,3 @@ WORKDIR /mnt/ddev-global-cache/traefik
 COPY /traefik_healthcheck.sh /healthcheck.sh
 RUN chmod ugo+rx /healthcheck.sh
 HEALTHCHECK --interval=1s --timeout=120s --retries=1 --start-period=120s CMD /healthcheck.sh
-

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:v1.23.4 as ddev-webserver-base
+FROM ddev/ddev-php-base:v1.23.4 AS ddev-webserver-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -74,7 +74,7 @@ RUN mkdir -p /usr/local/mariadb-old/bin && cp -ap /tmp/extracted/usr/bin/{mariad
 
 ### ---------------------------ddev-webserver-dev-base--------------------------------------
 ### Build ddev-webserver-dev-base from ddev-webserver-base
-FROM ddev-webserver-base as ddev-webserver-dev-base
+FROM ddev-webserver-base AS ddev-webserver-dev-base
 ENV CAROOT=/mnt/ddev-global-cache/mkcert
 ENV PHP_DEFAULT_VERSION="8.2"
 
@@ -194,7 +194,7 @@ RUN update-alternatives --set php /usr/bin/php${PHP_DEFAULT_VERSION}
 ### This could be known as ddev-webserver-dev as it's development-env targeted
 ### But for historical reasons, it's just ddev-webserver
 ### Build ddev-webserver by turning ddev-webserver-dev-base into one layer
-FROM scratch as ddev-webserver
+FROM scratch AS ddev-webserver
 ENV PHP_DEFAULT_VERSION="8.2"
 ENV NGINX_SITE_TEMPLATE=/etc/nginx/nginx-site.conf
 ENV APACHE_SITE_TEMPLATE=/etc/apache2/apache-site.conf
@@ -221,7 +221,7 @@ CMD ["/start.sh"]
 ### ---------------------------ddev-webserver-prod-base--------------------------------------
 ### Build ddev-webserver-prod-base from ddev-webserver-base
 ### This image is aimed at actual hardened production environments
-FROM ddev-webserver-base as ddev-webserver-prod-base
+FROM ddev-webserver-base AS ddev-webserver-prod-base
 ENV CAROOT=/mnt/ddev-global-cache/mkcert
 ENV PHP_DEFAULT_VERSION="8.2"
 ARG TARGETPLATFORM
@@ -304,7 +304,7 @@ RUN update-alternatives --set php /usr/bin/php${PHP_DEFAULT_VERSION}
 ### ---------------------------ddev-webserver-prod--------------------------------------
 ### Build ddev-webserver-prod, the hardened version of ddev-webserver-base
 ### (Withut dev features, single layer)
-FROM scratch as ddev-webserver-prod
+FROM scratch AS ddev-webserver-prod
 ENV PHP_DEFAULT_VERSION="8.2"
 ENV NGINX_SITE_TEMPLATE=/etc/nginx/nginx-site.conf
 ENV APACHE_SITE_TEMPLATE=/etc/apache2/apache-site.conf

--- a/containers/test-ssh-server/Dockerfile
+++ b/containers/test-ssh-server/Dockerfile
@@ -11,4 +11,3 @@ EXPOSE 22
 COPY /files /
 RUN chmod -R go-rwx /root/.ssh
 CMD ["/usr/sbin/sshd","-D", "-e"]
-


### PR DESCRIPTION
## The Issue

- #6462
- https://docs.docker.com/reference/build-checks/from-as-casing/

```
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 6)
```

## How This PR Solves The Issue

* uses the same casting for `FROM ... AS ...`
* removes extra lines at the end of files
* uses an indent of 4 spaces

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
