### PR TITLE
docs: Add database management examples including how to create empty database

### DIFF
--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -44,6 +44,7 @@ You can export in the same way: `ddev export-db -f mysite.sql.gz` will export yo
 You can manage databases in DDEV like you would do on a regular server.
 
 To create an empty, extra database for later usage run this command:
+
 ```
 ddev mysql -uroot -proot -e 'CREATE DATABASE newdatabase; GRANT ALL on newdatabase.* to "db"@"%";'
 ```

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -37,6 +37,8 @@ DDEV creates a default database named `db` and default permissions for the `db` 
 
 You can easily create and populate additional databases. For example, `ddev import-db --database=backend --file=backend.sql.gz` will create the database named `backend` with permissions for that same `db` user and import from the `backend.sql.gz` dumpfile.
 
+To create an empty, extra database for later usage, simply create an empty file with `touch dummy_db.sql` and import it with `ddev import-db --database=civicrm_db --file=dummy_db.sql`. This creates an empty database named `civicrm_db`, with permissions for the `db` user.
+
 You can export in the same way: `ddev export-db -f mysite.sql.gz` will export your default database (`db`). `ddev export-db --database=backend -f backend-export.sql.gz` will dump the database named `backend`.
 
 ## Snapshots

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -37,9 +37,18 @@ DDEV creates a default database named `db` and default permissions for the `db` 
 
 You can easily create and populate additional databases. For example, `ddev import-db --database=backend --file=backend.sql.gz` will create the database named `backend` with permissions for that same `db` user and import from the `backend.sql.gz` dumpfile.
 
-To create an empty, extra database for later usage, create an empty file with `touch dummy_db.sql` and import it with `ddev import-db --database=civicrm_db --file=dummy_db.sql`. This creates an empty database named `civicrm_db`, with permissions for the `db` user.
-
 You can export in the same way: `ddev export-db -f mysite.sql.gz` will export your default database (`db`). `ddev export-db --database=backend -f backend-export.sql.gz` will dump the database named `backend`.
+
+## Database Query Examples
+
+You can do anything with the DDEV server that you would do on a server.
+
+To create an empty, extra database for later usage run this command:
+```
+ddev mysql -uroot -proot -e 'CREATE DATABASE newdatabase; GRANT ALL on newdatabase.* to "db"@"%";'
+```
+
+Alternatively, create an empty file and import it.
 
 ## Snapshots
 

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -37,7 +37,7 @@ DDEV creates a default database named `db` and default permissions for the `db` 
 
 You can easily create and populate additional databases. For example, `ddev import-db --database=backend --file=backend.sql.gz` will create the database named `backend` with permissions for that same `db` user and import from the `backend.sql.gz` dumpfile.
 
-To create an empty, extra database for later usage, simply create an empty file with `touch dummy_db.sql` and import it with `ddev import-db --database=civicrm_db --file=dummy_db.sql`. This creates an empty database named `civicrm_db`, with permissions for the `db` user.
+To create an empty, extra database for later usage, create an empty file with `touch dummy_db.sql` and import it with `ddev import-db --database=civicrm_db --file=dummy_db.sql`. This creates an empty database named `civicrm_db`, with permissions for the `db` user.
 
 You can export in the same way: `ddev export-db -f mysite.sql.gz` will export your default database (`db`). `ddev export-db --database=backend -f backend-export.sql.gz` will dump the database named `backend`.
 

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -41,7 +41,7 @@ You can export in the same way: `ddev export-db -f mysite.sql.gz` will export yo
 
 ## Database Query Examples
 
-You can do anything with the DDEV server that you would do on a server.
+You can manage databases in DDEV like you would do on a regular server.
 
 To create an empty, extra database for later usage run this command:
 ```

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -80,7 +80,7 @@ If you’d like to use a GUI database client, you’ll need the right connection
 
 ## Database Query Examples
 
-You can query, update, or alter databases in DDEV like you would do on a regular server, using `ddev mysql`,  `ddev mariadb`, or `ddev psql` or using those CLI tools inside the web or DB containers. Some examples are given below.
+You can query, update, or alter databases in DDEV like you would do on a regular server, using `ddev mysql`,  `ddev mariadb`, or `ddev psql` or using those command-line tools inside the web or DB containers. Some examples are given below.
 
 * Create a new empty database named `newdatabase`:
 

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -39,18 +39,6 @@ You can easily create and populate additional databases. For example, `ddev impo
 
 You can export in the same way: `ddev export-db -f mysite.sql.gz` will export your default database (`db`). `ddev export-db --database=backend -f backend-export.sql.gz` will dump the database named `backend`.
 
-## Database Query Examples
-
-You can manage databases in DDEV like you would do on a regular server.
-
-To create an empty, extra database for later usage run this command:
-
-```
-ddev mysql -uroot -proot -e 'CREATE DATABASE newdatabase; GRANT ALL on newdatabase.* to "db"@"%";'
-```
-
-Alternatively, create an empty file and import it.
-
 ## Snapshots
 
 Snapshots let you easily save the entire status of all of your databases, which can be great when you’re working incrementally on migrations or updates and want to save state so you can start right back where you were.
@@ -89,3 +77,45 @@ If you’d like to use a GUI database client, you’ll need the right connection
 * There’s a sample custom command that will run the free MySQL Workbench on macOS, Windows or Linux. To use it, run:
     * `cp ~/.ddev/commands/host/mysqlworkbench.example ~/.ddev/commands/host/mysqlworkbench`
     * `ddev mysqlworkbench`
+
+## Database Query Examples
+
+You can query, update, or alter databases in DDEV like you would do on a regular server, using `ddev mysql`,  `ddev mariadb`, or `ddev psql` or using those CLI tools inside the web or DB containers. Some examples are given below.
+
+* Create a new empty database named `newdatabase`:
+
+    ```bash
+    ddev mysql -e 'CREATE DATABASE newdatabase; GRANT ALL ON newdatabase.* TO "db"@"%";'
+    ```
+
+* Show tables whose name begins with `node` :
+
+    ```bash
+    ddev mysql -e 'SHOW TABLES LIKE "node%";'
+    ```
+
+* Use `ddev mysql` or `ddev mariadb` and issue interactive queries:
+
+    ```bash
+    ddev mariadb
+  
+    Reading table information for completion of table and column names
+    You can turn off this feature to get a quicker startup with -A
+    
+    Welcome to the MariaDB monitor.  Commands end with ; or \g.
+    Your MariaDB connection id is 28
+    Server version: 10.11.10-MariaDB-ubu2204-log mariadb.org binary distribution
+    
+    Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+    
+    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+    
+    MariaDB [db]> SELECT * FROM node WHERE type="article";
+    +-----+------+---------+--------------------------------------+----------+
+    | nid | vid  | type    | uuid                                 | langcode |
+    +-----+------+---------+--------------------------------------+----------+
+    |  11 |   56 | article | 8af917ea-b150-4006-aeb9-877b53ebf289 | en       |
+    |  12 |   54 | article | 27a53763-9fd8-4813-853b-b476f0a73849 | en       |
+    +-----+------+---------+--------------------------------------+----------+
+    2 rows in set (0.007 sec) 
+    ```


### PR DESCRIPTION
## The Issue

Sometimes, you need an empty database, for later usage. Maybe an install process requires a database present, but you don't want to import a huge database first, just for the install process to over-write it, and then import the big database again.

It is possible to create an empty database manually, as can be seen in [How can I create and load a second database in ddev?](https://stackoverflow.com/questions/49785023/how-can-i-create-and-load-a-second-database-in-ddev/49785024#49785024)

However it requires a few steps, and simply importing an empty text file is much easier.

**Future**: Maybe, in the future, the `ddev import-db` command could get a `--create-db` option, something like this?

```
ddev import-db --database=other_db --create-db
```

## How This PR Solves The Issue

Adds a new section on the https://ddev.readthedocs.io/en/stable/users/usage/database-management/ doc page, called "Database Query Examples" with the command to create an extra database. More examples can be added.

## Manual Testing Instructions

Review rendered at https://ddev--6848.org.readthedocs.build/en/6848/users/usage/database-management/#database-query-examples

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
