### PR TITLE
test: Remove a couple of tests from lima/colima/rancher execution

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1595,7 +1595,9 @@ func TestConfigFunctionality(t *testing.T) {
 // TestConfigDefaultContainerTimeout verifies that `default_container_timeout` works
 // properly
 func TestConfigDefaultContainerTimeout(t *testing.T) {
-
+	if dockerutil.IsLima() {
+		t.Skip("Skipping on Lima, unknown why non-writeable filesystem error")
+	}
 	origDir, _ := os.Getwd()
 	site := TestSites[0]
 	_ = os.Chdir(site.Dir)

--- a/pkg/ddevapp/hardened_test.go
+++ b/pkg/ddevapp/hardened_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -20,8 +19,8 @@ import (
 
 // TestHardenedStart makes sure we can do a start and basic use with hardened images
 func TestHardenedStart(t *testing.T) {
-	if dockerutil.IsLima() || dockerutil.IsColima() || (nodeps.IsAppleSilicon() && dockerutil.IsDockerDesktop()) {
-		t.Skip("Skipping TestHardenedStart because of useless failures to connect on some platforms")
+	if nodeps.IsAppleSilicon() {
+		t.Skip("Skipping TestHardenedStart because of useless failures to connect on some platforms, no need to test hardened on arm64")
 	}
 
 	assert := asrt.New(t)


### PR DESCRIPTION

## The Issue

* We've seen some interesting behavior from Apple Silicon docker providers on TestHardenedStart, and there's really no reason to run it there.
* TestConfigDefaultContainerTimeout has been failing on lima with the below, we don't know why, but it doesn't seem to be worth chasing.  "Read-only file system"

> failed to 'cp -r /var/tmp/TestConfigDefaultContainerTimeout120-mariadb_10.11.gz /mnt/ddev_config/db_snapshots': command 'cp -r /var/tmp/TestConfigDefaultContainerTimeout120-mariadb_10.11.gz /mnt/ddev_config/db_snapshots' returned exit code 1, stdout=, stderr=cp: cannot create regular file '/mnt/ddev_config/db_snapshots/TestConfigDefaultContainerTimeout120-mariadb_10.11.gz': Read-only file system
 
This PR disables those tests for the relevant architectures.

Related:
* https://github.com/ddev/maintainer-info/issues/1#issuecomment-2529615952
