### PR TITLE
build: bump images to v1.23.5 and docker-compose to v2.29.7, fixes #6606

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20241002_deviantintegral_vim_tiny AS ddev-webserver-base
+FROM ddev/ddev-php-base:v1.23.5 AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,22 +11,22 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241009_use_cmd_composer" // Note that this can be overridden by make
+var WebTag = "v1.23.5" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.23.4"
+var BaseDBTag = "v1.23.5"
 
-const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.23.4"
-const TraefikRouterImage = "ddev/ddev-traefik-router:v1.23.4"
+const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.23.5"
+const TraefikRouterImage = "ddev/ddev-traefik-router:v1.23.5"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.23.4"
+var SSHAuthTag = "v1.23.5"
 
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"
@@ -42,7 +42,7 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.17.2"
 
-const RequiredDockerComposeVersionDefault = "v2.29.5"
+const RequiredDockerComposeVersionDefault = "v2.29.7"
 
 // Drupal11RequiredSqlite3Version for ddev-webserver
 const Drupal11RequiredSqlite3Version = "3.45.1"


### PR DESCRIPTION
## The Issue

- #6606

It's time for a new release.

## How This PR Solves The Issue

- Updates Docker images to v1.23.5
- Updates docker-compose to v2.29.7

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
