### PR TITLE
test: Skip TestWriteableFilesDirectory on Rancher [skip ci]

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2420,6 +2420,9 @@ func TestDdevFullSiteSetup(t *testing.T) {
 // TestWriteableFilesDirectory tests to make sure that files created on host are writable on container
 // and files created in container are correct user on host.
 func TestWriteableFilesDirectory(t *testing.T) {
+	if dockerutil.IsRancherDesktop() {
+		t.Skip("Skipping on Rancher Desktop, sshfs is too slow")
+	}
 	origDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}
 	site := TestSites[0]


### PR DESCRIPTION

## The Issue

Rancher Desktop's sshfs filesystem is too slow for TestWriteableFilesDirectory. Exclude it from test.