### PR TITLE
feat: add CLI completion for sake for Silverstripe CMS 6+ (plus some docs changes)

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -567,7 +567,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
     For more advanced tasks like adding elasticsearch, building and watching storefront and administration, see [susi.dev](https://susi.dev/ddev-shopware-6).
 
-## Silverstripe
+## Silverstripe CMS
 
 Use a new or existing Composer project, or clone a Git repository.
 
@@ -593,12 +593,12 @@ Use a new or existing Composer project, or clone a Git repository.
     ddev sake dev/build flush=all
     ```
 
-Your Silverstripe project is now ready.
-The CMS can be found at /admin, log into the default admin account using `admin` and `password`.
+Your Silverstripe CMS project is now ready.
+The CMS can be found at `/admin`, log into the default admin account using `admin` and `password`.
 
-Visit the [Silverstripe documentation](https://userhelp.silverstripe.org/en/5/) for more information.
+Visit the Silverstripe CMS [user documentation](https://userhelp.silverstripe.org/) and [developer documentation](https://docs.silverstripe.org/) for more information.
 
-`ddev sake` can be used as a shorthand for the Silverstripe Make command `ddev exec vendor/bin/sake`
+`ddev sake` can be used as a shorthand for the Silverstripe CLI command `ddev exec vendor/bin/sake`.
 
 To open the CMS directly from CLI, run `ddev launch /admin`.
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1306,13 +1306,13 @@ ddev restart --all
 
 ## `sake`
 
-Run the `sake` command, only available for Silverstripe projects and if the Silverstripe `sake` command is
+Run the `sake` command, only available for Silverstripe CMS projects and if the `sake` command is
 available in the `vendor/bin` folder.
 
 Common commands:
 
-* Build database: `ddev sake dev/build`
-* List of available tasks: `ddev sake dev/tasks`
+* Build database: `ddev sake dev/build` (or `ddev sake db:build` from Silverstripe CMS 6 onwards)
+* List of available tasks: `ddev sake dev/tasks` (or `ddev sake tasks` from Silverstripe CMS 6 onwards)
 
 ## `self-upgrade`
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/sake
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/sake
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+
+# Check if this is a version of Silverstripe CMS with the symfony/console style sake
+# If not, just exit out as older versions of sake can't handle autocomplete
+if ! [ -f 'vendor/silverstripe/framework/bin/sake' ]; then
+    exit 0;
+fi
+
+# Prepare arguments required for symfony/console completion requests
+COMP_CWORD=$(($# - 1))
+INPUT=''
+for w in $@; do
+    if [ ! -z "$w" ]; then
+        INPUT+=("-i$w")
+    fi
+done
+
+# There's no way to add the completion script to .bashrc for only silverstripe projects,
+# so we've got to explicitly call the _complete command directly
+sfcomplete=$(vendor/bin/sake _complete --no-interaction -a1 -sbash -c$COMP_CWORD ${INPUT[@]})
+
+# If suggestions contains backslash (e.g. a FQCN) we need to escape the values.
+if [[ "$sfcomplete" =~ \\ ]]; then
+    # This works regardless of the host shell, while just quoting worked for bash but failed for zsh
+    suggestions=$(for s in $sfcomplete; do printf $'%q\n' "$s"; done)
+else
+    suggestions=$sfcomplete
+fi
+
+# Output the result as a new-line delimited string
+printf "%s\n" "${suggestions[@]}"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

1. Some of the documentation about the "silverstripe" project type needed a touch up
2. Silverstripe CMS 6 adds completion to the `sake` command, but that's not exposed via `ddev sake`

## How This PR Solves The Issue

For the docs:
- "Silverstripe" usually refers to the company. The open source CMS and
  framework is referred to as "Silverstripe CMS". These references are updated.
- Add link to developer docs, which will be more useful to devs than the user docs.
- Add new CMS 6 syntax for sake command examples (e.g. `sake db:build`)

For sake completion:
Adds a completion script. This script exits early if an older version of Silverstripe CMS is detected.
For CMS 6+ it forwards the completion request to sake.

## Manual Testing Instructions

Setup:
```bash
# Create a new DDEV project of type "silverstripe"
ddev config --project-type silverstripe --php-version 8.3
# Start the project and install Silverstripe CMS 6 (alpha)
ddev start && ddev composer create silverstripe/installer:6.0.0-alpha1
```

Try out the completion! For example:
- `ddev sake <tab>` to get a list of commands
- `ddev sake f<tab>` should complete to `ddev sake flush`
- `ddev sake db:b<tab> --f<tab>` should complete to `ddev sake db:build --flush`

Also try with `ddev composer create silverstripe/installer:^5` and validate that tab completion just defaults to giving file names from the cwd, which is the default behaviour for ddev completion.

## Automated Testing Overview

N/A - https://github.com/ddev/test-silverstripe is set up with a constraint against Silverstripe CMS 5 which is still the latest _stable_ version of Silverstripe CMS.

I'll likely update that when Silverstripe CMS 6 goes stable around April next year, and include a test for the tab completion at that time. For now I think it's fine for this non-critical functionality to not have automated tests.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
N/A
