### PR TITLE
feat: streamline TYPO3 non-composer mode configuration support

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -125,32 +125,68 @@ func getTypo3Hooks() []byte {
 	return []byte(Typo3Hooks)
 }
 
-// setTypo3SiteSettingsPaths sets the paths to settings files for templating
+// setTypo3SiteSettingsPaths sets the paths to settings files for templating. TYPO3 supports different setup structures,
+// composer, legacy and mono repository which differs in places and naming of these files depending on mode and version.
+// Thus different detection function are provided to determine the best suitable place and filenames.
 func setTypo3SiteSettingsPaths(app *DdevApp) {
 	var settingsFilePath, localSettingsFilePath string
 
-	if isTypo3v12OrHigher(app) {
+	if isTypo3ComposerV12OrHigher(app) {
+		// Since TYPO3 v12 the configuration files are named `settings.php` and `additional.php` and expected
+		// to be in `project-folder/config/system` for composer mode installations. Set them now to ensure ddev
+		// writes them in the correct place.
 		settingsFileBasePath := filepath.Join(app.AppRoot, app.ComposerRoot)
 		settingsFilePath = filepath.Join(settingsFileBasePath, "config", "system", "settings.php")
 		localSettingsFilePath = filepath.Join(settingsFileBasePath, "config", "system", "additional.php")
-	} else if isTypo3App(app) {
+	} else if isTypo3LegacyV12OrHigher(app) {
+		// Since TYPO3 v12 the configuration files are names `settings.php` and `additional.php` and expected to
+		// be in `docroot/typo3conf/system/` which differs from TYPO3 v12 or higher composer mode installations
+		// above. TYPO3 v12 or higher Core Development mono repository is basically a non-composer mode installation
+		// albeit having a composer.json in the project root folder. Set now the correct path and configuration file
+		// names suitable for these setups.
+		settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
+		settingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "system", "settings.php")
+		localSettingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "system", "additional.php")
+	} else if isTypo3LegacyV11OrLower(app) {
+		// Up to TYPO3 v11 configuration files had the same naming and resided in the `docroot/typo3conf/` folder
+		// which dates back to times before composer has been a gamechanger in the PHP ecosystem. TYPO3 Core Development
+		// mono repository shared the same and we do not have to differenciate between composer and legacy mode here.
 		settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
 		settingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "LocalConfiguration.php")
 		localSettingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "AdditionalConfiguration.php")
 	} else {
-		// As long as TYPO3 is not installed, the file paths are set to the
-		// AppRoot to avoid the creation of the .gitignore in the wrong location.
+		// As long as TYPO3 is not installed, the file paths are set to the AppRoot to avoid the creation of the
+		// .gitignore in the wrong location. Set the longstanding and old names here as it does not matter at all.
+		// createTypo3SettingsFile skips early if these configuration are returned to be in the AppRoot which has
+		// never been a suitable place for TYPO3 literally not writing them and flags them skipable.
 		settingsFilePath = filepath.Join(app.AppRoot, "LocalConfiguration.php")
 		localSettingsFilePath = filepath.Join(app.AppRoot, "AdditionalConfiguration.php")
 	}
 
-	// Update file paths
+	// Update file paths to the above determined paths
 	app.SiteSettingsPath = settingsFilePath
 	app.SiteDdevSettingsFile = localSettingsFilePath
 }
 
-// isTypoApp returns true if the app is of type typo3
+// isTypo3App returns true if the app is of type typo3 including composer mode, legacy mode and mono repository
 func isTypo3App(app *DdevApp) bool {
+	if isTypo3ComposerV12OrHigher(app) {
+		return true
+	}
+	if isTypo3LegacyV12OrHigher(app) {
+		return true
+	}
+	if isTypo3LegacyV11OrLower(app) {
+		return true
+	}
+	return false
+}
+
+// Up to TYPO3 v11 legacy and composer mode installation provided the system extensions and the configuration in the
+// same structure within the docroot. Only difference is that for composer mode a public subfolder is used as docroot
+// which make no difference in the way to detect both variants. TYPO3 Core Development monorepository also shared the
+// same filestem layout. Thus using only a simple docroot/typo3 folder check here and be fine.
+func isTypo3LegacyV11OrLower(app *DdevApp) bool {
 	typo3Folder := filepath.Join(app.AppRoot, app.Docroot, "typo3")
 
 	// Check if the folder exists, fails if a symlink target does not exist.
@@ -164,6 +200,100 @@ func isTypo3App(app *DdevApp) bool {
 	}
 
 	return false
+}
+
+// Since TYPO3 v12 system extensions are no longer installed into `public/typo3/sysext/` and extension no longer into
+// `public/typo3conf/ext/`. This function verifies for a composer mode installation first and extract the TYPO3 version
+// from the `Typo3Version` php class if composer dependencies are installed and looks that source file up within the
+// composer vendor folder. The TYPO3 Core Development mono repository has a root composer.json but does not have the
+// system extensions within the vendor folder like composer mode installations and thus making it safe to check for the
+// Typo3Version class within the typo3/cms-core package folder.
+func isTypo3ComposerV12OrHigher(app *DdevApp) bool {
+	composerManifest, _ := composer.NewManifest(filepath.Join(app.AppRoot, app.ComposerRoot, "composer.json"))
+	vendorDir := "vendor"
+	if composerManifest != nil {
+		vendorDir = composerManifest.GetVendorDir()
+	}
+
+	versionFilePath := filepath.Join(app.AppRoot, app.ComposerRoot, vendorDir, "typo3", "cms-core", "Classes", "Information", "Typo3Version.php")
+	versionFile, err := fileutil.ReadFileIntoString(versionFilePath)
+
+	// Typo3Version class exists since v10.3.0. Before v11.5.0 the core was always
+	// installed into the folder public/typo3 so we can early return if the file
+	// is not found in the vendor folder.
+	if err != nil {
+		util.Debug("TYPO3 version class not found in '%s' for project %s, installed version is assumed to be older than 11.5.0: %v", versionFilePath, app.Name, err)
+		return false
+	}
+
+	// We may have a TYPO3 version 11 or higher and therefor have to parse the
+	// class file to properly detect the version.
+	re := regexp.MustCompile(`const\s+VERSION\s*=\s*'([^']+)`)
+
+	matches := re.FindStringSubmatch(versionFile)
+
+	if len(matches) < 2 {
+		util.Warning("Unexpected Typo3Version found for project %s in %v.", app.Name, versionFile)
+		return false
+	}
+
+	version, err := semver.NewVersion(matches[1])
+	if err != nil {
+		// This case never should happen
+		util.Warning("Unexpected error while parsing TYPO3 version ('%s') for project %s: %v.", matches[1], app.Name, err)
+		return false
+	}
+
+	util.Debug("Found TYPO3 version %v for project %s.", version.Original(), app.Name)
+
+	return version.Major() >= 12
+}
+
+// TYPO3 v12 changed some stuff, mostly for composer mode. Place and names of main and additional configuration changed
+// for composer and legacy mode with different places and also differs in places where system extensions can be found or
+// user extensions are installed. This function verifies if the current project reflects a TYPO3 v12 or higher legacy
+// mode installation to set the correct configuration folder and names in function `setTypo3SiteSettingsPaths`.
+// The TYPO3 Core Development mono repository uses literally the same layout albeit having a composer.json in the root
+// folder. In the mono repository the TYPO3 system extensions resides not within the composer vendor folder.
+func isTypo3LegacyV12OrHigher(app *DdevApp) bool {
+	if !isTypo3LegacyV11OrLower(app) {
+		return false
+	}
+
+	typo3Folder := filepath.Join(app.AppRoot, app.Docroot, "typo3")
+
+	versionFilePath := filepath.Join(typo3Folder, "sysext", "core", "Classes", "Information", "Typo3Version.php")
+	versionFile, err := fileutil.ReadFileIntoString(versionFilePath)
+
+	// Typo3Version class exists since v10.3.0. Before v11.5.0 the core was always
+	// installed into the folder public/typo3 so we can early return if the file
+	// is not found in the vendor folder.
+	if err != nil {
+		util.Debug("TYPO3 version class not found in '%s' for project %s, installed version is assumed to be older than 11.5.0: %v", versionFilePath, app.Name, err)
+		return false
+	}
+
+	// We may have a TYPO3 version 11 or higher and therefor have to parse the
+	// class file to properly detect the version.
+	re := regexp.MustCompile(`const\s+VERSION\s*=\s*'([^']+)`)
+
+	matches := re.FindStringSubmatch(versionFile)
+
+	if len(matches) < 2 {
+		util.Warning("Unexpected Typo3Version found for project %s in %v.", app.Name, versionFile)
+		return false
+	}
+
+	version, err := semver.NewVersion(matches[1])
+	if err != nil {
+		// This case never should happen
+		util.Warning("Unexpected error while parsing TYPO3 version ('%s') for project %s: %v.", matches[1], app.Name, err)
+		return false
+	}
+
+	util.Debug("Found TYPO3 version %v for project %s.", version.Original(), app.Name)
+
+	return version.Major() >= 12
 }
 
 // typo3ImportFilesAction defines the TYPO3 workflow for importing project files.
@@ -209,46 +339,4 @@ func typo3ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string)
 	}
 
 	return nil
-}
-
-// isTypo3v12OrHigher returns true if the TYPO3 version is 12 or higher.
-func isTypo3v12OrHigher(app *DdevApp) bool {
-	composerManifest, _ := composer.NewManifest(filepath.Join(app.AppRoot, app.ComposerRoot, "composer.json"))
-	vendorDir := "vendor"
-	if composerManifest != nil {
-		vendorDir = composerManifest.GetVendorDir()
-	}
-
-	versionFilePath := filepath.Join(app.AppRoot, app.ComposerRoot, vendorDir, "typo3", "cms-core", "Classes", "Information", "Typo3Version.php")
-	versionFile, err := fileutil.ReadFileIntoString(versionFilePath)
-
-	// Typo3Version class exists since v10.3.0. Before v11.5.0 the core was always
-	// installed into the folder public/typo3 so we can early return if the file
-	// is not found in the vendor folder.
-	if err != nil {
-		util.Debug("TYPO3 version class not found in '%s' for project %s, installed version is assumed to be older than 11.5.0: %v", versionFilePath, app.Name, err)
-		return false
-	}
-
-	// We may have a TYPO3 version 11 or higher and therefor have to parse the
-	// class file to properly detect the version.
-	re := regexp.MustCompile(`const\s+VERSION\s*=\s*'([^']+)`)
-
-	matches := re.FindStringSubmatch(versionFile)
-
-	if len(matches) < 2 {
-		util.Warning("Unexpected Typo3Version found for project %s in %v.", app.Name, versionFile)
-		return false
-	}
-
-	version, err := semver.NewVersion(matches[1])
-	if err != nil {
-		// This case never should happen
-		util.Warning("Unexpected error while parsing TYPO3 version ('%s') for project %s: %v.", matches[1], app.Name, err)
-		return false
-	}
-
-	util.Debug("Found TYPO3 version %v for project %s.", version.Original(), app.Name)
-
-	return version.Major() >= 12
 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

TYPO3 v12 changed the naming of the configuration files and also the place depending on the installation mode, which differs between composer and non-composer setups.

Since #4268 ddev already uses the correct files and places for composer based installations but not for non-composer mode setups, which includes also TYPO3 Core Development monorepo setups.

TYPO3 is going to remove the silent upgrade and also not writing the invalid `trustedHostsPattern` required for ddev. That means, that without the correct
pattern ddev setup for non-composer modes AND monorepo needs manual adjustmenst
and copy of the written file mainly because the default of typo3 no longer matches
the ddev variant. That means, the installer needs to be executed with `http` instead of `https`.

pkg/ddevapp/typo3.go` contains detection for TYPO3 v12 composer mode and TYPO3 legacy mode, using `app` in the method name which makes it hard to connect it with TYPO3 ecosystem known facts.

TYPO3 v12 changed the nameing of the main configuration file and the additional configuration file:

| TYPO3 <= v11                  | TYPO3 >= v12     |                    
|-------------------------------|------------------|
| `LocalConfiguration.php`      | `system.php`     |
| `AdditionalConfiguration.php` | `additional.php` |

Since TYPO3 v12 the place for these configuration files changed depending on the installation mode (composer or legacy mode):

| mode     | <= TYPO3 v11           | TYPO3 >= v12                  |
|----------|------------------------|-------------------------------|
| legacy   | `<docroot>/typo3conf/` | `<docroot>/typo3conf/system/` |
| composer | `<docroot>/typo3conf/` | `<project>/config/system/`    |

Note that in legacy mode `<project>` and `<docroot>` is the same folder,
where in composer mode `<docroot>` is usually `<project>/public/`

ddev respects this change only for TYPO3 v12 or higher in composer mode,
but not for the legacy mode and also not for the TYPO3 Core Development
mono repository.

That has been undetected so far because of two factors:

* many legacy setups may not be used with TYPO3 or developers has taken care of that manually anyway by disabling the ddev config writing for existing projects
* the fact that TYPO3 used to execute silent upgrade procedures also during installing new instances - which makes absolutly no sense and has been removed for TYPO3 v13 (main) and TYPO3 v12 [[1]](https://review.typo3.org/c/Packages/TYPO3.CMS/+/81793) along with writing the TYPO3 `trustedHostPattern` configuration to `.*.*`. That is also written by ddev to the `additional.php/AdditionalConfiguration.php`.

Because the old nameing is no longer migrated the web installer cannot be acces using `https://` and throwing exception in some cases related to the not suitable trustedHostPattern.

`trustedHostPattern` is used to verify hosts when reverse proxies are used, which is the case internally in ddev.

The issue is a combination of not updated detection (failed communication from TYPO3 to ddev) and the fact that TYPO3 removed unneeded code exection from the installation process and using more suitable `trustedHostPattern` by default which has hidden the issue away for quite some time.

[1] [https://review.typo3.org/c/Packages/TYPO3.CMS/+/81793](https://review.typo3.org/c/Packages/TYPO3.CMS/+/81793)

## How This PR Solves The Issue

This change renames all existing `isTypo3*()` function in `pkg/ddevapp/typo3.go` into more speaking function names and adds function comments to describe the background for the mode it detects. In the same manner a new mode detect function is added to detect TYPO3 v12 or higher in legacy mode properly.

The renamed `isTypo3App()` function has been used only as sub detection within `setTypo3SiteSettingsPaths()` and thus the renaming is okay so far. However,
the same function is used within the `pkg/ddevapp/apptypes.go` file as appTypeDetect function for the `nodeps.AppTypeTYPO3` type. Only checking for one "possible" type is not really usefull and thus the `isTypo3()` function is readded and now calls the different mode detection function in a chain to properly detect all possible TYPO3 setup flavours.

These changes takes care that the correct places and filenames are used for every possible case and ddev experiance is a breeze again like it should be. And not having to worry what to change or move or copy files arround while digging through support logs and chats.

To make that more clearer for developer and maintainers looking onto this code and not knowing these literally publicly known differences in the TYPO3 ecosystem and community,
the detection functions gets now some comments explaining the background a little bit
more in detail.

## Manual Testing Instructions

In all below descripted variants, instead of `typo3conf/LocalConfiguration.php` and `typo3conf/AdditionalConfiguration.php` the files `typo3conf/system/settings.php` and `typo3conf/system/additional.php` should be created and used.

That reads in ddev output like:

```terminal
TYPO3 does not seem to have been set up yet, missing settings.php (/home/sbuerk/work/TYPO3-Contribute/typo3conf/system/settings.php) 
Generating additional.php file for database connection. 
```

and using the installer works. Specially the monorepo with the change in TYPO3 no longer using the silentupgradeservice and not writing the ddev required trustedHostsPattern makes the difference.

### TYPO3 "legacy" (classic) mode, mono-repo (composer for dependencies, not the actual project!)

```terminal
git clone https://github.com/typo3/typo3.git ./
ddev config --project-name 't3c-main' --project-type 'typo3' --docroot '.' --database 'mariadb:10.11' --php-version '8.2' --webserver-type 'apache-fpm' --web-environment='TYPO3_CONTEXT=Development'
ddev start
# This is run locally, not within ddev by intent (otherwise would be docker-in-docker).
# Don't be disturbed by our main dispatcher called "runTests", it's not only for tests.
ddev composer install
ddev exec touch FIRST_INSTALL
ddev launch /typo3/install.php
```

### Legacy/Classic mode, NON-Composer

```terminal
# TYPO3 "legacy" (classic) mode, latest v13 release (NO composer)
wget --content-disposition https://get.typo3.org/13.3.0
tar xzf typo3_src-13.3.0.tar.gz
ln -s typo3_src-13.3.0 typo3_src && ln -s typo3_src/index.php index.php && ln -s typo3_src/typo3 typo3
ddev config --project-name 't3c-main' --project-type 'typo3' --docroot '.' --database 'mariadb:10.11' --php-version '8.2' --webserver-type 'apache-fpm' --web-environment='TYPO3_CONTEXT=Development'
ddev start
ddev exec touch FIRST_INSTALL
ddev launch /typo3/install.php

# TYPO3 "legacy" (classic) mode, stable v12 release (NO composer)
# differences to above only in version numbers and DDEV PHP-Version!
wget --content-disposition https://get.typo3.org/12.4.20
tar xzf typo3_src-12.4.20.tar.gz
ln -s typo3_src-12.4.20 typo3_src && ln -s typo3_src/index.php index.php && ln -s typo3_src/typo3 typo3
ddev config --project-name 't3c-main' --project-type 'typo3' --docroot '.' --database 'mariadb:10.11' --php-version '8.1' --webserver-type 'apache-fpm' --web-environment='TYPO3_CONTEXT=Development'
ddev start
ddev exec touch FIRST_INSTALL
ddev launch /typo3/install.php

# TYPO3 "legacy" (classic) mode, oldstable v11 release (NO composer)
# differences to above only in version number
wget --content-disposition https://get.typo3.org/11.5.39
tar xzf typo3_src-11.5.39.tar.gz
ln -s typo3_src-11.5.39 typo3_src && ln -s typo3_src/index.php index.php && ln -s typo3_src/typo3 typo3
ddev config --project-name 't3c-main' --project-type 'typo3' --docroot '.' --database 'mariadb:10.11' --php-version '8.1' --webserver-type 'apache-fpm' --web-environment='TYPO3_CONTEXT=Development'
ddev start
ddev exec touch FIRST_INSTALL
ddev launch /typo3/install.php
```

### TYPO3 composer mode (unchanged)

```terminal
# TYPO3 composer mode, latest v13 release
ddev config --project-name 't3c-main' --project-type 'typo3' --docroot 'public' --database 'mariadb:10.11' --php-version '8.2' --webserver-type 'apache-fpm' --web-environment='TYPO3_CONTEXT=Development'
ddev start
ddev composer create "typo3/cms-base-distribution:^13"
ddev exec touch public/FIRST_INSTALL
ddev launch /typo3/install.php

# TYPO3 composer mode, stable v12 release
# difference only in version numvers!
ddev config --project-name 't3c-main' --project-type 'typo3' --docroot 'public' --database 'mariadb:10.11' --php-version '8.1' --webserver-type 'apache-fpm' --web-environment='TYPO3_CONTEXT=Development'
ddev start
ddev composer create "typo3/cms-base-distribution:^12"
ddev exec touch public/FIRST_INSTALL
ddev launch /typo3/install.php

# TYPO3 composer mode, oldstable v11 release
# difference only in version numvers!
ddev config --project-name 't3c-main' --project-type 'typo3' --docroot 'public' --database 'mariadb:10.11' --php-version '8.1' --webserver-type 'apache-fpm' --web-environment='TYPO3_CONTEXT=Development'
ddev start
ddev composer create "typo3/cms-base-distribution:^11"
ddev exec touch public/FIRST_INSTALL
ddev launch /typo3/install.php
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
