### PR TITLE
docs: add CiviCRM Standalone to quickstart.md

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -14,6 +14,7 @@ CakePHP
 Callgraph
 CGroups
 CIFS
+CiviCRM
 CLI
 Cloudflare
 CMD

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -74,53 +74,27 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
 [CiviCRM Standalone](https://civicrm.org/blog/ufundo/next-steps-civicrm-standalone) allows running [CiviCRM](https://civicrm.org/) without a CMS.
 
-=== "macOS and Linux"
-
-    ```bash
-    curl -L https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz > civicrm-standalone.tar.gz
-    tar -xzf civicrm-standalone.tar.gz
-    cd civicrm-standalone
-    ddev config --project-type=php
-    ddev start
-    curl -LsS https://download.civicrm.org/cv/cv.phar --create-dirs -o bin/cv
-    chmod +x bin/cv
-    # You can now install CiviCRM manually in your browser using `ddev launch`
-    # and selecting `db` for the server and `db` for database/username/password
-    # or do the same automatically using the command below:
-    # The parameter `-m loadGenerated=1` includes sample data
-    ddev exec cv core:install \
-        --cms-base-url='$DDEV_PRIMARY_URL' \
-        --db=mysql://db:db@db/db \
-        -m loadGenerated=1 \
-        -m extras.adminUser=admin \
-        -m extras.adminPass=admin \
-        -m extras.adminEmail=admin@example.com
-    ddev launch
-    ```
-
-=== "Windows"
-
-    ```bash
-    mkdir my-civicrm-site && cd my-civicrm-site
-    ddev config --project-type=php --upload-dirs=public/media
-    echo "RUN curl -L --fail -o /tmp/civicrm-standalone.tar.gz -sSL https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz" > .ddev/web-build/Dockerfile.civicrm-standalone
-    echo "RUN curl -L --fail -o /usr/local/bin/cv -sSL https://download.civicrm.org/cv/cv.phar && chmod ugo+wx /usr/local/bin/cv" > .ddev/web-build/Dockerfile.cv
-    ddev start
-    ddev exec tar --strip-components=1 -xzf /tmp/civicrm-standalone.tar.gz
-    # You can now install CiviCRM manually in your browser using `ddev launch`
-    # and selecting `db:3306` for the server and `db` for database/username/password
-    # or do the same automatically using the command below:
-    # The parameter `-m loadGenerated=1` includes sample data
-    ddev exec cv core:install \
-        --cms-base-url='$DDEV_PRIMARY_URL' \
-        --db=mysql://db:db@db/db \
-        -m loadGenerated=1 \
-        -m extras.adminUser=admin \
-        -m extras.adminPass=admin \
-        -m extras.adminEmail=admin@example.com
-    # Login using `admin` user and `admin` password
-    ddev launch
-    ```
+```bash
+mkdir my-civicrm-site && cd my-civicrm-site
+ddev config --project-type=php
+ddev start
+ddev exec curl -L https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz > civicrm-standalone.tar.gz
+ddev exec tar --strip-components=1 -xzf civicrm-standalone.tar.gz
+ddev exec curl -LsS https://download.civicrm.org/cv/cv.phar --create-dirs -o bin/cv
+ddev exec chmod +x bin/cv
+# You can now install CiviCRM manually in your browser using `ddev launch`
+# and selecting `db` for the server and `db` for database/username/password
+# or do the same automatically using the command below:
+# The parameter `-m loadGenerated=1` includes sample data
+ddev exec cv core:install \
+    --cms-base-url='$DDEV_PRIMARY_URL' \
+    --db=mysql://db:db@db/db \
+    -m loadGenerated=1 \
+    -m extras.adminUser=admin \
+    -m extras.adminPass=admin \
+    -m extras.adminEmail=admin@example.com
+ddev launch
+```
 
 Visit [Install CiviCRM (Standalone)](https://docs.civicrm.org/installation/en/latest/standalone) for more installation details.
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -76,7 +76,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
 ```bash
 mkdir my-civicrm-site && cd my-civicrm-site
-ddev config --project-type=php
+ddev config --project-type=php --upload-dirs=public/media
 echo "RUN curl -L --fail -o /tmp/civicrm-standalone.tar.gz -sSL https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz" > .ddev/web-build/Dockerfile.civicrm-standalone
 echo "RUN curl -L --fail -o /usr/local/bin/cv -sSL https://download.civicrm.org/cv/cv.phar && chmod ugo+wx /usr/local/bin/cv" > .ddev/web-build/Dockerfile.cv
 ddev start

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -79,7 +79,7 @@ mkdir my-civicrm-site && cd my-civicrm-site
 ddev config --project-type=php
 ddev start
 ddev exec curl -L https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz > civicrm-standalone.tar.gz
-ddev exec tar --strip-components=1 -xzf civicrm-standalone.tar.gz
+ddev exec tar --strip-components=1 -xzf civicrm-standalone.tar.gz && ddev exec rm civicrm-standalone.tar.gz
 ddev exec curl -LsS https://download.civicrm.org/cv/cv.phar --create-dirs -o bin/cv
 ddev exec chmod +x bin/cv
 # You can now install CiviCRM manually in your browser using `ddev launch`

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -70,6 +70,35 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
     ddev launch
     ```
 
+## CiviCRM (Standalone)
+
+[CiviCRM Standalone](https://civicrm.org/blog/ufundo/next-steps-civicrm-standalone) allows running [CiviCRM](https://civicrm.org/) without a CMS.
+
+```bash
+curl -L https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz > civicrm-standalone.tar.gz
+tar -xzf civicrm-standalone.tar.gz
+cd civicrm-standalone
+ddev config --project-type=php
+ddev start
+curl -LsS https://download.civicrm.org/cv/cv.phar --create-dirs -o bin/cv
+chmod +x bin/cv
+# The parameter `-m loadGenerated=1` includes sample data
+ddev exec cv core:install \
+    --cms-base-url="https://civicrm-standalone.ddev.site" \
+    --db=mysql://db:db@db/db \
+    -m loadGenerated=1 \
+    -m extras.adminUser=admin \
+    -m extras.adminPass=admin \
+    -m extras.adminEmail=admin@example.com
+ddev launch
+```
+
+In the web browser, log in using `admin` and `admin`.
+
+Alternatively, install manually via https://civicrm-standalone.ddev.site/
+
+Visit [Install CiviCRM (Standalone)](https://docs.civicrm.org/installation/en/latest/standalone) for more installation details.
+
 ## Contao
 
 Further information on the DDEV procedure can also be found in the [Contao documentation](https://docs.contao.org/manual/en/guides/local-installation/ddev/).

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -76,53 +76,51 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
 === "MacOS and Linux"
 
-```bash
-curl -L https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz > civicrm-standalone.tar.gz
-tar -xzf civicrm-standalone.tar.gz
-cd civicrm-standalone
-ddev config --project-type=php
-ddev start
-curl -LsS https://download.civicrm.org/cv/cv.phar --create-dirs -o bin/cv
-chmod +x bin/cv
-# You can now install CiviCRM manually in your browser using `ddev launch`
-# and selecting `db` for the server and `db` for database/username/password
-# or do the same automatically using the command below:
-# The parameter `-m loadGenerated=1` includes sample data
-ddev exec cv core:install \
-    --cms-base-url='$DDEV_PRIMARY_URL' \
-    --db=mysql://db:db@db/db \
-    -m loadGenerated=1 \
-    -m extras.adminUser=admin \
-    -m extras.adminPass=admin \
-    -m extras.adminEmail=admin@example.com
-ddev launch
-```
-
-Visit [Install CiviCRM (Standalone)](https://docs.civicrm.org/installation/en/latest/standalone) for more installation details.
+    ```bash
+    curl -L https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz > civicrm-standalone.tar.gz
+    tar -xzf civicrm-standalone.tar.gz
+    cd civicrm-standalone
+    ddev config --project-type=php
+    ddev start
+    curl -LsS https://download.civicrm.org/cv/cv.phar --create-dirs -o bin/cv
+    chmod +x bin/cv
+    # You can now install CiviCRM manually in your browser using `ddev launch`
+    # and selecting `db` for the server and `db` for database/username/password
+    # or do the same automatically using the command below:
+    # The parameter `-m loadGenerated=1` includes sample data
+    ddev exec cv core:install \
+        --cms-base-url='$DDEV_PRIMARY_URL' \
+        --db=mysql://db:db@db/db \
+        -m loadGenerated=1 \
+        -m extras.adminUser=admin \
+        -m extras.adminPass=admin \
+        -m extras.adminEmail=admin@example.com
+    ddev launch
+    ```
 
 === "Windows"
 
-```bash
-mkdir my-civicrm-site && cd my-civicrm-site
-ddev config --project-type=php --upload-dirs=public/media
-echo "RUN curl -L --fail -o /tmp/civicrm-standalone.tar.gz -sSL https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz" > .ddev/web-build/Dockerfile.civicrm-standalone
-echo "RUN curl -L --fail -o /usr/local/bin/cv -sSL https://download.civicrm.org/cv/cv.phar && chmod ugo+wx /usr/local/bin/cv" > .ddev/web-build/Dockerfile.cv
-ddev start
-ddev exec tar --strip-components=1 -xzf /tmp/civicrm-standalone.tar.gz
-# You can now install CiviCRM manually in your browser using `ddev launch`
-# and selecting `db:3306` for the server and `db` for database/username/password
-# or do the same automatically using the command below:
-# The parameter `-m loadGenerated=1` includes sample data
-ddev exec cv core:install \
-    --cms-base-url='$DDEV_PRIMARY_URL' \
-    --db=mysql://db:db@db/db \
-    -m loadGenerated=1 \
-    -m extras.adminUser=admin \
-    -m extras.adminPass=admin \
-    -m extras.adminEmail=admin@example.com
-# Login using `admin` user and `admin` password
-ddev launch
-```
+    ```bash
+    mkdir my-civicrm-site && cd my-civicrm-site
+    ddev config --project-type=php --upload-dirs=public/media
+    echo "RUN curl -L --fail -o /tmp/civicrm-standalone.tar.gz -sSL https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz" > .ddev/web-build/Dockerfile.civicrm-standalone
+    echo "RUN curl -L --fail -o /usr/local/bin/cv -sSL https://download.civicrm.org/cv/cv.phar && chmod ugo+wx /usr/local/bin/cv" > .ddev/web-build/Dockerfile.cv
+    ddev start
+    ddev exec tar --strip-components=1 -xzf /tmp/civicrm-standalone.tar.gz
+    # You can now install CiviCRM manually in your browser using `ddev launch`
+    # and selecting `db:3306` for the server and `db` for database/username/password
+    # or do the same automatically using the command below:
+    # The parameter `-m loadGenerated=1` includes sample data
+    ddev exec cv core:install \
+        --cms-base-url='$DDEV_PRIMARY_URL' \
+        --db=mysql://db:db@db/db \
+        -m loadGenerated=1 \
+        -m extras.adminUser=admin \
+        -m extras.adminPass=admin \
+        -m extras.adminEmail=admin@example.com
+    # Login using `admin` user and `admin` password
+    ddev launch
+    ```
 
 Visit [Install CiviCRM (Standalone)](https://docs.civicrm.org/installation/en/latest/standalone) for more installation details.
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -74,7 +74,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
 [CiviCRM Standalone](https://civicrm.org/blog/ufundo/next-steps-civicrm-standalone) allows running [CiviCRM](https://civicrm.org/) without a CMS.
 
-=== "MacOS and Linux"
+=== "macOS and Linux"
 
     ```bash
     curl -L https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz > civicrm-standalone.tar.gz

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -75,27 +75,26 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 [CiviCRM Standalone](https://civicrm.org/blog/ufundo/next-steps-civicrm-standalone) allows running [CiviCRM](https://civicrm.org/) without a CMS.
 
 ```bash
-curl -L https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz > civicrm-standalone.tar.gz
-tar -xzf civicrm-standalone.tar.gz
-cd civicrm-standalone
+mkdir my-civicrm-site && cd my-civicrm-site
 ddev config --project-type=php
+echo "RUN curl -L --fail -o /tmp/civicrm-standalone.tar.gz -sSL https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz" > .ddev/web-build/Dockerfile.civicrm-standalone
+echo "RUN curl -L --fail -o /usr/local/bin/cv -sSL https://download.civicrm.org/cv/cv.phar && chmod ugo+wx /usr/local/bin/cv" > .ddev/web-build/Dockerfile.cv
 ddev start
-curl -LsS https://download.civicrm.org/cv/cv.phar --create-dirs -o bin/cv
-chmod +x bin/cv
+ddev exec tar --strip-components=1 -xzf /tmp/civicrm-standalone.tar.gz
+# You can now install CiviCRM manually in your browser using `ddev launch`
+# and selecting `db:3306` for the server and `db` for database/username/password
+# or do the same automatically using the command below:
 # The parameter `-m loadGenerated=1` includes sample data
 ddev exec cv core:install \
-    --cms-base-url="https://civicrm-standalone.ddev.site" \
+    --cms-base-url='$DDEV_PRIMARY_URL' \
     --db=mysql://db:db@db/db \
     -m loadGenerated=1 \
     -m extras.adminUser=admin \
     -m extras.adminPass=admin \
     -m extras.adminEmail=admin@example.com
+# Login using `admin` user and `admin` password
 ddev launch
 ```
-
-In the web browser, log in using `admin` and `admin`.
-
-Alternatively, install manually via https://civicrm-standalone.ddev.site/
 
 Visit [Install CiviCRM (Standalone)](https://docs.civicrm.org/installation/en/latest/standalone) for more installation details.
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -74,6 +74,34 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
 [CiviCRM Standalone](https://civicrm.org/blog/ufundo/next-steps-civicrm-standalone) allows running [CiviCRM](https://civicrm.org/) without a CMS.
 
+=== "MacOS and Linux"
+
+```bash
+curl -L https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz > civicrm-standalone.tar.gz
+tar -xzf civicrm-standalone.tar.gz
+cd civicrm-standalone
+ddev config --project-type=php
+ddev start
+curl -LsS https://download.civicrm.org/cv/cv.phar --create-dirs -o bin/cv
+chmod +x bin/cv
+# You can now install CiviCRM manually in your browser using `ddev launch`
+# and selecting `db` for the server and `db` for database/username/password
+# or do the same automatically using the command below:
+# The parameter `-m loadGenerated=1` includes sample data
+ddev exec cv core:install \
+    --cms-base-url='$DDEV_PRIMARY_URL' \
+    --db=mysql://db:db@db/db \
+    -m loadGenerated=1 \
+    -m extras.adminUser=admin \
+    -m extras.adminPass=admin \
+    -m extras.adminEmail=admin@example.com
+ddev launch
+```
+
+Visit [Install CiviCRM (Standalone)](https://docs.civicrm.org/installation/en/latest/standalone) for more installation details.
+
+=== "Windows"
+
 ```bash
 mkdir my-civicrm-site && cd my-civicrm-site
 ddev config --project-type=php --upload-dirs=public/media

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -78,10 +78,9 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 mkdir my-civicrm-site && cd my-civicrm-site
 ddev config --project-type=php
 ddev start
-ddev exec curl -L https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz > civicrm-standalone.tar.gz
-ddev exec tar --strip-components=1 -xzf civicrm-standalone.tar.gz && ddev exec rm civicrm-standalone.tar.gz
-ddev exec curl -LsS https://download.civicrm.org/cv/cv.phar --create-dirs -o bin/cv
-ddev exec chmod +x bin/cv
+ddev exec "curl -LsS https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz -o /tmp/civicrm-standalone.tar.gz"
+ddev exec "tar --strip-components=1 -xzf /tmp/civicrm-standalone.tar.gz"
+ddev exec "curl -LsS https://download.civicrm.org/cv/cv.phar --create-dirs -o bin/cv && chmod +x bin/cv"
 # You can now install CiviCRM manually in your browser using `ddev launch`
 # and selecting `db` for the server and `db` for database/username/password
 # or do the same automatically using the command below:

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -76,7 +76,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
 ```bash
 mkdir my-civicrm-site && cd my-civicrm-site
-ddev config --project-type=php --upload-dirs=public/media
+ddev config --project-type=php --composer-root=core --upload-dirs=public/media
 ddev start
 ddev exec "curl -LsS https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz -o /tmp/civicrm-standalone.tar.gz"
 ddev exec "tar --strip-components=1 -xzf /tmp/civicrm-standalone.tar.gz"

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -76,7 +76,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
 ```bash
 mkdir my-civicrm-site && cd my-civicrm-site
-ddev config --project-type=php
+ddev config --project-type=php --upload-dirs=public/media
 ddev start
 ddev exec "curl -LsS https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz -o /tmp/civicrm-standalone.tar.gz"
 ddev exec "tar --strip-components=1 -xzf /tmp/civicrm-standalone.tar.gz"

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -80,7 +80,7 @@ ddev config --project-type=php --composer-root=core --upload-dirs=public/media
 ddev start
 ddev exec "curl -LsS https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz -o /tmp/civicrm-standalone.tar.gz"
 ddev exec "tar --strip-components=1 -xzf /tmp/civicrm-standalone.tar.gz"
-ddev exec "curl -LsS https://download.civicrm.org/cv/cv.phar --create-dirs -o bin/cv && chmod +x bin/cv"
+ddev composer require civicrm/cli-tools --no-scripts
 # You can now install CiviCRM manually in your browser using `ddev launch`
 # and selecting `db` for the server and `db` for database/username/password
 # or do the same automatically using the command below:

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -72,7 +72,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
 ## CiviCRM (Standalone)
 
-[CiviCRM Standalone](https://civicrm.org/blog/ufundo/next-steps-civicrm-standalone) allows running [CiviCRM](https://civicrm.org/) without a CMS.
+[CiviCRM Standalone](https://civicrm.org/blog/ufundo/next-steps-civicrm-standalone) allows running [CiviCRM](https://civicrm.org/) without a CMS. Visit [Install CiviCRM (Standalone)](https://docs.civicrm.org/installation/en/latest/standalone) for more installation details.
 
 ```bash
 mkdir my-civicrm-site && cd my-civicrm-site
@@ -94,8 +94,6 @@ ddev exec cv core:install \
     -m extras.adminEmail=admin@example.com
 ddev launch
 ```
-
-Visit [Install CiviCRM (Standalone)](https://docs.civicrm.org/installation/en/latest/standalone) for more installation details.
 
 ## Contao
 


### PR DESCRIPTION
## The Issue

Historically, [CiviCRM](https://civicrm.org/) required a CMS such as Drupal or Wordpress, but [CiviCRM Standalone](https://civicrm.org/blog/ufundo/next-steps-civicrm-standalone) allows running it without a CMS.

## How This PR Solves The Issue

Adds CiviCRM Standalone to the [CMS Quickstarts](https://ddev.readthedocs.io/en/stable/users/quickstart) page.

## Manual Testing Instructions

https://ddev--6846.org.readthedocs.build/en/6846/users/quickstart/#civicrm-standalone

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
