### PR TITLE
feat: add `ddev cd` command, fixes #6639

### DIFF
--- a/cmd/ddev/cmd/cd.go
+++ b/cmd/ddev/cmd/cd.go
@@ -1,42 +1,47 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
+	"path/filepath"
 )
 
 // CdCmd is the top-level "ddev cd" command
 var CdCmd = &cobra.Command{
 	Use:   "cd [project-name]",
 	Short: "Uses shell built-in 'cd' to change to a project directory",
-	Long: `For bash/zsh add this function to your ~/.bashrc or ~/.zshrc,
-then restart your shell, and use 'ddev cd project-name':
+	Long: fmt.Sprintf(`To enable 'ddev cd' command, source the ddev.sh script from your rc-script.
 
-ddev() {
-  if [ "$1" = "cd" ] && [ -n "$2" ]; then
-    cd "$(DDEV_VERBOSE=false command ddev cd "$2")"
-  else
-    command ddev "$@"
-  fi
-}
+From bash:
 
-For fish add this function to your ~/.config/fish/config.fish,
-then restart your shell, and use 'ddev cd project-name':
+printf '\nsource "%s"' >> ~/.bashrc
 
-function ddev
-  if test (count $argv) -eq 2 -a "$argv[1]" = "cd"
-    cd "$(DDEV_VERBOSE=false command ddev cd $argv[2])"
-  else
-    command ddev $argv
-  end
-end`,
+From zsh:
+
+printf '\nsource "%s"' >> ~/.zshrc
+
+From fish:
+
+echo \n'source "%s"' >> ~/.config/fish/config.fish
+
+Restart your shell, and use 'ddev cd project-name'.
+`, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh"), filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh"), filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish")),
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
 	Example: `ddev cd
 command ddev cd project-name
 ddev cd project-name`,
 	Run: func(cmd *cobra.Command, args []string) {
+		for _, file := range []string{"ddev.sh", "ddev.fish"} {
+			if !fileutil.FileExists(filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells", file)) {
+				util.Failed("Unable to find %s in %s", file, globalconfig.GetGlobalDdevDir())
+			}
+
+		}
 		if len(args) < 1 {
 			output.UserOut.Println(cmd.Long)
 			return

--- a/cmd/ddev/cmd/cd.go
+++ b/cmd/ddev/cmd/cd.go
@@ -11,6 +11,9 @@ import (
 	"path/filepath"
 )
 
+var bashFile = filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh")
+var fishFile = filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish")
+
 // CdCmd is the top-level "ddev cd" command
 var CdCmd = &cobra.Command{
 	Use:   "cd [project-name]",
@@ -19,26 +22,26 @@ var CdCmd = &cobra.Command{
 
 From bash:
 
-printf '\nsource "%s"' >> ~/.bashrc
+printf '\n[ -f "%s" ] && source "%s"' >> ~/.bashrc
 
 From zsh:
 
-printf '\nsource "%s"' >> ~/.zshrc
+printf '\n[ -f "%s" ] && source "%s"' >> ~/.zshrc
 
 From fish:
 
-echo \n'source "%s"' >> ~/.config/fish/config.fish
+echo \n'[ -f "%s" ] && source "%s"' >> ~/.config/fish/config.fish
 
 Restart your shell, and use 'ddev cd project-name'.
-`, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh"), filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh"), filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish")),
+`, bashFile, bashFile, bashFile, bashFile, fishFile, fishFile),
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
 	Example: `ddev cd
 command ddev cd project-name
 ddev cd project-name`,
 	Run: func(cmd *cobra.Command, args []string) {
-		for _, file := range []string{"ddev.sh", "ddev.fish"} {
-			if !fileutil.FileExists(filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells", file)) {
-				util.Failed("Unable to find %s in %s", file, globalconfig.GetGlobalDdevDir())
+		for _, file := range []string{bashFile, fishFile} {
+			if !fileutil.FileExists(file) {
+				util.Failed("Unable to find file: %s", file)
 			}
 
 		}

--- a/cmd/ddev/cmd/cd.go
+++ b/cmd/ddev/cmd/cd.go
@@ -20,15 +20,15 @@ var CdCmd = &cobra.Command{
 	Short: "Uses shell built-in 'cd' to change to a project directory",
 	Long: fmt.Sprintf(`To enable 'ddev cd' command, source the ddev.sh script from your rc-script.
 
-From bash:
+For bash:
 
 printf '\n[ -f "%s" ] && source "%s"' >> ~/.bashrc
 
-From zsh:
+For zsh:
 
 printf '\n[ -f "%s" ] && source "%s"' >> ~/.zshrc
 
-From fish:
+For fish:
 
 echo \n'[ -f "%s" ] && source "%s"' >> ~/.config/fish/config.fish
 

--- a/cmd/ddev/cmd/cd.go
+++ b/cmd/ddev/cmd/cd.go
@@ -5,35 +5,39 @@ import (
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/heredoc"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 	"path/filepath"
 )
 
-var bashFile = filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh")
-var fishFile = filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish")
+var (
+	bashFile = filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh")
+	fishFile = filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish")
+)
 
 // CdCmd is the top-level "ddev cd" command
 var CdCmd = &cobra.Command{
 	Use:   "cd [project-name]",
 	Short: "Uses shell built-in 'cd' to change to a project directory",
-	Long: fmt.Sprintf(`To enable the 'ddev cd' command, source the ddev.sh script from your rc-script.
+	Long: heredoc.Doc(fmt.Sprintf(`
+		To enable the 'ddev cd' command, source the ddev.sh script from your rc-script.
 
-For bash:
+		For bash:
 
-printf '\n[ -f "%s" ] && source "%s"' >> ~/.bashrc
+		printf '\n[ -f "%s" ] && source "%s"\n' >> ~/.bashrc
 
-For zsh:
+		For zsh:
 
-printf '\n[ -f "%s" ] && source "%s"' >> ~/.zshrc
+		printf '\n[ -f "%s" ] && source "%s"\n' >> ~/.zshrc
 
-For fish:
+		For fish:
 
-echo \n'[ -f "%s" ] && source "%s"' >> ~/.config/fish/config.fish
+		printf '\n[ -f "%s" ] && source "%s"\n' >> ~/.config/fish/config.fish
 
-Restart your shell, and use 'ddev cd project-name'.
-`, bashFile, bashFile, bashFile, bashFile, fishFile, fishFile),
+		Restart your shell, and use 'ddev cd project-name'.
+		`, bashFile, bashFile, bashFile, bashFile, fishFile, fishFile)),
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
 	Example:           `ddev cd project-name`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/ddev/cmd/cd.go
+++ b/cmd/ddev/cmd/cd.go
@@ -18,7 +18,7 @@ var fishFile = filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/she
 var CdCmd = &cobra.Command{
 	Use:   "cd [project-name]",
 	Short: "Uses shell built-in 'cd' to change to a project directory",
-	Long: fmt.Sprintf(`To enable 'ddev cd' command, source the ddev.sh script from your rc-script.
+	Long: fmt.Sprintf(`To enable the 'ddev cd' command, source the ddev.sh script from your rc-script.
 
 For bash:
 
@@ -36,7 +36,6 @@ Restart your shell, and use 'ddev cd project-name'.
 `, bashFile, bashFile, bashFile, bashFile, fishFile, fishFile),
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
 	Example: `ddev cd
-command ddev cd project-name
 ddev cd project-name`,
 	Run: func(cmd *cobra.Command, args []string) {
 		for _, file := range []string{bashFile, fishFile} {

--- a/cmd/ddev/cmd/cd.go
+++ b/cmd/ddev/cmd/cd.go
@@ -35,18 +35,13 @@ echo \n'[ -f "%s" ] && source "%s"' >> ~/.config/fish/config.fish
 Restart your shell, and use 'ddev cd project-name'.
 `, bashFile, bashFile, bashFile, bashFile, fishFile, fishFile),
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
-	Example: `ddev cd
-ddev cd project-name`,
+	Example:           `ddev cd project-name`,
 	Run: func(cmd *cobra.Command, args []string) {
 		for _, file := range []string{bashFile, fishFile} {
 			if !fileutil.FileExists(file) {
 				util.Failed("Unable to find file: %s", file)
 			}
 
-		}
-		if len(args) < 1 {
-			output.UserOut.Println(cmd.Long)
-			return
 		}
 		if len(args) != 1 {
 			util.Failed("This command only takes one argument: project-name")
@@ -56,10 +51,16 @@ ddev cd project-name`,
 		if err != nil {
 			util.Failed("Failed to find path for project: %v", err)
 		}
-		output.UserOut.Println(app.AppRoot)
+		if cmd.Flags().Changed("get-approot") {
+			output.UserOut.Println(app.AppRoot)
+		} else {
+			output.UserOut.Println(cmd.Long)
+		}
 	},
 }
 
 func init() {
+	CdCmd.Flags().BoolP("get-approot", "", false, "Get the full path to the project root directory")
+	_ = CdCmd.Flags().MarkHidden("get-approot")
 	RootCmd.AddCommand(CdCmd)
 }

--- a/cmd/ddev/cmd/cd.go
+++ b/cmd/ddev/cmd/cd.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// CdCmd is the top-level "ddev cd" command
+var CdCmd = &cobra.Command{
+	Use:   "cd [project-name]",
+	Short: "Uses shell built-in 'cd' to change to a project directory",
+	Long: `For bash/zsh add this function to your ~/.bashrc or ~/.zshrc,
+then restart your shell, and use 'ddev cd project-name':
+
+ddev() {
+  if [ "$1" = "cd" ] && [ -n "$2" ]; then
+    cd "$(DDEV_VERBOSE=false command ddev cd "$2")"
+  else
+    command ddev "$@"
+  fi
+}
+
+For fish add this function to your ~/.config/fish/config.fish,
+then restart your shell, and use 'ddev cd project-name':
+
+function ddev
+  if test (count $argv) -eq 2 -a "$argv[1]" = "cd"
+    cd "$(DDEV_VERBOSE=false command ddev cd $argv[2])"
+  else
+    command ddev $argv
+  end
+end`,
+	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
+	Example: `ddev cd
+command ddev cd project-name
+ddev cd project-name`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			output.UserOut.Println(cmd.Long)
+			return
+		}
+		if len(args) != 1 {
+			util.Failed("This command only takes one argument: project-name")
+		}
+		projectName := args[0]
+		app, err := ddevapp.GetActiveApp(projectName)
+		if err != nil {
+			util.Failed("Failed to find path for project: %v", err)
+		}
+		output.UserOut.Println(app.AppRoot)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(CdCmd)
+}

--- a/cmd/ddev/cmd/cd_test.go
+++ b/cmd/ddev/cmd/cd_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	asrt "github.com/stretchr/testify/assert"
+	"path/filepath"
+	"testing"
+)
+
+// TestCdCmd runs `ddev cd` to see if it works.
+func TestCdCmd(t *testing.T) {
+	assert := asrt.New(t)
+	out, err := exec.RunHostCommand(DdevBin, "cd")
+	assert.NoError(err)
+	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh"))
+	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish"))
+}

--- a/cmd/ddev/cmd/cd_test.go
+++ b/cmd/ddev/cmd/cd_test.go
@@ -14,12 +14,7 @@ import (
 func TestCdCmd(t *testing.T) {
 	assert := asrt.New(t)
 	// Shows help
-	out, err := exec.RunHostCommand(DdevBin, "cd")
-	assert.NoError(err)
-	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh"))
-	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish"))
-	// Shows help
-	out, err = exec.RunHostCommand(DdevBin, "cd")
+	out, err := exec.RunHostCommand(DdevBin, "cd", TestSites[0].Name)
 	assert.NoError(err)
 	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh"))
 	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish"))
@@ -31,4 +26,8 @@ func TestCdCmd(t *testing.T) {
 	out, err = exec.RunHostCommand(DdevBin, "cd", "does-not-exist-"+util.RandString(4))
 	assert.Error(err)
 	assert.Contains(out, "Failed to find path for project")
+	// Shows error
+	out, err = exec.RunHostCommand(DdevBin, "cd")
+	assert.Error(err)
+	assert.Contains(out, "This command only takes one argument: project-name")
 }

--- a/cmd/ddev/cmd/cd_test.go
+++ b/cmd/ddev/cmd/cd_test.go
@@ -3,16 +3,32 @@ package cmd
 import (
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 // TestCdCmd runs `ddev cd` to see if it works.
 func TestCdCmd(t *testing.T) {
 	assert := asrt.New(t)
+	// Shows help
 	out, err := exec.RunHostCommand(DdevBin, "cd")
 	assert.NoError(err)
 	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh"))
 	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish"))
+	// Shows help
+	out, err = exec.RunHostCommand(DdevBin, "cd")
+	assert.NoError(err)
+	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh"))
+	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish"))
+	// Returns the path to the project
+	out, err = exec.RunHostCommand(DdevBin, "cd", TestSites[0].Name, "--get-approot")
+	assert.NoError(err)
+	assert.Equal(strings.TrimRight(out, "\n"), TestSites[0].Dir)
+	// Shows error
+	out, err = exec.RunHostCommand(DdevBin, "cd", "does-not-exist-"+util.RandString(4))
+	assert.Error(err)
+	assert.Contains(out, "Failed to find path for project")
 }

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -229,13 +229,11 @@ ddev cake
 
 ## `cd`
 
-Uses shell built-in `cd` to change to a project directory.
+Uses shell built-in `cd` to change to a project directory. For example, `ddev cd some-project` will change directories to the project root of the project named `some-project`. 
 
-```shell
-# Goes to the project-name directory
-# Works only if you applied the instructions from this command
-ddev cd project-name
-```
+Note that this command can't work until you make a small addition to your `.bashrc`, `.zshrc`, or `config.fish`. To see the explanation of what you need to do:
+
+`ddev cd show-me-how`
 
 ## `clean`
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -229,11 +229,14 @@ ddev cake
 
 ## `cd`
 
-Uses shell built-in `cd` to change to a project directory. For example, `ddev cd some-project` will change directories to the project root of the project named `some-project`. 
+Uses shell built-in `cd` to change to a project directory. For example, `ddev cd some-project` will change directories to the project root of the project named `some-project`.
 
 Note that this command can't work until you make a small addition to your `.bashrc`, `.zshrc`, or `config.fish`. To see the explanation of what you need to do:
 
-`ddev cd show-me-how`
+```shell
+# Where some-project is a project from the `ddev list`
+ddev cd some-project
+```
 
 ## `clean`
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -227,6 +227,20 @@ Run the `cake` command; available only in projects of type `cakephp`, and only a
 ddev cake
 ```
 
+## `cd`
+
+Uses shell built-in `cd` to change to a project directory.
+
+```shell
+# Shows help to make `ddev cd` work in your shell
+ddev cd
+# Returns the path to the project-name
+command ddev cd project-name
+# Goes to the project-name directory
+# Works only if you applied the instructions from `ddev cd`
+ddev cd project-name
+```
+
 ## `clean`
 
 Removes items DDEV has created. (See [Uninstalling DDEV](../usage/uninstall.md).)

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -232,12 +232,8 @@ ddev cake
 Uses shell built-in `cd` to change to a project directory.
 
 ```shell
-# Shows help to make `ddev cd` work in your shell
-ddev cd
-# Returns the path to the project-name
-command ddev cd project-name
 # Goes to the project-name directory
-# Works only if you applied the instructions from `ddev cd`
+# Works only if you applied the instructions from this command
 ddev cd project-name
 ```
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
@@ -12,7 +12,7 @@ function ddev
       case '-*'
         command ddev $argv
       case '*'
-        cd (DDEV_VERBOSE=false command ddev cd $argv[2] --get-approot)
+        cd (DDEV_VERBOSE=false command ddev cd "$argv[2]" --get-approot)
     end
   else
     command ddev $argv

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
@@ -1,0 +1,15 @@
+#ddev-generated
+# This script should be sourced in the context of your shell like so:
+# source $HOME/.ddev/commands/host/shells/ddev.fish
+# Alternatively, it can be installed into one of the directories
+# that fish uses to autoload functions (e.g ~/.config/fish/functions)
+# Once the ddev() function is defined, you can type
+# "ddev cd project-name" to cd into the project directory.
+
+function ddev
+  if test (count $argv) -eq 2 -a "$argv[1]" = "cd"
+    cd "$(DDEV_VERBOSE=false command ddev cd $argv[2])"
+  else
+    command ddev $argv
+  end
+end

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
@@ -8,7 +8,12 @@
 
 function ddev
   if test (count $argv) -eq 2 -a "$argv[1]" = "cd"
-    cd "$(DDEV_VERBOSE=false command ddev cd $argv[2])"
+    switch "$argv[2]"
+      case '-*'
+        command ddev $argv
+      case '*'
+        cd (DDEV_VERBOSE=false command ddev cd $argv[2] --get-approot)
+    end
   else
     command ddev $argv
   end

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
@@ -6,7 +6,7 @@
 # "ddev cd project-name" to cd into the project directory.
 
 ddev() {
-  if [ "$1" = "cd" ] && [ -n "$2" ]; then
+  if [ "$#" -eq 2 ] && [ "$1" = "cd" ]; then
     case "$2" in
       -*) command ddev "$@" ;;
       *) cd "$(DDEV_VERBOSE=false command ddev cd "$2" --get-approot)" ;;

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+#ddev-generated
+# This script should be sourced in the context of your shell like so:
+# source $HOME/.ddev/commands/host/shells/ddev.sh
+# Once the ddev() function is defined, you can type
+# "ddev cd project-name" to cd into the project directory.
+
+ddev() {
+  if [ "$1" = "cd" ] && [ -n "$2" ]; then
+    cd "$(DDEV_VERBOSE=false command ddev cd "$2")"
+  else
+    command ddev "$@"
+  fi
+}

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
@@ -7,7 +7,10 @@
 
 ddev() {
   if [ "$1" = "cd" ] && [ -n "$2" ]; then
-    cd "$(DDEV_VERBOSE=false command ddev cd "$2")"
+    case "$2" in
+      -*) command ddev "$@" ;;
+      *) cd "$(DDEV_VERBOSE=false command ddev cd "$2" --get-approot)" ;;
+    esac
   else
     command ddev "$@"
   fi


### PR DESCRIPTION
## The Issue

- #6639

## How This PR Solves The Issue

Adds the `ddev cd` command.

## Manual Testing Instructions

I tested it with bash, zsh, fish on Linux.

```
# do what it says, restart shell and use it (autocompletion should also work)
ddev cd my-project
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
