### PR TITLE
docs: note that setting a nodejs version always downloads something

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -392,7 +392,7 @@ Node.js version for the web container’s “system” version. [`n`](https://ww
 
 There is no need to reconfigure `nodejs_version` unless you want a version other than the version already specified, which will be the default version at the time the project was configured.
 
-Note that specifying any Node.js version will cause ddev to download and install that version when running `ddev start`. If optimizing startup speed is your biggest concern (such as in CI), consider only using the version of Node that is included with DDEV by default.
+Note that specifying any non-default Node.js version will cause DDEV to download and install that version when running `ddev start` the first time on a project. If optimizing first-time startup speed (as in Continuous Integration) is your biggest concern, consider using the default version of Node.js.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -392,6 +392,8 @@ Node.js version for the web container’s “system” version. [`n`](https://ww
 
 There is no need to reconfigure `nodejs_version` unless you want a version other than the version already specified, which will be the default version at the time the project was configured.
 
+Note that specifying any Node.js version will cause ddev to download and install that version when running `ddev start`. If optimizing startup speed is your biggest concern (such as in CI), consider only using the version of Node that is included with DDEV by default.
+
 | Type | Default | Usage
 | -- | -- | --
 | :octicons-file-directory-16: project | current LTS version | any [node version](https://www.npmjs.com/package/n#specifying-nodejs-versions), like `16`, `18.2`, `18.19.2`, etc.


### PR DESCRIPTION
## The Issue

I noticed that even if a `.nvmrc` file specifies the version of nodejs that ddev already has, that it is redownloaded and installed. I think this makes sense (so all specified versions are installed consistently), but it surprised me to see on my local that this added ~5 seconds of startup time for new projects. Surprisingly, this even happened given the global cache, so perhaps there's a bug lurking as well.

On a basic php project with no code, default settings for me give a startup time of ~14.5 seconds:

```
$ hyperfine --prepare 'ddev delete -Oy || true' 'ddev start'
Benchmark 1: ddev start
  Time (mean ± σ):     14.525 s ±  0.122 s    [User: 0.561 s, System: 0.289 s]
  Range (min … max):   14.358 s … 14.730 s    10 runs
```

But once a nodejs_version is set, it goes up:

```
$ hyperfine --prepare 'ddev delete -Oy || true' 'ddev start'
Benchmark 1: ddev start
  Time (mean ± σ):     19.828 s ±  0.636 s    [User: 0.589 s, System: 0.278 s]
  Range (min … max):   19.371 s … 21.059 s    10 runs
```

## How This PR Solves The Issue

Adds the note to the docs!