### PR TITLE
build: add timeout to `docker-compose build`

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1496,6 +1496,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
 		Action:       []string{"--progress=" + progress, "build"},
 		Progress:     true,
+		Timeout:      time.Hour * 1,
 	})
 	if err != nil {
 		return fmt.Errorf("docker-compose build failed: %v, output='%s', stderr='%s'", err, out, stderr)
@@ -1512,6 +1513,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 			ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
 			Action:       []string{"--progress=" + progress, "build", "web", "--no-cache"},
 			Progress:     true,
+			Timeout:      time.Hour * 1,
 		})
 		if err != nil {
 			return fmt.Errorf("docker-compose build web --no-cache failed: %v, output='%s', stderr='%s'", err, out, stderr)


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/actions/runs/11915882563/job/33207216994

```
=== RUN   TestPHPConfig
...
Building project images...
2024-11-19T15:17:48.612 Executing docker-compose -f /home/runner/tmp/ddevtest/TestPkgDrupal101551583127/.ddev/.ddev-docker-compose-full.yaml build --progress=plain
......................................panic: test timed out after 4h0m0s
	running tests:
		TestPHPConfig (3h55m4s)
...
```

## How This PR Solves The Issue

We started to see tests randomly fail when running a `docker-compose build`, but we cannot debug it because we don't see where it is stuck.
Let's add a relatively large timeout of 1 hour to at least see where it doesn't work.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
