### PR TITLE
test: buildkite testbot_maintenance.sh apt upgrade hung on linux, remove it

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -37,7 +37,7 @@ windows)
     (yes | choco upgrade -y golang nodejs markdownlint-cli mkcert mkdocs postgresql) || true
     ;;
 linux)
-    sudo apt update && sudo apt upgrade -y
+    sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests
     # linux no longer needs homebrew
 esac
 

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -36,9 +36,6 @@ darwin)
 windows)
     (yes | choco upgrade -y golang nodejs markdownlint-cli mkcert mkdocs postgresql) || true
     ;;
-linux)
-    sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests
-    # linux no longer needs homebrew
 esac
 
 echo "Deleting unused images with ddev delete images"


### PR DESCRIPTION
## The Issue

In 
* https://github.com/ddev/ddev/pull/6558 

~~I added an apt update/apt upgrade for Linux machines (WSL2) that actually hung, apparently waiting for user input.~~

~~Fix this with DEBIAN_FRONTEND=noninteractive and use `apt-get upgrade`~~

However, I tried that, and the buildkite-agent upgrade still hung and needed manual intervention (`sudo dpkg --configure -a`) so not trying that here any more. They'll get manually updated.