### PR TITLE
fix: don't copy Dockerfiles to `*imageBuild` folder, add examples to assets, fixes #6757

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -101,14 +101,16 @@ These files’ content will be inserted into the constructed Dockerfile for each
 
 For certain use cases, you might need to add directives very early on the Dockerfile like proxy settings or SSL termination. You can use `pre.` variants for this that are inserted *before* everything else:
 
+* `.ddev/web-build/pre.Dockerfile`
 * `.ddev/web-build/pre.Dockerfile.*`
+* `.ddev/db-build/pre.Dockerfile`
 * `.ddev/db-build/pre.Dockerfile.*`
 
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with [`ddev debug rebuild`](../usage/commands.md#debug-rebuild).
 
-Examples of possible Dockerfiles are `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example`, created in your project when you run [`ddev config`](../usage/commands.md#config).
+Examples of possible Dockerfiles are `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example`, created in your project when you run [`ddev start`](../usage/commands.md#start).
 
-You can use the `.ddev/*-build` directory as the Docker “context” directory as well. So for example, if a file named `README.txt` exists in `.ddev/web-build`, you can use `ADD README.txt /` in the Dockerfile.
+You can use the `.ddev/*-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/web-build`, you can use `ADD file.txt /` in the Dockerfile.
 
 An example web image `.ddev/web-build/Dockerfile` might be:
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -101,10 +101,10 @@ These files’ content will be inserted into the constructed Dockerfile for each
 
 For certain use cases, you might need to add directives very early on the Dockerfile like proxy settings or SSL termination. You can use `pre.` variants for this that are inserted *before* everything else:
 
-* `.ddev/web-build/pre.Dockerfile`
 * `.ddev/web-build/pre.Dockerfile.*`
-* `.ddev/db-build/pre.Dockerfile`
+* `.ddev/web-build/pre.Dockerfile`
 * `.ddev/db-build/pre.Dockerfile.*`
+* `.ddev/db-build/pre.Dockerfile`
 
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with [`ddev debug rebuild`](../usage/commands.md#debug-rebuild).
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -108,7 +108,7 @@ For certain use cases, you might need to add directives very early on the Docker
 
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with [`ddev debug rebuild`](../usage/commands.md#debug-rebuild).
 
-Examples of possible Dockerfiles are `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example`, created in your project when you run [`ddev start`](../usage/commands.md#start).
+Examples of possible Dockerfiles are `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example`, created in your project when you run [`ddev config`](../usage/commands.md#config).
 
 You can use the `.ddev/*-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/web-build`, you can use `ADD file.txt /` in the Dockerfile.
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -257,6 +257,12 @@ func (app *DdevApp) WriteConfig() error {
 		return err
 	}
 
+	// The .ddev directory may still need to be populated, especially in tests
+	err = PopulateExamplesCommandsHomeadditions(appcopy.Name)
+	if err != nil {
+		return err
+	}
+
 	// Allow project-specific post-config action
 	err = appcopy.PostConfigAction()
 	if err != nil {
@@ -1501,18 +1507,6 @@ func PrepDdevDirectory(app *DdevApp) error {
 		}).Debug("Config Directory does not exist, attempting to create.")
 
 		err = os.MkdirAll(dir, 0755)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Pre-create a few dirs so we can be sure they are owned by the user and not root.
-	dirs := []string{
-		"web-entrypoint.d",
-		"xhprof",
-	}
-	for _, subdir := range dirs {
-		err = os.MkdirAll(filepath.Join(dir, subdir), 0755)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1321,7 +1321,7 @@ fi`, app.Database.Version, app.GetStartScriptTimeout(), psqlVersion) + "\n\n"
 	// Assets in the web-build directory copied to .webimageBuild so .webimageBuild can be "context"
 	// This actually copies the Dockerfile, but it is then immediately overwritten by WriteImageDockerfile()
 	if userDockerfilePath != "" {
-		err = copy2.Copy(userDockerfilePath, filepath.Dir(fullpath), copy2.Options{Skip: func(srcinfo os.FileInfo, src, dest string) (bool, error) {
+		err = copy2.Copy(userDockerfilePath, filepath.Dir(fullpath), copy2.Options{Skip: func(_ os.FileInfo, src, _ string) (bool, error) {
 			// Always copy if this is a directory
 			if fileutil.IsDirectory(src) {
 				return false, nil

--- a/pkg/ddevapp/dotddev_assets/db-build/Dockerfile.example
+++ b/pkg/ddevapp/dotddev_assets/db-build/Dockerfile.example
@@ -1,0 +1,5 @@
+## #ddev-generated
+## You can copy this Dockerfile.example to Dockerfile to add configuration
+## or packages or anything else to your dbimage
+## These additions will be appended last to DDEV's own Dockerfile
+# RUN echo "Built on $(date)" > /build-date.txt

--- a/pkg/ddevapp/dotddev_assets/db-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/db-build/README.txt
@@ -1,0 +1,16 @@
+#ddev-generated
+Files in this directory will be used to customize the dbimage, you can add:
+
+* .ddev/db-build/Dockerfile
+* .ddev/db-build/Dockerfile.*
+
+Additionally, you can use `pre.` variants that are inserted before everything else:
+
+* .ddev/db-build/pre.Dockerfile
+* .ddev/db-build/pre.Dockerfile.*
+
+Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.dbimageBuild/Dockerfile`. You can force a rebuild with `ddev debug rebuild -s db`.
+
+You can use the `.ddev/db-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/db-build`, you can use `ADD file.txt /` in the Dockerfile.
+
+See https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/ for advanced examples.

--- a/pkg/ddevapp/dotddev_assets/web-build/Dockerfile.example
+++ b/pkg/ddevapp/dotddev_assets/web-build/Dockerfile.example
@@ -1,0 +1,5 @@
+## #ddev-generated
+## You can copy this Dockerfile.example to Dockerfile to add configuration
+## or packages or anything else to your webimage
+## These additions will be appended last to DDEV's own Dockerfile
+# RUN echo "Built on $(date)" > /build-date.txt

--- a/pkg/ddevapp/dotddev_assets/web-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/web-build/README.txt
@@ -1,0 +1,16 @@
+#ddev-generated
+Files in this directory will be used to customize the webimage, you can add:
+
+* .ddev/web-build/Dockerfile
+* .ddev/web-build/Dockerfile.*
+
+Additionally, you can use `pre.` variants that are inserted before everything else:
+
+* .ddev/web-build/pre.Dockerfile
+* .ddev/web-build/pre.Dockerfile.*
+
+Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with `ddev debug rebuild -s web`.
+
+You can use the `.ddev/web-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/web-build`, you can use `ADD file.txt /` in the Dockerfile.
+
+See https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/ for advanced examples.

--- a/pkg/ddevapp/dotddev_assets/web-entrypoint.d/README.txt
+++ b/pkg/ddevapp/dotddev_assets/web-entrypoint.d/README.txt
@@ -1,0 +1,6 @@
+#ddev-generated
+Custom scripts (named *.sh) in this directory will be run during web container startup,
+before the php-fpm server or other daemons are run.
+
+This can be useful, for example, for introducing environment variables into the context of the nginx and php-fpm servers.
+Use this carefully, because custom entrypoints can very easily break things.


### PR DESCRIPTION
## The Issue

- #6757

## How This PR Solves The Issue

Creates example Dockerfiles in `.ddev/web-build` and `.ddev/db-build` on `ddev config` and `ddev start`. This lets people understand that they can customize Docker images when they get a project from someone else (i.e. they don't run `ddev config`).

Populates app assets on `ddev config` in addition to `ddev start`.

Adds README.txt to `.ddev/web-build`, `.ddev/db-build` and `.ddev/web-entrypoint.d`.

Skips all Dockerfiles that end on `*.example`, not only `Dockerfile.example`.

Updates tests.

## Manual Testing Instructions

```
$ rm -rf .ddev/web-build && ddev start

# assets should be here
$ ls .ddev/web-build 
Dockerfile.example  README.txt

# and they shouldn't be copied to the build directory
$ ls .ddev/.webimageBuild 
Dockerfile

# create context
$ touch .ddev/web-build/file && mkdir -p .ddev/web-build/folder && ddev start

# context should be here
$ ls .ddev/.webimageBuild 
Dockerfile  file  folder
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
