### PR TITLE
fix: use correct path for Windows in custom configs

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -260,12 +260,12 @@ func (app *DdevApp) WriteConfig() error {
 
 	// Write example Dockerfiles into build directories
 	contents := []byte(`
-#ddev-generated
-# You can copy this Dockerfile.example to Dockerfile to add configuration
-# or packages or anything else to your webimage
-# These additions will be appended last to ddev's own Dockerfile
-RUN npm install --global forever
-RUN echo "Built on $(date)" > /build-date.txt
+## #ddev-generated
+## You can copy this Dockerfile.example to Dockerfile to add configuration
+## or packages or anything else to your webimage
+## These additions will be appended last to DDEV's own Dockerfile
+## See examples here https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/#adding-extra-dockerfiles-for-webimage-and-dbimage
+# RUN echo "Built on $(date)" > /build-date.txt
 `)
 
 	err = WriteImageDockerfile(app.GetConfigPath("web-build")+"/Dockerfile.example", contents)
@@ -273,10 +273,12 @@ RUN echo "Built on $(date)" > /build-date.txt
 		return err
 	}
 	contents = []byte(`
-#ddev-generated
-# You can copy this Dockerfile.example to Dockerfile to add configuration
-# or packages or anything else to your dbimage
-RUN echo "Built on $(date)" > /build-date.txt
+## #ddev-generated
+## You can copy this Dockerfile.example to Dockerfile to add configuration
+## or packages or anything else to your dbimage
+## These additions will be appended last to DDEV's own Dockerfile
+## See examples here https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/#adding-extra-dockerfiles-for-webimage-and-dbimage
+# RUN echo "Built on $(date)" > /build-date.txt
 `)
 
 	err = WriteImageDockerfile(app.GetConfigPath("db-build")+"/Dockerfile.example", contents)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -607,7 +607,7 @@ func (app *DdevApp) CheckCustomConfig() {
 	if app.WebserverType == nodeps.WebserverNginxFPM {
 		nginxPath := filepath.Join(ddevDir, "nginx")
 		if _, err := os.Stat(nginxPath); err == nil {
-			nginxFiles, err := filepath.Glob(nginxPath + "/*.conf")
+			nginxFiles, err := filepath.Glob(filepath.Join(nginxPath, "*.conf"))
 			util.CheckErr(err)
 			if len(nginxFiles) > 0 {
 				printableFiles, _ := util.ArrayToReadableOutput(nginxFiles)
@@ -619,7 +619,7 @@ func (app *DdevApp) CheckCustomConfig() {
 
 	mysqlPath := filepath.Join(ddevDir, "mysql")
 	if _, err := os.Stat(mysqlPath); err == nil {
-		mysqlFiles, err := filepath.Glob(mysqlPath + "/*.cnf")
+		mysqlFiles, err := filepath.Glob(filepath.Join(mysqlPath, "*.cnf"))
 		util.CheckErr(err)
 		if len(mysqlFiles) > 0 {
 			printableFiles, _ := util.ArrayToReadableOutput(mysqlFiles)
@@ -630,7 +630,7 @@ func (app *DdevApp) CheckCustomConfig() {
 
 	phpPath := filepath.Join(ddevDir, "php")
 	if _, err := os.Stat(phpPath); err == nil {
-		phpFiles, err := filepath.Glob(phpPath + "/*.ini")
+		phpFiles, err := filepath.Glob(filepath.Join(phpPath, "*.ini"))
 		util.CheckErr(err)
 		if len(phpFiles) > 0 {
 			printableFiles, _ := util.ArrayToReadableOutput(phpFiles)
@@ -641,7 +641,7 @@ func (app *DdevApp) CheckCustomConfig() {
 
 	customDockerPath := filepath.Join(ddevDir, "web-build")
 	if _, err := os.Stat(customDockerPath); err == nil {
-		dockerFiles, err := filepath.Glob(customDockerPath + "/*Dockerfile*")
+		dockerFiles, err := filepath.Glob(filepath.Join(customDockerPath, "*Dockerfile*"))
 		util.CheckErr(err)
 		dockerFiles = slices.DeleteFunc(dockerFiles, func(s string) bool {
 			return strings.HasSuffix(s, ".example")
@@ -655,7 +655,7 @@ func (app *DdevApp) CheckCustomConfig() {
 
 	webEntrypointPath := filepath.Join(ddevDir, "web-entrypoint.d")
 	if _, err := os.Stat(webEntrypointPath); err == nil {
-		entrypointFiles, err := filepath.Glob(webEntrypointPath + "/*.sh")
+		entrypointFiles, err := filepath.Glob(filepath.Join(webEntrypointPath, "*.sh"))
 		util.CheckErr(err)
 		if len(entrypointFiles) > 0 {
 			printableFiles, _ := util.ArrayToReadableOutput(entrypointFiles)
@@ -1141,7 +1141,7 @@ RUN START_SCRIPT_TIMEOUT=%s /usr/local/bin/install_php_extensions.sh "php%s" "${
 
 	// If there are user pre.Dockerfile* files, insert their contents
 	if userDockerfilePath != "" {
-		files, err := filepath.Glob(userDockerfilePath + "/pre.Dockerfile*")
+		files, err := filepath.Glob(filepath.Join(userDockerfilePath, "pre.Dockerfile*"))
 		if err != nil {
 			return err
 		}
@@ -1232,14 +1232,14 @@ fi`, app.Database.Version, app.GetStartScriptTimeout(), psqlVersion) + "\n\n"
 
 	// If there are user dockerfiles, appends their contents
 	if userDockerfilePath != "" {
-		files, err := filepath.Glob(userDockerfilePath + "/Dockerfile*")
+		files, err := filepath.Glob(filepath.Join(userDockerfilePath, "Dockerfile*"))
 		if err != nil {
 			return err
 		}
 
 		for _, file := range files {
 			// Skip the example file
-			if file == userDockerfilePath+"/Dockerfile.example" {
+			if file == filepath.Join(userDockerfilePath, "Dockerfile.example") {
 				continue
 			}
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1314,13 +1314,6 @@ RUN mkdir -p "/var/tmp/my-arch-info-is-${TARGETOS}-${TARGETARCH}-${TARGETPLATFOR
 		Cmd: fmt.Sprintf("ls /var/tmp/running-php-%s >/dev/null", app.PHPVersion),
 	})
 	assert.NoError(err)
-
-	// We have "npm install --global forever" in .ddev/web-build/Dockerfile.example
-	// It should not be added to the web container.
-	_, _, err = app.Exec(&ddevapp.ExecOpts{
-		Cmd: "command -v forever >/dev/null",
-	})
-	assert.Error(err)
 }
 
 // TestConfigLoadingOrder verifies that configs load in lexicographical order

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1314,6 +1314,13 @@ RUN mkdir -p "/var/tmp/my-arch-info-is-${TARGETOS}-${TARGETARCH}-${TARGETPLATFOR
 		Cmd: fmt.Sprintf("ls /var/tmp/running-php-%s >/dev/null", app.PHPVersion),
 	})
 	assert.NoError(err)
+
+	// We have "npm install --global forever" in .ddev/web-build/Dockerfile.example
+	// It should not be added to the web container.
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
+		Cmd: "command -v forever >/dev/null",
+	})
+	assert.Error(err)
 }
 
 // TestConfigLoadingOrder verifies that configs load in lexicographical order

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -560,7 +560,8 @@ func ShortHomeJoin(elem ...string) string {
 	if err != nil {
 		logrus.Fatalf("Could not get home directory for current user. Is it set? err=%v", err)
 	}
-	fullPath := filepath.Join(elem...)
+	userHome = util.WindowsPathToCygwinPath(userHome)
+	fullPath := util.WindowsPathToCygwinPath(filepath.Join(elem...))
 	if strings.HasPrefix(fullPath, userHome) {
 		return strings.Replace(fullPath, userHome, "~", 1)
 	}


### PR DESCRIPTION
## The Issue

We had `ddev-windows-mutagen` failures https://buildkite.com/ddev/ddev-windows-mutagen/builds/4923

It failed on installing `npm install --global forever`.

The contents of `.ddev/web-build/Dockerfile.example` was added on Windows by mistake:

```dockerfile
### From user Dockerfile C:\Users\testbot\tmp\ddevtest\TestPretestAndEnv1956093451\.ddev\web-build\Dockerfile.example:

#ddev-generated
# You can copy this Dockerfile.example to Dockerfile to add configuration
# or packages or anything else to your webimage
# These additions will be appended last to ddev's own Dockerfile
RUN npm install --global forever
RUN echo "Built on $(date)" > /build-date.txt
```

## How This PR Solves The Issue

The contents of `Dockerfile.example` should never be added to the final `Dockerfile`: fixed using the correct file path in Windows.
And I added a check for `forever`, it should not be installed.
I think that `filepath.Glob` worked fine, but I added `filepath.Join` to make sure the path is right for Windows.
Change `~\.ddev` to `~/.ddev` in `ddev list` on Windows.
```
 Router │ healthy      │ ~\.ddev          │ http://127.0.0.1:10999 │ traefik
```

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
