### PR TITLE
docs: add note about XHGui

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -711,6 +711,7 @@ xdebug's
 xtrabackup
 xeyes
 xhprof
+xhgui
 xz'd
 yaml
 yml

--- a/docs/content/users/debugging-profiling/xhprof-profiling.md
+++ b/docs/content/users/debugging-profiling/xhprof-profiling.md
@@ -22,6 +22,12 @@ For example, you may want to add a link to the profile run to the bottom of the 
 
 Another example: you could exclude memory profiling so there are fewer columns to study. Change `xhprof_enable(XHPROF_FLAGS_MEMORY);` to `xhprof_enable();` in `.ddev/xhprof/xhprof_prepend.php` and remove the `#ddev-generated` at the top of the file. See the docs on [xhprof_enable()](https://www.php.net/manual/en/function.xhprof-enable.php).
 
+## XHGui
+
+XHGui is a graphical interface for XHProf profiling data that can store the results in MongoDB or PDO database.
+
+XHGui is a available via the official ddev-xhgui addon. See <https://github.com/ddev/ddev-xhgui> for the latest information.
+
 ## Information Links
 
 * [php.net xhprof](https://www.php.net/manual/en/book.xhprof.php)

--- a/docs/content/users/debugging-profiling/xhprof-profiling.md
+++ b/docs/content/users/debugging-profiling/xhprof-profiling.md
@@ -26,7 +26,7 @@ Another example: you could exclude memory profiling so there are fewer columns t
 
 XHGui is a graphical interface for XHProf profiling data that can store the results in MongoDB or PDO database.
 
-XHGui is a available via the official ddev-xhgui addon. See <https://github.com/ddev/ddev-xhgui> for the latest information.
+XHGui is a available via the official ddev-xhgui add-on. See <https://github.com/ddev/ddev-xhgui> for the latest information.
 
 ## Information Links
 

--- a/docs/content/users/debugging-profiling/xhprof-profiling.md
+++ b/docs/content/users/debugging-profiling/xhprof-profiling.md
@@ -24,7 +24,7 @@ Another example: you could exclude memory profiling so there are fewer columns t
 
 ## XHGui
 
-XHGui is a graphical interface for XHProf profiling data that can store the results in MongoDB or PDO database.
+XHGui is a graphical interface for XHProf profiling data that can store the results in the database.
 
 XHGui is a available via the official ddev-xhgui add-on. See <https://github.com/ddev/ddev-xhgui> for the latest information.
 

--- a/docs/content/users/debugging-profiling/xhprof-profiling.md
+++ b/docs/content/users/debugging-profiling/xhprof-profiling.md
@@ -26,7 +26,7 @@ Another example: you could exclude memory profiling so there are fewer columns t
 
 XHGui is a graphical interface for XHProf profiling data that can store the results in the database.
 
-XHGui is a available via the official ddev-xhgui add-on. See <https://github.com/ddev/ddev-xhgui> for the latest information.
+XHGui is a available via the official [ddev-xhgui add-on](https://github.com/ddev/ddev-xhgui), `ddev add-on get ddev/ddev-xhgui`.
 
 ## Information Links
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

XHprof is great but its UI is minimalist.
WIth the official ddev-xhgui, we should promote a more user-friendly experience.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR adds a reference to the XHGui addon in the relevant profiling section.

Ideally, I would like to see the page inverted; xhgui being the main focus, with xhprof mentioned as fallback.

I consider this PR a bare-minimal approach. I encourage others to make suggestion and changes.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
