### PR TITLE
docs: Remove non-working DDEV doc reference in TYPO3 docs

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -727,8 +727,6 @@ If your project uses a database you'll want to set the [DB connection string](ht
 
 ## TYPO3
 
-TYPO3 provides a [detailed DDEV installation guide](https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/TutorialDdev.html) for each major version.
-
 === "Composer"
 
     ```bash


### PR DESCRIPTION

## The Issue

TYPO3 is reorganizing their docs and changing rendering styles.

I haven't been able to figure out where the link ended up that is failing, so removing it.

