### PR TITLE
test: Exclude Colima from TestHardenedStart [skip ci]

### DIFF
--- a/pkg/ddevapp/hardened_test.go
+++ b/pkg/ddevapp/hardened_test.go
@@ -20,8 +20,8 @@ import (
 
 // TestHardenedStart makes sure we can do a start and basic use with hardened images
 func TestHardenedStart(t *testing.T) {
-	if nodeps.IsAppleSilicon() && (dockerutil.IsLima() || dockerutil.IsDockerDesktop()) {
-		t.Skip("Skipping TestHardenedStart on Apple Silicon because of useless failures to connect")
+	if dockerutil.IsLima() || dockerutil.IsColima() || (nodeps.IsAppleSilicon() && dockerutil.IsDockerDesktop()) {
+		t.Skip("Skipping TestHardenedStart because of useless failures to connect on some platforms")
 	}
 
 	assert := asrt.New(t)


### PR DESCRIPTION

## The Issue

I excluded Lima from TestHardenedStart for random test failures. We have adequate coverage of this and it's normally used only on Linux anyway. Now it will still be tested on OrbStack. 

## How This PR Solves The Issue

Add test exclusion

