### PR TITLE
fix: improve `ddev debug test`

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -160,7 +160,7 @@ docker ps -a
 if command -v mkcert >/dev/null; then
   header "mkcert information"
   which -a mkcert
-  echo "JAVA_HOME=${JAVA_HOME:-}"
+  echo "CAROOT=${CAROOT:-} WSLENV=${WSLENV:-} JAVA_HOME=${JAVA_HOME:-}"
   mkcert -CAROOT
   ls -l "$(mkcert -CAROOT)"
 fi


### PR DESCRIPTION
## The Issue

`RUN timeout 120 apt-get update || true` has too high timeout, people with network troubles may think that `ddev debug test` is stuck.

## How This PR Solves The Issue

- Lowers the timeout.
- Adds info about `$JAVA_HOME` for mkcert (so we know if there is something wrong with it).
- Prints curl location (I remember there were some issues with curl installed with homebrew or other place).
- Shows customizations in `.ddev/traefik/config`.

## Manual Testing Instructions

Run

```
ddev debug test
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
