### PR TITLE
fix: ddev debug test - show customizations in .ddev/nginx if they exist [skip ci]

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -50,6 +50,11 @@ ddev debug configyaml | grep -v web_environment
 header "existing project customizations"
 grep -r -L "#ddev-generated" .ddev/docker-compose.*.yaml .ddev/php .ddev/mutagen .ddev/apache .ddev/nginx* .ddev/*-build .ddev/mysql .ddev/postgres 2>/dev/null
 
+if ls .ddev/nginx >/dev/null 2>&1 ; then
+  echo "Customizations in .ddev/nginx:"
+  ls -l .ddev/nginx
+fi
+
 header "installed DDEV add-ons"
 
 ddev add-on list --installed


### PR DESCRIPTION

## The Issue

A user has customizations in .ddev/nginx/custom.conf that broke the site, but it didn't show up in `ddev debug test`

## How This PR Solves The Issue

Make it show up

## Manual Testing Instructions

Do `ddev debug test` with and without a .ddev/nginx/custom.conf file


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
