### PR TITLE
test: Revert "Try to get lima and colima sane with LIMA_SSH_PORT_FORWARDER (#6697)"

### DIFF
--- a/.buildkite/macos-colima.yml
+++ b/.buildkite/macos-colima.yml
@@ -14,5 +14,4 @@
       DDEV_TEST_SHARE_CMD: "false"
       DDEV_RUN_GET_TESTS: "false"
       DOCKER_TYPE: "colima"
-      LIMA_SSH_PORT_FORWARDER: "true"
     parallelism: 1

--- a/.buildkite/macos-colima_vz.yml
+++ b/.buildkite/macos-colima_vz.yml
@@ -15,5 +15,4 @@
       DDEV_TEST_SHARE_CMD: "false"
       DDEV_RUN_GET_TESTS: "false"
       DOCKER_TYPE: "colima_vz"
-      LIMA_SSH_PORT_FORWARDER: "true"
     parallelism: 1

--- a/.buildkite/macos-lima.yml
+++ b/.buildkite/macos-lima.yml
@@ -15,5 +15,4 @@
       DDEV_TEST_SHARE_CMD: "false"
       DDEV_RUN_GET_TESTS: "false"
       DOCKER_TYPE: "lima"
-      LIMA_SSH_PORT_FORWARDER: "true"
     parallelism: 1


### PR DESCRIPTION

## The Issue

* #6697

Lima 1.0.0 port forwarder broke tests, it was fixed via #6697, but now in 1.0.1 they reverted that, so we can revert the workaround.

