### PR TITLE
build: add more timeouts for `apt-get update`, remove custom `php8.0-xdebug`, for #6745

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           source ~/.bashrc
           docker version
+          docker info
           mkcert --version
           set -eu -o pipefail
 

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -87,7 +87,7 @@ function cleanup {
 
 ddev config --project-type=php --docroot=web --disable-upload-dirs-warning || (printf "\n\nPlease run 'ddev debug test' in the root of the existing project where you're having trouble.\n\n" && exit 4)
 
-printf "RUN apt-get update\nRUN curl -I https://www.google.com\n" > .ddev/web-build/Dockerfile.test
+printf "RUN timeout 120 apt-get update || true\nRUN curl -I https://www.google.com\n" > .ddev/web-build/Dockerfile.test
 
 set +eu
 

--- a/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
@@ -20,8 +20,8 @@ EXTENSION_FILE=$4
 # install pecl
 if ! command -v pecl >/dev/null 2>&1 || [ "$(dpkg -l | grep "php${PHP_VERSION}-dev")" = "" ]; then
   echo "Installing pecl to build php${PHP_VERSION}-${EXTENSION_NAME}"
-  apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
-  apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/debian.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
+  timeout "${START_SCRIPT_TIMEOUT:-30}" apt-get update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
+  timeout "${START_SCRIPT_TIMEOUT:-30}" apt-get update -o Dir::Etc::sourcelist="sources.list.d/debian.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
   DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y build-essential php-pear "php${PHP_VERSION}-dev" || exit $?
 fi
 
@@ -38,7 +38,7 @@ fi
 
 # PECL does not allow to install multiple versions of extension at the same time,
 # use `rm -f /usr/share/php/.registry/.channel.pecl.php.net/extension.reg` to make it forget about another version.
-(pecl channel-update pecl.php.net && \
+(timeout "${START_SCRIPT_TIMEOUT:-30}" pecl channel-update pecl.php.net && \
   echo "Building php${PHP_VERSION}-${EXTENSION_NAME}..." && \
   pecl -d php_suffix="${PHP_VERSION}" install -f "${PECL_EXTENSION}" >/dev/null && \
   rm -f "/usr/share/php/.registry/.channel.pecl.php.net/${EXTENSION_NAME}.reg") || true

--- a/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/install_php_extensions.sh
@@ -24,6 +24,6 @@ pkgs=$(yq ".${PHP_VERSION//.}.${ARCH} | join(\" \")" /etc/php-packages.yaml | aw
 # Echo the packages to be installed for logging
 echo "Installing packages for PHP ${PHP_VERSION/php/} on ${ARCH}: $pkgs"
 
-apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
-apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/debian.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
+timeout "${START_SCRIPT_TIMEOUT:-30}" apt-get update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
+timeout "${START_SCRIPT_TIMEOUT:-30}" apt-get update -o Dir::Etc::sourcelist="sources.list.d/debian.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
 DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y $pkgs || exit $?

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20241117_remove_python_django AS ddev-webserver-base
+FROM ddev/ddev-php-base:20241120_stasadev_timeout_apt_get_update AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
@@ -20,9 +20,9 @@ if [ "${MARIADB_VERSION}" = "11.4" ]; then
   set -x
   log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --skip-key-import || exit $?
   rm -f /etc/apt/sources.list.d/mariadb.list.old_*
-  # --skip-key-import flag doesn't download the existing key again and omits "apt-get -qq update",
-  # so we can run "apt-get -qq update" manually only for mariadb repo to make it faster
-  apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/mariadb.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || exit $?
+  # --skip-key-import flag doesn't download the existing key again and omits "apt-get update",
+  # so we can run "apt-get update" manually only for mariadb repo to make it faster
+  timeout "${START_SCRIPT_TIMEOUT:-30}" apt-get update -o Dir::Etc::sourcelist="sources.list.d/mariadb.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || exit $?
   # Install the mariadb-client and MySQL symlinks
   # MariaDB 11.x moved MySQL symlinks into a separate package
   DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y mariadb-client mariadb-client-compat || exit $?

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1041,23 +1041,23 @@ redirect_stderr=true
 		// However, they do have a postgres:11-bullseye, but we won't start using it yet
 		// because of awkward changes to $DBIMAGE. PostgreSQL 11 will be EOL Nov 2023
 		if nodeps.ArrayContainsString([]string{nodeps.Postgres9, nodeps.Postgres10, nodeps.Postgres11}, app.Database.Version) {
-			extraDBContent = extraDBContent + `
+			extraDBContent = extraDBContent + fmt.Sprintf(`
 RUN rm -f /etc/apt/sources.list.d/pgdg.list
 RUN echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list
-RUN apt-get update || true
+RUN timeout %s apt-get update || true
 RUN apt-get -y install apt-transport-https
 RUN printf "deb http://apt-archive.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-`
+`, app.GetMinimalContainerTimeout())
 		}
-		extraDBContent = extraDBContent + `
+		extraDBContent = extraDBContent + fmt.Sprintf(`
 ENV PATH=$PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 ADD postgres_healthcheck.sh /
 RUN chmod ugo+rx /postgres_healthcheck.sh
 RUN mkdir -p /etc/postgresql/conf.d && chmod 777 /etc/postgresql/conf.d
 RUN echo "*:*:db:db:db" > ~postgres/.pgpass && chown postgres:postgres ~postgres/.pgpass && chmod 600 ~postgres/.pgpass && chmod 777 /var/tmp && ln -sf /mnt/ddev_config/postgres/postgresql.conf /etc/postgresql && echo "restore_command = 'true'" >> /var/lib/postgresql/recovery.conf
 RUN printf "# TYPE DATABASE USER CIDR-ADDRESS  METHOD \nhost  all  all 0.0.0.0/0 md5\nlocal all all trust\nhost    replication    db             0.0.0.0/0  trust\nhost replication all 0.0.0.0/0 trust\nlocal replication all trust\nlocal replication all peer\n" >/etc/postgresql/pg_hba.conf
-RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests bzip2 less procps pv vim
-`
+RUN (timeout %s apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests bzip2 less procps pv vim
+`, app.GetMinimalContainerTimeout())
 	}
 
 	err = WriteBuildDockerfile(app, app.GetConfigPath(".dbimageBuild/Dockerfile"), app.GetConfigPath("db-build"), app.DBImageExtraPackages, "", extraDBContent)
@@ -1136,8 +1136,8 @@ SHELL ["/bin/bash", "-c"]
 					hasMultiStageBuild = true
 				}
 				contents = contents + fmt.Sprintf(`
-RUN /usr/local/bin/build_php_extension.sh "php%s" "%s" "%s" "%s" || true
-`, ext["php"], ext["name"], ext["version"], ext["file"])
+RUN START_SCRIPT_TIMEOUT=%s /usr/local/bin/build_php_extension.sh "php%s" "%s" "%s" "%s" || true
+`, app.GetStartScriptTimeout(), ext["php"], ext["name"], ext["version"], ext["file"])
 			}
 		}
 	}
@@ -1165,8 +1165,8 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 		if _, ok := nodeps.PreinstalledPHPVersions[app.PHPVersion]; !ok {
 			contents = contents + fmt.Sprintf(`
 ### DDEV-injected addition of not-preinstalled PHP version
-RUN /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETARCH}"
-	`, app.PHPVersion)
+RUN START_SCRIPT_TIMEOUT=%s /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETARCH}"
+`, app.GetStartScriptTimeout(), app.PHPVersion)
 		}
 		for _, ext := range phpExtensions {
 			if app.PHPVersion == ext["php"] {
@@ -1204,9 +1204,10 @@ COPY --from=ddev-php-extension-build %s %v
 	}
 
 	if extraPackages != nil {
-		contents = contents + `
+		contents = contents + fmt.Sprintf(`
 ### DDEV-injected from webimage_extra_packages or dbimage_extra_packages
-RUN (apt-get -qq update || true) && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests ` + strings.Join(extraPackages, " ") + "\n"
+RUN (timeout %s apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests %v
+`, app.GetMinimalContainerTimeout(), strings.Join(extraPackages, " "))
 	}
 
 	// webimage only things
@@ -1261,7 +1262,7 @@ RUN phpdismod blackfire xdebug xhprof
 ### DDEV-injected postgresql-client setup
 RUN EXISTING_PSQL_VERSION=$(psql --version | awk -F '[\. ]*' '{ print $3 }'); \
 if [ "${EXISTING_PSQL_VERSION}" != "%s" ]; then \
-  log-stderr.sh bash -c "apt-get -qq update -o Dir::Etc::sourcelist="sources.list.d/pgdg.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
+  log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" bash -c "apt-get update -o Dir::Etc::sourcelist="sources.list.d/pgdg.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
   apt-get install -y postgresql-client-%s && \
   apt-get remove -y postgresql-client-${EXISTING_PSQL_VERSION}" || true; \
 fi`, app.Database.Version, psqlVersion) + "\n\n"

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1222,10 +1222,10 @@ RUN phpdismod blackfire xdebug xhprof
 ### DDEV-injected postgresql-client setup
 RUN EXISTING_PSQL_VERSION=$(psql --version | awk -F '[\. ]*' '{ print $3 }'); \
 if [ "${EXISTING_PSQL_VERSION}" != "%s" ]; then \
-  log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" bash -c "apt-get update -o Dir::Etc::sourcelist="sources.list.d/pgdg.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
+  log-stderr.sh --timeout %s bash -c "apt-get update -o Dir::Etc::sourcelist="sources.list.d/pgdg.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
   apt-get install -y postgresql-client-%s && \
   apt-get remove -y postgresql-client-${EXISTING_PSQL_VERSION}" || true; \
-fi`, app.Database.Version, psqlVersion) + "\n\n"
+fi`, app.Database.Version, app.GetStartScriptTimeout(), psqlVersion) + "\n\n"
 		}
 
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -3333,6 +3333,21 @@ func (app *DdevApp) GetStartScriptTimeout() string {
 	return timeoutForScriptsOnStart
 }
 
+// GetMinimalContainerTimeout returns the timeout depending on the container timeout.
+// It returns the default timeout if the container's specified timeout is less than the default.
+func (app *DdevApp) GetMinimalContainerTimeout() string {
+	containerTimeout, err := strconv.Atoi(app.DefaultContainerTimeout)
+	defaultTimeout, _ := strconv.Atoi(nodeps.DefaultDefaultContainerTimeout)
+	if err != nil {
+		containerTimeout = defaultTimeout
+	}
+	minimalTimeout := strconv.Itoa(containerTimeout)
+	if containerTimeout <= defaultTimeout {
+		minimalTimeout = nodeps.DefaultDefaultContainerTimeout
+	}
+	return minimalTimeout
+}
+
 // genericImportFilesAction defines the workflow for importing project files.
 func genericImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
 	destPath := app.calculateHostUploadDirFullPath(uploadDir)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241117_remove_python_django" // Note that this can be overridden by make
+var WebTag = "20241120_stasadev_timeout_apt_get_update" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #6745

https://github.com/ddev/ddev/actions/runs/11927136921/job/33242061289?pr=6739

Stuck here:
```
RUN (apt-get -qq update || true) && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests dnsutils
```

I think the reason why it's stuck is that some repo, e.g. deb.sury downloads with a very low speed.

## How This PR Solves The Issue

- Add more timeouts for `apt-get update` that are done on the user side:
	- I used 30 seconds (1/4 of the `--default-container-timeout`) for single repo `apt-get update`
	- And 120 seconds for full `apt-get update`.
- Removes `-qq` that hid the output
- Removes custom `php8.0-xdebug` build because multi-stage build can fail if you have slow connection.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
