### PR TITLE
refactor: exclude web and db from waiting for containers, fixes #6493, for #6422

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1628,8 +1628,10 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	if err != nil {
 		return err
 	}
-	containerNames := dockerutil.GetContainerNames(containersAwaited)
-	output.UserOut.Printf("Waiting %ds for additional project containers %v to become ready...", app.GetMaxContainerWaitTime(), containerNames)
+	containerNames := dockerutil.GetContainerNames(containersAwaited, []string{GetContainerName(app, "web"), GetContainerName(app, "db")})
+	if len(containerNames) > 0 {
+		output.UserOut.Printf("Waiting %ds for additional project containers %v to become ready...", app.GetMaxContainerWaitTime(), containerNames)
+	}
 	err = app.WaitByLabels(waitLabels)
 	if err != nil {
 		return err

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1622,7 +1622,6 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 	}
 
-	output.UserOut.Printf("Waiting for additional project containers to become ready...")
 	waitLabels := map[string]string{"com.ddev.site-name": app.GetName()}
 	containersAwaited, err := dockerutil.FindContainersByLabels(waitLabels)
 	if err != nil {
@@ -1636,7 +1635,6 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	if err != nil {
 		return err
 	}
-	output.UserOut.Printf("All project containers are now ready.")
 
 	if _, err = app.CreateSettingsFile(); err != nil {
 		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1888,13 +1888,17 @@ func GetLiveDockerComposeVersion() (string, error) {
 
 // GetContainerNames takes an array of Container
 // and returns an array of strings with container names
-func GetContainerNames(containers []dockerTypes.Container) []string {
+func GetContainerNames(containers []dockerTypes.Container, excludeContainerNames []string) []string {
 	var names []string
 	for _, container := range containers {
-		if len(container.Names) > 0 {
-			name := container.Names[0][1:] // Trimming the leading '/' from the container name
-			names = append(names, name)
+		if len(container.Names) == 0 {
+			continue
 		}
+		name := container.Names[0][1:] // Trimming the leading '/' from the container name
+		if slices.Contains(excludeContainerNames, name) {
+			continue
+		}
+		names = append(names, name)
 	}
 	return names
 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6493
- #6422

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Removes `web` and `db`, and hides the second waiting message if there are no additional containers.

## Manual Testing Instructions

```
ddev config --auto
ddev start
```

```
...
Waiting for containers to become ready: [web db] 
Starting ddev-router if necessary... 
 Container ddev-router  Created 
 Container ddev-router  Started
Waiting for additional project containers to become ready... 
All project containers are now ready.
...
```

```
ddev add-on get ddev/ddev-redis
ddev restart
```

```
...
Waiting for containers to become ready: [web db] 
Starting ddev-router if necessary... 
 Container ddev-router  Created 
 Container ddev-router  Started 
Waiting for additional project containers to become ready... 
Waiting 120s for additional project containers [ddev-d11-redis] to become ready... 
All project containers are now ready.
...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
