### PR TITLE
fix: Set correct DATABASE_URL for CakePHP project using Postgres, fixes #6760

### DIFF
--- a/pkg/ddevapp/cakephp.go
+++ b/pkg/ddevapp/cakephp.go
@@ -49,16 +49,18 @@ func cakephpPostStartAction(app *DdevApp) error {
 	}
 	port := "3306"
 	dbConnection := "mysql"
+	dbParams := ""
 	if app.Database.Type == nodeps.Postgres {
-		dbConnection = "pgsql"
+		dbConnection = "postgres"
 		port = "5432"
+		dbParams = "?encoding=utf8"
 	}
 	envMap := map[string]string{
 		"export APP_NAME":                    app.GetName(),
 		"export DEBUG":                       "true",
 		"export APP_ENCODING":                "UTF-8",
 		"export APP_DEFAULT_LOCALE":          "en_US",
-		"export DATABASE_URL":                dbConnection + "://db:db@db:" + port + "/db",
+		"export DATABASE_URL":                dbConnection + "://db:db@db:" + port + "/db" + dbParams,
 		"export EMAIL_TRANSPORT_DEFAULT_URL": "smtp://localhost:1025",
 		"export SECURITY_SALT":               util.HashSalt(app.GetName()),
 		"export DEBUG_KIT_SAFE_TLD":          "site",


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6760 

The wrong connection string is set when using Postgres instead of default database

## How This PR Solves The Issue
Changed to correct database driver for CakePHP, postgres instead of pgsql
To avoid inherit the wrong encoding from default database (utf8mb4) we need to specify utf8 explicit.

## Manual Testing Instructions
Follow instructions in the CMS Quickstarts part, but add --database param to the ddev config
```
mkdir my-cakephp-site && cd my-cakephp-site
ddev config --project-type=cakephp --docroot=webroot --database=postgres:14
ddev composer create --prefer-dist --no-interaction cakephp/app:~5.0
ddev launch

```
When the project launches, CakePHP should be able to connect to the database

## Automated Testing Overview

I could not find any tests related to this DATABASE_URL setting.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
Not that I am aware of, since this is limited to CakePHP only, and a non-working configuration
