### PR TITLE
fix: update usage syntax for `ddev exec`, fixes #6660

### DIFF
--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -15,7 +15,7 @@ var execDirArg string
 
 // DdevExecCmd allows users to execute arbitrary sh commands within a container.
 var DdevExecCmd = &cobra.Command{
-	Use:     "exec <command>",
+	Use:     "exec [flags] [command] [command-flags]",
 	Aliases: []string{"."},
 	Short:   "Execute a shell command in the container for a service. Uses the web service by default.",
 	Long:    `Execute a shell command in the container for a service. Uses the web service by default. To run your command in the container for another service, run "ddev exec --service <service> <cmd>". If you want to use raw, uninterpreted command inside container use --raw as in example.`,


### PR DESCRIPTION
## The Issue

- #6660

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Updates the syntax, which is used for `ddev help exec`.

## Manual Testing Instructions

Before:
```
$ ddev help exec
...
Usage:
  ddev exec <command> [flags]
...
```

After:
```
$ ddev help exec
...
Usage:
  ddev exec [flags] [command] [command-flags]
...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
