### PR TITLE
test: tests.yml needs to check out full depth [skip ci]

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -62,6 +62,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # We need to get all branches and tags for git describe to work properly
+          fetch-depth: 0
 
       - name: Get Date
         id: get-date

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # We need to get all branches and tags for git describe to work properly
+          fetch-depth: 0
 
       - name: Get Date
         id: get-date


### PR DESCRIPTION

## The Issue

Over in 
* https://github.com/ddev/ddev/pull/6645

we're struggling because the `ddev --version` is a hash instead of a proper version number

It turns out that tests.yml doesn't check out the repo with depth like almost every other github action.

