### PR TITLE
refactor: use `ddevcd` function with `ddev debug cd` instead of `ddev cd`, fixes #6737

### DIFF
--- a/cmd/ddev/cmd/cd.go
+++ b/cmd/ddev/cmd/cd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 	"path/filepath"
+	"strings"
 )
 
 var (
@@ -22,7 +23,7 @@ var CdCmd = &cobra.Command{
 	Use:   "cd [project-name]",
 	Short: "Uses shell built-in 'cd' to change to a project directory",
 	Long: heredoc.Doc(fmt.Sprintf(`
-		To enable the 'ddev cd' command, source the ddev.sh script from your rc-script.
+		To enable the 'ddevcd' function, source the ddev.sh script from your rc-script.
 
 		For bash:
 
@@ -36,35 +37,47 @@ var CdCmd = &cobra.Command{
 
 		printf '\n[ -f "%s" ] && source "%s"\n' >> ~/.config/fish/config.fish
 
-		Restart your shell, and use 'ddev cd project-name'.
+		Restart your shell, and use 'ddevcd project-name'.
 		`, bashFile, bashFile, bashFile, bashFile, fishFile, fishFile)),
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
-	Example:           `ddev cd project-name`,
+	Example: heredoc.DocI2S(`
+		ddev cd
+		ddevcd project-name
+	`),
 	Run: func(cmd *cobra.Command, args []string) {
 		for _, file := range []string{bashFile, fishFile} {
 			if !fileutil.FileExists(file) {
 				util.Failed("Unable to find file: %s", file)
 			}
-
 		}
-		if len(args) != 1 {
-			util.Failed("This command only takes one argument: project-name")
-		}
-		projectName := args[0]
-		app, err := ddevapp.GetActiveApp(projectName)
-		if err != nil {
-			util.Failed("Failed to find path for project: %v", err)
+		if cmd.Flags().Changed("list") {
+			if len(args) != 0 {
+				util.Failed("The provided flag does not take any arguments")
+			}
+			projects, _ := cmd.ValidArgsFunction(cmd, args, "")
+			output.UserOut.Println(strings.Join(projects, "\n"))
+			return
 		}
 		if cmd.Flags().Changed("get-approot") {
+			if len(args) != 1 {
+				util.Failed("This command only takes one argument: project-name")
+			}
+			projectName := args[0]
+			app, err := ddevapp.GetActiveApp(projectName)
+			if err != nil {
+				util.Failed("Failed to find path for project: %v", err)
+			}
 			output.UserOut.Println(app.AppRoot)
-		} else {
-			output.UserOut.Println(cmd.Long)
+			return
 		}
+		output.UserOut.Println(cmd.Long)
 	},
 }
 
 func init() {
 	CdCmd.Flags().BoolP("get-approot", "", false, "Get the full path to the project root directory")
 	_ = CdCmd.Flags().MarkHidden("get-approot")
+	CdCmd.Flags().BoolP("list", "", false, "Get project names")
+	_ = CdCmd.Flags().MarkHidden("list")
 	RootCmd.AddCommand(CdCmd)
 }

--- a/cmd/ddev/cmd/cd.go
+++ b/cmd/ddev/cmd/cd.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	bashFile = filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh")
+	zshFile  = filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.zsh")
 	fishFile = filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish")
 )
 
@@ -38,7 +39,7 @@ var CdCmd = &cobra.Command{
 		printf '\n[ -f "%s" ] && source "%s"\n' >> ~/.config/fish/config.fish
 
 		Restart your shell, and use 'ddevcd project-name'.
-		`, bashFile, bashFile, bashFile, bashFile, fishFile, fishFile)),
+		`, bashFile, bashFile, zshFile, zshFile, fishFile, fishFile)),
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
 	Example: heredoc.DocI2S(`
 		ddev cd

--- a/cmd/ddev/cmd/cd_test.go
+++ b/cmd/ddev/cmd/cd_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/util"
@@ -13,21 +14,33 @@ import (
 // TestCdCmd runs `ddev cd` to see if it works.
 func TestCdCmd(t *testing.T) {
 	assert := asrt.New(t)
+	bashScript := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh")
+	fishScript := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish")
 	// Shows help
 	out, err := exec.RunHostCommand(DdevBin, "cd", TestSites[0].Name)
 	assert.NoError(err)
-	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh"))
-	assert.Contains(out, filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish"))
+	assert.Contains(out, bashScript)
+	assert.Contains(out, fishScript)
+	// Shows help
+	out, err = exec.RunHostCommand(DdevBin, "cd", "does-not-exist-"+util.RandString(4))
+	assert.NoError(err)
+	assert.Contains(out, bashScript)
+	assert.Contains(out, fishScript)
+	// Shows help
+	out, err = exec.RunHostCommand(DdevBin, "cd")
+	assert.NoError(err)
+	assert.Contains(out, bashScript)
+	assert.Contains(out, fishScript)
 	// Returns the path to the project
 	out, err = exec.RunHostCommand(DdevBin, "cd", TestSites[0].Name, "--get-approot")
 	assert.NoError(err)
 	assert.Equal(strings.TrimRight(out, "\n"), TestSites[0].Dir)
-	// Shows error
-	out, err = exec.RunHostCommand(DdevBin, "cd", "does-not-exist-"+util.RandString(4))
-	assert.Error(err)
-	assert.Contains(out, "Failed to find path for project")
-	// Shows error
-	out, err = exec.RunHostCommand(DdevBin, "cd")
-	assert.Error(err)
-	assert.Contains(out, "This command only takes one argument: project-name")
+	// Returns list of projects for autocompletion
+	out, err = exec.RunHostCommand(DdevBin, "cd", "--list")
+	assert.NoError(err)
+	projects, err := ddevapp.GetProjects(false)
+	assert.NoError(err)
+	for _, project := range projects {
+		assert.Contains(out, project.Name)
+	}
 }

--- a/cmd/ddev/cmd/cd_test.go
+++ b/cmd/ddev/cmd/cd_test.go
@@ -15,21 +15,25 @@ import (
 func TestCdCmd(t *testing.T) {
 	assert := asrt.New(t)
 	bashScript := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh")
+	zshScript := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.zsh")
 	fishScript := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish")
 	// Shows help
 	out, err := exec.RunHostCommand(DdevBin, "cd", TestSites[0].Name)
 	assert.NoError(err)
 	assert.Contains(out, bashScript)
+	assert.Contains(out, zshScript)
 	assert.Contains(out, fishScript)
 	// Shows help
 	out, err = exec.RunHostCommand(DdevBin, "cd", "does-not-exist-"+util.RandString(4))
 	assert.NoError(err)
 	assert.Contains(out, bashScript)
+	assert.Contains(out, zshScript)
 	assert.Contains(out, fishScript)
 	// Shows help
 	out, err = exec.RunHostCommand(DdevBin, "cd")
 	assert.NoError(err)
 	assert.Contains(out, bashScript)
+	assert.Contains(out, zshScript)
 	assert.Contains(out, fishScript)
 	// Returns the path to the project
 	out, err = exec.RunHostCommand(DdevBin, "cd", TestSites[0].Name, "--get-approot")

--- a/cmd/ddev/cmd/debug-cd.go
+++ b/cmd/ddev/cmd/debug-cd.go
@@ -19,10 +19,10 @@ var (
 	fishFile = filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish")
 )
 
-// CdCmd is the top-level "ddev cd" command
-var CdCmd = &cobra.Command{
-	Use:   "cd [project-name]",
-	Short: "Uses shell built-in 'cd' to change to a project directory",
+// DebugCdCmd implements the ddev debug cd command
+var DebugCdCmd = &cobra.Command{
+	Use:   "cd",
+	Short: "Use the 'ddevcd' function to quickly change to your project directory",
 	Long: heredoc.Doc(fmt.Sprintf(`
 		To enable the 'ddevcd' function, source the ddev.sh script from your rc-script.
 
@@ -42,7 +42,7 @@ var CdCmd = &cobra.Command{
 		`, bashFile, bashFile, zshFile, zshFile, fishFile, fishFile)),
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
 	Example: heredoc.DocI2S(`
-		ddev cd
+		ddev debug cd
 		ddevcd project-name
 	`),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -76,9 +76,9 @@ var CdCmd = &cobra.Command{
 }
 
 func init() {
-	CdCmd.Flags().BoolP("get-approot", "", false, "Get the full path to the project root directory")
-	_ = CdCmd.Flags().MarkHidden("get-approot")
-	CdCmd.Flags().BoolP("list", "", false, "Get project names")
-	_ = CdCmd.Flags().MarkHidden("list")
-	RootCmd.AddCommand(CdCmd)
+	DebugCdCmd.Flags().BoolP("get-approot", "", false, "Get the full path to the project root directory")
+	_ = DebugCdCmd.Flags().MarkHidden("get-approot")
+	DebugCdCmd.Flags().BoolP("list", "", false, "Get project names")
+	_ = DebugCdCmd.Flags().MarkHidden("list")
+	DebugCmd.AddCommand(DebugCdCmd)
 }

--- a/cmd/ddev/cmd/debug-cd_test.go
+++ b/cmd/ddev/cmd/debug-cd_test.go
@@ -11,36 +11,36 @@ import (
 	"testing"
 )
 
-// TestCdCmd runs `ddev cd` to see if it works.
-func TestCdCmd(t *testing.T) {
+// TestDebugCdCmd runs `ddev debug cd` to see if it works.
+func TestDebugCdCmd(t *testing.T) {
 	assert := asrt.New(t)
 	bashScript := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.sh")
 	zshScript := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.zsh")
 	fishScript := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/host/shells/ddev.fish")
 	// Shows help
-	out, err := exec.RunHostCommand(DdevBin, "cd", TestSites[0].Name)
+	out, err := exec.RunHostCommand(DdevBin, "debug", "cd", TestSites[0].Name)
 	assert.NoError(err)
 	assert.Contains(out, bashScript)
 	assert.Contains(out, zshScript)
 	assert.Contains(out, fishScript)
 	// Shows help
-	out, err = exec.RunHostCommand(DdevBin, "cd", "does-not-exist-"+util.RandString(4))
+	out, err = exec.RunHostCommand(DdevBin, "debug", "cd", "does-not-exist-"+util.RandString(4))
 	assert.NoError(err)
 	assert.Contains(out, bashScript)
 	assert.Contains(out, zshScript)
 	assert.Contains(out, fishScript)
 	// Shows help
-	out, err = exec.RunHostCommand(DdevBin, "cd")
+	out, err = exec.RunHostCommand(DdevBin, "debug", "cd")
 	assert.NoError(err)
 	assert.Contains(out, bashScript)
 	assert.Contains(out, zshScript)
 	assert.Contains(out, fishScript)
 	// Returns the path to the project
-	out, err = exec.RunHostCommand(DdevBin, "cd", TestSites[0].Name, "--get-approot")
+	out, err = exec.RunHostCommand(DdevBin, "debug", "cd", TestSites[0].Name, "--get-approot")
 	assert.NoError(err)
 	assert.Equal(strings.TrimRight(out, "\n"), TestSites[0].Dir)
 	// Returns list of projects for autocompletion
-	out, err = exec.RunHostCommand(DdevBin, "cd", "--list")
+	out, err = exec.RunHostCommand(DdevBin, "debug", "cd", "--list")
 	assert.NoError(err)
 	projects, err := ddevapp.GetProjects(false)
 	assert.NoError(err)

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -236,13 +236,15 @@ ddev cake
 
 ## `cd`
 
-Uses shell built-in `cd` to change to a project directory. For example, `ddev cd some-project` will change directories to the project root of the project named `some-project`.
+Uses shell built-in `cd` to change to a project directory. For example, `ddevcd some-project` will change directories to the project root of the project named `some-project`.
 
-Note that this command can't work until you make a small addition to your `.bashrc`, `.zshrc`, or `config.fish`. To see the explanation of what you need to do:
+Note that this command can't work until you make a small addition to your `.bashrc`, `.zshrc`, or `config.fish`.
 
 ```shell
+# To see the explanation of what you need to do
+ddev cd
 # Where some-project is a project from the `ddev list`
-ddev cd some-project
+ddevcd some-project
 ```
 
 ## `clean`

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -234,19 +234,6 @@ Run the `cake` command; available only in projects of type `cakephp`, and only a
 ddev cake
 ```
 
-## `cd`
-
-Uses shell built-in `cd` to change to a project directory. For example, `ddevcd some-project` will change directories to the project root of the project named `some-project`.
-
-Note that this command can't work until you make a small addition to your `.bashrc`, `.zshrc`, or `config.fish`.
-
-```shell
-# To see the explanation of what you need to do
-ddev cd
-# Where some-project is a project from the `ddev list`
-ddevcd some-project
-```
-
 ## `clean`
 
 Removes items DDEV has created. (See [Uninstalling DDEV](../usage/uninstall.md).)
@@ -446,6 +433,19 @@ ddev debug capabilities
 
 # List capabilities of `my-project`
 ddev debug capabilities my-project
+```
+
+### `debug cd`
+
+Uses shell built-in `cd` to change to a project directory. For example, `ddevcd some-project` will change directories to the project root of the project named `some-project`.
+
+Note that this command can't work until you make a small addition to your `.bashrc`, `.zshrc`, or `config.fish`.
+
+```shell
+# To see the explanation of what you need to do
+ddev debug cd
+# Where some-project is a project from the `ddev list`
+ddevcd some-project
 ```
 
 ### `debug check-db-match`

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
@@ -8,11 +8,11 @@
 # "ddevcd project-name" to cd into the project directory.
 
 function ddevcd
-  cd (DDEV_VERBOSE=false ddev cd $argv[1] --get-approot)
+  cd (DDEV_VERBOSE=false ddev debug cd "$argv[1]" --get-approot)
 end
 
 function __ddevcd_autocomplete
-  DDEV_VERBOSE=false ddev cd --list
+  DDEV_VERBOSE=false ddev debug cd --list
 end
 
 complete -c ddevcd -f -a "(__ddevcd_autocomplete)"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
@@ -1,3 +1,4 @@
+#!/usr/bin/env fish
 #ddev-generated
 # This script should be sourced in the context of your shell like so:
 # source $HOME/.ddev/commands/host/shells/ddev.fish

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
@@ -3,18 +3,15 @@
 # source $HOME/.ddev/commands/host/shells/ddev.fish
 # Alternatively, it can be installed into one of the directories
 # that fish uses to autoload functions (e.g ~/.config/fish/functions)
-# Once the ddev() function is defined, you can type
-# "ddev cd project-name" to cd into the project directory.
+# Once the ddevcd() function is defined, you can type
+# "ddevcd project-name" to cd into the project directory.
 
-function ddev
-  if test (count $argv) -eq 2 -a "$argv[1]" = "cd"
-    switch "$argv[2]"
-      case '-*'
-        command ddev $argv
-      case '*'
-        cd (DDEV_VERBOSE=false command ddev cd "$argv[2]" --get-approot)
-    end
-  else
-    command ddev $argv
-  end
+function ddevcd
+  cd (DDEV_VERBOSE=false ddev cd $argv[1] --get-approot)
 end
+
+function __ddevcd_autocomplete
+  DDEV_VERBOSE=false ddev cd --list
+end
+
+complete -c ddevcd -f -a "(__ddevcd_autocomplete)"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
@@ -6,11 +6,11 @@
 # "ddevcd project-name" to cd into the project directory.
 
 ddevcd() {
-  cd "$(DDEV_VERBOSE=false ddev cd "$1" --get-approot)"
+  cd "$(DDEV_VERBOSE=false ddev debug cd "$1" --get-approot)"
 }
 
 _ddevcd_autocomplete() {
-  COMPREPLY=( $(compgen -W "$(DDEV_VERBOSE=false ddev cd --list)" -- "${COMP_WORDS[COMP_CWORD]}") )
+  COMPREPLY=( $(compgen -W "$(DDEV_VERBOSE=false ddev debug cd --list)" -- "${COMP_WORDS[COMP_CWORD]}") )
 }
 
 complete -F _ddevcd_autocomplete ddevcd

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
@@ -2,16 +2,15 @@
 #ddev-generated
 # This script should be sourced in the context of your shell like so:
 # source $HOME/.ddev/commands/host/shells/ddev.sh
-# Once the ddev() function is defined, you can type
-# "ddev cd project-name" to cd into the project directory.
+# Once the ddevcd() function is defined, you can type
+# "ddevcd project-name" to cd into the project directory.
 
-ddev() {
-  if [ "$#" -eq 2 ] && [ "$1" = "cd" ]; then
-    case "$2" in
-      -*) command ddev "$@" ;;
-      *) cd "$(DDEV_VERBOSE=false command ddev cd "$2" --get-approot)" ;;
-    esac
-  else
-    command ddev "$@"
-  fi
+ddevcd() {
+  cd "$(DDEV_VERBOSE=false ddev cd "$1" --get-approot)"
 }
+
+_ddevcd_autocomplete() {
+  COMPREPLY=( $(compgen -W "$(DDEV_VERBOSE=false ddev cd --list)" -- "${COMP_WORDS[COMP_CWORD]}") )
+}
+
+complete -F _ddevcd_autocomplete ddevcd

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.zsh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.zsh
@@ -1,0 +1,16 @@
+#!/usr/bin/env zsh
+#ddev-generated
+# This script should be sourced in the context of your shell like so:
+# source $HOME/.ddev/commands/host/shells/ddev.zsh
+# Once the ddevcd() function is defined, you can type
+# "ddevcd project-name" to cd into the project directory.
+
+ddevcd() {
+  cd "$(DDEV_VERBOSE=false ddev cd "$1" --get-approot)"
+}
+
+_ddevcd_autocomplete() {
+  compadd $(DDEV_VERBOSE=false ddev cd --list)
+}
+
+compdef _ddevcd_autocomplete ddevcd

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.zsh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.zsh
@@ -6,11 +6,11 @@
 # "ddevcd project-name" to cd into the project directory.
 
 ddevcd() {
-  cd "$(DDEV_VERBOSE=false ddev cd "$1" --get-approot)"
+  cd "$(DDEV_VERBOSE=false ddev debug cd "$1" --get-approot)"
 }
 
 _ddevcd_autocomplete() {
-  compadd $(DDEV_VERBOSE=false ddev cd --list)
+  compadd $(DDEV_VERBOSE=false ddev debug cd --list)
 }
 
 compdef _ddevcd_autocomplete ddevcd


### PR DESCRIPTION
## The Issue

- #6737

## How This PR Solves The Issue

Replaces global `ddev` function wrapper with `ddevcd` function while keeping autocompletion.

Hides top level `ddev cd` to `ddev debug cd`.

## Manual Testing Instructions

Follow instructions from `ddev debug cd`, restart your shell, and use `ddevcd <tab>`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
