### PR TITLE
docs: add Laravel Installer quickstart

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -421,7 +421,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'
 
     # Remove the Laravel installer and the .env file
-    ddev exec 'rm -rf .ddev/web-build/Dockerfile.laravel .env'
+    rm -rf .ddev/web-build/Dockerfile.laravel .env
 
     # Restart the project and execute the post-install actions
     ddev restart

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -403,7 +403,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     mkdir my-laravel-site && cd my-laravel-site
     ddev config --project-type=laravel --docroot=public
 
-    # Temporarily add the Laravel installer
+    # Temporarily add the Laravel installer as /usr/local/bin/laravel in the web container
     echo 'ARG COMPOSER_HOME=/usr/local/composer
     RUN composer global require laravel/installer
     RUN ln -s $COMPOSER_HOME/vendor/bin/laravel /usr/local/bin/laravel

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -409,9 +409,11 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     RUN ln -s $COMPOSER_HOME/vendor/bin/laravel /usr/local/bin/laravel
     ' > .ddev/web-build/Dockerfile.laravel
 
-    # Start the project and select a starter kit of your choice
-    # The database is temporarily set to SQLite and will be switched to MariaDB
+    # Start the project
     ddev start
+
+    # Select a starter kit of your choice.
+    # The database is temporarily set to SQLite and will be switched to MariaDB
     ddev exec laravel new temp --database=sqlite
 
     # Move the installed files

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -397,6 +397,35 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ddev launch
     ```
 
+=== "Laravel Installer"
+
+    ```bash
+    mkdir my-laravel-site && cd my-laravel-site
+    ddev config --project-type=laravel --docroot=public
+
+    # Temporarily add the Laravel installer
+    echo 'ARG COMPOSER_HOME=/usr/local/composer
+    RUN composer global require laravel/installer
+    RUN ln -s $COMPOSER_HOME/vendor/bin/laravel /usr/local/bin/laravel
+    ' > .ddev/web-build/Dockerfile.laravel
+
+    # Start the project and select a starter kit of your choice
+    # The database is temporarily set to SQLite and will be switched to MariaDB
+    ddev start
+    ddev exec laravel new temp --database=sqlite
+
+    # Move the installed files
+    ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'
+
+    # Remove the Laravel installer and the .env file
+    ddev exec 'rm -rf .ddev/web-build/Dockerfile.laravel .env'
+
+    # Restart the project and execute the post-install actions
+    ddev restart
+    ddev composer run-script post-create-project-cmd
+    ddev launch
+    ```
+
 === "Git Clone"
 
     ```bash

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -416,7 +416,8 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     # The database is temporarily set to SQLite and will be switched to MariaDB
     ddev exec laravel new temp --database=sqlite
 
-    # Move the installed files
+    # 'laravel new' can't install in the current directory right away,
+    # so we use 'rsync' to move the installed files one level up
     ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'
 
     # Remove the Laravel installer and the .env file
@@ -738,6 +739,8 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev start
     ddev exec symfony check:requirements
     ddev exec symfony new temp --version="7.1.*" --webapp
+    # 'symfony new' can't install in the current directory right away,
+    # so we use 'rsync' to move the installed files one level up
     ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'
     ddev launch
     ```


### PR DESCRIPTION
## The Issue

Laravel has its own installer, but it's distributed only with Composer.

This installer allows you to select a [starter kit](https://laravel.com/docs/11.x/starter-kits) with additional options when you create the app:

```
$ laravel new
   _                               _
  | |                             | |
  | |     __ _ _ __ __ ___   _____| |
  | |    / _` | '__/ _` \ \ / / _ \ |
  | |___| (_| | | | (_| |\ V /  __/ |
  |______\__,_|_|  \__,_| \_/ \___|_|


 ┌ Would you like to install a starter kit? ────────────────────┐
 │   ○ No starter kit                                           │
 │   ○ Laravel Breeze                                           │
 │ › ● Laravel Jetstream                                        │
 └──────────────────────────────────────────────────────────────┘

 ┌ Which Jetstream stack would you like to install? ────────────┐
 │   ○ Livewire                                                 │
 │ › ● Vue with Inertia                                         │
 └──────────────────────────────────────────────────────────────┘

┌ Would you like any optional features? ───────────────────────┐
 │   ◻ API support                                              │
 │   ◼ Dark mode                                                │
 │ › ◼ Email verification                                       │
 │   ◻ Team support                                             │
 │   ◼ Inertia SSR                                              │
 └──────────────────────────────────────────────────────────────┘

 ┌ Which testing framework do you prefer? ──────────────────────┐
 │ › ● Pest                                                     │
 │   ○ PHPUnit                                                  │
 └──────────────────────────────────────────────────────────────┘
```

Without the Laravel installer, all of this would need to be done manually, and I believe most people prefer having a starter kit from the beginning.

## How This PR Solves The Issue

Adds a quickstart for this.

I chose to add the Laravel Installer temporarily via the Dockerfile, since it’s not needed once the app is created.

I don't believe we need to package this installer inside the `ddev-webserver` Docker image, as it’s more than just one file.

It also serves as a good example for users on how to install a global package with Composer.

## Manual Testing Instructions

https://ddev--6850.org.readthedocs.build/en/6850/users/quickstart/#laravel-laravel-installer

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
