### PR TITLE
build: fix Docker's InvalidDefaultArgInFrom warning

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_IMAGE
-ARG DB_PINNED_VERSION
+ARG BASE_IMAGE="scratch"
+ARG DB_PINNED_VERSION="latest"
 FROM ${BASE_IMAGE}:${DB_PINNED_VERSION}
 
 # This must be reiterated because everything is emptied on FROM

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1125,7 +1125,7 @@ func WriteBuildDockerfile(app *DdevApp, fullpath string, userDockerfilePath stri
 #ddev-generated - Do not modify this file; your modifications will be overwritten.
 
 ### DDEV-injected base Dockerfile contents
-ARG BASE_IMAGE
+ARG BASE_IMAGE="scratch"
 FROM $BASE_IMAGE
 SHELL ["/bin/bash", "-c"]
 `


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

When running `ddev debug refresh`:

```
WARN: InvalidDefaultArgInFrom: Default value for ARG $BASE_IMAGE results in empty or invalid base image name (line 6)
```

https://docs.docker.com/reference/build-checks/invalid-default-arg-in-from/

## How This PR Solves The Issue

Adds defaults, that will never be used, because we always pass the `ARG BASE_IMAGE`.

This PR goal is to silence this warning.

## Manual Testing Instructions

Run `ddev debug refresh`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
