### PR TITLE
docs: add Magento tools to docs

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -95,6 +95,7 @@ Magento's
 Mailpit
 Mailpit's
 Mailgun
+Magerun
 Manage
 MariaDB
 Matthias
@@ -461,6 +462,8 @@ mysite
 mysql
 mysqldump
 mysqlworkbench
+n98-magerun
+n98-magerun2
 namlen
 natively
 netstat

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -15,6 +15,8 @@ Hundreds of useful developer tools are included inside the containers and can be
 * [Drush](http://www.drush.org) - Command-line shell and Unix scripting interface for Drupal.
 * [PHIVE](https://phar.io/) - Command-line tool for “PHAR Installation and Verification Environment”.
 * [WP-CLI](http://wp-cli.org/) - Command-line tools for managing WordPress installations, available both as `wp` and as `wp-cli`.
+* [n98-magerun](https://github.com/netz98/n98-magerun) - Command-line tool for Magento 1 / OpenMage installations, available as `magerun`.
+* [n98-magerun2](https://github.com/netz98/n98-magerun2) - Command-line tool for Magento Open Source / Mage-OS / Adobe Commerce installations, available as `magerun2`.
 * `npm`, `nvm`, and `yarn` (these also have `ddev` shortcuts like [`ddev npm`](../usage/commands.md#npm), [`ddev nvm`](../usage/commands.md#nvm), [`ddev yarn`](../usage/commands.md#yarn)).
 * `node`
 * `sqlite3`


### PR DESCRIPTION
Add n98-magerun and n98-magerun2 to list of pre-installed tools in web container.
Only a small doc addition.