### PR TITLE
docs: remove markdown link check on archive.org

### DIFF
--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -65,7 +65,11 @@
     },
     {
       "pattern": "^https://team-ddev.1password.com"
+    },
+    {
+      "pattern": "^https://.*.archive.org"
     }
+
   ],
   "httpHeaders": [
     {


### PR DESCRIPTION

## The Issue

`archive.org` has been under DDOS attack, and links are failing.

We don't need to check that one link.