### PR TITLE
test: Make forked PRs skip loading secrets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,7 @@ jobs:
           DDEV_PANTHEON_SSH_KEY: "op://test-secrets/DDEV_PANTHEON_SSH_KEY/private key?ssh-format=openssh"
           DDEV_PLATFORM_API_TOKEN: "op://test-secrets/DDEV_PLATFORM_API_TOKEN/credential"
           DDEV_UPSUN_API_TOKEN: "op://test-secrets/DDEV_UPSUN_API_TOKEN/credential"
-        if: ${{ matrix.pull-push-test-platforms }}
+        if: ${{ matrix.pull-push-test-platforms && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
 
       - name: Override environment variables for plain nginx
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,7 @@ jobs:
           DDEV_PANTHEON_SSH_KEY: "op://test-secrets/DDEV_PANTHEON_SSH_KEY/private key?ssh-format=openssh"
           DDEV_PLATFORM_API_TOKEN: "op://test-secrets/DDEV_PLATFORM_API_TOKEN/credential"
           DDEV_UPSUN_API_TOKEN: "op://test-secrets/DDEV_UPSUN_API_TOKEN/credential"
-        if: ${{ matrix.pull-push-test-platforms && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ matrix.pull-push-test-platforms && (github.repository_owner == 'ddev' || github.repository_owner == 'ddev-test') }}
 
       - name: Override environment variables for plain nginx
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,8 +139,7 @@ jobs:
           DDEV_PANTHEON_SSH_KEY: "op://test-secrets/DDEV_PANTHEON_SSH_KEY/private key?ssh-format=openssh"
           DDEV_PLATFORM_API_TOKEN: "op://test-secrets/DDEV_PLATFORM_API_TOKEN/credential"
           DDEV_UPSUN_API_TOKEN: "op://test-secrets/DDEV_UPSUN_API_TOKEN/credential"
-        if: ${{ matrix.pull-push-test-platforms && secrets.TESTS_SERVICE_ACCOUNT_TOKEN }}
-
+        if: ${{ matrix.pull-push-test-platforms && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner) }}
       - name: Override environment variables for plain nginx
         run: |
           echo "DDEV_SKIP_NODEJS_TEST=false" >> $GITHUB_ENV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,7 @@ jobs:
           DDEV_PANTHEON_SSH_KEY: "op://test-secrets/DDEV_PANTHEON_SSH_KEY/private key?ssh-format=openssh"
           DDEV_PLATFORM_API_TOKEN: "op://test-secrets/DDEV_PLATFORM_API_TOKEN/credential"
           DDEV_UPSUN_API_TOKEN: "op://test-secrets/DDEV_UPSUN_API_TOKEN/credential"
-        if: ${{ matrix.pull-push-test-platforms && (github.repository_owner == 'ddev' || github.repository_owner == 'ddev-test') }}
+        if: ${{ matrix.pull-push-test-platforms && secrets.TESTS_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Override environment variables for plain nginx
         run: |


### PR DESCRIPTION

## The Issue

* https://github.com/ddev/ddev/pull/6536#issuecomment-2348824760

With the addition of 1Password secrets to the tests workflow, forked PRs started failing

## How This PR Solves The Issue

Don't load secrets on forked PRs

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
