### PR TITLE
docs: remove import/export 'redirect operator' examples

### DIFF
--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -624,9 +624,6 @@ ddev export-db --gzip=false --file /tmp/db.sql
 # Dump and compress the current project’s `foo` database instead of `db`
 ddev export-db --database=foo --file=/tmp/db.sql.gz
 
-# Output the current project’s database and use `>` to write to `/tmp/db.sql.gz`
-ddev export-db > /tmp/db.sql.gz
-
 # Dump my-project’s database, without compressing it, to `/tmp/my-project.sql`
 ddev export-db my-project --gzip=false --file=/tmp/my-project.sql
 ```
@@ -827,12 +824,6 @@ ddev import-db --file=.tarballs/db.sql.gz
 
 # Import the compressed `.tarballs/db.sql.gz` dump to a `other_db` database
 ddev import-db --database=additional_db --file=.tarballs/db.sql.gz
-
-# Import the `db.sql` dump to the project database
-ddev import-db < db.sql
-
-# Import the `db.sql` dump to the `my-project` default database
-ddev import-db my-project < db.sql
 
 # Uncompress `db.sql.gz` and pipe the result to the `import-db` command
 gzip -dc db.sql.gz | ddev import-db


### PR DESCRIPTION
### Reason for change

Neither of these examples works reliably, and they should not be recommended to the average user.

### Example of export issue

See 
* #6583.

### Example of import issue

Using `ddev import-db < ../db.sql.gz` (note that the file is gzipped) drops the database and then fails with something like:

```
grep: (standard input): binary file matches
Error: failed to import database 'db' for project: failed to import database: composeCmd failed to run 'COMPOSE_PROJECT_NAME=ddev-project docker-compose -f /Users/cooperka/project/.ddev/.ddev-docker-compose-full.yaml exec -T db bash -c set -eu -o pipefail && mysql -uroot -proot -e "DROP DATABASE IF EXISTS db; CREATE DATABASE IF NOT EXISTS db; GRANT ALL ON db.* TO 'db'@'%';"  2> >(grep -v 'Deprecated program name.' >&2)  && perl -p -e 's/^(CREATE DATABASE \/\*|USE `)[^;]*;//' | mysql db  2> >(grep -v 'Deprecated program name.' >&2) ', action='[exec -T db bash -c set -eu -o pipefail && mysql -uroot -proot -e "DROP DATABASE IF EXISTS db; CREATE DATABASE IF NOT EXISTS db; GRANT ALL ON db.* TO 'db'@'%';"  2> >(grep -v 'Deprecated program name.' >&2)  && perl -p -e 's/^(CREATE DATABASE \/\*|USE `)[^;]*;//' | mysql db  2> >(grep -v 'Deprecated program name.' >&2) ]', err='exit status 1', stdout='', stderr='grep: (standard input): binary file matches'
stdout:
stderr: grep: (standard input): binary file matches
```

It's not clear in the docs that the redirect operator ONLY works for uncompressed files, unlike every other example which works for both compressed and uncompressed files.