### PR TITLE
build: experimentally change default innodb_page_size to 32768 for Craft CMS monster rows with too many columns

### DIFF
--- a/containers/ddev-dbserver/files/etc/my.cnf
+++ b/containers/ddev-dbserver/files/etc/my.cnf
@@ -80,6 +80,7 @@ innodb-buffer-pool-size        = 1024M
 ;innodb_file_format=barracuda
 innodb_file_per_table=true
 innodb_doublewrite=0
+innodb_page_size=32768
 
 # LOGGING #
 log-error                      = /var/log/mysqld.err

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "20240904_rocketeerbkw_fix_lagoon_tests" // Note that this can be o
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.23.4"
+var BaseDBTag = "20240917_innodb_page_size"
 
 const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.23.4"
 const TraefikRouterImage = "ddev/ddev-traefik-router:v1.23.4"


### PR DESCRIPTION

## The Issue

Strictly experimental:

* https://github.com/orgs/ddev/discussions/6543

On Craft CMS, it huge field/row/column sizes may require increasing the innodb_page_size

## How This PR Solves The Issue

Experiment with this. Note that it will require some additional work as mysql:5.5 and 5.6 don't seems to support this.

## Manual Testing Instructions

Try using with mysql 8.0 on a new project. `ddev mysql` and `SHOW GLOBAL VARIABLES LIKE 'innodb_page_size';`

Try starting an existing project, should stay at default



## Automated Testing Overview

mysql 5.5/5.6 will fail

## Release/Deployment Notes

New projects created this way (or deleted and recreated) will have the new value. It shouldn't affect existing projects.