### PR TITLE
docs: for phpstorm plugin, prerequisite is not necessary

### DIFF
--- a/docs/content/users/install/phpstorm.md
+++ b/docs/content/users/install/phpstorm.md
@@ -8,14 +8,6 @@ If you work with the [PhpStorm](https://www.jetbrains.com/phpstorm/) IDE, you ca
 - DDEV v1.21.1 or higher.
 - Make sure to get at least one project going with `ddev start` before trying to set up the plugin, because the plugin assumes it has a project to work with.
 
-## Prerequisite
-
-Regardless of your setup, you need to have PhpStorm use DDEV’s private docker-compose executable.
-
-In PhpStorm, navigate to *Preferences* → *Build, Execution, Deployment* → *Docker* → *Tools*, and set the docker-compose executable to the full path of your `.ddev/bin/docker-compose` file relative to your home directory.
-
-If you’re using WSL2 and running PhpStorm on the Windows side, PhpStorm can’t use docker-compose from WSL2, so configure Docker Desktop in *Settings* → *General* to “Use Docker Compose V2” and use a recent version of Docker Desktop.
-
 ## DDEV Integration Plugin
 
 It’s easiest to use the DDEV Integration Plugin, which you can install from [its landing page](https://plugins.jetbrains.com/plugin/18813-ddev-integration) or by searching the in-app marketplace (*Preferences* → *Plugins* → *Marketplace*) for “DDEV”. The integration plugin handles nearly everything on this page automatically, and works on all platforms.
@@ -24,7 +16,17 @@ Install and enable the plugin, then [set up `phpunit`](#enabling-phpunit) since 
 
 ## Manual Setup
 
-If you’re not using the DDEV Integration Plugin, you can follow these steps instead:
+If you’re not using the DDEV Integration Plugin, you can follow these steps.
+
+### Prerequisite
+
+You need to configure PhpStorm to use DDEV’s private docker-compose executable.
+
+In PhpStorm, navigate to *Preferences* → *Build, Execution, Deployment* → *Docker* → *Tools*, and set the docker-compose executable to the full path of your `.ddev/bin/docker-compose` file relative to your home directory.
+
+If you’re using WSL2 and running PhpStorm on the Windows side, PhpStorm can’t use docker-compose from WSL2, so configure Docker Desktop in *Settings* → *General* to “Use Docker Compose V2” and use a recent version of Docker Desktop.
+
+### Manual Setup Procedure
 
 1. Start your project by running [`ddev start`](../usage/commands.md#start).
 2. Open the DDEV project. In this example, the project name is `drup` and the site is `drup.ddev.site`.

--- a/docs/content/users/install/phpstorm.md
+++ b/docs/content/users/install/phpstorm.md
@@ -22,7 +22,7 @@ If you’re not using the DDEV Integration Plugin, you can follow these steps.
 
 You need to configure PhpStorm to use DDEV’s private docker-compose executable.
 
-In PhpStorm, navigate to *Preferences* → *Build, Execution, Deployment* → *Docker* → *Tools*, and set the docker-compose executable to the full path of your `.ddev/bin/docker-compose` file relative to your home directory.
+In PhpStorm, navigate to *Preferences* → *Build, Execution, Deployment* → *Docker* → *Tools*, and set the docker-compose executable to the absolute path of ddev's docker-compose in your home directory (for example, `~/.ddev/bin/docker-compose`).
 
 If you’re using WSL2 and running PhpStorm on the Windows side, PhpStorm can’t use docker-compose from WSL2, so configure Docker Desktop in *Settings* → *General* to “Use Docker Compose V2” and use a recent version of Docker Desktop.
 


### PR DESCRIPTION
Make it clear that the "prerequisite" is not necessary if using the PHPStorm plugin

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #<issue number>

Even though I was using the PHPStorm plugin, because of the structure of the docs page, I attempted to configure PHPStorm as described in the "Prerequisite" section even though that is not necessary.

## How This PR Solves The Issue

Restructures the doc to make it clear that PHPStorm does not need to be configured if using the plugin.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
