### PR TITLE
build: Use 1password secrets for most push secrets instead of github secrets

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -183,6 +183,8 @@ jobs:
 
   artifacts:
     env:
+      AUR_EDGE_GIT_URL: ${{ vars.AUR_EDGE_GIT_URL }}
+      AUR_STABLE_GIT_URL: ${{ vars.AUR_STABLE_GIT_URL }}
       DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
     name: Upload artifacts
     runs-on: ubuntu-22.04

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -36,9 +36,15 @@ jobs:
   build-most:
     name: Build DDEV executables except Windows
     runs-on: ubuntu-22.04
-    env:
-      AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY }}
     steps:
+      - name: Load 1password secret(s)
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
+          AmplitudeAPIKey: "op://push-secrets/AmplitudeAPIKey/credential"
+
       - uses: actions/checkout@v4
         with:
           # We need to get all branches and tags for git describe to work properly

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -200,7 +200,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
           AUR_SSH_PRIVATE_KEY: "op://push-secrets/AUR_SSH_PRIVATE_KEY/private key?ssh-format=openssh"
           CHOCOLATEY_API_KEY: "op://push-secrets/CHOCOLATEY_API_KEY/credential"
-          DDEV_GITHUB_TOKEN: "op://push-secrets/DDEV_GITHUB_TOKEN/credential"
+          GITHUB_TOKEN: "op://push-secrets/DDEV_GITHUB_TOKEN/credential"
           DDEV_MACOS_APP_PASSWORD: "op://push-secrets/DDEV_MACOS_APP_PASSWORD/credential"
           DDEV_MACOS_SIGNING_PASSWORD: "op://push-secrets/DDEV_MACOS_SIGNING_PASSWORD/credential"
           DOCKERHUB_TOKEN: "op://push-secrets/DOCKERHUB_TOKEN/credential"

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -182,6 +182,8 @@ jobs:
           key: ${{ github.sha }}-${{ github.ref }}-notarize-macos
 
   artifacts:
+    env:
+      DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
     name: Upload artifacts
     runs-on: ubuntu-22.04
     needs: [build-most, sign-windows, notarize-macos]

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -198,7 +198,7 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
-          AUR_SSH_PRIVATE_KEY: "op://test-secrets/AUR_SSH_PRIVATE_KEY/private key?ssh-format=openssh"
+          AUR_SSH_PRIVATE_KEY: "op://push-secrets/AUR_SSH_PRIVATE_KEY/private key?ssh-format=openssh"
           CHOCOLATEY_API_KEY: "op://push-secrets/CHOCOLATEY_API_KEY/credential"
           DDEV_GITHUB_TOKEN: "op://push-secrets/DDEV_GITHUB_TOKEN/credential"
           DDEV_MACOS_APP_PASSWORD: "op://push-secrets/DDEV_MACOS_APP_PASSWORD/credential"

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -27,11 +27,10 @@ env:
   BUILDKIT_PROGRESS: plain
   DOCKER_CLI_EXPERIMENTAL: enabled
   DDEV_DEBUG: true
-  GITHUB_REPOSITORY_OWNER: ${{ secrets.GITHUB_REPOSITORY_OWNER }}
-  DDEV_WINDOWS_SIGN: ${{ secrets.DDEV_WINDOWS_SIGN }}
-  HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  FURY_ACCOUNT: ${{ vars.FURY_ACCOUNT }}
+  HOMEBREW_EDGE_REPOSITORY: ${{ vars.HOMEBREW_EDGE_REPOSITORY }}
+  HOMEBREW_STABLE_REPOSITORY: ${{ vars.HOMEBREW_STABLE_REPOSITORY }}
+  REPOSITORY_OWNER: ${{ github.repository_owner }}
 
 jobs:
   build-most:
@@ -89,14 +88,22 @@ jobs:
   sign-windows:
     name: Build and Sign Windows binaries
     runs-on: [ self-hosted, windows-signer ]
-    env:
-      AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY }}
     steps:
+      - name: Load 1password secret(s)
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
+          AmplitudeAPIKey: "op://push-secrets/AmplitudeAPIKey/credential"
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Build and sign windows amd64 + arm64 binaries and amd64 installer
         shell: bash
+        env:
+          DDEV_WINDOWS_SIGN: ${{ vars.DDEV_WINDOWS_SIGN }}
         run: |
           if [ "${DDEV_WINDOWS_SIGN}" != "true" ]; then echo "Warning: DDEV_WINDOWS_SIGN is not true"; fi
           make windows_install
@@ -131,6 +138,16 @@ jobs:
     runs-on: macos-latest
     needs: build-most
     steps:
+      - name: Load 1password secret(s)
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
+          AmplitudeAPIKey: "op://push-secrets/AmplitudeAPIKey/credential"
+          DDEV_MACOS_APP_PASSWORD: "op://push-secrets/DDEV_MACOS_APP_PASSWORD/credential"
+          DDEV_MACOS_SIGNING_PASSWORD: "op://push-secrets/DDEV_MACOS_SIGNING_PASSWORD/credential"
+
       - name: "setup macOS"
         run: |
           brew install coreutils gnu-getopt jq
@@ -155,8 +172,6 @@ jobs:
 
       - name: Sign and notarize binaries (amd64 and arm64)
         env:
-          DDEV_MACOS_SIGNING_PASSWORD: ${{ secrets.DDEV_MACOS_SIGNING_PASSWORD }}
-          DDEV_MACOS_APP_PASSWORD: ${{ secrets.DDEV_MACOS_APP_PASSWORD }}
           TEAM_ID: "9HQ298V2BW"
         run: |
           set -o errexit -o pipefail
@@ -178,9 +193,6 @@ jobs:
     name: Upload artifacts
     runs-on: ubuntu-22.04
     needs: [build-most, sign-windows, notarize-macos]
-    env:
-      DDEV_GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
-      CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
 
     steps:
       - name: Setup tmate session
@@ -188,6 +200,22 @@ jobs:
         with:
           limit-access-to-actor: true
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+
+      - name: Load 1password secret(s)
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
+          AmplitudeAPIKey: "op://push-secrets/AmplitudeAPIKey/credential"
+          AUR_SSH_PRIVATE_KEY: "op://test-secrets/AUR_SSH_PRIVATE_KEY/private key?ssh-format=openssh"
+          CHOCOLATEY_API_KEY: "op://push-secrets/CHOCOLATEY_API_KEY/credential"
+          DDEV_GITHUB_TOKEN: "op://push-secrets/DDEV_GITHUB_TOKEN/credential"
+          DDEV_MACOS_APP_PASSWORD: "op://push-secrets/DDEV_MACOS_APP_PASSWORD/credential"
+          DDEV_MACOS_SIGNING_PASSWORD: "op://push-secrets/DDEV_MACOS_SIGNING_PASSWORD/credential"
+          DOCKERHUB_TOKEN: "op://push-secrets/DOCKERHUB_TOKEN/credential"
+          FURY_TOKEN: "op://push-secrets/FURY_TOKEN/credential"
+          GORELEASER_KEY: "op://push-secrets/GORELEASER_KEY/credential"
 
       - uses: actions/checkout@v4
         with:
@@ -245,13 +273,6 @@ jobs:
         env:
           CGO_ENABLED: 0
           DOCKER_ORG: ddev
-          GITHUB_TOKEN: ${{ secrets.DDEV_GITHUB_TOKEN }}
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-          FURY_ACCOUNT: ${{ secrets.FURY_ACCOUNT }}
-          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
-          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          AUR_STABLE_GIT_URL: ${{ secrets.AUR_STABLE_GIT_URL }}
-          AUR_EDGE_GIT_URL: ${{ secrets.AUR_EDGE_GIT_URL }}
 
       # Do artifacts for upload to workflow URL
       - name: Generate artifacts
@@ -296,8 +317,9 @@ jobs:
       - name: Show github.ref
         run: echo ${{ github.ref }}
 
+      # TODO: This can be done by goreleaser these days
       - name: Chocolatey windows release
-        if: env.CHOCOLATEY_API_KEY != '' && startsWith( github.ref, 'refs/tags/v1')
+        if: github.repository == 'ddev/ddev' && startsWith(github.ref, 'refs/tags/v1')
         run: |
           pushd .gotmp/bin/windows_amd64/chocolatey
           docker run --rm -v $PWD:/tmp/chocolatey -w /tmp/chocolatey linuturk/mono-choco push -s https://push.chocolatey.org/ --api-key "${CHOCOLATEY_API_KEY}"

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -24,6 +24,7 @@ on:
 #  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
+  AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY }}
   BUILDKIT_PROGRESS: plain
   DOCKER_CLI_EXPERIMENTAL: enabled
   DDEV_DEBUG: true
@@ -36,8 +37,6 @@ jobs:
   build-most:
     name: Build DDEV executables except Windows
     runs-on: ubuntu-22.04
-    env:
-      AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY }}
     steps:
 
       - uses: actions/checkout@v4
@@ -89,13 +88,7 @@ jobs:
   sign-windows:
     name: Build and Sign Windows binaries
     runs-on: [ self-hosted, windows-signer ]
-    env:
-      AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY }}
     steps:
-      - name: Load 1password secret(s)
-        uses: 1password/load-secrets-action@v2
-        with:
-          export-env: true
 
       - uses: actions/checkout@v4
         with:
@@ -137,8 +130,6 @@ jobs:
     name: Sign and Notarize ddev on macOS
     runs-on: macos-latest
     needs: build-most
-    env:
-      AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY }}
     steps:
       - name: Load 1password secret(s)
         uses: 1password/load-secrets-action@v2
@@ -194,7 +185,6 @@ jobs:
     name: Upload artifacts
     runs-on: ubuntu-22.04
     needs: [build-most, sign-windows, notarize-macos]
-
     steps:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
@@ -208,7 +198,6 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
-          AmplitudeAPIKey: "op://push-secrets/AmplitudeAPIKey/credential"
           AUR_SSH_PRIVATE_KEY: "op://test-secrets/AUR_SSH_PRIVATE_KEY/private key?ssh-format=openssh"
           CHOCOLATEY_API_KEY: "op://push-secrets/CHOCOLATEY_API_KEY/credential"
           DDEV_GITHUB_TOKEN: "op://push-secrets/DDEV_GITHUB_TOKEN/credential"

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -36,14 +36,9 @@ jobs:
   build-most:
     name: Build DDEV executables except Windows
     runs-on: ubuntu-22.04
+    env:
+      AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY }}
     steps:
-      - name: Load 1password secret(s)
-        uses: 1password/load-secrets-action@v2
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
-          AmplitudeAPIKey: "op://push-secrets/AmplitudeAPIKey/credential"
 
       - uses: actions/checkout@v4
         with:
@@ -94,14 +89,13 @@ jobs:
   sign-windows:
     name: Build and Sign Windows binaries
     runs-on: [ self-hosted, windows-signer ]
+    env:
+      AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY }}
     steps:
       - name: Load 1password secret(s)
         uses: 1password/load-secrets-action@v2
         with:
           export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
-          AmplitudeAPIKey: "op://push-secrets/AmplitudeAPIKey/credential"
 
       - uses: actions/checkout@v4
         with:
@@ -143,6 +137,8 @@ jobs:
     name: Sign and Notarize ddev on macOS
     runs-on: macos-latest
     needs: build-most
+    env:
+      AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY }}
     steps:
       - name: Load 1password secret(s)
         uses: 1password/load-secrets-action@v2
@@ -150,7 +146,6 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
-          AmplitudeAPIKey: "op://push-secrets/AmplitudeAPIKey/credential"
           DDEV_MACOS_APP_PASSWORD: "op://push-secrets/DDEV_MACOS_APP_PASSWORD/credential"
           DDEV_MACOS_SIGNING_PASSWORD: "op://push-secrets/DDEV_MACOS_SIGNING_PASSWORD/credential"
 

--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -34,6 +34,15 @@ jobs:
       fail-fast: false
 
     steps:
+    - name: Load 1password secret(s)
+      uses: 1password/load-secrets-action@v2
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
+      with:
+        export-env: true
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
+        DOCKERHUB_TOKEN: "op://push-secrets/DOCKERHUB_TOKEN/credential"
+
     - uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -42,8 +51,8 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_TOKEN }}
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
       with:

--- a/.github/workflows/push-tagged-image.yml
+++ b/.github/workflows/push-tagged-image.yml
@@ -42,6 +42,15 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+    - name: Load 1password secret(s)
+      uses: 1password/load-secrets-action@v2
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
+      with:
+        export-env: true
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
+        DOCKERHUB_TOKEN: "op://push-secrets/DOCKERHUB_TOKEN/credential"
+
     - uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -50,8 +59,8 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_TOKEN }}
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,6 +140,7 @@ jobs:
           DDEV_PLATFORM_API_TOKEN: "op://test-secrets/DDEV_PLATFORM_API_TOKEN/credential"
           DDEV_UPSUN_API_TOKEN: "op://test-secrets/DDEV_UPSUN_API_TOKEN/credential"
         if: ${{ matrix.pull-push-test-platforms && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner) }}
+
       - name: Override environment variables for plain nginx
         run: |
           echo "DDEV_SKIP_NODEJS_TEST=false" >> $GITHUB_ENV

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -146,7 +146,7 @@ checksum:
 release:
   prerelease: auto
   github:
-    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
+    owner: "{{ .Env.REPOSITORY_OWNER }}"
     name: ddev
 
 brews:
@@ -154,7 +154,7 @@ brews:
   ids:
   - ddev
   repository:
-    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
+    owner: "{{ .Env.REPOSITORY_OWNER }}"
     name: homebrew-ddev
   description: DDEV
   directory: Formula
@@ -192,7 +192,7 @@ brews:
   ids:
   - ddev
   repository:
-    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
+    owner: "{{ .Env.REPOSITORY_OWNER }}"
     name: homebrew-ddev-edge
   description: DDEV
   directory: Formula

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ chocolatey: $(GOTMP)/bin/windows_amd64/ddev_windows_installer.exe
 	rm -rf $(GOTMP)/bin/windows_amd64/chocolatey && cp -r winpkg/chocolatey $(GOTMP)/bin/windows_amd64/chocolatey
 	perl -pi -e 's/REPLACE_DDEV_VERSION/$(NO_V_VERSION)/g' $(GOTMP)/bin/windows_amd64/chocolatey/*.nuspec
 	perl -pi -e 's/REPLACE_DDEV_VERSION/$(VERSION)/g' $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1
-	perl -pi -e 's/REPLACE_GITHUB_ORG/$(GITHUB_REPOSITORY_OWNER)/g' $(GOTMP)/bin/windows_amd64/chocolatey/*.nuspec $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1 #GITHUB_ORG is for testing, for example when the binaries are on rfay acct
+	perl -pi -e 's/REPLACE_GITHUB_ORG/$(REPOSITORY_OWNER)/g' $(GOTMP)/bin/windows_amd64/chocolatey/*.nuspec $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1 #GITHUB_ORG is for testing, for example when the binaries are on rfay acct
 	perl -pi -e "s/REPLACE_INSTALLER_CHECKSUM/$$(cat $(GOTMP)/bin/windows_amd64/ddev_windows_installer.exe.sha256.txt | awk '{ print $$1; }')/g" $(GOTMP)/bin/windows_amd64/chocolatey/tools/*
 	if [[ "$(NO_V_VERSION)" =~ -g[0-9a-f]+ ]]; then \
 		echo "Skipping chocolatey build on interim version"; \

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -29,8 +29,8 @@ These are normally configured in the repository environment variables.
 * `AUR_STABLE_GIT_URL`: The Git URL for AUR stable (normally `ddev-bin`), for example `ssh://aur@aur.archlinux.org/ddev-bin.git`.
 * `DOCKERHUB_USERNAME`: Username for pushing to `hub.docker.com` or updating image descriptions.
 * `FURY_ACCOUNT`: [Gemfury](https://gemfury.com) account that receives package pushes.
-* `HOMEBREW_EDGE_REPOSITORY`: Like `ddev/homebrew-ddev-edge` but might be another repo like be `ddev-test/homebrew-ddev-edge`.
-* `HOMEBREW_STABLE_REPOSITORY`: Like `ddev/homebrew-ddev` but might be another repo like `ddev-test/homebrew-ddev`.
+* `HOMEBREW_EDGE_REPOSITORY`: Like `ddev/homebrew-ddev-edge` but might be another repository like be `ddev-test/homebrew-ddev-edge`.
+* `HOMEBREW_STABLE_REPOSITORY`: Like `ddev/homebrew-ddev` but might be another repository like `ddev-test/homebrew-ddev`.
 
 ### GitHub Actions Secrets Required
 

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -32,13 +32,16 @@ These are normally configured in the repository environment variables.
 * `HOMEBREW_EDGE_REPOSITORY`: Like `ddev/homebrew-ddev-edge` but might be another repo like be `ddev-test/homebrew-ddev-edge`.
 * `HOMEBREW_STABLE_REPOSITORY`: Like `ddev/homebrew-ddev` but might be another repo like `ddev-test/homebrew-ddev`.
 
-### Actual secrets required
+### GitHub Actions Secrets Required
+
+* `AMPLITUDE_API_KEY`: Key that enables Amplitude reporting. Environment variable for Make is `AmplitudeAPIKey`. Unfortunately, the `1password/load-secrets-action` does not work with Windows (see [issue](https://github.com/1Password/load-secrets-action/issues/46)).
+* `AMPLITUDE_API_KEY_DEV`: Key that enables Amplitude reporting for development versions e.g. a PR build. Environment variable for Make is `AmplitudeAPIKey`.
+
+### 1Password secrets required
 
 <!-- markdown-link-check-disable-next-line -->
 The following “Repository secret” environment variables must be configured in 1Password:
 
-* `AMPLITUDE_API_KEY`: Key that enables Amplitude reporting. Environment variable for Make is `AmplitudeAPIKey`.
-* `AMPLITUDE_API_KEY_DEV`: Key that enables Amplitude reporting for development versions e.g. a PR build. Environment variable for Make is `AmplitudeAPIKey`.
 * `AUR_SSH_PRIVATE_KEY`: Private SSH key for the `ddev-releaser` user. This must be processed into a single line, for example, `perl -p -e 's/\n/<SPLIT>/' ~/.ssh/id_rsa_ddev_releaser| pbcopy`.
 * `CHOCOLATEY_API_KEY`: API key for Chocolatey.
 * `DDEV_GITHUB_TOKEN`: GitHub personal token (`repo` scope, classic PAT) that gives access to create releases and push to the Homebrew repositories.

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -21,29 +21,33 @@ search:
 * Discord
 * Docker
 
+### Environment variables required
+
+These are normally configured in the repository environment variables.
+
+* `AUR_EDGE_GIT_URL`: The Git URL for AUR edge (normally `ddev-edge-bin`), for example `ssh://aur@aur.archlinux.org/ddev-edge-bin.git`.
+* `AUR_STABLE_GIT_URL`: The Git URL for AUR stable (normally `ddev-bin`), for example `ssh://aur@aur.archlinux.org/ddev-bin.git`.
+* `DOCKERHUB_USERNAME`: Username for pushing to `hub.docker.com` or updating image descriptions.
+* `FURY_ACCOUNT`: [Gemfury](https://gemfury.com) account that receives package pushes.
+* `HOMEBREW_EDGE_REPOSITORY`: Like `ddev/homebrew-ddev-edge` but might be another repo like be `ddev-test/homebrew-ddev-edge`.
+* `HOMEBREW_STABLE_REPOSITORY`: Like `ddev/homebrew-ddev` but might be another repo like `ddev-test/homebrew-ddev`.
+
 ### Actual secrets required
 
 <!-- markdown-link-check-disable-next-line -->
-The following “Repository secret” environment variables must be added to <https://github.com/ddev/ddev/settings/secrets/actions>:
+The following “Repository secret” environment variables must be configured in 1Password:
 
 * `AMPLITUDE_API_KEY`: Key that enables Amplitude reporting. Environment variable for Make is `AmplitudeAPIKey`.
 * `AMPLITUDE_API_KEY_DEV`: Key that enables Amplitude reporting for development versions e.g. a PR build. Environment variable for Make is `AmplitudeAPIKey`.
-* `AUR_EDGE_GIT_URL`: The Git URL for AUR edge (normally `ddev-edge-bin`), for example `ssh://aur@aur.archlinux.org/ddev-edge-bin.git`.
-* `AUR_STABLE_GIT_URL`: The Git URL for AUR stable (normally `ddev-bin`), for example `ssh://aur@aur.archlinux.org/ddev-bin.git`.
 * `AUR_SSH_PRIVATE_KEY`: Private SSH key for the `ddev-releaser` user. This must be processed into a single line, for example, `perl -p -e 's/\n/<SPLIT>/' ~/.ssh/id_rsa_ddev_releaser| pbcopy`.
 * `CHOCOLATEY_API_KEY`: API key for Chocolatey.
 * `DDEV_GITHUB_TOKEN`: GitHub personal token (`repo` scope, classic PAT) that gives access to create releases and push to the Homebrew repositories.
 * `DDEV_MACOS_APP_PASSWORD`: Password used for notarization, see [signing_tools](https://github.com/ddev/signing_tools).
 * `DDEV_MACOS_SIGNING_PASSWORD`: Password for the macOS signing key, see [signing_tools](https://github.com/ddev/signing_tools).
-* `DDEV_MAIN_REPO_ORGNAME`: The organization to be used for testing, normally `ddev` but it may be `ddev-test` for the test organization.
 * `DDEV_WINDOWS_SIGNING_PASSWORD`: Windows signing password.
-* `DOCKERHUB_USERNAME`: Username for pushing to `hub.docker.com` or updating image descriptions.
 * `DOCKERHUB_TOKEN`: Token for pushing to `hub.docker.com`. or updating image descriptions.
-* `FURY_ACCOUNT`: [Gemfury](https://gemfury.com) account that receives package pushes.
 * `FURY_TOKEN`: Push token assigned to the above Gemfury account.
 * `GORELEASER_KEY`: License key for GoReleaser Pro.
-* `HOMEBREW_EDGE_REPOSITORY`: Like `ddev/homebrew-ddev-edge` but may be `ddev-test/homebrew-ddev-edge`.
-* `HOMEBREW_STABLE_REPOSITORY`: Like `ddev/homebrew-ddev-edge` but may be `ddev/homebrew-ddev-edge`.
 
 ## Creating a Release
 
@@ -219,7 +223,7 @@ Prerequisites:
 * `export GORELEASER_KEY=<key>`
 
 ```bash
-export GITHUB_REPOSITORY_OWNER=ddev-test
+export REPOSITORY_OWNER=ddev-test
 git tag <tagname> # Try to include context like PR number, for example v1.22.8-PR5824
 make windows_amd64 windows_arm64 darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 completions
 goreleaser release --prepare --nightly --clean


### PR DESCRIPTION

## The Issue

It's really difficult to manage our secrets in github actions secrets

## How This PR Solves The Issue

Manage most secrets in our team 1password account, and let Github Actions pull from that.

## Manual Testing Instructions

Review build from here and where it was tried out for
* [release](https://github.com/ddev-test/ddev/actions/runs/10856961949)
* [commit](https://github.com/ddev-test/ddev/actions/runs/10856949449)
* [push tagged image](https://github.com/ddev-test/ddev/actions/runs/10853648361)
* [push tagged dbimage](https://github.com/ddev-test/ddev/actions/runs/10853653152)

Most of the drama and learning was on 
* https://github.com/ddev-test/ddev/pull/5

And followup commits that show here and in https://github.com/ddev-test/ddev/commits/master/