### PR TITLE
feat: Remove 127.0.0.1 from start and restart message, place in one function, fixes #6500

### DIFF
--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"strings"
-
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/output"
@@ -53,11 +51,7 @@ ddev restart --all`,
 			}
 
 			util.Success("Restarted %s", app.GetName())
-			httpURLs, urlList, _ := app.GetAllURLs()
-			if app.CanUseHTTPOnly() {
-				urlList = httpURLs
-			}
-			util.Success("Your project can be reached at %s", strings.Join(urlList, " "))
+			emitReachProjectMessage(app)
 		}
 	},
 }

--- a/cmd/ddev/cmd/restart_test.go
+++ b/cmd/ddev/cmd/restart_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -24,12 +26,19 @@ func TestCmdRestart(t *testing.T) {
 	out, err := exec.RunCommand(DdevBin, args)
 	assert.NoError(err)
 
-	_, err = ddevapp.GetActiveApp("")
+	app, err := ddevapp.GetActiveApp("")
 	if err != nil {
 		assert.Fail("Could not find an active DDEV configuration: %v", err)
 	}
 
 	assert.Contains(string(out), "Your project can be reached at")
+	switch slices.Contains(globalconfig.DdevGlobalConfig.OmitContainersGlobal, "ddev-router") {
+	case true:
+		assert.Contains(string(out), "127.0.0.1")
+	case false:
+		assert.NotContains(string(out), "127.0.0.1")
+		assert.Contains(string(out), app.GetPrimaryURL())
+	}
 	cleanup()
 }
 

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -137,14 +137,14 @@ ddev start --all`,
 			}
 
 			util.Success("Successfully started %s", project.GetName())
-			httpURLs, httpsURLs, _ := project.GetAllURLs()
-			if project.CanUseHTTPOnly() {
-				httpsURLs = httpURLs
-			}
-			util.Success("Project can be reached at %s", strings.Join(httpsURLs, " "))
+			emitReachProjectMessage(project)
 		}
 		amplitude.CheckSetUp()
 	},
+}
+
+func emitReachProjectMessage(project *ddevapp.DdevApp) {
+	util.Success("Project can be reached at %s - see ddev describe for alternate URLs", project.GetPrimaryURL())
 }
 
 func init() {

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -144,7 +144,7 @@ ddev start --all`,
 }
 
 func emitReachProjectMessage(project *ddevapp.DdevApp) {
-	util.Success("Your project can be reached at %s - see ddev describe for alternate URLs", project.GetPrimaryURL())
+	util.Success("Your project can be reached at %s\nSee 'ddev describe' for alternate URLs.", project.GetPrimaryURL())
 }
 
 func init() {

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -144,7 +144,7 @@ ddev start --all`,
 }
 
 func emitReachProjectMessage(project *ddevapp.DdevApp) {
-	util.Success("Project can be reached at %s - see ddev describe for alternate URLs", project.GetPrimaryURL())
+	util.Success("Your project can be reached at %s - see ddev describe for alternate URLs", project.GetPrimaryURL())
 }
 
 func init() {


### PR DESCRIPTION
## The Issue

- #6500 

We don't want to output the 127.0.0.1 URL when the router is enabled.

## How This PR Solves The Issue
Only shows the primary URL when the app is started/restarted

## Manual Testing Instructions
Run `ddev stop && ddev start` or `ddev restart`. Then you should see the updated output on the final line:
"Your project can be reached at mysite.ddev.site - see ddev describe for alternate URLs"

With the router omitted you should see the 127.0.0.1 URL.
Run: `ddev config global --omit-containers=ddev-router && ddev restart`

## Automated Testing Overview

Updated TestCmdRestart and TestCmdStart
## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
