### PR TITLE
fix: Move the custom php8.0-xdebug build from ddev-webserver to user Dockerfile

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -44,12 +44,12 @@ RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/deb
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && rm -f /tmp/debsuryorg-archive-keyring.deb && \
     echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && apt-get update
 ARG XDEBUG_VERSION="3.2.2"
-ARG XDEBUG_BUILD_PACKAGES="build-essential php-pear php8.0-dev php8.1-dev php8.2-dev"
+ARG XDEBUG_BUILD_PACKAGES="build-essential php-pear php8.1-dev php8.2-dev"
 RUN set -eu -o pipefail; \
     apt-get -qq update && \
     apt-get -qq install --no-install-recommends --no-install-suggests -y ${XDEBUG_BUILD_PACKAGES}
 RUN pecl channel-update pecl.php.net && \
-    for version in 8.0 8.1 8.2; do \
+    for version in 8.1 8.2; do \
         (apt-get -qq remove -y php${version}-xdebug || true) && \
         pecl -d php_suffix=${version} install -f xdebug-${XDEBUG_VERSION} && \
         rm -f /usr/share/php/.registry/.channel.pecl.php.net/xdebug.reg || exit $?; \

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -37,23 +37,13 @@ ADD generic-files /
 ### Xdebug compile specific version because 3.3 is not fully reliable
 ### See https://github.com/ddev/ddev/issues/6159
 ### We don't need to recompile every Xdebug library https://xdebug.org/docs/compat (only PHP 8.0, 8.1, 8.2 can have Xdebug 3.2)
-### PECL does not allow you to install multiple versions of Xdebug, so there is `rm -f xdebug.reg`
 FROM base AS ddev-xdebug-build
 SHELL ["/bin/bash", "-c"]
 RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && rm -f /tmp/debsuryorg-archive-keyring.deb && \
     echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && apt-get update
-ARG XDEBUG_VERSION="3.2.2"
-ARG XDEBUG_BUILD_PACKAGES="build-essential php-pear php8.1-dev php8.2-dev"
-RUN set -eu -o pipefail; \
-    apt-get -qq update && \
-    apt-get -qq install --no-install-recommends --no-install-suggests -y ${XDEBUG_BUILD_PACKAGES}
-RUN pecl channel-update pecl.php.net && \
-    for version in 8.1 8.2; do \
-        (apt-get -qq remove -y php${version}-xdebug || true) && \
-        pecl -d php_suffix=${version} install -f xdebug-${XDEBUG_VERSION} && \
-        rm -f /usr/share/php/.registry/.channel.pecl.php.net/xdebug.reg || exit $?; \
-    done
+RUN /usr/local/bin/build_php_extension.sh "8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
+RUN /usr/local/bin/build_php_extension.sh "8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
 #END ddev-xdebug-build
 
 ### ---------------------------ddev-php-base--------------------------------------

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -31,20 +31,25 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     wget
 RUN url="https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETPLATFORM#linux/}"; wget ${url} -q -O /usr/bin/yq && chmod +x /usr/bin/yq
 ADD generic-files /
-#END base
 
-### ---------------------------ddev-xdebug-build--------------------------------------
-### Xdebug compile specific version because 3.3 is not fully reliable
-### See https://github.com/ddev/ddev/issues/6159
-### We don't need to recompile every Xdebug library https://xdebug.org/docs/compat (only PHP 8.0, 8.1, 8.2 can have Xdebug 3.2)
-FROM base AS ddev-xdebug-build
-SHELL ["/bin/bash", "-c"]
+RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
+    | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
+
 RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb && rm -f /tmp/debsuryorg-archive-keyring.deb && \
-    echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && apt-get update
-RUN /usr/local/bin/build_php_extension.sh "8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
-RUN /usr/local/bin/build_php_extension.sh "8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
-#END ddev-xdebug-build
+    echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && apt-get -qq update
+#END base
+
+### ---------------------------ddev-php-extension-build--------------------------------------
+FROM base AS ddev-php-extension-build
+SHELL ["/bin/bash", "-c"]
+### Xdebug compile specific version because 3.3 is not fully reliable
+### See https://github.com/ddev/ddev/issues/6159
+RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
+RUN /usr/local/bin/build_php_extension.sh "php8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
+#END ddev-php-extension-build
 
 ### ---------------------------ddev-php-base--------------------------------------
 ### Build ddev-php-base, which is the base for ddev-php-prod and ddev-webserver-*
@@ -66,15 +71,6 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 SHELL ["/bin/bash", "-c"]
-
-RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
-    | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
-RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
-http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
-
-RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
-    dpkg -i /tmp/debsuryorg-archive-keyring.deb && rm -f /tmp/debsuryorg-archive-keyring.deb && \
-    echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && apt-get update
 
 RUN apt-get -qq update
 RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
@@ -111,12 +107,12 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/ru
     chmod ugo+rx /usr/local/bin/* && \
     ln -sf /usr/sbin/php-fpm${PHP_DEFAULT_VERSION} /usr/sbin/php-fpm
 
-### ---------------------------ddev-xdebug-build--------------------------------------
+### ---------------------------ddev-php-extension-build--------------------------------------
 ### The dates from /usr/lib/php/YYYYMMDD/ represent PHP API versions https://unix.stackexchange.com/a/591771
 RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug
-COPY --from=ddev-xdebug-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
-COPY --from=ddev-xdebug-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
-#END ddev-xdebug-build
+COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
+COPY --from=ddev-php-extension-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
+#END ddev-php-extension-build
 RUN phpdismod xhprof
 RUN apt-get -qq autoremove -y
 RUN curl -L --fail -o /usr/local/bin/composer -sSL https://getcomposer.org/composer-stable.phar && chmod ugo+wx /usr/local/bin/composer

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -123,8 +123,7 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/ru
 
 ### ---------------------------ddev-xdebug-build--------------------------------------
 ### The dates from /usr/lib/php/YYYYMMDD/ represent PHP API versions https://unix.stackexchange.com/a/591771
-RUN apt-get -qq remove -y php8.0-xdebug php8.1-xdebug php8.2-xdebug
-COPY --from=ddev-xdebug-build /usr/lib/php/20200930/xdebug.so /usr/lib/php/20200930/xdebug.so
+RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug
 COPY --from=ddev-xdebug-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
 COPY --from=ddev-xdebug-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
 #END ddev-xdebug-build

--- a/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
@@ -8,7 +8,7 @@ if [ "$#" -ne 4 ]; then
 fi
 
 # 8.0
-PHP_VERSION=$1
+PHP_VERSION=${1/php/}
 # xdebug
 EXTENSION_NAME=$2
 # 3.2.2

--- a/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
@@ -31,11 +31,11 @@ if [ -f "${EXTENSION_FILE}" ]; then
 fi
 
 # PECL does not allow to install multiple versions of extension at the same time,
-# use `rm -f /usr/share/php/.registry/.channel.pecl.php.net/xdebug.reg` to make it forget about another version.
+# use `rm -f /usr/share/php/.registry/.channel.pecl.php.net/extension.reg` to make it forget about another version.
 (pecl channel-update pecl.php.net && \
   echo "Building php${PHP_VERSION}-${EXTENSION_NAME}..." && \
   pecl -d php_suffix="${PHP_VERSION}" install -f "${EXTENSION_NAME}-${EXTENSION_VERSION}" >/dev/null && \
-  rm -f /usr/share/php/.registry/.channel.pecl.php.net/xdebug.reg) || true
+  rm -f "/usr/share/php/.registry/.channel.pecl.php.net/${EXTENSION_NAME}.reg") || true
 
 if [ ! -f "${EXTENSION_FILE}" ]; then
   echo "Failed to build ${EXTENSION_FILE}"

--- a/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
@@ -11,7 +11,7 @@ fi
 PHP_VERSION=${1/php/}
 # xdebug
 EXTENSION_NAME=$2
-# 3.2.2
+# 3.2.2, latest
 EXTENSION_VERSION=$3
 # /usr/lib/php/20210902/xdebug.so
 # The dates from /usr/lib/php/YYYYMMDD/ represent PHP API versions https://unix.stackexchange.com/a/591771
@@ -30,11 +30,17 @@ if [ -f "${EXTENSION_FILE}" ]; then
   mv "${EXTENSION_FILE}" "${EXTENSION_FILE}.bak"
 fi
 
+if [ "${EXTENSION_VERSION}" = "latest" ]; then
+  PECL_EXTENSION="${EXTENSION_NAME}"
+else
+  PECL_EXTENSION="${EXTENSION_NAME}-${EXTENSION_VERSION}"
+fi
+
 # PECL does not allow to install multiple versions of extension at the same time,
 # use `rm -f /usr/share/php/.registry/.channel.pecl.php.net/extension.reg` to make it forget about another version.
 (pecl channel-update pecl.php.net && \
   echo "Building php${PHP_VERSION}-${EXTENSION_NAME}..." && \
-  pecl -d php_suffix="${PHP_VERSION}" install -f "${EXTENSION_NAME}-${EXTENSION_VERSION}" >/dev/null && \
+  pecl -d php_suffix="${PHP_VERSION}" install -f "${PECL_EXTENSION}" >/dev/null && \
   rm -f "/usr/share/php/.registry/.channel.pecl.php.net/${EXTENSION_NAME}.reg") || true
 
 if [ ! -f "${EXTENSION_FILE}" ]; then

--- a/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "Usage: $0 <PHP_VERSION> <EXTENSION_NAME> <EXTENSION_VERSION> <EXTENSION_FILE>"
+  exit 1
+fi
+
+# 8.0
+PHP_VERSION=$1
+# xdebug
+EXTENSION_NAME=$2
+# 3.2.2
+EXTENSION_VERSION=$3
+# /usr/lib/php/20210902/xdebug.so
+# The dates from /usr/lib/php/YYYYMMDD/ represent PHP API versions https://unix.stackexchange.com/a/591771
+EXTENSION_FILE=$4
+
+# install pecl
+if ! command -v pecl >/dev/null 2>&1 || [ "$(dpkg -l | grep "php${PHP_VERSION}-dev")" = "" ]; then
+  echo "Installing pecl to build php${PHP_VERSION}-${EXTENSION_NAME}"
+  apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
+  apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/debian.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y build-essential php-pear "php${PHP_VERSION}-dev" || exit $?
+fi
+
+if [ -f "${EXTENSION_FILE}" ]; then
+  echo "Moving existing ${EXTENSION_FILE} to ${EXTENSION_FILE}.bak"
+  mv "${EXTENSION_FILE}" "${EXTENSION_FILE}.bak"
+fi
+
+# PECL does not allow to install multiple versions of extension at the same time,
+# use `rm -f /usr/share/php/.registry/.channel.pecl.php.net/xdebug.reg` to make it forget about another version.
+(pecl channel-update pecl.php.net && \
+  echo "Building php${PHP_VERSION}-${EXTENSION_NAME}..." && \
+  pecl -d php_suffix="${PHP_VERSION}" install -f "${EXTENSION_NAME}-${EXTENSION_VERSION}" >/dev/null && \
+  rm -f /usr/share/php/.registry/.channel.pecl.php.net/xdebug.reg) || true
+
+if [ ! -f "${EXTENSION_FILE}" ]; then
+  echo "Failed to build ${EXTENSION_FILE}"
+
+  if [ -f "${EXTENSION_FILE}.bak" ]; then
+    echo "Restoring previously existing file ${EXTENSION_FILE}"
+    mv "${EXTENSION_FILE}.bak" "${EXTENSION_FILE}"
+  fi
+
+  exit 2
+fi
+
+echo "Done building php${PHP_VERSION}-${EXTENSION_NAME} to ${EXTENSION_FILE}"
+exit 0

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20241111_stasadev_n_install_cleanup AS ddev-webserver-base
+FROM ddev/ddev-php-base:20241112_remove_php8.0-xdebug AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1141,7 +1141,7 @@ SHELL ["/bin/bash", "-c"]
 					hasMultiStageBuild = true
 				}
 				contents = contents + fmt.Sprintf(`
-RUN /usr/local/bin/build_php_extension.sh "%s" "%s" "%s" "%s" || true
+RUN /usr/local/bin/build_php_extension.sh "php%s" "%s" "%s" "%s" || true
 `, ext["php"], ext["name"], ext["version"], ext["file"])
 			}
 		}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1176,9 +1176,10 @@ RUN /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETARCH}"
 		for _, ext := range phpExtensions {
 			if app.PHPVersion == ext["php"] {
 				contents = contents + fmt.Sprintf(`
-### DDEV-injected copy of %s %v for PHP %v
+### DDEV-injected copy of %s %v
+RUN apt-get -qq remove -y php%s-%s || true
 COPY --from=ddev-php-extension-build %s %v
-`, ext["name"], ext["version"], app.PHPVersion, ext["file"], ext["file"])
+`, ext["name"], ext["version"], app.PHPVersion, ext["name"], ext["file"], ext["file"])
 			}
 		}
 	}

--- a/pkg/ddevapp/hooks_test.go
+++ b/pkg/ddevapp/hooks_test.go
@@ -65,7 +65,7 @@ func TestProcessHooks(t *testing.T) {
 		//{"composer: install", "", "Running task: Composer command '[install]' in web container"},
 		//{"composer: licenses --format=json", "no-version-set", "Running task: Composer command 'licenses --format=json' in web container"},
 		//{"composer:\n    exec_raw: [licenses, --format=json]", "no-version-set", "Running task: Composer command '[licenses --format=json]' in web container"},
-		{"exec: ls /usr/local/bin", "acli\ncomposer", "Running task: Exec command 'ls /usr/local/bin'"},
+		{"exec: ls /usr/local/bin", "acli\nbuild_php_extension.sh\ncomposer", "Running task: Exec command 'ls /usr/local/bin'"},
 		{"exec-host: \"echo something\"", "something\n", "Running task: Exec command 'echo something' on the host"},
 		{"exec: echo MYSQL_PWD=${MYSQL_PWD:-}\n    service: db", "MYSQL_PWD=db\n", "Running task: Exec command 'echo MYSQL_PWD=${MYSQL_PWD:-}' in container/service 'db'"},
 		{"exec: \"echo TestProcessHooks > /var/www/html/TestProcessHooks-php-version-${DDEV_PHP_VERSION}.txt\"", "", "Running task: Exec command 'echo TestProcessHooks > /var/www/html/TestProcessHooks-php-version-${DDEV_PHP_VERSION}.txt'"},

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "20241111_stasadev_n_install_cleanup" // Note that this can be over
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20241109_use_bin_env"
+var BaseDBTag = "20241112_remove_php8.0-xdebug"
 
 const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:20241109_use_bin_env"
 const TraefikRouterImage = "ddev/ddev-traefik-router:20241109_use_bin_env"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,13 +11,13 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241111_stasadev_n_install_cleanup" // Note that this can be overridden by make
+var WebTag = "20241112_remove_php8.0-xdebug" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20241112_remove_php8.0-xdebug"
+var BaseDBTag = "20241109_use_bin_env"
 
 const TraditionalRouterImage = "ddev/ddev-nginx-proxy-router:20241109_use_bin_env"
 const TraefikRouterImage = "ddev/ddev-traefik-router:20241109_use_bin_env"


### PR DESCRIPTION
## The Issue

- #6159
- #6181

@stasadev pointed out that we're still building a custom php8.0-xdebug for a small number of users that experienced a crash with xdebug.

It's time to let that go, since PHP 8.0 is no longer supported.

## How This PR Solves The Issue

* Stop doing the build of php8.0-xdebug (move it to the user Dockerfile).
* Stop using the results (move it to the user Dockerfile).

## Manual Testing Instructions

Check that Xdebug 3.2.2 is installed for PHP 8.0, 8.1, 8.2.

```
ddev config --php-version=8.0
ddev restart
ddev xdebug

ddev php -v
PHP 8.0.30 (cli) (built: Sep 27 2024 04:08:13) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.30, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.30, Copyright (c), by Zend Technologies
    with Xdebug v3.2.2, Copyright (c) 2002-2023, by Derick Rethans

# the modified time should be now
ddev exec "ls -l /usr/lib/php/20200930/xdebug.so"
```

```
ddev config --php-version=8.1
ddev restart
ddev xdebug

ddev php -v
PHP 8.1.30 (cli) (built: Sep 27 2024 04:06:59) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.30, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.30, Copyright (c), by Zend Technologies
    with Xdebug v3.2.2, Copyright (c) 2002-2023, by Derick Rethans

# the modified time should be the ddev-php-base build time
ddev exec "ls -l /usr/lib/php/20210902/xdebug.so"
```

```
ddev config --php-version=8.2
ddev restart
ddev xdebug

ddev php -v
PHP 8.2.25 (cli) (built: Nov  4 2024 23:34:15) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.25, Copyright (c) Zend Technologies
    with Zend OPcache v8.2.25, Copyright (c), by Zend Technologies
    with Xdebug v3.2.2, Copyright (c) 2002-2023, by Derick Rethans

# the modified time should be the ddev-php-base build time
ddev exec "ls -l /usr/lib/php/20220829/xdebug.so"
```