### PR TITLE
docs: add docker volumes to ddev uninstall docs

### DIFF
--- a/docs/content/users/usage/uninstall.md
+++ b/docs/content/users/usage/uninstall.md
@@ -6,7 +6,7 @@ A DDEV installation consists of:
 * Each project’s `.ddev` directory.
 * The global `~/.ddev` directory where various global items are stored. (This directory can be [moved](./architecture.md#global-files) to another location.)
 * The global `~/.ddev_mutagen_data_directory` directory where Mutagen sync data may be stored.
-* The associated Docker images and containers DDEV created.
+* The associated Docker images, containers and volumes DDEV created.
 * Any entries in `/etc/hosts`.
 
 Please use [`ddev snapshot`](commands.md#snapshot) or [`ddev export-db`](commands.md#export-db) to make backups of your databases before deleting projects or uninstalling.


### PR DESCRIPTION
I was trying to wipe the database and didn't know that volumes were being used. This is an attempt to surface that information for whoever comes across this next.