### PR TITLE
docs: use apache-fpm for Kirby CMS

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -390,7 +390,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     mkdir my-kirby-site && cd my-kirby-site
 
     # Set up the DDEV environment
-    ddev config --omit-containers=db
+    ddev config --omit-containers=db --webserver-type=apache-fpm
 
     # Spin up the project and install the Kirby Starterkit
     ddev start
@@ -409,7 +409,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     cd my-kirby-site
 
     # Set up the DDEV environment
-    ddev config --omit-containers=db
+    ddev config --omit-containers=db --webserver-type=apache-fpm
 
     # Spin up the project
     ddev start


### PR DESCRIPTION
## The Issue

From Discord https://discord.com/channels/664580571770388500/1303992169429860362

When you have a different router port, media is not loaded:

```yaml
router_https_port: "8443"
```

That's because Kirby needs an additional config for nginx https://getkirby.com/docs/cookbook/development-deployment/nginx

```
server {
    ...
    location ~ \.php$ {
        ...
        fastcgi_param SERVER_PORT 8443;
    }
}
```

## How This PR Solves The Issue

Uses Apache 2 instead, where it works out of the box.

## Manual Testing Instructions

Setup a new Kirby CMS project https://ddev.readthedocs.io/en/stable/users/quickstart/#kirby-cms

And run the below:

Before:

```
ddev config --router-http-port 8080 --router-https-port 8443
ddev restart
```

![image](https://github.com/user-attachments/assets/47a5a22a-71c9-4f3a-bafb-48c3fc76a050)

After:

```
ddev config --webserver-type=apache-fpm
ddev restart
```

![image](https://github.com/user-attachments/assets/5f9e0c5e-58f5-407d-9c52-6e791994bdd7)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
