### PR TITLE
feat: Node.js back-end to nginx, fixes #4854

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/nodejs.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/nodejs.conf
@@ -1,5 +1,5 @@
 [program:nodejs]
-command = bash -c "cd /var/www/html/${DDEV_DOCROOT} && npm run dev"
+command = bash -c "cd /var/www/html && ./node_modules/http-server/bin/http-server -p 3000"
 priority=5
 stdout_logfile=/var/tmp/logpipe
 stdout_logfile_maxbytes=0

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/nodejs.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/nodejs.conf
@@ -1,0 +1,8 @@
+[program:nodejs]
+command = bash -c "cd /var/www/html/${DDEV_DOCROOT} && npm run dev"
+priority=5
+stdout_logfile=/var/tmp/logpipe
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+autorestart=true
+startretries=3

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/supervisord-nginx-nodejs.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/supervisor/supervisord-nginx-nodejs.conf
@@ -1,0 +1,11 @@
+[include]
+files = /etc/supervisor/nodejs.conf /etc/supervisor/conf.d/*.conf
+
+[program:nginx]
+command=/usr/sbin/nginx
+priority=10
+stdout_logfile=/var/tmp/logpipe
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+autorestart=true
+startretries=3

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/healthcheck.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/healthcheck.sh
@@ -31,6 +31,7 @@ done
 phpstatus="false"
 htmlaccess="false"
 mailpit="false"
+nodestatus="false"
 
 if ls /var/www/html >/dev/null; then
     htmlaccess="true"
@@ -58,7 +59,13 @@ if [ "${DDEV_WEBSERVER_TYPE#*-}" = "fpm" ]; then
   fi
 fi
 
-if [ "${phpstatus}" = "true" ] && [ "${mailpit}" = "true" ]; then
+if [ "${DDEV_WEBSERVER_TYPE#*-}" = "nodejs" ]; then
+  gunicornstatus="true"
+  phpstatus="true"
+  nodestatus="true"
+fi
+
+if [ "${phpstatus}" = "true" ] && [ "${htmlaccess}" = "true" ] && [ "${mailpit}" = "true" ]; then
     touch /tmp/healthy
     exit 0
 fi

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -207,6 +207,11 @@ func init() {
 			importFilesAction:    magentoImportFilesAction,
 		},
 
+		// TODO: Fill it in.
+		nodeps.AppTypeNodeJS: {
+			configOverrideAction: nodejsConfigOverrideAction,
+		},
+
 		nodeps.AppTypePHP: {
 			postStartAction: nil,
 		},

--- a/pkg/ddevapp/nodejs.go
+++ b/pkg/ddevapp/nodejs.go
@@ -1,0 +1,8 @@
+package ddevapp
+
+import "github.com/ddev/ddev/pkg/nodeps"
+
+func nodejsConfigOverrideAction(app *DdevApp) error {
+	app.WebserverType = nodeps.WebserverNginxNodeJS
+	return nil
+}

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -41,7 +41,7 @@ const ConfigInstructions = `
 # "ddev xhprof" to enable Xhprof and "ddev xhprof off" to disable it work better,
 # as leaving Xhprof enabled all the time is a big performance hit.
 
-# webserver_type: nginx-fpm or apache-fpm
+# webserver_type: nginx-fpm, apache-fpm, nginx-nodejs
 
 # timezone: Europe/Berlin
 # If timezone is unset, DDEV will attempt to derive it from the host system timezone

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-nodejs.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-nodejs.conf
@@ -33,7 +33,10 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
         proxy_set_header X-Nginx-Proxy true;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
         proxy_http_version 1.1;
+        proxy_cache_bypass $http_upgrade;
         proxy_pass http://127.0.0.1:3000;
     }
 

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-nodejs.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-nodejs.conf
@@ -1,0 +1,73 @@
+# ddev nodejs config
+
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-nginx-configuration
+
+server {
+    listen 80 default_server;
+    listen 443 ssl default_server;
+
+    root {{ .Docroot }};
+
+    ssl_certificate /etc/ssl/certs/master.crt;
+    ssl_certificate_key /etc/ssl/certs/master.key;
+
+    include /etc/nginx/monitoring.conf;
+
+    index index.php index.htm index.html;
+
+    # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+    sendfile off;
+    error_log /dev/stdout info;
+    access_log /var/log/nginx/access.log;
+
+    location / {
+        absolute_redirect off;
+        try_files $uri $uri/ /index.php?$query_string; # For Drupal >= 7
+    }
+
+    location / {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Nginx-Proxy true;
+        proxy_http_version 1.1;
+        proxy_pass http://127.0.0.1:3000;
+    }
+
+    # Expire rules for static content
+
+    # Prevent clients from accessing hidden files (starting with a dot)
+    # This is particularly important if you store .htpasswd files in the site hierarchy
+    # Access to `/.well-known/` is allowed.
+    # https://www.mnot.net/blog/2010/04/07/well-known
+    # https://tools.ietf.org/html/rfc5785
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    # Prevent clients from accessing to backup/config/source files
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
+    }
+
+    # js and css always loaded
+    location ~* \.(js|css)$ {
+        try_files $uri @rewrite;
+        expires -1;
+        log_not_found off;
+    }
+
+    include /etc/nginx/common.d/*.conf;
+    include /mnt/ddev_config/nginx/*.conf;
+}

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-nodejs.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-nodejs.conf
@@ -24,11 +24,6 @@ server {
     access_log /var/log/nginx/access.log;
 
     location / {
-        absolute_redirect off;
-        try_files $uri $uri/ /index.php?$query_string; # For Drupal >= 7
-    }
-
-    location / {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -38,9 +38,9 @@ const (
 
 // Webserver types
 const (
-	WebserverNginxFPM      = "nginx-fpm"
-	WebserverApacheFPM     = "apache-fpm"
-	WebserverNginxNodeJS   = "nginx-nodejs"
+	WebserverNginxFPM    = "nginx-fpm"
+	WebserverApacheFPM   = "apache-fpm"
+	WebserverNginxNodeJS = "nginx-nodejs"
 )
 
 // ValidOmitContainers is the list of things that can be omitted
@@ -82,9 +82,9 @@ var GoroutineLimit = 10
 // ValidWebserverTypes should be updated whenever supported webserver types are added or
 // removed, and should be used to ensure user-supplied values are valid.
 var ValidWebserverTypes = map[string]bool{
-	WebserverNginxFPM:      true,
-	WebserverApacheFPM:     true,
-	WebserverNginxNodeJS:   true,
+	WebserverNginxFPM:    true,
+	WebserverApacheFPM:   true,
+	WebserverNginxNodeJS: true,
 }
 
 const AppTypeDrupalLatestStable = AppTypeDrupal11

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -38,8 +38,9 @@ const (
 
 // Webserver types
 const (
-	WebserverNginxFPM  = "nginx-fpm"
-	WebserverApacheFPM = "apache-fpm"
+	WebserverNginxFPM      = "nginx-fpm"
+	WebserverApacheFPM     = "apache-fpm"
+	WebserverNginxNodeJS   = "nginx-nodejs"
 )
 
 // ValidOmitContainers is the list of things that can be omitted
@@ -81,8 +82,9 @@ var GoroutineLimit = 10
 // ValidWebserverTypes should be updated whenever supported webserver types are added or
 // removed, and should be used to ensure user-supplied values are valid.
 var ValidWebserverTypes = map[string]bool{
-	WebserverNginxFPM:  true,
-	WebserverApacheFPM: true,
+	WebserverNginxFPM:      true,
+	WebserverApacheFPM:     true,
+	WebserverNginxNodeJS:   true,
 }
 
 const AppTypeDrupalLatestStable = AppTypeDrupal11
@@ -102,6 +104,7 @@ const (
 	// AppTypeDrupal is an alias for "most recent Drupal version"
 	AppTypeDrupal       = "drupal"
 	AppTypeLaravel      = "laravel"
+	AppTypeNodeJS       = "nodejs"
 	AppTypeSilverstripe = "silverstripe"
 	AppTypeSymfony      = "symfony"
 	AppTypeMagento      = "magento"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250120_mailhog_mailpit" // Note that this can be overridden by make
+var WebTag = "20240718_rfay_node_backend" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #4854 

## TODO

- [ ] Docs
  - [ ] General explanation (Call it "experimental"?)
  - [ ] Simple examples 
  - [ ] Explain how this differs from the earlier (and more common support) of general daemons and node daemons.
- [ ] Add `ddev npx` custom command
- [ ] Tests
- [x] Do we also need `apache-nodejs` webserver type?
- [ ] consider doing a `generic` project type (alias of `php`?) when working on node project type.
- [ ] Consider configuration of the node.js daemon port. Default to 3000 because they always do.
- [ ] Consider changing config.yaml setup so it only shows relevant items. For example, don't add `php_version` by default when it's not being used.
- [ ] Consider svelte or sveltekit project type
- [ ] Consider new configuration for node (the port would then have to be injected into the nginx configuration:
    ```yaml
    nodejs_start_command: "npm start"
    nodejs_port: 3000
    ```
- [ ] Or consider using `web_extra_daemons` and just use that, but the port would still need to be handled

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
