### PR TITLE
feat: Add iTerm2 status bar component

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
@@ -15,3 +15,19 @@ ddev() {
     command ddev "$@"
   fi
 }
+
+iterm2_ddev_status_user_var() {
+  # Warn if DDEV isn't installed.
+  command -v ddev > /dev/null 2>&1 || { echo "ᙌ DDEV isn't installed"; return; }
+
+  # Get the DDEV status in the current directory.
+  ddev_describe_raw=$(ddev describe --json-output 2>/dev/null | jq -r .raw 2>/dev/null) || return
+  project_name=$(echo "$ddev_describe_raw" | jq -r .name 2>/dev/null)
+  project_status=$(echo "$ddev_describe_raw" | jq -r .status 2>/dev/null)
+
+  # Exit silently if not in a DDEV project.
+  [ -z "$project_name" ] && return
+
+  # Output the project name and status.
+  echo "ᙌ $project_name: $project_status"
+}


### PR DESCRIPTION
Okay, I admit to being a little excited about this. I worked hard on it. 😛 I've created an [iTerm2](https://iterm2.com/)* DDEV status component. As shown below, it sits up in your iTerm2 status bar and it shows its name and status if you're anywhere inside a DDEV project. (If you're not inside a DDEV project, it disappears.) It works just like the built-in Git state component.

\*You _are_ using iTerm2 if you're on Mac, aren't you? 😉

![ddev-iterm2-component](https://github.com/user-attachments/assets/c8836350-e22d-4664-89b5-c11394f5056c)

Note: I used the `ᙌ` character for the icon because it's the closest thing I could find to the DDEV logo. It may be possible to provide a custom icon, but I haven't looked into that yet. (If we _can_ provide such an icon, it looks like it needs to be 13 pixels tall--for example, depending on whether a wide icon is allowed: ![Icon Wide](https://github.com/user-attachments/assets/40a33eb4-29c2-45e7-84c2-4cf616c21389) (wide) or ![Icon Squished](https://github.com/user-attachments/assets/186eb55c-8c08-49d8-9f22-32c7da7dad3e) (squished).

## How This PR Solves The Issue

The feature has three parts:

1. A shell function that gets the DDEV status string. That's what's included in this PR so far. (`iterm2_ddev_status_user_var()`) Alternatively, a DDEV command could provide the output, like `ddev autocomplete, for example. (I've seen that pattern elsewhere, though I can't remember where at the moment.)
2. A special iTerm2 function that assigns the output to an iTerm2 user variable in your shell config file (e.g., `.bashrc`, `.zshrc`, or `.config/fish/config.fish`):
   ```shell
   function iterm2_print_user_vars() {
     iterm2_set_user_var ddevStatus "$(iterm2_ddev_status_user_var)"
   }
   ```
   (This part will probably have to be a manual step, like `ddev cd`.)
3. An iTerm2 Status Bar Interpolated String Component that displays the new variable. It's stored in a preferences file, so it should be possible to automate this, but I haven't worked on that part yet. It can also be done manually. (See Manual Testing Instructions below.)
    ```shell
    $ plutil -p ~/Library/Preferences/com.googlecode.iterm2.plist
    # Under "New Bookmarks" => "Status Bar Layout" => "components"...
    {
      class = iTermStatusBarSwiftyStringComponent;
      configuration = {
        knobs = {
          "base: compression resistance" = 1;
          "base: priority" = 5;
          expression = "\\\\(user.ddevStatus)";
          maxwidth = inf;
          minwidth = 0;
          "shared font" = "";
          "shared text color" = {
            "Alpha Component" = 1;
            "Blue Component" = "0.8654927611351013";
            "Color Space" = P3;
            "Green Component" = "0.6488561034202576";
            "Red Component" = "0.2934519946575165";
          };
        };
        "layout advanced configuration dictionary value" = {
          algorithm = 1;
          "auto-rainbow style" = 0;
          font = ".AppleSystemUIFont 12";
          "remove empty components" = 1;
        };
      };
    },
    ```

## Manual Testing Instructions

As a proof of concept, without modifying DDEV itself yet, you can take the following steps:

1. Put all the operative code right in your shell RC file:
    ```shell
    # .bashrc, .zshrc, .config/fish/config.fish, etc.
    
    iterm2_ddev_status_user_var() {
      # Warn if DDEV isn't installed.
      command -v ddev > /dev/null 2>&1 || { echo "ᙌ DDEV isn't installed"; return; }
    
      # Get the DDEV status in the current directory.
      ddev_describe_raw=$(ddev describe --json-output 2>/dev/null | jq -r .raw 2>/dev/null) || return
    
      # Get project name and status from the raw JSON.
      project_name=$(echo "$ddev_describe_raw" | jq -r .name 2>/dev/null)
      project_status=$(echo "$ddev_describe_raw" | jq -r .status 2>/dev/null)
    
      # Exit silently if not in a DDEV project.
      [ -z "$project_name" ] && return
    
      # Output the project name and status.
      echo "ᙌ $project_name: $project_status"
    }
    
    function iterm2_print_user_vars() {
      iterm2_set_user_var ddevStatus "$(iterm2_ddev_status_user_var)"
    }
    ```
2. Create a an iTerm2 status bar component:
  1. Right-click on the status bar and click "Configure Status Bar":
     ![Add an iTerm2 status bar component](https://github.com/user-attachments/assets/4d120f9b-2a09-432a-8801-ce7dec5a5ab9)
  2. Drag an "Interpolated String" component onto the "Active Components" section:
     ![Interpolated String Component](https://github.com/user-attachments/assets/7075b7dd-a532-44b6-9940-b2bcee4ec7b9)
  3. Click on the new component to select it and then click on the "Configure Component" at the bottom left. Set the "String Value" to `\(user.ddevStatus)` and the "Text Color" "sRGB" to `01a8e2`. Then click "OK".
     ![Interpolated String Settings](https://github.com/user-attachments/assets/5764ee06-ee92-43ae-9fc5-19363e7c3e43)
  4. Click the "Advanced..." button
     ![Advanced Settings](https://github.com/user-attachments/assets/c089c047-2a6d-4ef1-a9e0-a6c03e2f2df7)
  5. Click "OK" and then "OK" again.
  6. `cd` into any DDEV project, and you should see the status in the new component. 🎉

### What remains to do?

1. The first part of step #1 is already done with this pull request.
2. It's probably best not to automate the second step (since a user may already have a `iterm2_print_user_vars()` doing other things, like I do), which means it needs to be documented.
3. Automate the addition of the status bar component. We should reach out in [the iTerm2 issue queue](https://github.com/gnachman/iTerm2) issue queue to make sure there isn't a better way to do this than I began to lay out above.
4. While we're in that issue queue, we should ee to see if it's possible to embed a graphic for the logo.
5. We should consider minimal automated tests, as below...

## Automated Testing Overview

CI jobs on macOS could verify that any shell commands we provide execute without errors, but it's probably not feasible/worthwhile to actually test the UI aspect.

## Release/Deployment Notes

This is a completely new feature that should have minimal ramifications for other code. It would of course, warrant appropriate documentation.
