### PR TITLE
build: bump docker-compose to 2.29.5

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -42,7 +42,7 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.17.2"
 
-const RequiredDockerComposeVersionDefault = "v2.29.1"
+const RequiredDockerComposeVersionDefault = "v2.29.5"
 
 // Drupal11RequiredSqlite3Version for ddev-webserver
 const Drupal11RequiredSqlite3Version = "3.45.1"


### PR DESCRIPTION
## The Issue

- https://github.com/docker/compose/issues/12129

New docker-compose release https://github.com/docker/compose/releases/tag/v2.29.5 seems to have a fix.

## How This PR Solves The Issue

Try it out.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
