### PR TITLE
fix: use Cmd instead of RawCmd to execute composer and put vendor/bin first in PATH, fixes #6602

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
@@ -6,7 +6,7 @@
 # If not running interactively, don't do anything
 [ -z "$PS1" ] && return
 
-export PATH="${DDEV_COMPOSER_ROOT}/vendor/bin:${PATH}"
+export PATH="${DDEV_COMPOSER_ROOT:-/var/www/html}/vendor/bin:${PATH}"
 
 # check the window size after each command and, if necessary,
 # update the values of LINES and COLUMNS.

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
@@ -6,6 +6,8 @@
 # If not running interactively, don't do anything
 [ -z "$PS1" ] && return
 
+export PATH="${DDEV_COMPOSER_ROOT}/vendor/bin:${PATH}"
+
 # check the window size after each command and, if necessary,
 # update the values of LINES and COLUMNS.
 shopt -s checkwinsize

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.nointeractive.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.nointeractive.bashrc
@@ -1,4 +1,5 @@
 # This file is loaded in non-interactive bash shells through $BASH_ENV
+export PATH="${DDEV_COMPOSER_ROOT}/vendor/bin:${PATH}"
 for f in /etc/bashrc/*.bashrc; do
   source $f;
 done

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.nointeractive.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.nointeractive.bashrc
@@ -1,5 +1,5 @@
 # This file is loaded in non-interactive bash shells through $BASH_ENV
-export PATH="${DDEV_COMPOSER_ROOT}/vendor/bin:${PATH}"
+export PATH="${DDEV_COMPOSER_ROOT:-/var/www/html}/vendor/bin:${PATH}"
 for f in /etc/bashrc/*.bashrc; do
   source $f;
 done

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
@@ -1,4 +1,4 @@
-export PATH="~/bin:$PATH"
+export PATH="~/bin:$PATH:/var/www/html/bin"
 
 [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
 [ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
@@ -1,4 +1,4 @@
-export PATH="~/bin:$PATH:/var/www/html/vendor/bin:/var/www/html/bin:$DDEV_COMPOSER_ROOT/vendor/bin"
+export PATH="~/bin:$PATH"
 
 [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
 [ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"

--- a/pkg/ddevapp/composer.go
+++ b/pkg/ddevapp/composer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/mattn/go-isatty"
@@ -17,10 +18,11 @@ func (app *DdevApp) Composer(args []string) (string, string, error) {
 		return "", "", fmt.Errorf("failed to process pre-composer hooks: %v", err)
 	}
 
+	argString := strings.Join(args, " ")
 	stdout, stderr, err := app.Exec(&ExecOpts{
 		Service: "web",
 		Dir:     app.GetComposerRoot(true, true),
-		RawCmd:  append([]string{"composer"}, args...),
+		Cmd:     "composer " + argString,
 		Tty:     isatty.IsTerminal(os.Stdin.Fd()),
 		// Prevent Composer from debugging when Xdebug is enabled
 		Env: []string{"XDEBUG_MODE=off"},

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241002_deviantintegral_vim_tiny" // Note that this can be overridden by make
+var WebTag = "20241009_use_cmd_composer" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #6602

We should really prefer the COMPOSER_ROOT/vendor/bin in our $PATH instead of having it later in the PATH.

If composer/composer is in vendor/bin, it should be used from there when possible

## How This PR Solves The Issue

* Change the PATH setup that the image uses
* Change `ddev composer` to use `Cmd` instead of `RawCmd` so it gets interpreted by bash

## Manual Testing Instructions

What I did was `ddev composer require composer/composer:v2.8.0` and then used `ddev composer --version` and `ddev exec composer --version` for testing.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

Right now, this is experimental, since this could possibly affect things we don't expect to affect: It can certainly change behavior when composer/composer is required, but it could also change something where something is in vendor/bin otherwise and thus masks something elsewhere in the container.

This also makes the vendor/bin/composer *override* anything that might be set for `composer_version`