### PR TITLE
fix: don't try to release not-bound ports

### DIFF
--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -283,7 +283,9 @@ func GetRouterBoundPorts() ([]uint16, error) {
 	}
 
 	for _, p := range r.Ports {
-		boundPorts = append(boundPorts, p.PublicPort)
+		if p.PublicPort != 0 {
+			boundPorts = append(boundPorts, p.PublicPort)
+		}
 	}
 	return boundPorts, nil
 }

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -40,7 +40,7 @@ func IsPortActive(port string) bool {
 		}
 	}
 	// Otherwise, hmm, something else happened. It's not a fatal but can be reported.
-	util.Warning("Unable to properly check port status: %v", oe)
+	util.Warning("Unable to properly check port status for %s:%s: err=%v", dockerIP, port, err)
 	return false
 }
 


### PR DESCRIPTION
## The Issue

I've been using Colima as Docker Provider for the last few days, and I kept seeing these unexpected warnings:

```
Unable to properly check port status: dial tcp 127.0.0.1:0: connect: can't assign requested address
```

It turns out that we were trying to wait for release of ports that weren't bound, and the reason was that GetRouterBoundPorts() was walking through the router's ports, and some of those were not actually bound. Port 80 in this case was active inside but not bound.  So on Lima/Colima/Rancher, when it waits for ports to be unbound, this was shown.

## How This PR Solves The Issue

If port PublicPort is 0 (not externally bound) then don't include it in GetRouterBoundPorts()

## Manual Testing Instructions

Using Colima or Lima:

Force it to use alternate ports (so 80 doesn't get bound):
```
echo 80 443 8025 8026 | xargs -n 1 -P 4 -I{} nc -k -l {}
```

Start and stop a project, using alternate ports
```
ddev start
DDEV_DEBUG=true ddev stop
```

This will show the actual port release sequence. You shouldn't see warnings.

