### PR TITLE
fix: make drupal detection only detect drupal8+

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"text/template"
 
 	"github.com/ddev/ddev/pkg/archive"
@@ -341,10 +342,18 @@ func GetDrupalVersion(app *DdevApp) (string, error) {
 	return v, err
 }
 
-// isDrupalApp returns true if the app is drupal
+// isDrupalApp returns true if the app is drupal (drupal8+)
 func isDrupalApp(app *DdevApp) bool {
-	v, err := GetDrupalVersion(app)
-	if err == nil && v != "" {
+	vStr, err := GetDrupalVersion(app)
+	if err != nil {
+		return false
+	}
+	v, err := strconv.Atoi(vStr)
+	if err != nil {
+		return false
+	}
+
+	if v >= 8 {
 		return true
 	}
 	return false


### PR DESCRIPTION
## The Issue

I noticed in testing another issue that a `drupal7` project (and probably `drupal6` could randomly be detected as a `drupal` project, due to two errors in logic:

1. Assumption that map would be traversed in stable order (it isn't in go)
2. IsDrupalApp() assumed that any "drupal" project was of type "drupal", not just drupal8+

## How This PR Solves The Issue

IsDrupalApp() now checks to see if it's drupal8+

## Manual Testing Instructions

It's a little hard to test, but `ddev config --database=postgres:16` in a drupal7 project is how I discovered it. It complained that the project was of type drupal but was configured as drupal7.

I had to add `util.Debug()` statements to see the various attempts to discover project type. Debugging through it didn't help, as that provided a stable traversal of the map.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
