### PR TITLE
refactor: use `n install --cleanup`

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -100,8 +100,8 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     sqlite3
 
 RUN curl -L --fail -o /usr/local/bin/n -sSL https://raw.githubusercontent.com/tj/n/master/bin/n && chmod ugo+wx /usr/local/bin/n
-# Install node, remove it from cache, make a symlink for nodejs
-RUN n install "${NODE_VERSION}" && n rm "${NODE_VERSION}" && ln -sf "$(which node)" "$(which node)js"
+# Install node without cache, make a symlink for nodejs
+RUN n install --cleanup "${NODE_VERSION}" && ln -sf "$(which node)" "$(which node)js"
 RUN npm install --unsafe-perm=true --global gulp-cli yarn
 # Normal user needs to be able to write to php sessions
 RUN set -eu -o pipefail && LATEST=$(curl -L --fail --silent "https://api.github.com/repos/nvm-sh/nvm/releases/latest" | jq -r .tag_name) && curl --fail -sL https://raw.githubusercontent.com/nvm-sh/nvm/${LATEST}/install.sh -o /usr/local/bin/install_nvm.sh && chmod +x /usr/local/bin/install_nvm.sh

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20241105_less_php_versions AS ddev-webserver-base
+FROM ddev/ddev-php-base:20241111_stasadev_n_install_cleanup AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241109_use_bin_env" // Note that this can be overridden by make
+var WebTag = "20241111_stasadev_n_install_cleanup" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- https://github.com/tj/n/issues/809#issuecomment-2465891240

## How This PR Solves The Issue

Uses new `n install --cleanup` flag instead of `n install && n rm`.
This is the same thing, but with only one command.

## Manual Testing Instructions

```
$ ddev exec 'ls -la /usr/local/n/versions/node' # should be no files here
total 8
drwxr-xr-x 2 root root 4096 Nov 12 20:48 .
drwxr-xr-x 3 root root 4096 Nov 12 20:48 ..

$ ddev exec 'sudo n install --cleanup 20'
installing : node-v20.18.0
       mkdir : /usr/local/n/versions/node/20.18.0
       fetch : https://nodejs.org/dist/v20.18.0/node-v20.18.0-linux-x64.tar.xz
     copying : node/20.18.0
   installed : v20.18.0 (with npm 10.8.2)
     cleanup : removing cached node/20.18.0

$ ddev exec 'ls -la /usr/local/n/versions/node' # should be no files here
drwxr-xr-x 1 root root 4096 Nov 12 22:37 .
drwxr-xr-x 1 root root 4096 Nov 12 20:48 ..
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
