### PR TITLE
test: fix Windows path in TestCmdAddonComplex

### DIFF
--- a/cmd/ddev/cmd/addon-get_test.go
+++ b/cmd/ddev/cmd/addon-get_test.go
@@ -74,9 +74,9 @@ func TestCmdAddonComplex(t *testing.T) {
 	require.NoError(t, err, "stat of no-ddev-generated.txt failed")
 	assert.True(info.Size() == 0)
 
-	assert.Contains(out, "👍 extra/has-ddev-generated.txt")
-	assert.NotContains(out, "👍 extra/no-ddev-generated.txt")
-	assert.Regexp(regexp.MustCompile(`NOT overwriting [^ ]*`+"extra/no-ddev-generated.txt"), out)
+	assert.Contains(out, fmt.Sprintf("👍 %s", filepath.Join("extra", "has-ddev-generated.txt")))
+	assert.NotContains(out, fmt.Sprintf("👍 %s", filepath.Join("extra", "no-ddev-generated.txt")))
+	assert.Regexp(regexp.MustCompile(`NOT overwriting [^ ]*`+filepath.Join("extra", "no-ddev-generated.txt")), out)
 }
 
 // TestCmdAddonDependencies tests the dependency behavior is correct

--- a/cmd/ddev/cmd/addon-get_test.go
+++ b/cmd/ddev/cmd/addon-get_test.go
@@ -76,7 +76,7 @@ func TestCmdAddonComplex(t *testing.T) {
 
 	assert.Contains(out, fmt.Sprintf("👍 %s", filepath.Join("extra", "has-ddev-generated.txt")))
 	assert.NotContains(out, fmt.Sprintf("👍 %s", filepath.Join("extra", "no-ddev-generated.txt")))
-	assert.Regexp(regexp.MustCompile(`NOT overwriting [^ ]*`+filepath.Join("extra", "no-ddev-generated.txt")), out)
+	assert.Regexp(regexp.MustCompile(fmt.Sprintf(`NOT overwriting [^ ]*%s`, regexp.QuoteMeta(filepath.Join("extra", "no-ddev-generated.txt")))), out)
 }
 
 // TestCmdAddonDependencies tests the dependency behavior is correct


### PR DESCRIPTION
## The Issue

I enabled `TestCmdAddonComplex` for all environments in:

- #6406

But it failed on Windows:

https://buildkite.com/ddev/ddev-windows-mutagen/builds/4820#01925524-771f-481c-a816-a38cd172e632/14772-14793

```
=== RUN   TestCmdAddonComplex
    addon-get_test.go:77:
        	Error Trace:	C:/Users/testbot/tmp/buildkite/tb-win11-06-1/ddev/ddev-windows-mutagen/cmd/ddev/cmd/addon-get_test.go:77
        	Error:      	"\nExecuting pre-install actions:\nC:/Users/testbot/tmp/buildkite/tb-win11-06-1/ddev/ddev-windows-mutagen/.gotmp/bin/windows_amd64/ddev.exe\n\n\nInstalling project-level components:\n👍 junk_windows_amd64.txt\n👍 extra\\has-ddev-generated.txt\nNOT overwriting C:\\Users\\testbot\\tmp\\ddevtest\\TestCmdWordpress3774037344\\.ddev\\extra\\no-ddev-generated.txt. The #ddev-generated signature was not found in the file, so it will not be overwritten. You can remove the file and use ddev add-on get again if you want it to be replaced: signature was not found in file C:\\Users\\testbot\\tmp\\ddevtest\\TestCmdWordpress3774037344\\.ddev\\extra\\no-ddev-generated.txt\n\nInstalled DDEV add-on C:\\Users\\testbot\\tmp\\buildkite\\tb-win11-06-1\\ddev\\ddev-windows-mutagen\\cmd\\ddev\\cmd\\testdata\\TestCmdAddonComplex\\recipe, use `ddev restart` to enable.\nInstalled sample_get: from C:\\Users\\testbot\\tmp\\buildkite\\tb-win11-06-1\\ddev\\ddev-windows-mutagen\\cmd\\ddev\\cmd\\testdata\\TestCmdAddonComplex\\recipe\n" does not contain "👍 extra/has-ddev-generated.txt"
```

## How This PR Solves The Issue

Uses the correct path for Windows.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
