### PR TITLE
fix: match snapshot using full filename, fixes #6694

### DIFF
--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -297,19 +297,25 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 func GetSnapshotFileFromName(name string, app *DdevApp) (string, error) {
 	snapshotsDir := app.GetConfigPath("db_snapshots")
 	snapshotFullPath := filepath.Join(snapshotsDir, name)
+
 	// If old-style directory-based snapshot, then use the name, no massaging required
 	if fileutil.IsDirectory(snapshotFullPath) {
 		return name, nil
 	}
+
 	// But if it's a gzipped tarball, we have to get the filename.
 	files, err := fileutil.ListFilesInDir(snapshotsDir)
 	if err != nil {
 		return "", err
 	}
+
+	m := regexp.MustCompile("^" + regexp.QuoteMeta(name) + `-(mariadb|mysql|postgres)_[0-9.]*\.gz$`)
+
 	for _, file := range files {
-		if strings.HasPrefix(file, name+"-") {
+		if m.MatchString(file) {
 			return file, nil
 		}
 	}
+
 	return "", fmt.Errorf("snapshot %s not found in %s", name, snapshotsDir)
 }

--- a/pkg/ddevapp/snapshot_test.go
+++ b/pkg/ddevapp/snapshot_test.go
@@ -44,7 +44,7 @@ func TestDdevSnapshotCleanup(t *testing.T) {
 	snapshotName, err := app.Snapshot(t.Name() + "_1")
 	assert.NoError(err)
 
-	// Provide a second snapshot that should not be deleted and whose filename will be lexicographically earlier (Issue #6694).
+	// Provide a second snapshot that should not be deleted and whose filename will be lexicographically earlier (See https://github.com/ddev/ddev/issues/6694).
 	_, err = app.Snapshot(t.Name() + "_1-a")
 	assert.NoError(err)
 

--- a/pkg/ddevapp/snapshot_test.go
+++ b/pkg/ddevapp/snapshot_test.go
@@ -44,6 +44,10 @@ func TestDdevSnapshotCleanup(t *testing.T) {
 	snapshotName, err := app.Snapshot(t.Name() + "_1")
 	assert.NoError(err)
 
+	// Provide a second snapshot that should not be deleted and whose filename will be lexicographically earlier (Issue #6694).
+	_, err = app.Snapshot(t.Name() + "_1-a")
+	assert.NoError(err)
+
 	err = app.Init(site.Dir)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## The Issue

- #6694

Only matching a snapshot file by prefix can accidentally select a different snapshot that is lexicographically earlier.

## How This PR Solves The Issue

Now a fully anchored regular expression is used to match the full filename. The regular expression is based on the one in `ListSnapshots`.

## Manual Testing Instructions

Create the snapshots `foo` and `foo-bar`. Attempt to delete the snapshot `foo`. List snapshots to see which actually got deleted.

## Automated Testing Overview

Such a small change didn't seem like it needed its own test. If a test is desired anyway, `TestDdevSnapshotCleanup` can probably be extended to cover this case as well.

## Release/Deployment Notes

Should not have any effects or require any action.
