### PR TITLE
test: Use 1password for test secrets [skip buildkite]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,9 +67,7 @@ jobs:
 
     env:
       CGO_ENABLED: 0
-      DDEV_ACQUIA_SSH_KEY: ${{ secrets.DDEV_ACQUIA_SSH_KEY }}
       DDEV_NONINTERACTIVE: "true"
-      DDEV_PANTHEON_SSH_KEY: ${{ secrets.DDEV_PANTHEON_SSH_KEY }}
       DDEV_SKIP_NODEJS_TEST: "true"
       GOTEST_SHORT: "12" # 12 is drupal10; means in TestFullSiteSetup we only use drupal10
       DDEV_TEST_WEBSERVER_TYPE: ${{ matrix.webserver }}
@@ -125,13 +123,22 @@ jobs:
           echo "MAKE_TARGET=test" >> $GITHUB_ENV
           echo "TESTARGS=-failfast -run '(TestDdevFullSite.*|TestDdevImportFiles|TestDdevAllDatabases|TestComposerCreateCmd|Test.*(Push|Pull)|TestAutocomplet)'" >> $GITHUB_ENV
           echo "GOTEST_SHORT=" >> $GITHUB_ENV
-          echo "DDEV_PLATFORM_API_TOKEN=${{ secrets.DDEV_PLATFORM_API_TOKEN }}" >> $GITHUB_ENV
-          echo "DDEV_UPSUN_API_TOKEN=${{ secrets.DDEV_UPSUN_API_TOKEN }}" >> $GITHUB_ENV
-          echo "DDEV_PANTHEON_API_TOKEN=${{ secrets.DDEV_PANTHEON_API_TOKEN }}" >> $GITHUB_ENV
-          echo "DDEV_ALLOW_ACQUIA_PUSH=${{ secrets.DDEV_ALLOW_ACQUIA_PUSH }}" >> $GITHUB_ENV
-          echo "DDEV_ACQUIA_API_KEY=${{ secrets.DDEV_ACQUIA_API_KEY }}" >> $GITHUB_ENV
-          echo "DDEV_ACQUIA_API_SECRET=${{ secrets.DDEV_ACQUIA_API_SECRET }}" >> $GITHUB_ENV
-          echo "DDEV_LAGOON_SSH_KEY=${{ secrets.DDEV_LAGOON_SSH_KEY }}" >> $GITHUB_ENV
+        if: ${{ matrix.pull-push-test-platforms }}
+
+      - name: Load 1password secret(s) for push-pull-test-platforms
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.TESTS_SERVICE_ACCOUNT_TOKEN }}"
+          DDEV_ACQUIA_API_KEY: "op://test-secrets/DDEV_ACQUIA_API_KEY/credential"
+          DDEV_ACQUIA_API_SECRET: "op://test-secrets/DDEV_ACQUIA_API_SECRET/credential"
+          DDEV_ACQUIA_SSH_KEY: "op://test-secrets/DDEV_ACQUIA_SSH_KEY/private key?ssh-format=openssh"
+          DDEV_LAGOON_SSH_KEY: "op://test-secrets/DDEV_LAGOON_SSH_KEY/private key?ssh-format=openssh"
+          DDEV_PANTHEON_API_TOKEN: "op://test-secrets/DDEV_PANTHEON_API_TOKEN/credential"
+          DDEV_PANTHEON_SSH_KEY: "op://test-secrets/DDEV_PANTHEON_SSH_KEY/private key?ssh-format=openssh"
+          DDEV_PLATFORM_API_TOKEN: "op://test-secrets/DDEV_PLATFORM_API_TOKEN/credential"
+          DDEV_UPSUN_API_TOKEN: "op://test-secrets/DDEV_UPSUN_API_TOKEN/credential"
         if: ${{ matrix.pull-push-test-platforms }}
 
       - name: Override environment variables for plain nginx

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -70,7 +70,7 @@ var AuthSSHCommand = &cobra.Command{
 		}
 		sshKeyPath = util.WindowsPathToCygwinPath(sshKeyPath)
 
-		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--entrypoint=", "--mount=type=bind,src=" + sshKeyPath + ",dst=/tmp/sshtmp", versionconstants.SSHAuthImage + ":" + versionconstants.SSHAuthTag + "-built", "bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && ssh-add $(file * | awk -F: "/private key/ { print \$1 }")`}
+		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--entrypoint=", "--mount=type=bind,src=" + sshKeyPath + ",dst=/tmp/sshtmp", versionconstants.SSHAuthImage + ":" + versionconstants.SSHAuthTag + "-built", "bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && grep -l '^-----BEGIN .* PRIVATE KEY-----' * | xargs -d '\n' ssh-add`}
 
 		err = exec.RunInteractiveCommand("docker", dockerCmd)
 

--- a/docs/content/developers/secret-management.md
+++ b/docs/content/developers/secret-management.md
@@ -1,0 +1,7 @@
+# Secret Management
+
+Most secrets used in our build process are managed via 1Password.
+
+## Pull and Push Secrets
+
+Secrets for the TestPlatformPull, TestAcquiaPull, and similar tests are in the `test-secrets` vault in the DDEV 1Password instance. They can be rotated and otherwise managed there.

--- a/docs/content/developers/secret-management.md
+++ b/docs/content/developers/secret-management.md
@@ -1,7 +1,9 @@
 # Secret Management
 
-Most secrets used in our build process are managed via 1Password.
+Most secrets used in our build process are managed via 1Password. The technique is documented in [developer.1password.com](https://developer.1password.com/docs/ci-cd/github-actions/).
 
 ## Pull and Push Secrets
 
 Secrets for the TestPlatformPull, TestAcquiaPull, and similar tests are in the `test-secrets` vault in the DDEV 1Password instance. They can be rotated and otherwise managed there.
+
+The `test-secrets` vault allows access to the service account [`tests`](https://team-ddev.1password.com/developer-tools/infrastructure-secrets/serviceaccount/76URGQSBMVEUHPEWVHQRFJ4N3Q) whose auth token is in "1Password Service Account Auth Token: Tests"

--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -62,6 +62,9 @@
     },
     {
       "pattern": "^https://aur.archlinux.org"
+    },
+    {
+      "pattern": "^https://team-ddev.1password.com"
     }
   ],
   "httpHeaders": [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,3 +224,4 @@ nav:
       - developers/writing-style-guide.md
       - developers/remote-config.md
       - developers/maintainers.md
+      - developers/secret-management.md

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -48,8 +48,6 @@ func TestAcquiaPull(t *testing.T) {
 		t.Skipf("No DDEV_ACQUIA_SSH_KEY env var has been set. Skipping %v", t.Name())
 	}
 
-	sshkey = strings.Replace(sshkey, "<SPLIT>", "\n", -1)
-
 	require.True(t, isPullSiteValid(acquiaPullSiteURL, acquiaSiteExpectation), "acquiaPullSiteURL %s isn't working right", acquiaPullSiteURL)
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)
@@ -142,7 +140,6 @@ func TestAcquiaPush(t *testing.T) {
 	if sshkey = os.Getenv("DDEV_ACQUIA_SSH_KEY"); sshkey == "" {
 		t.Skipf("No DDEV_ACQUIA_SSH_KEY env var has been set. Skipping %v", t.Name())
 	}
-	sshkey = strings.Replace(sshkey, "<SPLIT>", "\n", -1)
 
 	// Set up tests and give ourselves a working directory.
 	assert := asrt.New(t)

--- a/pkg/ddevapp/providerLagoon_test.go
+++ b/pkg/ddevapp/providerLagoon_test.go
@@ -27,7 +27,7 @@ const lagoonProjectName = "amazeeio-ddev"
 const lagoonPullTestSiteEnvironment = "pull"
 const lagoonPushTestSiteEnvironment = "push"
 
-// TODO: Change this to the actual dediicated pull environment
+// TODO: Change this to the actual dedicated pull environment
 const lagoonPullSiteURL = "https://nginx.pull.amazeeio-ddev.us2.amazee.io/"
 const lagoonSiteExpectation = "Super easy vegetarian pasta"
 
@@ -38,7 +38,6 @@ func lagoonSetupSSHKey(t *testing.T) string {
 	if sshkey = os.Getenv("DDEV_LAGOON_SSH_KEY"); sshkey == "" {
 		t.Skipf("No DDEV_LAGOON_SSH_KEY env var has been set. Skipping %v", t.Name())
 	}
-	sshkey = strings.Replace(sshkey, "<SPLIT>", "\n", -1)
 	return sshkey + "\n"
 }
 

--- a/scripts/read-1password-secrets.sh
+++ b/scripts/read-1password-secrets.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Read secrets into environment from 1password
+
+for item in DDEV_ACQUIA_API_KEY DDEV_ACQUIA_API_SECRET DDEV_PANTHEON_API_TOKEN DDEV_PLATFORM_API_TOKEN DDEV_UPSUN_API_TOKEN; do
+  printf "export ${item}=$(op item get ${item} --field=credential --reveal)\n"
+done >/tmp/1penv.sh
+
+for item in DDEV_ACQUIA_SSH_KEY DDEV_LAGOON_SSH_KEY DDEV_PANTHEON_SSH_KEY; do
+  printf "export ${item}=$(op item get --field='private key' --reveal ${item})\n"
+done >> /tmp/1penv.sh
+
+echo "You can now 'source /tmp/1penv.sh' to get the new environment variables"


### PR DESCRIPTION
## The Issue

We'd like to use 1Password to manage secrets

## How This PR Solves The Issue

This is a first step, using 1Password for the testing secrets, like TestAcquiaPull, etc.

## Manual Testing Instructions

Review the test logs. 
- [x] The push-pull tests should run successfully in that one
- [x] Tests like TestPlatformPull should *not* run in the other github tests

## Release/Deployment Notes

These secrets live in the `test-secrets` vault
The `test-secrets` vault allows access to the service account [`tests`](https://team-ddev.1password.com/developer-tools/infrastructure-secrets/serviceaccount/76URGQSBMVEUHPEWVHQRFJ4N3Q) whose auth token is in "1Password Service Account Auth Token: Tests"

The technique is documented in https://developer.1password.com/docs/ci-cd/github-actions/