### PR TITLE
feat: validation for database versions in `schema.json` [skip ci]

### DIFF
--- a/pkg/ddevapp/schema.json
+++ b/pkg/ddevapp/schema.json
@@ -74,6 +74,85 @@
           "description": "Specify the database version to use.",
           "type": "string"
         }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "const": "mariadb"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "version": {
+            "enum": [
+              "5.5",
+              "10.0",
+              "10.1",
+              "10.2",
+              "10.3",
+              "10.4",
+              "10.5",
+              "10.6",
+              "10.7",
+              "10.8",
+              "10.11",
+              "11.4"
+            ]
+          }
+        }
+      },
+      "else": {
+        "if": {
+          "properties": {
+            "type": {
+              "const": "mysql"
+            }
+          }
+        },
+        "then": {
+          "properties": {
+            "version": {
+              "enum": [
+                "5.5",
+                "5.6",
+                "5.7",
+                "8.0"
+              ]
+            }
+          }
+        },
+        "else": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "postgres"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "version": {
+                "enum": [
+                  "9",
+                  "10",
+                  "11",
+                  "12",
+                  "13",
+                  "14",
+                  "15",
+                  "16",
+                  "17"
+                ]
+              }
+            }
+          },
+          "else": {
+            "not": {
+              "required": ["version"]
+            }
+          }
+        }
       }
     },
     "dbimage_extra_packages": {


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

We don't have validation for database versions:

![image](https://github.com/user-attachments/assets/7b7011e4-76a4-4d55-84d5-3c8cdc7a2772)

## How This PR Solves The Issue

Adds validation:

![image](https://github.com/user-attachments/assets/89d21e55-1c60-4006-9e10-99cd79899e0f)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
