### PR TITLE
feat: accept all args in `ddev composer create`, add `create-project` alias, fixes #6766

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -329,12 +329,9 @@ func checkForComposerCreateAllowedPaths(app *ddevapp.DdevApp) {
 				return filepath.SkipDir
 			}
 			if !slices.Contains(composerCreateAllowedPaths, checkPath) {
-				return fmt.Errorf("'%s' is not allowed to be present. composer create needs to be run on a clean/empty project with only the following paths: %v - please clean up the project before using 'ddev composer create'", filepath.Join(composerRoot, checkPath), composerCreateAllowedPaths)
+				return fmt.Errorf("'%s' is not allowed to be present. composer create needs to be run on a clean/empty project with only the following paths: %v - please clean up the project before using 'ddev composer create'", filepath.Join(appRoot, checkPath), composerCreateAllowedPaths)
 			}
-			if err != nil {
-				return err
-			}
-			return nil
+			return err
 		})
 	if err != nil {
 		util.Failed("Failed to create project: %v", err)

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -159,7 +159,10 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 			util.Warning("Could not flush Mutagen: %v", err)
 		}
 
-		composerManifest, _ := composer.NewManifest(path.Join(composerRoot, composerDirectoryArg, "composer.json"))
+		composerManifest, err := composer.NewManifest(path.Join(composerRoot, composerDirectoryArg, "composer.json"))
+		if err != nil {
+			util.Failed("Failed to read composer.json: %v", err)
+		}
 		var validRunScriptArgs []string
 
 		if !noScriptsPresent && composerManifest != nil && composerManifest.HasPostRootPackageInstallScript() {
@@ -254,7 +257,10 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 		}
 
 		// Reload composer.json if it has changed in the meantime.
-		composerManifest, _ = composer.NewManifest(path.Join(composerRoot, composerDirectoryArg, "composer.json"))
+		composerManifest, err = composer.NewManifest(path.Join(composerRoot, composerDirectoryArg, "composer.json"))
+		if err != nil {
+			util.Failed("Failed to read composer.json: %v", err)
+		}
 
 		if !noScriptsPresent && composerManifest != nil && composerManifest.HasPostCreateProjectCmdScript() {
 			// Try to run post-create-project-cmd.

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -293,9 +293,9 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 			if len(stderr) > 0 {
 				output.UserErr.Println(stderr)
 			}
-		}
 
-		prepareAppForComposer(app)
+			prepareAppForComposer(app)
+		}
 
 		util.Success("\nddev composer create was successful.")
 

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -25,6 +25,7 @@ var composerDirectoryArg = ""
 var ComposerCreateCmd = &cobra.Command{
 	DisableFlagParsing: true,
 	Use:                "create [args] [flags]",
+	Aliases:            []string{"create-project"},
 	Short:              "Executes 'composer create-project' within the web container with the arguments and flags provided",
 	Long: `Directs basic invocations of 'composer create-project' within the context of the
 web container. Projects will be installed to a temporary directory and moved to
@@ -458,21 +459,6 @@ func isValidComposerOption(app *ddevapp.DdevApp, command string, option string) 
 	return false
 }
 
-// ComposerCreateProjectCmd sends people to the right thing
-// when they try ddev composer create-project
-var ComposerCreateProjectCmd = &cobra.Command{
-	Use:                "create-project",
-	Short:              "Unsupported, use `ddev composer create` instead",
-	DisableFlagParsing: true,
-	Hidden:             true,
-	Run: func(_ *cobra.Command, _ []string) {
-		util.Failed(`'ddev composer create-project' is unsupported. Please use 'ddev composer create'
-for basic project creation or 'ddev ssh' into the web container and execute
-'composer create-project' directly.`)
-	},
-}
-
 func init() {
-	ComposerCmd.AddCommand(ComposerCreateProjectCmd)
 	ComposerCmd.AddCommand(ComposerCreateCmd)
 }

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -360,6 +360,14 @@ func appendAllArgsAtTheEnd(args []string, containerInstallPath string, app *ddev
 				util.Failed("Failed to create project: directory '%s' is outside the project root '%s'", absComposerDirectory, appRoot)
 			}
 			composerDirectoryArg = strings.TrimPrefix(absComposerDirectory, appRoot)
+			if composerDirectoryArg != "" {
+				y := util.Confirm("It's uncommon to install a project in a subdirectory. Continue?")
+				if !y {
+					util.Warning("Aborting: no permission to install in %s", strings.TrimPrefix(composerDirectoryArg, "/"))
+					util.Warning("You can retry using '.' (current directory) as the directory argument.")
+					os.Exit(1)
+				}
+			}
 			composerArgs = append(composerArgs, path.Join(containerInstallPath, composerDirectoryArg))
 		} else {
 			// Else add it without changes

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -154,10 +154,9 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 			util.Failed("Failed to create project: %v", err)
 		}
 
-		// Make sure composer.json is here with Mutagen enabled
-		err = app.MutagenSyncFlush()
-		if err != nil {
-			util.Failed("Failed to flush Mutagen: %v", err)
+		// Flush Mutagen for composer.json
+		if err = app.MutagenSyncFlush(); err != nil {
+			util.Warning("Could not flush Mutagen: %v", err)
 		}
 
 		composerManifest, _ := composer.NewManifest(path.Join(composerRoot, composerDirectoryArg, "composer.json"))
@@ -200,13 +199,11 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 			if len(stderr) > 0 {
 				output.UserErr.Println(stderr)
 			}
-		}
 
-		// Do a spare restart, which will create any needed settings files
-		// and also restart mutagen
-		err = app.Restart()
-		if err != nil {
-			util.Warning("Failed to restart project after composer create: %v", err)
+			// Flush Mutagen after post-root-package-install
+			if err = app.MutagenSyncFlush(); err != nil {
+				util.Warning("Could not flush Mutagen: %v", err)
+			}
 		}
 
 		// If --no-install was not provided by the user, call composer install
@@ -248,6 +245,11 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 
 			if len(stderr) > 0 {
 				output.UserErr.Println(stderr)
+			}
+
+			// Flush Mutagen after install
+			if err = app.MutagenSyncFlush(); err != nil {
+				util.Warning("Could not flush Mutagen: %v", err)
 			}
 		}
 

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -365,15 +365,12 @@ func appendAllArgsAtTheEnd(args []string, containerInstallPath string, app *ddev
 			}
 			composerDirectoryArg = strings.TrimPrefix(absComposerDirectory, appRoot)
 			composerDirectoryArg = strings.TrimPrefix(composerDirectoryArg, "/")
+			// Don't allow to create a project in a subdirectory
 			if composerDirectoryArg != "" {
-				util.Warning("Installing the project in the '%s' subdirectory is uncommon.", composerDirectoryArg)
-				util.Warning("DDEV won't properly apply CMS configuration in a subdirectory.")
-				util.Warning("This will be similar to running 'composer create-project' without DDEV.")
-				if yes := util.Confirm("Continue?"); !yes {
-					util.Warning("Aborting: no permission to install in the '%s' subdirectory", composerDirectoryArg)
-					util.Warning("You can retry using '.' (current directory) as the directory argument.")
-					os.Exit(1)
-				}
+				util.Warning("Installing the project in the '%s' subdirectory is unsupported.", composerDirectoryArg)
+				util.Warning("Replace the subdirectory with a dot '.' and try again.")
+				util.Warning("Or use 'ddev ssh' to run 'composer create-project' in the web container.")
+				os.Exit(1)
 			}
 			composerArgs = append(composerArgs, path.Join(containerInstallPath, composerDirectoryArg))
 		} else {

--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -356,11 +356,12 @@ func appendAllArgsAtTheEnd(args []string, containerInstallPath string, app *ddev
 		}
 		// Add the second arg here, which is a directory
 		if len(composerArgs) == 1 {
-			appRoot := app.GetAbsAppRoot(false)
+			appRoot := util.WindowsPathToCygwinPath(app.GetAbsAppRoot(false))
 			absComposerDirectory, err := filepath.Abs(arg)
 			if err != nil {
 				util.Failed("Failed to get absolute path for '%s': %v", arg, err)
 			}
+			absComposerDirectory = util.WindowsPathToCygwinPath(absComposerDirectory)
 			if !strings.HasPrefix(absComposerDirectory, appRoot) {
 				util.Failed("Failed to create project: directory '%s' is outside the project root '%s'", absComposerDirectory, appRoot)
 			}
@@ -454,6 +455,10 @@ func isValidComposerOption(app *ddevapp.DdevApp, command string, option string) 
 	}
 	// The option is not valid for other commands on any error.
 	return false
+}
+
+func getComposerRoot(app *ddevapp.DdevApp) string {
+	return path.Join(app.GetComposerRoot(true, false), composerDirectoryArg)
 }
 
 func init() {

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -35,7 +35,7 @@ func TestComposerCreateCmd(t *testing.T) {
 				t.Logf("== SKIP drupal6 projects uses a very old php version and composer create is very unlikely to be used")
 				continue
 			}
-			t.Logf("== BEGIN TestComposerCreateCmd for project of type '%s' with docroot  '%s'\n", projectType, docRoot)
+			t.Logf("== BEGIN TestComposerCreateCmd for project of type '%s' with docroot '%s'\n", projectType, docRoot)
 			tmpDir := testcommon.CreateTmpDir(t.Name() + projectType)
 			err = os.Chdir(tmpDir)
 			require.NoError(t, err)
@@ -84,62 +84,56 @@ func TestComposerCreateCmd(t *testing.T) {
 			require.NoError(t, err)
 			require.Contains(t, out, fmt.Sprintf("Composer version %s", composerVersionForThisTest))
 
-			composerCommandTypeCheck := ""
-			args := []string{}
-
+			cmd := ""
 			// These are different conditions to test different composer flag combinations
 			// Conditions for docRoot and projectType are not important here, they are only needed to make the test act different each time
 			if docRoot == "" {
-				composerCommandTypeCheck = "installation with --no-plugins --no-scripts"
+				cmd = "ddev composer create --no-plugins --no-scripts ddev/ddev-test-composer-create"
 				if projectType == nodeps.AppTypePHP {
-					composerCommandTypeCheck = "installation with -vvv --fake-flag"
+					cmd = "ddev composer create --no-install ddev/ddev-test-composer-create custom_directory"
+					composerDirOnHost = filepath.Join(composerDirOnHost, "custom_directory")
+					err = os.MkdirAll(composerDirOnHost, 0755)
+					require.NoError(t, err)
 				}
 			} else {
-				composerCommandTypeCheck = "installation with --no-install --prefer-install auto"
-				if projectType == nodeps.AppTypePHP {
-					composerCommandTypeCheck = "installation with --no-dev --prefer-install=auto"
+				if projectType != nodeps.AppTypePHP {
+					cmd = "ddev composer create ddev/ddev-test-composer-create --prefer-install auto another_directory --no-dev v1.0.0"
+					composerDirOnHost = filepath.Join(composerDirOnHost, "another_directory")
+					err = os.MkdirAll(composerDirOnHost, 0755)
+					require.NoError(t, err)
+				} else {
+					cmd = "ddev composer create -vvv ddev/ddev-test-composer-create --prefer-install=auto --fake-flag ."
 				}
 			}
 
-			t.Logf("Attempting composerCommandTypeCheck='%s' with docroot='%s' projectType=%s", composerCommandTypeCheck, docRoot, projectType)
-			// ddev composer create --no-plugins --no-scripts ddev/ddev-test-composer-create
-			if composerCommandTypeCheck == "installation with --no-plugins --no-scripts" {
-				args = []string{"composer", "create", "--no-plugins", "--no-scripts", "ddev/ddev-test-composer-create"}
-			}
-
-			// ddev composer create -vvv --fake-flag ddev/ddev-test-composer-create
-			if composerCommandTypeCheck == "installation with -vvv --fake-flag" {
-				args = []string{"composer", "create", "-vvv", "--fake-flag", "ddev/ddev-test-composer-create"}
-			}
-
-			// ddev composer create --no-install --prefer-install auto ddev/ddev-test-composer-create
-			if composerCommandTypeCheck == "installation with --no-install --prefer-install auto" {
-				args = []string{"composer", "create", "--no-install", "--prefer-install", "auto", "ddev/ddev-test-composer-create"}
-			}
-
-			// ddev composer create --no-dev --prefer-install=auto ddev/ddev-test-composer-create
-			if composerCommandTypeCheck == "installation with --no-dev --prefer-install=auto" {
-				args = []string{"composer", "create", "--no-dev", "--prefer-install=auto", "ddev/ddev-test-composer-create"}
-			}
+			t.Logf("Attempting cmd='%s' with docroot='%s' composer_root='%s' type='%s'", cmd, docRoot, docRoot, projectType)
+			args := strings.Split(strings.TrimPrefix(cmd, "ddev "), " ")
 
 			// If a file exists in the composer root then composer create should fail
 			file, err := os.Create(filepath.Join(composerDirOnHost, "touch1.txt"))
+			require.NoError(t, err)
 			out, err = exec.RunHostCommand(DdevBin, args...)
 			require.Error(t, err)
 			require.Contains(t, out, "touch1.txt")
 			_ = file.Close()
 			_ = os.Remove(filepath.Join(composerDirOnHost, "touch1.txt"))
 
+			// At this point, custom_directory and another_directory are empty
+			// Remove custom_directory to see if it will be created by Composer
+			// And do not remove another_directory to see if Composer will write to it
+			if strings.Contains(cmd, "custom_directory") {
+				_ = os.RemoveAll(composerDirOnHost)
+			}
+
 			// Test success
 			out, err = exec.RunHostCommand(DdevBin, args...)
-			require.NoError(t, err, "['%s'] failed to run %v: err=%v, output=\n=====\n%s\n=====\n", composerCommandTypeCheck, args, err, out)
+			require.NoError(t, err, "['%s'] failed to run %v: err=%v, output=\n=====\n%s\n=====\n", cmd, args, err, out)
 			require.Contains(t, out, "Created project in ")
 			require.FileExists(t, filepath.Join(composerDirOnHost, "composer.json"))
 
-			// ddev composer create --no-plugins --no-scripts ddev/ddev-test-composer-create
-			if composerCommandTypeCheck == "installation with --no-plugins --no-scripts" {
+			if cmd == "ddev composer create --no-plugins --no-scripts ddev/ddev-test-composer-create" {
 				// Check what was executed or not
-				require.Contains(t, out, "Executing Composer command: [composer create-project --no-plugins --no-scripts ddev/ddev-test-composer-create --no-install")
+				require.Contains(t, out, "Executing Composer command: [composer create-project --no-plugins --no-scripts --no-install ddev/ddev-test-composer-create /tmp/")
 				require.NotContains(t, out, "Executing Composer command: [composer run-script post-root-package-install")
 				require.Contains(t, out, "Executing Composer command: [composer install --no-plugins --no-scripts]")
 				require.NotContains(t, out, "Executing Composer command: [composer run-script post-create-project-cmd")
@@ -152,12 +146,11 @@ func TestComposerCreateCmd(t *testing.T) {
 				require.FileExists(t, filepath.Join(composerDirOnHost, "vendor", "ddev", "ddev-test-composer-require-dev", "composer.json"))
 			}
 
-			// ddev composer create -vvv --fake-flag ddev/ddev-test-composer-create
-			if composerCommandTypeCheck == "installation with -vvv --fake-flag" {
+			if cmd == "ddev composer create -vvv ddev/ddev-test-composer-create --prefer-install=auto --fake-flag ." {
 				// Check what was executed or not
-				require.Contains(t, out, "Executing Composer command: [composer create-project -vvv ddev/ddev-test-composer-create --no-plugins --no-scripts --no-install")
+				require.Contains(t, out, "Executing Composer command: [composer create-project -vvv --prefer-install=auto --no-plugins --no-scripts --no-install ddev/ddev-test-composer-create /tmp/")
 				require.Contains(t, out, "Executing Composer command: [composer run-script post-root-package-install -vvv]")
-				require.Contains(t, out, "Executing Composer command: [composer install -vvv]")
+				require.Contains(t, out, "Executing Composer command: [composer install -vvv --prefer-install=auto]")
 				require.Contains(t, out, "Executing Composer command: [composer run-script post-create-project-cmd -vvv]")
 				require.NotContains(t, out, "--fake-flag")
 				// Check the actual result of executing composer scripts
@@ -169,10 +162,10 @@ func TestComposerCreateCmd(t *testing.T) {
 				require.FileExists(t, filepath.Join(composerDirOnHost, "vendor", "ddev", "ddev-test-composer-require-dev", "composer.json"))
 			}
 
-			// ddev composer create --no-install --prefer-install auto ddev/ddev-test-composer-create
-			if composerCommandTypeCheck == "installation with --no-install --prefer-install auto" {
+			if cmd == "ddev composer create --no-install ddev/ddev-test-composer-create custom_directory" {
 				// Check what was executed or not
-				require.Contains(t, out, "Executing Composer command: [composer create-project --no-install --prefer-install auto ddev/ddev-test-composer-create --no-plugins --no-scripts")
+				require.Contains(t, out, "Executing Composer command: [composer create-project --no-install --no-plugins --no-scripts ddev/ddev-test-composer-create /tmp/")
+				require.Contains(t, out, "custom_directory")
 				require.Contains(t, out, "Executing Composer command: [composer run-script post-root-package-install]")
 				require.NotContains(t, out, "Executing Composer command: [composer install")
 				require.Contains(t, out, "Executing Composer command: [composer run-script post-create-project-cmd]")
@@ -183,12 +176,12 @@ func TestComposerCreateCmd(t *testing.T) {
 				require.NoDirExists(t, filepath.Join(composerDirOnHost, "vendor"))
 			}
 
-			// ddev composer create --no-dev --prefer-install=auto ddev/ddev-test-composer-create
-			if composerCommandTypeCheck == "installation with --no-dev --prefer-install=auto" {
+			if cmd == "ddev composer create ddev/ddev-test-composer-create --prefer-install auto another_directory --no-dev v1.0.0" {
 				// Check what was executed or not
-				require.Contains(t, out, "Executing Composer command: [composer create-project --no-dev --prefer-install=auto ddev/ddev-test-composer-create --no-plugins --no-scripts --no-install")
+				require.Contains(t, out, "Executing Composer command: [composer create-project --prefer-install auto --no-dev --no-plugins --no-scripts --no-install ddev/ddev-test-composer-create /tmp/")
+				require.Contains(t, out, "another_directory v1.0.0")
 				require.Contains(t, out, "Executing Composer command: [composer run-script post-root-package-install --no-dev]")
-				require.Contains(t, out, "Executing Composer command: [composer install --no-dev --prefer-install=auto]")
+				require.Contains(t, out, "Executing Composer command: [composer install --prefer-install auto --no-dev]")
 				require.Contains(t, out, "Executing Composer command: [composer run-script post-create-project-cmd --no-dev]")
 				// Check the actual result of executing composer scripts
 				require.FileExists(t, filepath.Join(composerDirOnHost, "created-by-post-root-package-install"))

--- a/cmd/ddev/cmd/composer-create_test.go
+++ b/cmd/ddev/cmd/composer-create_test.go
@@ -90,17 +90,11 @@ func TestComposerCreateCmd(t *testing.T) {
 			if docRoot == "" {
 				cmd = "ddev composer create --no-plugins --no-scripts ddev/ddev-test-composer-create"
 				if projectType == nodeps.AppTypePHP {
-					cmd = "ddev composer create --no-install ddev/ddev-test-composer-create custom_directory"
-					composerDirOnHost = filepath.Join(composerDirOnHost, "custom_directory")
-					err = os.MkdirAll(composerDirOnHost, 0755)
-					require.NoError(t, err)
+					cmd = "ddev composer create --no-install ddev/ddev-test-composer-create ."
 				}
 			} else {
 				if projectType != nodeps.AppTypePHP {
-					cmd = "ddev composer create ddev/ddev-test-composer-create --prefer-install auto another_directory --no-dev v1.0.0"
-					composerDirOnHost = filepath.Join(composerDirOnHost, "another_directory")
-					err = os.MkdirAll(composerDirOnHost, 0755)
-					require.NoError(t, err)
+					cmd = "ddev composer create ddev/ddev-test-composer-create --prefer-install auto . --no-dev v1.0.0"
 				} else {
 					cmd = "ddev composer create -vvv ddev/ddev-test-composer-create --prefer-install=auto --fake-flag ."
 				}
@@ -117,13 +111,6 @@ func TestComposerCreateCmd(t *testing.T) {
 			require.Contains(t, out, "touch1.txt")
 			_ = file.Close()
 			_ = os.Remove(filepath.Join(composerDirOnHost, "touch1.txt"))
-
-			// At this point, custom_directory and another_directory are empty
-			// Remove custom_directory to see if it will be created by Composer
-			// And do not remove another_directory to see if Composer will write to it
-			if strings.Contains(cmd, "custom_directory") {
-				_ = os.RemoveAll(composerDirOnHost)
-			}
 
 			// Test success
 			out, err = exec.RunHostCommand(DdevBin, args...)
@@ -162,10 +149,9 @@ func TestComposerCreateCmd(t *testing.T) {
 				require.FileExists(t, filepath.Join(composerDirOnHost, "vendor", "ddev", "ddev-test-composer-require-dev", "composer.json"))
 			}
 
-			if cmd == "ddev composer create --no-install ddev/ddev-test-composer-create custom_directory" {
+			if cmd == "ddev composer create --no-install ddev/ddev-test-composer-create ." {
 				// Check what was executed or not
 				require.Contains(t, out, "Executing Composer command: [composer create-project --no-install --no-plugins --no-scripts ddev/ddev-test-composer-create /tmp/")
-				require.Contains(t, out, "custom_directory")
 				require.Contains(t, out, "Executing Composer command: [composer run-script post-root-package-install]")
 				require.NotContains(t, out, "Executing Composer command: [composer install")
 				require.Contains(t, out, "Executing Composer command: [composer run-script post-create-project-cmd]")
@@ -176,10 +162,10 @@ func TestComposerCreateCmd(t *testing.T) {
 				require.NoDirExists(t, filepath.Join(composerDirOnHost, "vendor"))
 			}
 
-			if cmd == "ddev composer create ddev/ddev-test-composer-create --prefer-install auto another_directory --no-dev v1.0.0" {
+			if cmd == "ddev composer create ddev/ddev-test-composer-create --prefer-install auto . --no-dev v1.0.0" {
 				// Check what was executed or not
 				require.Contains(t, out, "Executing Composer command: [composer create-project --prefer-install auto --no-dev --no-plugins --no-scripts --no-install ddev/ddev-test-composer-create /tmp/")
-				require.Contains(t, out, "another_directory v1.0.0")
+				require.Contains(t, out, "v1.0.0")
 				require.Contains(t, out, "Executing Composer command: [composer run-script post-root-package-install --no-dev]")
 				require.Contains(t, out, "Executing Composer command: [composer install --prefer-install auto --no-dev]")
 				require.Contains(t, out, "Executing Composer command: [composer run-script post-create-project-cmd --no-dev]")

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -392,19 +392,10 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	// Ensure that the docroot exists
 	if docrootRelPathArg != "" {
 		app.Docroot = docrootRelPathArg
-		if _, err = os.Stat(docrootRelPathArg); os.IsNotExist(err) {
-			var docrootAbsPath string
-			docrootAbsPath, err = filepath.Abs(app.Docroot)
-			if err != nil {
-				util.Failed("Could not create docroot at %s: %v", docrootRelPathArg, err)
-			}
-
-			if err = os.MkdirAll(docrootAbsPath, 0755); err != nil {
-				util.Failed("Could not create docroot at %s: %v", docrootAbsPath, err)
-			}
-
-			util.Success("Created docroot directory at %s", docrootAbsPath)
+		if err = app.CreateDocroot(); err != nil {
+			util.Failed("Could not create docroot at %s: %v", app.Docroot, err)
 		}
+		util.Success("Created docroot directory at %s", app.GetAbsDocroot(false))
 	} else if !cmd.Flags().Changed("docroot") {
 		app.Docroot = ddevapp.DiscoverDefaultDocroot(app)
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -490,6 +490,22 @@ func (app DdevApp) GetAbsDocroot(inContainer bool) string {
 	return filepath.Join(app.GetAbsAppRoot(false), app.GetDocroot())
 }
 
+// CreateDocroot creates the docroot directory for DDEV app if it doesn't exist
+func (app DdevApp) CreateDocroot() error {
+	if app.Docroot == "" {
+		return nil
+	}
+	docrootAbsPath, err := filepath.Abs(app.Docroot)
+	if err != nil {
+		return err
+	}
+	if !fileutil.IsDirectory(docrootAbsPath) {
+		err := os.MkdirAll(docrootAbsPath, 0755)
+		return err
+	}
+	return nil
+}
+
 // GetAbsAppRoot returns the absolute path to the project root on the host or if
 // inContainer is set to true in the container.
 func (app DdevApp) GetAbsAppRoot(inContainer bool) string {


### PR DESCRIPTION
## The Issue

- #6766

## How This PR Solves The Issue

- Makes `ddev composer create` fully compatible (except for installing into a subdirectory) with `composer create-project`.
- Removes two `ddev restart` from `ddev composer create` (to speed up the process).
- Creates `docroot` (if it doesn't exist) inside `ddev composer create`, and runs `ddev restart` in this case.
- Adds `ddev composer create-project` alias to `ddev composer create`.
- Moves some logic from the main function to smaller functions.

## Manual Testing Instructions

Use quickstarts https://ddev.readthedocs.io/en/latest/users/quickstart/

Use `[<package> [<directory> [<version>]]]` syntax when running `ddev composer create`

```
# Works:
ddev composer create laravel/laravel
ddev composer create laravel/laravel .
ddev composer create laravel/laravel . "~11"
ddev composer create laravel/laravel . "^11"

# Fails:
ddev composer create laravel/laravel ..
ddev composer create laravel/laravel test
ddev composer create laravel/laravel test2 v11.0.0
```

The tests provide more complex scenarios.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

Replacing `ddev composer create vendor/package` => `ddev composer create-project vendor/package .` in the documentation should only be done after a few releases, when most DDEV users have this feature.