### PR TITLE
fix: Change traefik log level to ERROR and limit accessLog

### DIFF
--- a/containers/ddev-traefik-router/test/testdata/.static_config.yaml
+++ b/containers/ddev-traefik-router/test/testdata/.static_config.yaml
@@ -1,8 +1,11 @@
 #ddev-generated
 
 log:
-  level: DEBUG
-accesslog: { }
+  level: ERROR
+accessLog:
+  filters:
+    statusCodes:
+      - "300-510"
 
 api:
   dashboard: true
@@ -23,16 +26,16 @@ ping:
 entryPoints:
   traefik:
     address: ":10999"
-  
+
   http-443:
     address: ":443"
-  
+
   http-80:
     address: ":80"
-  
+
   http-8025:
     address: ":8025"
-  
+
   http-8026:
     address: ":8026"
-  
+

--- a/docs/content/users/extend/traefik-router.md
+++ b/docs/content/users/extend/traefik-router.md
@@ -20,10 +20,10 @@ All Traefik configuration uses the *file* provider, not the *Docker* provider. E
 Static configuration is automatically generated in the `~/.ddev/traefik` directory. "Static" configuration means Traefik configuration which is only read when the router is started.
 
 * `.static_config.yaml` (a hidden file) is the configuration that gets used. It is not to be edited; it is generated from DDEV's base configuration while merging any files named `static_config.*.yaml`. It is read on router startup, and does not change until the router starts again (normally after `ddev poweroff`).
-* Additional static configuration may be added by adding `static_config.*.yaml` files, which will be merged into the generated `.static_config.yaml`. For example, a `static_config.logs.yaml` might override logging configuration, a `static_config.plugin.yaml` might contain external Traefik plugins, or a `static_config.dnschallenge.yaml` might provide configuration for additional `certificatesResolvers`. Merging is done with an **override** strategy, meaning that the final file in alphanumeric sort to touch a particular element of the YAML structure wins.
+* Additional static configuration may be added by adding `static_config.*.yaml` files, which will be merged into the generated `.static_config.yaml`. For example, a `static_config.loglevel.yaml` might override logging configuration, a `static_config.plugin.yaml` might contain external Traefik plugins, or a `static_config.dnschallenge.yaml` might provide configuration for additional `certificatesResolvers`. Merging is done with an **override** strategy, meaning that the final file in alphanumeric sort to touch a particular element of the YAML structure wins.
     Some examples of `static_config.*.yaml` files are:
 
-    * `static_config.logs.yaml`:
+    * `static_config.loglevel.yaml`:
 
         ```yaml
         # Enable extensive error and access logging
@@ -79,7 +79,7 @@ Project-specific configuration is automatically generated in the project’s `.d
 ## Debugging Traefik Routing
 
 Traefik provides a dynamic description of its configuration you can visit at `http://localhost:10999`.
-When things seem to be going wrong, run [`ddev poweroff`](../usage/commands.md#poweroff) and then start your project again by running [`ddev start`](../usage/commands.md#start). Examine the router’s logs to see what the Traefik daemon is doing (or failing at) by running `docker logs ddev-router` or `docker logs -f ddev-router`. The Traefik logs are set to a minimal set by default, but you can enable much more extensive logging and access logs with a `static_config.logs.yaml` as described above.
+When things seem to be going wrong, run [`ddev poweroff`](../usage/commands.md#poweroff) and then start your project again by running [`ddev start`](../usage/commands.md#start). Examine the router’s logs to see what the Traefik daemon is doing (or failing at) by running `docker logs ddev-router` or `docker logs -f ddev-router`. The Traefik logs are set to a minimal set by default, but you can enable much more extensive logging and access logs with a `static_config.loglevel.yaml` as described above.
 
 ## Router `docker-compose` Customization
 

--- a/docs/content/users/extend/traefik-router.md
+++ b/docs/content/users/extend/traefik-router.md
@@ -25,23 +25,23 @@ Static configuration is automatically generated in the `~/.ddev/traefik` directo
 
     * `static_config.logs.yaml`:
 
-      ```yaml
-      # Enable extensive error and access logging
-      log:
-        level: DEBUG
-      accessLog: {}
-      ```
+        ```yaml
+        # Enable extensive error and access logging
+        log:
+          level: DEBUG
+        accessLog: {}
+        ```
 
     * `static_config.cloudflare.yaml`:
 
-      ```yaml
-      certificatesResolvers:
-        acme-dnsChallenge:
-          acme:
-            email: admin@example.com
-            dnsChallenge:
-              provider: cloudflare
-      ```
+        ```yaml
+        certificatesResolvers:
+          acme-dnsChallenge:
+            acme:
+              email: admin@example.com
+              dnsChallenge:
+                provider: cloudflare
+        ```
 
     * `static_config.fail2ban.yaml`
 
@@ -51,7 +51,7 @@ Static configuration is automatically generated in the `~/.ddev/traefik` directo
             fail2ban:
               moduleName: "github.com/tomMoulard/fail2ban"
               version: "v0.8.1"
-      ```
+        ```
 
 * `certs/default_cert.*` files are the default DDEV-generated certificates, normally created by `mkcert`.
 * `config/default_config.yaml` contains global *dynamic* configuration, including pointers to the default certificates. It is possible to add other Traefik configuration in the `config` directory, which will apply to all projects. For example, a `config/router_middlewares.yaml` file might provide middleware implementations that would apply to all projects.

--- a/docs/content/users/extend/traefik-router.md
+++ b/docs/content/users/extend/traefik-router.md
@@ -29,7 +29,9 @@ Static configuration is automatically generated in the `~/.ddev/traefik` directo
         # Enable extensive error and access logging
         log:
           level: DEBUG
-        accessLog: {}
+        accessLog:
+          filters:
+            statusCodes: {}
         ```
 
     * `static_config.cloudflare.yaml`:

--- a/docs/content/users/extend/traefik-router.md
+++ b/docs/content/users/extend/traefik-router.md
@@ -20,8 +20,18 @@ All Traefik configuration uses the *file* provider, not the *Docker* provider. E
 Static configuration is automatically generated in the `~/.ddev/traefik` directory. "Static" configuration means Traefik configuration which is only read when the router is started.
 
 * `.static_config.yaml` (a hidden file) is the configuration that gets used. It is not to be edited; it is generated from DDEV's base configuration while merging any files named `static_config.*.yaml`. It is read on router startup, and does not change until the router starts again (normally after `ddev poweroff`).
-* Additional static configuration may be added by adding `static_config.*.yaml` files, which will be merged into the generated `.static_config.yaml`. For example, a `static_config.plugin.yaml` might contain external Traefik plugins, or a `static_config.dnschallenge.yaml` might provide configuration for additional `certificatesResolvers`. Merging is done with an **override** strategy, meaning that the final file in alphanumeric sort to touch a particular element of the YAML structure wins.
+* Additional static configuration may be added by adding `static_config.*.yaml` files, which will be merged into the generated `.static_config.yaml`. For example, a `static_config.logs.yaml` might override logging configuration, a `static_config.plugin.yaml` might contain external Traefik plugins, or a `static_config.dnschallenge.yaml` might provide configuration for additional `certificatesResolvers`. Merging is done with an **override** strategy, meaning that the final file in alphanumeric sort to touch a particular element of the YAML structure wins.
     Some examples of `static_config.*.yaml` files are:
+
+    * `static_config.logs.yaml`:
+
+      ```yaml
+      # Enable extensive error and access logging
+      log:
+        level: DEBUG
+      accessLog: {}
+      ```
+
     * `static_config.cloudflare.yaml`:
 
       ```yaml
@@ -67,7 +77,7 @@ Project-specific configuration is automatically generated in the project’s `.d
 ## Debugging Traefik Routing
 
 Traefik provides a dynamic description of its configuration you can visit at `http://localhost:10999`.
-When things seem to be going wrong, run [`ddev poweroff`](../usage/commands.md#poweroff) and then start your project again by running [`ddev start`](../usage/commands.md#start). Examine the router’s logs to see what the Traefik daemon is doing (or failing at) by running `docker logs ddev-router` or `docker logs -f ddev-router`.
+When things seem to be going wrong, run [`ddev poweroff`](../usage/commands.md#poweroff) and then start your project again by running [`ddev start`](../usage/commands.md#start). Examine the router’s logs to see what the Traefik daemon is doing (or failing at) by running `docker logs ddev-router` or `docker logs -f ddev-router`. The Traefik logs are set to a minimal set by default, but you can enable much more extensive logging and access logs with a `static_config.logs.yaml` as described above.
 
 ## Router `docker-compose` Customization
 

--- a/pkg/ddevapp/global_dotddev_assets/traefik/README.md
+++ b/pkg/ddevapp/global_dotddev_assets/traefik/README.md
@@ -18,4 +18,4 @@ adding `static_config.*.yaml` files. For example, a `static_config.test.yaml` wi
 
 would be appended to the `.static_config.yaml`
 
-A more significant example (a Traefik plugin) is shown in the `static_config.fail2ban.yaml.example`.
+More significant examples are increasing log verbosity (`static_config.loglevel.yaml.example`) and a Traefik plugin in the `static_config.fail2ban.yaml.example`.

--- a/pkg/ddevapp/global_dotddev_assets/traefik/static_config.loglevel.yaml.example
+++ b/pkg/ddevapp/global_dotddev_assets/traefik/static_config.loglevel.yaml.example
@@ -1,0 +1,8 @@
+#ddev-generated
+
+# Enable extensive error and access logging
+log:
+  level: DEBUG
+accessLog:
+  filters:
+    statusCodes: {}

--- a/pkg/ddevapp/testdata/TestTraefikStaticConfig/extraPlugin/expectation.yaml
+++ b/pkg/ddevapp/testdata/TestTraefikStaticConfig/extraPlugin/expectation.yaml
@@ -1,4 +1,9 @@
-accesslog: {}
+log:
+  level: ERROR
+accessLog:
+  filters:
+    statusCodes:
+      - "300-510"
 api:
   dashboard: true
   insecure: true
@@ -28,8 +33,6 @@ experimental:
       version: v0.8.1
 global:
   sendAnonymousUsage: false
-log:
-  level: DEBUG
 ping:
   entryPoint: traefik
 providers:

--- a/pkg/ddevapp/testdata/TestTraefikStaticConfig/logChange/expectation.yaml
+++ b/pkg/ddevapp/testdata/TestTraefikStaticConfig/logChange/expectation.yaml
@@ -1,4 +1,3 @@
-accesslog: {}
 api:
   dashboard: true
   insecure: true
@@ -24,7 +23,11 @@ entryPoints:
 global:
   sendAnonymousUsage: false
 log:
-  level: INFO
+  level: DEBUG
+accessLog:
+  filters:
+    statusCodes:
+      - "300-510"
 ping:
   entryPoint: traefik
 providers:

--- a/pkg/ddevapp/testdata/TestTraefikStaticConfig/logChange/static_config.log_change.yaml
+++ b/pkg/ddevapp/testdata/TestTraefikStaticConfig/logChange/static_config.log_change.yaml
@@ -1,2 +1,2 @@
 log:
-  level: INFO
+  level: DEBUG

--- a/pkg/ddevapp/traefik_static_config_template.yaml
+++ b/pkg/ddevapp/traefik_static_config_template.yaml
@@ -5,8 +5,11 @@
 # regularly to update `entryPoints`
 
 log:
-  level: DEBUG
-accesslog: { }
+  level: ERROR
+accessLog:
+  filters:
+    statusCodes:
+      - "300-510"
 
 api:
   dashboard: true


### PR DESCRIPTION
## The Issue

In reviewing 
- #6787

I noted that we had loads of log info we don't need, and way too much (access logs) in general.

## How This PR Solves The Issue

* Change the default log level to ERROR (affects traefik events like config fails, etc)
* Change access log to only "unusual" things like 300-510

## Manual Testing Instructions

Try `docker logs -f ddev-router` with a number of configurations.

Rendered Traefik configuration updates in https://ddev--6794.org.readthedocs.build/en/6794/users/extend/traefik-router/#traefik-static-configuration

