### PR TITLE
refactor: add `drush` and `composer` command aliases, fixes #6642

### DIFF
--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -17,6 +17,7 @@ var ComposerCmd = &cobra.Command{
 	Use:                "composer [command]",
 	Short:              "Executes a Composer command within the web container",
 	Long: `Executes a Composer command at the Composer root in the web container. Generally,
+	Aliases:            []string{"co"},
 any Composer command can be forwarded to the container context by prepending
 the command with 'ddev'.`,
 	Example: `ddev composer install

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -17,9 +17,9 @@ var ComposerCmd = &cobra.Command{
 	Use:                "composer [command]",
 	Short:              "Executes a Composer command within the web container",
 	Long: `Executes a Composer command at the Composer root in the web container. Generally,
-	Aliases:            []string{"co"},
 any Composer command can be forwarded to the container context by prepending
 the command with 'ddev'.`,
+	Aliases:            []string{"co"},
 	Example: `ddev composer install
 ddev composer require <package>
 ddev composer outdated --minor-only

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -19,7 +19,7 @@ var ComposerCmd = &cobra.Command{
 	Long: `Executes a Composer command at the Composer root in the web container. Generally,
 any Composer command can be forwarded to the container context by prepending
 the command with 'ddev'.`,
-	Aliases:            []string{"co"},
+	Aliases: []string{"co"},
 	Example: `ddev composer install
 ddev composer require <package>
 ddev composer outdated --minor-only

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -251,6 +251,8 @@ ddev clean my-project my-other-project
 
 ## `composer`
 
+*Alias: `co`.*
+
 Executes a [Composer command](../usage/developer-tools.md#ddev-and-composer) within the web container.
 
 `ddev composer create` is a special command that is an adaptation of `composer create-project`. See [DDEV and Composer](../usage/developer-tools.md#ddev-and-composer) for more information.
@@ -704,6 +706,8 @@ ddev dotenv set .ddev/.env.redis --redis-tag 7-bookworm
 ```
 
 ## `drush`
+
+*Alias: `dr`.*
 
 Run the `drush` command; available only in projects of type `drupal*`, and only available if `drush` is in the project. On projects of type `drupal`, `drush` should be installed in the project itself, (`ddev composer require drush/drush`). On projects of type `drupal7` `drush` 8 is provided by DDEV.
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/drush
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/drush
@@ -4,6 +4,7 @@
 ## Description: Run drush CLI inside the web container
 ## Usage: drush [flags] [args]
 ## Example: "ddev drush uli" or "ddev drush sql-cli" or "ddev drush --version"
+## Aliases: dr
 ## ProjectTypes: drupal,drupal10,drupal9,drupal8,drupal7,backdrop
 ## ExecRaw: true
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6642

This adds command aliases for `ddev composer` and `ddev drush`: `ddev co` and `ddev dr` respectively.

I only had a few minutes to throw this together. Did I do it right?

<!-- ## How This PR Solves The Issue -->

<!-- ## Manual Testing Instructions -->

## Automated Testing Overview

I assume no tests are needed for a simple, non-functional change like this.

<!-- ## Release/Deployment Notes -->

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
