### PR TITLE
fix: use TARGETARCH instead of TARGETPLATFORM in user Dockerfiles

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -985,8 +985,8 @@ ENV N_INSTALL_VERSION="%s"
 ### Drupal 11+ requires a minimum sqlite3 version (3.45 currently)
 ARG SQLITE_VERSION=%s
 RUN log-stderr.sh bash -c "mkdir -p /tmp/sqlite3 && \
-wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
-wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETPLATFORM##linux/}.deb && \
+wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
+wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
 apt-get install -y /tmp/sqlite3/*.deb && \
 rm -rf /tmp/sqlite3" || true
 			`, versionconstants.Drupal11RequiredSqlite3Version)
@@ -1139,7 +1139,7 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 		if _, ok := nodeps.PreinstalledPHPVersions[app.PHPVersion]; !ok {
 			contents = contents + fmt.Sprintf(`
 ### DDEV-injected addition of not-preinstalled PHP version
-RUN /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETPLATFORM#linux/}"
+RUN /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETARCH}"
 	`, app.PHPVersion)
 		}
 	}


### PR DESCRIPTION
## The Issue

From Drupal Slack https://drupal.slack.com/archives/C5TQRQZRR/p1731341586120089

```
Waiting for containers to become ready: [web db] 
Warning: command 'bash -c mkdir -p /tmp/sqlite3 && wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_3.45.1-1_arm64/v8.deb && wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_3.45.1-1_arm64/v8.deb && apt-get install -y /tmp/sqlite3/*.deb && rm -rf /tmp/sqlite3' run as 'root' failed with exit code 8:
--2024-11-11 16:30:05--  https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_3.45.1-1_arm64/v8.deb
Resolving snapshot.debian.org (snapshot.debian.org)... 185.213.153.170
Connecting to snapshot.debian.org (snapshot.debian.org)|185.213.153.170|:443... connected.
HTTP request sent, awaiting response... 404 NOT FOUND
2024-11-11 16:30:05 ERROR 404: NOT FOUND. 
```

Looking at that URL, I suspect that the Docker build engine is using `arm64/v8` as the target platform, which makes sense, but that maybe makes the URL of the SQLite `.deb` wrong.
If I remove the `/v8` from that URL in my browser, it actually tries to download something.
Is there a way I can override the `TARGETPLATFORM` build argument in `.ddev/config.yaml` to force it to be `arm64` , as a workaround?

From https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/#adding-extra-dockerfiles-for-webimage-and-dbimage, it looks like maybe the workaround that installs SQLite should be using `TARGETARCH` instead of `TARGETPLATFORM`.

## How This PR Solves The Issue

Uses `TARGETARCH` in the user Dockerfile, this change is also important for the newly added 'install_php_extensions.sh'

## Manual Testing Instructions

Should pass the tests.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
