### PR TITLE
fix: make "Shopware Update" work with nginx, fixes #6656

### DIFF
--- a/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
@@ -35,6 +35,15 @@ server {
         rewrite ^ /index.php;
     }
 
+    # Shopware install / update
+    location /shopware-installer.phar.php {
+        try_files $uri /shopware-installer.phar.php$is_args$args;
+    }
+
+    location ~ ^/shopware-installer\.phar\.php/.+\.(?:css|js|png|svg|woff)$ {
+        try_files $uri /shopware-installer.phar.php$is_args$args;
+    }
+
     # Needed for Shopware install / update
     location /recovery/install {
         index index.php;


### PR DESCRIPTION
## The Issue

- #6656

## How This PR Solves The Issue

Updates nginx config with https://developer.shopware.com/docs/resources/references/config-reference/server/nginx.html to make Shopware Update work.

(It already works for `apache-fpm`.)

## Manual Testing Instructions

1. Use our quickstart for Shopware https://ddev.readthedocs.io/en/stable/users/quickstart/#shopware
2. Open `composer.json` in the project root and replace the version to make it older, e.g.:
	```diff
	-"shopware/core": "v6.6.8.2"
	+"shopware/core": "v6.6.8.1"
	```
3. Run `ddev exec "rm -f composer.lock && composer install"`
4. Open admin panel `ddev launch /admin`
5. Login with credentials (admin / shopware)
6. `ddev launch "/admin#/sw/settings/shopware/updates/wizard"` (or Settings > System > Shopware updates)
7. Click "Start Update", follow instructions, it should update Shopware to the latest version.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
