### PR TITLE
feat: allow files and symlinks in `ddev auth ssh`, fixes #5465, fixes #6677

### DIFF
--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -26,9 +26,9 @@ var AuthSSHCommand = &cobra.Command{
 	Long:  `Use this command to provide the password to your SSH key to the ddev-ssh-agent container, where it can be used by other containers.`,
 	Example: heredoc.DocI2S(`
 		ddev auth ssh
-		ddev auth ssh -d ~/.ssh
+		ddev auth ssh -d ~/custom/path/to/ssh
 		ddev auth ssh -f ~/.ssh/id_ed25519 -f ~/.ssh/id_rsa
-		ddev auth ssh -d ~/.ssh -f /path/to/id_ed25519
+		ddev auth ssh -d ~/.ssh -f ~/custom/path/to/ssh/id_ed25519
 	`),
 	Run: func(_ *cobra.Command, args []string) {
 		var err error

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -118,7 +118,7 @@ ddev auth ssh -f ~/.ssh/id_ed25519`,
 			if _, exists := addedKeys[filename]; exists {
 				filename = fmt.Sprintf("%s_%d", filename, i)
 			}
-			addedKeys[keyPath] = struct{}{}
+			addedKeys[filename] = struct{}{}
 			mount := mount.Mount{
 				Type:     mount.TypeBind,
 				Source:   keyPath,

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -2,20 +2,19 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/docker"
+	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/heredoc"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
-
-	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/exec"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/util"
-	"github.com/spf13/cobra"
 )
 
 var sshKeyFiles, sshKeyDirs []string
@@ -31,7 +30,7 @@ var AuthSSHCommand = &cobra.Command{
 		ddev auth ssh -f ~/.ssh/id_ed25519 -f ~/.ssh/id_rsa
 		ddev auth ssh -d ~/.ssh -f /path/to/id_ed25519
 	`),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		var err error
 		if len(args) > 0 {
 			util.Failed("This command takes no arguments.")

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -63,7 +63,7 @@ var AuthSSHCommand = &cobra.Command{
 			}
 		}
 		if len(keys) == 0 {
-			util.Failed("No SSH keys found in %s", strings.Join(files, ", "))
+			util.Failed("No SSH keys found in %s", strings.Join(append(sshKeyDirs, sshKeyFiles...), ", "))
 		}
 
 		app, err := ddevapp.GetActiveApp("")

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -95,7 +95,7 @@ var AuthSSHCommand = &cobra.Command{
 
 		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--entrypoint="}
 		dockerCmd = append(dockerCmd, mounts...)
-		dockerCmd = append(dockerCmd, versionconstants.SSHAuthImage+":"+versionconstants.SSHAuthTag+"-built", "bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && grep -d skip -l '^-----BEGIN .* PRIVATE KEY-----' * | xargs -d '\n' ssh-add`)
+		dockerCmd = append(dockerCmd, versionconstants.SSHAuthImage+":"+versionconstants.SSHAuthTag+"-built", "bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && grep -l '^-----BEGIN .* PRIVATE KEY-----' * | xargs -d '\n' ssh-add`)
 
 		err = exec.RunInteractiveCommand("docker", dockerCmd)
 

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -141,7 +141,7 @@ ddev auth ssh -f ~/.ssh/id_ed25519`,
 			helpMessage := ""
 			// Add a more helpful message to the obscure error from Docker
 			// Can be triggered if key is in /tmp on macOS
-			if strings.Contains(out, "bind source path does not exist") {
+			if strings.Contains(err.Error(), "bind source path does not exist") {
 				helpMessage = "\n\nThe specified SSH key path is not shared with your Docker provider."
 			}
 			util.Failed("Unable to run auth ssh: %v; output='%s'%s", err, out, helpMessage)

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -1,32 +1,43 @@
 package cmd
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/docker"
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/ddev/ddev/pkg/versionconstants"
+	dockerContainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/spf13/cobra"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
-// sshKeyPath is the full path to the *directory* containing SSH keys.
+// sshKeyPath is the full path to the path containing SSH keys.
 var sshKeyPath string
 
 // AuthSSHCommand implements the "ddev auth ssh" command
 var AuthSSHCommand = &cobra.Command{
-	Use:     "ssh",
-	Short:   "Add SSH key authentication to the ddev-ssh-agent container",
-	Long:    `Use this command to provide the password to your SSH key to the ddev-ssh-agent container, where it can be used by other containers. Normal usage is "ddev auth ssh", or if your key is not in ~/.ssh, ddev auth ssh --ssh-key-path=/some/path/.ssh"`,
-	Example: `ddev auth ssh`,
-	Run: func(_ *cobra.Command, args []string) {
+	Use:   "ssh",
+	Short: "Add SSH key authentication to the ddev-ssh-agent container",
+	Long:  `Use this command to provide the password to your SSH key to the ddev-ssh-agent container, where it can be used by other containers. Normal usage is "ddev auth ssh", or if your key is not in ~/.ssh, ddev auth ssh --ssh-key-path=/some/path/.ssh"`,
+	Example: `ddev auth ssh
+ddev auth ssh -d ~/.ssh
+ddev auth ssh -f ~/.ssh/id_ed25519`,
+	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 		if len(args) > 0 {
 			util.Failed("This command takes no arguments.")
+		}
+
+		if cmd.Flags().Changed("ssh-key-path") {
+			sshKeyPath = cmd.Flag("ssh-key-path").Value.String()
+		} else if cmd.Flags().Changed("ssh-key-file") {
+			sshKeyPath = cmd.Flag("ssh-key-file").Value.String()
 		}
 
 		uidStr, _, _ := util.GetContainerUIDGid()
@@ -55,8 +66,14 @@ var AuthSSHCommand = &cobra.Command{
 		var paths []string
 		var files []string
 		if !fi.IsDir() {
+			if cmd.Flags().Changed("ssh-key-path") {
+				util.Failed("SSH key path %s is not a directory", sshKeyPath)
+			}
 			files = append(files, sshKeyPath)
 		} else {
+			if cmd.Flags().Changed("ssh-key-file") {
+				util.Failed("SSH key path %s is not a file", sshKeyPath)
+			}
 			files, err = fileutil.ListFilesInDirFullPath(sshKeyPath, true)
 			if err != nil {
 				util.Failed("Failed to list files in %s: %v", sshKeyPath, err)
@@ -86,27 +103,37 @@ var AuthSSHCommand = &cobra.Command{
 			util.Failed("Failed to start ddev-ssh-agent container: %v", err)
 		}
 
-		var mounts []string
+		var mounts []mount.Mount
 		for _, keyPath := range paths {
-			filename := filepath.Base(keyPath)
-			keyPath = util.WindowsPathToCygwinPath(keyPath)
-			mounts = append(mounts, "--mount=type=bind,src="+keyPath+",dst=/tmp/sshtmp/"+filename)
+			mount := mount.Mount{
+				Type:     mount.TypeBind,
+				Source:   keyPath,
+				Target:   "/tmp/sshtmp/" + filepath.Base(keyPath),
+				ReadOnly: true,
+			}
+			mounts = append(mounts, mount)
 		}
-
-		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--entrypoint="}
-		dockerCmd = append(dockerCmd, mounts...)
-		dockerCmd = append(dockerCmd, versionconstants.SSHAuthImage+":"+versionconstants.SSHAuthTag+"-built", "bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && grep -l '^-----BEGIN .* PRIVATE KEY-----' * | xargs -d '\n' ssh-add`)
-
-		err = exec.RunInteractiveCommand("docker", dockerCmd)
-
+		sshAddCmd := []string{"bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && key_files=$(grep -l '^-----BEGIN .* PRIVATE KEY-----' *); if [ -z "$key_files" ]; then echo 'No private keys found.' >&2; exit 1; else echo $key_files | xargs -d '\n' ssh-add; fi`}
+		config := &dockerContainer.Config{
+			Entrypoint: []string{},
+		}
+		hostConfig := &dockerContainer.HostConfig{
+			Mounts:      mounts,
+			VolumesFrom: []string{ddevapp.SSHAuthName},
+		}
+		_, out, err := dockerutil.RunSimpleContainerExtended(docker.GetSSHAuthImage()+"-built", "auth-ssh-"+util.RandString(6), sshAddCmd, uidStr, true, false, config, hostConfig)
+		out = strings.TrimSpace(out)
 		if err != nil {
-			util.Failed("Docker command 'docker %v' failed: %v", dockerCmd, err)
+			util.Failed("Unable to run auth ssh: %v; output='%s'", err, out)
 		}
+		output.UserOut.Println(out)
 	},
 }
 
 func init() {
-	AuthSSHCommand.Flags().StringVarP(&sshKeyPath, "ssh-key-path", "d", "", "full path to SSH key directory or file")
+	AuthSSHCommand.Flags().StringP("ssh-key-file", "f", "", "full path to SSH key file")
+	AuthSSHCommand.Flags().StringP("ssh-key-path", "d", "", "full path to SSH key directory")
+	AuthSSHCommand.MarkFlagsMutuallyExclusive("ssh-key-file", "ssh-key-path")
 
 	AuthCmd.AddCommand(AuthSSHCommand)
 }

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -55,7 +55,8 @@ var AuthSSHCommand = &cobra.Command{
 		for _, file := range files {
 			key, err := filepath.EvalSymlinks(file)
 			if err != nil {
-				util.Failed("Error resolving symlinks for %s: %v", file, err)
+				util.Warning("Unable to read %s file: %v", file, err)
+				continue
 			}
 			if !slices.Contains(keys, key) {
 				if isPrivateKey, _ := fileIsPrivateKey(key); isPrivateKey {

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -138,7 +138,13 @@ ddev auth ssh -f ~/.ssh/id_ed25519`,
 		_, out, err := dockerutil.RunSimpleContainerExtended(docker.GetSSHAuthImage()+"-built", "auth-ssh-"+util.RandString(6), sshAddCmd, uidStr, true, false, config, hostConfig)
 		out = strings.TrimSpace(out)
 		if err != nil {
-			util.Failed("Unable to run auth ssh: %v; output='%s'", err, out)
+			helpMessage := ""
+			// Add a more helpful message to the obscure error from Docker
+			// Can be triggered if key is in /tmp on macOS
+			if strings.Contains(out, "bind source path does not exist") {
+				helpMessage = "\n\nThe specified SSH key path is not shared with your Docker provider."
+			}
+			util.Failed("Unable to run auth ssh: %v; output='%s'%s", err, out, helpMessage)
 		}
 		output.UserOut.Println(out)
 	},

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -2,96 +2,70 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/docker"
-	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/output"
-	"github.com/ddev/ddev/pkg/util"
-	dockerContainer "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
-	"github.com/spf13/cobra"
+	"github.com/ddev/ddev/pkg/heredoc"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
 )
 
-// sshKeyPath is the full path to the path containing SSH keys.
-var sshKeyPath string
+var sshKeyFiles, sshKeyDirs []string
 
 // AuthSSHCommand implements the "ddev auth ssh" command
 var AuthSSHCommand = &cobra.Command{
 	Use:   "ssh",
 	Short: "Add SSH key authentication to the ddev-ssh-agent container",
-	Long:  `Use this command to provide the password to your SSH key to the ddev-ssh-agent container, where it can be used by other containers. Normal usage is "ddev auth ssh", or if your key is not in ~/.ssh, ddev auth ssh --ssh-key-path=/some/path/.ssh"`,
-	Example: `ddev auth ssh
-ddev auth ssh -d ~/.ssh
-ddev auth ssh -f ~/.ssh/id_ed25519`,
+	Long:  `Use this command to provide the password to your SSH key to the ddev-ssh-agent container, where it can be used by other containers.`,
+	Example: heredoc.DocI2S(`
+		ddev auth ssh
+		ddev auth ssh -d ~/.ssh
+		ddev auth ssh -f ~/.ssh/id_ed25519 -f ~/.ssh/id_rsa
+		ddev auth ssh -d ~/.ssh -f /path/to/id_ed25519
+	`),
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 		if len(args) > 0 {
 			util.Failed("This command takes no arguments.")
 		}
 
-		if cmd.Flags().Changed("ssh-key-path") {
-			sshKeyPath = cmd.Flag("ssh-key-path").Value.String()
-		} else if cmd.Flags().Changed("ssh-key-file") {
-			sshKeyPath = cmd.Flag("ssh-key-file").Value.String()
-		}
-
 		uidStr, _, _ := util.GetContainerUIDGid()
 
-		if sshKeyPath == "" {
+		// Use ~/.ssh if nothing is provided
+		if sshKeyFiles == nil && sshKeyDirs == nil {
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				util.Failed("Unable to determine home directory: %v", err)
 			}
-			sshKeyPath = filepath.Join(homeDir, ".ssh")
-		}
-		if !filepath.IsAbs(sshKeyPath) {
-			sshKeyPath, err = filepath.Abs(sshKeyPath)
-			if err != nil {
-				util.Failed("Failed to derive absolute path for SSH key path %s: %v", sshKeyPath, err)
-			}
-		}
-		fi, err := os.Stat(sshKeyPath)
-		if os.IsNotExist(err) {
-			util.Failed("The SSH key path %s was not found", sshKeyPath)
-		}
-		if err != nil {
-			util.Failed("Failed to check status of SSH key path %s: %v", sshKeyPath, err)
+			sshKeyDirs = append(sshKeyDirs, filepath.Join(homeDir, ".ssh"))
 		}
 
-		var paths []string
-		var files []string
-		if !fi.IsDir() {
-			if cmd.Flags().Changed("ssh-key-path") {
-				util.Failed("SSH key path %s is not a directory", sshKeyPath)
-			}
-			files = append(files, sshKeyPath)
-		} else {
-			if cmd.Flags().Changed("ssh-key-file") {
-				util.Failed("SSH key path %s is not a file", sshKeyPath)
-			}
-			files, err = fileutil.ListFilesInDirFullPath(sshKeyPath, true)
-			if err != nil {
-				util.Failed("Failed to list files in %s: %v", sshKeyPath, err)
-			}
-		}
+		files := getSSHKeyPaths(sshKeyDirs, true, false)
+		files = append(files, getSSHKeyPaths(sshKeyFiles, false, true)...)
+
+		var keys []string
 		// Get real paths to key files in case they are symlinks
 		for _, file := range files {
-			realPath, err := filepath.EvalSymlinks(file)
+			key, err := filepath.EvalSymlinks(file)
 			if err != nil {
 				util.Failed("Error resolving symlinks for %s: %v", file, err)
 			}
-			if fileutil.FileIsReadable(realPath) {
-				paths = append(paths, realPath)
+			if !slices.Contains(keys, key) {
+				if isPrivateKey, _ := fileIsPrivateKey(key); isPrivateKey {
+					keys = append(keys, key)
+				}
 			}
 		}
-		if len(paths) == 0 {
-			util.Failed("No SSH keys found in %s", sshKeyPath)
+		if len(keys) == 0 {
+			util.Failed("No SSH keys found in %s", strings.Join(files, ", "))
 		}
 
 		app, err := ddevapp.GetActiveApp("")
@@ -109,51 +83,107 @@ ddev auth ssh -f ~/.ssh/id_ed25519`,
 			util.Failed("Failed to start ddev-ssh-agent container: %v", err)
 		}
 
+		var mounts []string
 		// Map to track already added keys
 		addedKeys := make(map[string]struct{})
-		var mounts []mount.Mount
-		for i, keyPath := range paths {
+		for i, keyPath := range keys {
 			filename := filepath.Base(keyPath)
 			// If it has the same name, change it to avoid conflicts
+			// This can happen if you have symlinks to the same key
 			if _, exists := addedKeys[filename]; exists {
 				filename = fmt.Sprintf("%s_%d", filename, i)
 			}
 			addedKeys[filename] = struct{}{}
-			mount := mount.Mount{
-				Type:     mount.TypeBind,
-				Source:   keyPath,
-				Target:   "/tmp/sshtmp/" + filename,
-				ReadOnly: true,
-			}
-			mounts = append(mounts, mount)
+			keyPath = util.WindowsPathToCygwinPath(keyPath)
+			mounts = append(mounts, "--mount=type=bind,src="+keyPath+",dst=/tmp/sshtmp/"+filename)
 		}
-		sshAddCmd := []string{"bash", "-c", fmt.Sprintf(`cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && grep -l '^-----BEGIN .* PRIVATE KEY-----' * | xargs -d '\n' ssh-add; exit_code=$?; if [ $exit_code -eq 123 ]; then echo >&2 "No SSH keys found in %s"; fi; exit $exit_code`, sshKeyPath)}
-		config := &dockerContainer.Config{
-			Entrypoint: []string{},
-		}
-		hostConfig := &dockerContainer.HostConfig{
-			Mounts:      mounts,
-			VolumesFrom: []string{ddevapp.SSHAuthName},
-		}
-		_, out, err := dockerutil.RunSimpleContainerExtended(docker.GetSSHAuthImage()+"-built", "auth-ssh-"+util.RandString(6), sshAddCmd, uidStr, true, false, config, hostConfig)
-		out = strings.TrimSpace(out)
+
+		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--entrypoint="}
+		dockerCmd = append(dockerCmd, mounts...)
+		dockerCmd = append(dockerCmd, docker.GetSSHAuthImage()+"-built", "bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && grep -l '^-----BEGIN .* PRIVATE KEY-----' * | xargs -d '\n' ssh-add`)
+
+		err = exec.RunInteractiveCommand("docker", dockerCmd)
+
 		if err != nil {
 			helpMessage := ""
-			// Add a more helpful message to the obscure error from Docker
-			// Can be triggered if key is in /tmp on macOS
+			// Add more helpful message to the obscure error from Docker
+			// Can be triggered if the key is in /tmp on macOS
 			if strings.Contains(err.Error(), "bind source path does not exist") {
 				helpMessage = "\n\nThe specified SSH key path is not shared with your Docker provider."
 			}
-			util.Failed("Unable to run auth ssh: %v; output='%s'%s", err, out, helpMessage)
+			util.Failed("Docker command 'docker %v' failed: %v %v", echoDockerCmd(dockerCmd), err, helpMessage)
 		}
-		output.UserOut.Println(out)
 	},
 }
 
+// getSSHKeyPaths returns an array of full paths to SSH keys
+// with checks to ensure they are valid.
+func getSSHKeyPaths(sshKeyPathArray []string, acceptsDirsOnly bool, acceptsFilesOnly bool) []string {
+	var files []string
+	for _, sshKeyPath := range sshKeyPathArray {
+		if !filepath.IsAbs(sshKeyPath) {
+			sshKeyPath, err := filepath.Abs(sshKeyPath)
+			if err != nil {
+				util.Failed("Failed to derive absolute path for SSH key path %s: %v", sshKeyPath, err)
+			}
+		}
+		fi, err := os.Stat(sshKeyPath)
+		if os.IsNotExist(err) {
+			util.Failed("The SSH key path %s was not found", sshKeyPath)
+		}
+		if err != nil {
+			util.Failed("Failed to check status of SSH key path %s: %v", sshKeyPath, err)
+		}
+		if !fi.IsDir() {
+			if acceptsDirsOnly {
+				util.Failed("SSH key path %s is not a directory", sshKeyPath)
+			}
+			files = append(files, sshKeyPath)
+		} else {
+			if acceptsFilesOnly {
+				util.Failed("SSH key path %s is not a file", sshKeyPath)
+			}
+			files, err = fileutil.ListFilesInDirFullPath(sshKeyPath, true)
+			if err != nil {
+				util.Failed("Failed to list files in %s: %v", sshKeyPath, err)
+			}
+		}
+	}
+	return files
+}
+
+// fileIsPrivateKey checks if a file is readable and that it is a private key.
+// Regex isn't used here because files can be huge.
+// The full check if it's really a private key is done with grep -l '^-----BEGIN .* PRIVATE KEY-----'.
+func fileIsPrivateKey(filePath string) (bool, error) {
+	file, err := os.OpenFile(filePath, os.O_RDONLY, 0666)
+	if err != nil {
+		return false, err
+	}
+	// nolint: errcheck
+	defer file.Close()
+	prefix := []byte("-----BEGIN")
+	buffer := make([]byte, len(prefix))
+	_, err = file.Read(buffer)
+	if err != nil {
+		return false, err
+	}
+	return string(buffer) == string(prefix), nil
+}
+
+// echoDockerCmd formats the Docker command to be more readable.
+func echoDockerCmd(dockerCmd []string) string {
+	for i, arg := range dockerCmd {
+		if strings.Contains(arg, " ") {
+			dockerCmd[i] = `"` + arg + `"`
+		}
+	}
+	return strings.Join(dockerCmd, " ")
+}
+
 func init() {
-	AuthSSHCommand.Flags().StringP("ssh-key-file", "f", "", "full path to SSH key file")
-	AuthSSHCommand.Flags().StringP("ssh-key-path", "d", "", "full path to SSH key directory")
-	AuthSSHCommand.MarkFlagsMutuallyExclusive("ssh-key-file", "ssh-key-path")
+	AuthSSHCommand.Flags().StringArrayVarP(&sshKeyFiles, "ssh-key-file", "f", nil, "full path to SSH key file")
+	AuthSSHCommand.Flags().StringArrayVarP(&sshKeyDirs, "ssh-key-path", "d", nil, "full path to SSH key directory")
 
 	AuthCmd.AddCommand(AuthSSHCommand)
 }

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -189,14 +189,14 @@ Add [SSH key authentication](../usage/cli.md#ssh-into-containers) to the `ddev-s
 Example:
 
 ```shell
-# Add your SSH keys to the SSH agent container (~/.ssh folder is used)
+# Add your SSH keys to the SSH agent container
 ddev auth ssh
-# Add your SSH keys from ~/.ssh
-ddev auth ssh -d ~/.ssh
-# Add your SSH key from ~/.ssh/id_ed25519 and ~/.ssh/id_rsa
+# Add your SSH keys from ~/custom/path/to/ssh
+ddev auth ssh -d ~/custom/path/to/ssh
+# Add your SSH keys from ~/.ssh/id_ed25519 and ~/.ssh/id_rsa
 ddev auth ssh -f ~/.ssh/id_ed25519 -f ~/.ssh/id_rsa
-# Add your SSH key from ~/.ssh and /path/to/id_ed25519
-ddev auth ssh -d ~/.ssh -f /path/to/id_ed25519
+# Add your SSH keys from ~/.ssh and ~/custom/path/to/ssh/id_ed25519
+ddev auth ssh -d ~/.ssh -f ~/custom/path/to/ssh/id_ed25519
 ```
 
 Flags:

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -189,12 +189,14 @@ Add [SSH key authentication](../usage/cli.md#ssh-into-containers) to the `ddev-s
 Example:
 
 ```shell
-# Add your SSH keys to the SSH agent container
+# Add your SSH keys to the SSH agent container (~/.ssh folder is used)
 ddev auth ssh
 # Add your SSH keys from ~/.ssh
 ddev auth ssh -d ~/.ssh
-# Add your SSH key from ~/.ssh/id_ed25519
-ddev auth ssh -f ~/.ssh/id_ed25519
+# Add your SSH key from ~/.ssh/id_ed25519 and ~/.ssh/id_rsa
+ddev auth ssh -f ~/.ssh/id_ed25519 -f ~/.ssh/id_rsa
+# Add your SSH key from ~/.ssh and /path/to/id_ed25519
+ddev auth ssh -d ~/.ssh -f /path/to/id_ed25519
 ```
 
 Flags:

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -195,7 +195,7 @@ ddev auth ssh
 
 Flags:
 
-* `--ssh-key-path`, `-d`: Full path to SSH key directory.
+* `--ssh-key-path`, `-d`: Full path to SSH key directory or file.
 
 ## `blackfire`
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -191,11 +191,16 @@ Example:
 ```shell
 # Add your SSH keys to the SSH agent container
 ddev auth ssh
+# Add your SSH keys from ~/.ssh
+ddev auth ssh -d ~/.ssh
+# Add your SSH key from ~/.ssh/id_ed25519
+ddev auth ssh -f ~/.ssh/id_ed25519
 ```
 
 Flags:
 
-* `--ssh-key-path`, `-d`: Full path to SSH key directory or file.
+* `--ssh-key-file`, `-f`: Full path to SSH key file.
+* `--ssh-key-path`, `-d`: Full path to SSH key directory.
 
 ## `blackfire`
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1013,7 +1013,7 @@ func RunSimpleContainerExtended(image string, name string, cmd []string, uid str
 
 	container, err := client.ContainerCreate(ctx, config, hostConfig, nil, nil, name)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to create/start Docker container %v (%v, %v): %v", name, config, hostConfig, err)
+		return "", "", fmt.Errorf("failed to create/start Docker container %v from image %v with cmd %v: %v", name, image, cmd, err)
 	}
 
 	if removeContainerAfterRun {

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -944,22 +944,6 @@ func GetDockerIP() (string, error) {
 // https://pkg.go.dev/github.com/moby/docker-image-spec/specs-go/v1#HealthcheckConfig
 // Returns containerID, output, error
 func RunSimpleContainer(image string, name string, cmd []string, entrypoint []string, env []string, binds []string, uid string, removeContainerAfterRun bool, detach bool, labels map[string]string, portBindings nat.PortMap, healthConfig *dockerContainer.HealthConfig) (containerID string, output string, returnErr error) {
-	config := &dockerContainer.Config{
-		Env:         env,
-		Labels:      labels,
-		Entrypoint:  entrypoint,
-		Healthcheck: healthConfig,
-	}
-	hostConfig := &dockerContainer.HostConfig{
-		Binds:        binds,
-		PortBindings: portBindings,
-	}
-	return RunSimpleContainerExtended(image, name, cmd, uid, removeContainerAfterRun, detach, config, hostConfig)
-}
-
-// RunSimpleContainerExtended runs a container (non-daemonized) and captures the stdout/stderr.
-// Accepts any config and hostConfig.
-func RunSimpleContainerExtended(image string, name string, cmd []string, uid string, removeContainerAfterRun bool, detach bool, config *dockerContainer.Config, hostConfig *dockerContainer.HostConfig) (containerID string, output string, returnErr error) {
 	ctx, client := GetDockerClient()
 
 	// Ensure image string includes a tag
@@ -986,34 +970,49 @@ func RunSimpleContainerExtended(image string, name string, cmd []string, uid str
 		}
 	}
 
-	for i := range hostConfig.Binds {
-		hostConfig.Binds[i] = util.WindowsPathToCygwinPath(hostConfig.Binds[i])
-	}
-	for i := range hostConfig.Mounts {
-		hostConfig.Mounts[i].Source = util.WindowsPathToCygwinPath(hostConfig.Mounts[i].Source)
+	// Windows 10 Docker toolbox won't handle a bind mount like C:\..., so must convert to /c/...
+	if runtime.GOOS == "windows" {
+		for i := range binds {
+			binds[i] = strings.Replace(binds[i], `\`, `/`, -1)
+			if strings.Index(binds[i], ":") == 1 {
+				binds[i] = strings.Replace(binds[i], ":", "", 1)
+				binds[i] = "/" + binds[i]
+				// And amazingly, the drive letter must be lower-case.
+				re := regexp.MustCompile("^/[A-Z]/")
+				driveLetter := re.FindString(binds[i])
+				if len(driveLetter) == 3 {
+					binds[i] = strings.TrimPrefix(binds[i], driveLetter)
+					binds[i] = strings.ToLower(driveLetter) + binds[i]
+				}
+
+			}
+		}
 	}
 
-	config.Image = image
-	config.Cmd = cmd
-	config.User = uid
-	config.AttachStderr = true
-	config.AttachStdout = true
-
-	if config.Labels == nil {
-		config.Labels = make(map[string]string)
-	}
-	// Assign a default label so this container can be removed with 'ddev poweroff'
-	if _, exists := config.Labels["com.ddev.site-name"]; !exists {
-		config.Labels["com.ddev.site-name"] = ""
+	containerConfig := &dockerContainer.Config{
+		Image:        image,
+		Cmd:          cmd,
+		Env:          env,
+		User:         uid,
+		Labels:       labels,
+		Entrypoint:   entrypoint,
+		AttachStderr: true,
+		AttachStdout: true,
+		Healthcheck:  healthConfig,
 	}
 
-	if runtime.GOOS == "linux" && !IsDockerDesktop() && !slices.Contains(hostConfig.ExtraHosts, "host.docker.internal:host-gateway") {
-		hostConfig.ExtraHosts = append(hostConfig.ExtraHosts, "host.docker.internal:host-gateway")
+	containerHostConfig := &dockerContainer.HostConfig{
+		Binds:        binds,
+		PortBindings: portBindings,
 	}
 
-	container, err := client.ContainerCreate(ctx, config, hostConfig, nil, nil, name)
+	if runtime.GOOS == "linux" && !IsDockerDesktop() {
+		containerHostConfig.ExtraHosts = []string{"host.docker.internal:host-gateway"}
+	}
+
+	container, err := client.ContainerCreate(ctx, containerConfig, containerHostConfig, nil, nil, name)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to create/start Docker container %v from image %v with cmd %v: %v", name, image, cmd, err)
+		return "", "", fmt.Errorf("failed to create/start Docker container %v (%v, %v): %v", name, containerConfig, containerHostConfig, err)
 	}
 
 	if removeContainerAfterRun {


### PR DESCRIPTION
## The Issue

- #5465

- #6677

## How This PR Solves The Issue

- Allows single file or symlink to a file or directory to be passed in `ddev auth ssh`.
- Fixes a warning from `grep -l` by mounting only files.
- Allows to mount several files and directories.

I didn't add a new flag for the file, I decided it would only complicate the code.

## Manual Testing Instructions

```
mkdir ~/temp_ssh
cp ~/.ssh/id_ed25519 ~/temp_ssh/id_ed25519
cp ~/.ssh/id_ed25519 ~/temp_ssh/id_ed25519_copy
ln -s ~/.ssh/id_ed25519 ~/temp_ssh/id_ed25519_symlink
ln -s ~/.ssh ~/temp_ssh/.ssh

ddev auth ssh -d ~/.ssh
ddev auth ssh -d ~/temp_ssh
ddev auth ssh -d ~/temp_ssh/.ssh
ddev auth ssh -f ~/temp_ssh/id_ed25519
ddev auth ssh -f ~/temp_ssh/id_ed25519_copy -f ~/temp_ssh/id_ed25519_symlink

# also works if there are files with the same name
ddev auth ssh -f ~/temp_ssh/id_ed25519 -f ~/.ssh/id_ed25519

rm -r ~/temp_ssh
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
