### PR TITLE
docs: Fix copy-paste error in add-on list docs

### DIFF
--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -140,7 +140,7 @@ Flags:
 
 * `--all`: List unofficial *and* official add-ons. (default `true`)
 * `--installed`: List installed add-ons
-* `--project <projectName>`: Specify a project to remove the add-on from. Can only be used with the `--installed` flag. Defaults to checking for a project in the current directory.
+* `--project <projectName>`: Specify a project to list add-ons for. Can only be used with the `--installed` flag. Defaults to checking for a project in the current directory.
 
 Example:
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -140,7 +140,7 @@ Flags:
 
 * `--all`: List unofficial *and* official add-ons. (default `true`)
 * `--installed`: List installed add-ons
-* `--project <projectName>`: Specify a project to list add-ons for. Can only be used with the `--installed` flag. Defaults to checking for a project in the current directory.
+* `--project <projectName>`: Specify the project for which to list add-ons. Can only be used with the `--installed` flag. Defaults to checking for a project in the current directory.
 
 Example:
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- N/A

The `ddev add-on list` docs have a copy-paste error where the docs from `ddev add-on remove` were copied and not updated.

## How This PR Solves The Issue

Updates the documentation to reference list, instead of remove.

## Manual Testing Instructions

Just read it and make sure it's sensible

## Automated Testing Overview

N/A - docs only

## Release/Deployment Notes

N/A - docs only