### PR TITLE
feat: Add CLI Wrappers for CiviCRM Tools (`civistrings`, `civix`, `coworker` and `cv`) in Web Container

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/civistrings
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/civistrings
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run civistrings CLI inside the web container
+## Usage: civistrings [flags] [args]
+## Example: "ddev civistrings -o myfile.pot myfolder" or "ddev civistrings --version"
+## Aliases: cvstr
+## ProjectTypes: drupal,drupal11,drupal10,drupal9,drupal8,drupal7,backdrop
+## ExecRaw: true
+
+if ! command -v civistrings >/dev/null; then
+  echo "civistrings is not available. You may need to 'ddev composer require civicrm/cli-tools'"
+  exit 1
+fi
+./vendor/bin/civistrings "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/civix
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/civix
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run civix CLI inside the web container
+## Usage: civix [flags] [args]
+## Example: "ddev civix build:zip" or "ddev civix upgrade" or "ddev civix --version"
+## Aliases: cvx
+## ProjectTypes: drupal,drupal11,drupal10,drupal9,drupal8,drupal7,backdrop
+## ExecRaw: true
+
+if ! command -v civix >/dev/null; then
+  echo "civix is not available. You may need to 'ddev composer require civicrm/cli-tools'"
+  exit 1
+fi
+./vendor/bin/civix "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/coworker
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/coworker
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run coworker CLI inside the web container
+## Usage: coworker [flags] [args]
+## Example: "ddev coworker list" or "ddev coworker debug" or "ddev coworker --version"
+## Aliases: cowkr
+## ProjectTypes: drupal,drupal11,drupal10,drupal9,drupal8,drupal7,backdrop
+## ExecRaw: true
+
+if ! command -v coworker >/dev/null; then
+  echo "coworker is not available. You may need to 'ddev composer require civicrm/cli-tools'"
+  exit 1
+fi
+./vendor/bin/coworker "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/cv
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/cv
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run cv CLI inside the web container
+## Usage: cv [flags] [args]
+## Example: "ddev cv flush" or "ddev cv upgrade:db" or "ddev cv --version"
+## Aliases: cv
+## ProjectTypes: drupal,drupal11,drupal10,drupal9,drupal8,drupal7,backdrop
+## ExecRaw: true
+
+if ! command -v cv >/dev/null; then
+  echo "cv is not available. You may need to 'ddev composer require civicrm/cli-tools'"
+  exit 1
+fi
+./vendor/bin/cv "$@"


### PR DESCRIPTION
## The Issue

CiviCRM developers require tools like `civistrings`, `civix`, `coworker`, and `cv` for their workflows. Running these tools within DDEV-managed environments currently involves manual setup, making it cumbersome to integrate them seamlessly into the containerized workflow.

## How This PR Solves The Issue

This PR introduces four new CLI wrappers (`civistrings`, `civix`, `coworker`, and `cv`) that:
- Simplify the execution of these commands using DDEV's `ddev <command>` syntax.
- Automatically validate the presence of the required CLI tool and provide actionable error messages if missing.
- Support popular CMS platforms integrated with CiviCRM, including Drupal (all major versions) and Backdrop.

### Key Features

1. **`ddev civistrings`**
   - Executes the `civistrings` CLI tool inside the web container.
   - **Alias**: `cvstr`
   - **Examples**:
     - `ddev civistrings -o myfile.pot myfolder`
     - `ddev civistrings --version`

2. **`ddev civix`**
   - Executes the `civix` CLI tool inside the web container.
   - **Alias**: `cvx`
   - **Examples**:
     - `ddev civix build:zip`
     - `ddev civix upgrade`

3. **`ddev coworker`**
   - Executes the `coworker` CLI tool inside the web container.
   - **Alias**: `cowkr`
   - **Examples**:
     - `ddev coworker list`
     - `ddev coworker debug`

4. **`ddev cv`**
   - Executes the `cv` CLI tool inside the web container.
   - **Alias**: `cv`
   - **Examples**:
     - `ddev cv flush`
     - `ddev cv upgrade:db`

### Supported Project Types
- `drupal`, `drupal11`, `drupal10`, `drupal9`, `drupal8`, `drupal7`, `backdrop`

### Error Handling
- If a CLI tool is missing, users are informed and guided to install the required dependency via `ddev composer require civicrm/cli-tools`.

## Testing Overview

- Validating error messages when tools are missing.
- Confirming proper command execution when tools are available.
- Ensuring commands work across supported project types.

## Release/Deployment Notes

- No breaking changes; this PR introduces additional functionality.
- Update the DDEV documentation to include these new commands, their usage, and examples. Please check PR #6858
- Users must ensure `civicrm/cli-tools` is installed via `ddev composer require civicrm/cli-tools` for these commands to work.