### PR TITLE
fix: Lagoon integration automated tests

### DIFF
--- a/pkg/ddevapp/providerLagoon_test.go
+++ b/pkg/ddevapp/providerLagoon_test.go
@@ -189,7 +189,7 @@ func TestLagoonPush(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test that the database row was added
-	c := fmt.Sprintf(`echo 'SELECT title FROM %s WHERE title="%s";' | lagoon ssh -p %s -e %s -C 'mysql --host=$MARIADB_HOST --user=$MARIADB_USERNAME --password=$MARIADB_PASSWORD --database=$MARIADB_DATABASE'`, t.Name(), tval, lagoonProjectName, lagoonPushTestSiteEnvironment)
+	c := fmt.Sprintf(`echo 'SELECT title FROM %s WHERE title="%s";' | lagoon ssh --strict-host-key-checking no -p %s -e %s -C 'mysql --host=$MARIADB_HOST --user=$MARIADB_USERNAME --password=$MARIADB_PASSWORD --database=$MARIADB_DATABASE'`, t.Name(), tval, lagoonProjectName, lagoonPushTestSiteEnvironment)
 	//t.Logf("attempting command '%s'", c)
 	out, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd: c,
@@ -199,7 +199,7 @@ func TestLagoonPush(t *testing.T) {
 
 	// Test that the file arrived there
 	out, _, err = app.Exec(&ddevapp.ExecOpts{
-		Cmd: fmt.Sprintf(`lagoon ssh -p %s -e %s -C 'ls -l /app/web/sites/default/files/%s'`, lagoonProjectName, lagoonPushTestSiteEnvironment, fName),
+		Cmd: fmt.Sprintf(`lagoon ssh --strict-host-key-checking no -p %s -e %s -C 'ls -l /app/web/sites/default/files/%s'`, lagoonProjectName, lagoonPushTestSiteEnvironment, fName),
 	})
 	assert.NoError(err)
 	assert.Contains(out, tval)


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

A recent lagoon-cli release enabled strict host key checking for ssh by default https://github.com/uselagoon/lagoon-cli/pull/370

## How This PR Solves The Issue

Adding a flag to disable this option for the test automation.

## Manual Testing Instructions

## Automated Testing Overview

Fixes existing tests.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
