### PR TITLE
feat: add WordPress WP_ENVIRONMENT_TYPE support to wp-config-ddev.php

### DIFF
--- a/pkg/ddevapp/wordpress/wp-config-ddev.php
+++ b/pkg/ddevapp/wordpress/wp-config-ddev.php
@@ -29,7 +29,7 @@ if ( getenv( 'IS_DDEV_PROJECT' ) == 'true' ) {
 	defined( 'WP_DEBUG' ) || define( 'WP_DEBUG', true );
 
 	/** WordPress environment type. */
-	define( 'WP_ENVIRONMENT_TYPE', 'local' );
+	defined( 'WP_ENVIRONMENT_TYPE' ) || define( 'WP_ENVIRONMENT_TYPE', 'local' );
 
 	/**
 	 * Set WordPress Database Table prefix if not already set.

--- a/pkg/ddevapp/wordpress/wp-config-ddev.php
+++ b/pkg/ddevapp/wordpress/wp-config-ddev.php
@@ -28,6 +28,9 @@ if ( getenv( 'IS_DDEV_PROJECT' ) == 'true' ) {
 	/** Enable debug */
 	defined( 'WP_DEBUG' ) || define( 'WP_DEBUG', true );
 
+	/** WordPress environment type. */
+	define( 'WP_ENVIRONMENT_TYPE', 'local' );
+
 	/**
 	 * Set WordPress Database Table prefix if not already set.
 	 *


### PR DESCRIPTION
## The Issue

`wp_get_environment_type()` returns `production` (which is expected as nothing is telling WordPress otherwise). This PR sets DDEV projects to identify themselves as a `local` environment.

## How This PR Solves The Issue

This PR defines your DDEV local site as a local environment using the `WP_ENVIRONMENT_TYPE` constant in the `wp-config-ddev.php` file. 

As outlined here: 
https://make.wordpress.org/core/2020/07/24/new-wp_get_environment_type-function-in-wordpress-5-5/

## Manual Testing Instructions

Execute `wp_get_environment_type()` anywhere and it should return `local`. 

## Automated Testing Overview

N/A

## Release/Deployment Notes

This would only affect WordPress projects using `wp_get_environment_type()` and expecting their local site to be one of the other values `development | staging | production`