### PR TITLE
docs: show results of including composer/composer

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -94,6 +94,9 @@ Composer version for the web container and the [`ddev composer`](../usage/comman
 | -- | -- | --
 | :octicons-file-directory-16: project | `2` | Can be `2`, `1`, or empty (`""`) for latest major version at container build time.<br><br>Can also be a minor version like `2.2` for the latest release of that branch, an explicit version like `1.0.22`, or a keyword like `stable`, `preview` or `snapshot`. See Composer documentation.
 
+!!!note "If your `composer.json` requires `composer/composer` that version will be used instead"
+    If your project `composer.json` includes `composer/composer`, then the version specified there will normally be used instead of any version specified by `composer_version`, since `vendor/bin/composer` will come first in the in-container `$PATH`.
+
 ## `corepack_enable`
 
 Whether to `corepack enable` on Node.js configuration.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -304,7 +304,7 @@ Flags:
 * `--bind-all-interfaces`: Bind host ports on all interfaces, not only on localhost network interface.
 * `--composer-root`: Overrides the default Composer root directory for the web service.
 * `--composer-root-default`: Unsets a web service Composer root directory override.
-* `--composer-version`: Specify override for Composer version in the web container. This may be `""`, `"1"`, `"2"`, `"2.2"`, `"stable"`, `"preview"`, `"snapshot"`, or a specific version.
+* `--composer-version`: Specify override for Composer version in the web container. This may be `""`, `"1"`, `"2"`, `"2.2"`, `"stable"`, `"preview"`, `"snapshot"`, or a specific version. (Note that if your project composer build requires `composer/composer` then the version you require there will be used instead of the version specified here.)
 * `--database`: Specify the database type:version to use. Defaults to `mariadb:10.11`.
 * `--db-image`: Sets the db container image.
 * `--db-image-default`: Sets the default db container image for this DDEV version.

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -55,8 +55,6 @@ To execute a fully-featured `composer create-project` command, you can execute t
 
 `ddev exec composer create-project ...`
 
-DDEV uses Composer 2 by default. Use the `--composer-version` option to roll back to version 1: `ddev config --composer-version=1 && ddev start`.
-
 **composer.json Location**: It’s most common for `composer.json` to be in the project root, but you can specify an alternate Composer root using DDEV’s `composer_root` option in `.ddev/config.yaml`, or `ddev config --composer-root <dir>`. The `composer_root` value is the *relative* path from the project root to the directory containing `composer.json`. If yours is at `docroot/composer.json`, for example, the `composer_root` value should be `docroot`.
 
 !!!tip "Careful with Global Requirements!"
@@ -64,9 +62,12 @@ DDEV uses Composer 2 by default. Use the `--composer-version` option to roll bac
 
     You may want to synchronize created Composer configuration and installed packages with the DDEV’s [`homeadditions` directory](../extend/in-container-configuration.md) on your host machine.
 
+!!!tip "If you require `composer/composer` the version you require will be used"
+    If your `composer.json` specifies `composer/composer`, that version of composer will most likely be used by `ddev composer` and `ddev exec composer`, since it will be first in the `$PATH` inside the container. The `.ddev/config.yaml` `composer_version` will be ignored.
+
 <a name="windows-os-and-ddev-composer"></a>
 
-### Windows OS and `ddev composer`
+### Windows OS (Traditional Windows) and `ddev composer`
 
 DDEV attempts to help with Composer and some configurations of Docker Desktop for Windows that introduce complex filesystem workarounds.
 


### PR DESCRIPTION
## The Issue

Docs on composer:

* https://github.com/ddev/ddev/pull/6604
* https://github.com/ddev/ddev/issues/6602

In those issues, we put vendor/bin first. If people require `composer/composer`, then the version they require will take precedence. 

## Review

Review rendered docs  by searching composer/composer:
* https://ddev--6611.org.readthedocs.build/en/6611/users/usage/developer-tools/#ddev-and-composer
* https://ddev--6611.org.readthedocs.build/en/6611/users/usage/commands/#config
* https://ddev--6611.org.readthedocs.build/en/6611/users/configuration/config/#composer_version
