### PR TITLE
docs: explain how to update/remove/override `vendor/bin/composer`, for #6604

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -94,7 +94,7 @@ Composer version for the web container and the [`ddev composer`](../usage/comman
 | -- | -- | --
 | :octicons-file-directory-16: project | `2` | Can be `2`, `1`, or empty (`""`) for latest major version at container build time.<br><br>Can also be a minor version like `2.2` for the latest release of that branch, an explicit version like `1.0.22`, or a keyword like `stable`, `preview` or `snapshot`. See Composer documentation.
 
-!!!warning "Why `composer_version` is not being used?"
+!!!warning "Why is `composer_version` not being used?"
     If your project's `composer.json` and/or `composer.lock` includes `composer/composer`, that version will take precedence over the one specified by `composer_version`, because `vendor/bin/composer` comes first in the in-container `$PATH`. You have three options:
 
     1. Update `vendor/bin/composer` in the container:

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -94,13 +94,18 @@ Composer version for the web container and the [`ddev composer`](../usage/comman
 | -- | -- | --
 | :octicons-file-directory-16: project | `2` | Can be `2`, `1`, or empty (`""`) for latest major version at container build time.<br><br>Can also be a minor version like `2.2` for the latest release of that branch, an explicit version like `1.0.22`, or a keyword like `stable`, `preview` or `snapshot`. See Composer documentation.
 
-!!!warning "Why my project's `composer_version` is not being used?"
+!!!warning "Why `composer_version` is not being used?"
     If your project's `composer.json` or `composer.lock` includes `composer/composer`, that version will take precedence over the one specified by `composer_version`, because `vendor/bin/composer` comes first in the in-container `$PATH`.
 
-    To use `composer_version` instead, either remove `composer/composer` from your `composer.json` or change the `$PATH` order:
+    To update `vendor/bin/composer` in the container to the latest version, run:
+    ```shell
+    ddev composer require composer/composer -W
+    ```
+
+    To use `composer_version` instead, either remove `composer/composer` from your `composer.json` or adjust the `$PATH` order:
     ```shell
     mkdir -p .ddev/homeadditions/.bashrc.d
-    echo 'export PATH=/usr/local/bin:$PATH' > .ddev/homeadditions/.bashrc.d/path.sh
+    echo 'export PATH=/usr/local/bin:$PATH' >.ddev/homeadditions/.bashrc.d/path.sh
     ddev restart
     ```
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -94,8 +94,15 @@ Composer version for the web container and the [`ddev composer`](../usage/comman
 | -- | -- | --
 | :octicons-file-directory-16: project | `2` | Can be `2`, `1`, or empty (`""`) for latest major version at container build time.<br><br>Can also be a minor version like `2.2` for the latest release of that branch, an explicit version like `1.0.22`, or a keyword like `stable`, `preview` or `snapshot`. See Composer documentation.
 
-!!!note "If your `composer.json` requires `composer/composer` that version will be used instead"
-    If your project `composer.json` includes `composer/composer`, then the version specified there will normally be used instead of any version specified by `composer_version`, since `vendor/bin/composer` will come first in the in-container `$PATH`.
+!!!warning "Why my project's `composer_version` is not being used?"
+    If your project's `composer.json` or `composer.lock` includes `composer/composer`, that version will take precedence over the one specified by `composer_version`, because `vendor/bin/composer` comes first in the in-container `$PATH`.
+
+    To use `composer_version` instead, either remove `composer/composer` from your `composer.json` or change the `$PATH` order:
+    ```shell
+    mkdir -p .ddev/homeadditions/.bashrc.d
+    echo 'export PATH=/usr/local/bin:$PATH' > .ddev/homeadditions/.bashrc.d/path.sh
+    ddev restart
+    ```
 
 ## `corepack_enable`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -95,14 +95,19 @@ Composer version for the web container and the [`ddev composer`](../usage/comman
 | :octicons-file-directory-16: project | `2` | Can be `2`, `1`, or empty (`""`) for latest major version at container build time.<br><br>Can also be a minor version like `2.2` for the latest release of that branch, an explicit version like `1.0.22`, or a keyword like `stable`, `preview` or `snapshot`. See Composer documentation.
 
 !!!warning "Why `composer_version` is not being used?"
-    If your project's `composer.json` or `composer.lock` includes `composer/composer`, that version will take precedence over the one specified by `composer_version`, because `vendor/bin/composer` comes first in the in-container `$PATH`.
+    If your project's `composer.json` and/or `composer.lock` includes `composer/composer`, that version will take precedence over the one specified by `composer_version`, because `vendor/bin/composer` comes first in the in-container `$PATH`. You have three options:
 
-    To update `vendor/bin/composer` in the container to the latest version, run:
+    1. Update `vendor/bin/composer` in the container:
     ```shell
     ddev composer require composer/composer -W
     ```
 
-    To use `composer_version` instead, either remove `composer/composer` from your `composer.json` or adjust the `$PATH` order:
+    2. Remove `composer/composer` from `composer.json`:
+    ```shell
+    ddev exec /usr/local/bin/composer remove composer/composer
+    ```
+
+    3. Adjust the `$PATH` order:
     ```shell
     mkdir -p .ddev/homeadditions/.bashrc.d
     echo 'export PATH=/usr/local/bin:$PATH' >.ddev/homeadditions/.bashrc.d/path.sh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,7 +184,6 @@ nav:
     - users/extend/database-types.md
     - users/configuration/hooks.md
     - users/extend/additional-hostnames.md
-    - users/configuration/experimental.md
   - 'Extending':
     - users/extend/customization-extendibility.md
     - users/extend/additional-services.md


### PR DESCRIPTION
## The Issue

- #6604

People keep asking why their `composer_version` doesn't work, and `vendor/bin/composer` is used instead.

## How This PR Solves The Issue

Explains how to update/remove/override it in the docs.

https://ddev--6762.org.readthedocs.build/en/6762/users/configuration/config/#composer_version

## Manual Testing Instructions

```
ddev composer require composer/composer -W
ddev exec /usr/local/bin/composer remove composer/composer
ddev composer -V # Composer version 2.8.3 2024-11-17 13:13:04

ddev composer require composer/composer:v2.8.0
ddev composer -V # Composer version 2.8.0 2024-10-02 16:40:29
mkdir -p .ddev/homeadditions/.bashrc.d
echo 'export PATH=/usr/local/bin:$PATH' >.ddev/homeadditions/.bashrc.d/path.sh
ddev restart
ddev composer -V # Composer version 2.8.3 2024-11-17 13:13:04
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
