### PR TITLE
build: fix static errors from golangci-lint

### DIFF
--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -301,7 +301,7 @@ func (p *Provider) getDownloadDir() string {
 	return destDir
 }
 
-func (p *Provider) doFilesPullCommand() (filename []string, error error) {
+func (p *Provider) doFilesPullCommand() ([]string, error) {
 	destDir := filepath.Join(p.getDownloadDir(), "files")
 	_ = os.RemoveAll(destDir)
 	_ = os.MkdirAll(destDir, 0755)
@@ -324,7 +324,7 @@ func (p *Provider) doFilesPullCommand() (filename []string, error error) {
 
 // getDatabaseBackups retrieves database using `generic backup database`, then
 // describe until it appears, then download it.
-func (p *Provider) getDatabaseBackups() (filename []string, error error) {
+func (p *Provider) getDatabaseBackups() ([]string, error) {
 	err := os.RemoveAll(p.getDownloadDir())
 	if err != nil {
 		return nil, err

--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -37,10 +37,10 @@ func TestGetFreePort(t *testing.T) {
 	// Put 100 used ports in the UsedHostPorts
 	i, err := strconv.Atoi(startPort)
 	i = i + 1
-	max := i + 100
+	maximum := i + 100
 	require.NoError(t, err)
 	ports := []string{}
-	for ; i < max; i++ {
+	for ; i < maximum; i++ {
 		ports = append(ports, strconv.Itoa(i))
 	}
 	// Make sure we have a global config set up.


### PR DESCRIPTION
## The Issue

golangci-lint 1.62.0 added more checks:

```
golangci-lint: 
pkg/globalconfig/global_config_test.go:40:2: redefines-builtin-id: redefinition of the built-in function max (revive)
        max := i + 100
        ^
pkg/ddevapp/provider.go:304:61: redefines-builtin-id: redefinition of the built-in type error (revive)
func (p *Provider) doFilesPullCommand() (filename []string, error error) {
                                                            ^
pkg/ddevapp/provider.go:327:61: redefines-builtin-id: redefinition of the built-in type error (revive)
func (p *Provider) getDatabaseBackups() (filename []string, error error) {
                                                            ^
make: *** [Makefile:290: golangci-lint] Error 1
```

## How This PR Solves The Issue

Fixes it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
