### PR TITLE
docs: use shortlink for discord access

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 DDEV Community Discord
-    url: https://discord.gg/5wjP76mBJD
+    url: https://ddev.com/s/discord
     about: Join the DDEV Community to talk, exchange experiences or ask and answer questions.
   - name: 📒 Stack Overflow
     url: https://stackoverflow.com/questions/tagged/ddev

--- a/containers/ddev-dbserver/README.md
+++ b/containers/ddev-dbserver/README.md
@@ -37,7 +37,7 @@ The [DDEV Docker Maintainers](https://github.com/ddev)
 
 ## Where to get help:
 
-* [DDEV Community Discord](https://discord.gg/5wjP76mBJD)
+* [DDEV Community Discord](https://ddev.com/s/discord)
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
 
 ## Where to file issues:

--- a/containers/ddev-gitpod-base/README.md
+++ b/containers/ddev-gitpod-base/README.md
@@ -36,7 +36,7 @@ The [DDEV Docker Maintainers](https://github.com/ddev)
 
 ## Where to get help:
 
-* [DDEV Community Discord](https://discord.gg/5wjP76mBJD)
+* [DDEV Community Discord](https://ddev.com/s/discord)
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
 
 ## Where to file issues:

--- a/containers/ddev-nginx-proxy-router/README.md
+++ b/containers/ddev-nginx-proxy-router/README.md
@@ -39,7 +39,7 @@ The [DDEV Docker Maintainers](https://github.com/ddev)
 
 ## Where to get help:
 
-* [DDEV Community Discord](https://discord.gg/5wjP76mBJD)
+* [DDEV Community Discord](https://ddev.com/s/discord)
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
 
 ## Where to file issues:

--- a/containers/ddev-php-base/README.md
+++ b/containers/ddev-php-base/README.md
@@ -36,7 +36,7 @@ The [DDEV Docker Maintainers](https://github.com/ddev)
 
 ## Where to get help:
 
-* [DDEV Community Discord](https://discord.gg/5wjP76mBJD)
+* [DDEV Community Discord](https://ddev.com/s/discord)
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
 
 ## Where to file issues:

--- a/containers/ddev-ssh-agent/README.md
+++ b/containers/ddev-ssh-agent/README.md
@@ -28,7 +28,7 @@ See [DDEV docs](https://ddev.readthedocs.io/en/stable/developers/release-managem
 The [DDEV Docker Maintainers](https://github.com/ddev)
 
 ## Where to get help:
-* [DDEV Community Discord](https://discord.gg/5wjP76mBJD)
+* [DDEV Community Discord](https://ddev.com/s/discord)
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
 
 ## Where to file issues:

--- a/containers/ddev-traefik-router/README.md
+++ b/containers/ddev-traefik-router/README.md
@@ -39,7 +39,7 @@ The [DDEV Docker Maintainers](https://github.com/ddev)
 
 ## Where to get help:
 
-* [DDEV Community Discord](https://discord.gg/5wjP76mBJD)
+* [DDEV Community Discord](https://ddev.com/s/discord)
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
 
 ## Where to file issues:

--- a/containers/ddev-webserver/README.md
+++ b/containers/ddev-webserver/README.md
@@ -43,7 +43,7 @@ docker run -it --rm ddev/ddev-webserver:<tag> bash
 The [DDEV Maintainers](https://github.com/ddev)
 
 ## Where to get help:
-* [DDEV Community Discord](https://discord.gg/5wjP76mBJD)
+* [DDEV Community Discord](https://ddev.com/s/discord)
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
 
 ## Where to file issues:

--- a/containers/image_readme_template.md
+++ b/containers/image_readme_template.md
@@ -36,7 +36,7 @@ The [DDEV Docker Maintainers](https://github.com/ddev)
 
 ## Where to get help:
 
-* [DDEV Community Discord](https://discord.gg/5wjP76mBJD)
+* [DDEV Community Discord](https://ddev.com/s/discord)
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
 
 ## Where to file issues:

--- a/containers/test-ssh-server/README.md
+++ b/containers/test-ssh-server/README.md
@@ -33,7 +33,7 @@ The [DDEV Docker Maintainers](https://github.com/ddev)
 
 ## Where to get help:
 
-* [DDEV Community Discord](https://discord.gg/5wjP76mBJD)
+* [DDEV Community Discord](https://ddev.com/s/discord)
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
 
 ## Where to file issues:

--- a/docs/content/developers/maintainers.md
+++ b/docs/content/developers/maintainers.md
@@ -10,7 +10,7 @@ Not all maintainers can do all these things at any given time, but these are the
 
 * **Support**: We try to give friendly, accurate, and timely responses to those who need help in:
     * [Issue queue](https://github.com/ddev/ddev/issues) (and discussions, etc). Please follow all in at least the ddev/ddev project. On the Watch/Unwatch button at the top of the repository, consider selecting "All Activity". Also consider this on other projects in the `ddev` organization or other projects that are in your interest area.
-    * Discord: Please read everything that happens in the [DDEV Discord](https://discord.gg/5wjP76mBJD) and respond to questions that you can help with.
+    * Discord: Please read everything that happens in the [DDEV Discord](https://ddev.com/s/discord) and respond to questions that you can help with.
     * Stack Overflow. You can subscribe to the [ddev tag on Stack Overflow](https://stackoverflow.com/questions/tagged/ddev) using the [email filter](https://meta.stackoverflow.com/a/400613/8097891) and answer or comment on questions there.
     * Often in [Drupal Slack](https://www.drupal.org/join-slack) #ddev channel. We have tried and tried to get people over to Discord, but it's still pretty active there.
     * Other add-on repositories or related repos where we can help.

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -199,10 +199,9 @@ Go templating resources:
 
 ## Additional services in ddev-contrib
 
-Commonly-used services are being migrated from the [ddev-contrib](https://github.com/ddev/ddev-contrib) repository to individual, tested, supported add-on repositories, but the repository still has a wealth of additional examples and instructions:
+Most commonly-used services have been migrated from the [ddev-contrib](https://github.com/ddev/ddev-contrib) repository to individual, tested, supported add-on repositories, but the repository still has a wealth of additional examples and instructions, but it's mostly obsolete.
 
 * **Old PHP Versions to Run Old Sites**: See [Old PHP Versions](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/old_php)
 * **RabbitMQ**: See [RabbitMQ](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/rabbitmq)
-* **TYPO3 Solr Integration**: See [TYPO3 Solr](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/typo3-solr)
 
 While we welcome requests to integrate other services at [ddev-contrib](https://github.com/ddev/ddev-contrib), we encourage creating a supported add-on that’s more beneficial to the community.

--- a/docs/content/users/extend/custom-compose-files.md
+++ b/docs/content/users/extend/custom-compose-files.md
@@ -4,7 +4,7 @@
 
 Much of DDEV’s customization ability and extensibility comes from leveraging features and functionality provided by [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/overview/). Some working knowledge of these tools is required in order to customize or extend the environment DDEV provides.
 
-There are [many examples of custom docker-compose files](https://github.com/ddev/ddev-contrib#additional-services-added-via-docker-composeserviceyaml) available on [ddev-contrib](https://github.com/ddev/ddev-contrib).
+There are [many examples of custom docker-compose files](https://github.com/ddev/ddev-contrib#additional-services-added-via-docker-composeserviceyaml). The best examples are in the many available maintained DDEV add-ons.
 
 ## Background
 

--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -111,7 +111,7 @@ There are many ways to deploy Node.js in any project, so DDEV tries to let you s
 * You can manually run Node.js scripts using [`ddev exec <script>`](../usage/commands.md#exec) or `ddev exec node <script>`.
 
 !!!tip "Please share your techniques!"
-    There are several ways to share your favorite Node.js tips and techniques. Best are [ddev-get add-ons](additional-services.md), [Stack Overflow](https://stackoverflow.com/tags/ddev), and [ddev-contrib](https://github.com/ddev/ddev-contrib).
+    There are several ways to share your favorite Node.js tips and techniques. Best are [ddev-get add-ons](additional-services.md) and [Stack Overflow](https://stackoverflow.com/tags/ddev).
 
 ## Running Extra Daemons in the Web Container
 

--- a/docs/content/users/providers/index.md
+++ b/docs/content/users/providers/index.md
@@ -25,7 +25,7 @@ Each provider recipe is a YAML file that can have whatever name you want. The ex
 - [rsync](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/rsync.yaml.example)
 - [Upsun](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/upsun.yaml)
 
-We know you’ll find improvements to these examples and will have lots to contribute for other hosting providers, and we look forward to your contributions as pull requests here or in [ddev-contrib](https://github.com/ddev/ddev-contrib).
+We know you’ll find improvements to these examples and will have lots to contribute for other hosting providers, and we look forward to your contributions as pull requests here or as new add-ons.
 
 Each provider recipe is a file named `<provider>.yaml` and consists of several mostly-optional stanzas:
 

--- a/docs/content/users/support.md
+++ b/docs/content/users/support.md
@@ -9,7 +9,7 @@ We love to hear from you and want you to be successful with DDEV!
 
 * See the included [`ddev help`](./usage/commands.md#help) command, which includes lots of examples.
 * [FAQ](./usage/faq.md)
-* [Discord](https://discord.gg/5wjP76mBJD) interactive community support.
+* [Discord](https://ddev.com/s/discord) interactive community support.
 * [DDEV issue queue](https://github.com/ddev/ddev/issues) for bugs and feature requests.
 * [Mastodon](https://fosstodon.org/@ddev)
 * [Bluesky](https://bsky.app/profile/ddev.bsky.social)
@@ -17,5 +17,4 @@ We love to hear from you and want you to be successful with DDEV!
 ## Additional Resources
 
 * [DDEV Stack Overflow](https://stackoverflow.com/questions/tagged/ddev) for support and frequently asked questions. We respond quickly here and the results provide quite a library of user-curated solutions.
-* [ddev-contrib](https://github.com/ddev/ddev-contrib) repository provides a number of vetted, user-contributed recipes for extending and using DDEV. Your contributions are welcome.
 * [awesome-ddev](https://github.com/ddev/awesome-ddev) repository has loads of external resources, blog posts, recipes, screencasts, and the like. Your contributions are welcome.

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -41,7 +41,7 @@ A project’s `.ddev` directory can be intimidating at first, so let’s take a 
 : Where snapshots go when you run the [`ddev snapshot`](../usage/commands.md#snapshot) command. You can safely delete anything in here that you don’t need.
 
 `docker-compose.*.yaml` files
-: Where Docker-friendly users can provide their own [custom compose files](../extend/custom-compose-files.md) that add or override services. Read more in [Additional Service Configurations & Add-ons](../extend/additional-services.md) and check out examples in [ddev-contrib](https://github.com/ddev/ddev-contrib).
+: Where Docker-friendly users can provide their own [custom compose files](../extend/custom-compose-files.md) that add or override services. Read more in [Additional Service Configurations & Add-ons](../extend/additional-services.md).
 
 `homeadditions` directory
 : Files to be copied into the web container on startup. You could use this, for example, to override the default home directory contents (`.profile`, `.bashrc`, `.composer`, `.ssh`), or include scripts that you’d like to be available inside the container. (You can do the same thing globally in `~/.ddev/homeadditions`.) Check out the [homeadditions docs](../extend/in-container-configuration.md) for more.

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -328,7 +328,7 @@ If anything in `.ddev/config.yaml` is wrong, you can edit that directly or use [
 
 ### How do I get support?
 
-See the [support options](../support.md), including [Discord](https://discord.gg/5wjP76mBJD), [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev) and the [issue queue](https://github.com/ddev/ddev/issues).
+See the [support options](../support.md), including [Discord](https://ddev.com/s/discord), [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev) and the [issue queue](https://github.com/ddev/ddev/issues).
 
 ### How can I contribute to DDEV?
 
@@ -336,8 +336,7 @@ We love and welcome contributions of knowledge, support, docs, and code:
 
 * Submit an issue or pull request to the [main repository](https://github.com/ddev/ddev).
 * Add your external resource to [awesome-ddev](https://github.com/ddev/awesome-ddev).
-* Add your recipe or HOWTO to [ddev-contrib](https://github.com/ddev/ddev-contrib).
-* Help others in [Discord](https://discord.gg/5wjP76mBJD) and on [Stack Overflow](https://stackoverflow.com/tags/ddev).
+* Help others in [Discord](https://ddev.com/s/discord) and on [Stack Overflow](https://stackoverflow.com/tags/ddev).
 * Contribute financially via [GitHub Sponsors](https://github.com/sponsors/rfay).
 * Get involved with DDEV governance and the [Advisory Group](https://github.com/ddev/ddev/discussions/categories/ddev-advisory-group).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,7 +88,7 @@ extra:
   - icon: fontawesome/brands/github
     link: https://github.com/ddev/ddev
   - icon: fontawesome/brands/discord
-    link: https://discord.gg/5wjP76mBJD
+    link: https://ddev.com/s/discord
   - icon: fontawesome/brands/stack-overflow
     link: https://stackoverflow.com/tags/ddev
 


### PR DESCRIPTION

## The Issue

* https://github.com/ddev/ddev.com/pull/288

We now have a shortlink for discord, so we don't have to use the odd one. Update that.

I also discovered a number of probably inappropriate references to ddev-contrib, so trimmed some of those.

I imagine this will run tests, but don't want to short-circuit that.