### PR TITLE
fix: mount OpenSSH certificate for `auth ssh`, fixes #6832

### DIFF
--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -93,6 +93,13 @@ var AuthSSHCommand = &cobra.Command{
 			addedKeys[filename] = struct{}{}
 			keyPath = util.WindowsPathToCygwinPath(keyPath)
 			mounts = append(mounts, "--mount=type=bind,src="+keyPath+",dst=/tmp/sshtmp/"+filename)
+			// Mount optional OpenSSH certificate
+			// https://www.man7.org/linux/man-pages/man1/ssh-keygen.1.html#CERTIFICATES
+			certPath := keyPath + "-cert.pub"
+			if fileutil.FileIsReadable(certPath) {
+				certName := filename + "-cert.pub"
+				mounts = append(mounts, "--mount=type=bind,src="+certPath+",dst=/tmp/sshtmp/"+certName)
+			}
 		}
 
 		dockerCmd := []string{"run", "-it", "--rm", "--volumes-from=" + ddevapp.SSHAuthName, "--user=" + uidStr, "--entrypoint="}


### PR DESCRIPTION
## The Issue

- #6832

## How This PR Solves The Issue

OpenSSH uses a [hardcoded convention](https://github.com/openssh/openssh-portable/blob/bbc9c18e84de29c83fa03e69290979fcca54a2b2/authfile.c#L308) for `-cert.pub`, we can mount it if it exists.

```c
if (asprintf(&file, "%s-cert.pub", filename) == -1)
```

## Manual Testing Instructions

To generate such a certificate, I used https://goteleport.com/blog/how-to-configure-ssh-certificate-based-authentication/

```
mkdir ssh-test && cd ssh-test

ssh-keygen -t rsa -b 4096 -f host_ca -C host_ca
ssh-keygen -t rsa -b 4096 -f user_ca -C user_ca
ssh-keygen -f ssh_host_rsa_key -N '' -b 4096 -t rsa
ssh-keygen -s host_ca -I host.example.com -h -n host.example.com -V +52w ssh_host_rsa_key.pub

# add the file:
$ ddev auth ssh -f ssh_host_rsa_key
Identity added: ssh_host_rsa_key (stas@dev)
Certificate added: ssh_host_rsa_key-cert.pub (host.example.com)

# repeat the same with directory:
$ ddev auth ssh -d .
Identity added: host_ca (host_ca)
Identity added: ssh_host_rsa_key (stas@dev)
Certificate added: ssh_host_rsa_key-cert.pub (host.example.com)
Identity added: user_ca (user_ca)
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
