### PR TITLE
fix: Improve interactive ddev config text, fixes #6542

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1412,8 +1412,8 @@ func DiscoverDefaultDocroot(app *DdevApp) string {
 func (app *DdevApp) docrootPrompt() error {
 
 	// Determine the document root.
-	util.Warning("\nThe docroot is the directory from which your site is served.\nThis is a relative path from your project root at %s", app.AppRoot)
-	output.UserOut.Println("You may leave this value blank if your site files are in the project root")
+	output.UserOut.Printf("\nThe docroot is the directory from which your site is served.\nThis is a relative path from your project root at %s\n", app.AppRoot)
+	output.UserOut.Printf("Leave docroot empty (hit <RETURN>) if your index.php is in the project root.\n")
 	var docrootPrompt = "Docroot Location"
 	var defaultDocroot = DiscoverDefaultDocroot(app)
 	// If there is a default docroot, display it in the prompt.


### PR DESCRIPTION

## The Issue

- #6542 

Misleading text in interactive `ddev config` of new project

## How This PR Solves The Issue

Improve the text.

## Manual Testing Instructions

* Use `ddev config` in an empty directory (uses default `php` type)
* Use `ddev config` on an already-configured project that has docroot = ""

