### PR TITLE
build: bump images to v1.24.0 for release

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -56,8 +56,6 @@ ARG XDEBUG_MODE=off
 ### See https://github.com/ddev/ddev/issues/6159
 RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
-# TODO: php8.4-xdebug installed with PECL
-RUN /usr/local/bin/build_php_extension.sh "php8.4" "xdebug" "latest" "/usr/lib/php/20240924/xdebug.so"
 #END ddev-php-extension-build
 
 ### ---------------------------ddev-php-base--------------------------------------
@@ -122,8 +120,6 @@ ARG XDEBUG_MODE=off
 RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug
 COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
 COPY --from=ddev-php-extension-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
-# TODO: php8.4-xdebug installed with PECL
-COPY --from=ddev-php-extension-build /usr/lib/php/20240924/xdebug.so /usr/lib/php/20240924/xdebug.so
 #END ddev-php-extension-build
 RUN phpdismod xhprof xdebug
 RUN apt-get -qq autoremove -y

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.4/mods-available/xdebug.ini
@@ -5,7 +5,5 @@ xdebug.client_port=9003
 xdebug.mode=debug,develop
 xdebug.start_with_request=yes
 xdebug.max_nesting_level=1000
-# TODO: php8.4-xdebug installed with PECL
 # See https://bugs.xdebug.org/view.php?id=2293
-# Remove this once php8.4-xdebug is ready
 opcache.jit=disable

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -38,8 +38,6 @@ php83:
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
   arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
-# 2024-11-26 missing: xdebug
-# TODO: php8.4-xdebug installed with PECL
 php84:
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xhprof", "xml", "xmlrpc", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20241126_rfay_bump_drush AS ddev-webserver-base
+FROM ddev/ddev-php-base:v1.24.0 AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,21 +11,21 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241126_rfay_bump_drush" // Note that this can be overridden by make
+var WebTag = "v1.24.0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20241109_use_bin_env"
+var BaseDBTag = "v1.24.0"
 
-const TraefikRouterImage = "ddev/ddev-traefik-router:20241128_stasadev_traefik"
+const TraefikRouterImage = "ddev/ddev-traefik-router:v1.24.0"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "20241115_rfay_ssh_agent_update"
+var SSHAuthTag = "v1.24.0"
 
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION
## The Issue

It's time to build new images for v1.24.0.
Xdebug 3.4.0 is available in deb.sury.org.

## How This PR Solves The Issue

This PR is based on

- #6787

Rebase it after that one is pulled.

---

I didn't remove `opcache.jit=disable` from `/etc/php/8.4/mods-available/xdebug.ini` because it still shows this warning: 
```
PHP Warning:  JIT is incompatible with third party extensions that override zend_execute_ex(). JIT disabled. in Unknown on line 0
```

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
