### PR TITLE
fix: do not run project validation for `ddevcd`, for #6743

### DIFF
--- a/cmd/ddev/cmd/debug-cd.go
+++ b/cmd/ddev/cmd/debug-cd.go
@@ -64,10 +64,13 @@ var DebugCdCmd = &cobra.Command{
 				util.Failed("This command only takes one argument: project-name")
 			}
 			projectName := args[0]
+			originalRunValidateConfig := ddevapp.RunValidateConfig
+			ddevapp.RunValidateConfig = false
 			app, err := ddevapp.GetActiveApp(projectName)
 			if err != nil {
 				util.Failed("Failed to find path for project: %v", err)
 			}
+			ddevapp.RunValidateConfig = originalRunValidateConfig
 			output.UserOut.Println(app.AppRoot)
 			return
 		}

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
@@ -8,11 +8,11 @@
 # "ddevcd project-name" to cd into the project directory.
 
 function ddevcd
-  cd (DDEV_VERBOSE=false ddev debug cd "$argv[1]" --get-approot)
+  cd (DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd "$argv[1]" --get-approot)
 end
 
 function __ddevcd_autocomplete
-  DDEV_VERBOSE=false ddev debug cd --list 2>/dev/null
+  DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd --list 2>/dev/null
 end
 
 complete -c ddevcd -f -a "(__ddevcd_autocomplete)"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
@@ -12,7 +12,7 @@ function ddevcd
 end
 
 function __ddevcd_autocomplete
-  DDEV_VERBOSE=false ddev debug cd --list
+  DDEV_VERBOSE=false ddev debug cd --list 2>/dev/null
 end
 
 complete -c ddevcd -f -a "(__ddevcd_autocomplete)"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
@@ -10,7 +10,7 @@ ddevcd() {
 }
 
 _ddevcd_autocomplete() {
-  COMPREPLY=( $(compgen -W "$(DDEV_VERBOSE=false ddev debug cd --list)" -- "${COMP_WORDS[COMP_CWORD]}") )
+  COMPREPLY=( $(compgen -W "$(DDEV_VERBOSE=false ddev debug cd --list 2>/dev/null)" -- "${COMP_WORDS[COMP_CWORD]}") )
 }
 
 complete -F _ddevcd_autocomplete ddevcd

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
@@ -6,11 +6,11 @@
 # "ddevcd project-name" to cd into the project directory.
 
 ddevcd() {
-  cd "$(DDEV_VERBOSE=false ddev debug cd "$1" --get-approot)"
+  cd "$(DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd "$1" --get-approot)"
 }
 
 _ddevcd_autocomplete() {
-  COMPREPLY=( $(compgen -W "$(DDEV_VERBOSE=false ddev debug cd --list 2>/dev/null)" -- "${COMP_WORDS[COMP_CWORD]}") )
+  COMPREPLY=( $(compgen -W "$(DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd --list 2>/dev/null)" -- "${COMP_WORDS[COMP_CWORD]}") )
 }
 
 complete -F _ddevcd_autocomplete ddevcd

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.zsh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.zsh
@@ -6,11 +6,11 @@
 # "ddevcd project-name" to cd into the project directory.
 
 ddevcd() {
-  cd "$(DDEV_VERBOSE=false ddev debug cd "$1" --get-approot)"
+  cd "$(DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd "$1" --get-approot)"
 }
 
 _ddevcd_autocomplete() {
-  compadd $(DDEV_VERBOSE=false ddev debug cd --list 2>/dev/null)
+  compadd $(DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd --list 2>/dev/null)
 }
 
 compdef _ddevcd_autocomplete ddevcd

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.zsh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.zsh
@@ -10,7 +10,7 @@ ddevcd() {
 }
 
 _ddevcd_autocomplete() {
-  compadd $(DDEV_VERBOSE=false ddev debug cd --list)
+  compadd $(DDEV_VERBOSE=false ddev debug cd --list 2>/dev/null)
 }
 
 compdef _ddevcd_autocomplete ddevcd

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -835,9 +835,9 @@ func IsInternetActive() bool {
 
 	// Internet is active (active == true) if both err and ctx.Err() were nil
 	active := err == nil && ctx.Err() == nil
-	if os.Getenv("DDEV_DEBUG") != "" {
+	if DdevDebug {
 		if active == false {
-			output.UserErr.Println("Internet connection not detected, DNS may not work, see https://ddev.readthedocs.io/en/stable/users/usage/faq/ for info.")
+			output.UserErr.Println("Internet connection not detected, DNS may not work, see https://ddev.readthedocs.io/en/stable/users/usage/offline/ for info.")
 		}
 		output.UserErr.Debugf("IsInternetActive(): err=%v ctx.Err()=%v addrs=%v IsInternetactive==%v, testURL=%v internet_detection_timeout_ms=%dms\n", err, ctx.Err(), addrs, active, testURL, DdevGlobalConfig.InternetDetectionTimeout)
 	}


### PR DESCRIPTION
## The Issue

- #6743

I noticed that I couldn't `ddevcd` to a project with a broken configuration, but DDEV should allow it.

## How This PR Solves The Issue

- Disables project validation for `ddevcd`.
- Hides `stderr` from completions for `ddevcd`, I noticed that when I press `<TAB>` when `ddevcd` is available and when I use v1.23.5, it shows an error, but I didn't even press enter.

## Manual Testing Instructions

Break project config and run `ddevcd`:

```
ddevcd d11

# break it, for example replace type with `type: blablabla`
vim .ddev/config.yaml

cd ~

# it should `cd` to `d11` project
ddevcd d11
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
