### PR TITLE
fix: validate `--all` flag with args in `ddev delete`, for #6209

### DIFF
--- a/cmd/ddev/cmd/delete.go
+++ b/cmd/ddev/cmd/delete.go
@@ -30,7 +30,9 @@ ddev delete --all`,
 		if noConfirm && deleteAll {
 			util.Failed("Sorry, it's not possible to use flags --all and --yes together")
 		}
-
+		if deleteAll && len(args) > 0 {
+			util.Failed("Sorry, it's not possible to use flag --all and project names together")
+		}
 		// Skip project validation if --omit-snapshot is provided
 		originalRunValidateConfig := ddevapp.RunValidateConfig
 		ddevapp.RunValidateConfig = !omitSnapshot


### PR DESCRIPTION
## The Issue

From Drupal Slack https://drupal.slack.com/archives/C5TQRQZRR/p1729847516981059

Hi after updating ddev to the latest version i discovered that `ddev delete --all` command could probably be secured a bit (not talking of security).
If you try to run `ddev delete` with a name that doesn't exist, it will ask to delete the first project in your project list (i guess that if i type yes then it will cycle through the whole list.
I saw it by misspelling images in `ddev delete image --all` command.
See :
```
❯ ddev delete immages --all
OK to delete this project and its database?
  myproject in /Volumes/Server/myproject/public_html
The code and its .ddev directory will not be touched.
A database snapshot will be made before the database is deleted.
OK to delete myproject? [Y/n] (yes): ^C
```
IMHO it should return an error if the command contain the name of a non existing project.

---

This is a related to the change made in:

- #6209

## How This PR Solves The Issue

Adds a check for `--all` flag with args.

## Manual Testing Instructions

```
ddev delete --all # should ask to delete projects
ddev delete immages --all # should fail
ddev delete images --all # should work as before
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
