### PR TITLE
fix: help mutagen work with Drupal's read-only settings files, fixes #6491

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -384,9 +384,15 @@ func (app *DdevApp) MutagenStatus() (status string, shortResult string, mapResul
 		if _, ok = alpha["scanProblems"]; ok {
 			problems = true
 		}
+		if _, ok = alpha["transitionProblems"]; ok {
+			problems = true
+		}
 	}
 	if beta, ok := session["beta"].(map[string]interface{}); ok {
 		if _, ok = beta["scanProblems"]; ok {
+			problems = true
+		}
+		if _, ok = beta["transitionProblems"]; ok {
 			problems = true
 		}
 	}


### PR DESCRIPTION
## The Issue

* https://github.com/ddev/ddev/issues/6491#issuecomment-2336466328

## How This PR Solves The Issue

The overall problem is an obscure interaction of Drupal install and mutagen:

* Drupal install (especially before drupal 8) setting sites/default/settings.php to read-only
* Edit settings.php on the host (which hasn't been synced)
* Mutagen can't then sync settings.php, so nothing happens inside the container, which is where it matters

## Manual Testing Instructions

```
# Drupal 7 project
ddev start
ddev drush si -y
ddev exec ls -l sites/default # See settings.php is read-only now
# Edit file on host side
ddev mutagen st # will report the transitionProblem
ddev mutagen st -l # Will show failure as in issue
ddev restart
ddev exec ls -l sites/default # See settings.php is now writeable
ddev mutagen st -l. # will now be happy
```

## Automated Testing Overview

I don't think anything needs to be added.

