### PR TITLE
docs: update magento2, pimcore, sulu quickstarts

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -454,15 +454,15 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
             ```
 
     ```bash
-    mkdir my-magento2-site && cd my-magento2-site
+    export MAGENTO_HOSTNAME=my-magento2-site
+    mkdir ${MAGENTO_HOSTNAME} && cd ${MAGENTO_HOSTNAME}
     ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
     ddev add-on get ddev/ddev-elasticsearch
     ddev start
     ddev composer create --repository https://repo.magento.com/ magento/project-community-edition
     rm -f app/etc/env.php
 
-    # Change the base-url below to your project's URL
-    ddev magento setup:install --base-url="https://my-magento2-site.ddev.site/" \
+    ddev magento setup:install --base-url="https://${MAGENTO_HOSTNAME}.ddev.site/" \
         --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db \
         --elasticsearch-host=elasticsearch --search-engine=elasticsearch7 --elasticsearch-port=9200 \
         --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
@@ -638,8 +638,8 @@ ddev config --project-type=php --docroot=public --upload-dirs=uploads --database
 ddev start
 ddev composer create sulu/skeleton
 # Create your default webspace configuration `config/webspaces/my-sulu-site.xml`
-# from `config/webspaces/website.xml`. The command below will adjust the values
-# for `<name>` and `<key>`, so that they are matching your project:
+# from `config/webspaces/website.xml`. Alternately, the command below will adjust the values
+# for `<name>` and `<key>` to match the project you have set up:
 # <name>My Sulu Site</name>
 # <key>my-sulu-site</key>
 ddev exec 'name="$(echo "${DDEV_PROJECT}" | sed "s/\b\(.\)/\U\1/g" | tr "-" " ")"; key="${DDEV_PROJECT}"; xmlstarlet ed -u "//_:webspace/_:name" -v "${name}" -u "//_:webspace/_:key" -v "${key}" -u "//_:portals/_:portal/_:name" -v "${name}" -u "//_:portals/_:portal/_:key" -v "${key}" config/webspaces/website.xml > config/webspaces/${DDEV_PROJECT}.xml && rm -f config/webspaces/website.xml'

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -473,7 +473,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ddev config --disable-settings-management=false
     # Change the backend frontname URL to /admin_ddev
     ddev magento setup:config:set --backend-frontname="admin_ddev" --no-interaction
-    # Log into your account using `admin` and `Password123`
+    # Login using `admin` user and `Password123` password
     ddev launch /admin_ddev
     ```
 
@@ -637,8 +637,9 @@ mkdir my-sulu-site && cd my-sulu-site
 ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0 --webimage-extra-packages="xmlstarlet"
 ddev start
 ddev composer create sulu/skeleton
-# Create your default webspace configuration `config/webspaces/my-sulu-site.xml` from `config/webspaces/website.xml`
-# The command below will adjust the values for `<name>` and `<key>` so that they are matching your project:
+# Create your default webspace configuration `config/webspaces/my-sulu-site.xml`
+# from `config/webspaces/website.xml`. The command below will adjust the values
+# for `<name>` and `<key>`, so that they are matching your project:
 # <name>My Sulu Site</name>
 # <key>my-sulu-site</key>
 ddev exec 'name="$(echo "${DDEV_PROJECT}" | sed "s/\b\(.\)/\U\1/g" | tr "-" " ")"; key="${DDEV_PROJECT}"; xmlstarlet ed -u "//_:webspace/_:name" -v "${name}" -u "//_:webspace/_:key" -v "${key}" -u "//_:portals/_:portal/_:name" -v "${name}" -u "//_:portals/_:portal/_:key" -v "${key}" config/webspaces/website.xml > config/webspaces/${DDEV_PROJECT}.xml && rm -f config/webspaces/website.xml'
@@ -653,6 +654,7 @@ Now build the database. Building with the `dev` argument adds the user `admin` w
 # Set APP_ENV and DATABASE_URL in .env.local
 ddev dotenv set .env.local --app-env=dev --database-url="mysql://db:db@db:3306/db?serverVersion=8.0&charset=utf8mb4"
 ddev exec bin/adminconsole sulu:build dev
+# Login using `admin` user and `admin` password
 ddev launch /admin
 ```
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -652,13 +652,14 @@ Create your default webspace configuration `mv config/webspaces/website.xml conf
     <key>my-sulu-site</key>
 ```
 
-Alternately, the command below will adjust the values for `<name>` and `<key>` to match the project you have set up:
+Alternatively, use the following commands to adjust the values for `<name>` and `<key>` to match your project setup:
 
 ```bash
 export SULU_PROJECT_NAME="My Sulu Site"
 export SULU_PROJECT_KEY="my-sulu-site"
-ddev exec "mv config/webspaces/website.xml config/webspaces/${SULU_PROJECT_KEY}.xml"
-ddev exec "sed -i -e 's|<name>.*</name>|<name>${SULU_PROJECT_NAME}</name>|g' -e 's|<key>.*</key>|<key>${SULU_PROJECT_KEY}</key>|g' config/webspaces/${SULU_PROJECT_KEY}.xml"
+export SULU_PROJECT_CONFIG_FILE="config/webspaces/my-sulu-site.xml"
+ddev exec "mv config/webspaces/website.xml ${SULU_PROJECT_CONFIG_FILE}"
+ddev exec "sed -i -e 's|<name>.*</name>|<name>${SULU_PROJECT_NAME}</name>|g' -e 's|<key>.*</key>|<key>${SULU_PROJECT_KEY}</key>|g' ${SULU_PROJECT_CONFIG_FILE}"
 ```
 
 !!!warning "Caution"

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -634,15 +634,31 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
 
 ```bash
 mkdir my-sulu-site && cd my-sulu-site
-ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0 --webimage-extra-packages="xmlstarlet"
+ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0
 ddev start
 ddev composer create sulu/skeleton
-# Create your default webspace configuration `config/webspaces/my-sulu-site.xml`
-# from `config/webspaces/website.xml`. Alternately, the command below will adjust the values
-# for `<name>` and `<key>` to match the project you have set up:
-# <name>My Sulu Site</name>
-# <key>my-sulu-site</key>
-ddev exec 'name="$(echo "${DDEV_PROJECT}" | sed "s/\b\(.\)/\U\1/g" | tr "-" " ")"; key="${DDEV_PROJECT}"; xmlstarlet ed -u "//_:webspace/_:name" -v "${name}" -u "//_:webspace/_:key" -v "${key}" -u "//_:portals/_:portal/_:name" -v "${name}" -u "//_:portals/_:portal/_:key" -v "${key}" config/webspaces/website.xml > config/webspaces/${DDEV_PROJECT}.xml && rm -f config/webspaces/website.xml'
+```
+
+Create your default webspace configuration `mv config/webspaces/website.xml config/webspaces/my-sulu-site.xml` and adjust the values for `<name>` and `<key>` so that they are matching your project:
+
+```bash
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+    <!-- See: http://docs.sulu.io/en/latest/book/webspaces.html how to configure your webspace-->
+
+    <name>My Sulu Site</name>
+    <key>my-sulu-site</key>
+```
+
+Alternately, the command below will adjust the values for `<name>` and `<key>` to match the project you have set up:
+
+```bash
+export SULU_PROJECT_NAME="My Sulu Site"
+export SULU_PROJECT_KEY="my-sulu-site"
+ddev exec "mv config/webspaces/website.xml config/webspaces/${SULU_PROJECT_KEY}.xml"
+ddev exec "sed -i -e 's|<name>.*</name>|<name>${SULU_PROJECT_NAME}</name>|g' -e 's|<key>.*</key>|<key>${SULU_PROJECT_KEY}</key>|g' config/webspaces/${SULU_PROJECT_KEY}.xml"
 ```
 
 !!!warning "Caution"
@@ -653,7 +669,7 @@ Now build the database. Building with the `dev` argument adds the user `admin` w
 ```bash
 # Set APP_ENV and DATABASE_URL in .env.local
 ddev dotenv set .env.local --app-env=dev --database-url="mysql://db:db@db:3306/db?serverVersion=8.0&charset=utf8mb4"
-ddev exec bin/adminconsole sulu:build dev
+ddev exec bin/adminconsole sulu:build dev --no-interaction
 # Login using `admin` user and `admin` password
 ddev launch /admin
 ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -543,7 +543,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
         command: 'while true; do /var/www/html/bin/console messenger:consume pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update --memory-limit=250M --time-limit=3600; done'
         directory: /var/www/html" >.ddev/config.pimcore.yaml
 
-    ddev start
+    ddev restart
     ddev launch /admin
     ```
 


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/6784#pullrequestreview-2486662032
- https://gist.github.com/rpkoller/d0fa272b81b7705dd3f56c35e01c8f8a

@rpkoller pointed out some problems in our quickstarts.

## How This PR Solves The Issue

Magento 2:

I didn't notice any issue, the quickstart works for my in the current state.
But I decided to update the admin URL to the persistent value: `/admin_ddev`

Pimcore:

They require `amqp` extension:

- https://github.com/pimcore/skeleton/issues/186

Sulu:

They changed the filename to `website.xml`:

- https://github.com/sulu/skeleton/pull/248

Additionally, I automated setting `<name>` and `<key>` with `xmlstarlet`.

## Manual Testing Instructions

Test these quickstarts:

- https://ddev--6822.org.readthedocs.build/en/6822/users/quickstart/#magento
- https://ddev--6822.org.readthedocs.build/en/6822/users/quickstart/#pimcore
- https://ddev--6822.org.readthedocs.build/en/6822/users/quickstart/#sulu

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
