### PR TITLE
build: always use /usr/local/bin/composer, fixes #6771

### DIFF
--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -16,12 +16,6 @@ import (
 )
 
 func TestComposerCreateCmd(t *testing.T) {
-	// Composer 2.8.1 changed the behavior of `composer create-project` for the local `--repository` flag.
-	// This test no longer uses `--repository`, but the original behavior is preserved
-	// with this Packagist package https://github.com/ddev/ddev-test-composer-create
-	// https://github.com/ddev/ddev/pull/6596
-	// https://github.com/composer/composer/issues/12150
-	// https://github.com/ddev/ddev/issues/6586
 	composerVersionForThisTest := nodeps.ComposerDefault
 	//composerVersionForThisTest := "2.8.0"
 

--- a/cmd/ddev/cmd/composer.go
+++ b/cmd/ddev/cmd/composer.go
@@ -109,7 +109,7 @@ func getComposerCompletionFunc(isCreateCommand bool) func(*cobra.Command, []stri
 		stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 			Service: "web",
 			Dir:     app.GetComposerRoot(true, true),
-			RawCmd:  append([]string{"composer", "_complete", "-S2.6.6", "-n", "-sbash", "-c" + current, "-icomposer"}, input...),
+			RawCmd:  append([]string{"composer", "_complete", "-S2.8.3", "-n", "-sbash", "-c" + current, "-icomposer"}, input...),
 			Tty:     false,
 			// Prevent Composer from debugging when Xdebug is enabled
 			Env: []string{"XDEBUG_MODE=off"},

--- a/cmd/ddev/cmd/composer_test.go
+++ b/cmd/ddev/cmd/composer_test.go
@@ -170,18 +170,6 @@ func TestComposerCmdCreateRequireRemoveConfigVersion(t *testing.T) {
 		composerJSON, err := fileutil.ReadFileIntoString(filepath.Join(tmpDir, composerRoot, "composer.json"))
 		assert.NoError(err, "failed to read %v: err=%v", filepath.Join(tmpDir, composerRoot, "composer.json"), err)
 		assert.Contains(composerJSON, "https://packagist.org")
-		// Test a composer binary override using /var/www/html/vendor/bin from $PATH
-		args = []string{"composer", "--version"}
-		out, err = exec.RunHostCommand(DdevBin, args...)
-		assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
-		assert.NotContains(out, "2.8.0")
-		args = []string{"composer", "require", "composer/composer:v2.8.0"}
-		out, err = exec.RunHostCommand(DdevBin, args...)
-		assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
-		args = []string{"composer", "--version"}
-		out, err = exec.RunHostCommand(DdevBin, args...)
-		assert.NoError(err, "failed to run %v: err=%v, output=\n=====\n%s\n=====\n", args, err, out)
-		assert.Contains(out, "2.8.0")
 	}
 }
 

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.bashrc
@@ -15,6 +15,8 @@ case ":$PATH:" in
 esac
 # And don't forget to export the new $PATH.
 export PATH
+# Hide vendor/bin/composer from $PATH.
+export EXECIGNORE="${DDEV_COMPOSER_ROOT:-/var/www/html}/vendor/bin/composer"
 
 # check the window size after each command and, if necessary,
 # update the values of LINES and COLUMNS.

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.nointeractive.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bash.nointeractive.bashrc
@@ -9,6 +9,8 @@ case ":$PATH:" in
 esac
 # And don't forget to export the new $PATH.
 export PATH
+# Hide vendor/bin/composer from $PATH.
+export EXECIGNORE="${DDEV_COMPOSER_ROOT:-/var/www/html}/vendor/bin/composer"
 
 for f in /etc/bashrc/*.bashrc; do
     source $f;

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -94,26 +94,6 @@ Composer version for the web container and the [`ddev composer`](../usage/comman
 | -- | -- | --
 | :octicons-file-directory-16: project | `2` | Can be `2`, `1`, or empty (`""`) for latest major version at container build time.<br><br>Can also be a minor version like `2.2` for the latest release of that branch, an explicit version like `1.0.22`, or a keyword like `stable`, `preview` or `snapshot`. See Composer documentation.
 
-!!!warning "Why is `composer_version` not being used?"
-    If your project's `composer.json` and/or `composer.lock` includes `composer/composer`, that version will take precedence over the one specified by `composer_version`, because `vendor/bin/composer` comes first in the in-container `$PATH`. You have three options:
-
-    1. Update `vendor/bin/composer` in the container:
-    ```shell
-    ddev composer require composer/composer -W
-    ```
-
-    2. Remove `composer/composer` from `composer.json`:
-    ```shell
-    ddev exec /usr/local/bin/composer remove composer/composer
-    ```
-
-    3. Adjust the `$PATH` order:
-    ```shell
-    mkdir -p .ddev/homeadditions/.bashrc.d
-    echo 'export PATH=/usr/local/bin:$PATH' >.ddev/homeadditions/.bashrc.d/path.sh
-    ddev restart
-    ```
-
 ## `corepack_enable`
 
 Whether to `corepack enable` on Node.js configuration.
@@ -498,7 +478,7 @@ Specific docker-compose version for download.
 | -- | -- | --
 | :octicons-globe-16: global | &zwnj; | &zwnj;
 
-If set to `v2.8.0`, for example, it will download and use that version instead of the expected version for docker-compose.
+If set to `v2.8.3`, for example, it will download and use that version instead of the expected version for docker-compose.
 
 !!!warning "Troubleshooting Only!"
     This should only be used in specific cases like troubleshooting. Please don't experiment with it unless directed to do so.

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -95,6 +95,7 @@ Composer version for the web container and the [`ddev composer`](../usage/comman
 | :octicons-file-directory-16: project | `2` | Can be `2`, `1`, or empty (`""`) for latest major version at container build time.<br><br>Can also be a minor version like `2.2` for the latest release of that branch, an explicit version like `1.0.22`, or a keyword like `stable`, `preview` or `snapshot`. See Composer documentation.
 
 !!!tip "How to run Composer from `vendor/bin/composer`?"
+
     ```shell
     ddev exec vendor/bin/composer --version
     # If you have a custom composer_root:

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -94,6 +94,13 @@ Composer version for the web container and the [`ddev composer`](../usage/comman
 | -- | -- | --
 | :octicons-file-directory-16: project | `2` | Can be `2`, `1`, or empty (`""`) for latest major version at container build time.<br><br>Can also be a minor version like `2.2` for the latest release of that branch, an explicit version like `1.0.22`, or a keyword like `stable`, `preview` or `snapshot`. See Composer documentation.
 
+!!!tip "How to run Composer from `vendor/bin/composer`?"
+    ```shell
+    ddev exec vendor/bin/composer --version
+    # If you have a custom composer_root:
+    ddev exec '$DDEV_COMPOSER_ROOT/vendor/bin/composer --version'
+    ```
+
 ## `corepack_enable`
 
 Whether to `corepack enable` on Node.js configuration.

--- a/pkg/ddevapp/composer.go
+++ b/pkg/ddevapp/composer.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mattn/go-isatty"
 	"os"
 	"runtime"
-	"strings"
 )
 
 // Composer runs Composer commands in the web container, managing pre- and post- hooks
@@ -17,23 +16,13 @@ func (app *DdevApp) Composer(args []string) (string, string, error) {
 		return "", "", fmt.Errorf("failed to process pre-composer hooks: %v", err)
 	}
 
-	// Prevent Composer from debugging when Xdebug is enabled
-	env := []string{"XDEBUG_MODE=off"}
-	// Let Composer know which binary to run from the PATH
-	path, _, err := app.Exec(&ExecOpts{
-		Cmd: "echo $PATH",
-	})
-	path = strings.Trim(path, "\n")
-	if err == nil && path != "" {
-		env = append(env, "PATH="+path)
-	}
-
 	stdout, stderr, err := app.Exec(&ExecOpts{
 		Service: "web",
 		Dir:     app.GetComposerRoot(true, true),
 		RawCmd:  append([]string{"composer"}, args...),
 		Tty:     isatty.IsTerminal(os.Stdin.Fd()),
-		Env:     env,
+		// Prevent Composer from debugging when Xdebug is enabled
+		Env: []string{"XDEBUG_MODE=off"},
 	})
 	if err != nil {
 		return stdout, stderr, fmt.Errorf("composer command failed: %v", err)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241119_update_v1.24.0_php_default" // Note that this can be overridden by make
+var WebTag = "20241125_stasadev_composer" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #6771

`vendor/bin/composer` doesn't seem to be what we want, it's confusing and people can't override it with `ddev config --composer-version=<version>`

## How This PR Solves The Issue

Reverts behavior to use `/usr/local/bin/composer`.
Removes `vendor/bin/composer` from `$PATH` inside the container with `EXECIGNORE` https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html

This way it will use `/usr/local/bin/composer` instead of `/var/www/html/vendor/bin/composer` with `ddev ssh`.

(Prior to this PR, `ddev ssh` && `composer -V` had always preferred `vendor/bin/composer` no matter what.)
`vendor/bin/composer` can still be called directly.

## Manual Testing Instructions

https://ddev--6772.org.readthedocs.build/en/6772/users/configuration/config/#composer_version

```
ddev composer require composer/composer:v2.8.0

ddev composer -V
Composer version 2.8.3 2024-11-17 13:13:04

ddev exec composer -V
Composer version 2.8.3 2024-11-17 13:13:04

ddev exec vendor/bin/composer -V       
Composer version 2.8.0 2024-10-02 16:40:29

ddev ssh

composer -V
Composer version 2.8.3 2024-11-17 13:13:04

vendor/bin/composer -V
Composer version 2.8.0 2024-10-02 16:40:29
```

The only downside is that `EXECIGNORE` has no effect on `which`, so it will still show `/var/www/html/vendor/bin/composer`, but will actually use `/usr/local/bin/composer`, so we will have consistency between inside and outside:

```
ddev ssh

which composer
/var/www/html/vendor/bin/composer

which -a composer
/var/www/html/vendor/bin/composer
/usr/local/bin/composer

composer -V
Composer version 2.8.3 2024-11-17 13:13:04

/var/www/html/vendor/bin/composer -V
Composer version 2.8.0 2024-10-02 16:40:29

/usr/local/bin/composer -V
Composer version 2.8.3 2024-11-17 13:13:04
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
