### PR TITLE
test: leave docker desktop context as desktop-linux [skip ci]

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -26,8 +26,10 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
     docker context use default
     # Leave orbstack running as the most likely to be reliable, otherwise Docker Desktop
     if command -v orb 2>/dev/null ; then
+      docker context use orbstack
       echo "Starting orbstack" && (nohup orb start &)
     else
+      docker context use desktop-linux
       open -a Docker
     fi
     sleep 5


### PR DESCRIPTION

## The Issue

The current buildkite test.sh tries to leave the docker context in a "sane" place by setting the context to "default"

However, something always deletes the `docker.sock` link on macstadium-m1. (/var/run/docker.sock). This can be fixed with `cd /var/run && sudo ln -s /Users/testbot/.docker/run/docker.sock` but it probably makes more sense to use the native context.

## How This PR Solves The Issue

On exit of test.sh, if orb not installed, use `docker context use desktop-linux` 


