### PR TITLE
refactor: add better message for `ddev composer create` error, fixes #6766

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -127,20 +127,10 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 		// We add the three options to "composer create-project": --no-plugins, --no-scripts, --no-install
 		// These options make the difference between "composer create-project" and "ddev composer create".
 		var createArgs []string
-		// For example, drupal/recommended-project
-		hasVendorPackage := false
 
 		for _, arg := range args {
 			if isValidComposerOption("create-project", arg) {
-				// Skip it if we already have one argument for "composer create-project"
-				if !strings.HasPrefix(arg, "-") && hasVendorPackage {
-					util.Warning("Ignoring argument: %s", arg)
-					continue
-				}
 				createArgs = append(createArgs, arg)
-				if !strings.HasPrefix(arg, "-") {
-					hasVendorPackage = true
-				}
 			}
 		}
 
@@ -184,7 +174,12 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 		})
 
 		if err != nil {
-			util.Failed("failed to create project: %v\nstderr=%v", err, stderr)
+			message := ""
+			if stderr != "" {
+				message = fmt.Sprintf("\nstderr=%v", stderr)
+			}
+			message = message + "\nThe optional <directory> and <version> arguments are not supported by 'ddev composer create'.\nIf you have included them, please remove and try again."
+			util.Failed("failed to create project: %v\n%v", err, message)
 		}
 
 		if len(stdout) > 0 {

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -127,10 +127,19 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 		// We add the three options to "composer create-project": --no-plugins, --no-scripts, --no-install
 		// These options make the difference between "composer create-project" and "ddev composer create".
 		var createArgs []string
+		// For example, drupal/recommended-project
+		hasVendorPackage := false
 
 		for _, arg := range args {
 			if isValidComposerOption("create-project", arg) {
+				// Skip it if we already have one argument for "composer create-project"
+				if !strings.HasPrefix(arg, "-") && hasVendorPackage {
+					continue
+				}
 				createArgs = append(createArgs, arg)
+				if !strings.HasPrefix(arg, "-") {
+					hasVendorPackage = true
+				}
 			}
 		}
 

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -134,6 +134,7 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 			if isValidComposerOption("create-project", arg) {
 				// Skip it if we already have one argument for "composer create-project"
 				if !strings.HasPrefix(arg, "-") && hasVendorPackage {
+					util.Warning("Ignoring argument: %s", arg)
 					continue
 				}
 				createArgs = append(createArgs, arg)


### PR DESCRIPTION
## The Issue

- #6766

## How This PR Solves The Issue

`ddev composer create` works properly only with one argument `<package>`.
We see that any other additional arg provided inside breaks `ddev composer create`.

This change should simply clear up the confusion when people who are familiar with Composer run the following:
```
ddev composer create drupal/recommended-project:^11 .
```
Which is an alternative to this working command:
```
composer create-project drupal/recommended-project:^11 .
```

## Manual Testing Instructions

Run `ddev composer create drupal/recommended-project:^11 .`

See error:

```
failed to create project: exit status 1

The optional <directory> and <version> arguments are not supported by 'ddev composer create'.
If you have included them, please remove and try again.
````

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
