### PR TITLE
test: use Wordpress for testing Windows

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -7,6 +7,8 @@ export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
 
 # GOTEST_SHORT=16 means drupal11
 export GOTEST_SHORT=16
+if [ ${OSTYPE:-unknown}  = "msys" ]; then export GOTEST_SHORT=true; fi
+
 export DDEV_SKIP_NODEJS_TEST=true
 
 export DOCKER_SCAN_SUGGEST=false

--- a/pkg/ddevapp/hardened_test.go
+++ b/pkg/ddevapp/hardened_test.go
@@ -20,8 +20,8 @@ import (
 
 // TestHardenedStart makes sure we can do a start and basic use with hardened images
 func TestHardenedStart(t *testing.T) {
-	if nodeps.IsAppleSilicon() && dockerutil.IsDockerDesktop() {
-		t.Skip("Skipping TestHardenedStart on Mac M1 because of useless Docker Desktop failures to connect")
+	if nodeps.IsAppleSilicon() && (dockerutil.IsLima() || dockerutil.IsDockerDesktop()) {
+		t.Skip("Skipping TestHardenedStart on Apple Silicon because of useless failures to connect")
 	}
 
 	assert := asrt.New(t)


### PR DESCRIPTION

## The Issue

Since we started using drupal11 for buildkite tests, the Windows test is failing TestDdevImportFiles because the files tarball contains a directory with a `:` in it, which is odd. 

`archive extraction of C:\Users\testbot\.ddev\testcache\tarballs\8b642a48_files.tgz failed err=mkdir C:\Users\testbot\.ddev\testcache\8b642a48_files.tgz\php\twig\664a9388692f2_umami:card_w8ADP9JF68172bQEf0cJMFdyV: The directory name is invalid.`
 

## How This PR Solves The Issue

On Windows, don't bother with Drupal 11, use WordPress instead.

