### PR TITLE
fix: move pre.Dockerfile injection before installing PHP

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1201,15 +1201,6 @@ ARG DDEV_PHP_VERSION
 ARG DDEV_DATABASE
 RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || useradd  -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username" || useradd -l -m -s "/bin/bash" --comment '' $username )
 `
-	// If our PHP version is not already provided in the ddev-webserver, add it now
-	if strings.Contains(fullpath, "webimageBuild") {
-		if _, ok := nodeps.PreinstalledPHPVersions[app.PHPVersion]; !ok {
-			contents = contents + fmt.Sprintf(`
-### DDEV-injected addition of not-preinstalled PHP version
-RUN START_SCRIPT_TIMEOUT=%s /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETARCH}"
-`, app.GetStartScriptTimeout(), app.PHPVersion)
-		}
-	}
 
 	// If there are user pre.Dockerfile* files, insert their contents
 	if userDockerfilePath != "" {
@@ -1225,6 +1216,16 @@ RUN START_SCRIPT_TIMEOUT=%s /usr/local/bin/install_php_extensions.sh "php%s" "${
 			}
 
 			contents = contents + "\n\n### From user Dockerfile " + file + ":\n" + userContents
+		}
+	}
+
+	// If our PHP version is not already provided in the ddev-webserver, add it now
+	if strings.Contains(fullpath, "webimageBuild") {
+		if _, ok := nodeps.PreinstalledPHPVersions[app.PHPVersion]; !ok {
+			contents = contents + fmt.Sprintf(`
+### DDEV-injected addition of not-preinstalled PHP version
+RUN START_SCRIPT_TIMEOUT=%s /usr/local/bin/install_php_extensions.sh "php%s" "${TARGETARCH}"
+`, app.GetStartScriptTimeout(), app.PHPVersion)
 		}
 	}
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #6808 

This issue is only present when in an environment that requires custom SSL certificates.

`pre.Dockerfile` is injected too late, making it impossible to install older PHP versions, even when custom SSL certificates are added via the `pre.Dockerfile`

## How This PR Solves The Issue

This PR changes the generated `.ddev/webimageBuild/Dockerfile` by moving the contents of the `pre.Dockerfile` before the commands that install PHP. If we add custom SSL certificates with the `pre.Dockerfile`, then the next command that installs the requested PHP version will work.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

I didn't add any tests, mainly because of a lack of time.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

N/A
