### PR TITLE
docs: Add link to "omit" DB configuration

### DIFF
--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -6,7 +6,7 @@ search:
 
 DDEV provides lots of flexibility for managing your databases between your local, staging and production environments. You may commonly use the [`ddev import-db`](../usage/commands.md#import-db) and [`ddev export-db`](../usage/commands.md#export-db) commands, but there are plenty of other adaptable ways to work with your databases.
 
-If your project does _not_ require a database, you can exclude it with the the ["omit_containers" configuration option](https://ddev.readthedocs.io/en/stable/users/configuration/config/#omit_containers).
+If your project does _not_ require a database, you can exclude it with the the [`omit_containers` configuration option](../configuration/config.md#omit_containers).
 
 !!!tip
     You can run `ddev [command] --help` for more info on many of the topics below.

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -6,6 +6,8 @@ search:
 
 DDEV provides lots of flexibility for managing your databases between your local, staging and production environments. You may commonly use the [`ddev import-db`](../usage/commands.md#import-db) and [`ddev export-db`](../usage/commands.md#export-db) commands, but there are plenty of other adaptable ways to work with your databases.
 
+If your project does _not_ require a database, you can exclude it with the the ["omit_containers" configuration option](https://ddev.readthedocs.io/en/stable/users/configuration/config/#omit_containers).
+
 !!!tip
     You can run `ddev [command] --help` for more info on many of the topics below.
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

The database management page provides no details for removing the db container.

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue
Adds a link the configuration.

I debated about putting a specific section about removing it. However, I felt this might lead to duplication. Linking the the option centralizes it as the single source of truth.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
