### PR TITLE
feat: Add pager to database output

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -212,6 +212,7 @@ services:
     - MYSQL_PWD=db
     - NODE_EXTRA_CA_CERTS=/mnt/ddev-global-cache/mkcert/rootCA.pem
     - npm_config_cache=/mnt/ddev-global-cache/npm
+    - PAGER=less -SFX
     - PGDATABASE=db
     - PGHOST=db
     - PGPASSWORD=db

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -71,6 +71,7 @@ services:
       - POSTGRES_PASSWORD=db
       - POSTGRES_USER=db
       - POSTGRES_DB=db
+      - PAGER=less -SFX
       - TZ={{ .Timezone }}
       - USER={{ .Username }}
     command: ${DDEV_DB_CONTAINER_COMMAND}

--- a/pkg/ddevapp/global_dotddev_assets/commands/db/mysql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/db/mysql
@@ -8,4 +8,4 @@
 ## DBTypes: mysql,mariadb
 ## ExecRaw: true
 
-mysql -udb -pdb "$@"
+mysql -udb -pdb --pager "$@"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

Database CLI commands (`ddev mysql`, `ddev psql`) are not configured to use a pager. This results is text wrapping on smaller terminal windows.

MySQL: 
![image](https://github.com/user-attachments/assets/d96b26c0-e00d-4fe0-b34a-77dd6c66a0da)

Postgres:
![image](https://github.com/user-attachments/assets/74001a83-3b6f-4131-832e-0a49b5f2ddf9)

## How This PR Solves The Issue

This PR configures the pager option for databases, improving the readability of output.

- A PAGER environmental variable is defined
- It uses `less`  (see [man less](https://man7.org/linux/man-pages/man1/less.1.html) for `-SFX` switch descriptions.
- If output wraps, the pager is invoked. Press <kbd>right-arrow</kbd> to page right, <kbd>left-arrow</kbd> to page left.
- If output does not wrap, no pager is used (aka current behavior).

> [!IMPORTANT] 
> This PR changes the default behavior of the database CLI, and therefore may be "controversial"
> This PR using an environmental variable, developers can override the value through the various methods.

I manually testd on the following:

- MariaDB: `10.11`
- Postgres: `16 `
- MySQL: `8.0`

### MariaDB 10.11

![image](https://github.com/user-attachments/assets/82eb641c-10bc-477d-ad55-f65dc102962f)
Press <kbd>right-arrow</kbd> to page right

![image](https://github.com/user-attachments/assets/e478d49c-8326-4928-8306-209edbbea76e)


Example of wide terminal that does not invoke pager; 
![image](https://github.com/user-attachments/assets/09064fa1-365b-4667-acc9-e550847547de)

### Postgres:16 

> If the environment variable PAGER is set, the output is piped to the specified program. Otherwise a platform-dependent default (such as more) is used.
https://www.postgresql.org/docs/7.4/app-psql.html

Postgres: paged
![image](https://github.com/user-attachments/assets/f34a006b-cc48-4945-979c-d544b583056f)


### MySQL 8.0

MySQL requires the `--pager` switch passed in the command. When no value is provided, it fallsback to the environmental variable defined. See https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-using-pager.html

MySQL: paged
![image](https://github.com/user-attachments/assets/ea51cb3f-cc7b-4d94-9a67-6abd3b9c36f9)

## Manual Testing Instructions

Setup project. For existing project skip to "pager test".

1. Create a Laravel project following quickstart guide.
2. Migrate database.

```shell
ddev artisan migrate:fresh
```

3. Populate database with random data

```shell
$ ddev artisan tinker
User::factory(5)->create()
exit
```

### Test pager

5. Start database CLI via `ddev mysql` or `ddev psql`
6. Enter SQL command to view content. Eg. `select * from Users;`

## Automated Testing Overview


## Other



## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
