### PR TITLE
test: ignore TestCmdVersion when running in IDE without make [skip ci]

### DIFF
--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -17,6 +17,9 @@ import (
 func TestCmdVersion(t *testing.T) {
 	assert := asrt.New(t)
 
+	if versionconstants.DdevVersion == `v0.0.0-overridden-by-make` {
+		t.Skip("skipping because not built with make, has no embedded version")
+	}
 	versionData := make(map[string]interface{})
 
 	args := []string{"version", "--json-output"}


### PR DESCRIPTION

## The Issue


New DDEV devs have often been annoyed by the failure of TextCmdVersion when run in GoLand or vscode without a `make` build that embeds the version.

## How This PR Solves The Issue

Don't check when built that way.

