### PR TITLE
docs: Use `brew upgrade ddev` instead of `brew upgrade ddev/ddev/ddev` (old brew `drud/ddev` tap)

### DIFF
--- a/docs/content/users/install/ddev-upgrade.md
+++ b/docs/content/users/install/ddev-upgrade.md
@@ -13,7 +13,7 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ```bash
     # Upgrade DDEV to the latest version
-    brew upgrade ddev/ddev/ddev
+    brew upgrade ddev
     ```
 
     ### Install Script


### PR DESCRIPTION
Bear with my as this is my first PR for this repo.

On my machine (OSX) I had to do `brew upgrade ddev` instead of `brew upgrade ddev/ddev/ddev` I hope this fixes the documentation for the next person.

- I did not create an issue number, I don't care about pr credits. I just saw an issue while using the readme.

## How This PR Solves The Issue
Readme is updated.

## Manual Testing Instructions
Tested with new command and it now works on my machine

## Automated Testing Overview

No tests as it is a readme update.

## Release/Deployment Notes

Does not change anything other then the documentation.
