### PR TITLE
test: Fix TestLagoonPush by upgrading lagoon CLI, replaces #6524

### DIFF
--- a/pkg/ddevapp/providerLagoon_test.go
+++ b/pkg/ddevapp/providerLagoon_test.go
@@ -189,7 +189,7 @@ func TestLagoonPush(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test that the database row was added
-	c := fmt.Sprintf(`echo 'SELECT title FROM %s WHERE title="%s";' | lagoon ssh -p %s -e %s -C 'mysql --host=$MARIADB_HOST --user=$MARIADB_USERNAME --password=$MARIADB_PASSWORD --database=$MARIADB_DATABASE'`, t.Name(), tval, lagoonProjectName, lagoonPushTestSiteEnvironment)
+	c := fmt.Sprintf(`echo 'SELECT title FROM %s WHERE title="%s";' | lagoon ssh --strict-host-key-checking no -p %s -e %s -C 'mysql --host=$MARIADB_HOST --user=$MARIADB_USERNAME --password=$MARIADB_PASSWORD --database=$MARIADB_DATABASE'`, t.Name(), tval, lagoonProjectName, lagoonPushTestSiteEnvironment)
 	//t.Logf("attempting command '%s'", c)
 	out, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd: c,
@@ -199,7 +199,7 @@ func TestLagoonPush(t *testing.T) {
 
 	// Test that the file arrived there
 	out, _, err = app.Exec(&ddevapp.ExecOpts{
-		Cmd: fmt.Sprintf(`lagoon ssh -p %s -e %s -C 'ls -l /app/web/sites/default/files/%s'`, lagoonProjectName, lagoonPushTestSiteEnvironment, fName),
+		Cmd: fmt.Sprintf(`lagoon ssh --strict-host-key-checking no -p %s -e %s -C 'ls -l /app/web/sites/default/files/%s'`, lagoonProjectName, lagoonPushTestSiteEnvironment, fName),
 	})
 	assert.NoError(err)
 	assert.Contains(out, tval)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240830_saitho_imagemagick_svg" // Note that this can be overridden by make
+var WebTag = "20240904_rocketeerbkw_fix_lagoon_tests" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

* TestLagoonPush started failing when the latest `lagoon` cli got implemented
* @rocketeerbkw responded very quickly with #6524 Thanks!
* Because that was a forked PR, TestLagoonPush didn't get run because the secrets were not available

## How This PR Solves The Issue

* Build the new released lagoon client v0.30.1 into ddev-webserver
* Run @rocketeerbkw original change

## Manual Testing Instructions

If TestLagoonPush runs here and succeeds, we're good.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
