### PR TITLE
docs: Update mkdocs installation as docker doesn't work [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,8 @@ markdownlint:
 		echo "Skipping markdownlint as not installed"; \
 	fi
 
-# Best to install mkdocs locally with "sudo pip3 install -r docs/mkdocs-pip-requirements"
+# Install mkdocs locally using
+# https://ddev.readthedocs.io/en/stable/developers/testing-docs/
 mkdocs:
 	@echo "mkdocs: "
 	@CMD="mkdocs -q build -d /tmp/mkdocsbuild"; \
@@ -157,22 +158,15 @@ mkdocs:
 		echo "Not running mkdocs because it's not installed"; \
 	fi
 
-# To see what the docs build will be, you can use `make mkdocs-serve`
-# It works best with mkdocs installed, `pip3 install mkdocs`,
-# see https://www.mkdocs.org/user-guide/installation/
-# But it will also work using docker.
-MKDOCS_TAG := 1.5.2
-ifeq ($(BUILD_ARCH),arm64)
-    MKDOCS_TAG := arm64v8-$(MKDOCS_TAG)
-endif
+# To see what the docs will look like, you can use `make mkdocs-serve`
+# It does require installing mkdocs and its requirements
+# See https://ddev.readthedocs.io/en/stable/developers/testing-docs/
 mkdocs-serve:
-	set -x; \
-	if command -v mkdocs >/dev/null ; then \
+	@if command -v mkdocs >/dev/null ; then \
   		mkdocs serve; \
 	else \
-		docker run -it -p 8000:8000 -v "${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" "polinux/mkdocs:$(MKDOCS_TAG)"; \
+		echo "mkdocs is not installed." && exit 2; \
 	fi; \
-	set +x
 
 # Install markdown-link-check locally with "sudo npm install -g @umbrelladocs/linkspector"
 markdown-link-check:

--- a/docs/content/developers/testing-docs.md
+++ b/docs/content/developers/testing-docs.md
@@ -40,15 +40,6 @@ Preview your changes locally by running `make mkdocs-serve`.
 
 This will launch a web server on port 8000 and automatically refresh pages as they’re edited.
 
-!!!tip "No need to install MkDocs locally!"
-    It’s easiest to [install MkDocs locally](https://www.mkdocs.org/user-guide/installation/), but you don’t have to. The `make mkdocs-serve` command will look for and use a local binary, otherwise using `make` to build and serve the documentation. If you don’t have `make` installed on your system, you can directly run the command it would have instead:
-
-    ```
-    TAG=$(arch)
-    if [ "${TAG}" = "arm64" ]; then TAG="${TAG}v8-1.5.2"; else TAG=1.5.2; fi
-    docker run -it -p 8000:8000 -v "${PWD}:/docs" -e "ADD_MODULES=mkdocs-material mkdocs-redirects mkdocs-minify-plugin mdx_truly_sane_lists mkdocs-git-revision-date-localized-plugin" -e "LIVE_RELOAD_SUPPORT=true" -e "FAST_MODE=true" -e "DOCS_DIRECTORY=./docs" "polinux/mkdocs:$TAG"
-    ```
-
 !!!tip "Installing mkdocs locally on macOS"
     On macOS with recent versions of Homebrew use this technique to install mkdocs:
 
@@ -58,6 +49,15 @@ This will launch a web server on port 8000 and automatically refresh pages as th
     pipx install mkdocs
     pipx runpip mkdocs install -r docs/mkdocs-pip-requirements
     pipx ensurepath
+    ```
+
+!!!tip "Installing mkdocs locally on Debian/Ubuntu Linux"
+
+    ```bash
+    sudo apt update && sudo apt install python3-full python-is-python3 pipx
+    export PIPX_BIN_DIR=/usr/local/bin
+    export PIPX_HOME=/usr/local/pipx
+    sudo --preserve-env pipx install mkdocs --pip-args "-r docs/mkdocs-pip-requirements"
     ```
 
 ## Check Markdown for Errors

--- a/docs/content/developers/testing-docs.md
+++ b/docs/content/developers/testing-docs.md
@@ -51,7 +51,7 @@ This will launch a web server on port 8000 and automatically refresh pages as th
     pipx ensurepath
     ```
 
-!!!tip "Installing mkdocs locally on Debian/Ubuntu Linux"
+!!!tip "Installing mkdocs locally on Debian/Ubuntu Linux or WSL2 with Ubuntu"
 
     ```bash
     sudo apt update && sudo apt install python3-full python-is-python3 pipx


### PR DESCRIPTION
## The Issue

I noted that the `make mkdocs-serve` docker technique was no longer working

## How This PR Solves The Issue

Explain how to install `mkdocs` with proper requirements using pipx.

## Manual Testing Instructions

Rendered at https://ddev--6864.org.readthedocs.build/en/6864/developers/testing-docs/#preview-changes

- [x] Install with Ubuntu
- [x] Install with macOS and pipx

I confirm that the existing macOS instructions still work.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
