### PR TITLE
build: reorganize `ddev-webserver` packages, add `vim` alternative, fixes #6840

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -38,15 +38,38 @@ RUN apt-get install -y postgresql-common && /usr/share/postgresql-common/pgdg/ap
 RUN apt-get -qq update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
     bash-completion \
+    fontconfig \
+    gettext \
+    git \
+    graphviz \
+    iproute2 \
+    iputils-ping \
+    jq \
+    less \
     libcap2-bin \
+    libldap-common \
     libmagickcore-6.q16-6-extra \
+    libpcre3 \
     locales \
     mariadb-client \
+    nano \
+    ncurses-bin \
+    netcat-traditional \
+    openssh-client \
+    patch \
     postgresql-client \
     pv \
+    python-is-python3 \
+    rsync \
+    sqlite3 \
     supervisor \
     symfony-cli \
-    xz-utils
+    unzip \
+    vim-tiny \
+    xz-utils \
+    zip
+
+RUN update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 10
 
 RUN printf "${DEFAULT_LOCALES}" > /etc/locale.gen && locale-gen
 
@@ -101,31 +124,9 @@ RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
     blackfire \
     blackfire-php \
-    fontconfig \
-    gettext \
-    git \
-    graphviz \
-    iproute2 \
-    iputils-ping \
-    jq \
-    less \
-    libldap-common \
-    libpcre3 \
-    nano \
-    ncurses-bin \
-    netcat-traditional \
-    openssh-client \
-    patch \
-    python-is-python3 \
-    rsync \
-    sqlite3 \
     sudo \
     telnet \
-    tree \
-    unzip \
-    vim-tiny \
-    zip
-RUN update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 10
+    tree
 
 # Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
 RUN rm /etc/apt/sources.list.d/blackfire.list
@@ -247,25 +248,7 @@ RUN apt-get update
 
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
-    blackfire-php \
-    fontconfig \
-    gettext \
-    git \
-    iproute2 \
-    iputils-ping \
-    jq \
-    libpcre3 \
-    nano \
-    ncurses-bin \
-    netcat-traditional \
-    openssh-client \
-    patch \
-    rsync \
-    sqlite3 \
-    unzip \
-    vim-tiny \
-    zip
-RUN update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 10
+    blackfire-php
 
 # Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
 RUN rm /etc/apt/sources.list.d/blackfire.list

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -38,25 +38,14 @@ RUN apt-get install -y postgresql-common && /usr/share/postgresql-common/pgdg/ap
 RUN apt-get -qq update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
     bash-completion \
-    fontconfig \
     gettext \
-    git \
     graphviz \
-    iproute2 \
-    iputils-ping \
-    jq \
     less \
     libcap2-bin \
     libldap-common \
     libmagickcore-6.q16-6-extra \
-    libpcre3 \
     locales \
     mariadb-client \
-    nano \
-    ncurses-bin \
-    netcat-traditional \
-    openssh-client \
-    patch \
     postgresql-client \
     pv \
     python-is-python3 \
@@ -124,6 +113,17 @@ RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
     blackfire \
     blackfire-php \
+    fontconfig \
+    git \
+    iproute2 \
+    iputils-ping \
+    jq \
+    libpcre3 \
+    nano \
+    ncurses-bin \
+    netcat-traditional \
+    openssh-client \
+    patch \
     sudo \
     telnet \
     tree

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -125,6 +125,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     unzip \
     vim-tiny \
     zip
+RUN update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 10
 
 # Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
 RUN rm /etc/apt/sources.list.d/blackfire.list
@@ -262,7 +263,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     rsync \
     sqlite3 \
     unzip \
+    vim-tiny \
     zip
+RUN update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 10
 
 # Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
 RUN rm /etc/apt/sources.list.d/blackfire.list

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.24.1" // Note that this can be overridden by make
+var WebTag = "20241212_wazum_vim-tiny-vi" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The issue

* #6840 

As a _vim_ power user, you are used to typing `vim` to start your favorite editor.
The `vim-tiny` package only adds a `/usr/bin/vi` binary.

## How this PR solves the problem

This PR explicitly adds the `vim-tiny` package and then adds an alternative name “vim” via Debian's alternative system.
If someone needs to install the full `vim` package (`vim-nox` etc), this will then take precedence without conflict.

## Manual Testing Instructions

Difference between v1.24.1 and this PR

```
docker run --rm -it ddev/ddev-webserver:v1.24.1 apt-mark showmanual > 1.24.1.txt
docker run --rm -it ddev/ddev-webserver-prod:v1.24.1 apt-mark showmanual > 1.24.1-prod.txt
docker run --rm -it ddev/ddev-webserver:20241212_wazum_vim-tiny-vi apt-mark showmanual > pr.txt
docker run --rm -it ddev/ddev-webserver-prod:20241212_wazum_vim-tiny-vi apt-mark showmanual > pr-prod.txt
```

No difference between `ddev-webserver` from v1.24.1 and from this PR:

```
diff 1.24.1.txt pr.txt -y --suppress-common-lines
<nothing>
```

Difference between `ddev-webserver-prod` from v1.24.1 and from this PR:

```
diff 1.24.1-prod.txt pr-prod.txt -y --suppress-common-lines
fontconfig                                                    <
                                                              > graphviz
iproute2                                                      <
iputils-ping                                                  <
                                                              > less
                                                              > libldap-common
libpcre3                                                      <
nano                                                          <
ncurses-bin                                                   <
netcat-traditional                                            <
openssh-client                                                <
patch                                                         <
                                                              > python-is-python3
                                                              > vim-tiny
```

Difference between `ddev-webserver-prod` and `ddev-webserver` in v1.24.1 release.
```
diff 1.24.1-prod.txt 1.24.1.txt -y --suppress-common-lines
                                                              > blackfire
                                                              > graphviz
                                                              > less
                                                              > libldap-common
                                                              > platformsh-cli
                                                              > python-is-python3
                                                              > sudo
                                                              > telnet
                                                              > tree
                                                              > upsun-cli
                                                              > vim-tiny
```

Difference between `ddev-webserver-prod` and `ddev-webserver` in this PR.
```
diff pr-prod.txt pr.txt -y --suppress-common-lines
                                                              > blackfire
                                                              > fontconfig
                                                              > iproute2
                                                              > iputils-ping
                                                              > libpcre3
                                                              > nano
                                                              > ncurses-bin
                                                              > netcat-traditional
                                                              > openssh-client
                                                              > patch
                                                              > platformsh-cli
                                                              > sudo
                                                              > telnet
                                                              > tree
                                                              > upsun-cli
```

---

This should work:
```
ddev exec vim
```