### PR TITLE
build: bump Xdebug to 3.4.0 and docker-compose to v2.31.0

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -55,7 +55,7 @@ SHELL ["/bin/bash", "-c"]
 RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
 # TODO: php8.4-xdebug installed with PECL
-RUN /usr/local/bin/build_php_extension.sh "php8.4" "xdebug" "3.4.0beta1" "/usr/lib/php/20240924/xdebug.so"
+RUN /usr/local/bin/build_php_extension.sh "php8.4" "xdebug" "latest" "/usr/lib/php/20240924/xdebug.so"
 #END ddev-php-extension-build
 
 ### ---------------------------ddev-php-base--------------------------------------

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20241122_stasadev_php_pecl AS ddev-webserver-base
+FROM ddev/ddev-php-base:20241128_stasadev_xdebug AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241122_stasadev_php_pecl" // Note that this can be overridden by make
+var WebTag = "20241128_stasadev_xdebug" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
@@ -41,4 +41,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.18.0"
 
-const RequiredDockerComposeVersionDefault = "v2.30.3"
+const RequiredDockerComposeVersionDefault = "v2.31.0"


### PR DESCRIPTION
## The Issue

Xdebug has a stable release https://xdebug.org/announcements/2024-11-28
And `docker-compose` v2.31.0 is out https://github.com/docker/compose/releases/tag/v2.31.0

## How This PR Solves The Issue

Bumps it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
