### PR TITLE
feat: rename refresh to rebuild in `ddev debug refresh`, allow to build different services, add cache flag

### DIFF
--- a/cmd/ddev/cmd/debug-rebuild.go
+++ b/cmd/ddev/cmd/debug-rebuild.go
@@ -18,11 +18,12 @@ var (
 	service  string
 )
 
-// DebugRefreshCmd implements the ddev debug refresh command
-var DebugRefreshCmd = &cobra.Command{
+// DebugRebuildCmd implements the ddev debug rebuild command
+var DebugRebuildCmd = &cobra.Command{
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
-	Use:               "refresh",
-	Short:             "Refreshes Docker cache for project with verbose output",
+	Use:               "rebuild",
+	Short:             "Rebuilds Docker cache for project with verbose output",
+	Aliases:           []string{"refresh"},
 	Run: func(cmd *cobra.Command, args []string) {
 		projectName := ""
 
@@ -79,7 +80,7 @@ var DebugRefreshCmd = &cobra.Command{
 			util.Failed("Failed to execute `%s %v`: %v", composeBinaryPath, strings.Join(buildArgs, " "), err)
 		}
 		buildDuration := util.FormatDuration(buildDurationStart())
-		util.Success("Refreshed Docker cache for project %s in %s", app.Name, buildDuration)
+		util.Success("Rebuilt Docker cache for project %s in %s", app.Name, buildDuration)
 
 		err = app.Restart()
 		if err != nil {
@@ -89,8 +90,8 @@ var DebugRefreshCmd = &cobra.Command{
 }
 
 func init() {
-	DebugCmd.AddCommand(DebugRefreshCmd)
-	DebugRefreshCmd.Flags().BoolVarP(&buildAll, "all", "a", false, "Rebuild all services")
-	DebugRefreshCmd.Flags().Bool("cache", false, "Keep Docker cache")
-	DebugRefreshCmd.Flags().StringVarP(&service, "service", "s", "web", "Rebuild specified service")
+	DebugCmd.AddCommand(DebugRebuildCmd)
+	DebugRebuildCmd.Flags().BoolVarP(&buildAll, "all", "a", false, "Rebuild all services")
+	DebugRebuildCmd.Flags().Bool("cache", false, "Keep Docker cache")
+	DebugRebuildCmd.Flags().StringVarP(&service, "service", "s", "web", "Rebuild specified service")
 }

--- a/cmd/ddev/cmd/debug-rebuild_test.go
+++ b/cmd/ddev/cmd/debug-rebuild_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ddev/ddev/pkg/testcommon"
 )
 
-// TestDebugRefreshCmd tests that ddev debug refresh actually clears Docker cache
-func TestDebugRefreshCmd(t *testing.T) {
+// TestDebugRebuildCmd tests that ddev debug rebuild actually clears Docker cache
+func TestDebugRebuildCmd(t *testing.T) {
 	assert := asrt.New(t)
 
 	// Create a temporary directory and switch to it.
@@ -84,11 +84,11 @@ RUN shuf -i 0-99999 -n1 > /random-db.txt
 	require.NoError(t, err)
 	assert.Equal(origRandomDb, newRandomDb)
 
-	// Now run ddev debug refresh to blow away the Docker cache
-	_, err = exec.RunHostCommand(DdevBin, "debug", "refresh")
+	// Now run ddev debug rebuild to blow away the Docker cache
+	_, err = exec.RunHostCommand(DdevBin, "debug", "rebuild")
 	require.NoError(t, err)
 
-	// Now with refresh having been done, we should see a new value for random
+	// Now with rebuild having been done, we should see a new value for random
 	err = app.Restart()
 	require.NoError(t, err)
 	freshRandomWeb, _, err := app.Exec(&ddevapp.ExecOpts{
@@ -105,8 +105,8 @@ RUN shuf -i 0-99999 -n1 > /random-db.txt
 	require.NoError(t, err)
 	assert.Equal(origRandomDb, freshRandomDb)
 
-	// Now run ddev debug refresh to blow away the Docker cache for db
-	_, err = exec.RunHostCommand(DdevBin, "debug", "refresh", "--service", "db")
+	// Now run ddev debug rebuild to blow away the Docker cache for db
+	_, err = exec.RunHostCommand(DdevBin, "debug", "rebuild", "--service", "db")
 	require.NoError(t, err)
 
 	// It should remain the same for web
@@ -129,7 +129,7 @@ RUN shuf -i 0-99999 -n1 > /random-db.txt
 	assert.NotEqual(freshRandomDb, freshRandomDbNew)
 
 	// Repeat the same with all services, but use cache
-	_, err = exec.RunHostCommand(DdevBin, "debug", "refresh", "--all", "--cache")
+	_, err = exec.RunHostCommand(DdevBin, "debug", "rebuild", "--all", "--cache")
 	require.NoError(t, err)
 
 	// It should remain the same for web

--- a/cmd/ddev/cmd/debug-refresh.go
+++ b/cmd/ddev/cmd/debug-refresh.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	exec2 "github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
+	"strings"
 	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
@@ -12,12 +13,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	buildAll bool
+	service  string
+)
+
 // DebugRefreshCmd implements the ddev debug refresh command
 var DebugRefreshCmd = &cobra.Command{
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
 	Use:               "refresh",
-	Short:             "Refreshes Docker cache for project",
-	Run: func(_ *cobra.Command, args []string) {
+	Short:             "Refreshes Docker cache for project with verbose output",
+	Run: func(cmd *cobra.Command, args []string) {
 		projectName := ""
 
 		if len(args) > 1 {
@@ -26,6 +32,10 @@ var DebugRefreshCmd = &cobra.Command{
 
 		if len(args) == 1 {
 			projectName = args[0]
+		}
+
+		if cmd.Flags().Changed("all") && cmd.Flags().Changed("service") {
+			util.Failed("--all flag cannot be used with --service flag")
 		}
 
 		_, err := dockerutil.DownloadDockerComposeIfNeeded()
@@ -50,11 +60,23 @@ var DebugRefreshCmd = &cobra.Command{
 		output.UserOut.Printf("Rebuilding project images...")
 		buildDurationStart := util.ElapsedDuration(time.Now())
 		composeRenderedPath := app.DockerComposeFullRenderedYAMLPath()
-		util.Success("Rebuilding web image with `%s -f %s build web --no-cache`", composeBinaryPath, composeRenderedPath)
+		withoutCache := !cmd.Flags().Changed("cache")
 
-		err = exec2.RunInteractiveCommand(composeBinaryPath, []string{"-f", composeRenderedPath, "build", "web", "--no-cache"})
+		buildArgs := []string{"-f", composeRenderedPath, "--progress", "plain", "build"}
+
+		if !buildAll {
+			buildArgs = append(buildArgs, cmd.Flag("service").Value.String())
+		}
+
+		if withoutCache {
+			buildArgs = append(buildArgs, "--no-cache")
+		}
+
+		util.Success("Rebuilding project %s with `%s %v`", app.Name, composeBinaryPath, strings.Join(buildArgs, " "))
+
+		err = exec2.RunInteractiveCommand(composeBinaryPath, buildArgs)
 		if err != nil {
-			util.Failed("Failed to execute %s -f %s build web --no-cache: %v", composeBinaryPath, composeRenderedPath, err)
+			util.Failed("Failed to execute `%s %v`: %v", composeBinaryPath, strings.Join(buildArgs, " "), err)
 		}
 		buildDuration := util.FormatDuration(buildDurationStart())
 		util.Success("Refreshed Docker cache for project %s in %s", app.Name, buildDuration)
@@ -68,4 +90,7 @@ var DebugRefreshCmd = &cobra.Command{
 
 func init() {
 	DebugCmd.AddCommand(DebugRefreshCmd)
+	DebugRefreshCmd.Flags().BoolVarP(&buildAll, "all", "a", false, "Rebuild all services")
+	DebugRefreshCmd.Flags().Bool("cache", false, "Keep Docker cache")
+	DebugRefreshCmd.Flags().StringVarP(&service, "service", "s", "web", "Rebuild specified service")
 }

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -178,8 +178,8 @@ cat <<END >web/index.php
   printf("The output file for Discord or issue queue is in\n<b>%s</b><br />\nfile://%s<br />\n", "$1", "$1", "$1");
 END
 
-header "ddev debug refresh"
-ddev debug refresh
+header "ddev debug rebuild"
+ddev debug rebuild
 
 header "Project startup"
 DDEV_DEBUG=true ddev start -y || ( \

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -93,7 +93,7 @@ For certain use cases, you might need to add directives very early on the Docker
 * `.ddev/web-build/pre.Dockerfile.*`
 * `.ddev/db-build/pre.Dockerfile.*`
 
-Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with [`ddev debug refresh`](../usage/commands.md#debug-refresh).
+Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with [`ddev debug rebuild`](../usage/commands.md#debug-rebuild).
 
 Examples of possible Dockerfiles are `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example`, created in your project when you run [`ddev config`](../usage/commands.md#config).
 
@@ -187,4 +187,4 @@ It can be complicated to figure out what’s going on when building a Dockerfile
 
 1. Use [`ddev ssh`](../usage/commands.md#ssh) first of all to pioneer the steps you want to take. You can do all the things you need to do there and see if it works. If you’re doing something that affects PHP, you may need to `sudo killall -USR2 php-fpm` for it to take effect.
 2. Put the steps you pioneered into `.ddev/web-build/Dockerfile` as above.
-3. If you can’t figure out what’s failing or why, running `ddev debug refresh` will show the full output of the build process. You can also run `export DDEV_VERBOSE=true && ddev start` to see what’s happening during the `ddev start` Dockerfile build.
+3. If you can’t figure out what’s failing or why, running `ddev debug rebuild` will show the full output of the build process. You can also run `export DDEV_VERBOSE=true && ddev start` to see what’s happening during the `ddev start` Dockerfile build.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -446,13 +446,28 @@ ddev debug nfsmount
 
 ### `debug refresh`
 
-Refreshes the project’s Docker cache.
+Refreshes the project’s Docker cache with verbose output.
+
+Flags:
+
+* `--all`, `-a`: Rebuild all services.
+* `--cache`: Keep Docker cache.
+* `--service`, `-s`: Rebuild specified service. (default `web`)
 
 Example:
 
 ```shell
-# Refresh the current project’s Docker cache
+# Refresh the current project’s web service without cache
 ddev debug refresh
+
+# Refresh the current project’s web service with cache
+ddev debug refresh --cache
+
+# Refresh the current project’s db service without cache
+ddev debug refresh --service db
+
+# Refresh the current project’s all services without cache
+ddev debug refresh --all
 ```
 
 ### `debug router-nginx-config`

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -444,9 +444,11 @@ Example:
 ddev debug nfsmount
 ```
 
-### `debug refresh`
+### `debug rebuild`
 
-Refreshes the project’s Docker cache with verbose output.
+*Aliases: `debug refresh`.*
+
+Rebuilds the project’s Docker cache with verbose output.
 
 Flags:
 
@@ -457,17 +459,17 @@ Flags:
 Example:
 
 ```shell
-# Refresh the current project’s web service without cache
-ddev debug refresh
+# Rebuild the current project’s web service without cache
+ddev debug rebuild
 
-# Refresh the current project’s web service with cache
-ddev debug refresh --cache
+# Rebuild the current project’s web service with cache
+ddev debug rebuild --cache
 
-# Refresh the current project’s db service without cache
-ddev debug refresh --service db
+# Rebuild the current project’s db service without cache
+ddev debug rebuild --service db
 
-# Refresh the current project’s all services without cache
-ddev debug refresh --all
+# Rebuild the current project’s all services without cache
+ddev debug rebuild --all
 ```
 
 ### `debug router-nginx-config`

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -270,7 +270,7 @@ The error messages you get will be more informative than messages that come when
 You can also see the output from the full Docker build using either
 
 ```
-ddev debug refresh
+ddev debug rebuild
 ```
 
 or
@@ -285,7 +285,7 @@ The Docker build environment (where all projects have a little bit happening) is
 
 * **WSL2**: On WSL2 it's a known issue that the WSL2 environment time can get out of sync with the real time. This is an [ongoing problem](https://github.com/microsoft/WSL/issues/10006) with WSL2, and can be fixed with various workarounds. One good workaround is to install `ntpdate` and `sudo ntpdate pool.ntp.org` to sync the time. The time in WSL2 can get out of sync due to laptop sleeping or other causes. A reboot also fixes it.
 * **VPN**: If you are on a packet-inspection VPN, it often causes problems with validation of certificates on internet sites. In that situation you'll need to get the CA updates required and install them with a custom Dockerfile, as described on [Stack Overflow](https://stackoverflow.com/questions/71595327/corporate-network-ddev-composer-create-results-in-ssl-certificate-error/71595428#71595428).
-* **Other Docker Build**: The Dockerfile build environment is different from the host-side build and different from what you get with `ddev ssh`. If you're having trouble with it it may be caused by name resolution or IP connectivity problems, most often caused by a firewall or VPN. Turn off your firewall temporarily and VPN. A good debugging technique would be to do a simple `.ddev/web-build/Dockerfile` that does `RUN curl -I https://www.google.com` and then use `ddev debug refresh` to see the result. If it gets a 200 result, then your name resolution and internet connectivity are working in the Docker build environment.
+* **Other Docker Build**: The Dockerfile build environment is different from the host-side build and different from what you get with `ddev ssh`. If you're having trouble with it it may be caused by name resolution or IP connectivity problems, most often caused by a firewall or VPN. Turn off your firewall temporarily and VPN. A good debugging technique would be to do a simple `.ddev/web-build/Dockerfile` that does `RUN curl -I https://www.google.com` and then use `ddev debug rebuild` to see the result. If it gets a 200 result, then your name resolution and internet connectivity are working in the Docker build environment.
 
 ## DDEV Starts but Browser Can’t Access URL
 

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -66,7 +66,7 @@ const ConfigInstructions = `
 #   - preview
 #   - snapshot
 # Alternatively, an explicit Composer version may be specified, for example "2.2.18".
-# To reinstall Composer after the image was built, run "ddev debug refresh".
+# To reinstall Composer after the image was built, run "ddev debug rebuild".
 
 # nodejs_version: "20"
 # change from the default system Node.js version to any other version.


### PR DESCRIPTION
## The Issue

`ddev debug refresh` is not flexible enough. It runs rebuild without cache only for the web service.

## How This PR Solves The Issue

- adds `--service=name` and `--all` flag to build specified service.
- adds `--cache` flag that will not add `--no-cache` to the underlying `docker-compose build` command.
- adds `--progress plain` to `docker-compose build`, because it was squashed by default.

## Manual Testing Instructions

```
ddev debug refresh # this command is the same as it was before
ddev debug refresh --cache # should show cached output
ddev debug refresh --all # should rebuild all services (if you have web, db, redis: all of them should be rebuilt)
ddev debug refresh --service db # the same as usual command, but for the db service
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
