### PR TITLE
fix: show system databases in DBeaver, add more Windows binaries, fixes #6730, fixes #6654

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -5,7 +5,7 @@
 ## Usage: dbeaver
 ## Example: "ddev dbeaver [db] [user]"
 ## OSTypes: darwin,linux,wsl2
-## HostBinaryExists: /mnt/c/Program Files/dbeaver/dbeaver.exe,/Applications/DBeaver.app,/usr/bin/dbeaver,/usr/bin/dbeaver-ce,/usr/bin/dbeaver-le,/usr/bin/dbeaver-ue,/usr/bin/dbeaver-ee,/var/lib/flatpak/exports/bin/io.dbeaver.DBeaverCommunity,/snap/bin/dbeaver-ce
+## HostBinaryExists: /Applications/DBeaver.app,/usr/bin/dbeaver,/usr/bin/dbeaver-ce,/usr/bin/dbeaver-le,/usr/bin/dbeaver-ue,/usr/bin/dbeaver-ee,/var/lib/flatpak/exports/bin/io.dbeaver.DBeaverCommunity,/snap/bin/dbeaver-ce,/mnt/c/Program Files/DBeaver/dbeaver.exe,/mnt/c/Program Files/DBeaverLite/dbeaver.exe,/mnt/c/Program Files/DBeaverUltimate/dbeaver.exe,/mnt/c/Program Files/DBeaverEE/dbeaver.exe
 
 if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
@@ -29,7 +29,7 @@ if [ "${type}" = "postgres" ]; then
 fi
 
 # See: https://dbeaver.com/docs/wiki/Command-Line/#connection-parameters
-CONNECTION="name=ddev-${DDEV_PROJECT}|driver=${type}|database=${database}|user=${user}|password=${user}|savePassword=true|host=127.0.0.1|port=${DDEV_HOST_DB_PORT}|openConsole=true|folder=DDEV"
+CONNECTION="name=ddev-${DDEV_PROJECT}|driver=${type}|database=${database}|user=${user}|password=${user}|savePassword=true|showSystemObjects=true|showUtilityObjects=true|host=127.0.0.1|port=${DDEV_HOST_DB_PORT}|openConsole=true|folder=DDEV"
 
 case $OSTYPE in
   "linux-gnu")
@@ -38,7 +38,7 @@ case $OSTYPE in
       /usr/bin/dbeaver{,-ce,-le,-ue,-ee}
       /var/lib/flatpak/exports/bin/io.dbeaver.DBeaverCommunity
       /snap/bin/dbeaver-ce
-      '/mnt/c/Program Files/dbeaver/dbeaver.exe'
+      '/mnt/c/Program Files/DBeaver'{,Lite,Ultimate,EE}'/dbeaver.exe'
     )
     for binary in "${BINARIES[@]}"; do
       if [ -x "$binary" ]; then


### PR DESCRIPTION
## The Issue

- #6730
- #6654

## How This PR Solves The Issue

For #6730, I added `showSystemObjects=true|showUtilityObjects=true`, see https://github.com/dbeaver/dbeaver/issues/4440#issuecomment-431572518

For #6654, I installed different DBeaver versions on Windows to get the correct path.

## Manual Testing Instructions

```
ddev dbeaver
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
