### PR TITLE
fix: Make xhprof-prepend.php mount writable, for #3782

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -143,7 +143,7 @@ services:
       - ddev-config:/mnt/ddev_config
       {{- else }}
       - .:/mnt/ddev_config:ro
-      - ./xhprof:/usr/local/bin/xhprof:ro
+      - ./xhprof:/usr/local/bin/xhprof:rw
         {{- if .MutagenEnabled }}
           {{- range $uploadDirMap := .UploadDirsMap}}
       - {{ $uploadDirMap }}:rw


### PR DESCRIPTION

## The Issue

Working on
- #3782 

In ddev/ddev-xhprof, one of the possible things to do is to overwrite the xhprof-prepend.php inside the container, but because we mount it read-only that's not possible

## How This PR Solves The Issue

Mount .ddev/xhprof read-write

I imagine we'll end up completely change this approach and not use a bind-mount.

## Manual Testing Instructions

`ddev ssh` and `touch /usr/local/bin/xhprof/x`. If it works, it works.

