### PR TITLE
build: try new mutagen 0.18.0

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -40,7 +40,7 @@ var BUILDINFO = "BUILDINFO should have new info"
 // MutagenVersion is filled with the version we find for Mutagen in use
 var MutagenVersion = ""
 
-const RequiredMutagenVersion = "0.17.2"
+const RequiredMutagenVersion = "0.18.0"
 
 const RequiredDockerComposeVersionDefault = "v2.29.7"
 


### PR DESCRIPTION

## The Issue

Mutagen 0.18.0 has been released, and  @xenoscopic says it may benefit us and shouldn't hurt us. This should be a good point in release cycle to try it out.

## How This PR Solves The Issue

Bump mutagen version.

## Manual Testing Instructions

Use it! Watch `ddev mutagen st -l`

