### PR TITLE
feat: Don't force Drush's Xdebug environment variable to 1

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -198,7 +198,6 @@ services:
     {{ if not .DisableSettingsManagement }}
     - DRUSH_OPTIONS_URI=$DDEV_PRIMARY_URL
     {{ end }}
-    - DRUSH_ALLOW_XDEBUG=1
     - DOCKER_IP={{ .DockerIP }}
     - GOARCH
     - GOOS


### PR DESCRIPTION
Drush launcher (deprecated a long time ago) used to care about this env variable. I dont know why we would have set this to 1 but we did. This env variable is now being repurposed by Drush itself at https://github.com/drush-ops/drush/pull/6119/files. So lets not manage the variable in DDEV anymore.