### PR TITLE
fix: remove nfs setup script from install_ddev.sh [skip ci]

### DIFF
--- a/scripts/install_ddev.sh
+++ b/scripts/install_ddev.sh
@@ -11,7 +11,7 @@ set -o nounset
 if [ ! -d /usr/local/bin ]; then echo 'using sudo to mkdir missing /usr/local/bin' && sudo mkdir -p /usr/local/bin; fi
 
 GITHUB_OWNER=${GITHUB_OWNER:-ddev}
-ARTIFACTS="ddev mkcert macos_ddev_nfs_setup.sh"
+ARTIFACTS="ddev mkcert"
 TMPDIR=/tmp
 
 RED='\033[31m'
@@ -140,7 +140,6 @@ fi
 
 curl -fsSL "$RELEASE_BASE_URL/$TARBALL" -o "${TMPDIR}/${TARBALL}" || (printf "${RED}Failed downloading $RELEASE_BASE_URL/$TARBALL${RESET}\n" && exit 108)
 curl -fsSL "$RELEASE_BASE_URL/$SHAFILE" -o "${TMPDIR}/${SHAFILE}" || (printf "${RED}Failed downloading $RELEASE_BASE_URL/$SHAFILE${RESET}\n" && exit 109)
-curl -fsSL "https://raw.githubusercontent.com/${GITHUB_OWNER}/ddev/master/scripts/macos_ddev_nfs_setup.sh" -o "${TMPDIR}/macos_ddev_nfs_setup.sh" || (printf "${RED}Failed downloading "https://raw.githubusercontent.com/${GITHUB_OWNER}/ddev/master/scripts/macos_ddev_nfs_setup.sh"${RESET}\n" && exit 110)
 
 cd $TMPDIR
 $SHACMD -c "$SHAFILE"


### PR DESCRIPTION

## The Issue

I happened to notice that the install_ddev.sh is still downloading the NFS setup script... and always for macos.

## How This PR Solves The Issue

Remove that.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
