### PR TITLE
fix: not-included PHP version should work with webimage_extra_packages

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1280,7 +1280,7 @@ fi`, app.Database.Version, psqlVersion) + "\n\n"
 		contents = contents + fmt.Sprintf(`
 ### DDEV-injected folders permission fix
 RUN chmod 777 /run/php /var/log
-RUN chmod -R ugo+w /etc/php /var/lib/php /tmp/xhprof
+RUN mkdir -p /tmp/xhprof && chmod -R ugo+w /etc/php /var/lib/php /tmp/xhprof
 `)
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1280,6 +1280,7 @@ fi`, app.Database.Version, psqlVersion) + "\n\n"
 		contents = contents + fmt.Sprintf(`
 ### DDEV-injected folders permission fix
 RUN chmod 777 /run/php /var/log
+RUN chmod -fR ugo+w /etc/php /var/lib/php /tmp/xhprof
 `)
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1280,7 +1280,7 @@ fi`, app.Database.Version, psqlVersion) + "\n\n"
 		contents = contents + fmt.Sprintf(`
 ### DDEV-injected folders permission fix
 RUN chmod 777 /run/php /var/log
-RUN chmod -fR ugo+w /etc/php /var/lib/php /tmp/xhprof
+RUN chmod -R ugo+w /etc/php /var/lib/php /tmp/xhprof
 `)
 	}
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -824,9 +824,9 @@ func TestPHPOverrides(t *testing.T) {
 
 // TestPHPConfig checks some key PHP configuration items
 func TestPHPConfig(t *testing.T) {
-	if dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() {
-		t.Skip("skipping on Lima/Colima/Rancher because of unpredictable behavior, unable to connect")
-	}
+	//if dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() {
+	//	t.Skip("skipping on Lima/Colima/Rancher because of unpredictable behavior, unable to connect")
+	//}
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}
@@ -861,6 +861,7 @@ func TestPHPConfig(t *testing.T) {
 
 	for _, v := range phpKeys {
 		app.PHPVersion = v
+		app.WebImageExtraPackages = []string{"php" + app.PHPVersion + "-redis"}
 		err = app.Restart()
 		require.NoError(t, err)
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -824,9 +824,9 @@ func TestPHPOverrides(t *testing.T) {
 
 // TestPHPConfig checks some key PHP configuration items
 func TestPHPConfig(t *testing.T) {
-	//if dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() {
-	//	t.Skip("skipping on Lima/Colima/Rancher because of unpredictable behavior, unable to connect")
-	//}
+	if dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() {
+		t.Skip("skipping on Lima/Colima/Rancher because of unpredictable behavior, unable to connect")
+	}
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}
@@ -861,7 +861,10 @@ func TestPHPConfig(t *testing.T) {
 
 	for _, v := range phpKeys {
 		app.PHPVersion = v
-		app.WebImageExtraPackages = []string{"php" + app.PHPVersion + "-redis"}
+		// TODO: Remove this exclusion when redis is available for PHP 8.4
+		if app.PHPVersion != nodeps.PHP84 {
+			app.WebImageExtraPackages = []string{"php" + app.PHPVersion + "-redis"}
+		}
 		err = app.Restart()
 		require.NoError(t, err)
 


### PR DESCRIPTION

## The Issue

After 
* https://github.com/ddev/ddev/pull/6691

The ddev-platformsh add-on tests started failing on HEAD, https://github.com/ddev/ddev-platformsh/actions/runs/11758075483/job/32757492720

I had to use tmate to debug, but it turned out that ddev-platformsh installs several php modules for drupal9 and drupal10. And those use php8.0, which is not there by default. 

After they install modules, /var/lib/php/modules is not writable, and ddev fails to start.

## How This PR Solves The Issue

* chmod /var/lib/php later
* Add some test coverage by adding redis.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
