### PR TITLE
test: Try to get lima and colima sane with LIMA_SSH_PORT_FORWARDER

### DIFF
--- a/.buildkite/macos-colima.yml
+++ b/.buildkite/macos-colima.yml
@@ -14,4 +14,5 @@
       DDEV_TEST_SHARE_CMD: "false"
       DDEV_RUN_GET_TESTS: "false"
       DOCKER_TYPE: "colima"
+      LIMA_SSH_PORT_FORWARDER: "true"
     parallelism: 1

--- a/.buildkite/macos-colima_vz.yml
+++ b/.buildkite/macos-colima_vz.yml
@@ -15,4 +15,5 @@
       DDEV_TEST_SHARE_CMD: "false"
       DDEV_RUN_GET_TESTS: "false"
       DOCKER_TYPE: "colima_vz"
+      LIMA_SSH_PORT_FORWARDER: "true"
     parallelism: 1

--- a/.buildkite/macos-lima.yml
+++ b/.buildkite/macos-lima.yml
@@ -15,4 +15,5 @@
       DDEV_TEST_SHARE_CMD: "false"
       DDEV_RUN_GET_TESTS: "false"
       DOCKER_TYPE: "lima"
+      LIMA_SSH_PORT_FORWARDER: "true"
     parallelism: 1


### PR DESCRIPTION

## The Issue

Since Lima v1.0.0 dropped this morning, we haven't been able to succeed with any automated tests of Lima or Colima. We always get a hang, as shown here:

https://buildkite.com/ddev/macos-lima/builds/1819#0193036a-edb3-4cf3-9b38-8abf2d84d027

https://lima-vm.io/docs/config/port/ explains that there's a major change in port binding in v1, but that we can go back with `LIMA_SSH_PORT_FORWARDER=true limactl start`

We also have seen very serious problems with port binding, discussed in https://discord.com/channels/664580571770388500/1303763382343700634 and https://cloud-native.slack.com/archives/C043N6ZFV9S/p1730925198340189

## How This PR Solves The Issue

For lima and colima buildkite builds, set the env var LIMA_SSH_PORT_FORWARDER to "true"

