### PR TITLE
feat: pass X-Accel-* headers to client, fixes #6563

### DIFF
--- a/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
@@ -55,6 +55,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
@@ -60,6 +60,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Prevent clients from accessing hidden files (starting with a dot)

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal.conf
@@ -54,6 +54,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
@@ -54,6 +54,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
@@ -65,6 +65,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
@@ -58,6 +58,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
@@ -53,6 +53,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
@@ -53,6 +53,12 @@ server {
         # fastcgi_read_timeout should match max_execution_time in php.ini
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
         fastcgi_param HTTPS $fcgi_https;
     }
 

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
@@ -49,6 +49,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
@@ -58,6 +58,12 @@ server {
         fastcgi_param HTTPS $fcgi_https;
         fastcgi_param MAGE_RUN_CODE $mage_run_code;
         fastcgi_param MAGE_RUN_TYPE $mage_run_type;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
@@ -49,6 +49,12 @@ server {
         fastcgi_param HTTPS $fcgi_https;
         fastcgi_param MAGE_RUN_CODE $mage_run_code;
         fastcgi_param MAGE_RUN_TYPE $mage_run_type;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
@@ -50,6 +50,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Prevent clients from accessing hidden files (starting with a dot)

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
@@ -66,6 +66,12 @@ server {
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
         http2_push_preload on;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -83,6 +83,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
@@ -76,6 +76,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/ddevapp/webserver_config_assets/nginx_second_docroot_example-site-php.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx_second_docroot_example-site-php.conf
@@ -53,6 +53,12 @@ server {
         fastcgi_read_timeout 10m;
         fastcgi_param SERVER_NAME $host;
         fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
     }
 
     # Expire rules for static content

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240927_andriokha_nginx_headers" // Note that this can be overridden by make
+var WebTag = "20241002_deviantintegral_vim_tiny" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241002_deviantintegral_vim_tiny" // Note that this can be overridden by make
+var WebTag = "20240927_andriokha_nginx_headers" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #6563

By default, nginx [does not pass the header field `X-Accel-...` from the response of a FastCGI server to a client](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_hide_header). It can be useful however during development for manual or automated testing of nginx-specific behavior. For example [Drupal's BigPipe test checks the value of the 'X-Accel-Buffering' header](https://git.drupalcode.org/project/drupal/-/blob/79a4904009909e83b94b6cbbfcc55600def67233/core/modules/big_pipe/tests/src/Functional/BigPipeTest.php#L346).

## How This PR Solves The Issue

It uses `fastcgi_pass_header` to forward the headers to the client.

## Manual Testing Instructions

Visit a page that sets one of the headers and verify you can see it in your client. [This gist tests all the headers except `X-Accel-Redirect`](https://gist.github.com/andriokha/38d92be900a3315861cc3fd8b8037ebd) (I don't know nginx well enough to coax it into giving a reply with that set.)

## Automated Testing Overview

No tests introduced, not sure if I should, don't knew DDEV well (:

## Release/Deployment Notes

Any `X-Accel-*` headers set by a PHP application will now be passed onto the client.
