### PR TITLE
fix: improve timezone detection, for #6468

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -1188,35 +1187,13 @@ func (app *DdevApp) GetLocalTimezone() (string, error) {
 		timezone = os.Getenv("TZ")
 	} else {
 		localtimeFile := filepath.Join("/etc", "localtime")
-		timezoneFile, err := filepath.EvalSymlinks(localtimeFile)
+		var err error
+		timezone, err = filepath.EvalSymlinks(localtimeFile)
 		if err != nil {
 			return "", fmt.Errorf("unable to read timezone from %s file: %v", localtimeFile, err)
 		}
-		// /etc/localtime is a symlink to a file, for example:
-		// /usr/share/zoneinfo/Europe/London on Linux and WSL2
-		// /var/db/timezone/zoneinfo/Europe/London on macOS (the exact path to /zoneinfo/ may differ)
-		// /usr/share/zoneinfo.default/Europe/London on macOS
-		// We can search for anything after /zoneinfo/ in the file path.
-		regex := regexp.MustCompile(`/zoneinfo.*?/`)
-		parts := regex.Split(strings.TrimSpace(timezoneFile), 2)
-		if len(parts) != 2 {
-			return "", fmt.Errorf("unable to read timezone from %s file", timezoneFile)
-		}
-		timezone = parts[1]
-		// Remove leading prefixes if they exist.
-		// https://stackoverflow.com/a/67888343/8097891
-		for _, prefix := range []string{"posix/", "right/"} {
-			timezone = strings.TrimPrefix(timezone, prefix)
-		}
-		if timezone == "" {
-			return "", fmt.Errorf("unable to read timezone from %s file", timezoneFile)
-		}
 	}
-	_, err := time.LoadLocation(timezone)
-	if err != nil {
-		return "", fmt.Errorf("failed to load timezone '%s': %v", timezone, err)
-	}
-	return timezone, nil
+	return util.GetTimezone(timezone)
 }
 
 // Start initiates docker-compose up


### PR DESCRIPTION
## The Issue

While attending today's contributor training on `ddev debug test`, I noticed a problem with timezone detection on Randy's MBP:

```
$ DDEV_DEBUG=true ddev start -y
...
2024-10-09T07:42:08.796 Unable to autodetect timezone: unable to read timezone from /usr/share/zoneinfo.default/America/Denver file
...
```

- #6468

## How This PR Solves The Issue

After research, we found that `filepath.EvalSymlinks()` evaluates hidden symlinks on macOS:

```
$ ls -l /etc/localtime
lrwxr-xr-x  1 root  wheel  40 Oct  6 13:46 /etc/localtime -> /var/db/timezone/zoneinfo/America/Denver
```

```
$ ls -ltd /var/db/timezone/zoneinfo
lrwxr-xr-x  1 root  wheel  38 May 21 14:48 /var/db/timezone/zoneinfo -> /var/db/timezone/tz/2024a.1.0/zoneinfo
```

```
$ ls -ltd /var/db/timezone/zoneinfo
lrwxr-xr-x  1 root  wheel  27 Oct  6 13:45 /var/db/timezone/zoneinfo -> /usr/share/zoneinfo.default
```

---

And I noticed my own comment https://github.com/ddev/ddev/pull/6468#issuecomment-2273287479
> TODO remove optional right/ and posix/ from the timezone symlink https://stackoverflow.com/q/67885319/8097891

Which I forgot about, so I added it in this PR.

## Manual Testing Instructions

Run `DDEV_DEBUG=true ddev start` on macOS Sequoia.

The output should have this:
```
Using automatically detected timezone: TZ=America/Denver
```

And `ddev exec 'echo $TZ'` should show an appropriate timezone from the host.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
