### PR TITLE
fix: correct panic on ddev describe on gitpod

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -143,8 +143,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 
 			// Router disabled, but not because of Gitpod, use direct http url
 			case ddevapp.IsRouterDisabled(app):
-				httpURL = v["host_http_url"].(string)
-				if httpURL != "" {
+				if httpURL, ok := v["host_http_url"].(string); ok && httpURL != "" {
 					urlPortParts = append(urlPortParts, httpURL)
 				}
 			}


### PR DESCRIPTION

## The Issue

In doing some debugging on gitpod for
* https://github.com/ddev/ddev/pull/6589

I noted a panic in `ddev describe`. It's a result of trying to convert nil to string. 

## How This PR Solves The Issue

Check before converting.

## Manual Testing Instructions

`ddev describe` on gitpod

