### PR TITLE
build: do not run `.buildkite/test.sh` if we want to skip

### DIFF
--- a/.buildkite/macos-colima.yml
+++ b/.buildkite/macos-colima.yml
@@ -1,8 +1,10 @@
 # Colima with qemu and sshfs
 # See https://buildkite.com/ddev/macos-colima/settings/repository
-# Runs on master and PRs, including forked PRs
+# Not currently used.
 
   - command: ".buildkite/test.sh"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
     agents:
       - "os=macos"
       - "colima=true"

--- a/.buildkite/macos-colima_vz.yml
+++ b/.buildkite/macos-colima_vz.yml
@@ -3,6 +3,8 @@
 # Runs on master and PRs, including forked PRs
 
   - command: ".buildkite/test.sh"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
     agents:
       - "os=macos"
       - "colima=true"

--- a/.buildkite/macos-docker-desktop-amd64.yml
+++ b/.buildkite/macos-docker-desktop-amd64.yml
@@ -1,8 +1,10 @@
 # Docker Desktop on macOS amd64
 # See https://buildkite.com/ddev/ddev-macos-amd64-mutagen/settings/repository
-# Runs on master only
+# Runs on master only, not on PRs
 
   - command: ".buildkite/test.sh"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
     agents:
       - "os=macos"
       - "docker-desktop=true"

--- a/.buildkite/macos-docker-desktop-arm64.yml
+++ b/.buildkite/macos-docker-desktop-arm64.yml
@@ -3,6 +3,8 @@
 # Runs on master and PRs, including forked PRs
 
   - command: ".buildkite/test.sh"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
     agents:
       - "os=macos"
       - "docker-desktop=true"

--- a/.buildkite/macos-lima.yml
+++ b/.buildkite/macos-lima.yml
@@ -1,8 +1,10 @@
- # macOS Lima on arm64 with VZ/Virtiofs
- # Experimental, not yet enabled
- # See https://buildkite.com/ddev/macos-lima/settings/repository
+# macOS Lima on arm64 with VZ/Virtiofs
+# See https://buildkite.com/ddev/macos-lima/settings/repository
+# Runs on master and PRs, including forked PRs
 
   - command: ".buildkite/test.sh"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
     agents:
       - "os=macos"
       - "lima=true"

--- a/.buildkite/macos-orbstack.yml
+++ b/.buildkite/macos-orbstack.yml
@@ -3,6 +3,8 @@
 # Runs on master and PRs, including forked PRs
 
   - command: ".buildkite/test.sh"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
     agents:
       - "os=macos"
       - "orbstack=true"

--- a/.buildkite/macos-rancher-desktop.yml
+++ b/.buildkite/macos-rancher-desktop.yml
@@ -1,8 +1,10 @@
 # Rancher Desktop on macOS arm64
 # See https://buildkite.com/ddev/macos-rancher-desktop/settings/repository
-# Runs on ddev/ddev only, not on PRs
+# Runs on master only, not on PRs
 
   - command: ".buildkite/test.sh"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
     agents:
       - "os=macos"
       - "rancher-desktop=true"

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -194,12 +194,8 @@ fi
 unset MUTAGEN_DATA_DIRECTORY
 if [ -f ~/.ddev/bin/mutagen -o -f ~/.ddev/bin/mutagen.exe ]; then
   MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen sync terminate -a || true
-  # This line can be removed when all PRs will not use ~/.ddev/.mdd
-  MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd/ ~/.ddev/bin/mutagen sync terminate -a || true
   MUTAGEN_DATA_DIRECTORY=~/.mutagen ~/.ddev/bin/mutagen daemon stop || true
   MUTAGEN_DATA_DIRECTORY=~/.ddev_mutagen_data_directory/ ~/.ddev/bin/mutagen daemon stop || true
-  # This line can be removed when all PRs will not use ~/.ddev/.mdd
-  MUTAGEN_DATA_DIRECTORY=~/.ddev/.mdd/ ~/.ddev/bin/mutagen daemon stop || true
 fi
 if command -v killall >/dev/null ; then
   killall mutagen || true

--- a/.buildkite/windows10_container.yml
+++ b/.buildkite/windows10_container.yml
@@ -1,6 +1,9 @@
-# Not currently used. This would build and run containers on Windows.
+# Build and run containers on Windows.
+# Not currently used.
 
   - command: ".buildkite/test_containers.cmd"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
     agents:
       - "os=windows"
       - "dockertype=dockerforwindows"

--- a/.buildkite/windows10dockerforwindows.yml
+++ b/.buildkite/windows10dockerforwindows.yml
@@ -1,8 +1,10 @@
 # Windows native with Mutagen, used by ddev-windows-mutagen
 # See https://buildkite.com/ddev/ddev-windows-mutagen/settings/repository
-# Runs on branches/PRs on ddev/ddev only
+# Runs on master and PRs, not including forked PRs
 
   - command: ".buildkite/test.cmd"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
     agents:
       - "os=windows"
       - "dockertype=dockerforwindows"

--- a/.buildkite/wsl2-docker-desktop.yml
+++ b/.buildkite/wsl2-docker-desktop.yml
@@ -1,9 +1,10 @@
 # WSL2 using Docker Desktop
 # See https://buildkite.com/ddev/wsl2-docker-desktop/settings/repository
-# Runs on master only because DD is pretty flaky, so we can't keep up with
-# restarts on PRs
+# Runs on master and PRs, not including forked PRs
 
   - command: ".buildkite/test.sh"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
     agents:
       - "os=wsl2"
       - "architecture=amd64"

--- a/.buildkite/wsl2-docker-inside.yml
+++ b/.buildkite/wsl2-docker-inside.yml
@@ -1,8 +1,10 @@
 # WSL2 with docker-ce (docker native inside WSL2 == Docker inside)
 # See https://buildkite.com/ddev/wsl2-docker-inside/settings/repository
-# Runs on master and all PRs, including forked PRs
+# Runs on master and PRs, including forked PRs
 
   - command: ".buildkite/test.sh"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
     agents:
       - "os=wsl2"
       - "architecture=amd64"
@@ -13,4 +15,3 @@
       BUILDKIT_PROGRESS: plain
       DOCKER_TYPE: "wsl2dockerinside"
     parallelism: 1
-


### PR DESCRIPTION
## The Issue

All builds are waiting for agents to be available, and we have this check:

https://github.com/ddev/ddev/blob/aa269d58ea9b13c4a1ccb51b249e168cde314314/.buildkite/test.sh#L154-L158

It only runs when the agent is available, but we can do it with Buildkite itself without waiting for the agent:

```yaml
if: |
  build.message !~ /\[(skip ci|skip buildkite)\]/
```

## How This PR Solves The Issue

Adds conditional https://buildkite.com/docs/pipelines/configure/conditionals#conditionals-in-steps

## Manual Testing Instructions

Check if `[skip ci]` or `[skip buildkite]` will skip the test from running i.e. remove this endless waiting for the agent.

I mean these tests:

![image](https://github.com/user-attachments/assets/948dc1b5-c88c-4ab6-9977-8f1d51228f09)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
