### PR TITLE
test: Remove brew setup for linux from buildkite testbot_maintenance.sh [skip ci]

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -18,9 +18,6 @@ if ! command -v ngrok >/dev/null; then
     windows)
         (yes | choco install -y ngrok) || true
         ;;
-    linux)
-        curl -sSL --fail -o /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip && sudo unzip -o -d /usr/local/bin /tmp/ngrok.zip
-        ;;
     esac
 fi
 
@@ -39,7 +36,9 @@ darwin)
 windows)
     (yes | choco upgrade -y golang nodejs markdownlint-cli mkcert mkdocs postgresql) || true
     ;;
-# linux no longer needs homebrew
+linux)
+    sudo apt update && sudo apt upgrade -y
+    # linux no longer needs homebrew
 esac
 
 echo "Deleting unused images with ddev delete images"
@@ -48,11 +47,6 @@ ddev delete images -y || true
 # Remove any -built images, as we want to make sure tests do the building.
 docker rmi -f $(docker images --filter "dangling=true" -q --no-trunc) >/dev/null 2>&1 || true
 docker rmi -f $(docker images | awk '/ddev.*-built/ {print $3}' ) >/dev/null 2>&1 || true
-
-# Make sure there aren't any dangling NFS volumes
-if docker volume ls | grep '[Tt]est.*_nfsmount'; then
-  docker volume rm -f $(docker volume ls | awk '/[Tt]est.*_nfsmount/ { print $2; }') || true
-fi
 
 # Clean the docker build cache
 docker buildx prune -f -a || true

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -39,17 +39,7 @@ darwin)
 windows)
     (yes | choco upgrade -y golang nodejs markdownlint-cli mkcert mkdocs postgresql) || true
     ;;
-# linux is currently WSL2 only
-linux)
-    # homebrew is only on amd64
-    if [ "$(arch)" = "x86_64" ]; then
-      for item in libpq mkdocs; do
-        brew upgrade $item || brew install $item || true
-      done
-      brew link --force libpq
-    fi
-    ;;
-
+# linux no longer needs homebrew
 esac
 
 echo "Deleting unused images with ddev delete images"

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -53,12 +53,12 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 8. `curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg`
 9. `echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list`
 10. `sudo apt-get update && sudo apt-get install -y buildkite-agent`
-11. `buildkite-agent` should have home directory `/var/lib/buildkite-agent`: `sudo usermod -d /var/lib/buildkite-agent buildkite-agent`
+11. Change `buildkite-agent` home directory to `/var/lib/buildkite-agent`: `sudo usermod -d /var/lib/buildkite-agent buildkite-agent`
 12. Configure buildkite agent in /etc/buildkite-agent:
      * `tags="os=wsl2,architecture=amd64,dockertype=dockerforwindows"`
      * token="xxx"
 13. `sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent`
-14. In PowerShell: `wsl.exe --update`. Watch for the escalation to complete, it does require escalation.
+14. In PowerShell: `wsl.exe --update`. Watch for the escalation to complete, it may require escalation.
 15. Open WSL2 and check out [ddev/ddev](https://github.com/ddev/ddev).
 16. Install Homebrew: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
 17. Configure brew in PATH with:

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -232,7 +232,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         * If you have WSL2 but not an Ubuntu distro, install one with `wsl --install Ubuntu`.  
           If that doesn't work for you, see [manual installation](https://docs.microsoft.com/en-us/windows/wsl/install-manual) and [troubleshooting](https://docs.microsoft.com/en-us/windows/wsl/troubleshooting#installation-issues).
 
-        If you prefer to use another Ubuntu distro, install it and set it as default. For example, `wsl --set-default Ubuntu-22.04`.
+        If you prefer to use another Ubuntu distro, install it and set it as default. For example, `wsl --set-default Ubuntu-24.04`.
 
     5. In *Windows Update Settings* → *Advanced Options* enable *Receive updates for other Microsoft products*. You may want to occasionally run `wsl.exe --update` as well.
 


### PR DESCRIPTION

## The Issue

Buildkite WSL2 testbot_maintenance.sh: We no longer need or use homebrew here

## How This PR Solves The Issue

Remove the check and update

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
