### PR TITLE
feat: add dynamic timeout for scripts on start

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
@@ -104,7 +104,7 @@ if [ "${timeout}" -gt 0 ] && [ "${exit_code}" -eq 124 ]; then
   echo "Command '${command[*]}' timed out after ${timeout} seconds" | tee -a "${tmp_error_file}" >&2
   # START_SCRIPT_TIMEOUT default is 30 seconds (or default_container_timeout / 4)
   # 30 * 4 * 2 = 240 seconds (double the default timeout), which gives 240 / 4 = 60 seconds suggestion instead of the default 30
-  echo "If your internet connection is slow, consider increasing the timeout by running 'ddev config --default-container-timeout=$(( ${START_SCRIPT_TIMEOUT:-30} * 4 * 2 )) && ddev restart'" >&2
+  echo "If your internet connection is slow, consider increasing the timeout by running 'ddev config --default-container-timeout=$(( ${START_SCRIPT_TIMEOUT:-30} * 4 * 2 )) && ddev restart'" | tee -a "${tmp_error_file}" >&2
 fi
 
 # If stderr is empty

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
@@ -102,6 +102,9 @@ fi
 # If it is a timeout error (see 'timeout --help')
 if [ "${timeout}" -gt 0 ] && [ "${exit_code}" -eq 124 ]; then
   echo "Command '${command[*]}' timed out after ${timeout} seconds" | tee -a "${tmp_error_file}" >&2
+  # START_SCRIPT_TIMEOUT default is 30 seconds (or default_container_timeout / 4)
+  # 30 * 4 * 2 = 240 seconds (double the default timeout), which gives 240 / 4 = 60 seconds suggestion instead of the default 30
+  echo "If your internet connection is slow, consider increasing the timeout by running 'ddev config --default-container-timeout=$(( ${START_SCRIPT_TIMEOUT:-30} * 4 * 2 )) && ddev restart'" >&2
 fi
 
 # If stderr is empty

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
@@ -107,6 +107,7 @@ if [ "${timeout}" -gt 0 ] && [ "${exit_code}" -eq 124 ]; then
   # 30 * 4 * 2 = 240 seconds (double the default timeout), which gives 240 / 4 = 60 seconds suggestion instead of the default 30
   echo "If your internet connection is slow, consider increasing the timeout by running this:" | tee -a "${tmp_error_file}" >&2
   echo "\`ddev config --default-container-timeout=$(( ${START_SCRIPT_TIMEOUT:-30} * 4 * 2 )) && ddev restart\`" | tee -a "${tmp_error_file}" >&2
+  echo | tee -a "${tmp_error_file}" >&2
 fi
 
 # If stderr is empty

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/log-stderr.sh
@@ -101,10 +101,12 @@ fi
 
 # If it is a timeout error (see 'timeout --help')
 if [ "${timeout}" -gt 0 ] && [ "${exit_code}" -eq 124 ]; then
+  echo | tee -a "${tmp_error_file}" >&2
   echo "Command '${command[*]}' timed out after ${timeout} seconds" | tee -a "${tmp_error_file}" >&2
   # START_SCRIPT_TIMEOUT default is 30 seconds (or default_container_timeout / 4)
   # 30 * 4 * 2 = 240 seconds (double the default timeout), which gives 240 / 4 = 60 seconds suggestion instead of the default 30
-  echo "If your internet connection is slow, consider increasing the timeout by running 'ddev config --default-container-timeout=$(( ${START_SCRIPT_TIMEOUT:-30} * 4 * 2 )) && ddev restart'" | tee -a "${tmp_error_file}" >&2
+  echo "If your internet connection is slow, consider increasing the timeout by running this:" | tee -a "${tmp_error_file}" >&2
+  echo "\`ddev config --default-container-timeout=$(( ${START_SCRIPT_TIMEOUT:-30} * 4 * 2 )) && ddev restart\`" | tee -a "${tmp_error_file}" >&2
 fi
 
 # If stderr is empty

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
@@ -18,7 +18,7 @@ MARIADB_VERSION=${DDEV_DATABASE#*:}
 if [ "${MARIADB_VERSION}" = "11.4" ]; then
   # Configure the correct repository for mariadb
   set -x
-  log-stderr.sh --timeout 30 mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --skip-key-import || exit 2
+  log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --skip-key-import || exit 2
   rm -f /etc/apt/sources.list.d/mariadb.list.old_*
   # --skip-key-import flag doesn't download the existing key again and omits "apt-get -qq update",
   # so we can run "apt-get -qq update" manually only for mariadb repo to make it faster

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
@@ -18,14 +18,14 @@ MARIADB_VERSION=${DDEV_DATABASE#*:}
 if [ "${MARIADB_VERSION}" = "11.4" ]; then
   # Configure the correct repository for mariadb
   set -x
-  log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --skip-key-import || exit 2
+  log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --skip-key-import || exit $?
   rm -f /etc/apt/sources.list.d/mariadb.list.old_*
   # --skip-key-import flag doesn't download the existing key again and omits "apt-get -qq update",
   # so we can run "apt-get -qq update" manually only for mariadb repo to make it faster
-  apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/mariadb.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || exit 3
+  apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/mariadb.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || exit $?
   # Install the mariadb-client and MySQL symlinks
   # MariaDB 11.x moved MySQL symlinks into a separate package
-  apt-get install -y mariadb-client mariadb-client-compat || exit 4
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y mariadb-client mariadb-client-compat || exit $?
 else
-  echo "This script is not intended to run with mariadb:${MARIADB_VERSION}" && exit 5
+  echo "This script is not intended to run with mariadb:${MARIADB_VERSION}" && exit 1
 fi

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
@@ -23,7 +23,7 @@ TARBALL_URL=https://github.com/ddev/mysql-client-build/releases/download/${TARBA
 
 # Install the related mysql client if available
 set -x
-cd /tmp && log-stderr.sh --timeout 30 curl -L -o /tmp/mysql.tgz --fail -s ${TARBALL_URL}
+cd /tmp && log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" curl -L -o /tmp/mysql.tgz --fail -s ${TARBALL_URL}
 tar -zxf /tmp/mysql.tgz -C /usr/local/bin && rm -f /tmp/mysql.tgz
 
 # Remove any existing mariadb installs

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
@@ -23,7 +23,7 @@ TARBALL_URL=https://github.com/ddev/mysql-client-build/releases/download/${TARBA
 
 # Install the related mysql client if available
 set -x
-cd /tmp && log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" curl -L -o /tmp/mysql.tgz --fail -s ${TARBALL_URL}
+cd /tmp && log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" curl -L -o /tmp/mysql.tgz --fail ${TARBALL_URL}
 tar -zxf /tmp/mysql.tgz -C /usr/local/bin && rm -f /tmp/mysql.tgz
 
 # Remove any existing mariadb installs

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/n-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/n-install.sh
@@ -33,10 +33,10 @@ ln -sf "/mnt/ddev-global-cache/n_prefix/${HOSTNAME}" "${N_PREFIX}"
 
 # try online install that also uses cache
 n_install_result=true
-log-stderr.sh --timeout 30 n install "${N_INSTALL_VERSION}" || n_install_result=false
+log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" n install "${N_INSTALL_VERSION}" || n_install_result=false
 
 # try offline install on fail
-if [ "${n_install_result}" = "false" ] && timeout 30 n install "${N_INSTALL_VERSION}" --offline; then
+if [ "${n_install_result}" = "false" ] && timeout "${START_SCRIPT_TIMEOUT:-30}" n install "${N_INSTALL_VERSION}" --offline; then
   n_install_result=true
   # remove stderr log from the previous command
   log-stderr.sh --remove n install "${N_INSTALL_VERSION}" || true

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -112,7 +112,7 @@ fi)
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ~/.nvm
-if [ ! -f ~/.nvm/nvm.sh ]; then (timeout 30 install_nvm.sh || true); fi
+if [ ! -f ~/.nvm/nvm.sh ]; then (log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" install_nvm.sh || true); fi
 
 # /mnt/ddev_config/.homeadditions may be either
 # a bind-mount, or a volume mount, but we don't care,

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -108,7 +108,7 @@ fi)
 mkdir -p ~/.yarn/berry
 ln -sf /mnt/ddev-global-cache/yarn/berry ~/.yarn/berry/cache
 ln -sf /mnt/ddev-global-cache/nvm_dir/${HOSTNAME} ~/.nvm
-if [ ! -f ~/.nvm/nvm.sh ]; then (timeout 30 install_nvm.sh || true); fi
+if [ ! -f ~/.nvm/nvm.sh ]; then (log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" install_nvm.sh || true); fi
 
 # chown of ddev-global-cache must be done with privileged container in app.Start()
 # chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -220,6 +220,7 @@ services:
     - TZ={{ .Timezone }}
     - USER={{ .Username }}
     - VIRTUAL_HOST=${DDEV_HOSTNAME}
+    - START_SCRIPT_TIMEOUT={{ .StartScriptTimeout }}
     {{ range $env := .WebEnvironment }}- "{{ $env }}"
     {{ end }}
     labels:

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -792,6 +792,7 @@ type composeYAMLVars struct {
 	IsGitpod                        bool
 	IsCodespaces                    bool
 	DefaultContainerTimeout         string
+	StartScriptTimeout              string
 	UseHostDockerInternalExtraHosts bool
 	WebExtraHTTPPorts               string
 	WebExtraHTTPSPorts              string
@@ -889,6 +890,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		IsCodespaces:       nodeps.IsCodespaces(),
 		// Default max time we wait for containers to be healthy
 		DefaultContainerTimeout: app.DefaultContainerTimeout,
+		StartScriptTimeout:      app.GetStartScriptTimeout(),
 		// Only use the extra_hosts technique for Linux and only if not WSL2 and not Colima
 		// If WSL2 we have to figure out other things, see GetHostDockerInternalIP()
 		UseHostDockerInternalExtraHosts: (runtime.GOOS == "linux" && !nodeps.IsWSL2() && !dockerutil.IsColima()) || (nodeps.IsWSL2() && globalconfig.DdevGlobalConfig.XdebugIDELocation == globalconfig.XdebugIDELocationWSL2),

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1027,11 +1027,11 @@ redirect_stderr=true
 	}
 	// For MySQL 5.5+ we'll install the matching mysql client (and mysqldump) in the ddev-webserver
 	if app.Database.Type == nodeps.MySQL {
-		extraWebContent = extraWebContent + "\nRUN mysql-client-install.sh || true\n"
+		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN START_SCRIPT_TIMEOUT=%s mysql-client-install.sh || true\n", app.GetStartScriptTimeout())
 	}
 	// Some MariaDB versions may have their own client in the ddev-webserver
 	if app.Database.Type == nodeps.MariaDB {
-		extraWebContent = extraWebContent + "\nRUN mariadb-client-install.sh || true\n"
+		extraWebContent = extraWebContent + fmt.Sprintf("\nRUN START_SCRIPT_TIMEOUT=%s mariadb-client-install.sh || true\n", app.GetStartScriptTimeout())
 	}
 
 	err = WriteBuildDockerfile(app, app.GetConfigPath(".webimageBuild/Dockerfile"), app.GetConfigPath("web-build"), app.WebImageExtraPackages, app.ComposerVersion, extraWebContent)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -3284,6 +3284,22 @@ func FormatSiteStatus(status string) string {
 	return formattedStatus
 }
 
+// GetStartScriptTimeout returns the timeout for scripts on start
+// Used for START_SCRIPT_TIMEOUT
+func (app *DdevApp) GetStartScriptTimeout() string {
+	containerTimeout, err := strconv.Atoi(app.DefaultContainerTimeout)
+	if err != nil {
+		containerTimeout, _ = strconv.Atoi(nodeps.DefaultDefaultContainerTimeout)
+	}
+	// Use 1/4 of the default container timeout for scripts on start
+	timeoutForScriptsOnStart := strconv.Itoa(containerTimeout / 4)
+	// With 30 seconds minimum
+	if containerTimeout/4 <= 30 {
+		timeoutForScriptsOnStart = "30"
+	}
+	return timeoutForScriptsOnStart
+}
+
 // genericImportFilesAction defines the workflow for importing project files.
 func genericImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
 	destPath := app.calculateHostUploadDirFullPath(uploadDir)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241112_remove_php8.0-xdebug" // Note that this can be overridden by make
+var WebTag = "20241105_stasadev_start_script_timeout" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

From Discord https://discord.com/channels/664580571770388500/1303391707416498238

A colleague of mine receives the warning below when starting a ddev project:
```
Warning: command 'n install 14' run as '<user>' failed with exit code 124
Command 'n install 14' timed out after 30 seconds
```

`ddev exec 'sudo n install 14'` succeeds.

Using 16MBit/s internet. OS is Windows with WSL2

## How This PR Solves The Issue

We should allow more timeouts.
This PR sets the timeout to 1/4 of `default_container_timeout`

## Manual Testing Instructions

Set timeout to 31 seconds (124 / 4):
```
ddev config --default-container-timeout=124
```

Set your bandwidth to a really low speed.
In my case I did in on router https://www.asus.com/support/faq/1013333/

And use non default config to trigger timeout:

```
ddev config --database=mysql:8.0
ddev debug rebuild
...
Warning: command 'curl -L -o /tmp/mysql.tgz --fail https://github.com/ddev/mysql-client-build/releases/download/v0.2.3/mysql-8.0-amd64.tar.gz' run as 'root' failed with exit code 124:
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0 8701k    0  1369    0     0   2012      0  1:13:48 --:--:--  1:13:48  2012
Command 'curl -L -o /tmp/mysql.tgz --fail https://github.com/ddev/mysql-client-build/releases/download/v0.2.3/mysql-8.0-amd64.tar.gz' timed out after 31 seconds
If your internet connection is slow, consider increasing the timeout by running this:
`ddev config --default-container-timeout=248 && ddev restart`

Warning: command 'install_nvm.sh' run as 'stas' failed with exit code 124:
Cloning into '/home/stas/.nvm'...
Command 'install_nvm.sh' timed out after 31 seconds
If your internet connection is slow, consider increasing the timeout by running this:
`ddev config --default-container-timeout=248 && ddev restart`
...
```

```
ddev config --nodejs-version=18
ddev debug rebuild
...
Warning: command 'n install 18' run as 'stas' failed with exit code 124:
Command 'n install 18' timed out after 31 seconds
If your internet connection is slow, consider increasing the timeout by running this:
`ddev config --default-container-timeout=248 && ddev restart`

Warning: command 'install_nvm.sh' run as 'stas' failed with exit code 124:
Cloning into '/home/stas/.nvm'...
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry with 'git restore --source=HEAD :/'

Command 'install_nvm.sh' timed out after 31 seconds
If your internet connection is slow, consider increasing the timeout by running this:
`ddev config --default-container-timeout=248 && ddev restart`
...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
