### PR TITLE
test: Use composer 2.8.0 for TestComposerCreateCmd until composer bug is fixed, for #6586

### DIFF
--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -29,7 +29,7 @@ func TestComposerCreateCmd(t *testing.T) {
 	assert := asrt.New(t)
 
 	origDir, err := os.Getwd()
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	validAppTypes := ddevapp.GetValidAppTypesWithoutAliases()
 	if os.Getenv("GOTEST_SHORT") != "" {
@@ -53,7 +53,7 @@ func TestComposerCreateCmd(t *testing.T) {
 			t.Logf("== BEGIN TestComposerCreateCmd for project of type '%s' with docroot  '%s'\n", projectType, docRoot)
 			tmpDir := testcommon.CreateTmpDir(t.Name() + projectType)
 			err = os.Chdir(tmpDir)
-			assert.NoError(err)
+			require.NoError(t, err)
 
 			// Prepare arguments
 			arguments := []string{"config", "--project-type", projectType}
@@ -70,20 +70,20 @@ func TestComposerCreateCmd(t *testing.T) {
 
 			// Basic config
 			_, err = exec.RunHostCommand(DdevBin, arguments...)
-			assert.NoError(err)
+			require.NoError(t, err)
 
 			// Test trivial command
 			out, err := exec.RunHostCommand(DdevBin, "composer")
-			assert.NoError(err)
-			assert.Contains(out, "Available commands:")
+			require.NoError(t, err)
+			require.Contains(t, out, "Available commands:")
 
 			// Get an app so we can do waits
 			app, err := ddevapp.NewApp(tmpDir, true)
-			assert.NoError(err)
+			require.NoError(t, err)
 
 			t.Cleanup(func() {
 				err = os.Chdir(origDir)
-				assert.NoError(err)
+				require.NoError(t, err)
 				_ = os.RemoveAll(tmpDir)
 			})
 
@@ -138,86 +138,86 @@ func TestComposerCreateCmd(t *testing.T) {
 			// Test failure
 			file, err := os.Create(filepath.Join(composerRoot, "touch1.txt"))
 			out, err = exec.RunHostCommand(DdevBin, args...)
-			assert.Error(err)
-			assert.Contains(out, "touch1.txt")
+			require.Error(t, err)
+			require.Contains(t, out, "touch1.txt")
 			_ = file.Close()
 			_ = os.Remove(filepath.Join(composerRoot, "touch1.txt"))
 
 			// Test success
 			out, err = exec.RunHostCommand(DdevBin, args...)
-			assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
-			assert.Contains(out, "Created project in ")
-			assert.FileExists(filepath.Join(composerRoot, "composer.json"))
+			require.NoError(t, err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
+			require.Contains(t, out, "Created project in ")
+			require.FileExists(t, filepath.Join(composerRoot, "composer.json"))
 
 			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-plugins --no-scripts test/ddev-composer-create
 			if composerCommandTypeCheck == "installation with --no-plugins --no-scripts" {
 				// Check what was executed or not
-				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s --no-plugins --no-scripts test/ddev-composer-create --no-install`, repository))
-				assert.NotContains(out, "Executing Composer command: [composer run-script post-root-package-install")
-				assert.Contains(out, "Executing Composer command: [composer install --no-plugins --no-scripts]")
-				assert.NotContains(out, "Executing Composer command: [composer run-script post-create-project-cmd")
+				require.Contains(t, out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s --no-plugins --no-scripts test/ddev-composer-create --no-install`, repository))
+				require.NotContains(t, out, "Executing Composer command: [composer run-script post-root-package-install")
+				require.Contains(t, out, "Executing Composer command: [composer install --no-plugins --no-scripts]")
+				require.NotContains(t, out, "Executing Composer command: [composer run-script post-create-project-cmd")
 				// Check the actual result of executing composer scripts
-				assert.NoFileExists(filepath.Join(composerRoot, "created-by-post-root-package-install"))
-				assert.NoFileExists(filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
+				require.NoFileExists(t, filepath.Join(composerRoot, "created-by-post-root-package-install"))
+				require.NoFileExists(t, filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
 				// Check vendor directory
-				assert.FileExists(filepath.Join(composerRoot, "vendor", "autoload.php"))
-				assert.FileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require", "composer.json"))
-				assert.FileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
+				require.FileExists(t, filepath.Join(composerRoot, "vendor", "autoload.php"))
+				require.FileExists(t, filepath.Join(composerRoot, "vendor", "test", "ddev-require", "composer.json"))
+				require.FileExists(t, filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
 			}
 
 			// ddev composer create --repository='{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' -vvv --fake-flag test/ddev-composer-create
 			if composerCommandTypeCheck == "installation with -vvv --fake-flag" {
 				// Check what was executed or not
-				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository=%s -vvv test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
-				assert.Contains(out, "Executing Composer command: [composer run-script post-root-package-install -vvv]")
-				assert.Contains(out, "Executing Composer command: [composer install -vvv]")
-				assert.Contains(out, "Executing Composer command: [composer run-script post-create-project-cmd -vvv]")
-				assert.NotContains(out, "--fake-flag")
+				require.Contains(t, out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository=%s -vvv test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
+				require.Contains(t, out, "Executing Composer command: [composer run-script post-root-package-install -vvv]")
+				require.Contains(t, out, "Executing Composer command: [composer install -vvv]")
+				require.Contains(t, out, "Executing Composer command: [composer run-script post-create-project-cmd -vvv]")
+				require.NotContains(t, out, "--fake-flag")
 				// Check the actual result of executing composer scripts
-				assert.FileExists(filepath.Join(composerRoot, "created-by-post-root-package-install"))
-				assert.FileExists(filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
+				require.FileExists(t, filepath.Join(composerRoot, "created-by-post-root-package-install"))
+				require.FileExists(t, filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
 				// Check vendor directory
-				assert.FileExists(filepath.Join(composerRoot, "vendor", "autoload.php"))
-				assert.FileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require", "composer.json"))
-				assert.FileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
+				require.FileExists(t, filepath.Join(composerRoot, "vendor", "autoload.php"))
+				require.FileExists(t, filepath.Join(composerRoot, "vendor", "test", "ddev-require", "composer.json"))
+				require.FileExists(t, filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
 			}
 
 			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-install test/ddev-composer-create
 			if composerCommandTypeCheck == "installation with --no-install" {
 				// Check what was executed or not
-				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s --no-install test/ddev-composer-create --no-plugins --no-scripts`, repository))
-				assert.Contains(out, "Executing Composer command: [composer run-script post-root-package-install]")
-				assert.NotContains(out, "Executing Composer command: [composer install")
-				assert.Contains(out, "Executing Composer command: [composer run-script post-create-project-cmd]")
+				require.Contains(t, out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository %s --no-install test/ddev-composer-create --no-plugins --no-scripts`, repository))
+				require.Contains(t, out, "Executing Composer command: [composer run-script post-root-package-install]")
+				require.NotContains(t, out, "Executing Composer command: [composer install")
+				require.Contains(t, out, "Executing Composer command: [composer run-script post-create-project-cmd]")
 				// Check the actual result of executing composer scripts
-				assert.FileExists(filepath.Join(composerRoot, "created-by-post-root-package-install"))
-				assert.FileExists(filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
+				require.FileExists(t, filepath.Join(composerRoot, "created-by-post-root-package-install"))
+				require.FileExists(t, filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
 				// Check vendor directory
-				assert.NoDirExists(filepath.Join(composerRoot, "vendor"))
+				require.NoDirExists(t, filepath.Join(composerRoot, "vendor"))
 			}
 
 			// ddev composer create --repository='{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-dev test/ddev-composer-create
 			if composerCommandTypeCheck == "installation with --no-dev" {
 				// Check what was executed or not
-				assert.Contains(out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository=%s --no-dev test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
-				assert.Contains(out, "Executing Composer command: [composer run-script post-root-package-install --no-dev]")
-				assert.Contains(out, "Executing Composer command: [composer install --no-dev]")
-				assert.Contains(out, "Executing Composer command: [composer run-script post-create-project-cmd --no-dev]")
+				require.Contains(t, out, fmt.Sprintf(`Executing Composer command: [composer create-project --repository=%s --no-dev test/ddev-composer-create --no-plugins --no-scripts --no-install`, repository))
+				require.Contains(t, out, "Executing Composer command: [composer run-script post-root-package-install --no-dev]")
+				require.Contains(t, out, "Executing Composer command: [composer install --no-dev]")
+				require.Contains(t, out, "Executing Composer command: [composer run-script post-create-project-cmd --no-dev]")
 				// Check the actual result of executing composer scripts
-				assert.FileExists(filepath.Join(composerRoot, "created-by-post-root-package-install"))
-				assert.FileExists(filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
+				require.FileExists(t, filepath.Join(composerRoot, "created-by-post-root-package-install"))
+				require.FileExists(t, filepath.Join(composerRoot, "created-by-post-create-project-cmd"))
 				// Check vendor directory
-				assert.FileExists(filepath.Join(composerRoot, "vendor", "autoload.php"))
-				assert.FileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require", "composer.json"))
-				assert.NoFileExists(filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
+				require.FileExists(t, filepath.Join(composerRoot, "vendor", "autoload.php"))
+				require.FileExists(t, filepath.Join(composerRoot, "vendor", "test", "ddev-require", "composer.json"))
+				require.NoFileExists(t, filepath.Join(composerRoot, "vendor", "test", "ddev-require-dev", "composer.json"))
 			}
 
-			assert.Contains(out, "Moving install to Composer root")
-			assert.Contains(out, "ddev composer create was successful")
+			require.Contains(t, out, "Moving install to Composer root")
+			require.Contains(t, out, "ddev composer create was successful")
 
 			// Check that resulting composer.json (copied from testdata) has post-root-package-install and post-create-project-cmd scripts
 			composerManifest, err := composer.NewManifest(filepath.Join(composerRoot, "composer.json"))
-			assert.NoError(err)
+			require.NoError(t, err)
 			assert.True(composerManifest != nil)
 			assert.True(composerManifest.HasPostRootPackageInstallScript())
 			assert.True(composerManifest.HasPostCreateProjectCmdScript())
@@ -229,7 +229,6 @@ func TestComposerCreateCmd(t *testing.T) {
 }
 
 func TestComposerCreateAutocomplete(t *testing.T) {
-	assert := asrt.New(t)
 	// DDEV_DEBUG may result in extra output that we don't want
 	origDdevDebug := os.Getenv("DDEV_DEBUG")
 	_ = os.Unsetenv("DDEV_DEBUG")
@@ -237,13 +236,13 @@ func TestComposerCreateAutocomplete(t *testing.T) {
 	// We don't really care what the project is, they should
 	// all have composer installed in the web container.
 	origDir, err := os.Getwd()
-	assert.NoError(err)
+	require.NoError(t, err)
 	err = os.Chdir(TestSites[0].Dir)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		err = os.Chdir(origDir)
-		assert.NoError(err)
+		require.NoError(t, err)
 		_ = os.Setenv("DDEV_DEBUG", origDdevDebug)
 	})
 
@@ -253,13 +252,13 @@ func TestComposerCreateAutocomplete(t *testing.T) {
 
 	// Pressing tab after `composer completion` should result in the completion "bash"
 	out, err := exec.RunHostCommand(DdevBin, "__complete", "composer", "create", "--")
-	assert.NoError(err)
+	require.NoError(t, err)
 	// Completions are terminated with ":4", so just grab the stuff before that
 	completions, _, found := strings.Cut(out, ":")
-	assert.True(found)
+	require.True(t, found)
 	// We don't need to check all of the possible options - just check that
 	// we're getting some completion suggestions that make sense and not just garbage
-	assert.Contains(completions, "--no-install")
-	assert.Contains(completions, "--no-scripts")
-	assert.Contains(completions, "--keep-vcs")
+	require.Contains(t, completions, "--no-install")
+	require.Contains(t, completions, "--no-scripts")
+	require.Contains(t, completions, "--keep-vcs")
 }

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/ddev/ddev/pkg/composer"
-	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -19,13 +18,6 @@ import (
 )
 
 func TestComposerCreateCmd(t *testing.T) {
-	// 2022-05-24: I've spent lots of time debugging intermittent `composer create` failures when NFS
-	// is enabled, both on macOS and Windows. As far as I can tell, it only happens in this test, I've
-	// never recreated manually. I do see https://github.com/composer/composer/issues/9627 which seemed
-	// to deal with similar issues in vagrant context, and has a hack now embedded into Composer.
-	if nodeps.PerformanceModeDefault == types.PerformanceModeNFS {
-		t.Skip("Composer has strange behavior in NFS context, so skipping")
-	}
 	assert := asrt.New(t)
 
 	origDir, err := os.Getwd()

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -18,6 +18,11 @@ import (
 )
 
 func TestComposerCreateCmd(t *testing.T) {
+	// Skip this
+	//runTestComposerCreateCmd := os.Getenv("DDEV_RUN_TEST_COMPOSER_CREATE_CMD")
+	//if runTestComposerCreateCmd != "true" {
+	//	t.Skip("Skipping: DDEV_RUN_TEST_COMPOSER_CREATE_CMD is not set, turn it back on when composer bug is fixed")
+	//}
 	assert := asrt.New(t)
 
 	origDir, err := os.Getwd()
@@ -78,6 +83,12 @@ func TestComposerCreateCmd(t *testing.T) {
 				require.NoError(t, err)
 				_ = os.RemoveAll(tmpDir)
 			})
+
+			// Until https://github.com/ddev/ddev/issues/6586 is fixed (composer 2.8.1 breaks it all)
+			// then use 2.8.0
+			// TODO: Remove this when possible
+			out, err = exec.RunHostCommand(DdevBin, "config", "--composer-version=2.8.0")
+			require.NoError(t, err)
 
 			err = app.StartAndWait(5)
 			require.NoError(t, err)

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -115,6 +115,7 @@ func TestComposerCreateCmd(t *testing.T) {
 				}
 			}
 
+			t.Logf("Attempting composerCommandTypeCheck='%s' with docroot='%s' projectType=%s", composerCommandTypeCheck, docRoot, projectType)
 			// ddev composer create --repository '{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}' --no-plugins --no-scripts test/ddev-composer-create
 			if composerCommandTypeCheck == "installation with --no-plugins --no-scripts" {
 				args = []string{"composer", "create", "--repository", repository, "--no-plugins", "--no-scripts", "test/ddev-composer-create"}
@@ -145,7 +146,7 @@ func TestComposerCreateCmd(t *testing.T) {
 
 			// Test success
 			out, err = exec.RunHostCommand(DdevBin, args...)
-			require.NoError(t, err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
+			require.NoError(t, err, "['%s'] failed to run %v: err=%v, output=\n=====\n%s\n=====\n", composerCommandTypeCheck, args, err, out)
 			require.Contains(t, out, "Created project in ")
 			require.FileExists(t, filepath.Join(composerRoot, "composer.json"))
 

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -56,7 +56,10 @@ func TestComposerCreateCmd(t *testing.T) {
 			composerDirOnHost := tmpDir
 			if docRoot != "" {
 				arguments = append(arguments, "--docroot", docRoot)
-				// For Drupal, we test that the composer root is the same as the created root
+				// For Drupal, we arbitrarily place the composer root to be the docroot
+				// Normally for Drupal the docroot would be web, and the composer root would be the
+				// project root (default). But here we're making sure we can use the docroot
+				// as the composer_root. Acquia sites often do this...
 				if projectType == nodeps.AppTypeDrupal {
 					arguments = append(arguments, "--composer-root", docRoot)
 					composerDirOnHost = filepath.Join(tmpDir, docRoot)

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -13,23 +13,15 @@ import (
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
-	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestComposerCreateCmd(t *testing.T) {
-	// Skip this
-	//runTestComposerCreateCmd := os.Getenv("DDEV_RUN_TEST_COMPOSER_CREATE_CMD")
-	//if runTestComposerCreateCmd != "true" {
-	//	t.Skip("Skipping: DDEV_RUN_TEST_COMPOSER_CREATE_CMD is not set, turn it back on when composer bug is fixed")
-	//}
-	assert := asrt.New(t)
-
-	// TODO: Change to just "2" or to global default when bug in 2.8.1 is fixed
+	// TODO: Change to global default when bug in 2.8.1 is fixed
 	// https://github.com/composer/composer/issues/12150
 	// https://github.com/ddev/ddev/issues/6586
-	//defaultComposerVersion := "2"
-	defaultComposerVersion := "2.8.0"
+	//composerVersionForThisTest := nodeps.ComposerDefault
+	composerVersionForThisTest := "2.8.0"
 
 	origDir, err := os.Getwd()
 	require.NoError(t, err)
@@ -59,7 +51,7 @@ func TestComposerCreateCmd(t *testing.T) {
 			require.NoError(t, err)
 
 			// Prepare arguments
-			arguments := []string{"config", "--project-type", projectType, "--composer-version", defaultComposerVersion}
+			arguments := []string{"config", "--project-type", projectType, "--composer-version", composerVersionForThisTest}
 
 			composerRoot := tmpDir
 			if docRoot != "" {
@@ -86,7 +78,7 @@ func TestComposerCreateCmd(t *testing.T) {
 
 			t.Cleanup(func() {
 				err = app.Stop(true, false)
-				assert.NoError(err)
+				require.NoError(t, err)
 				err = os.Chdir(origDir)
 				require.NoError(t, err)
 				_ = os.RemoveAll(tmpDir)
@@ -97,7 +89,7 @@ func TestComposerCreateCmd(t *testing.T) {
 
 			out, err = exec.RunHostCommand(DdevBin, "composer", "--version")
 			require.NoError(t, err)
-			require.Contains(t, out, fmt.Sprintf("Composer version %s", defaultComposerVersion))
+			require.Contains(t, out, fmt.Sprintf("Composer version %s", composerVersionForThisTest))
 
 			// This is a local package that we can use to test composer create
 			repository := `{"type": "path", "url": ".ddev/test-ddev-composer-create", "options": {"symlink": false}}`
@@ -228,9 +220,9 @@ func TestComposerCreateCmd(t *testing.T) {
 			// Check that resulting composer.json (copied from testdata) has post-root-package-install and post-create-project-cmd scripts
 			composerManifest, err := composer.NewManifest(filepath.Join(composerRoot, "composer.json"))
 			require.NoError(t, err)
-			assert.True(composerManifest != nil)
-			assert.True(composerManifest.HasPostRootPackageInstallScript())
-			assert.True(composerManifest.HasPostCreateProjectCmdScript())
+			require.True(t, composerManifest != nil)
+			require.True(t, composerManifest.HasPostRootPackageInstallScript())
+			require.True(t, composerManifest.HasPostCreateProjectCmdScript())
 
 			err = app.Stop(true, false)
 			require.NoError(t, err)


### PR DESCRIPTION
## The Issue

* #6586 

Composer 2.8.1 introduces new probably unwanted behavior that breaks TestComposerCreateCmd

Upstream issue: 
* https://github.com/composer/composer/issues/12150

## How This PR Solves The Issue

* Temporarily use composer 2.8.0 for that test.
* Use `require` instead of `assert` so we don't run along and use invalid data and get a panic
* Minor fiddles with test flow

## Manual Testing Instructions

Read the test output.

## Misc

A comment about TestComposerCreateCmd: This is so impressive how much test coverage you built into this @stasadev, so great. In retrospect, I imagine all the if statements would be cleaner as a switch statement, or perhaps they could be a test matrix.