### PR TITLE
build: make latest tag same hash, push latest for most

### DIFF
--- a/containers/ddev-dbserver/build_image.sh
+++ b/containers/ddev-dbserver/build_image.sh
@@ -113,10 +113,15 @@ if [ ${DB_TYPE} = "mysql" ] && [[ "$ARCHS" == *"linux/arm64"* ]]; then
 fi
 printf "\n\n========== Building ddev/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG} from ${BASE_IMAGE} for ${ARCHS} with pinned version ${DB_PINNED_VERSION} ==========\n"
 
+# Build up the -t section with optionally both tags
+tag_directive="-t ${DOCKER_ORG}/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
+if [[ ${IMAGE_TAG} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  tag_directive="$tag_directive -t ${DOCKER_ORG}/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:latest"
+fi
 if [ ! -z ${PUSH:-} ]; then
   echo "building/pushing ddev/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
   set -x
-  docker buildx build --push --platform ${ARCHS} ${DOCKER_ARGS} --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DB_VERSION=${DB_MAJOR_VERSION}" -t "${DOCKER_ORG}/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}" .
+  docker buildx build --push --platform ${ARCHS} ${DOCKER_ARGS} --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DB_VERSION=${DB_MAJOR_VERSION}" ${tag_directive}  .
   set +x
 fi
 
@@ -124,5 +129,5 @@ fi
 set -x
 if [ -z "${PUSH:-}" ]; then
     echo "Loading to local docker ddev/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
-    docker buildx build --load ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_VERSION=${DB_MAJOR_VERSION}" --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" -t "${DOCKER_ORG}/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}" .
+    docker buildx build --load ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_VERSION=${DB_MAJOR_VERSION}" --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" ${tag_directive} .
 fi

--- a/containers/ddev-gitpod-base/Dockerfile
+++ b/containers/ddev-gitpod-base/Dockerfile
@@ -1,6 +1,6 @@
 # https://github.com/ddev/ddev/pull/6613 had an attempt to build our own
 # multi-arch workspace-base image, but it had its own problems and was abandoned.
-FROM gitpod/workspace-base:latest AS workspace-base
+FROM gitpod/workspace-base:latest AS ddev-gitpod-base
 SHELL ["/bin/bash", "-c"]
 
 USER root

--- a/containers/ddev-gitpod-base/Makefile
+++ b/containers/ddev-gitpod-base/Makefile
@@ -1,5 +1,6 @@
 # Docker repo for a push
 DOCKER_REPO ?= $(DOCKER_ORG)/ddev-gitpod-base
+DEFAULT_IMAGES = ddev-gitpod-base
 
 VERSION := $(shell git describe --tags --always --dirty)
 

--- a/containers/ddev-nginx-proxy-router/Dockerfile
+++ b/containers/ddev-nginx-proxy-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.20.1
+FROM nginx:1.20.1 AS ddev-nginx-proxy-router
 
 ENV MKCERT_VERSION=v1.4.6
 

--- a/containers/ddev-nginx-proxy-router/Makefile
+++ b/containers/ddev-nginx-proxy-router/Makefile
@@ -1,5 +1,6 @@
 # Docker repo for a push
 DOCKER_REPO ?= $(DOCKER_ORG)/ddev-nginx-proxy-router
+DEFAULT_IMAGES = ddev-nginx-proxy-router
 
 VERSION := $(shell git describe --tags --always --dirty)
 

--- a/containers/ddev-php-base/Makefile
+++ b/containers/ddev-php-base/Makefile
@@ -34,18 +34,10 @@ images: $(DEFAULT_IMAGES)
 
 $(DEFAULT_IMAGES):
 	set -eu -o pipefail; \
-	 DOCKER_BUILDKIT=1 docker build --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
-
-
-push:
-	set -eu -o pipefail; \
-	for item in $(DEFAULT_IMAGES); do \
-		docker buildx build --push --platform $(BUILD_ARCHS) --label com.ddev.buildhost=${shell hostname} --target=$$item  -t $(DOCKER_ORG)/$$item:$(VERSION) $(DOCKER_ARGS) .; \
-		echo "pushed $(DOCKER_ORG)/$$item:$(VERSION)"; \
-	done
+	docker buildx build --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 test: $(DEFAULT_IMAGES)
-	DOCKER_BUILDKIT=1 docker build --label com.ddev.buildhost=${shell hostname} --label com.ddev.buildinfo="$(BUILDINFO)" -t $(DOCKER_ORG)/$<:$(VERSION) $(DOCKER_ARGS) .
+	docker buildx build --label com.ddev.buildhost=${shell hostname} --label com.ddev.buildinfo="$(BUILDINFO)" -t $(DOCKER_ORG)/$<:$(VERSION) $(DOCKER_ARGS) .
 	for item in $(DEFAULT_IMAGES); do \
 		if [ -x tests/$$item/test.sh ]; then tests/$$item/test.sh $(DOCKER_ORG)/$$item:$(VERSION); fi; \
 	done

--- a/containers/ddev-ssh-agent/Dockerfile
+++ b/containers/ddev-ssh-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim AS ddev-ssh-agent
 
 RUN apt-get update && apt-get install -y bash expect file gpg openssh-client socat psmisc && apt-get autoclean
 

--- a/containers/ddev-ssh-agent/Makefile
+++ b/containers/ddev-ssh-agent/Makefile
@@ -1,6 +1,8 @@
 
 VERSION := $(shell git describe --tags --always --dirty)
 
+DEFAULT_IMAGES = ddev-ssh-agent
+
 # Tests always run against amd64 (build host). Once tests have passed, a multi-arch build
 # will be generated and pushed (the amd64 build will be cached automatically to prevent it from building twice).
 BUILD_ARCHS=linux/amd64,linux/arm64
@@ -8,10 +10,6 @@ BUILD_ARCHS=linux/amd64,linux/arm64
 include ../containers_shared.mk
 
 DOCKER_REPO ?= $(DOCKER_ORG)/ddev-ssh-agent
-
-multi-arch:
-	docker buildx build --platform $(BUILD_ARCHS) -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) .; \
-	echo "created multi-arch builds $(BUILD_ARCHS) for $(DOCKER_REPO)";
 
 test: container
 	test/test.sh $(DOCKER_REPO):$(VERSION)

--- a/containers/ddev-traefik-router/Dockerfile
+++ b/containers/ddev-traefik-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:3.0
+FROM traefik:3.0 AS ddev-traefik-router
 
 ENV TRAEFIK_MONITOR_PORT=10999
 RUN apk add bash curl htop vim

--- a/containers/ddev-traefik-router/Makefile
+++ b/containers/ddev-traefik-router/Makefile
@@ -1,4 +1,5 @@
 VERSION := $(shell git describe --tags --always --dirty)
+DEFAULT_IMAGES = ddev-traefik-router
 
 # Tests always run against amd64 (build host). Once tests have passed, a multi-arch build
 # will be generated and pushed (the amd64 build will be cached automatically to prevent it from building twice).

--- a/containers/ddev-webserver/Makefile
+++ b/containers/ddev-webserver/Makefile
@@ -15,20 +15,6 @@ DOCKER_REPO ?= $(DOCKER_ORG)/ddev-webserver
 
 images: $(DEFAULT_IMAGES)
 
-push:
-	set -eu -o pipefail; \
-	for item in $(DEFAULT_IMAGES); do \
-		docker buildx build --push --platform $(BUILD_ARCHS) --label com.ddev.buildhost=${shell hostname} --target=$$item  -t $(DOCKER_ORG)/$$item:$(VERSION) $(DOCKER_ARGS) .; \
-		echo "pushed $(DOCKER_ORG)/$$item"; \
-	done
-
-multi-arch:
-	set -eu -o pipefail; \
-	for item in $(DEFAULT_IMAGES); do \
-		docker buildx build --platform $(BUILD_ARCHS) --label com.ddev.buildhost=${shell hostname} --target=$$item  -t $(DOCKER_ORG)/$$item:$(VERSION) $(DOCKER_ARGS) .; \
-		echo "created multi-arch builds $(BUILD_ARCHS) for $(DOCKER_ORG)/$$item"; \
-	done
-
 $(DEFAULT_IMAGES):
 	 docker build --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 

--- a/containers/test-ssh-server/Dockerfile
+++ b/containers/test-ssh-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim AS test-ssh-server
 
 RUN apt-get -qq update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y bash openssh-server vim

--- a/containers/test-ssh-server/Makefile
+++ b/containers/test-ssh-server/Makefile
@@ -6,6 +6,7 @@
 # PKG := github.com/ddev/repo_name
 
 VERSION := $(shell git describe --tags --always --dirty)
+DEFAULT_IMAGES = test-ssh-server
 
 # Tests always run against amd64 (build host). Once tests have passed, a multi-arch build
 # will be generated and pushed (the amd64 build will be cached automatically to prevent it from building twice).
@@ -16,12 +17,6 @@ include ../containers_shared.mk
 
 # Docker repo for a push
 DOCKER_REPO ?= $(DOCKER_ORG)/test-ssh-server
-
-# Additional targets can be added here
-# Also, existing targets can be overridden by copying and customizing them.
-multi-arch:
-	docker buildx build --platform $(BUILD_ARCHS) -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) .; \
-	echo "created multi-arch builds $(BUILD_ARCHS) for $(DOCKER_REPO)";
 
 test: container
 	true


### PR DESCRIPTION

## The Issue

When we were reviewing the results of 
* https://github.com/ddev/ddev/pull/6613

today, Stas pointed out that

* `latest` didn't have the correct matching hash
* `ddev-dbserver` didn't get `latest` tag at all

## How This PR Solves The Issue

I couldn't help but work on it a bit, so here it is.

This should not go into DDEV v1.23.5, and testing was done against ddevhq org

## Manual Testing Instructions

Use the web UI to push images.

