### PR TITLE
build: Revert "build: bump docker-compose to 2.29.3 (#6538)"

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -42,7 +42,7 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.17.2"
 
-const RequiredDockerComposeVersionDefault = "v2.29.3"
+const RequiredDockerComposeVersionDefault = "v2.29.1"
 
 // Drupal11RequiredSqlite3Version for ddev-webserver
 const Drupal11RequiredSqlite3Version = "3.45.1"


### PR DESCRIPTION


## The Issue

This reverts commit b2e3801a8fed23e2cd445165a2985ebceb7a3fe8.

Moving from docker-compose 2.29.1  -> 2.29.3 has fundamental breakage on WSL2 Docker Desktop, see https://buildkite.com/ddev/wsl2-docker-desktop/builds/5626#0191fbdd-7474-4c79-a1a6-d4ecfa0b6691/291-501 - 

> Error response from daemon: path /var/lib/buildkite-agent/tmp/ddevtest/TestGetLocalHTTPResponse2320491494/.ddev is mounted on / but it is not a shared mount.'
 
## How This PR Solves The Issue

Revert to previous previous docker-compose, v2.29.1

In future when testing docker-compose new versions, test on ddev/ddev, not a forked PR, so that all the permutations get run

I did test docker-compose v2.29.4 and it didn't seem to solve this.

We'll probably want to file an issue with github.com/docker/compose