### PR TITLE
docs: how to add unsupported PHP versions without `ddev config`, fixes #6835

### DIFF
--- a/docs/content/users/extend/customization-extendibility.md
+++ b/docs/content/users/extend/customization-extendibility.md
@@ -85,7 +85,9 @@ The project's `.ddev/config.yaml` file defines the PHP version to use. The [`php
 
 ### Older Versions of PHP
 
-[Support for older versions of PHP is available on ddev-contrib](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/old_php) via [custom docker-compose files](custom-compose-files.md).
+[Support for older versions of PHP (< 5.6) is available on ddev-contrib](https://github.com/ddev/ddev-contrib/blob/master/docker-compose-services/old_php) via [custom docker-compose files](custom-compose-files.md).
+
+If your project requires multiple versions of PHP, and one of them is EOL, you can install it using [this technique](customizing-images.md#adding-eol-versions-of-php).
 
 ## Changing Web Server Type
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -84,7 +84,7 @@ The web image ships by default with a small number of locales, which work for mo
 
 If you need other locales, you can install all of them by adding `locales-all` to your `webimage_extra_packages`. For example, in `.ddev/config.yaml`:
 
-```
+```yaml
 webimage_extra_packages: [locales-all]
 ```
 
@@ -177,6 +177,18 @@ An example of using `$TARGETARCH` would be:
 ```dockerfile
 RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=linux/${TARGETARCH}"
 ```
+
+## Adding unsupported PHP versions
+
+If your project requires multiple PHP versions (e.g., you're using PHP 8.3 but also need PHP 7.4 for certain scripts), and you don’t want to switch completely to PHP 7.4 using `ddev config --php-version=7.4`, you can install it using the `pre.Dockerfile.*` technique from the previous section.
+
+Create a `.ddev/web-build/pre.Dockerfile.php7.4` file with the following content:
+
+```dockerfile
+RUN /usr/local/bin/install_php_extensions.sh "php7.4" "${TARGETARCH}"
+```
+
+After restarting the project, you can use PHP 7.4 with the command `ddev exec php7.4 -v`.
 
 ## Installing into the home directory
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -178,9 +178,9 @@ An example of using `$TARGETARCH` would be:
 RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=linux/${TARGETARCH}"
 ```
 
-## Adding unsupported PHP versions
+## Adding EOL Versions of PHP
 
-If your project requires multiple PHP versions (e.g., you're using PHP 8.3 but also need PHP 7.4 for certain scripts), and you don’t want to switch completely to PHP 7.4 using `ddev config --php-version=7.4`, you can install it using the `pre.Dockerfile.*` technique from the previous section.
+If your project requires multiple versions of PHP—such as using PHP 8.3 but also needing an older, unsupported, unmaintained version like PHP 7.4 for specific scripts—and you don’t want to fully switch to PHP 7.4 with `ddev config --php-version=7.4`, you can install it using the `pre.Dockerfile.*` technique from the previous section.
 
 Create a `.ddev/web-build/pre.Dockerfile.php7.4` file with the following content:
 


### PR DESCRIPTION
## The Issue

- #6835

## How This PR Solves The Issue

Adds instruction to the docs.

## Manual Testing Instructions

https://ddev--6836.org.readthedocs.build/en/6836/users/extend/customizing-images/#adding-eol-versions-of-php

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
