### PR TITLE
refactor: pre-download sqlite3 3.45.1 for Drupal 11, fixes #6807

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -75,6 +75,13 @@ RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then cd /tmp && curl -L -s 
 RUN set -x && cd /tmp && for item in *.deb; do dpkg-deb -x ${item} extracted; done
 RUN mkdir -p /usr/local/mariadb-old/bin && cp -ap /tmp/extracted/usr/bin/{mariadb,mariadb-dump,mysql,mysqldump} /usr/local/mariadb-old/bin
 
+### Drupal 11+ requires a minimum sqlite3 version (3.45 currently)
+### TODO: When we have this from upstream Debian 13 Trixie, we must remove this stanza
+ARG SQLITE_VERSION="3.45.1"
+RUN mkdir -p /usr/local/sqlite3-drupal11 && cd /usr/local/sqlite3-drupal11 && \
+    wget https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
+    wget https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb
+
 # END ddev-webserver-base
 
 
@@ -118,13 +125,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     unzip \
     vim-tiny \
     zip
-
-### Drupal 11+ requires a minimum sqlite3 version (3.45 currently)
-### TODO: When we have this from upstream Debian 13 Trixie, we must remove this stanza
-ARG SQLITE_VERSION="3.45.1"
-RUN mkdir -p /usr/local/sqlite3-drupal11 && cd /usr/local/sqlite3-drupal11 && \
-    wget https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
-    wget https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb
 
 # Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
 RUN rm /etc/apt/sources.list.d/blackfire.list

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -111,6 +111,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     patch \
     python-is-python3 \
     rsync \
+    sqlite3 \
     sudo \
     telnet \
     tree \
@@ -121,11 +122,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
 ### Drupal 11+ requires a minimum sqlite3 version (3.45 currently)
 ### TODO: When we have this from upstream Debian 13 Trixie, we must remove this stanza
 ARG SQLITE_VERSION="3.45.1"
-RUN mkdir -p /tmp/sqlite3 && \
-wget -O /tmp/sqlite3/sqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb
-RUN wget -O /tmp/sqlite3/libsqlite3.deb https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb
-RUN apt-get install -y /tmp/sqlite3/*.deb
-RUN rm -rf /tmp/sqlite3
+RUN mkdir -p /usr/local/sqlite3-drupal11 && cd /usr/local/sqlite3-drupal11 && \
+    wget https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
+    wget https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb
 
 # Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
 RUN rm /etc/apt/sources.list.d/blackfire.list

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1059,7 +1059,12 @@ ENV N_INSTALL_VERSION="%s"
 	if app.CorepackEnable {
 		extraWebContent = extraWebContent + "\nRUN corepack enable"
 	}
-
+	// TODO: When we have this from upstream Debian 13 Trixie, we must remove this condition
+	if app.Type == nodeps.AppTypeDrupal11 {
+		extraWebContent = extraWebContent + `
+### DDEV-injected SQLite 3.45.1 is required for Drupal 11 tests, change the project type if you don't need this
+RUN apt-get install -y /usr/local/sqlite3-drupal11/*.deb`
+	}
 	// Add supervisord config for WebExtraDaemons
 	var supervisorGroup []string
 	for _, appStart := range app.WebExtraDaemons {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2399,13 +2399,16 @@ func TestDdevFullSiteSetup(t *testing.T) {
 			assert.Contains(err.Error(), "upload_dirs is not set", app.Type)
 		}
 
+		// TODO: When we have this from upstream Debian 13 Trixie, we must remove this condition
 		// Special installed sqlite3 test for drupal11.
-		stdout, stderr, err := app.Exec(&ddevapp.ExecOpts{
-			Cmd: "sqlite3 --version | awk '{print $1}'",
-		})
-		require.NoError(t, err, "sqlite3 --version failed, output=%v, stderr=%v", stdout, stderr)
-		stdout = strings.Trim(stdout, "\r\n")
-		require.Equal(t, "3.45.1", stdout)
+		if app.Type == nodeps.AppTypeDrupal11 {
+			stdout, stderr, err := app.Exec(&ddevapp.ExecOpts{
+				Cmd: "sqlite3 --version | awk '{print $1}'",
+			})
+			require.NoError(t, err, "sqlite3 --version failed, output=%v, stderr=%v", stdout, stderr)
+			stdout = strings.Trim(stdout, "\r\n")
+			require.Equal(t, "3.45.1", stdout)
+		}
 
 		// We don't want all the projects running at once.
 		err = app.Stop(true, false)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241206_stasadev_python_cleanup" // Note that this can be overridden by make
+var WebTag = "20241206_stasadev_sqlite3" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #6807
- #6738

Adding sqlite3 3.45.1 for everyone is not good because it can break some dependencies.

## How This PR Solves The Issue

This PR pre-downloads `*.deb` for sqlite3 3.45.1 and installs it only for Drupal 11, the idea comes from:

- https://github.com/ddev/ddev/pull/6812#issuecomment-2521805065

It increases `ddev-webserver` size by 1 MB.

## Manual Testing Instructions

```
ddev config --project-type=drupal11 && ddev restart && echo && ddev exec sqlite3 --version
3.45.1

ddev config --project-type=php && ddev restart && echo && ddev exec sqlite3 --version
3.40.1
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
