### PR TITLE
fix: unset DDEV_NONINTERACTIVE in Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -27,6 +27,7 @@ tasks:
         ddev import-files --source=/tmp/${DDEV_ARTIFACTS##*/}/files.tgz
       fi
       gp ports await 8080 && sleep 1 && gp preview $(gp url 8080)
+      unset DDEV_NONINTERACTIVE
 
 vscode:
   extensions:


### PR DESCRIPTION
## The Issue

In Gitpod:
```
$ ddev phpmyadmin
Nothing has been changed.
```

Because `DDEV_NONINTERACTIVE` is set.

## How This PR Solves The Issue

Unsets it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
