### PR TITLE
fix: don't require go and make for ordinary homebrew installation, fixes #6156, fixes #6623

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -33,6 +33,7 @@ env:
   HOMEBREW_STABLE_REPOSITORY: ${{ vars.HOMEBREW_STABLE_REPOSITORY }}
   REPOSITORY_OWNER: ${{ github.repository_owner }}
   DOCKER_ORG: ${{ vars.DOCKER_ORG }}
+  HEAD_ARTIFACTS_SHA: blank-for-now
 
 permissions:
   packages: write

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -213,7 +213,7 @@ jobs:
           DDEV_MACOS_APP_PASSWORD: "op://push-secrets/DDEV_MACOS_APP_PASSWORD/credential"
           DDEV_MACOS_SIGNING_PASSWORD: "op://push-secrets/DDEV_MACOS_SIGNING_PASSWORD/credential"
           DOCKERHUB_TOKEN: "op://push-secrets/DOCKERHUB_TOKEN/credential"
-          FURY_TOKEN: "op://push-secrets/FURY_TOKEN/credential"
+          FURY_TOKEN: "op://push-secrets/FURY_TOKEN/credential_${{ github.repository_owner }}"
           GORELEASER_KEY: "op://push-secrets/GORELEASER_KEY/credential"
 
       - uses: actions/checkout@v4

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -312,6 +312,22 @@ jobs:
             artifacts/*.zip
             artifacts/checksums.txt
 
+      - name: Get SHA of uploaded artifact
+        run: |
+          # Get the artifact ID
+          ARTIFACT_ID=$(gh api /repos/${{ github.repository }}/actions/artifacts \
+            --jq '.artifacts[] | select(.name=="ddev-head-artifacts") | .id' \
+            --header "authorization: Bearer ${{ github.token }}")
+          
+          # Download the artifact directly from GitHub
+          gh api /repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip \
+            --header "authorization: Bearer ${{ github.token }}" \
+            -H "Accept: application/vnd.github.v3.raw" \
+            --output head-artifacts.zip
+          
+          ls -l head-artifacts.zip && sha256sum head-artifacts.zip
+          echo "HEAD_ARTIFACTS_SHA=$(sha256sum head-artifacts.zip | cut -d' ' -f1)" >> $GITHUB_ENV
+
       - name: Show github.ref
         run: echo ${{ github.ref }}
 

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -316,7 +316,7 @@ jobs:
 
       # TODO: This can be done by goreleaser these days
       - name: Chocolatey windows release
-        if: github.repository == 'ddev/ddev' && startsWith(github.ref, 'refs/tags/v1')
+        if: github.repository_owner == 'ddev' && startsWith(github.ref, 'refs/tags/v1')
         run: |
           pushd .gotmp/bin/windows_amd64/chocolatey
           docker run --rm -v $PWD:/tmp/chocolatey -w /tmp/chocolatey linuturk/mono-choco push -s https://push.chocolatey.org/ --api-key "${CHOCOLATEY_API_KEY}"

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -279,38 +279,56 @@ jobs:
         env:
           CGO_ENABLED: 0
 
-      - name: Create and checksum release archive
-        run: |
-          mkdir -p artifacts
-          pwd
-          set -eu -o pipefail
-          set -x
-          ls -lR artifacts .gotmp/bin
-          echo "# Archive checksums" > artifacts/checksums.txt
-          for item in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
-            pushd .gotmp/bin/${item} >/dev/null
-            cp -r ../completions/* .
-            ls -l $PWD
-            zip -v ../../../artifacts/ddev_${item}.zip ddev ddev_*completion* ddev_fig_spec.ts
-            popd >/dev/null
-          done
-          for item in windows_amd64 windows_arm64; do
-            pushd .gotmp/bin/${item} >/dev/null
-            zip -v ../../../artifacts/ddev_${item}.zip ddev.exe ddev*installer.exe
-            popd >/dev/null
-          done
-          
-          # Create checksums
-          cd artifacts
-          sha256sum *.zip >>checksums.txt
+      # Do artifacts for upload to workflow URL
+      - name: Generate artifacts
+        run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
 
       - name: Upload all artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ddev-head-artifacts
-          path: |
-            artifacts/*.zip
-            artifacts/checksums.txt
+          name: all-ddev-executables
+          path: ${{ github.workspace }}/artifacts/*
+      - name: Upload macos-amd64 binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddev-macos-amd64
+          path: .gotmp/bin/darwin_amd64/ddev
+      - name: Upload macos-arm64 binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddev-macos-arm64
+          path: .gotmp/bin/darwin_arm64/ddev
+      - name: Upload linux-arm64 binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddev-linux-arm64
+          path: .gotmp/bin/linux_arm64/ddev
+      - name: Upload linux-amd64 binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddev-linux-amd64
+          path: .gotmp/bin/linux_amd64/ddev
+      - name: Upload windows-amd64 binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddev-windows-amd64
+          path: .gotmp/bin/windows_amd64/ddev.exe
+
+      - name: Upload windows_amd64 installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddev-windows-amd64-installer
+          path: .gotmp/bin/windows_amd64/ddev_windows_amd64_installer*.exe
+      - name: Upload windows-arm64 binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddev-windows-arm64
+          path: .gotmp/bin/windows_arm64/ddev.exe
+      - name: Upload windows_arm64 installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddev-windows-arm64-installer
+          path: .gotmp/bin/windows_arm64/ddev_windows_arm64_installer*.exe
 
       - name: Show github.ref
         run: echo ${{ github.ref }}

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -289,7 +289,8 @@ jobs:
           echo "# Archive checksums" > artifacts/checksums.txt
           for item in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
             pushd .gotmp/bin/${item} >/dev/null
-            tar -zxf ../completions.tar.gz
+            cp -r ../completions/* .
+            ls -l $PWD
             zip -v ../../artifacts/ddev_${item}.zip ddev ddev_*completion* ddev_fig_spec.ts
             popd >/dev/null
           done

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -273,7 +273,7 @@ jobs:
         if: startsWith( github.ref, 'refs/tags/v1')
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           CGO_ENABLED: 0

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -194,6 +194,7 @@ jobs:
 
   artifacts:
     env:
+      AUR_PACKAGE_NAME: ${{ vars.AUR_PACKAGE_NAME }}
       AUR_EDGE_GIT_URL: ${{ vars.AUR_EDGE_GIT_URL }}
       AUR_STABLE_GIT_URL: ${{ vars.AUR_STABLE_GIT_URL }}
       DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -201,12 +201,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-most, sign-windows, notarize-macos]
     steps:
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-
       - name: Load 1password secret(s)
         uses: 1password/load-secrets-action@v2
         with:
@@ -267,6 +261,12 @@ jobs:
           cgo=$(".gotmp/bin/$(go env GOOS)_$(go env GOARCH)/ddev" version 2>/dev/null | awk '/cgo_enabled/ {print $2}')
           if [ "${cgo}" != "0" ]; then echo "CGO_ENABLED=${cgo} but it must be 0 in released binary" && exit 10; fi
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+
       # Goreleaser does GitHub release artifacts, homebrew, AUR, deb/rpm
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v6
@@ -282,16 +282,20 @@ jobs:
       - name: Create and checksum release archives
         run: |
           mkdir -p artifacts
+          pwd
+          set -eu -o pipefail
+          set -x
+          ls -lR .gotmp/bin
           echo "# Archive checksums" > artifacts/checksums.txt
           for item in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
             pushd .gotmp/bin/${item} >/dev/null
             tar -zxf ../completions.tar.gz
-            zip ../../artifacts/ddev_${item}.zip ddev ddev_*completion* ddev_fig_spec.ts
+            zip -v ../../artifacts/ddev_${item}.zip ddev ddev_*completion* ddev_fig_spec.ts
             popd >/dev/null
           done
           for item in windows_amd64 windows_arm64; do
             pushd .gotmp/bin/${item} >/dev/null
-            zip ../../artifacts/ddev_${item}.zip ddev.exe ddev*installer.exe
+            zip -v ../../artifacts/ddev_${item}.zip ddev.exe ddev*installer.exe
             popd >/dev/null
           done
           

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -33,7 +33,6 @@ env:
   HOMEBREW_STABLE_REPOSITORY: ${{ vars.HOMEBREW_STABLE_REPOSITORY }}
   REPOSITORY_OWNER: ${{ github.repository_owner }}
   DOCKER_ORG: ${{ vars.DOCKER_ORG }}
-  HEAD_ARTIFACTS_SHA: blank-for-now
 
 permissions:
   packages: write
@@ -313,21 +312,21 @@ jobs:
             artifacts/*.zip
             artifacts/checksums.txt
 
-      - name: Get SHA of uploaded artifact
-        run: |
-          # Get the artifact ID
-          ARTIFACT_ID=$(gh api /repos/${{ github.repository }}/actions/artifacts \
-            --jq '.artifacts[] | select(.name=="ddev-head-artifacts") | .id' \
-            --header "authorization: Bearer ${{ github.token }}")
-          
-          # Download the artifact directly from GitHub
-          gh api /repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip \
-            --header "authorization: Bearer ${{ github.token }}" \
-            -H "Accept: application/vnd.github.v3.raw" \
-            --output head-artifacts.zip
-          
-          ls -l head-artifacts.zip && sha256sum head-artifacts.zip
-          echo "HEAD_ARTIFACTS_SHA=$(sha256sum head-artifacts.zip | cut -d' ' -f1)" >> $GITHUB_ENV
+#      - name: Get SHA of uploaded artifact
+#        run: |
+#          # Get the artifact ID
+#          ARTIFACT_ID=$(gh api /repos/${{ github.repository }}/actions/artifacts \
+#            --jq '.artifacts[] | select(.name=="ddev-head-artifacts") | .id' \
+#            --header "authorization: Bearer ${{ github.token }}")
+#
+#          # Download the artifact directly from GitHub
+#          gh api /repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip \
+#            --header "authorization: Bearer ${{ github.token }}" \
+#            -H "Accept: application/vnd.github.v3.raw" \
+#            --output head-artifacts.zip
+#
+#          ls -l head-artifacts.zip && sha256sum head-artifacts.zip
+#          echo "HEAD_ARTIFACTS_SHA=$(sha256sum head-artifacts.zip | cut -d' ' -f1)" >> $GITHUB_ENV
 
       - name: Show github.ref
         run: echo ${{ github.ref }}

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -278,8 +278,7 @@ jobs:
         env:
           CGO_ENABLED: 0
 
-      # Replace the individual upload-artifact steps with this
-      - name: Create and checksum release archives
+      - name: Create and checksum release archive
         run: |
           mkdir -p artifacts
           pwd
@@ -311,22 +310,6 @@ jobs:
           path: |
             artifacts/*.zip
             artifacts/checksums.txt
-
-#      - name: Get SHA of uploaded artifact
-#        run: |
-#          # Get the artifact ID
-#          ARTIFACT_ID=$(gh api /repos/${{ github.repository }}/actions/artifacts \
-#            --jq '.artifacts[] | select(.name=="ddev-head-artifacts") | .id' \
-#            --header "authorization: Bearer ${{ github.token }}")
-#
-#          # Download the artifact directly from GitHub
-#          gh api /repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip \
-#            --header "authorization: Bearer ${{ github.token }}" \
-#            -H "Accept: application/vnd.github.v3.raw" \
-#            --output head-artifacts.zip
-#
-#          ls -l head-artifacts.zip && sha256sum head-artifacts.zip
-#          echo "HEAD_ARTIFACTS_SHA=$(sha256sum head-artifacts.zip | cut -d' ' -f1)" >> $GITHUB_ENV
 
       - name: Show github.ref
         run: echo ${{ github.ref }}

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -278,56 +278,34 @@ jobs:
         env:
           CGO_ENABLED: 0
 
-      # Do artifacts for upload to workflow URL
-      - name: Generate artifacts
-        run: ./.ci-scripts/generate_artifacts.sh ${{ github.workspace }}/artifacts
+      # Replace the individual upload-artifact steps with this
+      - name: Create and checksum release archives
+        run: |
+          mkdir -p artifacts
+          echo "# Archive checksums" > artifacts/checksums.txt
+          for item in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
+            pushd .gotmp/bin/${item} >/dev/null
+            tar -zxf ../completions.tar.gz
+            zip ../../artifacts/ddev_${item}.zip ddev ddev_*completion* ddev_fig_spec.ts
+            popd >/dev/null
+          done
+          for item in windows_amd64 windows_arm64; do
+            pushd .gotmp/bin/${item} >/dev/null
+            zip ../../artifacts/ddev_${item}.zip ddev.exe ddev*installer.exe
+            popd >/dev/null
+          done
+          
+          # Create checksums
+          cd artifacts
+          sha256sum *.zip >>checksums.txt
 
       - name: Upload all artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: all-ddev-executables
-          path: ${{ github.workspace }}/artifacts/*
-      - name: Upload macos-amd64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: ddev-macos-amd64
-          path: .gotmp/bin/darwin_amd64/ddev
-      - name: Upload macos-arm64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: ddev-macos-arm64
-          path: .gotmp/bin/darwin_arm64/ddev
-      - name: Upload linux-arm64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: ddev-linux-arm64
-          path: .gotmp/bin/linux_arm64/ddev
-      - name: Upload linux-amd64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: ddev-linux-amd64
-          path: .gotmp/bin/linux_amd64/ddev
-      - name: Upload windows-amd64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: ddev-windows-amd64
-          path: .gotmp/bin/windows_amd64/ddev.exe
-
-      - name: Upload windows_amd64 installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: ddev-windows-amd64-installer
-          path: .gotmp/bin/windows_amd64/ddev_windows_amd64_installer*.exe
-      - name: Upload windows-arm64 binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: ddev-windows-arm64
-          path: .gotmp/bin/windows_arm64/ddev.exe
-      - name: Upload windows_arm64 installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: ddev-windows-arm64-installer
-          path: .gotmp/bin/windows_arm64/ddev_windows_arm64_installer*.exe
+          name: ddev-head-artifacts
+          path: |
+            artifacts/*.zip
+            artifacts/checksums.txt
 
       - name: Show github.ref
         run: echo ${{ github.ref }}

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -285,18 +285,18 @@ jobs:
           pwd
           set -eu -o pipefail
           set -x
-          ls -lR .gotmp/bin
+          ls -lR artifacts .gotmp/bin
           echo "# Archive checksums" > artifacts/checksums.txt
           for item in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
             pushd .gotmp/bin/${item} >/dev/null
             cp -r ../completions/* .
             ls -l $PWD
-            zip -v ../../artifacts/ddev_${item}.zip ddev ddev_*completion* ddev_fig_spec.ts
+            zip -v ../../../artifacts/ddev_${item}.zip ddev ddev_*completion* ddev_fig_spec.ts
             popd >/dev/null
           done
           for item in windows_amd64 windows_arm64; do
             pushd .gotmp/bin/${item} >/dev/null
-            zip -v ../../artifacts/ddev_${item}.zip ddev.exe ddev*installer.exe
+            zip -v ../../../artifacts/ddev_${item}.zip ddev.exe ddev*installer.exe
             popd >/dev/null
           done
           

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -186,29 +186,25 @@ brews:
   custom_block: |
     head do
       url "https://github.com/ddev/ddev.git", branch: "master"
-
-      resource "ddev-binary" do
-        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        os = OS.mac? ? "macos" : "linux"
-        url "https://nightly.link/ddev/ddev/workflows/master-build/master/ddev-#{os}-#{arch}.zip"
-        sha256 "" # We'd need to figure out how to handle this for nightlies
-      end
+      depends_on "go" => :build
+      depends_on "make" => :build
     end
   install: |
     if build.head?
-        resource("ddev-binary").stage do
-          system "unzip", "-o", Dir["*.zip"].first if Dir["*.zip"].any?
-          bin.install "ddev"
-          bash_completion.install "ddev_bash_completion.sh" => "ddev"
-          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"          end
+        os = OS.mac? ? "darwin" : "linux"
+        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        system "mkdir", "-p", "#{bin}"
+        system "make", "build", "completions"
+        system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
+        bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
+        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
+        fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
     else
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"
         zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
-
 
   test: |
     system "#{bin}/ddev --version"
@@ -230,23 +226,19 @@ brews:
   custom_block: |
     head do
       url "https://github.com/ddev/ddev.git", branch: "master"
-
-      resource "ddev-binary" do
-        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        os = OS.mac? ? "macos" : "linux"
-        url "https://nightly.link/ddev/ddev/workflows/master-build/master/ddev-#{os}-#{arch}.zip"
-        sha256 "" # We'd need to figure out how to handle this for nightlies
-      end
+      depends_on "go" => :build
+      depends_on "make" => :build
     end
   install: |
     if build.head?
-        resource("ddev-binary").stage do
-          system "unzip", "-o", Dir["*.zip"].first if Dir["*.zip"].any?
-          bin.install "ddev"
-          bash_completion.install "ddev_bash_completion.sh" => "ddev"
-          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
-        end
+        os = OS.mac? ? "darwin" : "linux"
+        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        system "mkdir", "-p", "#{bin}"
+        system "make", "build", "completions"
+        system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
+        bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
+        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
+        fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
     else
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -186,33 +186,26 @@ brews:
   custom_block: |
     head do
       url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
-
-      resource "ddev-binary" do
+      resource "ddev-artifacts" do
         url "https://nightly.link/{{ .Env.REPOSITORY_OWNER }}/ddev/workflows/master-build/master/ddev-head-artifacts.zip"
-        sha256 "" # We'll need to skip checksum verification for nightlies
+        sha256 "{{ .Env.HEAD_ARTIFACTS_SHA }}"
       end
     end
   install: |
     if build.head?
-        resource("ddev-binary").stage do
-          # First unzip the main artifact
-          system "unzip", "-o", "ddev-head-artifacts.zip"
+        resource("ddev-artifacts").unpack buildpath
     
-          # Verify checksums
-          system "sha256sum", "-c", "checksums.txt"
+        # Get the appropriate inner zipfile based on architecture
+        os = OS.mac? ? "darwin" : "linux"
+        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        inner_zip = "ddev_#{os}_#{arch}.zip"
     
-          # Now get the appropriate inner zipfile based on architecture
-          os = OS.mac? ? "macos" : "linux"
-          arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-          inner_zip = "ddev_#{os}_#{arch}.zip"
+        system "unzip", "-o", inner_zip, "-d", buildpath
     
-          # Unzip the architecture-specific binary and completions
-          system "unzip", "-o", inner_zip
-          bin.install "ddev"
-          bash_completion.install "ddev_bash_completion.sh" => "ddev"
-          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
-        end
+        bin.install "ddev"
+        bash_completion.install "ddev_bash_completion.sh" => "ddev"
+        zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+        fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     else
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"
@@ -241,34 +234,26 @@ brews:
   custom_block: |
     head do
       url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
-
-      resource "ddev-binary" do
+      resource "ddev-artifacts" do
         url "https://nightly.link/{{ .Env.REPOSITORY_OWNER }}/ddev/workflows/master-build/master/ddev-head-artifacts.zip"
-        sha256 "" # We'll need to skip checksum verification for nightlies
+        sha256 "{{ .Env.HEAD_ARTIFACTS_SHA }}"
       end
     end
-
   install: |
     if build.head?
-        resource("ddev-binary").stage do
-          # First unzip the main artifact
-          system "unzip", "-o", "ddev-head-artifacts.zip"
+        resource("ddev-artifacts").unpack buildpath
     
-          # Verify checksums
-          system "sha256sum", "-c", "checksums.txt"
+        # Get the appropriate inner zipfile based on architecture
+        os = OS.mac? ? "darwin" : "linux"
+        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        inner_zip = "ddev_#{os}_#{arch}.zip"
     
-          # Now get the appropriate inner zipfile based on architecture
-          os = OS.mac? ? "macos" : "linux"
-          arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-          inner_zip = "ddev_#{os}_#{arch}.zip"
+        system "unzip", "-o", inner_zip, "-d", buildpath
     
-          # Unzip the architecture-specific binary and completions
-          system "unzip", "-o", inner_zip
-          bin.install "ddev"
-          bash_completion.install "ddev_bash_completion.sh" => "ddev"
-          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
-        end
+        bin.install "ddev"
+        bash_completion.install "ddev_bash_completion.sh" => "ddev"
+        zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+        fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     else
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -307,13 +307,12 @@ snapshot:
   version_template: '{{ .Version }}-{{.ShortCommit}}'
 
 before_publish:
-  hooks:
-    - cmd: |
-        echo "Debug before_publish"
-        echo "REPOSITORY_OWNER='{{.Env.REPOSITORY_OWNER}}'"
-        echo "Prerelease='{{.Prerelease}}'"
-        echo "Skip upload evaluates to: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'"
-
+  - cmd: |
+      echo "Debug before_publish"
+      echo "REPOSITORY_OWNER='{{.Env.REPOSITORY_OWNER}}'"
+      echo "Prerelease='{{.Prerelease}}'"
+      echo "Skip upload evaluates to: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'"
+    output: true
 
 aurs:
 - name: "ddev"
@@ -355,13 +354,6 @@ aurs:
     email: randy@randyfay.com
 
 - name: "ddev-edge"
-  hooks:
-    pre:
-      - cmd: |
-          echo "Debug for ddev-edge:"
-          echo "REPOSITORY_OWNER='{{.Env.REPOSITORY_OWNER}}'"
-          echo "Prerelease='{{.Prerelease}}'"
-          echo "Skip upload evaluates to: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'"
   ids:
   - ddev
   homepage: "https://github.com/ddev/ddev"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -306,17 +306,17 @@ nfpms:
 snapshot:
   version_template: '{{ .Version }}-{{.ShortCommit}}'
 
+before_publish:
+  hooks:
+    - cmd: |
+        echo "Debug before_publish"
+        echo "REPOSITORY_OWNER='{{.Env.REPOSITORY_OWNER}}'"
+        echo "Prerelease='{{.Prerelease}}'"
+        echo "Skip upload evaluates to: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'"
+
 
 aurs:
 - name: "ddev"
-  hooks:
-    pre:
-      - cmd: |
-          echo "Debug for ddev (stable):"
-          echo "REPOSITORY_OWNER='{{.Env.REPOSITORY_OWNER}}'"
-          echo "Prerelease='{{.Prerelease}}'"
-          echo "Skip upload evaluates to: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'"
-
   ids:
   - ddev
   homepage: "https://github.com/ddev/ddev"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -309,6 +309,14 @@ snapshot:
 
 aurs:
 - name: "ddev"
+  hooks:
+    pre:
+      - cmd: |
+          echo "Debug for ddev (stable):"
+          echo "REPOSITORY_OWNER='{{.Env.REPOSITORY_OWNER}}'"
+          echo "Prerelease='{{.Prerelease}}'"
+          echo "Skip upload evaluates to: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'"
+
   ids:
   - ddev
   homepage: "https://github.com/ddev/ddev"
@@ -347,6 +355,13 @@ aurs:
     email: randy@randyfay.com
 
 - name: "ddev-edge"
+  hooks:
+    pre:
+      - cmd: |
+          echo "Debug for ddev-edge:"
+          echo "REPOSITORY_OWNER='{{.Env.REPOSITORY_OWNER}}'"
+          echo "Prerelease='{{.Prerelease}}'"
+          echo "Skip upload evaluates to: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'"
   ids:
   - ddev
   homepage: "https://github.com/ddev/ddev"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -306,13 +306,13 @@ nfpms:
 snapshot:
   version_template: '{{ .Version }}-{{.ShortCommit}}'
 
-before_publish:
-  - cmd: |
-      echo "Debug before_publish"
-      echo "REPOSITORY_OWNER='{{.Env.REPOSITORY_OWNER}}'"
-      echo "Prerelease='{{.Prerelease}}'"
-      echo "Skip upload evaluates to: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'"
-    output: true
+#before_publish:
+#  - cmd: |
+#      echo "Debug before_publish"
+#      echo "REPOSITORY_OWNER='{{.Env.REPOSITORY_OWNER}}'"
+#      echo "Prerelease='{{.Prerelease}}'"
+#      echo "Skip upload evaluates to: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'"
+#    output: true
 
 aurs:
 - name: "ddev"
@@ -323,8 +323,8 @@ aurs:
   maintainers:
   - 'Randy Fay <randy.fay@ddev.com>'
   license: "Apache 2"
-  # main ddev repo will only be uploaded on non-prerelease and ddev/ddev repo
-  skip_upload: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'
+  # main ddev repo will only be uploaded on non-prerelease
+  skip_upload: auto
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
   # AUR_STABLE_GIT_URL should be something like ssh://aur@aur.archlinux.org/ddev-bin.git or ssh://aur@aur.archlinux.org/rfay-test-ddev-bin.git
   git_url: '{{ .Env.AUR_STABLE_GIT_URL }}'
@@ -361,8 +361,8 @@ aurs:
   maintainers:
   - 'Randy Fay <randy.fay@ddev.com>'
   license: "Apache 2"
-  # Always upload on ddev/ddev
-  skip_upload: '{{ if eq .Env.REPOSITORY_OWNER "ddev" }}false{{ else }}true{{ end }}'
+  # Always upload, even on prerelease
+  skip_upload: "false"
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
   # AUR_EDGE_GIT_URL should be something like ssh://aur@aur.archlinux.org/ddev-edge-bin.git or ssh://aur@aur.archlinux.org/rfay-test-ddev-edge-bin.git
   git_url: '{{ .Env.AUR_EDGE_GIT_URL }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -181,13 +181,10 @@ brews:
   # ddev brew will only be uploaded on non-prerelease
   skip_upload: auto
   dependencies:
-  - name: mkcert
+    - name: mkcert
   custom_block: |
-    head "https://github.com/ddev/ddev.git", branch: "master"
-    if build.head?
-      depends_on "go" => :build
-      depends_on "make" => :build
-    end
+    depends_on "go" => [:build, :head]
+    depends_on "make" => [:build, :head]
   install: |
     if build.head?
         os = OS.mac? ? "darwin" : "linux"
@@ -221,13 +218,10 @@ brews:
   # ddev-edge brew will always be uploaded
   skip_upload: "false"
   dependencies:
-  - name: mkcert
+    - name: mkcert
   custom_block: |
-    head "https://github.com/ddev/ddev.git", branch: "master"
-    if build.head?
-      depends_on "go" => :build
-      depends_on "make" => :build
-    end
+    depends_on "go" => [:build, :head]
+    depends_on "make" => [:build, :head]
   install: |
     if build.head?
         os = OS.mac? ? "darwin" : "linux"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -185,21 +185,33 @@ brews:
 
   custom_block: |
     head do
-      url "https://github.com/ddev/ddev.git", branch: "master"
+      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
 
       resource "ddev-binary" do
-        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        os = OS.mac? ? "macos" : "linux"
-        url "https://nightly.link/ddev/ddev/workflows/master-build/master/ddev-#{os}-#{arch}.zip"
-        sha256 "" # We'd need to figure out how to handle this for nightlies
+        url "https://nightly.link/{{ .Env.REPOSITORY_OWNER }}/ddev/workflows/master-build/master/ddev-head-artifacts.zip"
+        sha256 "" # We'll need to skip checksum verification for nightlies
       end
     end
   install: |
     if build.head?
         resource("ddev-binary").stage do
-          system "unzip", "-o", Dir["*.zip"].first if Dir["*.zip"].any?
+          # First unzip the main artifact
+          system "unzip", "-o", "ddev-head-artifacts.zip"
+    
+          # Verify checksums
+          system "sha256sum", "-c", "checksums.txt"
+    
+          # Now get the appropriate inner zipfile based on architecture
+          os = OS.mac? ? "macos" : "linux"
+          arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+          inner_zip = "ddev_#{os}_#{arch}.zip"
+    
+          # Unzip the architecture-specific binary and completions
+          system "unzip", "-o", inner_zip
           bin.install "ddev"
-          # In the future, we could get and install the completion files
+          bash_completion.install "ddev_bash_completion.sh" => "ddev"
+          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
         end
     else
         bin.install "ddev"
@@ -207,7 +219,6 @@ brews:
         zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
-
 
   test: |
     system "#{bin}/ddev --version"
@@ -226,23 +237,37 @@ brews:
   skip_upload: "false"
   dependencies:
     - name: mkcert
+
   custom_block: |
     head do
-      url "https://github.com/ddev/ddev.git", branch: "master"
+      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
 
       resource "ddev-binary" do
-        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        os = OS.mac? ? "macos" : "linux"
-        url "https://nightly.link/ddev/ddev/workflows/master-build/master/ddev-#{os}-#{arch}.zip"
-        sha256 "" # We'd need to figure out how to handle this for nightlies
+        url "https://nightly.link/{{ .Env.REPOSITORY_OWNER }}/ddev/workflows/master-build/master/ddev-head-artifacts.zip"
+        sha256 "" # We'll need to skip checksum verification for nightlies
       end
     end
+
   install: |
     if build.head?
         resource("ddev-binary").stage do
-          system "unzip", "-o", Dir["*.zip"].first if Dir["*.zip"].any?
+          # First unzip the main artifact
+          system "unzip", "-o", "ddev-head-artifacts.zip"
+    
+          # Verify checksums
+          system "sha256sum", "-c", "checksums.txt"
+    
+          # Now get the appropriate inner zipfile based on architecture
+          os = OS.mac? ? "macos" : "linux"
+          arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+          inner_zip = "ddev_#{os}_#{arch}.zip"
+    
+          # Unzip the architecture-specific binary and completions
+          system "unzip", "-o", inner_zip
           bin.install "ddev"
-          # In the future, we could get and install the completion files
+          bash_completion.install "ddev_bash_completion.sh" => "ddev"
+          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
         end
     else
         bin.install "ddev"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -184,8 +184,10 @@ brews:
   - name: mkcert
   custom_block: |
     head "https://github.com/ddev/ddev.git", branch: "master"
-    depends_on "go" => :build
-    depends_on "make" => :build
+    if build.head?
+      depends_on "go" => :build
+      depends_on "make" => :build
+    end
   install: |
     if build.head?
         os = OS.mac? ? "darwin" : "linux"
@@ -222,8 +224,10 @@ brews:
   - name: mkcert
   custom_block: |
     head "https://github.com/ddev/ddev.git", branch: "master"
-    depends_on "go" => :build
-    depends_on "make" => :build
+    if build.head?
+      depends_on "go" => :build
+      depends_on "make" => :build
+    end
   install: |
     if build.head?
         os = OS.mac? ? "darwin" : "linux"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -189,11 +189,21 @@ brews:
       depends_on "make" => :build
 
       def install
+        ENV["GOPATH"] = buildpath
+        ENV["GOBIN"] = buildpath
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        system "mkdir", "-p", "#{bin}"
-        system "make", "build", "completions"
-        system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
+
+        # Get the git commit SHA for versioning
+        git_hash = Utils.git_head
+        version = "HEAD-" + git_hash[0..7]
+
+        system "make", "VERSION=#{version}"
+
+        # Install the compiled binary
+        bin.install ".gotmp/bin/#{os}_#{arch}/ddev"
+
+        # Install completions
         bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
         zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
@@ -206,7 +216,6 @@ brews:
       zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
       fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
-
 
   test: |
     system "#{bin}/ddev --version"
@@ -232,11 +241,21 @@ brews:
       depends_on "make" => :build
 
       def install
+        ENV["GOPATH"] = buildpath
+        ENV["GOBIN"] = buildpath
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        system "mkdir", "-p", "#{bin}"
-        system "make", "build", "completions"
-        system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
+  
+        # Get the git commit SHA for versioning
+        git_hash = Utils.git_head
+        version = "HEAD-" + git_hash[0..7]
+  
+        system "make", "VERSION=#{version}"
+
+        # Install the compiled binary
+        bin.install ".gotmp/bin/#{os}_#{arch}/ddev"
+
+        # Install completions
         bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
         zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -183,8 +183,11 @@ brews:
   dependencies:
     - name: mkcert
   custom_block: |
-    depends_on "go" => [:build, :head]
-    depends_on "make" => [:build, :head]
+    head do
+      url "https://github.com/ddev/ddev.git", branch: "master"
+      depends_on "go" => :build
+      depends_on "make" => :build
+    end
   install: |
     if build.head?
         os = OS.mac? ? "darwin" : "linux"
@@ -220,8 +223,11 @@ brews:
   dependencies:
     - name: mkcert
   custom_block: |
-    depends_on "go" => [:build, :head]
-    depends_on "make" => [:build, :head]
+    head do
+      url "https://github.com/ddev/ddev.git", branch: "master"
+      depends_on "go" => :build
+      depends_on "make" => :build
+    end
   install: |
     if build.head?
         os = OS.mac? ? "darwin" : "linux"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -176,7 +176,7 @@ brews:
     name: homebrew-ddev
   description: DDEV
   directory: Formula
-  homepage: https://github.com/ddev/ddev
+  homepage: https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev
   license: "Apache 2"
   # ddev brew will only be uploaded on non-prerelease
   skip_upload: auto
@@ -231,7 +231,7 @@ brews:
     name: homebrew-ddev-edge
   description: DDEV
   directory: Formula
-  homepage: https://github.com/ddev/ddev
+  homepage: https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev
   license: "Apache 2"
   # ddev-edge brew will always be uploaded
   skip_upload: "false"
@@ -321,7 +321,7 @@ nfpms:
       - xdg-utils
 
 snapshot:
-  name_template: '{{ .Version }}-{{.ShortCommit}}'
+  version_template: '{{ .Version }}-{{.ShortCommit}}'
 
 
 aurs:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -199,9 +199,7 @@ brews:
         resource("ddev-binary").stage do
           system "unzip", "-o", Dir["*.zip"].first if Dir["*.zip"].any?
           bin.install "ddev"
-          bash_completion.install "ddev_bash_completion.sh" => "ddev"
-          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+          # In the future, we could get and install the completion files
         end
     else
         bin.install "ddev"
@@ -244,9 +242,7 @@ brews:
         resource("ddev-binary").stage do
           system "unzip", "-o", Dir["*.zip"].first if Dir["*.zip"].any?
           bin.install "ddev"
-          bash_completion.install "ddev_bash_completion.sh" => "ddev"
-          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+          # In the future, we could get and install the completion files
         end
     else
         bin.install "ddev"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -186,25 +186,30 @@ brews:
   custom_block: |
     head do
       url "https://github.com/ddev/ddev.git", branch: "master"
-      depends_on "go" => :build
-      depends_on "make" => :build
+
+      resource "ddev-binary" do
+        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        os = OS.mac? ? "macos" : "linux"
+        url "https://nightly.link/ddev/ddev/workflows/master-build/master/ddev-#{os}-#{arch}.zip"
+        sha256 "" # We'd need to figure out how to handle this for nightlies
+      end
     end
   install: |
     if build.head?
-        os = OS.mac? ? "darwin" : "linux"
-        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        system "mkdir", "-p", "#{bin}"
-        system "make", "build", "completions"
-        system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
-        bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
-        fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
+        resource("ddev-binary").stage do
+          system "unzip", "-o", Dir["*.zip"].first if Dir["*.zip"].any?
+          bin.install "ddev"
+          bash_completion.install "ddev_bash_completion.sh" => "ddev"
+          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+        end
     else
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"
         zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
+
 
   test: |
     system "#{bin}/ddev --version"
@@ -226,19 +231,23 @@ brews:
   custom_block: |
     head do
       url "https://github.com/ddev/ddev.git", branch: "master"
-      depends_on "go" => :build
-      depends_on "make" => :build
+
+      resource "ddev-binary" do
+        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        os = OS.mac? ? "macos" : "linux"
+        url "https://nightly.link/ddev/ddev/workflows/master-build/master/ddev-#{os}-#{arch}.zip"
+        sha256 "" # We'd need to figure out how to handle this for nightlies
+      end
     end
   install: |
     if build.head?
-        os = OS.mac? ? "darwin" : "linux"
-        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        system "mkdir", "-p", "#{bin}"
-        system "make", "build", "completions"
-        system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
-        bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
-        fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
+        resource("ddev-binary").stage do
+          system "unzip", "-o", Dir["*.zip"].first if Dir["*.zip"].any?
+          bin.install "ddev"
+          bash_completion.install "ddev_bash_completion.sh" => "ddev"
+          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+        end
     else
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -194,8 +194,8 @@ brews:
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
     
-        # Build in the git checkout directory
-        cd buildpath do
+        # Change to the git checkout directory, which is the last component of the URL
+        cd("ddev") do
           # Get the git commit SHA for versioning
           git_hash = Utils.git_head
           version = "HEAD-" + git_hash[0..7]
@@ -249,14 +249,14 @@ brews:
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
     
-        # Build in the git checkout directory
-        cd buildpath do
+        # Change to the git checkout directory, which is the last component of the URL
+        cd("ddev") do
           # Get the git commit SHA for versioning
           git_hash = Utils.git_head
           version = "HEAD-" + git_hash[0..7]
-
+    
           system "make", "VERSION=#{version}"
-  
+
           # Install the compiled binary
           bin.install ".gotmp/bin/#{os}_#{arch}/ddev"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -185,32 +185,30 @@ brews:
 
   custom_block: |
     head do
-      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
-      resource "ddev-artifacts" do
-        url "https://nightly.link/{{ .Env.REPOSITORY_OWNER }}/ddev/workflows/master-build/master/ddev-head-artifacts.zip"
+      url "https://github.com/ddev/ddev.git", branch: "master"
+
+      resource "ddev-binary" do
+        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        os = OS.mac? ? "macos" : "linux"
+        url "https://nightly.link/ddev/ddev/workflows/master-build/master/ddev-#{os}-#{arch}.zip"
+        sha256 "" # We'd need to figure out how to handle this for nightlies
       end
     end
   install: |
     if build.head?
-        resource("ddev-artifacts").unpack buildpath
-    
-        # Get the appropriate inner zipfile based on architecture
-        os = OS.mac? ? "darwin" : "linux"
-        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        inner_zip = "ddev_#{os}_#{arch}.zip"
-    
-        system "unzip", "-o", inner_zip, "-d", buildpath
-    
-        bin.install "ddev"
-        bash_completion.install "ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-        fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+        resource("ddev-binary").stage do
+          system "unzip", "-o", Dir["*.zip"].first if Dir["*.zip"].any?
+          bin.install "ddev"
+          bash_completion.install "ddev_bash_completion.sh" => "ddev"
+          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"          end
     else
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"
         zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
+
 
   test: |
     system "#{bin}/ddev --version"
@@ -229,29 +227,26 @@ brews:
   skip_upload: "false"
   dependencies:
     - name: mkcert
-
   custom_block: |
     head do
-      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
-      resource "ddev-artifacts" do
-        url "https://nightly.link/{{ .Env.REPOSITORY_OWNER }}/ddev/workflows/master-build/master/ddev-head-artifacts.zip"
+      url "https://github.com/ddev/ddev.git", branch: "master"
+
+      resource "ddev-binary" do
+        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        os = OS.mac? ? "macos" : "linux"
+        url "https://nightly.link/ddev/ddev/workflows/master-build/master/ddev-#{os}-#{arch}.zip"
+        sha256 "" # We'd need to figure out how to handle this for nightlies
       end
     end
   install: |
     if build.head?
-        resource("ddev-artifacts").unpack buildpath
-    
-        # Get the appropriate inner zipfile based on architecture
-        os = OS.mac? ? "darwin" : "linux"
-        arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        inner_zip = "ddev_#{os}_#{arch}.zip"
-    
-        system "unzip", "-o", inner_zip, "-d", buildpath
-    
-        bin.install "ddev"
-        bash_completion.install "ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-        fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+        resource("ddev-binary").stage do
+          system "unzip", "-o", Dir["*.zip"].first if Dir["*.zip"].any?
+          bin.install "ddev"
+          bash_completion.install "ddev_bash_completion.sh" => "ddev"
+          zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+          fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+        end
     else
         bin.install "ddev"
         bash_completion.install "ddev_bash_completion.sh" => "ddev"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -187,9 +187,8 @@ brews:
       url "https://github.com/ddev/ddev.git", branch: "master"
       depends_on "go" => :build
       depends_on "make" => :build
-    end
-  install: |
-    if build.head?
+
+      def install
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
         system "mkdir", "-p", "#{bin}"
@@ -198,12 +197,16 @@ brews:
         bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
         zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
-    else
-        bin.install "ddev"
-        bash_completion.install "ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-        fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+      end
     end
+
+    def install
+      bin.install "ddev"
+      bash_completion.install "ddev_bash_completion.sh" => "ddev"
+      zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+      fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+    end
+
 
   test: |
     system "#{bin}/ddev --version"
@@ -227,9 +230,8 @@ brews:
       url "https://github.com/ddev/ddev.git", branch: "master"
       depends_on "go" => :build
       depends_on "make" => :build
-    end
-  install: |
-    if build.head?
+
+      def install
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
         system "mkdir", "-p", "#{bin}"
@@ -238,16 +240,18 @@ brews:
         bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
         zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
-    else
-        bin.install "ddev"
-        bash_completion.install "ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-        fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+      end
+    end
+
+    def install
+      bin.install "ddev"
+      bash_completion.install "ddev_bash_completion.sh" => "ddev"
+      zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+      fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
 
   test: |
     system "#{bin}/ddev --version"
-
 
 nfpms:
 - maintainer: Randy Fay

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -188,7 +188,6 @@ brews:
       url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
       resource "ddev-artifacts" do
         url "https://nightly.link/{{ .Env.REPOSITORY_OWNER }}/ddev/workflows/master-build/master/ddev-head-artifacts.zip"
-        sha256 "{{ .Env.HEAD_ARTIFACTS_SHA }}"
       end
     end
   install: |
@@ -236,7 +235,6 @@ brews:
       url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
       resource "ddev-artifacts" do
         url "https://nightly.link/{{ .Env.REPOSITORY_OWNER }}/ddev/workflows/master-build/master/ddev-head-artifacts.zip"
-        sha256 "{{ .Env.HEAD_ARTIFACTS_SHA }}"
       end
     end
   install: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -193,20 +193,23 @@ brews:
         ENV["GOBIN"] = buildpath
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    
+        # Build in the git checkout directory
+        cd buildpath do
+          # Get the git commit SHA for versioning
+          git_hash = Utils.git_head
+          version = "HEAD-" + git_hash[0..7]
+    
+          system "make", "VERSION=#{version}"
 
-        # Get the git commit SHA for versioning
-        git_hash = Utils.git_head
-        version = "HEAD-" + git_hash[0..7]
+          # Install the compiled binary
+          bin.install ".gotmp/bin/#{os}_#{arch}/ddev"
 
-        system "make", "VERSION=#{version}"
-
-        # Install the compiled binary
-        bin.install ".gotmp/bin/#{os}_#{arch}/ddev"
-
-        # Install completions
-        bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
-        fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
+          # Install completions
+          bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
+          zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
+          fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
+        end
       end
     end
 
@@ -245,20 +248,23 @@ brews:
         ENV["GOBIN"] = buildpath
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-  
-        # Get the git commit SHA for versioning
-        git_hash = Utils.git_head
-        version = "HEAD-" + git_hash[0..7]
-  
-        system "make", "VERSION=#{version}"
+    
+        # Build in the git checkout directory
+        cd buildpath do
+          # Get the git commit SHA for versioning
+          git_hash = Utils.git_head
+          version = "HEAD-" + git_hash[0..7]
 
-        # Install the compiled binary
-        bin.install ".gotmp/bin/#{os}_#{arch}/ddev"
+          system "make", "VERSION=#{version}"
+  
+          # Install the compiled binary
+          bin.install ".gotmp/bin/#{os}_#{arch}/ddev"
 
-        # Install completions
-        bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
-        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
-        fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
+          # Install completions
+          bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
+          zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
+          fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
+        end
       end
     end
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -536,3 +536,81 @@ dockerhub:
     full_description:
       from_file:
         path: ./containers/test-ssh-server/README.md
+
+#chocolateys:
+#    name: ddev-test
+#
+#    package_source_url: https://github.com/ddev/ddev/tree/master/winpkg/chocolatey
+#
+#    # Your app's owner.
+#    # It basically means you.
+#    owners: DDEV Foundation
+#
+#    # Your app's authors (probably you).
+#    authors: DDEV Foundation
+#
+#    project_url: https://ddev.com/
+#
+#    # Which format to use.
+#    #
+#    # Valid options are:
+#    # - 'msi':     msi installers (requires the MSI pipe configured, Pro only)
+#    # - 'archive': archives (only if format is zip),
+#    #
+#    # Default: 'archive'.
+#    # This feature is only available in GoReleaser Pro.
+#    use: msi
+#
+#    # URL which is determined by the given Token (github,
+#    # gitlab or gitea).
+#    #
+#    # Default: depends on the git remote.
+#    # Templates: allowed.
+##    url_template: "https://github.com/foo/bar/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+#
+##    icon_url: "https://rawcdn.githack.com/foo/bar/efbdc760-395b-43f1-bf69-ba25c374d473/icon.png"
+#
+#    # Your app's copyright details.
+#    #
+#    # Templates: allowed.
+#    copyright: DDEV Foundation
+#
+#    license_url: https://github.com/ddev/ddev/blob/master/LICENSE
+#    require_license_acceptance: true
+#
+#    # Your app's source url.
+#    project_source_url: https://github.com/ddev/ddev
+#
+#    # Your app's documentation url.
+#    docs_url: https://ddev.readthedocs.io
+#
+#    # App's bugtracker url.
+#    bug_tracker_url: https://github.com/ddev/ddev/issues
+#
+#    tags: "ddev drupal TYPO3 backdrop php"
+#
+#    summary: DDEV is a local web development tool optimized for PHP projects and CMSs.
+#
+#    # This the description of your chocolatey package.
+#    # Supports markdown.
+#    description: |
+#      {{ .ProjectName }} allows developers to use both nginx and apache, and many versions of PHP, with no host configurations.
+#
+#    release_notes: "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev/releases/tag/v{{ .Version }}"
+#
+#    # App's dependencies
+#    # The version is not required.
+#    dependencies:
+#      - id: gsudo
+#      - id: ngrok
+#      - id: mkcert
+#
+#    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
+#
+#    # The source repository that will push the package to.
+#    source_repo: "https://push.chocolatey.org/"
+#
+#    # Setting this will prevent goreleaser to actually try to push the package
+#    # to chocolatey repository, leaving the responsibility of publishing it to
+#    # the user.
+#    skip_publish: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -326,7 +326,7 @@ aurs:
   # main ddev repo will only be uploaded on non-prerelease and ddev/ddev repo
   skip_upload: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
-  # AUR_EDGE_GIT_URL should be something like ssh://aur@aur.archlinux.org/ddev-bin.git or ssh://aur@aur.archlinux.org/rfay-test-ddev-bin.git
+  # AUR_STABLE_GIT_URL should be something like ssh://aur@aur.archlinux.org/ddev-bin.git or ssh://aur@aur.archlinux.org/rfay-test-ddev-bin.git
   git_url: '{{ .Env.AUR_STABLE_GIT_URL }}'
   depends:
   - docker
@@ -351,7 +351,7 @@ aurs:
   # Defaults are shown below.
   commit_author:
     name: Randy Fay
-    email: randy@randyfay.com
+    email: randy.fay@ddev.com
 
 - name: "ddev-edge"
   ids:
@@ -389,7 +389,7 @@ aurs:
   # Defaults are shown below.
   commit_author:
     name: Randy Fay
-    email: randy@randyfay.com
+    email: randy.fay@ddev.com
 
 furies:
 - account: "{{ .Env.FURY_ACCOUNT }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -182,42 +182,31 @@ brews:
   skip_upload: auto
   dependencies:
     - name: mkcert
+
   custom_block: |
     head do
       url "https://github.com/ddev/ddev.git", branch: "master"
       depends_on "go" => :build
       depends_on "make" => :build
-
-      def install
-        ENV["GOPATH"] = buildpath
-        ENV["GOBIN"] = buildpath
+    end
+  install: |
+    if build.head?
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        # Get the git commit SHA for versioning
+        git_hash = Utils.git_head
+        version = "HEAD-" + git_hash[0..7]
     
-        # Change to the git checkout directory, which is the last component of the URL
-        cd("ddev") do
-          # Get the git commit SHA for versioning
-          git_hash = Utils.git_head
-          version = "HEAD-" + git_hash[0..7]
-    
-          system "make", "VERSION=#{version}"
-
-          # Install the compiled binary
-          bin.install ".gotmp/bin/#{os}_#{arch}/ddev"
-
-          # Install completions
-          bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
-          zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
-          fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
-        end
-      end
-    end
-
-    def install
-      bin.install "ddev"
-      bash_completion.install "ddev_bash_completion.sh" => "ddev"
-      zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-      fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+        system "make", "VERSION=#{version}"
+        system "cp", ".gotmp/bin/#{os}_#{arch}/ddev", "#{bin}/ddev"
+        bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
+        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
+        fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
+    else
+        bin.install "ddev"
+        bash_completion.install "ddev_bash_completion.sh" => "ddev"
+        zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+        fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
 
   test: |
@@ -242,37 +231,25 @@ brews:
       url "https://github.com/ddev/ddev.git", branch: "master"
       depends_on "go" => :build
       depends_on "make" => :build
-
-      def install
-        ENV["GOPATH"] = buildpath
-        ENV["GOBIN"] = buildpath
+    end
+  install: |
+    if build.head?
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+        # Get the git commit SHA for versioning
+        git_hash = Utils.git_head
+        version = "HEAD-" + git_hash[0..7]
     
-        # Change to the git checkout directory, which is the last component of the URL
-        cd("ddev") do
-          # Get the git commit SHA for versioning
-          git_hash = Utils.git_head
-          version = "HEAD-" + git_hash[0..7]
-    
-          system "make", "VERSION=#{version}"
-
-          # Install the compiled binary
-          bin.install ".gotmp/bin/#{os}_#{arch}/ddev"
-
-          # Install completions
-          bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
-          zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
-          fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
-        end
-      end
-    end
-
-    def install
-      bin.install "ddev"
-      bash_completion.install "ddev_bash_completion.sh" => "ddev"
-      zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
-      fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
+        system "make", "VERSION=#{version}"
+        system "cp", ".gotmp/bin/#{os}_#{arch}/ddev", "#{bin}/ddev"
+        bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
+        zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
+        fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
+    else
+        bin.install "ddev"
+        bash_completion.install "ddev_bash_completion.sh" => "ddev"
+        zsh_completion.install "ddev_zsh_completion.sh" => "_ddev"
+        fish_completion.install "ddev_fish_completion.sh" => "ddev.fish"
     end
 
   test: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -193,12 +193,9 @@ brews:
     if build.head?
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        # Get the git commit SHA for versioning
-        git_hash = Utils.git_head
-        version = "HEAD-" + git_hash[0..7]
-    
-        system "make", "VERSION=#{version}"
-        system "cp", ".gotmp/bin/#{os}_#{arch}/ddev", "#{bin}/ddev"
+        system "mkdir", "-p", "#{bin}"
+        system "make", "build", "completions"
+        system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
         bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
         zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
@@ -236,12 +233,9 @@ brews:
     if build.head?
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-        # Get the git commit SHA for versioning
-        git_hash = Utils.git_head
-        version = "HEAD-" + git_hash[0..7]
-    
-        system "make", "VERSION=#{version}"
-        system "cp", ".gotmp/bin/#{os}_#{arch}/ddev", "#{bin}/ddev"
+        system "mkdir", "-p", "#{bin}"
+        system "make", "build", "completions"
+        system "cp", ".gotmp/bin/" + os + "_" + arch + "/ddev", "#{bin}/ddev"
         bash_completion.install ".gotmp/bin/completions/ddev_bash_completion.sh" => "ddev"
         zsh_completion.install ".gotmp/bin/completions/ddev_zsh_completion.sh" => "_ddev"
         fish_completion.install ".gotmp/bin/completions/ddev_fish_completion.sh" => "ddev.fish"
@@ -254,6 +248,7 @@ brews:
 
   test: |
     system "#{bin}/ddev --version"
+
 
 nfpms:
 - maintainer: Randy Fay

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -314,10 +314,10 @@ aurs:
   homepage: "https://github.com/ddev/ddev"
   description: "DDEV: a local web development environment"
   maintainers:
-  - 'Randy Fay <randy at randyfay.com>'
+  - 'Randy Fay <randy.fay@ddev.com>'
   license: "Apache 2"
-  # main ddev repo will only be uploaded on non-prerelease
-  skip_upload: auto
+  # main ddev repo will only be uploaded on non-prerelease and ddev/ddev repo
+  skip_upload: '{{ if and (eq .Env.REPOSITORY_OWNER "ddev") (not .Prerelease) }}false{{ else }}true{{ end }}'
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
   # AUR_EDGE_GIT_URL should be something like ssh://aur@aur.archlinux.org/ddev-bin.git or ssh://aur@aur.archlinux.org/rfay-test-ddev-bin.git
   git_url: '{{ .Env.AUR_STABLE_GIT_URL }}'
@@ -352,10 +352,10 @@ aurs:
   homepage: "https://github.com/ddev/ddev"
   description: "DDEV: a local web development environment (edge)"
   maintainers:
-  - 'Randy Fay <randy at randyfay.com>'
+  - 'Randy Fay <randy.fay@ddev.com>'
   license: "Apache 2"
-  # Always upload, even on prerelease
-  skip_upload: "false"
+  # Always upload on ddev/ddev
+  skip_upload: '{{ if eq .Env.REPOSITORY_OWNER "ddev" }}false{{ else }}true{{ end }}'
   private_key: '{{ .Env.AUR_SSH_PRIVATE_KEY }}'
   # AUR_EDGE_GIT_URL should be something like ssh://aur@aur.archlinux.org/ddev-edge-bin.git or ssh://aur@aur.archlinux.org/rfay-test-ddev-edge-bin.git
   git_url: '{{ .Env.AUR_EDGE_GIT_URL }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -315,7 +315,7 @@ snapshot:
 #    output: true
 
 aurs:
-- name: "ddev"
+- name: "{{ .Env.AUR_PACKAGE_NAME }}"
   ids:
   - ddev
   homepage: "https://github.com/ddev/ddev"
@@ -353,7 +353,7 @@ aurs:
     name: Randy Fay
     email: randy.fay@ddev.com
 
-- name: "ddev-edge"
+- name: "{{ .Env.AUR_PACKAGE_NAME }}-edge"
   ids:
   - ddev
   homepage: "https://github.com/ddev/ddev"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -196,6 +196,8 @@ brews:
     end
   install: |
     if build.head?
+        system "git", "fetch", "--unshallow" if File.exist?("#{HOMEBREW_REPOSITORY}/.git/shallow")
+        system "git", "fetch", "--tags"
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
         system "mkdir", "-p", "#{bin}"
@@ -236,6 +238,8 @@ brews:
     end
   install: |
     if build.head?
+        system "git", "fetch", "--unshallow" if File.exist?("#{HOMEBREW_REPOSITORY}/.git/shallow")
+        system "git", "fetch", "--tags"
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
         system "mkdir", "-p", "#{bin}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,8 @@
+# DDEV goreleaser configuration
+# Handles uploading built executables to most of the places they go
+# See https://ddev.readthedocs.io/en/stable/developers/release-management/#environment-variables-required
+# for environment variables that may be used.
+
 version: 2
 ##### BUILDS ######
 builds:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -196,8 +196,8 @@ brews:
     end
   install: |
     if build.head?
-        system "git", "fetch", "--unshallow" if File.exist?("#{HOMEBREW_REPOSITORY}/.git/shallow")
-        system "git", "fetch", "--tags"
+        system "sh", "-c", "git fetch --unshallow >/dev/null 2>&1" if File.exist?("#{HOMEBREW_REPOSITORY}/.git/shallow")
+        system "sh", "-c", "git fetch --tags -f >/dev/null 2>&1"
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
         system "mkdir", "-p", "#{bin}"
@@ -238,8 +238,8 @@ brews:
     end
   install: |
     if build.head?
-        system "git", "fetch", "--unshallow" if File.exist?("#{HOMEBREW_REPOSITORY}/.git/shallow")
-        system "git", "fetch", "--tags"
+        system "sh", "-c", "git fetch --unshallow >/dev/null 2>&1" if File.exist?("#{HOMEBREW_REPOSITORY}/.git/shallow")
+        system "sh", "-c", "git fetch --tags -f >/dev/null 2>&1"
         os = OS.mac? ? "darwin" : "linux"
         arch = Hardware::CPU.arm? ? "arm64" : "amd64"
         system "mkdir", "-p", "#{bin}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -190,7 +190,7 @@ brews:
 
   custom_block: |
     head do
-      url "https://github.com/ddev/ddev.git", branch: "master"
+      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
       depends_on "go" => :build
       depends_on "make" => :build
     end
@@ -230,7 +230,7 @@ brews:
     - name: mkcert
   custom_block: |
     head do
-      url "https://github.com/ddev/ddev.git", branch: "master"
+      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
       depends_on "go" => :build
       depends_on "make" => :build
     end

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ golangci-lint:
 	if command -v golangci-lint >/dev/null 2>&1; then \
 		$$CMD; \
 	else \
-		echo "Skipping golanci-lint as not installed"; \
+		echo "Skipping golangci-lint as not installed"; \
 	fi
 
 version:

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -9,7 +9,14 @@ search:
 There are several ways to use DDEV’s latest-committed HEAD version:
 
 * **Download** the latest master branch artifacts from [nightly.link](https://nightly.link/ddev/ddev/workflows/master-build/master). Each of these is built by the CI system, signed, and notarized. Get the one you need and place it in your `$PATH`.
-* **Homebrew install HEAD**: On macOS and Linux, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD --fetch-HEAD` to get the latest DDEV commit, even if it’s unreleased. Since you’re building this on your own computer, it’s not signed or notarized, and you’ll get a notification that instrumentation doesn’t work, which is fine. If you’re using Linux/WSL2, you’ll likely need to install build-essential by running the following command: `sudo apt-get install -y build-essential`. In case you want to regularly test and use the latest version of DDEV HEAD run `brew upgrade --fetch-head ddev` instead.
+* **Homebrew install HEAD**: On macOS and Linux, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD --fetch-HEAD` to get the latest DDEV commit, even if it’s unreleased.
+* **Install via script**: You can download and run the [install_ddev_head.sh](https://raw.githubusercontent.com/ddev/ddev/refs/heads/master/scripts/install_ddev_head.sh)  script, or run it automatically:
+
+    ```bash
+    # Download and run the install script
+    curl -fsSL https://raw.githubusercontent.com/ddev/ddev/refs/heads/master/scripts/install_ddev_head.sh | bash
+    ```
+
 * **Build manually**: If you have normal build tools like `make` and `go` installed, you can check out the code and run `make`.
 * **Gitpod** You can use the latest build by visiting DDEV on [Gitpod](https://gitpod.io/#https://github.com/ddev/ddev).
 

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -26,6 +26,7 @@ search:
 These are normally configured in the repository environment variables.
 
 * `AUR_EDGE_GIT_URL`: The Git URL for AUR edge (normally `ddev-edge-bin`), for example `ssh://aur@aur.archlinux.org/ddev-edge-bin.git`.
+* `AUR_PACKAGE_NAME`: The base name of the AUR package. Normally `ddev` for production, but `ddev-test` for testing repository.
 * `AUR_STABLE_GIT_URL`: The Git URL for AUR stable (normally `ddev-bin`), for example `ssh://aur@aur.archlinux.org/ddev-bin.git`.
 * `DOCKERHUB_USERNAME`: Username for pushing to `hub.docker.com` or updating image descriptions.
 * `DOCKER_ORG`: the `hub.docker.org` organization to push to

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -220,11 +220,7 @@ make windows_amd64 windows_arm64 darwin_amd64 darwin_arm64 linux_amd64 linux_arm
 goreleaser release --prepare --nightly --clean
 ```
 
-This will create all the artifacts that would have been pushed in the `dist` directory. You can copy Linux packages from there to test them manually, download the built tarballs for use elsewhere, install Homebrew package manually, for example:
-
-```bash
-brew install ./dist/homebrew/Formula/ddev.rb
-```
+This will create all the artifacts that would have been pushed in the `dist` directory. You can copy Linux packages from there to test them manually, download the built tarballs for use elsewhere.
 
 ### Creating a test release on `ddev-test/ddev`
 

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -28,9 +28,10 @@ These are normally configured in the repository environment variables.
 * `AUR_EDGE_GIT_URL`: The Git URL for AUR edge (normally `ddev-edge-bin`), for example `ssh://aur@aur.archlinux.org/ddev-edge-bin.git`.
 * `AUR_PACKAGE_NAME`: The base name of the AUR package. Normally `ddev` for production, but `ddev-test` for testing repository.
 * `AUR_STABLE_GIT_URL`: The Git URL for AUR stable (normally `ddev-bin`), for example `ssh://aur@aur.archlinux.org/ddev-bin.git`.
-* `DOCKERHUB_USERNAME`: Username for pushing to `hub.docker.com` or updating image descriptions.
-* `DOCKER_ORG`: the `hub.docker.org` organization to push to
-* `FURY_ACCOUNT`: [Gemfury](https://gemfury.com) account that receives package pushes.
+* `DDEV_WINDOWS_SIGN`: If the value is `"true"` then `make` will attempt to sign the Windows executables, which requires building on our self-hosted Windows runner.
+* `DOCKER_ORG`: the organization on `hub.docker.org` to push to. Currently `ddev` on `ddev/ddev` and `ddevhq` on `ddev-test/ddev`.
+* `DOCKERHUB_USERNAME`: Username for pushing to `hub.docker.com` or updating image descriptions. Usually `ddevmachinepush`.
+* `FURY_ACCOUNT`: [Gemfury](https://gemfury.com) account that receives package pushes. `drud` on `ddev/ddev` for historical reasons, and `rfay` on `ddev-test/ddev` because that's a spare account there.
 * `HOMEBREW_EDGE_REPOSITORY`: Like `ddev/homebrew-ddev-edge` but might be another repository like be `ddev-test/homebrew-ddev-edge`.
 * `HOMEBREW_STABLE_REPOSITORY`: Like `ddev/homebrew-ddev` but might be another repository like `ddev-test/homebrew-ddev`.
 

--- a/scripts/install_ddev_head.sh
+++ b/scripts/install_ddev_head.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+# Script to download and install DDEV HEAD build from GitHub Actions artifacts
+# Usage: install_ddev_head.sh
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [ ! -d /usr/local/bin ]; then echo 'using sudo to mkdir missing /usr/local/bin' && sudo mkdir -p /usr/local/bin; fi
+
+GITHUB_OWNER=${GITHUB_OWNER:-ddev}
+ARTIFACTS="ddev"
+TMPDIR=/tmp
+
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RESET='\033[0m'
+OS=$(uname)
+BINOWNER=$(ls -ld /usr/local/bin | awk '{print $3}')
+USER=$(whoami)
+SHACMD=""
+FILEBASE=""
+
+if [[ $EUID -eq 0 ]]; then
+  echo "This script must NOT be run with sudo/root. Please re-run without sudo." 1>&2
+  exit 102
+fi
+
+unamearch=$(uname -m)
+case ${unamearch} in
+  x86_64) ARCH="amd64";
+  ;;
+  aarch64) ARCH="arm64";
+  ;;
+  arm64) ARCH="arm64"
+  ;;
+  *) printf "${RED}Sorry, your machine architecture ${unamearch} is not currently supported.\n${RESET}" && exit 106
+  ;;
+esac
+
+if [[ "$OS" == "Darwin" ]]; then
+    SHACMD="shasum -a 256"
+    OS="darwin"
+elif [[ "$OS" == "Linux" ]]; then
+    SHACMD="sha256sum"
+    OS="linux"
+else
+    printf "${RED}Sorry, this installer does not support your platform at this time.${RESET}\n"
+    exit 1
+fi
+
+if ! docker --version >/dev/null 2>&1; then
+    printf "${YELLOW}A docker provider is required for ddev. Please see https://ddev.readthedocs.io/en/stable/users/install/docker-installation/.${RESET}\n"
+fi
+
+ARTIFACTS_URL="https://nightly.link/${GITHUB_OWNER}/ddev/workflows/master-build/master/ddev-head-artifacts.zip"
+printf "${GREEN}Downloading latest HEAD build from GitHub Actions...${RESET}\n"
+
+cd ${TMPDIR}
+curl -fsSL "$ARTIFACTS_URL" -o ddev-head-artifacts.zip || (printf "${RED}Failed downloading $ARTIFACTS_URL${RESET}\n" && exit 108)
+
+printf "${GREEN}Extracting artifacts...${RESET}\n"
+unzip -o ddev-head-artifacts.zip
+
+# Verify checksums
+${SHACMD} -c checksums.txt || (printf "${RED}Checksum verification failed${RESET}\n" && exit 109)
+
+# Extract the OS/arch specific archive
+INNER_ARCHIVE="ddev_${OS}_${ARCH}.zip"
+unzip -o ${INNER_ARCHIVE}
+
+printf "${GREEN}Download verified. Ready to place ddev in your /usr/local/bin.${RESET}\n"
+
+if command -v brew >/dev/null && brew info ddev >/dev/null 2>/dev/null ; then
+  echo "Attempting to unlink any homebrew-installed ddev with 'brew unlink ddev'"
+  brew unlink ddev >/dev/null 2>&1 || true
+fi
+
+if [ -L /usr/local/bin/ddev ] ; then
+    printf "${RED}ddev already exists as a link in /usr/local/bin/ddev. Was it installed with homebrew?${RESET}\n"
+    printf "${RED}Cowardly refusing to install over existing symlink${RESET}\n"
+    exit 101
+fi
+
+SUDO=""
+if [[ "$BINOWNER" != "$USER" ]]; then
+  SUDO=sudo
+fi
+
+if [ ! -z "${SUDO}" ]; then
+    printf "${YELLOW}Running \"sudo mv ddev /usr/local/bin/\" Please enter your password if prompted.${RESET}\n"
+fi
+
+chmod +x ddev
+${SUDO} mv ddev /usr/local/bin/
+
+# Install completions if available
+if command -v brew >/dev/null ; then
+    if [ -d "$(brew --prefix)/etc/bash_completion.d" ]; then
+        bash_completion_dir=$(brew --prefix)/etc/bash_completion.d
+        cp ddev_bash_completion.sh $bash_completion_dir/ddev
+        printf "${GREEN}Installed ddev bash completions in $bash_completion_dir${RESET}\n"
+    fi
+
+    if [ -d "$(brew --prefix)/share/zsh-completions" ] && [ -f ddev_zsh_completion.sh ]; then
+        zsh_completion_dir=$(brew --prefix)/share/zsh-completions
+        cp ddev_zsh_completion.sh $zsh_completion_dir/_ddev
+        printf "${GREEN}Installed ddev zsh completions in $zsh_completion_dir${RESET}\n"
+    fi
+fi
+
+# Cleanup
+rm -f ddev-head-artifacts.zip ${INNER_ARCHIVE} checksums.txt ddev_*_completion.sh
+
+hash -r
+
+printf "${GREEN}ddev HEAD build is now installed. Run \"ddev\" and \"ddev --version\" to verify your installation and see usage.${RESET}\n"


### PR DESCRIPTION
## The Issue

* #6156 
* #6623 

Normal users of ddev/ddev/ddev are forced to get make and go and their dependencies

## How This PR Solves The Issue

Don't do that. Fixes goreleaser.yaml, makes the release build test-able, including furies and AUR

## Manual Testing Instructions

foreach macos-arm64 macos-amd64 linux-amd64; do
    - [ ] brew uninstall -f ddev
    - [ ] `brew untap` any taps shown by `brew tap |grep ddev`
    - [ ] `brew install ddev-test/ddev/ddev` - should get v1.23.25
    - [ ] `brew unlink ddev`
    - [ ] `brew install --HEAD ddev-test/ddev/ddev` - should get reasonable version and hash (coming from ddev-test/ddev)
    - [ ] `brew uninstall ddev && brew untap ddev-test/ddev`
    - [ ] `curl -fsSL https://raw.githubusercontent.com/rfay/ddev/refs/heads/20241112_rfay_homebrew_go_make/scripts/install_ddev_head.sh | bash` - should get reasonable version and hash from ddev/ddev
    - [ ] `sudo rm /usr/local/bin/ddev && brew install ddev/ddev/ddev`
done

Doing a release is a resonable thing. I just did https://github.com/ddev-test/ddev/releases/tag/v1.23.25 from this branch. Build at https://github.com/ddev-test/ddev/actions/runs/11847489029
- [ ] Verify AUR pushed to right thing (new targets, ddev-test-bin and ddev-test-edge-bin)
- [ ] Furies pushed to FURY_ACCOUNT which is `rfay` on ddev-test/ddev (`drud` on ddev/ddev)
- [ ] Chocolatey not pushed because not on ddev/ddev
