### PR TITLE
docs: buildkite lima setup needs --mount-writable

### DIFF
--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -170,9 +170,9 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 
 Then the Buildkite agent must be configured with tags `colima=true` and `colima_vz=true`.
 
-## Additional Lima macOS setup (not yet working)
+## Additional Lima macOS setup
 
-1. `limactl create --name=lima-vz --vm-type=vz --mount-type=virtiofs --mount="~/:w" --memory=6 --cpus=4 --disk=100 template://docker`
+1. `limactl create --name=lima-vz --vm-type=vz --mount-type=virtiofs --mount-writable --mount="~/:w" --memory=6 --cpus=4 --disk=100 template://docker`
 2. `limactl start lima-vz`
 3. `docker context use lima-lima-vz`
 


### PR DESCRIPTION

## The Issue

**tb-macos-arm64-5** has been failing with "filesystem not writable" on lima.

## How This PR Solves The Issue

Use the correct setup to make it writable.

