### PR TITLE
fix: Move sqlite3 3.45 installation into ddev-webserver, fixes #6735

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -15,6 +15,7 @@ ENV CAROOT=/mnt/ddev-global-cache/mkcert
 # TARGETPLATFORM is Docker buildx's target platform (e.g. linux/arm64), while
 # BUILDPLATFORM is the platform of the build host (e.g. linux/amd64)
 ARG TARGETPLATFORM
+ARG TARGETARCH
 ARG BUILDPLATFORM
 ARG DEFAULT_LOCALES="en_CA.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\nen_GB.UTF-8 UTF-8\nde_DE.UTF-8 UTF-8\nde_AT.UTF-8 UTF-8\nfr_CA.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nja_JP.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\n"
 
@@ -126,10 +127,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
 ### TODO: When we have this from upstream Debian 13 Trixie, we must remove this stanza
 ARG SQLITE_VERSION="3.45.1"
 RUN mkdir -p /tmp/sqlite3 && \
-wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
-wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
-apt-get install -y /tmp/sqlite3/*.deb && \
-rm -rf /tmp/sqlite3"
+wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb
+RUN wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb
+RUN apt-get install -y /tmp/sqlite3/*.deb
+RUN rm -rf /tmp/sqlite3
 
 # Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
 RUN rm /etc/apt/sources.list.d/blackfire.list
@@ -144,7 +145,7 @@ ADD ddev-webserver-dev-base-files /
 RUN phpdismod blackfire xdebug
 RUN phpdismod xhprof
 
-RUN set -x && set -o pipefail && tag=$(curl -L --fail --silent "https://api.github.com/repos/axllent/mailpit/releases/latest" | jq -r .tag_name) && curl --fail -sSL "https://github.com/axllent/mailpit/releases/download/${tag}/mailpit-linux-${TARGETPLATFORM##linux/}.tar.gz" -o /tmp/mailpit.tar.gz && tar -zx -C /usr/local/bin -f /tmp/mailpit.tar.gz mailpit && rm /tmp/mailpit.tar.gz
+RUN set -x && set -o pipefail && tag=$(curl -L --fail --silent "https://api.github.com/repos/axllent/mailpit/releases/latest" | jq -r .tag_name) && curl --fail -sSL "https://github.com/axllent/mailpit/releases/download/${tag}/mailpit-linux-${TARGETARCH}.tar.gz" -o /tmp/mailpit.tar.gz && tar -zx -C /usr/local/bin -f /tmp/mailpit.tar.gz mailpit && rm /tmp/mailpit.tar.gz
 
 RUN curl -sSL --fail --output /usr/local/bin/phive "https://phar.io/releases/phive.phar" && chmod 777 /usr/local/bin/phive
 # Install terminus cli
@@ -154,9 +155,9 @@ RUN set -o pipefail && curl -fsSL https://raw.githubusercontent.com/platformsh/c
 # Install upsun cli
 RUN set -o pipefail && curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | VENDOR=upsun bash
 # Install lagoon cli
-RUN set -o pipefail && tag=$(curl -L --fail --silent "https://api.github.com/repos/uselagoon/lagoon-cli/releases/latest" | jq -r .tag_name) && curl --fail -sSL "https://github.com/uselagoon/lagoon-cli/releases/download/$tag/lagoon-cli-$tag-linux-${TARGETPLATFORM##linux/}" --output /usr/local/bin/lagoon && chmod 777 /usr/local/bin/lagoon
+RUN set -o pipefail && tag=$(curl -L --fail --silent "https://api.github.com/repos/uselagoon/lagoon-cli/releases/latest" | jq -r .tag_name) && curl --fail -sSL "https://github.com/uselagoon/lagoon-cli/releases/download/$tag/lagoon-cli-$tag-linux-${TARGETARCH}" --output /usr/local/bin/lagoon && chmod 777 /usr/local/bin/lagoon
 # Install lagoon-sync
-RUN set -x && set -o pipefail && tag=$(curl -L --fail --silent "https://api.github.com/repos/uselagoon/lagoon-sync/releases/latest" | jq -r .tag_name) && curl --fail -sSL "https://github.com/uselagoon/lagoon-sync/releases/download/${tag}/lagoon-sync_${tag:1}_linux_${TARGETPLATFORM##linux/}" --output /usr/local/bin/lagoon-sync && chmod 777 /usr/local/bin/lagoon-sync
+RUN set -x && set -o pipefail && tag=$(curl -L --fail --silent "https://api.github.com/repos/uselagoon/lagoon-sync/releases/latest" | jq -r .tag_name) && curl --fail -sSL "https://github.com/uselagoon/lagoon-sync/releases/download/${tag}/lagoon-sync_${tag:1}_linux_${TARGETARCH}" --output /usr/local/bin/lagoon-sync && chmod 777 /usr/local/bin/lagoon-sync
 
 RUN mkdir -p "/opt/phpstorm-coverage" && \
     chmod a+rw "/opt/phpstorm-coverage"
@@ -243,6 +244,7 @@ SHELL ["/bin/bash", "-eu", "-o", "pipefail", "-c"]
 ENV CAROOT=/mnt/ddev-global-cache/mkcert
 ENV PHP_DEFAULT_VERSION="8.2"
 ARG TARGETPLATFORM
+ARG TARGETARCH
 
 RUN curl -s --fail https://packages.blackfire.io/gpg.key > /usr/share/keyrings/blackfire-archive-keyring.asc
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/blackfire-archive-keyring.asc] http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -115,13 +115,21 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     python3-psycopg2 \
     python3-venv \
     rsync \
-    sqlite3 \
     sudo \
     telnet \
     tree \
     unzip \
     vim-tiny \
     zip
+
+### Drupal 11+ requires a minimum sqlite3 version (3.45 currently)
+### TODO: When we have this from upstream Debian 13 Trixie, we must remove this stanza
+ARG SQLITE_VERSION="3.45.1"
+RUN mkdir -p /tmp/sqlite3 && \
+wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
+wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
+apt-get install -y /tmp/sqlite3/*.deb && \
+rm -rf /tmp/sqlite3"
 
 # Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
 RUN rm /etc/apt/sources.list.d/blackfire.list

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	copy2 "github.com/otiai10/copy"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -976,23 +975,6 @@ ENV N_INSTALL_VERSION="%s"
 	}
 	if app.CorepackEnable {
 		extraWebContent = extraWebContent + "\nRUN corepack enable"
-	}
-	if app.Type == nodeps.AppTypeDrupal {
-		// TODO: When ddev-webserver has required drupal 11+ sqlite version we can remove this.
-		// These packages must be retrieved from snapshot.debian.org. We hope they'll be there
-		// when we need them.
-		drupalVersion, err := GetDrupalVersion(app)
-		if err == nil && drupalVersion == "11" {
-			extraWebContent = extraWebContent + "\n" + fmt.Sprintf(`
-### Drupal 11+ requires a minimum sqlite3 version (3.45 currently)
-ARG SQLITE_VERSION=%s
-RUN log-stderr.sh bash -c "mkdir -p /tmp/sqlite3 && \
-wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
-wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
-apt-get install -y /tmp/sqlite3/*.deb && \
-rm -rf /tmp/sqlite3" || true
-			`, versionconstants.Drupal11RequiredSqlite3Version)
-		}
 	}
 
 	// Add supervisord config for WebExtraDaemons

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2460,7 +2460,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 				})
 				require.NoError(t, err, "sqlite3 --version failed, output=%v, stderr=%v", stdout, stderr)
 				stdout = strings.Trim(stdout, "\r\n")
-				require.Equal(t, versionconstants.Drupal11RequiredSqlite3Version, stdout)
+				require.Equal(t, "3.45.1", stdout)
 			}
 		}
 		// We don't want all the projects running at once.

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241118_rfay_git_safe_directory" // Note that this can be overridden by make
+var WebTag = "20241118_rfay_d11_requirements_global" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
@@ -44,5 +44,3 @@ const RequiredMutagenVersion = "0.18.0"
 
 const RequiredDockerComposeVersionDefault = "v2.30.3"
 
-// Drupal11RequiredSqlite3Version for ddev-webserver
-const Drupal11RequiredSqlite3Version = "3.45.1"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -43,4 +43,3 @@ var MutagenVersion = ""
 const RequiredMutagenVersion = "0.18.0"
 
 const RequiredDockerComposeVersionDefault = "v2.30.3"
-


### PR DESCRIPTION

## The Issue

- #6735 

Sqlite 3.45 installation  per-project in Drupal 11 is fragile. We can control it better in the ddev-webserver Dockerfile, and it's unlikely to bother anybody else. 

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
