### PR TITLE
build: extend default locales with es_ES, es_MX, pt_PT and pt_BR

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -17,7 +17,7 @@ ENV CAROOT=/mnt/ddev-global-cache/mkcert
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG BUILDPLATFORM
-ARG DEFAULT_LOCALES="en_CA.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\nen_GB.UTF-8 UTF-8\nde_DE.UTF-8 UTF-8\nde_AT.UTF-8 UTF-8\nfr_CA.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nja_JP.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\n"
+ARG DEFAULT_LOCALES="en_CA.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\nen_GB.UTF-8 UTF-8\nes_ES.UTF-8 UTF-8\nes_MX.UTF-8 UTF-8\nde_DE.UTF-8 UTF-8\nde_AT.UTF-8 UTF-8\nfr_CA.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nja_JP.UTF-8 UTF-8\npt_PT.UTF-8 UTF-8\npt_BR.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\n"
 
 ADD ddev-webserver-etc-skel /
 RUN /sbin/mkhomedir_helper www-data

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -80,7 +80,7 @@ RUN chmod 666 /etc/php/${DDEV_PHP_VERSION}/mods-available/xdebug.ini
 ## Adding Locales
 
 The web image ships by default with a small number of locales, which work for most usages, including
-`en_CA`, `en_US`, `en_GB`, `de_DE`, `de_AT`, `fr_CA`, `fr_FR`, `ja_JP`, and `ru_RU`.
+`en_CA`, `en_US`, `en_GB`, `es_ES`, `es_MX`, `pt_BR`, `pt_PT`, `de_DE`, `de_AT`, `fr_CA`, `fr_FR`, `ja_JP`, and `ru_RU`.
 
 If you need other locales, you can install all of them by adding `locales-all` to your `webimage_extra_packages`. For example, in `.ddev/config.yaml`:
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.24.0" // Note that this can be overridden by make
+var WebTag = "20241204_jonhattan_locales" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

Extend default locales with some spanish and portuguese variants.

## Manual Testing Instructions

```
$ docker build containers/ddev-webserver -t ddev-locales
...
$ docker run --rm ddev-locales locale -a
C
C.utf8
POSIX
de_AT.utf8
de_DE.utf8
en_CA.utf8
en_GB.utf8
en_US.utf8
es_ES.utf8
es_MX.utf8
fr_CA.utf8
fr_FR.utf8
ja_JP.utf8
pt_BR.utf8
pt_PT.utf8
ru_RU.utf8
```

## Automated Testing Overview

This area is not tested afaik.

## Release/Deployment Notes

No.