### PR TITLE
docs: fix 8.3 typo and adding PHP version strategy

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -81,7 +81,6 @@ export PATH=$PATH:/var/www/html/somewhereelse/vendor/bin
 
 ## Changing PHP Version
 
-
 The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, or `8.4`.
 
 ### Older Versions of PHP

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -82,7 +82,7 @@ export PATH=$PATH:/var/www/html/somewhereelse/vendor/bin
 ## Changing PHP Version
 
 
-The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be changed to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, or `8.4`.
+The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, or `8.4`.
 
 ### Older Versions of PHP
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -81,7 +81,7 @@ export PATH=$PATH:/var/www/html/somewhereelse/vendor/bin
 
 ## Changing PHP Version
 
-The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, or `8.4`.
+The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be `5.6` through `8.4`, and new versions are added when they are released by the PHP Foundation.
 
 ### Older Versions of PHP
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -83,7 +83,7 @@ export PATH=$PATH:/var/www/html/somewhereelse/vendor/bin
 
 DDEV keeps up with the "more stable" release, which is one version behind the latest.
 
-The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be changed to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, 8.3`, or `8.4`.
+The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be changed to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, or `8.4`.
 
 ### Older Versions of PHP
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -81,7 +81,9 @@ export PATH=$PATH:/var/www/html/somewhereelse/vendor/bin
 
 ## Changing PHP Version
 
-The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be changed to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, '8.3', or `8.4`.
+DDEV keeps up with the "more stable" release, which is one version behind the latest.
+
+The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be changed to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, 8.3`, or `8.4`.
 
 ### Older Versions of PHP
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -81,7 +81,6 @@ export PATH=$PATH:/var/www/html/somewhereelse/vendor/bin
 
 ## Changing PHP Version
 
-DDEV keeps up with the "more stable" release, which is one version behind the latest.
 
 The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php_version`](../configuration/config.md#php_version) can be changed to `5.6`, `7.0`, `7.1`, `7.2`,  `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, or `8.4`.
 


### PR DESCRIPTION
## The Issue

8.3 is not marked up as code. Also, we could add the DDEV PHP version strategy? Maybe it belongs somewhere else?

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
