### PR TITLE
fix: check only for IPv4 in DNS lookup, fixes #6592

### DIFF
--- a/pkg/ddevapp/hostname_mgt.go
+++ b/pkg/ddevapp/hostname_mgt.go
@@ -1,6 +1,7 @@
 package ddevapp
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -94,11 +95,11 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 		if app.UseDNSWhenPossible && globalconfig.IsInternetActive() {
 			// If they have provided "*.<name>" then look up the suffix
 			checkName := strings.TrimPrefix(name, "*.")
-			hostIPs, err := net.LookupHost(checkName)
+			hostIPs, err := net.DefaultResolver.LookupIP(context.Background(), "ip4", checkName)
 
 			// If we had successful lookup and the IP address looked up is local
 			// then we don't have to add it to the /etc/hosts.
-			if err == nil && len(hostIPs) > 0 && netutil.IsLocalIP(hostIPs[0]) {
+			if err == nil && len(hostIPs) > 0 && netutil.HasLocalIP(hostIPs) {
 				continue
 			}
 		}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -919,9 +919,9 @@ func GetDockerIP() (string, error) {
 				addr := net.ParseIP(hostPart)
 				if addr == nil {
 					// If it wasn't an IP address, look it up to get IP address
-					ip, err := net.LookupHost(hostPart)
+					ip, err := net.DefaultResolver.LookupIP(context.Background(), "ip4", hostPart)
 					if err == nil && len(ip) > 0 {
-						hostPart = ip[0]
+						hostPart = ip[0].String()
 					} else {
 						return "", fmt.Errorf("failed to look up IP address for $DOCKER_HOST=%s, hostname=%s: %v", dockerHostRawURL, hostPart, err)
 					}

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -817,7 +817,7 @@ var IsInternetActiveResult = false
 // In order to override net.DefaultResolver with a stub, we have to define an
 // interface on our own since there is none from the standard library.
 var IsInternetActiveNetResolver interface {
-	LookupHost(ctx context.Context, host string) (addrs []string, err error)
+	LookupIP(ctx context.Context, network, host string) ([]net.IP, error)
 } = net.DefaultResolver
 
 // IsInternetActive checks to see if we have a viable
@@ -837,7 +837,7 @@ func IsInternetActive() bool {
 	// Using a random URL is more conclusive, but it's more intrusive because
 	// DNS may take some time, and it's really annoying.
 	testURL := "test.ddev.site"
-	addrs, err := IsInternetActiveNetResolver.LookupHost(ctx, testURL)
+	addrs, err := IsInternetActiveNetResolver.LookupIP(ctx, "ip4", testURL)
 
 	// Internet is active (active == true) if both err and ctx.Err() were nil
 	active := err == nil && ctx.Err() == nil

--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -132,8 +132,8 @@ type internetActiveNetResolverStub struct {
 	err       error
 }
 
-// LookupHost is a custom version of net.LookupHost that wastes some time and then returns
-func (t internetActiveNetResolverStub) LookupHost(ctx context.Context, _ string) ([]string, error) {
+// LookupIP is a custom version of net.LookupIP that wastes some time and then returns
+func (t internetActiveNetResolverStub) LookupIP(ctx context.Context, _, _ string) ([]net.IP, error) {
 	select {
 	case <-time.After(t.sleepTime):
 	case <-ctx.Done():
@@ -150,7 +150,7 @@ func internetActiveResetVariables() {
 	globalconfig.DdevGlobalConfig.InternetDetectionTimeout = nodeps.InternetDetectionTimeoutDefault
 }
 
-// TestIsInternetActiveErrorOccurred tests if IsInternetActive() returns false when LookupHost returns an error
+// TestIsInternetActiveErrorOccurred tests if IsInternetActive() returns false when LookupIP returns an error
 func TestIsInternetActiveErrorOccurred(t *testing.T) {
 	internetActiveResetVariables()
 
@@ -184,8 +184,8 @@ func TestIsInternetActiveAlreadyChecked(t *testing.T) {
 	asrt.True(t, globalconfig.IsInternetActive())
 }
 
-// TestIsInternetActive tests if IsInternetActive() returns true, when the LookupHost call goes well
-// and if it properly sets the globals so it won't execute the LookupHost again.
+// TestIsInternetActive tests if IsInternetActive() returns true, when the LookupIP call goes well
+// and if it properly sets the globals so it won't execute the LookupIP again.
 func TestIsInternetActive(t *testing.T) {
 	internetActiveResetVariables()
 


### PR DESCRIPTION
## The Issue

- #6592

## How This PR Solves The Issue

Checks only for IPv4 in DNS lookup.

## Manual Testing Instructions

It should work when local DNS is configured to resolve IPv4 and IPv6 for the same host at the same time.

I tested it with custom TLD `*.test` (to be sure it doesn't collide with online `*.ddev.site`) and `dnsmasq`:

dnsmasq config:
for IPv4:
```
address=/*.test/127.0.0.1
```
for IPv6:
```
address=/*.test/::1
```

DDEV config:
```
ddev config --project-tld test
```

Cases:
1. Resolve IPv4 `*.test` added, resolve IPv6 `*.test` added - `ddev start` works
2. Resolve IPv4 `*.test` added, resolve IPv6 `*.test` not added - `ddev start` works
3. Resolve IPv4 `*.test` not added, resolve IPv6 `*.test` added - `ddev start` asks for sudo as expected
4. Resolve IPv4 `*.test` not added, resolve IPv6 `*.test` not added - `ddev start` asks for sudo as expected

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
