### PR TITLE
build: add missing php8.4 extensions, use PECL for php8.4-xdebug, fixes #6465

### DIFF
--- a/cmd/ddev/cmd/xdebug_test.go
+++ b/cmd/ddev/cmd/xdebug_test.go
@@ -27,7 +27,7 @@ func TestCmdXdebug(t *testing.T) {
 
 	// TestDdevXdebugEnabled has already tested enough versions, so limit it here.
 	// and this is a pretty limited test, doesn't do much but turn on and off
-	phpVersions := []string{nodeps.PHP82, nodeps.PHP83}
+	phpVersions := []string{nodeps.PHP83, nodeps.PHP84}
 
 	pwd, _ := os.Getwd()
 	v := TestSites[0]

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -54,12 +54,10 @@ SHELL ["/bin/bash", "-c"]
 ### See https://github.com/ddev/ddev/issues/6159
 RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
-# TODO: installed with pecl: apcu redis uploadprogress xdebug xhprof
-RUN /usr/local/bin/build_php_extension.sh "php8.4" "apcu" "latest" "/usr/lib/php/20240924/apcu.so"
+# TODO: installed with pecl: memcached redis xdebug
+RUN /usr/local/bin/build_php_extension.sh "php8.4" "memcached" "latest" "/usr/lib/php/20240924/memcached.so" "libmemcached-dev zlib1g-dev libssl-dev"
 RUN /usr/local/bin/build_php_extension.sh "php8.4" "redis" "latest" "/usr/lib/php/20240924/redis.so"
-RUN /usr/local/bin/build_php_extension.sh "php8.4" "uploadprogress" "latest" "/usr/lib/php/20240924/uploadprogress.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.4" "xdebug" "3.4.0beta1" "/usr/lib/php/20240924/xdebug.so"
-RUN /usr/local/bin/build_php_extension.sh "php8.4" "xhprof" "latest" "/usr/lib/php/20240924/xhprof.so"
 #END ddev-php-extension-build
 
 ### ---------------------------ddev-php-base--------------------------------------
@@ -122,20 +120,14 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/ru
 RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug
 COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
 COPY --from=ddev-php-extension-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
-# TODO: installed with pecl: apcu redis uploadprogress xdebug xhprof
-COPY --from=ddev-php-extension-build /usr/lib/php/20240924/apcu.so /usr/lib/php/20240924/apcu.so
-COPY --from=ddev-php-extension-build /usr/include/php/20240924/ext/apcu /usr/include/php/20240924/ext/apcu
-RUN cp /etc/php/8.3/mods-available/apcu.ini /etc/php/8.4/mods-available/apcu.ini
-
+# TODO: installed with pecl: memcached redis xdebug
+COPY --from=ddev-php-extension-build /usr/lib/php/20240924/memcached.so /usr/lib/php/20240924/memcached.so
+RUN cp /etc/php/8.3/mods-available/memcached.ini /etc/php/8.4/mods-available/memcached.ini
+RUN phpenmod -v 8.4 memcached
 COPY --from=ddev-php-extension-build /usr/lib/php/20240924/redis.so /usr/lib/php/20240924/redis.so
 RUN cp /etc/php/8.3/mods-available/redis.ini /etc/php/8.4/mods-available/redis.ini
-
-COPY --from=ddev-php-extension-build /usr/lib/php/20240924/uploadprogress.so /usr/lib/php/20240924/uploadprogress.so
-RUN cp /etc/php/8.3/mods-available/uploadprogress.ini /etc/php/8.4/mods-available/uploadprogress.ini
-
+RUN phpenmod -v 8.4 redis
 COPY --from=ddev-php-extension-build /usr/lib/php/20240924/xdebug.so /usr/lib/php/20240924/xdebug.so
-
-COPY --from=ddev-php-extension-build /usr/lib/php/20240924/xhprof.so /usr/lib/php/20240924/xhprof.so
 #END ddev-php-extension-build
 RUN phpdismod xhprof
 RUN apt-get -qq autoremove -y

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -54,9 +54,7 @@ SHELL ["/bin/bash", "-c"]
 ### See https://github.com/ddev/ddev/issues/6159
 RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
-# TODO: installed with pecl: imagick memcached redis xdebug
-# Build from https://github.com/Imagick/imagick/pull/690
-RUN /usr/local/bin/build_php_extension.sh "php8.4" "imagick" "https://github.com/Imagick/imagick/archive/944b67fce68bcb5835999a149f917670555b6fcb.tar.gz" "/usr/lib/php/20240924/imagick.so" "libmagickwand-dev libmagickcore-dev"
+# TODO: installed with pecl: memcached redis xdebug
 RUN /usr/local/bin/build_php_extension.sh "php8.4" "memcached" "latest" "/usr/lib/php/20240924/memcached.so" "libmemcached-dev zlib1g-dev libssl-dev"
 RUN /usr/local/bin/build_php_extension.sh "php8.4" "redis" "latest" "/usr/lib/php/20240924/redis.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.4" "xdebug" "3.4.0beta1" "/usr/lib/php/20240924/xdebug.so"
@@ -122,11 +120,7 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/ru
 RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug
 COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
 COPY --from=ddev-php-extension-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
-# TODO: installed with pecl: imagick memcached redis xdebug
-COPY --from=ddev-php-extension-build /usr/lib/php/20240924/imagick.so /usr/lib/php/20240924/imagick.so
-COPY --from=ddev-php-extension-build /usr/include/php/20240924/ext/imagick/php_imagick_shared.h /usr/include/php/20240924/ext/imagick/php_imagick_shared.h
-RUN cp /etc/php/8.3/mods-available/imagick.ini /etc/php/8.4/mods-available/imagick.ini
-RUN phpenmod -v 8.4 imagick
+# TODO: installed with pecl: memcached redis xdebug
 COPY --from=ddev-php-extension-build /usr/lib/php/20240924/memcached.so /usr/lib/php/20240924/memcached.so
 RUN cp /etc/php/8.3/mods-available/memcached.ini /etc/php/8.4/mods-available/memcached.ini
 RUN phpenmod -v 8.4 memcached

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -54,7 +54,9 @@ SHELL ["/bin/bash", "-c"]
 ### See https://github.com/ddev/ddev/issues/6159
 RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
-# TODO: installed with pecl: memcached redis xdebug
+# TODO: installed with pecl: imagick memcached redis xdebug
+# Build from https://github.com/Imagick/imagick/pull/690
+RUN /usr/local/bin/build_php_extension.sh "php8.4" "imagick" "https://github.com/Imagick/imagick/archive/944b67fce68bcb5835999a149f917670555b6fcb.tar.gz" "/usr/lib/php/20240924/imagick.so" "libmagickwand-dev libmagickcore-dev"
 RUN /usr/local/bin/build_php_extension.sh "php8.4" "memcached" "latest" "/usr/lib/php/20240924/memcached.so" "libmemcached-dev zlib1g-dev libssl-dev"
 RUN /usr/local/bin/build_php_extension.sh "php8.4" "redis" "latest" "/usr/lib/php/20240924/redis.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.4" "xdebug" "3.4.0beta1" "/usr/lib/php/20240924/xdebug.so"
@@ -120,7 +122,11 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/ru
 RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug
 COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
 COPY --from=ddev-php-extension-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
-# TODO: installed with pecl: memcached redis xdebug
+# TODO: installed with pecl: imagick memcached redis xdebug
+COPY --from=ddev-php-extension-build /usr/lib/php/20240924/imagick.so /usr/lib/php/20240924/imagick.so
+COPY --from=ddev-php-extension-build /usr/include/php/20240924/ext/imagick/php_imagick_shared.h /usr/include/php/20240924/ext/imagick/php_imagick_shared.h
+RUN cp /etc/php/8.3/mods-available/imagick.ini /etc/php/8.4/mods-available/imagick.ini
+RUN phpenmod -v 8.4 imagick
 COPY --from=ddev-php-extension-build /usr/lib/php/20240924/memcached.so /usr/lib/php/20240924/memcached.so
 RUN cp /etc/php/8.3/mods-available/memcached.ini /etc/php/8.4/mods-available/memcached.ini
 RUN phpenmod -v 8.4 memcached

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -54,6 +54,12 @@ SHELL ["/bin/bash", "-c"]
 ### See https://github.com/ddev/ddev/issues/6159
 RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
+# TODO: installed with pecl: apcu redis uploadprogress xdebug xhprof
+RUN /usr/local/bin/build_php_extension.sh "php8.4" "apcu" "latest" "/usr/lib/php/20240924/apcu.so"
+RUN /usr/local/bin/build_php_extension.sh "php8.4" "redis" "latest" "/usr/lib/php/20240924/redis.so"
+RUN /usr/local/bin/build_php_extension.sh "php8.4" "uploadprogress" "latest" "/usr/lib/php/20240924/uploadprogress.so"
+RUN /usr/local/bin/build_php_extension.sh "php8.4" "xdebug" "3.4.0beta1" "/usr/lib/php/20240924/xdebug.so"
+RUN /usr/local/bin/build_php_extension.sh "php8.4" "xhprof" "latest" "/usr/lib/php/20240924/xhprof.so"
 #END ddev-php-extension-build
 
 ### ---------------------------ddev-php-base--------------------------------------
@@ -116,6 +122,20 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/ru
 RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug
 COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
 COPY --from=ddev-php-extension-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
+# TODO: installed with pecl: apcu redis uploadprogress xdebug xhprof
+COPY --from=ddev-php-extension-build /usr/lib/php/20240924/apcu.so /usr/lib/php/20240924/apcu.so
+COPY --from=ddev-php-extension-build /usr/include/php/20240924/ext/apcu /usr/include/php/20240924/ext/apcu
+RUN cp /etc/php/8.3/mods-available/apcu.ini /etc/php/8.4/mods-available/apcu.ini
+
+COPY --from=ddev-php-extension-build /usr/lib/php/20240924/redis.so /usr/lib/php/20240924/redis.so
+RUN cp /etc/php/8.3/mods-available/redis.ini /etc/php/8.4/mods-available/redis.ini
+
+COPY --from=ddev-php-extension-build /usr/lib/php/20240924/uploadprogress.so /usr/lib/php/20240924/uploadprogress.so
+RUN cp /etc/php/8.3/mods-available/uploadprogress.ini /etc/php/8.4/mods-available/uploadprogress.ini
+
+COPY --from=ddev-php-extension-build /usr/lib/php/20240924/xdebug.so /usr/lib/php/20240924/xdebug.so
+
+COPY --from=ddev-php-extension-build /usr/lib/php/20240924/xhprof.so /usr/lib/php/20240924/xhprof.so
 #END ddev-php-extension-build
 RUN phpdismod xhprof
 RUN apt-get -qq autoremove -y

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -54,9 +54,7 @@ SHELL ["/bin/bash", "-c"]
 ### See https://github.com/ddev/ddev/issues/6159
 RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
-# TODO: installed with pecl: memcached redis xdebug
-RUN /usr/local/bin/build_php_extension.sh "php8.4" "memcached" "latest" "/usr/lib/php/20240924/memcached.so" "libmemcached-dev zlib1g-dev libssl-dev"
-RUN /usr/local/bin/build_php_extension.sh "php8.4" "redis" "latest" "/usr/lib/php/20240924/redis.so"
+# TODO: php8.4-xdebug installed with PECL
 RUN /usr/local/bin/build_php_extension.sh "php8.4" "xdebug" "3.4.0beta1" "/usr/lib/php/20240924/xdebug.so"
 #END ddev-php-extension-build
 
@@ -120,13 +118,7 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/ru
 RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug
 COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
 COPY --from=ddev-php-extension-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
-# TODO: installed with pecl: memcached redis xdebug
-COPY --from=ddev-php-extension-build /usr/lib/php/20240924/memcached.so /usr/lib/php/20240924/memcached.so
-RUN cp /etc/php/8.3/mods-available/memcached.ini /etc/php/8.4/mods-available/memcached.ini
-RUN phpenmod -v 8.4 memcached
-COPY --from=ddev-php-extension-build /usr/lib/php/20240924/redis.so /usr/lib/php/20240924/redis.so
-RUN cp /etc/php/8.3/mods-available/redis.ini /etc/php/8.4/mods-available/redis.ini
-RUN phpenmod -v 8.4 redis
+# TODO: php8.4-xdebug installed with PECL
 COPY --from=ddev-php-extension-build /usr/lib/php/20240924/xdebug.so /usr/lib/php/20240924/xdebug.so
 #END ddev-php-extension-build
 RUN phpdismod xhprof

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
@@ -5,3 +5,7 @@ xdebug.client_port=9003
 xdebug.mode=debug,develop
 xdebug.start_with_request=yes
 xdebug.max_nesting_level=1000
+# TODO: installed with pecl: memcached redis xdebug
+# Per https://bugs.xdebug.org/view.php?id=2293
+# remove this once php8.4-xdebug is ready
+opcache.jit=disable

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
@@ -5,7 +5,7 @@ xdebug.client_port=9003
 xdebug.mode=debug,develop
 xdebug.start_with_request=yes
 xdebug.max_nesting_level=1000
-# TODO: installed with pecl: memcached redis xdebug
+# TODO: installed with pecl: imagick memcached redis xdebug
 # Per https://bugs.xdebug.org/view.php?id=2293
 # remove this once php8.4-xdebug is ready
 opcache.jit=disable

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
@@ -5,7 +5,7 @@ xdebug.client_port=9003
 xdebug.mode=debug,develop
 xdebug.start_with_request=yes
 xdebug.max_nesting_level=1000
-# TODO: installed with pecl: memcached redis xdebug
+# TODO: php8.4-xdebug installed with PECL
 # Per https://bugs.xdebug.org/view.php?id=2293
 # remove this once php8.4-xdebug is ready
 opcache.jit=disable

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
@@ -6,6 +6,6 @@ xdebug.mode=debug,develop
 xdebug.start_with_request=yes
 xdebug.max_nesting_level=1000
 # TODO: php8.4-xdebug installed with PECL
-# Per https://bugs.xdebug.org/view.php?id=2293
-# remove this once php8.4-xdebug is ready
+# See https://bugs.xdebug.org/view.php?id=2293
+# Remove this once php8.4-xdebug is ready
 opcache.jit=disable

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
@@ -5,7 +5,7 @@ xdebug.client_port=9003
 xdebug.mode=debug,develop
 xdebug.start_with_request=yes
 xdebug.max_nesting_level=1000
-# TODO: installed with pecl: imagick memcached redis xdebug
+# TODO: installed with pecl: memcached redis xdebug
 # Per https://bugs.xdebug.org/view.php?id=2293
 # remove this once php8.4-xdebug is ready
 opcache.jit=disable

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -1,67 +1,45 @@
 php56:
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt mysql opcache pgsql readline soap sqlite3 uploadprogress xdebug xml xhprof xmlrpc zip
   arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xml", "xhprof", "xmlrpc", "zip"]
 
 php70:
-  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php71:
-  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php72:
-  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common" , "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php73:
-  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php74:
-  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php80:
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php81:
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php82:
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php83:
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 # 2024-11-26 missing: xdebug
 # TODO: php8.4-xdebug installed with PECL
 php84:
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip
   arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -60,9 +60,10 @@ php83:
 
 # 2024-11-25 missing amd64: xdebug
 # 2024-11-25 missing arm64: memcached redis xdebug
+# php8.4 imagick is broken https://github.com/oerdnj/deb.sury.org/issues/2176#issuecomment-2430770813
 # TODO: installed with pecl: memcached redis xdebug
 php84:
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -60,10 +60,9 @@ php83:
 
 # 2024-11-25 missing amd64: xdebug
 # 2024-11-25 missing arm64: memcached redis xdebug
-# imagick - broken, building from https://github.com/Imagick/imagick/pull/690
-# TODO: installed with pecl: imagick memcached redis xdebug
+# TODO: installed with pecl: memcached redis xdebug
 php84:
-  # formerly apcu bcmath bz2 cli common curl fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 cli common curl fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -60,9 +60,10 @@ php83:
 
 # 2024-11-25 missing amd64: xdebug
 # 2024-11-25 missing arm64: memcached redis xdebug
-# TODO: installed with pecl: memcached redis xdebug
+# imagick - broken, building from https://github.com/Imagick/imagick/pull/690
+# TODO: installed with pecl: imagick memcached redis xdebug
 php84:
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -58,9 +58,10 @@ php83:
   # formerly apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   arm64: ["apcu", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
-# 2024-11-01 missing apcu redis uploadprogress xdebug xhprof xmlrpc
+# 2024-11-22 missing apcu imagick memcached redis uploadprogress xdebug xhprof xmlrpc
+# TODO: installed with pecl: apcu redis uploadprogress xdebug xhprof
 php84:
-  # formerly bcmath bz2 cli common curl fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip
-  amd64: ["bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "xml", "zip"]
-  # formerly bcmath bz2 cli common curl fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip
-  arm64: ["bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "xml", "zip"]
+  # formerly bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip
+  amd64: ["bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "xml", "zip"]
+  # formerly bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip
+  arm64: ["bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "xml", "zip"]

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -58,12 +58,10 @@ php83:
   # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
   arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
-# 2024-11-25 missing amd64: xdebug
-# 2024-11-25 missing arm64: memcached redis xdebug
-# php8.4 imagick is broken https://github.com/oerdnj/deb.sury.org/issues/2176#issuecomment-2430770813
-# TODO: installed with pecl: memcached redis xdebug
+# 2024-11-26 missing: xdebug
+# TODO: php8.4-xdebug installed with PECL
 php84:
-  # formerly apcu bcmath bz2 cli common curl fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 cli common curl fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -1,67 +1,68 @@
 php56:
-  # formerly apcu bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  amd64: ["apcu", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring mcrypt mysql opcache pgsql readline soap sqlite3 uploadprogress xdebug xml xhprof xmlrpc zip
-  arm64: ["apcu", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xml", "xhprof", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt mysql opcache pgsql readline soap sqlite3 uploadprogress xdebug xml xhprof xmlrpc zip
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xml", "xhprof", "xmlrpc", "zip"]
 
 php70:
-  # formerly apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php71:
-  # formerly apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php72:
-  # formerly apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common" , "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php73:
-  # formerly apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php74:
-  # formerly apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu apcu-bc bcmath bz2 cli common curl fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php80:
-  # formerly apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  amd64: ["apcu", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  arm64: ["apcu", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php81:
-  # formerly apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  amd64: ["apcu", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  arm64: ["apcu", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php82:
-  # formerly apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  amd64: ["apcu", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  arm64: ["apcu", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php83:
-  # formerly apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  amd64: ["apcu", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  # formerly apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
-  arm64: ["apcu", "bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
-# 2024-11-22 missing apcu imagick memcached redis uploadprogress xdebug xhprof xmlrpc
-# TODO: installed with pecl: apcu redis uploadprogress xdebug xhprof
+# 2024-11-25 missing amd64: xdebug
+# 2024-11-25 missing arm64: memcached redis xdebug
+# TODO: installed with pecl: memcached redis xdebug
 php84:
-  # formerly bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip
-  amd64: ["bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "xml", "zip"]
-  # formerly bcmath bz2 curl cli common fpm gd intl ldap mbstring mysql opcache pgsql readline soap sqlite3 xml zip
-  arm64: ["bcmath", "bz2", "curl", "cli", "common", "fpm", "gd", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "xml", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
+  # formerly apcu bcmath bz2 cli common curl fpm gd imagick intl ldap mbstring mysql opcache pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]

--- a/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
@@ -2,8 +2,8 @@
 
 set -eu -o pipefail
 
-if [ "$#" -ne 4 ]; then
-  echo "Usage: $0 <PHP_VERSION> <EXTENSION_NAME> <EXTENSION_VERSION> <EXTENSION_FILE>"
+if [ "$#" -ne 4 ] && [ "$#" -ne 5 ] && [ "$#" -ne 6 ]; then
+  echo "Usage: $0 <PHP_VERSION> <EXTENSION_NAME> <EXTENSION_VERSION> <EXTENSION_FILE> [<BUILD_PACKAGES>] [<CONFIGURE_OPTIONS>]"
   exit 1
 fi
 
@@ -16,13 +16,21 @@ EXTENSION_VERSION=$3
 # /usr/lib/php/20210902/xdebug.so
 # The dates from /usr/lib/php/YYYYMMDD/ represent PHP API versions https://unix.stackexchange.com/a/591771
 EXTENSION_FILE=$4
+# Optional build packages
+# Required for some extensions
+BUILD_PACKAGES="${5:-}"
+# Optional configureoptions:
+# How to use --configureoptions https://stackoverflow.com/a/72981491/8097891
+# See https://salsa.debian.org/php-team/pecl for package.xml files with <configureoption>
+# Pass "-i" for interactive mode
+CONFIGURE_OPTIONS="${6:-}"
 
 # install pecl
-if ! command -v pecl >/dev/null 2>&1 || [ "$(dpkg -l | grep "php${PHP_VERSION}-dev")" = "" ]; then
+if ! command -v pecl >/dev/null 2>&1 || [ "$(dpkg -l | grep "php${PHP_VERSION}-dev")" = "" ] || [ "${BUILD_PACKAGES}" != "" ]; then
   echo "Installing pecl to build php${PHP_VERSION}-${EXTENSION_NAME}"
   timeout "${START_SCRIPT_TIMEOUT:-30}" apt-get update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
   timeout "${START_SCRIPT_TIMEOUT:-30}" apt-get update -o Dir::Etc::sourcelist="sources.list.d/debian.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
-  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y build-essential php-pear "php${PHP_VERSION}-dev" || exit $?
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y build-essential php-pear "php${PHP_VERSION}-dev" ${BUILD_PACKAGES} || exit $?
 fi
 
 if [ -f "${EXTENSION_FILE}" ]; then
@@ -39,9 +47,17 @@ fi
 timeout "${START_SCRIPT_TIMEOUT:-30}" pecl channel-update pecl.php.net || true
 
 echo "Building php${PHP_VERSION}-${EXTENSION_NAME}..."
-# TODO: Some extensions ask for configuration options
-# We may want to have some options set, but for now let's accept default settings with yes
-(yes '' | pecl -d php_suffix="${PHP_VERSION}" install -f "${PECL_EXTENSION}" >/dev/null) || true
+
+if [ "${CONFIGURE_OPTIONS}" = "-i" ]; then
+  echo "pecl -d php_suffix=\"${PHP_VERSION}\" install -f \"${PECL_EXTENSION}\""
+  pecl -d php_suffix="${PHP_VERSION}" install -f "${PECL_EXTENSION}" || true
+elif [ "${CONFIGURE_OPTIONS}" != "" ]; then
+  echo "pecl -d php_suffix=\"${PHP_VERSION}\" install --configureoptions=\"${CONFIGURE_OPTIONS}\" -f \"${PECL_EXTENSION}\""
+  pecl -d php_suffix="${PHP_VERSION}" install --configureoptions="${CONFIGURE_OPTIONS}" -f "${PECL_EXTENSION}" || true
+else
+  echo "yes '' | pecl -d php_suffix=\"${PHP_VERSION}\" install -f \"${PECL_EXTENSION}\""
+  (yes '' | pecl -d php_suffix="${PHP_VERSION}" install -f "${PECL_EXTENSION}") || true
+fi
 
 # PECL does not allow to install multiple versions of extension at the same time,
 # use `rm -f /usr/share/php/.registry/.channel.pecl.php.net/extension.reg` to make it forget about another version.
@@ -58,5 +74,12 @@ if [ ! -f "${EXTENSION_FILE}" ]; then
   exit 2
 fi
 
+# Used as an example
+PHP_DEFAULT_VERSION=8.3
 echo "Done building php${PHP_VERSION}-${EXTENSION_NAME} to ${EXTENSION_FILE}"
+echo "If this is a multistage build, add: 'COPY --from=ddev-php-extension-build ${EXTENSION_FILE} ${EXTENSION_FILE}'"
+echo "If there is no /etc/php/${PHP_VERSION}/mods-available/${EXTENSION_NAME}.ini file, add: 'RUN cp /etc/php/${PHP_DEFAULT_VERSION}/mods-available/${EXTENSION_NAME}.ini /etc/php/${PHP_VERSION}/mods-available/${EXTENSION_NAME}.ini'"
+echo "Some extensions have more files than ${EXTENSION_FILE} and /etc/php/${PHP_VERSION}/mods-available/${EXTENSION_NAME}.ini:"
+echo "Check which files should be in php${PHP_VERSION}-${EXTENSION_NAME}: 'dpkg-query -L php${PHP_DEFAULT_VERSION}-${EXTENSION_NAME}'"
+echo "If the extension needs to be enabled, add: 'RUN phpenmod -v ${PHP_VERSION} ${EXTENSION_NAME}'"
 exit 0

--- a/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
@@ -83,3 +83,64 @@ echo "Some extensions have more files than ${EXTENSION_FILE} and /etc/php/${PHP_
 echo "Check which files should be in php${PHP_VERSION}-${EXTENSION_NAME}: 'dpkg-query -L php${PHP_DEFAULT_VERSION}-${EXTENSION_NAME}'"
 echo "If the extension needs to be enabled, add: 'RUN phpenmod -v ${PHP_VERSION} ${EXTENSION_NAME}'"
 exit 0
+
+# Examples:
+#
+# -------------
+# Install php8.4-apcu:
+# To understand what files you need in "COPY --from", use "dpkg-query -L php8.3-apcu"
+# -------------
+# FROM base AS ddev-php-extension-build
+# ...
+# RUN /usr/local/bin/build_php_extension.sh "php8.4" "apcu" "latest" "/usr/lib/php/20240924/apcu.so"
+# ...
+# FROM base AS ddev-php-base
+# ...
+# COPY --from=ddev-php-extension-build /usr/lib/php/20240924/apcu.so /usr/lib/php/20240924/apcu.so
+# COPY --from=ddev-php-extension-build /usr/include/php/20240924/ext/apcu /usr/include/php/20240924/ext/apcu
+# RUN cp /etc/php/8.3/mods-available/apcu.ini /etc/php/8.4/mods-available/apcu.ini
+# RUN phpenmod -v 8.4 apcu
+# ...
+#
+# -------------
+# Install php8.4-memcached:
+# To understand what files you need in "COPY --from", use "dpkg-query -L php8.3-memcached"
+# -------------
+# FROM base AS ddev-php-extension-build
+# ...
+# RUN /usr/local/bin/build_php_extension.sh "php8.4" "memcached" "latest" "/usr/lib/php/20240924/memcached.so" "libmemcached-dev zlib1g-dev libssl-dev"
+# ...
+# FROM base AS ddev-php-base
+# ...
+# COPY --from=ddev-php-extension-build /usr/lib/php/20240924/memcached.so /usr/lib/php/20240924/memcached.so
+# RUN cp /etc/php/8.3/mods-available/memcached.ini /etc/php/8.4/mods-available/memcached.ini
+# RUN phpenmod -v 8.4 memcached
+# ...
+#
+# -------------
+# Install php8.4-redis:
+# To understand what files you need in "COPY --from", use "dpkg-query -L php8.3-redis"
+# -------------
+# FROM base AS ddev-php-extension-build
+# ...
+# RUN /usr/local/bin/build_php_extension.sh "php8.4" "redis" "latest" "/usr/lib/php/20240924/redis.so"
+# ...
+# FROM base AS ddev-php-base
+# ...
+# COPY --from=ddev-php-extension-build /usr/lib/php/20240924/redis.so /usr/lib/php/20240924/redis.so
+# RUN cp /etc/php/8.3/mods-available/redis.ini /etc/php/8.4/mods-available/redis.ini
+# RUN phpenmod -v 8.4 redis
+# ...
+#
+# -------------
+# Install php8.4-xdebug (3.4.0beta1 comes from https://pecl.php.net/package/xdebug):
+# To understand what files you need in "COPY --from", use "dpkg-query -L php8.3-xdebug"
+# -------------
+# FROM base AS ddev-php-extension-build
+# ...
+# RUN /usr/local/bin/build_php_extension.sh "php8.4" "xdebug" "3.4.0beta1" "/usr/lib/php/20240924/xdebug.so"
+# ...
+# FROM base AS ddev-php-base
+# ...
+# COPY --from=ddev-php-extension-build /usr/lib/php/20240924/xdebug.so /usr/lib/php/20240924/xdebug.so
+# ...

--- a/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-if [[ "$#" -ne 4 && "$#" -ne 5 && "$#" -ne 6 ]]; then
+if [ "$#" -ne 4 ] && [ "$#" -ne 5 ] && [ "$#" -ne 6 ]; then
   echo "Usage: $0 <PHP_VERSION> <EXTENSION_NAME> <EXTENSION_VERSION> <EXTENSION_FILE> [<BUILD_PACKAGES>] [<CONFIGURE_OPTIONS>]"
   exit 1
 fi
@@ -26,25 +26,20 @@ BUILD_PACKAGES="${5:-}"
 CONFIGURE_OPTIONS="${6:-}"
 
 # install pecl
-if ! command -v pecl >/dev/null 2>&1 || [[ "$(dpkg -l | grep "php${PHP_VERSION}-dev")" == "" ]] || [[ "${BUILD_PACKAGES}" != "" ]]; then
+if ! command -v pecl >/dev/null 2>&1 || [ "$(dpkg -l | grep "php${PHP_VERSION}-dev")" = "" ] || [ "${BUILD_PACKAGES}" != "" ]; then
   echo "Installing pecl to build php${PHP_VERSION}-${EXTENSION_NAME}"
   timeout "${START_SCRIPT_TIMEOUT:-30}" apt-get update -o Dir::Etc::sourcelist="sources.list.d/php.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
   timeout "${START_SCRIPT_TIMEOUT:-30}" apt-get update -o Dir::Etc::sourcelist="sources.list.d/debian.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
   DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-install-suggests -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y build-essential php-pear "php${PHP_VERSION}-dev" ${BUILD_PACKAGES} || exit $?
 fi
 
-if [[ -f "${EXTENSION_FILE}" ]]; then
+if [ -f "${EXTENSION_FILE}" ]; then
   echo "Moving existing ${EXTENSION_FILE} to ${EXTENSION_FILE}.bak"
   mv "${EXTENSION_FILE}" "${EXTENSION_FILE}.bak"
 fi
 
-if [[ "${EXTENSION_VERSION}" == "latest" ]]; then
+if [ "${EXTENSION_VERSION}" = "latest" ]; then
   PECL_EXTENSION="${EXTENSION_NAME}"
-elif [[ "${EXTENSION_VERSION}" == *"tar.gz" ]]; then
-  # if this is an archive, download it
-  rm -rf "/tmp/${EXTENSION_NAME}" && mkdir "/tmp/${EXTENSION_NAME}"
-  timeout "${START_SCRIPT_TIMEOUT:-30}" curl -fsSL "${EXTENSION_VERSION}" | tar xvz -C "/tmp/${EXTENSION_NAME}" --strip-components=1 -f -
-  PECL_EXTENSION="/tmp/${EXTENSION_NAME}/package.xml"
 else
   PECL_EXTENSION="${EXTENSION_NAME}-${EXTENSION_VERSION}"
 fi
@@ -53,10 +48,10 @@ timeout "${START_SCRIPT_TIMEOUT:-30}" pecl channel-update pecl.php.net || true
 
 echo "Building php${PHP_VERSION}-${EXTENSION_NAME}..."
 
-if [[ "${CONFIGURE_OPTIONS}" == "-i" ]]; then
+if [ "${CONFIGURE_OPTIONS}" = "-i" ]; then
   echo "pecl -d php_suffix=\"${PHP_VERSION}\" install -f \"${PECL_EXTENSION}\""
   pecl -d php_suffix="${PHP_VERSION}" install -f "${PECL_EXTENSION}" || true
-elif [[ "${CONFIGURE_OPTIONS}" != "" ]]; then
+elif [ "${CONFIGURE_OPTIONS}" != "" ]; then
   echo "pecl -d php_suffix=\"${PHP_VERSION}\" install --configureoptions=\"${CONFIGURE_OPTIONS}\" -f \"${PECL_EXTENSION}\""
   pecl -d php_suffix="${PHP_VERSION}" install --configureoptions="${CONFIGURE_OPTIONS}" -f "${PECL_EXTENSION}" || true
 else
@@ -68,10 +63,10 @@ fi
 # use `rm -f /usr/share/php/.registry/.channel.pecl.php.net/extension.reg` to make it forget about another version.
 rm -f "/usr/share/php/.registry/.channel.pecl.php.net/${EXTENSION_NAME}.reg"
 
-if [[ ! -f "${EXTENSION_FILE}" ]]; then
+if [ ! -f "${EXTENSION_FILE}" ]; then
   echo "Failed to build ${EXTENSION_FILE}"
 
-  if [[ -f "${EXTENSION_FILE}.bak" ]]; then
+  if [ -f "${EXTENSION_FILE}.bak" ]; then
     echo "Restoring previously existing file ${EXTENSION_FILE}"
     mv "${EXTENSION_FILE}.bak" "${EXTENSION_FILE}"
   fi

--- a/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-if [ "$#" -ne 4 ] && [ "$#" -ne 5 ] && [ "$#" -ne 6 ]; then
+if [ "$#" -lt 4 ] || [ "$#" -gt 6 ]; then
   echo "Usage: $0 <PHP_VERSION> <EXTENSION_NAME> <EXTENSION_VERSION> <EXTENSION_FILE> [<BUILD_PACKAGES>] [<CONFIGURE_OPTIONS>]"
   exit 1
 fi

--- a/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
@@ -135,6 +135,9 @@ exit 0
 # -------------
 # Install php8.4-xdebug (3.4.0beta1 comes from https://pecl.php.net/package/xdebug):
 # To understand what files you need in "COPY --from", use "dpkg-query -L php8.3-xdebug"
+# When a new PHP version is released, Xdebug may show "PHP Warning: JIT is incompatible with third party extensions"
+# Add "opcache.jit=disable" to xdebug.ini to hide this warning
+# See https://bugs.xdebug.org/view.php?id=2293
 # -------------
 # FROM base AS ddev-php-extension-build
 # ...

--- a/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
+++ b/containers/ddev-php-base/generic-files/usr/local/bin/build_php_extension.sh
@@ -36,12 +36,16 @@ else
   PECL_EXTENSION="${EXTENSION_NAME}-${EXTENSION_VERSION}"
 fi
 
+timeout "${START_SCRIPT_TIMEOUT:-30}" pecl channel-update pecl.php.net || true
+
+echo "Building php${PHP_VERSION}-${EXTENSION_NAME}..."
+# TODO: Some extensions ask for configuration options
+# We may want to have some options set, but for now let's accept default settings with yes
+(yes '' | pecl -d php_suffix="${PHP_VERSION}" install -f "${PECL_EXTENSION}" >/dev/null) || true
+
 # PECL does not allow to install multiple versions of extension at the same time,
 # use `rm -f /usr/share/php/.registry/.channel.pecl.php.net/extension.reg` to make it forget about another version.
-(timeout "${START_SCRIPT_TIMEOUT:-30}" pecl channel-update pecl.php.net && \
-  echo "Building php${PHP_VERSION}-${EXTENSION_NAME}..." && \
-  pecl -d php_suffix="${PHP_VERSION}" install -f "${PECL_EXTENSION}" >/dev/null && \
-  rm -f "/usr/share/php/.registry/.channel.pecl.php.net/${EXTENSION_NAME}.reg") || true
+rm -f "/usr/share/php/.registry/.channel.pecl.php.net/${EXTENSION_NAME}.reg"
 
 if [ ! -f "${EXTENSION_FILE}" ]; then
   echo "Failed to build ${EXTENSION_FILE}"

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20241119_update_v1.24.0_php_default AS ddev-webserver-base
+FROM ddev/ddev-php-base:20241122_stasadev_php_pecl AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -76,13 +76,8 @@
 
   extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
   case ${PHP_VERSION} in
-  8.[123])
+  8.[1234])
     extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
-    ;;
-  8.4)
-    # TODO: Update this list as more become available
-    # 2024-11-25 php8.4 imagick is broken
-    extensions="apcu bcmath bz2 curl gd intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
     ;;
 
   esac

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -15,8 +15,6 @@
 
 @test "enable and disable xdebug for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
     CURRENT_ARCH=$(../get_arch.sh)
-    # TODO: Remove the exclusion below when xdebug is available for 8.4
-    if [ "${PHP_VERSION}" == "8.4" ]; then skip "Skipping because PHP8.4 xdebug not yet available"; fi
     docker exec -t $CONTAINER_NAME enable_xdebug
     if [[ ${PHP_VERSION} != 8.? ]] ; then
       docker exec -t $CONTAINER_NAME php --re xdebug | grep "xdebug.remote_enable"
@@ -31,8 +29,6 @@
 
 @test "enable and disable xhprof for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
     CURRENT_ARCH=$(../get_arch.sh)
-    # TODO: Remove the exclusion below when xhprof is available for 8.4
-    if [ "${PHP_VERSION}" == "8.4" ]; then skip "Skipping because PHP8.4 xhprof not yet available"; fi
 
     docker exec -t $CONTAINER_NAME enable_xhprof
     docker exec -t $CONTAINER_NAME php --re xhprof | grep "xhprof.output_dir"
@@ -85,7 +81,7 @@
     ;;
   8.4)
     # TODO: Update this list as more become available
-    extensions="bcmath bz2 curl gd intl ldap mbstring mysqli pgsql readline soap sqlite3 xml zip"
+    extensions="apcu bcmath bz2 curl gd intl json ldap mbstring mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml zip"
     ;;
 
   esac

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -76,12 +76,8 @@
 
   extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
   case ${PHP_VERSION} in
-  8.[123])
+  8.[1234])
     extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
-    ;;
-  8.4)
-    # TODO: Update this list as more become available
-    extensions="bcmath bz2 curl gd intl json ldap mbstring mysqli pgsql readline soap sqlite3 xml zip"
     ;;
 
   esac

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -76,7 +76,7 @@
 
   extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
   case ${PHP_VERSION} in
-  8.[1234])
+  8.[123])
     extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
     ;;
   8.4)

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -79,6 +79,11 @@
   8.[1234])
     extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
     ;;
+  8.4)
+    # TODO: Update this list as more become available
+    # 2024-11-25 php8.4 imagick is broken
+    extensions="apcu bcmath bz2 curl gd intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
+    ;;
 
   esac
 

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -81,7 +81,7 @@
     ;;
   8.4)
     # TODO: Update this list as more become available
-    extensions="apcu bcmath bz2 curl gd intl json ldap mbstring mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml zip"
+    extensions="bcmath bz2 curl gd intl json ldap mbstring mysqli pgsql readline soap sqlite3 xml zip"
     ;;
 
   esac

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1139,13 +1139,6 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 RUN START_SCRIPT_TIMEOUT=%s /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETARCH}"
 `, app.GetStartScriptTimeout(), app.PHPVersion)
 		}
-		// TODO: installed with pecl: apcu redis uploadprogress xdebug xhprof
-		if app.PHPVersion == nodeps.PHP84 {
-			contents = contents + `
-### DDEV-injected custom-built extensions for PHP8.4
-RUN phpenmod apcu redis uploadprogress
-`
-		}
 	}
 
 	// If there are user pre.Dockerfile* files, insert their contents

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1139,6 +1139,13 @@ RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (userad
 RUN START_SCRIPT_TIMEOUT=%s /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETARCH}"
 `, app.GetStartScriptTimeout(), app.PHPVersion)
 		}
+		// TODO: installed with pecl: apcu redis uploadprogress xdebug xhprof
+		if app.PHPVersion == nodeps.PHP84 {
+			contents = contents + `
+### DDEV-injected custom-built extensions for PHP8.4
+RUN phpenmod apcu redis uploadprogress
+`
+		}
 	}
 
 	// If there are user pre.Dockerfile* files, insert their contents

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -903,13 +903,14 @@ func TestPHPConfig(t *testing.T) {
 		assert.Contains(out, "DOLLAR_DOUBLE_QUOTES=someenv-value $ sign")
 		assert.Contains(out, "DOLLAR_DOUBLE_QUOTES_ESCAPED=$SOMEENV $ sign")
 
-		// Remove the PHP84 exception when it has missing extensions
-		if v != nodeps.PHP84 {
-			// This list does not contain all expected, as php5.6 is missing some, etc.
-			expectedExtensions := []string{"apcu", "bcmath", "bz2", "curl", "gd", "imagick", "intl", "ldap", "mbstring", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xml", "xmlrpc", "zip"}
-			for _, e := range expectedExtensions {
-				assert.Contains(out, fmt.Sprintf(`,%s,`, e))
-			}
+		// This list does not contain all expected, as php5.6 is missing some, etc.
+		expectedExtensions := []string{"apcu", "bcmath", "bz2", "curl", "gd", "imagick", "intl", "ldap", "mbstring", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xml", "xmlrpc", "zip"}
+		// TODO: php8.4 imagick is broken
+		if v == nodeps.PHP84 {
+			expectedExtensions = []string{"apcu", "bcmath", "bz2", "curl", "gd", "intl", "ldap", "mbstring", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xml", "xmlrpc", "zip"}
+		}
+		for _, e := range expectedExtensions {
+			assert.Contains(out, fmt.Sprintf(`,%s,`, e))
 		}
 	}
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -871,7 +871,10 @@ func TestPHPConfig(t *testing.T) {
 
 	for _, v := range phpKeys {
 		app.PHPVersion = v
-		app.WebImageExtraPackages = []string{"php" + app.PHPVersion + "-redis"}
+		// TODO: Remove this exclusion when redis is available for PHP 8.4
+		if app.PHPVersion != nodeps.PHP84 {
+			app.WebImageExtraPackages = []string{"php" + app.PHPVersion + "-redis"}
+		}
 		err = app.Restart()
 		require.NoError(t, err)
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -871,10 +871,7 @@ func TestPHPConfig(t *testing.T) {
 
 	for _, v := range phpKeys {
 		app.PHPVersion = v
-		// TODO: Remove this exclusion when redis is available for PHP 8.4
-		if app.PHPVersion != nodeps.PHP84 {
-			app.WebImageExtraPackages = []string{"php" + app.PHPVersion + "-redis"}
-		}
+		app.WebImageExtraPackages = []string{"php" + app.PHPVersion + "-redis"}
 		err = app.Restart()
 		require.NoError(t, err)
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -905,10 +905,6 @@ func TestPHPConfig(t *testing.T) {
 
 		// This list does not contain all expected, as php5.6 is missing some, etc.
 		expectedExtensions := []string{"apcu", "bcmath", "bz2", "curl", "gd", "imagick", "intl", "ldap", "mbstring", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xml", "xmlrpc", "zip"}
-		// TODO: php8.4 imagick is broken
-		if v == nodeps.PHP84 {
-			expectedExtensions = []string{"apcu", "bcmath", "bz2", "curl", "gd", "intl", "ldap", "mbstring", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xml", "xmlrpc", "zip"}
-		}
 		for _, e := range expectedExtensions {
 			assert.Contains(out, fmt.Sprintf(`,%s,`, e))
 		}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -898,8 +898,7 @@ func TestDdevXdebugEnabled(t *testing.T) {
 	// Default to testing all versions if GOTEST_SHORT is not set
 	phpKeys := nodeps.GetValidPHPVersions()
 
-	// TODO: Remove the PHP 8.4 exclusion when php8.4-xhprof is available
-	exclusions := []string{nodeps.PHP84}
+	exclusions := []string{}
 	phpKeys = util.SubtractSlices(phpKeys, exclusions)
 	sort.Strings(phpKeys)
 
@@ -944,8 +943,8 @@ func TestDdevXdebugEnabled(t *testing.T) {
 			t.Errorf("Aborting Xdebug check for php%s: %v", v, err)
 			continue
 		}
-		// PHP 7.2 through 8.3 get Xdebug 3.0+
-		if nodeps.ArrayContainsString([]string{nodeps.PHP72, nodeps.PHP73, nodeps.PHP74, nodeps.PHP80, nodeps.PHP81, nodeps.PHP82, nodeps.PHP83}, app.PHPVersion) {
+		// PHP 7.2 through 8.4 get Xdebug 3.0+
+		if nodeps.ArrayContainsString([]string{nodeps.PHP72, nodeps.PHP73, nodeps.PHP74, nodeps.PHP80, nodeps.PHP81, nodeps.PHP82, nodeps.PHP83, nodeps.PHP84}, app.PHPVersion) {
 			assert.Contains(stdout, "xdebug.mode => debug,develop => debug,develop", "xdebug is not enabled for %s", v)
 			assert.Contains(stdout, "xdebug.client_host => host.docker.internal => host.docker.internal")
 		} else {
@@ -1060,8 +1059,7 @@ func TestDdevXhprofEnabled(t *testing.T) {
 	// Does not work with php5.6 anyway (SEGV), for resource conservation
 	// skip older unsupported versions
 	phpKeys := nodeps.GetValidPHPVersions()
-	// TODO: Remove the PHP 8.4 exclusion when php8.4-xhprof is available
-	exclusions := []string{nodeps.PHP56, nodeps.PHP84}
+	exclusions := []string{nodeps.PHP56}
 	phpKeys = util.SubtractSlices(phpKeys, exclusions)
 	sort.Strings(phpKeys)
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241125_stasadev_composer" // Note that this can be overridden by make
+var WebTag = "20241122_stasadev_php_pecl" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #6465

## How This PR Solves The Issue

Add extensions from deb.sury.org: apcu imagick memcached redis uploadprogress xhprof xmlrpc
Installed with PECL: xdebug

## Manual Testing Instructions

```
ddev php -m
ddev xdebug
ddev xhprof
ddev php -m
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

The only missing thing is imagick.
