### PR TITLE
fix: Some UPSUN environment variables are now PLATFORM_ environment variables

### DIFF
--- a/docs/content/users/providers/upsun.md
+++ b/docs/content/users/providers/upsun.md
@@ -25,20 +25,20 @@ You need to obtain and configure an API token first. This only needs to be done 
 ## Upsun Per-Project Configuration
 
 1. Check out the Upsun site and configure it with [`ddev config`](../usage/commands.md#config). You’ll want to use [`ddev start`](../usage/commands.md#start) and make sure the basic functionality is working.
-2. Add `UPSUN_PROJECT` and `UPSUN_ENVIRONMENT` variables to your project.
+2. Add `PLATFORM_PROJECT` and `PLATFORM_ENVIRONMENT` variables to your project.
 
     * Either in `.ddev/config.yaml` or a `.ddev/config.*.yaml` file:
 
         ```yaml
         web_environment:
-            - UPSUN_PROJECT=nf4amudfn23biyourproject
-            - UPSUN_ENVIRONMENT=main
+            - PLATFORM_PROJECT=nf4amudfn23biyourproject
+            - PLATFORM_ENVIRONMENT=main
         ```
 
     * Or with a command from your terminal:
 
         ```bash
-        ddev config --web-environment-add="UPSUN_PROJECT=nf4amudfn23bi,UPSUN_ENVIRONMENT=main"
+        ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23bi,PLATFORM_ENVIRONMENT=main"
         ```
 
 3. Run [`ddev restart`](../usage/commands.md#restart).

--- a/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
@@ -34,7 +34,7 @@ auth_command:
   command: |
     set -eu -o pipefail
     export PLATFORM_PROJECT="${PLATFORM_PROJECT:-${UPSUN_PROJECT:-}}"
-    export PLATFORM_ENVIRONMENT="${PLATFORM_ENVIRONMENT:-${UPSUN_ENVIRONMENT}}"
+    export PLATFORM_ENVIRONMENT="${PLATFORM_ENVIRONMENT:-${UPSUN_ENVIRONMENT:-}}"
     if [ -z "${UPSUN_CLI_TOKEN:-}" ]; then echo "Please make sure you have set UPSUN_CLI_TOKEN." && exit 1; fi
     if [ -z "${PLATFORM_PROJECT:-}" ]; then echo "Please make sure you have set PLATFORM_PROJECT." && exit 1; fi
     if [ -z "${PLATFORM_ENVIRONMENT:-}" ]; then echo "Please make sure you have set PLATFORM_ENVIRONMENT." && exit 1; fi
@@ -43,6 +43,8 @@ db_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
+    export PLATFORM_PROJECT="${PLATFORM_PROJECT:-${UPSUN_PROJECT:-}}"
+    export PLATFORM_ENVIRONMENT="${PLATFORM_ENVIRONMENT:-${UPSUN_ENVIRONMENT:-}}"
     export UPSUN_CLI_NO_INTERACTION=1
     upsun db:dump --yes --gzip --file=/var/www/html/.ddev/.downloads/db.sql.gz --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}"
 
@@ -50,6 +52,8 @@ files_import_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
+    export PLATFORM_PROJECT="${PLATFORM_PROJECT:-${UPSUN_PROJECT:-}}"
+    export PLATFORM_ENVIRONMENT="${PLATFORM_ENVIRONMENT:-${UPSUN_ENVIRONMENT:-}}"
     export UPSUN_CLI_NO_INTERACTION=1
     upsun mount:download --all --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}"  --target=/var/www/html
 
@@ -59,6 +63,8 @@ db_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
+    export PLATFORM_PROJECT="${PLATFORM_PROJECT:-${UPSUN_PROJECT:-}}"
+    export PLATFORM_ENVIRONMENT="${PLATFORM_ENVIRONMENT:-${UPSUN_ENVIRONMENT:-}}"
     export UPSUN_CLI_NO_INTERACTION=1
     pushd /var/www/html/.ddev/.downloads >/dev/null
     gzip -dc db.sql.gz | upsun db:sql --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}"
@@ -69,5 +75,7 @@ files_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
+    export PLATFORM_PROJECT="${PLATFORM_PROJECT:-${UPSUN_PROJECT:-}}"
+    export PLATFORM_ENVIRONMENT="${PLATFORM_ENVIRONMENT:-${UPSUN_ENVIRONMENT:-}}"
     export UPSUN_CLI_NO_INTERACTION=1
     upsun mount:upload --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files

--- a/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
@@ -15,13 +15,13 @@
 #    ```
 #    You can also do this with `ddev config global --web-environment-add="UPSUN_CLI_TOKEN=abcdeyourtoken"`.
 #
-# 3. Add UPSUN_PROJECT and UPSUN_ENVIRONMENT variables to your project `.ddev/config.yaml` or a `.ddev/config.upsun.yaml`
+# 3. Add PLATFORM_PROJECT and PLATFORM_ENVIRONMENT variables to your project `.ddev/config.yaml` or a `.ddev/config.upsun.yaml`
 #    ```yaml
 #    web_environment:
-#        - UPSUN_PROJECT=nf4amudfn23biyourproject
-#        - UPSUN_ENVIRONMENT=main
+#        - PLATFORM_PROJECT=nf4amudfn23biyourproject
+#        - PLATFORM_ENVIRONMENT=main
 #    ```
-#    You can also do this with `ddev config --web-environment-add="UPSUN_PROJECT=nf4amudfn23biyourproject,UPSUN_ENVIRONMENT=main"`.
+#    You can also do this with `ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23biyourproject,PLATFORM_ENVIRONMENT=main"`.
 #
 # 4. `ddev restart`
 # 5. Run `ddev pull upsun`. After you agree to the prompt, the current upstream database and files will be downloaded.
@@ -34,25 +34,22 @@ auth_command:
   command: |
     set -eu -o pipefail
     if [ -z "${UPSUN_CLI_TOKEN:-}" ]; then echo "Please make sure you have set UPSUN_CLI_TOKEN." && exit 1; fi
-    if [ -z "${UPSUN_PROJECT:-}" ]; then echo "Please make sure you have set UPSUN_PROJECT." && exit 1; fi
-    if [ -z "${UPSUN_ENVIRONMENT:-}" ]; then echo "Please make sure you have set UPSUN_ENVIRONMENT." && exit 1; fi
+    if [ -z "${PLATFORM_PROJECT:${UPSUN_PROJECT:-}}" ]; then echo "Please make sure you have set PLATFORM_PROJECT." && exit 1; fi
+    if [ -z "${PLATFORM_ENVIRONMENT:${UPSUN_ENVIRONMENT:-}}" ]; then echo "Please make sure you have set PLATFORM_ENVIRONMENT." && exit 1; fi
 
 db_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     export UPSUN_CLI_NO_INTERACTION=1
-    ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
-    upsun db:dump --yes --gzip --file=/var/www/html/.ddev/.downloads/db.sql.gz --project="${UPSUN_PROJECT}" --environment="${UPSUN_ENVIRONMENT}"
+    upsun db:dump --yes --gzip --file=/var/www/html/.ddev/.downloads/db.sql.gz --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}"
 
 files_import_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     export UPSUN_CLI_NO_INTERACTION=1
-    # Use $UPSUN_MOUNTS if it exists to get list of mounts to download, otherwise just web/sites/default/files (drupal)
-    declare -a mounts=(${UPSUN_MOUNTS:-/web/sites/default/files})
-    upsun mount:download --all --yes --quiet --project="${UPSUN_PROJECT}" --environment="${UPSUN_ENVIRONMENT}"  --target=/var/www/html
+    upsun mount:download --all --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}"  --target=/var/www/html
 
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
@@ -61,9 +58,8 @@ db_push_command:
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     export UPSUN_CLI_NO_INTERACTION=1
-    ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     pushd /var/www/html/.ddev/.downloads >/dev/null
-    gzip -dc db.sql.gz | upsun db:sql --project="${UPSUN_PROJECT}" --environment="${UPSUN_ENVIRONMENT}"
+    gzip -dc db.sql.gz | upsun db:sql --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}"
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 # TODO: This is a naive, Drupal-centric push, which needs adjustment for the mount to be pushed.
@@ -72,5 +68,4 @@ files_push_command:
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     export UPSUN_CLI_NO_INTERACTION=1
-    ls "${DDEV_FILES_DIR}" >/dev/null # This just refreshes stale NFS if possible
-    upsun mount:upload --yes --quiet --project="${UPSUN_PROJECT}" --environment="${UPSUN_ENVIRONMENT}" --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files
+    upsun mount:upload --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" --source="${DDEV_FILES_DIR}" --mount=web/sites/default/files

--- a/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
@@ -33,9 +33,11 @@
 auth_command:
   command: |
     set -eu -o pipefail
+    export PLATFORM_PROJECT="${PLATFORM_PROJECT:-${UPSUN_PROJECT:-}}"
+    export PLATFORM_ENVIRONMENT="${PLATFORM_ENVIRONMENT:-${UPSUN_ENVIRONMENT}}"
     if [ -z "${UPSUN_CLI_TOKEN:-}" ]; then echo "Please make sure you have set UPSUN_CLI_TOKEN." && exit 1; fi
-    if [ -z "${PLATFORM_PROJECT:${UPSUN_PROJECT:-}}" ]; then echo "Please make sure you have set PLATFORM_PROJECT." && exit 1; fi
-    if [ -z "${PLATFORM_ENVIRONMENT:${UPSUN_ENVIRONMENT:-}}" ]; then echo "Please make sure you have set PLATFORM_ENVIRONMENT." && exit 1; fi
+    if [ -z "${PLATFORM_PROJECT:-}" ]; then echo "Please make sure you have set PLATFORM_PROJECT." && exit 1; fi
+    if [ -z "${PLATFORM_ENVIRONMENT:-}" ]; then echo "Please make sure you have set PLATFORM_ENVIRONMENT." && exit 1; fi
 
 db_pull_command:
   command: |

--- a/pkg/ddevapp/providerUpsun_test.go
+++ b/pkg/ddevapp/providerUpsun_test.go
@@ -86,8 +86,8 @@ func TestUpsunPull(t *testing.T) {
 	provider, err := app.GetProvider("upsun")
 	require.NoError(t, err)
 
-	provider.EnvironmentVariables["UPSUN_PROJECT"] = upsunTestSiteID
-	provider.EnvironmentVariables["UPSUN_ENVIRONMENT"] = upsunPullTestSiteEnvironment
+	provider.EnvironmentVariables["PLATFORM_PROJECT"] = upsunTestSiteID
+	provider.EnvironmentVariables["PLATFORM_ENVIRONMENT"] = upsunPullTestSiteEnvironment
 	provider.EnvironmentVariables["UPSUN_CLI_TOKEN"] = token
 
 	err = app.Start()
@@ -148,8 +148,8 @@ func TestUpsunPush(t *testing.T) {
 	provider, err := app.GetProvider("upsun")
 	require.NoError(t, err)
 
-	provider.EnvironmentVariables["UPSUN_PROJECT"] = upsunTestSiteID
-	provider.EnvironmentVariables["UPSUN_ENVIRONMENT"] = upsunPushTestSiteEnvironment
+	provider.EnvironmentVariables["PLATFORM_PROJECT"] = upsunTestSiteID
+	provider.EnvironmentVariables["PLATFORM_ENVIRONMENT"] = upsunPushTestSiteEnvironment
 	provider.EnvironmentVariables["UPSUN_CLI_TOKEN"] = token
 
 	err = app.Start()


### PR DESCRIPTION

## The Issue

I was using the `upsun` CLI and noted that it doesn't respect UPSUN_PROJECT and UPSUN_ENVIRONMENT

## How This PR Solves The Issue

Move to the PLATFORM_ environment variables.

## Manual Testing Instructions

`ddev pull upsun` and `ddev push upsun`

## Automated Testing Overview

Everything should stay the same.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
