### PR TITLE
fix: passes arguments to mysqld process in docker-entypoint.sh file, fixes #6668

### DIFF
--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -139,5 +139,18 @@ echo 'MySQL init process done. Ready for start up.'
 echo
 
 echo "Starting mysqld."
-tail -f /var/log/mysqld.log &
-exec mysqld --server-id=0
+
+# Checks if any arguments are present.
+elif ["$#" -eq 0]; then
+    tail -f /var/log/mysqld.log &
+    exec mysqld --server-id=0
+else
+    # Checks if --server-id argument is given.
+    elif [[ " $* " =~ "--server-id"([=[:space:]]|$) ]]; then
+        tail -f /var/log/mysqld.log &
+        exec mysqld "$@"
+    else
+        tail -f /var/log/mysqld.log &
+        exec mysqld --server-id=0 "$@"
+    fi
+fi

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -141,16 +141,16 @@ echo
 echo "Starting mysqld."
 
 # Checks if any arguments are present.
-elif ["$#" -eq 0]; then
-    tail -f /var/log/mysqld.log &
-    exec mysqld --server-id=0
+if [ "$#" -eq 0 ]; then
+  tail -f /var/log/mysqld.log &
+  exec mysqld --server-id=0
 else
-    # Checks if --server-id argument is given.
-    elif [[ " $* " =~ "--server-id"([=[:space:]]|$) ]]; then
-        tail -f /var/log/mysqld.log &
-        exec mysqld "$@"
-    else
-        tail -f /var/log/mysqld.log &
-        exec mysqld --server-id=0 "$@"
-    fi
+  # Checks if --server-id argument is given.
+  if [[ " $* " =~ "--server-id"([=[:space:]]|$) ]]; then
+    tail -f /var/log/mysqld.log &
+    exec mysqld "$@"
+  else
+    tail -f /var/log/mysqld.log &
+    exec mysqld --server-id=0 "$@"
+  fi
 fi

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2842,6 +2842,7 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 			return fmt.Errorf("failed to process post-stop hooks: %v", err)
 		}
 	}
+	_ = os.Setenv(`DDEV_DB_CONTAINER_COMMAND`, "")
 
 	return nil
 }

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "20241105_stasadev_composer_bin" // Note that this can be overridde
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.23.5"
+var BaseDBTag = "20241109_stijnveeke_mysql_args"
 
 const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:v1.23.5"
 const TraefikRouterImage = "ddev/ddev-traefik-router:v1.23.5"


### PR DESCRIPTION
## The Issue

- #6668

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Checks for arguments if present and passes them to the mysqld execution. In case not present it will use the default execution process which is`mysqld --server-id=0`.

## TODO

- [ ] Test coverage for this feature
- [ ] Documentation of how to use this feature in `docker-compose.*.yaml`

## Manual Testing Instructions

Extend the functionality of the db container by adding to a docker compose additional execution arguments like this.
` command: --server-id=1 --log-bin=mysql-bin --binlog-format=row` It should now check if a server-id is present in case it is it will add the above arguments to the execution of mysqld in case this is not present it will append these arguments to the already present --server-id=0 argument.

## Automated Testing Overview

No automatic tests are needed because it always defaults back to the default functionality which is: 
`mysqld --server-id=0` 

## Release/Deployment Notes

Nothing has to change during deployment.
