### PR TITLE
build: bump docker-compose to 2.30.0

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -42,7 +42,7 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.18.0"
 
-const RequiredDockerComposeVersionDefault = "v2.29.7"
+const RequiredDockerComposeVersionDefault = "v2.30.0"
 
 // Drupal11RequiredSqlite3Version for ddev-webserver
 const Drupal11RequiredSqlite3Version = "3.45.1"


### PR DESCRIPTION

## The Issue

Docker-compose 2.30.0 is out, https://github.com/docker/compose/releases/tag/v2.30.0

Check for compatibility/test run.

