### PR TITLE
build: Remove unsupported PHP versions by default, fixes #5984

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -62,7 +62,7 @@ RUN pecl channel-update pecl.php.net && \
 FROM base AS ddev-php-base
 ARG PHP_DEFAULT_VERSION="8.2"
 ENV DDEV_PHP_VERSION=$PHP_DEFAULT_VERSION
-ARG PHP_VERSIONS="php5.6 php7.0 php7.1 php7.2 php7.3 php7.4 php8.0 php8.1 php8.2 php8.3 php8.4"
+ARG PHP_VERSIONS="php8.1 php8.2 php8.3 php8.4"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 ARG DRUSH_VERSION=8.4.12
 ENV NODE_VERSION=20

--- a/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
@@ -24,5 +24,5 @@ pkgs=$(yq ".${PHP_VERSION//.}.${ARCH} | join(\" \")" /etc/php-packages.yaml | aw
 # Echo the packages to be installed for logging
 echo "Installing packages for PHP ${PHP_VERSION} on ${ARCH}: $pkgs"
 
-# TODO: I'm not convinced that the apt-get update should be here or outside the script
-(apt-get -qq update || true) && DEBIAN_FRONTEND=noninteractive apt-get -qq install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y $pkgs || exit $?
+apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
+DEBIAN_FRONTEND=noninteractive apt-get -qq install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y $pkgs || exit $?

--- a/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
@@ -25,4 +25,4 @@ pkgs=$(yq ".${PHP_VERSION//.}.${ARCH} | join(\" \")" /etc/php-packages.yaml | aw
 echo "Installing packages for PHP ${PHP_VERSION} on ${ARCH}: $pkgs"
 
 # TODO: I'm not convinced that the apt-get update should be here or outside the script
-DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -qq install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y $pkgs || exit $?
+(apt-get -qq update || true) && DEBIAN_FRONTEND=noninteractive apt-get -qq install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y $pkgs || exit $?

--- a/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
@@ -24,4 +24,5 @@ pkgs=$(yq ".${PHP_VERSION//.}.${ARCH} | join(\" \")" /etc/php-packages.yaml | aw
 # Echo the packages to be installed for logging
 echo "Installing packages for PHP ${PHP_VERSION} on ${ARCH}: $pkgs"
 
-apt-get -qq install --no-install-recommends --no-install-suggests -y $pkgs || exit $?
+# TODO: I'm not convinced that the apt-get update should be here or outside the script
+DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -qq install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y $pkgs || exit $?

--- a/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
@@ -24,5 +24,6 @@ pkgs=$(yq ".${PHP_VERSION//.}.${ARCH} | join(\" \")" /etc/php-packages.yaml | aw
 # Echo the packages to be installed for logging
 echo "Installing packages for PHP ${PHP_VERSION/php/} on ${ARCH}: $pkgs"
 
-apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourcelist="sources.list.d/debian.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
+apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
+apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/debian.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
 DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y $pkgs || exit $?

--- a/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
@@ -18,11 +18,11 @@ ARCH=$2
 # Retrieve and format the list of packages for the specified PHP version and architecture
 # Uses `yq` to get the proper list of extensions for the PHP version and architecture.
 # The awk transforms the list from something like "cli common fpm" to
-# somethign like "phpX.X-cli phpX.X-common phpX.X-fpm"
+# something like "phpX.X-cli phpX.X-common phpX.X-fpm"
 pkgs=$(yq ".${PHP_VERSION//.}.${ARCH} | join(\" \")" /etc/php-packages.yaml | awk -v v="$PHP_VERSION" 'BEGIN {RS=" ";} {printf "%s-%s ", v, $0}')
 
 # Echo the packages to be installed for logging
-echo "Installing packages for PHP ${PHP_VERSION} on ${ARCH}: $pkgs"
+echo "Installing packages for PHP ${PHP_VERSION/php/} on ${ARCH}: $pkgs"
 
-apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
-DEBIAN_FRONTEND=noninteractive apt-get -qq install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y $pkgs || exit $?
+apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourcelist="sources.list.d/debian.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
+DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y $pkgs || exit $?

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20241031_improve_php_image_build AS ddev-webserver-base
+FROM ddev/ddev-php-base:20241105_less_php_versions AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -80,13 +80,7 @@
 
   extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
   case ${PHP_VERSION} in
-  5.6)
-    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring mysql pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
-    ;;
-  7.[01234])
-    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring mysqli pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
-    ;;
-  8.[0123])
+  8.[123])
     extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
     ;;
   8.4)

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -21,7 +21,7 @@ export HOST_HTTPS_PORT="8443"
 export CONTAINER_HTTP_PORT="80"
 export CONTAINER_HTTPS_PORT="443"
 export CONTAINER_NAME=webserver-test
-export PHP_VERSION=8.0
+export PHP_VERSION=8.3
 export WEBSERVER_TYPE=nginx-fpm
 
 MOUNTUID=33
@@ -79,7 +79,7 @@ bats --show-output-of-passing-tests tests/ddev-webserver/general.bats
 
 cleanup
 
-for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4; do
+for PHP_VERSION in 8.1 8.2 8.3 8.4; do
     for WEBSERVER_TYPE in nginx-fpm apache-fpm; do
         export PHP_VERSION WEBSERVER_TYPE DOCKER_IMAGE
         docker run -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DDEV_PHP_VERSION=${PHP_VERSION}" -e "DDEV_WEBSERVER_TYPE=${WEBSERVER_TYPE}" -d --name $CONTAINER_NAME -v ddev-global-cache:/mnt/ddev-global-cache -d $DOCKER_IMAGE >/dev/null
@@ -94,12 +94,9 @@ for PHP_VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4; do
     done
 done
 
-for project_type in backdrop craftcms drupal drupal6 drupal7 drupal8 drupal9 drupal10 laravel magento magento2 typo3 wordpress default; do
-	export PHP_VERSION="8.0"
+for project_type in backdrop craftcms drupal drupal7 drupal8 drupal9 drupal10 laravel magento magento2 typo3 wordpress default; do
+	export PHP_VERSION="8.3"
     export project_type
-	if [ "$project_type" == "drupal6" ]; then
-	  PHP_VERSION="5.6"
-	fi
 	docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DOCROOT=docroot" -e "DDEV_PHP_VERSION=$PHP_VERSION" -e "DDEV_PROJECT_TYPE=$project_type" --name $CONTAINER_NAME -v ddev-global-cache:/mnt/ddev-global-cache -d $DOCKER_IMAGE >/dev/null
     if ! containerwait; then
         echo "=============== Failed containerwait after docker run with  DDEV_PROJECT_TYPE=${project_type} DDEV_PHP_VERSION=$PHP_VERSION ==================="
@@ -111,14 +108,14 @@ for project_type in backdrop craftcms drupal drupal6 drupal7 drupal8 drupal9 dru
     cleanup
 done
 
-docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DDEV_PHP_VERSION=8.0" --mount "type=bind,src=$PWD/tests/ddev-webserver/testdata,target=/mnt/ddev_config" -v ddev-global-cache:/mnt/ddev-global-cache --name $CONTAINER_NAME -d $DOCKER_IMAGE >/dev/null
+docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DDEV_PHP_VERSION=8.3" --mount "type=bind,src=$PWD/tests/ddev-webserver/testdata,target=/mnt/ddev_config" -v ddev-global-cache:/mnt/ddev-global-cache --name $CONTAINER_NAME -d $DOCKER_IMAGE >/dev/null
 containerwait
 
 bats tests/ddev-webserver/custom_config.bats
 
 cleanup
 
-docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DDEV_PHP_VERSION=8.0" --mount "type=bind,src=$PWD/tests/ddev-webserver/testdata,target=/mnt/ddev_config" -v ddev-global-cache:/mnt/ddev-global-cache --name $CONTAINER_NAME -d $DOCKER_IMAGE >/dev/null
+docker run  -u "$MOUNTUID:$MOUNTGID" -p $HOST_HTTP_PORT:$CONTAINER_HTTP_PORT -p $HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT -e "DDEV_PHP_VERSION=8.3" --mount "type=bind,src=$PWD/tests/ddev-webserver/testdata,target=/mnt/ddev_config" -v ddev-global-cache:/mnt/ddev-global-cache --name $CONTAINER_NAME -d $DOCKER_IMAGE >/dev/null
 containerwait
 bats tests/ddev-webserver/imagemagick.bats
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1175,7 +1175,7 @@ RUN /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETPLATFORM#linux/}";
 RUN update-alternatives --set php /usr/bin/php%s
 RUN chmod ugo+rw /var/log/php-fpm.log && chmod ugo+rwx /var/run && ln -sf /usr/sbin/php-fpm%s /usr/sbin/php-fpm
 RUN mkdir -p /tmp/xhprof
-RUN chmod -fR ugo+w /etc/php /var/lib/php/modules
+RUN chmod -fR ugo+w /etc/php /var/lib/php/modules /tmp/xhprof
 RUN phpdismod blackfire xdebug xhprof
 	`, app.PHPVersion, app.PHPVersion, app.PHPVersion)
 		}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1171,7 +1171,7 @@ RUN (apt-get -qq update || true) && DEBIAN_FRONTEND=noninteractive apt-get -qq i
 		if _, ok := nodeps.PreinstalledPHPVersions[app.PHPVersion]; !ok {
 			contents = contents + fmt.Sprintf(`
 ### DDEV-injected addition of not-preinstalled PHP version
-RUN /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETPLATFORM#linux/}";
+RUN /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETPLATFORM#linux/}"
 RUN update-alternatives --set php /usr/bin/php%s
 RUN chmod ugo+rw /var/log/php-fpm.log && chmod ugo+rwx /var/run && ln -sf /usr/sbin/php-fpm%s /usr/sbin/php-fpm
 RUN mkdir -p /tmp/xhprof

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1171,9 +1171,11 @@ RUN (apt-get -qq update || true) && DEBIAN_FRONTEND=noninteractive apt-get -qq i
 		if _, ok := nodeps.PreinstalledPHPVersions[app.PHPVersion]; !ok {
 			contents = contents + fmt.Sprintf(`
 ### DDEV-injected addition of not-preinstalled PHP version
-RUN /usr/local/bin/install_php_extensions.sh "%s" "${TARGETPLATFORM#linux/}";
+RUN /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETPLATFORM#linux/}";
 RUN update-alternatives --set php /usr/bin/php%s
 RUN chmod ugo+rw /var/log/php-fpm.log && chmod ugo+rwx /var/run && ln -sf /usr/sbin/php-fpm%s /usr/sbin/php-fpm
+RUN mkdir -p /tmp/xhprof
+RUN chmod -fR ugo+w /etc/php /var/lib/php/modules
 	`, app.PHPVersion, app.PHPVersion, app.PHPVersion)
 		}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1176,6 +1176,7 @@ RUN update-alternatives --set php /usr/bin/php%s
 RUN chmod ugo+rw /var/log/php-fpm.log && chmod ugo+rwx /var/run && ln -sf /usr/sbin/php-fpm%s /usr/sbin/php-fpm
 RUN mkdir -p /tmp/xhprof
 RUN chmod -fR ugo+w /etc/php /var/lib/php/modules
+RUN phpdismod blackfire xdebug xhprof
 	`, app.PHPVersion, app.PHPVersion, app.PHPVersion)
 		}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1192,7 +1192,7 @@ func TestDdevXhprofEnabled(t *testing.T) {
 
 			// Disable all to avoid confusion
 			_, _, err = app.Exec(&ddevapp.ExecOpts{
-				Cmd: "disable_xhprof && rm -rf /tmp/xhprof",
+				Cmd: "disable_xhprof && rm -rf /tmp/xhprof/*",
 			})
 			require.NoError(t, err)
 		}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -978,7 +978,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 			Cmd: "curl -sSfL localhost",
 		})
 		require.NoError(t, err)
-		require.Equal(t, `PHP_IDE_CONFIG is properly unset`, stdout)
+		require.True(t, strings.HasPrefix(stdout, `PHP_IDE_CONFIG is properly unset`), "PHP_IDE_CONFIG was incorrectly set")
 
 		opts := &ddevapp.ExecOpts{
 			Service: "web",

--- a/pkg/nodeps/php_values.go
+++ b/pkg/nodeps/php_values.go
@@ -34,5 +34,13 @@ var ValidPHPVersions = map[string]bool{
 	PHP84: true,
 }
 
+// PreinstalledPHPVersions is list of preinstalled versions (already in ddev-php-base and ddev-webserver
+var PreinstalledPHPVersions = map[string]bool{
+	PHP81: true,
+	PHP82: true,
+	PHP83: true,
+	PHP84: true,
+}
+
 // Composer version default - will get latest Composer v2
 var ComposerDefault = "2"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241031_improve_php_image_build" // Note that this can be overridden by make
+var WebTag = "20241105_less_php_versions" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

- #5984 

Every new PHP version has been adding heft to the default ddev-webserver. We'd like it to be smaller, for faster download and extraction times. And we'd like it not to grow with every new year's PHP version.

## How This PR Solves The Issue

* Only preinstall versions of PHP that are currently supported
* When earlier versions are required (like PHP 7.4) install them as needed during first-time project startup.
* This PR brings the ddev-webserver image size down significantly. In v1.23.5, we had 480MB compressed. After removing most locales, we had 425MB compressed, and now with this one we have 377MB compressed.

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/b33ce4d8-83e2-47eb-b44f-31e69fe33ba7">


## Manual Testing Instructions

- [ ] Use `ddev config --php-version=7.4` and `ddev config --php-version=5.6`
- [ ] Use all the normal things.

## Automated Testing Overview

I think that all the normal test coverage remains the same. It will mean that when we test all PHP versions that the tests will be a bit slower.

## Release/Deployment Notes

We need to boast about how much smaller the image is :)