### PR TITLE
docs: add setup step for macOS test runners (full disk access)

### DIFF
--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -160,6 +160,8 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
     PATH=$PATH:/usr/local/bin:/opt/homebrew/bin
     ```
 
+30. In macOS Settings visit "full disk access" and grant access to `buildkite-agent`, `docker`, `iterm`, `orbstack`. This may prevent startup modal dialogs that prevent `buildkite-agent` or `docker` from continuing properly.
+
 ## Additional Colima macOS setup
 
 1. `brew install colima`


### PR DESCRIPTION

## The Issue

On macOS machines, we sometimes see modal dialogs like "buildkite-agent would like to access your Documents folder" which can prevent buildkite-agent or Docker from running correctly. This may be preventable by pre-emptively granting full disk permissions.

