### PR TITLE
fix: In acquia.yaml, specify default site source for ddev pull acquia.

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/acquia.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/acquia.yaml
@@ -58,7 +58,7 @@ files_import_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
-    acli -n pull:files ${ACQUIA_ENVIRONMENT_ID}
+    acli -n pull:files ${ACQUIA_ENVIRONMENT_ID} default
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 db_push_command:

--- a/pkg/ddevapp/dotddev_assets/providers/acquia.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/acquia.yaml
@@ -50,7 +50,7 @@ db_pull_command:
     # just using `acli pull:db ${ACQUIA_ENVIRONMENT_ID}`
     echo "Using ACQUIA_ENVIRONMENT_ID=${ACQUIA_ENVIRONMENT_ID}"
     set -x   # You can enable bash debugging output by uncommenting
-    db_dump=$(acli pull:db ${ACQUIA_ENVIRONMENT_ID} --no-interaction --no-import | tail -2l | xargs |  sed 's/^.* //')
+    db_dump=$(acli pull:db ${ACQUIA_ENVIRONMENT_ID} default --no-interaction --no-import | tail -2l | xargs |  sed 's/^.* //')
     ls /var/www/html/.ddev >/dev/null # This just refreshes stale NFS if possible
     cp ${db_dump} /var/www/html/.ddev/.downloads/db.sql.gz
 


### PR DESCRIPTION
If you have multiple databases, `acli pull:db acquia` doesn't automatically use the default (the one initially created for the site). This causes ddev pull to instead pull a non-default database.

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

It specifies the default database.

## Manual Testing Instructions

Have an Acquia site with two databases. Run the ddev pull command. Confirm that the default database is pulled.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
