### PR TITLE
docs: use `drupal` in Drupal 11 Quickstart

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -187,10 +187,10 @@ The legacy type `drupal` will be interpreted as the latest stable version of Dru
 
     ```bash
     mkdir my-drupal11-site && cd my-drupal11-site
-    ddev config --project-type=drupal11 --docroot=web
-    ddev composer create drupal/recommended-project:^11
+    ddev config --project-type=drupal --docroot=web
+    ddev composer create drupal/recommended-project
     ddev composer require drush/drush
-    ddev drush site:install --account-name=admin --account-pass=admin -y
+    ddev drush site:install -y
     ddev launch
     # or automatically log in with
     ddev launch $(ddev drush uli)
@@ -203,7 +203,7 @@ The legacy type `drupal` will be interpreted as the latest stable version of Dru
     ddev config --project-type=drupal10 --docroot=web
     ddev composer create drupal/recommended-project:^10
     ddev composer require drush/drush
-    ddev drush site:install --account-name=admin --account-pass=admin -y
+    ddev drush site:install -y
     ddev launch
     # or automatically log in with
     ddev launch $(ddev drush uli)


### PR DESCRIPTION
Since you get the latest Drupal with `drupal`, we could use that?

The same way for `ddev composer create drupal/recommended-project`.

Also, since `ddev launch $(ddev drush uli)` logs you in anyway, maybe we can remove the user and password setting bit from `site:install`?

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
