### PR TITLE
feat: show warnings from stderr, auto rebuild for web image w/o cache on warnings, fixes #6451, for #5073

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
@@ -18,7 +18,7 @@ MARIADB_VERSION=${DDEV_DATABASE#*:}
 if [ "${MARIADB_VERSION}" = "11.4" ]; then
   # Configure the correct repository for mariadb
   set -x
-  timeout 30 mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --skip-key-import || exit 2
+  log-stderr.sh --timeout 30 mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --skip-key-import || exit 2
   rm -f /etc/apt/sources.list.d/mariadb.list.old_*
   # --skip-key-import flag doesn't download the existing key again and omits "apt-get -qq update",
   # so we can run "apt-get -qq update" manually only for mariadb repo to make it faster

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
@@ -23,7 +23,7 @@ TARBALL_URL=https://github.com/ddev/mysql-client-build/releases/download/${TARBA
 
 # Install the related mysql client if available
 set -x
-cd /tmp && timeout 30 curl -L -o /tmp/mysql.tgz --fail -s ${TARBALL_URL}
+cd /tmp && log-stderr.sh --timeout 30 curl -L -o /tmp/mysql.tgz --fail -s ${TARBALL_URL}
 tar -zxf /tmp/mysql.tgz -C /usr/local/bin && rm -f /tmp/mysql.tgz
 
 # Remove any existing mariadb installs

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1196,7 +1196,7 @@ RUN (apt-get -qq update || true) && DEBIAN_FRONTEND=noninteractive apt-get -qq i
 		// selecting a branch instead of a major version only.
 		contents = contents + fmt.Sprintf(`
 ### DDEV-injected composer update
-RUN export XDEBUG_MODE=off; composer self-update --stable || log-stderr.sh composer self-update --stable || true; composer self-update %s || log-stderr.sh composer self-update %s || true
+RUN export XDEBUG_MODE=off; composer self-update --stable || composer self-update --stable || true; composer self-update %s || log-stderr.sh composer self-update %s || true
 `, composerSelfUpdateArg, composerSelfUpdateArg)
 
 		// For Postgres, install the relevant PostgreSQL clients

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1677,6 +1677,14 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		return err
 	}
 
+	if logStderr != "" {
+		util.Warning(`Some components of the project %s were not installed properly.
+The project is running anyway, but see the warnings above for details.
+If offline, run 'ddev restart' once you are back online.
+If online, check your connection and run 'ddev restart' later.
+If this seems to be a config issue, update it accordingly.`, app.Name)
+	}
+
 	return nil
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1448,6 +1448,24 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	if globalconfig.DdevVerbose {
 		util.Debug("docker-compose build output:\n%s\n\n", out)
 	}
+
+	_, logStderrOutput, err := dockerutil.RunSimpleContainer(ddevImages.GetWebImage()+"-"+app.Name+"-built", "log-stderr-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "log-stderr.sh --show 2>/dev/null || true"}, []string{}, []string{}, nil, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil, nil)
+	// If the web image is dirty, try to rebuild it immediately
+	if err == nil && strings.TrimSpace(logStderrOutput) != "" && globalconfig.IsInternetActive() {
+		util.Debug("Executing docker-compose -f %s build web --progress=%s --no-cache", app.DockerComposeFullRenderedYAMLPath(), progress)
+		out, stderr, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
+			ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
+			Action:       []string{"--progress=" + progress, "build", "web", "--no-cache"},
+			Progress:     true,
+		})
+		if err != nil {
+			return fmt.Errorf("docker-compose build web --no-cache failed: %v, output='%s', stderr='%s'", err, out, stderr)
+		}
+		if globalconfig.DdevVerbose {
+			util.Debug("docker-compose build web --no-cache output:\n%s\n\n", out)
+		}
+	}
+
 	buildDuration := util.FormatDuration(buildDurationStart())
 	util.Success("Project images built in %s.", buildDuration)
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1469,6 +1469,15 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	buildDuration := util.FormatDuration(buildDurationStart())
 	util.Success("Project images built in %s.", buildDuration)
 
+	util.Debug("Removing dangling images for the project %s", app.GetComposeProjectName())
+	danglingImages, err := dockerutil.FindImagesByLabels(map[string]string{"com.ddev.buildhost": "", "com.docker.compose.project": app.GetComposeProjectName()}, true)
+	if err != nil {
+		return fmt.Errorf("unable to get dangling images for the project %s: %v", app.GetComposeProjectName(), err)
+	}
+	for _, danglingImage := range danglingImages {
+		_ = dockerutil.RemoveImage(danglingImage.ID)
+	}
+
 	util.Debug("Executing docker-compose -f %s up -d", app.DockerComposeFullRenderedYAMLPath())
 	_, _, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
 		ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240930_bash_completion" // Note that this can be overridden by make
+var WebTag = "20240916_stasadev_log_stderr" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #6451
- #5073

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Adds warnings for:
- mariadb-client
- mysql-client
- postgresql-client
- sqlite3 (Drupal 11)
- composer

Automatically runs `docker-compose build web --no-cache` on warnings if there is Internet available.

## Manual Testing Instructions

1. Disable internet.
2. Run `ddev debug refresh`, it should show warnings.
3. Enable internet.
4. Run `ddev restart`, it should rebuild web container without cache.
    If you run `ddev start` instead, it will show a warning, which will disappear on one more start or restart:
    ```
	Unable to delete sha256:a9ee9b4b2665f78697259e5b6a703ac6d24afb1dd8452c6b8d02ae48167fc0c5: Error response from daemon: conflict: unable to delete a9ee9b4b2665 (cannot be forced) - image is being used by running container cda3b436ea7d
	```
5. Run `ddev restart` again, it should not trigger rebuild without warnings.
6. Repeat these steps for different warnings from this PR.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
