### PR TITLE
test: get more disk space on hosted runner, switch to ubuntu 24.04, fixes #6865

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   build:
     name: Build DDEV executables
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY_DEV }}
     steps:

--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   push-tagged-dbimage:
     name: "push tagged dbimage"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         dbtype: [mariadb_5.5, mariadb_10.0, mariadb_10.1, mariadb_10.2, mariadb_10.3, mariadb_10.4, mariadb_10.5, mariadb_10.6, mariadb_10.7, mariadb_10.8, mariadb_10.11, mariadb_11.4, mysql_5.5, mysql_5.6, mysql_5.7, mysql_8.0, mysql_8.4]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
 
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       CGO_ENABLED: 0
@@ -109,7 +109,14 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Remove unnecessary items on disk
-        run: sudo rm -rf /usr/local/lib/android && df -h .
+        run: |
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/{aws*,julia*}
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/lib/node_modules
+          sudo rm -rf /usr/local/bin/minikube,bin/terraform,bin/oc
+          sudo rm -rf /usr/local/share/chromium /usr/local/share/powershell /usr/local/share/vcpkg
+          df -h .
 
       - name: Install Docker and deps (Linux)
         run: ./.github/workflows/linux-setup.sh

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2430,7 +2430,6 @@ func TestDdevFullSiteSetup(t *testing.T) {
 
 		// We don't want all the projects running at once.
 		err = app.Stop(true, false)
-		_ = os.RemoveAll(app.AppRoot)
 		assert.NoError(err)
 
 		runTime()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2423,6 +2423,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 
 		// We don't want all the projects running at once.
 		err = app.Stop(true, false)
+		_ = os.RemoveAll(app.AppRoot)
 		assert.NoError(err)
 
 		runTime()

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -56,6 +56,7 @@ var (
 		// 1: drupal8
 		{
 			Name:                          "TestPkgDrupal8",
+			Disable:                       true,
 			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-8.9.20.tar.gz",
 			ArchiveInternalExtractionPath: "drupal-8.9.20/",
 			FilesTarballURL:               "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/d8_umami.files.tar.gz",
@@ -87,6 +88,7 @@ var (
 		// 3: drupal6
 		{
 			Name:                          "TestPkgDrupal6",
+			Disable:                       true,
 			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-6.38.tar.gz",
 			ArchiveInternalExtractionPath: "drupal-6.38/",
 			DBTarURL:                      "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/drupal6.38_db.tar.gz",
@@ -167,6 +169,7 @@ var (
 		// 8: drupal9
 		{
 			Name:                          "TestPkgDrupal9",
+			Disable:                       true,
 			SourceURL:                     "https://ftp.drupal.org/files/projects/drupal-9.5.10.tar.gz",
 			ArchiveInternalExtractionPath: "drupal-9.5.10/",
 			FilesTarballURL:               "https://github.com/ddev/ddev_test_tarballs/releases/download/v1.1/d9_umami_files.tgz",
@@ -2290,6 +2293,10 @@ func TestDdevFullSiteSetup(t *testing.T) {
 	app := &ddevapp.DdevApp{}
 
 	for i, site := range TestSites {
+		if site.Disable {
+			t.Logf("Skipping TestSite %s=%d because disabled", site.Name, i)
+			continue
+		}
 		switchDir := site.Chdir()
 		defer switchDir()
 		runTime := util.TimeTrackC(fmt.Sprintf("%s DdevFullSiteSetup", site.Name))

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -88,8 +88,8 @@ func TestAcquiaPull(t *testing.T) {
 		globalconfig.DdevGlobalConfig.WebEnvironment = webEnvSave
 		err = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 		assert.NoError(err)
-
 		_ = os.Chdir(origDir)
+		_ = os.RemoveAll(app.AppRoot)
 	})
 
 	app.Name = t.Name()

--- a/pkg/ddevapp/providerAcquia_test.go
+++ b/pkg/ddevapp/providerAcquia_test.go
@@ -117,10 +117,11 @@ func TestAcquiaPull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	require.NoError(t, err)
 
-	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "chocolate-brownie-umami.jpg"))
+	require.FileExists(t, filepath.Join(app.GetHostUploadDirFullPath(), "chocolate-brownie-umami.jpg"))
 	out, err := exec.RunCommand("bash", []string{"-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="randy@example.com";' | %s mysql -B --skip-column-names `, DdevBin)})
-	assert.NoError(err)
-	assert.True(strings.HasSuffix(out, "\n1\n"), "out is unexpected '%s'", out)
+	require.NoError(t, err)
+	out = strings.Trim(out, " \n")
+	require.Equal(t, "1", out)
 }
 
 // TestAcquiaPush ensures we can push to acquia for a configured environment.

--- a/pkg/ddevapp/providerLagoon_test.go
+++ b/pkg/ddevapp/providerLagoon_test.go
@@ -43,7 +43,6 @@ func lagoonSetupSSHKey(t *testing.T) string {
 
 // TestLagoonPull ensures we can pull from lagoon
 func TestLagoonPull(t *testing.T) {
-	assert := asrt.New(t)
 	var err error
 
 	sshKey := lagoonSetupSSHKey(t)
@@ -58,9 +57,9 @@ func TestLagoonPull(t *testing.T) {
 	require.NoError(t, err)
 
 	err = os.Chdir(siteDir)
-	assert.NoError(err)
+	require.NoError(t, err)
 	app, err := ddevapp.NewApp(siteDir, true)
-	assert.NoError(err)
+	require.NoError(t, err)
 	app.Name = t.Name()
 	app.Type = nodeps.AppTypeDrupal11
 	err = app.Stop(true, false)
@@ -72,10 +71,10 @@ func TestLagoonPull(t *testing.T) {
 
 	t.Cleanup(func() {
 		err = app.Stop(true, false)
-		assert.NoError(err)
+		require.NoError(t, err)
 
 		err = os.Chdir(origDir)
-		assert.NoError(err)
+		require.NoError(t, err)
 		_ = os.RemoveAll(siteDir)
 	})
 
@@ -107,10 +106,11 @@ func TestLagoonPull(t *testing.T) {
 	err = app.Pull(provider, false, false, false)
 	require.NoError(t, err)
 
-	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "victoria-sponge-umami.jpg"))
+	require.FileExists(t, filepath.Join(app.GetHostUploadDirFullPath(), "victoria-sponge-umami.jpg"))
 	out, err := exec.RunHostCommand("bash", "-c", fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="margaret.hopper@example.com";' | %s mysql -N`, DdevBin))
-	assert.NoError(err)
-	assert.True(strings.HasSuffix(out, "\n1\n"))
+	require.NoError(t, err)
+	out = strings.Trim(out, " \n")
+	require.Equal(t, "1", out)
 }
 
 // TestLagoonPush ensures we can push to lagoon for a configured environment.

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -171,6 +171,7 @@ func TestPantheonPush(t *testing.T) {
 		assert.NoError(err)
 
 		_ = os.Chdir(origDir)
+		_ = os.RemoveAll(app.AppRoot)
 	})
 
 	app.Name = t.Name()

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -43,6 +43,8 @@ type URIWithExpect struct {
 type TestSite struct {
 	// Name is the generic name of the site, and is used as the default dir.
 	Name string
+	// Provide ability to disable
+	Disable bool
 	// SourceURL is the URL of the source code tarball to be used for building the site.
 	SourceURL string
 	// ArchiveExtractionPath is the relative path within the tarball which should be extracted, ending with /

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -2,6 +2,12 @@ package testcommon
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
@@ -9,11 +15,6 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"runtime"
-	"testing"
-	"time"
 )
 
 var DdevBin = "ddev"
@@ -192,33 +193,29 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 // TestGetCachedArchive tests download and extraction of archives for test sites
 // to testcache directory.
 func TestGetCachedArchive(t *testing.T) {
-	assert := asrt.New(t)
-
 	sourceURL := "https://raw.githubusercontent.com/ddev/ddev/master/.gitignore"
 	exPath, archPath, err := GetCachedArchive("TestInvalidArchive", "test", "", sourceURL)
-	assert.Error(err)
+	require.Error(t, err)
 	if err != nil {
-		assert.Contains(err.Error(), fmt.Sprintf("archive extraction of %s failed", archPath))
+		require.Contains(t, err.Error(), fmt.Sprintf("archive extraction of %s failed", archPath))
 	}
 
 	err = os.RemoveAll(exPath)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	err = os.RemoveAll(archPath)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	sourceURL = "http://invalid_domain/somefilethatdoesnotexists"
 	exPath, archPath, err = GetCachedArchive("TestInvalidDownloadURL", "test", "", sourceURL)
-	assert.Error(err)
-	if err != nil {
-		assert.Contains(err.Error(), fmt.Sprintf("failed to download url=%s into %s", sourceURL, archPath))
-	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("failed to download url=%s into %s", sourceURL, archPath))
 
 	err = os.RemoveAll(exPath)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	err = os.RemoveAll(archPath)
-	assert.NoError(err)
+	require.NoError(t, err)
 }
 
 // TestPretestAndEnv tests that the testsite PretestCmd works along with WebEvironment


### PR DESCRIPTION
## The Issue

- #6865 

We don't have enough room on disk. Try to resolve.

It may be that some test cleanup is in order as well.

## How This PR Solves The Issue

* Clean up more things that aren't needed in test runner
* Switch to Ubuntu 24.04 runner
* "Just because" I switched pr-build and push-tagged-dbimage to 24.04 as well. docscheck remains at 22.04 because of misbehavior of one of the actions.
* Clean up after a couple of TestPull/Push tests that weren't being cleaned up
* Clean up after each test in TestDdevFullSiteSetup
* Disable drupal 6/8/9 in TestDdevFullSiteSetup

This gets us from 28GB available to 43GB available at the start. We'll see if it breaks anything.
