### PR TITLE
fix: add validation to web_extra_exposed_ports, fixes #6417

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -530,8 +530,10 @@ func (app *DdevApp) ValidateConfig() error {
 			return fmt.Errorf("the %s project has the same 'http_port: %d' and 'https_port: %d' for 'name: %s' in web_extra_exposed_ports", app.Name, extraPort.HTTPPort, extraPort.HTTPSPort, extraPort.Name)
 		}
 
-		if extraPort.WebContainerPort == 0 || extraPort.HTTPPort == 0 || extraPort.HTTPSPort == 0 {
-			return fmt.Errorf("the %s project has an invalid empty port ('container_port: %d', 'http_port: %d', 'https_port: %d') for 'name: %s' in web_extra_exposed_ports", app.Name, extraPort.WebContainerPort, extraPort.HTTPPort, extraPort.HTTPSPort, extraPort.Name)
+		for name, port := range map[string]int{"container_port": extraPort.WebContainerPort, "http_port": extraPort.HTTPPort, "https_port": extraPort.HTTPSPort} {
+			if err := dockerutil.ValidatePort(port); err != nil {
+				return fmt.Errorf("the %s project has an invalid '%s: %d' for 'name: %s' in web_extra_exposed_ports", app.Name, name, port, extraPort.Name)
+			}
 		}
 
 		if usedWebContainerPorts[extraPort.WebContainerPort] {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -557,9 +557,9 @@ func TestConfigValidate(t *testing.T) {
 			app.DdevVersionConstraint = tc.versionConstraint
 			err = app.ValidateConfig()
 			if tc.error == "" {
-				assert.NoError(err)
+				require.NoError(t, err)
 			} else {
-				assert.Error(err)
+				require.Error(t, err)
 				assert.Contains(err.Error(), tc.error)
 			}
 			app.DdevVersionConstraint = ""
@@ -569,80 +569,139 @@ func TestConfigValidate(t *testing.T) {
 
 	app.Name = "Invalid!"
 	err = app.ValidateConfig()
-	assert.Error(err)
+	require.Error(t, err)
 	assert.Contains(err.Error(), "not a valid project name")
 
 	app.Name = appName
 	app.Type = "potato"
 	err = app.ValidateConfig()
-	assert.Error(err)
+	require.Error(t, err)
 	assert.Contains(err.Error(), "invalid app type")
 
 	app.Type = appType
 	app.PHPVersion = "1.1"
 	err = app.ValidateConfig()
-	assert.Error(err)
+	require.Error(t, err)
 	assert.Contains(err.Error(), "unsupported PHP")
 
 	app.PHPVersion = nodeps.PHPDefault
 	app.WebserverType = "server"
 	err = app.ValidateConfig()
-	assert.Error(err)
+	require.Error(t, err)
 	assert.Contains(err.Error(), "unsupported webserver type")
 
 	app.WebserverType = nodeps.WebserverDefault
 	app.AdditionalHostnames = []string{"good", "b@d"}
 	err = app.ValidateConfig()
-	assert.Error(err)
-	if err != nil {
-		assert.Contains(err.Error(), "invalid hostname")
-	}
+	require.Error(t, err)
+	assert.Contains(err.Error(), "invalid hostname")
 
 	app.AdditionalHostnames = []string{}
+	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
+		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
+		{Name: "foo", WebContainerPort: 4000, HTTPPort: 4000, HTTPSPort: 4001},
+	}
+	err = app.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(err.Error(), "duplicate 'name: foo'")
+
+	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
+		{Name: "foo", WebContainerPort: 0, HTTPPort: 3000, HTTPSPort: 3001},
+	}
+	err = app.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(err.Error(), "invalid empty port")
+
+	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
+		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3000},
+	}
+	err = app.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(err.Error(), "same 'http_port: 3000' and 'https_port: 3000'")
+
+	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
+		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
+		{Name: "bar", WebContainerPort: 3000, HTTPPort: 4000, HTTPSPort: 4001},
+	}
+	err = app.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(err.Error(), "duplicate 'container_port: 3000'")
+
+	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
+		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
+		{Name: "bar", WebContainerPort: 4000, HTTPPort: 3000, HTTPSPort: 4001},
+	}
+	err = app.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(err.Error(), "duplicate 'http_port: 3000'")
+
+	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
+		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
+		{Name: "bar", WebContainerPort: 4000, HTTPPort: 4000, HTTPSPort: 3001},
+	}
+	err = app.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(err.Error(), "duplicate 'https_port: 3001'")
+
+	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
+		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
+		{Name: "bar", WebContainerPort: 4000, HTTPPort: 3001, HTTPSPort: 4001},
+	}
+	err = app.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(err.Error(), "duplicate 'http_port: 3001'")
+
+	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
+		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
+		{Name: "bar", WebContainerPort: 4000, HTTPPort: 4000, HTTPSPort: 3000},
+	}
+	err = app.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(err.Error(), "duplicate 'https_port: 3000'")
+
+	app.WebExtraExposedPorts = nil
 	app.AdditionalFQDNs = []string{"good.com", "b@d.com"}
 	err = app.ValidateConfig()
-	assert.Error(err)
-	if err != nil {
-		assert.Contains(err.Error(), "invalid hostname")
-	}
+	require.Error(t, err)
+	assert.Contains(err.Error(), "invalid hostname")
 
 	app.AdditionalFQDNs = []string{}
 	// Timezone validation isn't possible on Windows.
 	if runtime.GOOS != "windows" {
 		app.Timezone = "xxx"
 		err = app.ValidateConfig()
-		assert.Error(err)
+		require.Error(t, err)
 		app.Timezone = "America/Chicago"
 		err = app.ValidateConfig()
-		assert.NoError(err)
+		require.NoError(t, err)
 	}
 
 	// Make sure that wildcards work
 	app.AdditionalHostnames = []string{"x", "*.any"}
 	err = app.ValidateConfig()
-	assert.NoError(err)
+	require.NoError(t, err)
 	err = app.WriteConfig()
-	assert.NoError(err)
+	require.NoError(t, err)
 	// This seems to completely fail on git-bash/Windows/mutagen. Hard to figure out why.
 	// Traditional Windows is not a very high priority
 	// This apparently started failing with Docker Desktop 4.19.0
 	// rfay 2023-05-02
 	if runtime.GOOS != "windows" {
 		err = app.Start()
-		assert.NoError(err)
+		require.NoError(t, err)
 		err = app.MutagenSyncFlush()
-		assert.NoError(err)
+		require.NoError(t, err)
 		staticURI := site.Safe200URIWithExpectation.URI
 		_, _, err = testcommon.GetLocalHTTPResponse(t, "http://x.ddev.site/"+staticURI)
-		assert.NoError(err)
+		require.NoError(t, err)
 		_, _, err = testcommon.GetLocalHTTPResponse(t, "http://somethjingrandom.any.ddev.site/"+staticURI)
-		assert.NoError(err)
+		require.NoError(t, err)
 	}
 
 	// Make sure that a bare "*" in the additional_hostnames does *not* work
 	app.AdditionalHostnames = []string{"x", "*"}
 	err = app.ValidateConfig()
-	assert.Error(err)
+	require.Error(t, err)
 }
 
 // TestWriteConfig tests writing config values to file

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -597,6 +597,7 @@ func TestConfigValidate(t *testing.T) {
 	assert.Contains(err.Error(), "invalid hostname")
 
 	app.AdditionalHostnames = []string{}
+	// web_extra_exposed_ports shouldn't allow duplicate names for different config items
 	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
 		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
 		{Name: "foo", WebContainerPort: 4000, HTTPPort: 4000, HTTPSPort: 4001},
@@ -604,21 +605,28 @@ func TestConfigValidate(t *testing.T) {
 	err = app.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(err.Error(), "duplicate 'name: foo'")
-
+	// web_extra_exposed_ports shouldn't allow not specified ports (for example, container_port: 0)
 	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
 		{Name: "foo", WebContainerPort: 0, HTTPPort: 3000, HTTPSPort: 3001},
 	}
 	err = app.ValidateConfig()
 	require.Error(t, err)
-	assert.Contains(err.Error(), "invalid empty port")
-
+	assert.Contains(err.Error(), "invalid 'container_port: 0'")
+	// web_extra_exposed_ports shouldn't allow wrong ports (for example, container_port: 123456)
+	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
+		{Name: "foo", WebContainerPort: 123456, HTTPPort: 3000, HTTPSPort: 3001},
+	}
+	err = app.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(err.Error(), "invalid 'container_port: 123456'")
+	// web_extra_exposed_ports shouldn't allow the same port for the same config item http_port/https_port
 	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
 		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3000},
 	}
 	err = app.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(err.Error(), "same 'http_port: 3000' and 'https_port: 3000'")
-
+	// web_extra_exposed_ports shouldn't allow the same port for different config items container_port/container_port
 	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
 		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
 		{Name: "bar", WebContainerPort: 3000, HTTPPort: 4000, HTTPSPort: 4001},
@@ -626,7 +634,7 @@ func TestConfigValidate(t *testing.T) {
 	err = app.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(err.Error(), "duplicate 'container_port: 3000'")
-
+	// web_extra_exposed_ports shouldn't allow the same port for different config items http_port/http_port
 	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
 		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
 		{Name: "bar", WebContainerPort: 4000, HTTPPort: 3000, HTTPSPort: 4001},
@@ -634,7 +642,7 @@ func TestConfigValidate(t *testing.T) {
 	err = app.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(err.Error(), "duplicate 'http_port: 3000'")
-
+	// web_extra_exposed_ports shouldn't allow the same port for different config items https_port/https_port
 	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
 		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
 		{Name: "bar", WebContainerPort: 4000, HTTPPort: 4000, HTTPSPort: 3001},
@@ -642,7 +650,7 @@ func TestConfigValidate(t *testing.T) {
 	err = app.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(err.Error(), "duplicate 'https_port: 3001'")
-
+	// web_extra_exposed_ports shouldn't allow the same port for the same config item container_port/http_port
 	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
 		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
 		{Name: "bar", WebContainerPort: 4000, HTTPPort: 3001, HTTPSPort: 4001},
@@ -650,7 +658,7 @@ func TestConfigValidate(t *testing.T) {
 	err = app.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(err.Error(), "duplicate 'http_port: 3001'")
-
+	// web_extra_exposed_ports shouldn't allow the same port for different config items container_port/https_port
 	app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
 		{Name: "foo", WebContainerPort: 3000, HTTPPort: 3000, HTTPSPort: 3001},
 		{Name: "bar", WebContainerPort: 4000, HTTPPort: 4000, HTTPSPort: 3000},

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1970,3 +1970,24 @@ func CanRunWithoutDocker() bool {
 	}
 	return false
 }
+
+// ValidatePort checks that the given port is valid (in range 1-65535)
+func ValidatePort(port interface{}) error {
+	var dockerPort int
+	switch v := port.(type) {
+	case int:
+		dockerPort = v
+	case string:
+		var err error
+		dockerPort, err = strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid port: %v", port)
+		}
+	default:
+		return fmt.Errorf("unsupported port type: %T", port)
+	}
+	if dockerPort < 1 || dockerPort > 65535 {
+		return fmt.Errorf("invalid port: %v", port)
+	}
+	return nil
+}


### PR DESCRIPTION
## The Issue

- #6417

## How This PR Solves The Issue

Adds validation to web_extra_exposed_ports.

Also I searched for a way to validate Traefik, and found only these:

- https://github.com/aminiun/traefik-validator
- https://github.com/otto-de/traefik-config-validator

Both of these projects seem to be unmaintained, and they are unofficial, I decided not to use them.
(Update: `traefik healthcheck --ping` seems to be working fine.)

## Manual Testing Instructions

Add this to `.ddev/config.yaml`:

```yaml
web_extra_exposed_ports:
  - name: example1
    container_port: 3000
    http_port: 3000
    https_port: 3001
  - name: example2
    container_port: 4000
    http_port: 4000
    https_port: 4001
```

Break the config above with duplicate ports, and run `ddev start`, for example:

```yaml
web_extra_exposed_ports:
  - name: example1
    container_port: 3000
    http_port: 3000
    https_port: 3001
  - name: example2
    container_port: 4000
    http_port: 4000
    https_port: 3001 # <= duplicate
```

```
$ ddev start
Failed to start project(s): the d11 project has a duplicate 'https_port: 3001' for 'name: example2' in web_extra_exposed_ports
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
