### PR TITLE
test: Fix TestGetAllURLs failure on tb-wsldd-16

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3611,7 +3611,7 @@ func TestGetAllURLs(t *testing.T) {
 
 	// We expect two URLs for each hostname (http/https) and two direct web container address.
 	expectedNumUrls := len(app.GetHostnames())*2 + 2
-	assert.Equal(len(urlMap), expectedNumUrls, "Unexpected number of URLs returned: %d. The urls are %v", len(urlMap), urlMap)
+	assert.Equal(expectedNumUrls, len(urlMap), "Unexpected number of URLs returned: %d. Actual URLs are %v. urls=%v app.GetHostnames()=%v", len(urlMap), urlMap, urls, app.GetHostnames())
 
 	// Ensure urlMap contains direct address of the web container
 	webContainer, err := app.FindContainerByType("web")

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3609,9 +3609,16 @@ func TestGetAllURLs(t *testing.T) {
 		urlMap[u] = true
 	}
 
-	// We expect two URLs for each hostname (http/https) and two direct web container address.
-	expectedNumUrls := len(app.GetHostnames())*2 + 2
-	assert.Equal(expectedNumUrls, len(urlMap), "Unexpected number of URLs returned: %d. Actual URLs are %v. urls=%v app.GetHostnames()=%v", len(urlMap), urlMap, urls, app.GetHostnames())
+	if app.CanUseHTTPOnly() {
+		t.Logf("Warning: app.CanUseHTTPOnly=%v", app.CanUseHTTPOnly())
+	}
+	// We expect one or two URLs for each hostname (http/https) and two direct web container address.
+	baseURLExpectation := len(app.GetHostnames())
+	if !app.CanUseHTTPOnly() {
+		baseURLExpectation = baseURLExpectation * 2
+	}
+	expectedNumUrls := baseURLExpectation + 2
+	assert.Equal(expectedNumUrls, len(urlMap), "Unexpected number of URLs returned: %d. CanUseHTTPOnly=%v Actual URLs are %v. urls=%v app.GetHostnames()=%v", len(urlMap), app.CanUseHTTPOnly(), urlMap, urls, app.GetHostnames())
 
 	// Ensure urlMap contains direct address of the web container
 	webContainer, err := app.FindContainerByType("web")

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3612,13 +3612,14 @@ func TestGetAllURLs(t *testing.T) {
 	if app.CanUseHTTPOnly() {
 		t.Logf("Warning: app.CanUseHTTPOnly=%v", app.CanUseHTTPOnly())
 	}
-	// We expect one or two URLs for each hostname (http/https) and two direct web container address.
+	// We expect one or two URLs for each hostname (http/https) and one or two direct web container address.
 	baseURLExpectation := len(app.GetHostnames())
 	if !app.CanUseHTTPOnly() {
-		baseURLExpectation = baseURLExpectation * 2
+		baseURLExpectation = baseURLExpectation*2 + 2
+	} else {
+		baseURLExpectation = baseURLExpectation + 1
 	}
-	expectedNumUrls := baseURLExpectation + 2
-	assert.Equal(expectedNumUrls, len(urlMap), "Unexpected number of URLs returned: %d. CanUseHTTPOnly=%v Actual URLs are %v. urls=%v app.GetHostnames()=%v", len(urlMap), app.CanUseHTTPOnly(), urlMap, urls, app.GetHostnames())
+	assert.Equal(baseURLExpectation, len(urlMap), "Unexpected number of URLs returned: %d. CanUseHTTPOnly=%v Actual URLs are %v. urls=%v app.GetHostnames()=%v", len(urlMap), app.CanUseHTTPOnly(), urlMap, urls, app.GetHostnames())
 
 	// Ensure urlMap contains direct address of the web container
 	webContainer, err := app.FindContainerByType("web")

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3611,7 +3611,7 @@ func TestGetAllURLs(t *testing.T) {
 
 	// We expect two URLs for each hostname (http/https) and two direct web container address.
 	expectedNumUrls := len(app.GetHostnames())*2 + 2
-	assert.Equal(len(urlMap), expectedNumUrls, "Unexpected number of URLs returned: %d", len(urlMap))
+	assert.Equal(len(urlMap), expectedNumUrls, "Unexpected number of URLs returned: %d. The urls are %v", len(urlMap), urlMap)
 
 	// Ensure urlMap contains direct address of the web container
 	webContainer, err := app.FindContainerByType("web")


### PR DESCRIPTION
## The Issue

TestGetAllURLs has been failing consistently with 5 URLs instead of 10 on tb-wsldd-16.  https://buildkite.com/ddev/wsl2-docker-desktop/builds/5721#01930e11-788c-4527-ab15-2db459abd3ec

This adds a little output on the fail that might help us understand why.

