### PR TITLE
feat: add validation for `ddev dotenv` flags, for #6406

### DIFF
--- a/cmd/ddev/cmd/addon-get_test.go
+++ b/cmd/ddev/cmd/addon-get_test.go
@@ -185,7 +185,7 @@ func TestCmdAddonGetWithDotEnv(t *testing.T) {
 	busyboxEnvFile := filepath.Join(site.Dir, ".ddev/.env.busybox")
 	require.NoFileExists(t, busyboxEnvFile, ".ddev/.env.busybox file should not exist at this point")
 
-	out, err = exec.RunHostCommand(DdevBin, "dotenv", "set", ".ddev/.env.busybox", "--busybox-tag=1.36.0", "--pre-install-variable=pre", "--pre-install-variable2=pre2", "--post-install-variable", "post", "-A", "short_flag_VALUE", "--force-run", "-yes", "--force-UPPERCASE=true")
+	out, err = exec.RunHostCommand(DdevBin, "dotenv", "set", ".ddev/.env.busybox", "--busybox-tag=1.36.0", "--pre-install-variable=pre", "--pre-install-variable2=pre2", "--post-install-variable", "post", "--force-run")
 	require.NoError(t, err, "out=%s", out)
 	out, err = exec.RunHostCommand(DdevBin, "add-on", "get", filepath.Join(origDir, "testdata", t.Name(), "busybox"))
 	require.NoError(t, err, "out=%s", out)
@@ -204,10 +204,6 @@ func TestCmdAddonGetWithDotEnv(t *testing.T) {
 	require.Contains(t, string(busyboxEnvFileContents), `POST_INSTALL_VARIABLE="post"`)
 	// --force-run is converted to empty string
 	require.Contains(t, string(busyboxEnvFileContents), `FORCE_RUN=""`)
-	// Some flags are ignored because they should not contain uppercase, or be a wrong flag:
-	require.NotContains(t, string(busyboxEnvFileContents), `A="short_flag_VALUE"`)
-	require.NotContains(t, string(busyboxEnvFileContents), "YES")
-	require.NotContains(t, string(busyboxEnvFileContents), "FORCE_UPPERCASE")
 
 	out, err = exec.RunHostCommand(DdevBin, "add-on", "get", filepath.Join(origDir, "testdata", t.Name(), "bare-busybox"))
 	require.NoError(t, err, "out=%s", out)

--- a/cmd/ddev/cmd/dotenv-get.go
+++ b/cmd/ddev/cmd/dotenv-get.go
@@ -54,7 +54,10 @@ ddev dotenv get .ddev/.env.redis --redis-tag`,
 		}
 
 		// Get unknown flags and ensure only one flag is passed
-		envFlags := GetUnknownFlags(cmd)
+		envFlags, err := GetUnknownFlags(cmd)
+		if err != nil {
+			util.Failed("Error reading command flags: %v", err)
+		}
 		if len(envFlags) < 1 {
 			_ = cmd.Help()
 			return
@@ -69,7 +72,7 @@ ddev dotenv get .ddev/.env.redis --redis-tag`,
 		}
 
 		if !strings.HasPrefix(flag, "--") {
-			util.Failed("The flag must be in a long format.")
+			util.Failed("The flag must be in long format, but received %s", flag)
 		}
 
 		// Extract the environment variable name

--- a/cmd/ddev/cmd/dotenv-set.go
+++ b/cmd/ddev/cmd/dotenv-set.go
@@ -63,7 +63,10 @@ ddev dotenv set .ddev/.env.redis --redis-tag 7-bookworm`,
 		}
 
 		// Get unknown flags and convert them to env variables
-		envSlice := GetUnknownFlags(cmd)
+		envSlice, err := GetUnknownFlags(cmd)
+		if err != nil {
+			util.Failed("Error reading command flags: %v", err)
+		}
 		hasUnknownFlags := false
 		changedEnvMap := make(map[string]string)
 		for flag, value := range envSlice {
@@ -72,6 +75,8 @@ ddev dotenv set .ddev/.env.redis --redis-tag 7-bookworm`,
 				envMap[envName] = value
 				changedEnvMap[envName] = value
 				hasUnknownFlags = true
+			} else {
+				util.Failed("The flag must be in long format, but received %s", flag)
 			}
 		}
 

--- a/cmd/ddev/cmd/dotenv_test.go
+++ b/cmd/ddev/cmd/dotenv_test.go
@@ -75,6 +75,18 @@ func TestCmdDotEnvGetAndSet(t *testing.T) {
 	require.Error(t, err, "out=%s", out)
 	require.Contains(t, out, "The file should have .env prefix")
 
+	out, err = exec.RunHostCommand(DdevBin, "dotenv", "set", envFile, "-a", "custom value")
+	require.Error(t, err, "out=%s", out)
+	require.Contains(t, out, "flag must be in long format")
+
+	out, err = exec.RunHostCommand(DdevBin, "dotenv", "set", envFile, "--TEST", "custom value")
+	require.Error(t, err, "out=%s", out)
+	require.Contains(t, out, "the flag must be lowercase and start with a letter")
+
+	out, err = exec.RunHostCommand(DdevBin, "dotenv", "set", envFile, "--1test", "custom value")
+	require.Error(t, err, "out=%s", out)
+	require.Contains(t, out, "the flag must be lowercase and start with a letter")
+
 	out, err = exec.RunHostCommand(DdevBin, "dotenv", "get", envFile, "--test-value", "--test-value-2")
 	require.Error(t, err, "out=%s", out)
 	require.Contains(t, out, "one environment variable can be retrieved at a time")
@@ -85,7 +97,7 @@ func TestCmdDotEnvGetAndSet(t *testing.T) {
 
 	out, err = exec.RunHostCommand(DdevBin, "dotenv", "get", envFile, "-a")
 	require.Error(t, err, "out=%s", out)
-	require.Contains(t, out, "flag must be in a long format")
+	require.Contains(t, out, "flag must be in long format")
 
 	out, err = exec.RunHostCommand(DdevBin, "dotenv", "set", envFile, "--test-value-with-special-characters", `Test$variable\nwith\n_new_lines`)
 	require.NoError(t, err, "out=%s", out)

--- a/pkg/appimport/appimport.go
+++ b/pkg/appimport/appimport.go
@@ -39,7 +39,7 @@ func ValidateAsset(unexpandedAssetPath string, assetType string) (string, bool, 
 	}
 
 	for _, ext := range extensions {
-		if strings.HasSuffix(assetPath, ext) {
+		if strings.HasSuffix(assetPath, "."+ext) {
 			return assetPath, true, nil
 		}
 	}


### PR DESCRIPTION
## The Issue

- #6406

Users should be aware that they have passed invalid flags to the `ddev dotenv`, as it may be unclear why some flags are simply ignored.

## How This PR Solves The Issue

Adds flag validation.

Fixes a small fail in the test, that was caused by random behavior from `util.RandString(4)`:

https://github.com/ddev/ddev/actions/runs/11346006773/job/31554123302?pr=6615#step:16:83

```
=== RUN   TestValidateAsset
    appimport_test.go:38: 
        	Error Trace:	/home/runner/work/ddev/ddev/pkg/appimport/appimport_test.go:38
        	Error:      	Should be false
        	Test:       	TestValidateAsset
--- FAIL: TestValidateAsset (0.00s)
```

## Manual Testing Instructions

Before:

```
$ ddev dotenv set .env --test=123 -1asd=asd
Updated /home/stas/code/ddev/d11/.env with:

TEST="123"

$ ddev dotenv get .env --1asd
// shows help for the command without any error
```

After:

```
$ ddev dotenv set .env --test=123 -1asd=asd
Error reading command flags: the flag must be lowercase and start with a letter, but received -1asd=asd

$ ddev dotenv get .env --1asd
Error reading command flags: the flag must be lowercase and start with a letter, but received --1asd
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
