### PR TITLE
fix: Deprecate and hide ddev service commands, fixes #6298

### DIFF
--- a/cmd/ddev/cmd/service-disable.go
+++ b/cmd/ddev/cmd/service-disable.go
@@ -2,20 +2,22 @@ package cmd
 
 import (
 	"fmt"
+	"io/fs"
+	"os"
+
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
-	"io/fs"
-	"os"
 )
 
 // ServiceDisable implements the ddev service disable command
 var ServiceDisable = &cobra.Command{
-	Use:     "disable service [project]",
-	Short:   "disable a 3rd party service",
-	Long:    fmt.Sprintf(`disable a 3rd party service. The docker-compose.*.yaml will be moved from .ddev into .ddev/%s.`, disabledServicesDir),
-	Example: `ddev service disable solr`,
+	Use:        "disable service [project]",
+	Short:      "The service commands have been deprecated and removed and replaced by ddev add-on",
+	Hidden:     true,
+	Deprecated: `true`,
 	Run: func(_ *cobra.Command, args []string) {
+		util.Warning("The service commands have been deprecated and removed and replaced by ddev add-on")
 		if len(args) < 1 {
 			util.Failed("You must specify a service to disable")
 		}

--- a/cmd/ddev/cmd/service-enable.go
+++ b/cmd/ddev/cmd/service-enable.go
@@ -12,11 +12,14 @@ const disabledServicesDir = ".disabled-services"
 
 // ServiceEnable implements the ddev service enable command
 var ServiceEnable = &cobra.Command{
-	Use:     "enable service [project]",
-	Short:   "Enable a 3rd party service",
-	Long:    fmt.Sprintf(`Enable a 3rd party service. The service must exist as .ddev/%s/docker-compose.<service>.yaml. Note that you can use "ddev add-on get" to obtain a service not already on your system.`, disabledServicesDir),
-	Example: `ddev service enable solr`,
+	Use:        "enable service [project]",
+	Short:      "Enable a 3rd party service",
+	Hidden:     true,
+	Deprecated: `true`,
+	Long:       fmt.Sprintf(`Enable a 3rd party service. The service must exist as .ddev/%s/docker-compose.<service>.yaml. Note that you can use "ddev add-on get" to obtain a service not already on your system.`, disabledServicesDir),
+	Example:    `ddev service enable solr`,
 	Run: func(_ *cobra.Command, args []string) {
+		util.Warning("The service commands have been deprecated and removed and replaced by ddev add-on")
 		if len(args) < 1 {
 			util.Failed("You must specify a service to enable")
 		}

--- a/cmd/ddev/cmd/service.go
+++ b/cmd/ddev/cmd/service.go
@@ -7,8 +7,10 @@ import (
 
 // ServiceCmd is the top-level "ddev service" command
 var ServiceCmd = &cobra.Command{
-	Use:   "service [command]",
-	Short: "Add or remove, enable or disable extra services",
+	Use:        "service [command]",
+	Short:      "The service commands have been deprecated and removed and replaced by ddev add-on",
+	Hidden:     true,
+	Deprecated: `true`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		err := cmd.Usage()
 		util.CheckErr(err)


### PR DESCRIPTION

## The Issue

- #6298 

Deprecate and hide `ddev service enable` and `ddev service disable` as long-since replaced by `ddev add-on`

## Manual Testing Instructions

* Verify that `ddev service` doesn't show up in `ddev` or `ddev help`
* Verify that these commands can still be used
* Verify that they show a warning.

