### PR TITLE
docs: Add `CiviCRM CLI Tools` to Developer Tools Documentation

### DIFF
--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -20,6 +20,11 @@ Hundreds of useful developer tools are included inside the containers and can be
 * `npm`, `nvm`, and `yarn` (these also have `ddev` shortcuts like [`ddev npm`](../usage/commands.md#npm), [`ddev nvm`](../usage/commands.md#nvm), [`ddev yarn`](../usage/commands.md#yarn)).
 * `node`
 * `sqlite3`
+* [CiviCRM CLI Tools](https://github.com/civicrm/civicrm-cli-tools):
+  * `civistrings` - Manage and manipulate strings and translations for CiviCRM.
+  * `civix` - Utility for managing CiviCRM extension development.
+  * `coworker` - Run tasks and worker threads for CiviCRM.
+  * `cv` - A general-purpose CiviCRM CLI for tasks like flushing caches or upgrading databases.
 
 These tools can be accessed for single commands using [`ddev exec <command>`](cli.md#executing-commands-in-containers) or [`ddev ssh`](cli.md#ssh-into-containers) for an interactive `bash` or `sh` session.
 

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -20,7 +20,7 @@ Hundreds of useful developer tools are included inside the containers and can be
 * `npm`, `nvm`, and `yarn` (these also have `ddev` shortcuts like [`ddev npm`](../usage/commands.md#npm), [`ddev nvm`](../usage/commands.md#nvm), [`ddev yarn`](../usage/commands.md#yarn)).
 * `node`
 * `sqlite3`
-* [CiviCRM CLI Tools](https://github.com/civicrm/civicrm-cli-tools):
+* [civicrm-cli-tools](https://github.com/civicrm/civicrm-cli-tools):
   * `civistrings` - Manage and manipulate strings and translations for CiviCRM.
   * `civix` - Utility for managing CiviCRM extension development.
   * `coworker` - Run tasks and worker threads for CiviCRM.
@@ -81,7 +81,7 @@ Use [`ddev composer`](../usage/commands.md#composer) (Composer inside the contai
 * On some older configurations of Docker Desktop for Windows, symlinks are created in the container as “simulated symlinks”, or XSym files. These special text files behave as symlinks inside the container (on CIFS filesystem), but appear as simple text files on the Windows host. (On the CIFS filesystem used by Docker for Windows, inside the container, there is no capability to create real symlinks even though Windows now has this capability.)
 * DDEV attempts to clean up for this situation. Since Windows 10/11+ (in developer mode) can create real symlinks, DDEV scans your repository after a `ddev composer` command and attempts to convert XSym files into real symlinks. On older versions of Windows 10, it can only do this if your Windows 10 workstation is set to “Developer Mode”.
 * To enable developer mode on Windows 10/11+, search for “developer” in settings:
-    ![Finding developer mode](../../images/developer-mode-1.png)  
+    ![Finding developer mode](../../images/developer-mode-1.png)
     ![Setting developer mode](../../images/developer-mode-2.png)
 
 ## Email Capture and Review (Mailpit)


### PR DESCRIPTION
## The Issue

The documentation for developer tools in DDEV currently does not mention the inclusion of `CiviCRM CLI Tools`, which are useful for developers working with CiviCRM in DDEV environments.

## How This PR Solves The Issue

This PR updates the **Developer Tools** section of the documentation to include a description of the `CiviCRM CLI Tools`. It highlights the tools available (`civistrings`, `civix`, `coworker`, and `cv`) and provides a brief explanation of their purpose. This ensures that CiviCRM developers are aware of these tools and can effectively utilize them.

### Key Changes
- Added an entry for **CiviCRM CLI Tools** to the list of developer tools.
- Provided a brief description of each tool:
  - `civistrings`: Manage and manipulate strings and translations for CiviCRM.
  - `civix`: Utility for managing CiviCRM extension development.
  - `coworker`: Run tasks and worker threads for CiviCRM.
  - `cv`: A general-purpose CiviCRM CLI for tasks like flushing caches or upgrading databases.

### Updated Section
The modified **Developer Tools** section now includes:

```markdown
* [CiviCRM CLI Tools](https://github.com/civicrm/civicrm-cli-tools):
  * `civistrings` - Manage and manipulate strings and translations for CiviCRM.
  * `civix` - Utility for managing CiviCRM extension development.
  * `coworker` - Run tasks and worker threads for CiviCRM.
  * `cv` - A general-purpose CiviCRM CLI for tasks like flushing caches or upgrading databases.
```

## Manual Testing Instructions

1. Open the updated documentation file: `docs/content/users/usage/developer-tools.md`.
2. Verify that the **CiviCRM CLI Tools** section is added correctly under the list of developer tools.
3. Click on the link to the [CiviCRM CLI Tools GitHub repository](https://github.com/civicrm/civicrm-cli-tools) to confirm that it redirects to the correct source.

## Automated Testing Overview

No automated tests are needed for this documentation update.

## Release/Deployment Notes

- This is a documentation-only change and does not affect application functionality.
- It ensures that developers are informed about the availability of CiviCRM CLI tools within DDEV environments.
