### PR TITLE
build: add bash-completion to standard packages

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get install -y postgresql-common && yes | /usr/share/postgresql-common/p
 
 RUN apt-get -qq update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
+    bash-completion \
     libcap2-bin \
     libmagickcore-6.q16-6-extra \
     locales-all \

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20240918_saitho_imagemagic_remove_policy" // Note that this can be overridden by make
+var WebTag = "20240930_bash_completion" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

Some people use git inside the container, and I note that git autocompletion doesn't work there.

Because bash completion is not installed, it's likely that plenty of other autocompletes don't work


## How This PR Solves The Issue

Add bash-completion.

## Manual Testing Instructions

Check out something inside the container and use git completion, especially of branches. For example, clone https://github.com/ddev/ddev and `git checkout 202409` and hit tab to get suggested branches.


## Release/Deployment Notes

This seems to add less than 1 MB to the image size, see https://hub.docker.com/r/ddev/ddev-webserver/tags

![image](https://github.com/user-attachments/assets/e6f00f09-f972-41fa-b236-f773ec57daf7)
