### PR TITLE
refactor: rename branch master to main, fixes #6476

### DIFF
--- a/.buildkite/macos-colima_vz.yml
+++ b/.buildkite/macos-colima_vz.yml
@@ -1,6 +1,6 @@
 # Colima with VZ and virtiofs
 # See https://buildkite.com/ddev/macos-colima-vz/settings/repository
-# Runs on master and PRs, including forked PRs
+# Runs on main and PRs, including forked PRs
 
   - command: ".buildkite/test.sh"
     if: |

--- a/.buildkite/macos-docker-desktop-amd64.yml
+++ b/.buildkite/macos-docker-desktop-amd64.yml
@@ -1,6 +1,6 @@
 # Docker Desktop on macOS amd64
 # See https://buildkite.com/ddev/ddev-macos-amd64-mutagen/settings/repository
-# Runs on master only, not on PRs
+# Runs on main only, not on PRs
 
   - command: ".buildkite/test.sh"
     if: |

--- a/.buildkite/macos-docker-desktop-arm64.yml
+++ b/.buildkite/macos-docker-desktop-arm64.yml
@@ -1,6 +1,6 @@
 # Docker Desktop on macOS arm64
 # See https://buildkite.com/ddev/ddev-macos-arm64-mutagen/settings/repository
-# Runs on master and PRs, including forked PRs
+# Runs on main and PRs, including forked PRs
 
   - command: ".buildkite/test.sh"
     if: |

--- a/.buildkite/macos-lima.yml
+++ b/.buildkite/macos-lima.yml
@@ -1,6 +1,6 @@
 # macOS Lima on arm64 with VZ/Virtiofs
 # See https://buildkite.com/ddev/macos-lima/settings/repository
-# Runs on master and PRs, including forked PRs
+# Runs on main and PRs, including forked PRs
 
   - command: ".buildkite/test.sh"
     if: |

--- a/.buildkite/macos-orbstack.yml
+++ b/.buildkite/macos-orbstack.yml
@@ -1,6 +1,6 @@
 # Orbstack on macOS arm64
 # See https://buildkite.com/ddev/macos-orbstack/settings/repository
-# Runs on master and PRs, including forked PRs
+# Runs on main and PRs, including forked PRs
 
   - command: ".buildkite/test.sh"
     if: |
@@ -9,7 +9,7 @@
       - "os=macos"
       - "orbstack=true"
       - "architecture=arm64"
-#    branches: "master"
+#    branches: "main"
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       BUILDKITE_BUILD_PATH: ~/tmp/buildkite_builds

--- a/.buildkite/macos-rancher-desktop.yml
+++ b/.buildkite/macos-rancher-desktop.yml
@@ -1,6 +1,6 @@
 # Rancher Desktop on macOS arm64
 # See https://buildkite.com/ddev/macos-rancher-desktop/settings/repository
-# Runs on master only, not on PRs
+# Runs on main only, not on PRs
 
   - command: ".buildkite/test.sh"
     if: |

--- a/.buildkite/windows10dockerforwindows.yml
+++ b/.buildkite/windows10dockerforwindows.yml
@@ -1,6 +1,6 @@
 # Windows native with Mutagen, used by ddev-windows-mutagen
 # See https://buildkite.com/ddev/ddev-windows-mutagen/settings/repository
-# Runs on master and PRs, not including forked PRs
+# Runs on main and PRs, not including forked PRs
 
   - command: ".buildkite/test.cmd"
     if: |

--- a/.buildkite/wsl2-docker-desktop.yml
+++ b/.buildkite/wsl2-docker-desktop.yml
@@ -1,6 +1,6 @@
 # WSL2 using Docker Desktop
 # See https://buildkite.com/ddev/wsl2-docker-desktop/settings/repository
-# Runs on master and PRs, not including forked PRs
+# Runs on main and PRs, not including forked PRs
 
   - command: ".buildkite/test.sh"
     if: |

--- a/.buildkite/wsl2-docker-inside.yml
+++ b/.buildkite/wsl2-docker-inside.yml
@@ -1,6 +1,6 @@
 # WSL2 with docker-ce (docker native inside WSL2 == Docker inside)
 # See https://buildkite.com/ddev/wsl2-docker-inside/settings/repository
-# Runs on master and PRs, including forked PRs
+# Runs on main and PRs, including forked PRs
 
   - command: ".buildkite/test.sh"
     if: |

--- a/.ci-scripts/bump_homebrew.sh
+++ b/.ci-scripts/bump_homebrew.sh
@@ -38,7 +38,7 @@ class Ddev < Formula
   url "${SOURCE_URL}"
   sha256 "${SOURCE_SHA}"
   license "apache-2.0"
-  head "https://github.com/ddev/ddev.git", branch: "master"
+  head "https://github.com/ddev/ddev.git", branch: "main"
 
   depends_on "mkcert" => :run
   depends_on "nss" => :run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,7 +521,7 @@ workflows:
     - lx_arm64_fpm_test:
         filters:
           branches:
-            only: master
+            only: main
             ignore:
               - gh-pages
 #    - lx_arm64_container_test
@@ -556,7 +556,7 @@ workflows:
 #          filters:
 #            branches:
 #              only:
-#                - master
+#                - main
 #                - "pull/[0-9]+"
 #    jobs:
 #    - lx_amd64_container_test

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
         Whether you’re having trouble or not, help us with context that will skip a bunch of questions we'd have to ask afterwards:
 
         1. Make sure you’re on the [latest stable version](https://github.com/ddev/ddev/releases/latest) before reporting, [upgrading](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/) if necessary.
-        2. Run a diagnostic and post the results as a new Gist (or your favorite equivalent). Run `ddev debug test`, or download and run [test_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/master/cmd/ddev/cmd/scripts/test_ddev.sh), and share a link to the results via https://gist.github.com. (If this works, there may not be something wrong with DDEV but something to [troubleshoot in your project](https://ddev.readthedocs.io/en/stable/users/usage/troubleshooting/).)
+        2. Run a diagnostic and post the results as a new Gist (or your favorite equivalent). Run `ddev debug test`, or download and run [test_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/main/cmd/ddev/cmd/scripts/test_ddev.sh), and share a link to the results via https://gist.github.com. (If this works, there may not be something wrong with DDEV but something to [troubleshoot in your project](https://ddev.readthedocs.io/en/stable/users/usage/troubleshooting/).)
     validations:
       required: false
   - type: textarea

--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -1,10 +1,10 @@
 # Installation/Upgrade
 
-See the [installation instructions](https://github.com/ddev/ddev/blob/master/docs/index.md) for details, but it's easy:
+See the [installation instructions](https://github.com/ddev/ddev/blob/main/docs/index.md) for details, but it's easy:
 
 - macOS or Linux Homebrew: `brew upgrade ddev`
 - Linux or macOS via script (an unusual and nonstandard approach):
-`curl https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh | bash`
+`curl https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev.sh | bash`
 - Windows: Download the ddev_windows_installer above or `choco upgrade ddev` (on Intel/AMD64 systems)
 
 And anywhere, you can download the tarball or zipball, un-tar or un-zip it, and place the executable in your path where it belongs.

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -115,12 +115,12 @@ jobs:
           colima restart
 
       - name: Build ddev
-        run: | 
+        run: |
           make
           ln -s $PWD/.gotmp/bin/darwin_amd64/ddev /usr/local/bin/ddev
 
       - name: Basic ddev usage
-        run: | 
+        run: |
           mkdir -p ~/workspace/d9 && cd ~/workspace/d9
           ddev config --project-type=drupal9 --docroot=web
           ddev debug download-images

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -5,9 +5,9 @@ defaults:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main, master ]
   pull_request:
-    branches: [ master ]
+    branches: [ main, master ]
     # Only run when something changes in the actual containers
     paths:
     - "containers/**"

--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -5,8 +5,7 @@ defaults:
 
 on:
   push:
-    branches:
-      - master
+    branches: [ main, master ]
   pull_request:
     paths:
       - "docs/**"

--- a/.github/workflows/docspublish.yml
+++ b/.github/workflows/docspublish.yml
@@ -1,9 +1,7 @@
 name: docspublish
 on:
   push:
-    branches:
-      - 20220710_mkdocs_material
-      - master
+    branches: [ main, master ]
 env:
   HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,9 +4,7 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - master
-      - main
+    branches: [ main, master ]
   pull_request:
     paths:
       - ".github/workflows/**"

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -1,5 +1,5 @@
 # Signs windows and macOS binaries and installers
-name: Master branch build/release (signed)
+name: Main branch build/release (signed)
 defaults:
   run:
     shell: bash

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -5,7 +5,7 @@ defaults:
     shell: bash
 on:
   push:
-    branches: [ master, main ]
+    branches: [ main, master ]
   release:
     types: [ created ]
   workflow_dispatch:
@@ -21,7 +21,7 @@ on:
 # to prevent builds on commits that don't matter.
 #concurrency:
 #  group: ${{ github.workflow }}-${{ github.ref }}
-#  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+#  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY }}

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -5,8 +5,7 @@ defaults:
 
 on:
   push:
-    branches:
-      - master
+    branches: [ main, master ]
   pull_request:
     paths:
       - "docs/content/users/quickstart.md"
@@ -52,4 +51,3 @@ jobs:
       - name: Run quickstart test
         run: |
           make quickstart-test
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
       - "vendor/**"
       - ".github/workflows/**"
   push:
-    branches: [ master, main ]
+    branches: [ main, master ]
 
 #  schedule:
 #    - cron: '01 00 * * *'
@@ -88,7 +88,7 @@ jobs:
 
       - name: DDEV test cache
         uses: actions/cache@v4
-        if: github.ref == 'refs/heads/master' && matrix.name == 'pull-push-test-platforms'
+        if: github.ref == 'refs/heads/main' && matrix.name == 'pull-push-test-platforms'
         with:
           path: ~/.ddev/testcache/tarballs
           key: ddev-test-cache-${{ steps.get-date.outputs.date }}
@@ -97,7 +97,7 @@ jobs:
 
       - name: DDEV test cache/restore
         uses: actions/cache/restore@v4
-        if: github.ref != 'refs/heads/master' || matrix.name != 'pull-push-test-platforms'
+        if: github.ref != 'refs/heads/main' || matrix.name != 'pull-push-test-platforms'
         with:
           path: ~/.ddev/testcache/tarballs
           key: ddev-test-cache-${{ steps.get-date.outputs.date }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -190,7 +190,7 @@ brews:
 
   custom_block: |
     head do
-      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
+      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "main"
       depends_on "go" => :build
       depends_on "make" => :build
     end
@@ -232,7 +232,7 @@ brews:
     - name: mkcert
   custom_block: |
     head do
-      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "master"
+      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "main"
       depends_on "go" => :build
       depends_on "make" => :build
     end
@@ -515,7 +515,7 @@ dockerhub:
 #chocolateys:
 #    name: ddev-test
 #
-#    package_source_url: https://github.com/ddev/ddev/tree/master/winpkg/chocolatey
+#    package_source_url: https://github.com/ddev/ddev/tree/main/winpkg/chocolatey
 #
 #    # Your app's owner.
 #    # It basically means you.
@@ -550,7 +550,7 @@ dockerhub:
 #    # Templates: allowed.
 #    copyright: DDEV Foundation
 #
-#    license_url: https://github.com/ddev/ddev/blob/master/LICENSE
+#    license_url: https://github.com/ddev/ddev/blob/main/LICENSE
 #    require_license_acceptance: true
 #
 #    # Your app's source url.

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -10,7 +10,7 @@ ignorePatterns:
   - pattern: "^https://.*blackfire.io"
   - pattern: "^https://twitter.com/search"
   - pattern: "^https://www.cyberciti.biz/"
-  - pattern: "^https://nightly.link/ddev/ddev/workflows/master-build/master"
+  - pattern: "^https://nightly.link/ddev/ddev/workflows/master-build/main"
   - pattern: "^https://github.com/ddev/maintainer-info"
   - pattern: "^https://buildkite.com/organizations/ddev"
   - pattern: "^https://github.com/orgs/ddev"

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -10,7 +10,7 @@ ignorePatterns:
   - pattern: "^https://.*blackfire.io"
   - pattern: "^https://twitter.com/search"
   - pattern: "^https://www.cyberciti.biz/"
-  - pattern: "^https://nightly.link/ddev/ddev/workflows/master-build/main"
+  - pattern: "^https://nightly.link/ddev/ddev/workflows/main-build/main"
   - pattern: "^https://github.com/ddev/maintainer-info"
   - pattern: "^https://buildkite.com/organizations/ddev"
   - pattern: "^https://github.com/orgs/ddev"

--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,3 +1,3 @@
-https://github.com/ddev/ddev/raw/refs/heads/master/funding.json
-https://github.com/ddev/ddev/blob/master/funding.json
-https://raw.githubusercontent.com/ddev/ddev/refs/heads/master/funding.json
+https://github.com/ddev/ddev/raw/refs/heads/main/funding.json
+https://github.com/ddev/ddev/blob/main/funding.json
+https://raw.githubusercontent.com/ddev/ddev/refs/heads/main/funding.json

--- a/cmd/ddev/cmd/debug-test.go
+++ b/cmd/ddev/cmd/debug-test.go
@@ -69,7 +69,7 @@ var DebugTestCmdCmd = &cobra.Command{
 		}
 		util.Success("Output file written to:\n%s\nfile://%s\nPlease provide the file for support in Discord or the issue queue.", outputFilename, outputFilename)
 		if testErr != nil {
-			util.Failed("Failed running test_ddev.sh: %v\n. You can run it manually with `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/master/cmd/ddev/cmd/scripts/test_ddev.sh && bash test_ddev.sh`", testErr)
+			util.Failed("Failed running test_ddev.sh: %v\n. You can run it manually with `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/main/cmd/ddev/cmd/scripts/test_ddev.sh && bash test_ddev.sh`", testErr)
 		}
 	},
 }

--- a/containers/ddev-dbserver/README.md
+++ b/containers/ddev-dbserver/README.md
@@ -29,7 +29,7 @@ docker run -it --rm --entrypoint=bash ddev/ddev-db-server-<mariadb|mysql>-<versi
 
 ## Source:
 
-[https://github.com/ddev/ddev/tree/master/containers/ddev-dbserver](https://github.com/ddev/ddev/tree/master/containers/ddev-dbserver)
+[https://github.com/ddev/ddev/tree/main/containers/ddev-dbserver](https://github.com/ddev/ddev/tree/main/containers/ddev-dbserver)
 
 ## Maintained by:
 
@@ -57,7 +57,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
 ## License
 
-View [license information](https://github.com/ddev/ddev/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/ddev/ddev/blob/main/LICENSE) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/containers/ddev-gitpod-base/Dockerfile
+++ b/containers/ddev-gitpod-base/Dockerfile
@@ -45,4 +45,4 @@ RUN for item in golang.org/x/tools/gopls@latest github.com/go-delve/delve/cmd/dl
     done && go clean -modcache
 RUN cp ~/go/bin/dlv ~/go/bin/dlv-dap
 
-RUN cd /tmp && curl -LO --fail https://raw.githubusercontent.com/ddev/ddev/master/docs/mkdocs-pip-requirements && pip3 install -r /tmp/mkdocs-pip-requirements
+RUN cd /tmp && curl -LO --fail https://raw.githubusercontent.com/ddev/ddev/main/docs/mkdocs-pip-requirements && pip3 install -r /tmp/mkdocs-pip-requirements

--- a/containers/ddev-gitpod-base/README.md
+++ b/containers/ddev-gitpod-base/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-ddev/ddev-gitpod-base is a base image for Gitpod integration with [DDEV](https://github.com/ddev/ddev). 
+ddev/ddev-gitpod-base is a base image for Gitpod integration with [DDEV](https://github.com/ddev/ddev).
 
 Details about how it is used are in https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/#gitpod
 
@@ -28,7 +28,7 @@ docker run -it --rm ddev/ddev-gitpod-base:<tag> bash
 
 ## Source:
 
-[https://github.com/ddev/ddev/blob/master/containers/ddev-gitpod-base](https://github.com/ddev/ddev/blob/master/containers/ddev-gitpod-base)
+[https://github.com/ddev/ddev/blob/main/containers/ddev-gitpod-base](https://github.com/ddev/ddev/blob/main/containers/ddev-gitpod-base)
 
 ## Maintained by:
 
@@ -56,7 +56,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
 ## License
 
-View [license information](https://github.com/ddev/ddev/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/ddev/ddev/blob/main/LICENSE) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/containers/ddev-nginx-proxy-router/README.md
+++ b/containers/ddev-nginx-proxy-router/README.md
@@ -31,7 +31,7 @@ docker run -it --rm ddev/ddev-nginx-proxy-router:<tag> bash
 
 ## Source:
 
-[https://github.com/ddev/ddev/tree/master/containers/ddev-nginx-proxy-router](https://github.com/ddev/ddev/tree/master/containers/ddev-nginx-proxy-router)
+[https://github.com/ddev/ddev/tree/main/containers/ddev-nginx-proxy-router](https://github.com/ddev/ddev/tree/main/containers/ddev-nginx-proxy-router)
 
 ## Maintained by:
 
@@ -59,7 +59,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
 ## License
 
-View [license information](https://github.com/ddev/ddev/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/ddev/ddev/blob/main/LICENSE) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/containers/ddev-php-base/README.md
+++ b/containers/ddev-php-base/README.md
@@ -28,7 +28,7 @@ docker run -it --rm ddev/php-base:<tag> bash
 
 ## Source:
 
-[https://github.com/ddev/ddev/tree/master/containers/ddev-php-base](https://github.com/ddev/ddev/tree/master/containers/ddev-php-base)
+[https://github.com/ddev/ddev/tree/main/containers/ddev-php-base](https://github.com/ddev/ddev/tree/main/containers/ddev-php-base)
 
 ## Maintained by:
 
@@ -56,7 +56,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
 ## License
 
-View [license information](https://github.com/ddev/ddev/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/ddev/ddev/blob/main/LICENSE) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/containers/ddev-ssh-agent/README.md
+++ b/containers/ddev-ssh-agent/README.md
@@ -22,7 +22,7 @@ See [DDEV docs](https://ddev.readthedocs.io/en/stable/developers/release-managem
 
 
 ## Source:
-[ddev-ssh-agent](https://github.com/ddev/ddev/tree/master/containers/ddev-ssh-agent)
+[ddev-ssh-agent](https://github.com/ddev/ddev/tree/main/containers/ddev-ssh-agent)
 
 ## Maintained by:
 The [DDEV Docker Maintainers](https://github.com/ddev)
@@ -46,7 +46,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
 ## License
 
-View [license information](https://github.com/ddev/ddev/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/ddev/ddev/blob/main/LICENSE) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/containers/ddev-traefik-router/README.md
+++ b/containers/ddev-traefik-router/README.md
@@ -31,7 +31,7 @@ docker run -it --rm ddev/ddev-traefik-router:<tag> bash
 
 ## Source:
 
-[https://github.com/ddev/ddev/tree/master/containers/ddev-traefik-router](https://github.com/ddev/ddev/tree/master/containers/ddev-traefik-router)
+[https://github.com/ddev/ddev/tree/main/containers/ddev-traefik-router](https://github.com/ddev/ddev/tree/main/containers/ddev-traefik-router)
 
 ## Maintained by:
 
@@ -59,7 +59,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
 ## License
 
-View [license information](https://github.com/ddev/ddev/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/ddev/ddev/blob/main/LICENSE) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/containers/ddev-webserver/README.md
+++ b/containers/ddev-webserver/README.md
@@ -36,7 +36,7 @@ docker run -it --rm ddev/ddev-webserver:<tag> bash
 ```
 
 ## Source:
-[ddev-webserver](https://github.com/ddev/ddev/tree/master/containers/ddev-webserver)
+[ddev-webserver](https://github.com/ddev/ddev/tree/main/containers/ddev-webserver)
 
 
 ## Maintained by:
@@ -61,7 +61,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
 ## License
 
-View [license information](https://github.com/ddev/ddev/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/ddev/ddev/blob/main/LICENSE) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/containers/image_readme_template.md
+++ b/containers/image_readme_template.md
@@ -28,7 +28,7 @@ docker run -it --rm ddev/ddev-{{ CONTAINER NAME }}:<tag> bash
 
 ## Source:
 
-[https://github.com/ddev/ddev/tree/master/containers/ddev-{{ CONTAINER NAME }}](https://github.com/ddev/ddev/tree/master/containers/ddev-{{ CONTAINER NAME }})
+[https://github.com/ddev/ddev/tree/main/containers/ddev-{{ CONTAINER NAME }}](https://github.com/ddev/ddev/tree/main/containers/ddev-{{ CONTAINER NAME }})
 
 ## Maintained by:
 
@@ -56,7 +56,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
 ## License
 
-View [license information](https://github.com/ddev/ddev/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/ddev/ddev/blob/main/LICENSE) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/containers/test-ssh-server/README.md
+++ b/containers/test-ssh-server/README.md
@@ -25,7 +25,7 @@ docker run -it --rm ddev/test-ssh-server:<tag> bash
 
 ## Source:
 
-[https://github.com/ddev/ddev/tree/master/containers/test-ssh-server](https://github.com/ddev/ddev/tree/master/containers/test-ssh-server)
+[https://github.com/ddev/ddev/tree/main/containers/test-ssh-server](https://github.com/ddev/ddev/tree/main/containers/test-ssh-server)
 
 ## Maintained by:
 
@@ -53,7 +53,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
 ## License
 
-View [license information](https://github.com/ddev/ddev/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/ddev/ddev/blob/main/LICENSE) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/docs/content/developers/brand-guide.md
+++ b/docs/content/developers/brand-guide.md
@@ -10,12 +10,12 @@ search:
 |-----------------------------------------|------------------------------------------------|
 | ![Figurative Mark](logos/1x/Logo.png) | ![Figurative Mark](logos/1x/Logo_w_text.png) |
 
-You can find a set of DDEV logos [here](https://github.com/ddev/ddev/tree/master/docs/content/developers/logos).
+You can find a set of DDEV logos [here](https://github.com/ddev/ddev/tree/main/docs/content/developers/logos).
 
-If possible, use the [SVG version](https://github.com/ddev/ddev/tree/master/docs/content/developers/logos/SVG) of the logo, as a vector graphic is independent of the resolution and gives the best results regardless of the pixel density of the display.
+If possible, use the [SVG version](https://github.com/ddev/ddev/tree/main/docs/content/developers/logos/SVG) of the logo, as a vector graphic is independent of the resolution and gives the best results regardless of the pixel density of the display.
 
-If the SVG format is not supported, you can use the exported PNG versions of the logo. Use [@2x](https://github.com/ddev/ddev/tree/master/docs/content/developers/logos/2x), [@3x](https://github.com/ddev/ddev/tree/master/docs/content/developers/logos/3x), and [@4x](https://github.com/ddev/ddev/tree/master/docs/content/developers/logos/4x) for high
-pixel density displays. Many applications support [@2x](https://github.com/ddev/ddev/tree/master/docs/content/developers/logos/2x) annotations in the image path and automatically choose the correct image for the display in use.
+If the SVG format is not supported, you can use the exported PNG versions of the logo. Use [@2x](https://github.com/ddev/ddev/tree/main/docs/content/developers/logos/2x), [@3x](https://github.com/ddev/ddev/tree/main/docs/content/developers/logos/3x), and [@4x](https://github.com/ddev/ddev/tree/main/docs/content/developers/logos/4x) for high
+pixel density displays. Many applications support [@2x](https://github.com/ddev/ddev/tree/main/docs/content/developers/logos/2x) annotations in the image path and automatically choose the correct image for the display in use.
 
 Currently there is no prepared version for dark backgrounds of the word/figurative mark.
 

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -8,13 +8,13 @@ search:
 
 There are several ways to use DDEV’s latest-committed HEAD version:
 
-* **Download** the latest master branch artifacts from [nightly.link](https://nightly.link/ddev/ddev/workflows/master-build/master). Each of these is built by the CI system, signed, and notarized. Get the one you need and place it in your `$PATH`.
+* **Download** the latest main branch artifacts from [nightly.link](https://nightly.link/ddev/ddev/workflows/master-build/main). Each of these is built by the CI system, signed, and notarized. Get the one you need and place it in your `$PATH`.
 * **Homebrew install HEAD**: On macOS and Linux, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD --fetch-HEAD` to get the latest DDEV commit, even if it’s unreleased.
-* **Install via script**: You can download and run the [install_ddev_head.sh](https://raw.githubusercontent.com/ddev/ddev/refs/heads/master/scripts/install_ddev_head.sh)  script, or run it automatically:
+* **Install via script**: You can download and run the [install_ddev_head.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_head.sh)  script, or run it automatically:
 
     ```bash
     # Download and run the install script
-    curl -fsSL https://raw.githubusercontent.com/ddev/ddev/refs/heads/master/scripts/install_ddev_head.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_head.sh | bash
     ```
 
 * **Build manually**: If you have normal build tools like `make` and `go` installed, you can check out the code and run `make`.
@@ -47,7 +47,7 @@ rm ddev-macos-arm64.zip
 
 ![Github Action PR Comment ZIP files](../images/github-action-pr-comment.png)
 
-Tip: If you need a zip-file to try out the "Testing a PR" process, see the [nightly builds](https://nightly.link/ddev/ddev/workflows/master-build/master).
+Tip: If you need a zip-file to try out the "Testing a PR" process, see the [nightly builds](https://nightly.link/ddev/ddev/workflows/master-build/main).
 
 ???warning "macOS and Unsigned Binaries (click me)"
     macOS doesn’t like these downloaded binaries, so you’ll need to bypass the automatic quarantine to use them:
@@ -56,7 +56,7 @@ Tip: If you need a zip-file to try out the "Testing a PR" process, see the [nigh
     xattr -r -d com.apple.quarantine ~/bin/ddev
     ```
 
-    (The binaries on the master branch and the final release binaries _are_ signed.)
+    (The binaries on the main branch and the final release binaries _are_ signed.)
 
 Verify the replacement worked by running `ddev -v`. The output should be something like `ddev version v1.23.5-98-g3c93ae87e`, instead of the regular `ddev version v1.23.5`. Valuable commands for debugging are `which -a ddev` and `echo $PATH`.
 
@@ -72,7 +72,7 @@ rm ~/bin/ddev
 
 [Gitpod](https://www.gitpod.io) provides a quick, preconfigured DDEV experience in the browser for testing a PR easily without the need to set up an environment. For any PR you can use the URL `https://gitpod.io/#https://github.com/ddev/ddev/pull/<YOUR-PR>` to open that PR and build it in Gitpod.
 
-It also allows you to work on the DDEV master branch and test modifiying DDEV's source code.
+It also allows you to work on the DDEV main branch and test modifiying DDEV's source code.
 
 To get started use the button below:
 
@@ -185,13 +185,13 @@ To manually push using GitHub Actions,
 
 * Visit [Actions → Push tagged image](https://github.com/ddev/ddev/actions/workflows/push-tagged-image.yml)
 * Click “Run workflow” in the blue band near the top.
-* Choose the branch, usually `master` and then the image to be pushed, `ddev-webserver`, `ddev-dbserver`, etc. Also you can use `all` to build and push all of them. Include a tag for the pushed image and GitHub will do all the work.
+* Choose the branch, usually `main` and then the image to be pushed, `ddev-webserver`, `ddev-dbserver`, etc. Also you can use `all` to build and push all of them. Include a tag for the pushed image and GitHub will do all the work.
 
 #### For `ddev-dbserver`
 
 * Visit [Actions → Push tagged db image](https://github.com/ddev/ddev/actions/workflows/push-tagged-dbimage.yml)
 * Click “Run workflow” in the blue band near the top.
-* Choose the branch, usually `master`. Include a tag for the pushed image and GitHub will do all the work.
+* Choose the branch, usually `main`. Include a tag for the pushed image and GitHub will do all the work.
 
 ## Instrumentation
 
@@ -304,7 +304,7 @@ To test with race detection, `make test TESTARGS="-race"` for example.
 
 To see which DDEV commands the tests are executing, set the environment variable `DDEV_DEBUG=true`.
 
-Use `GOTEST_SHORT=true` to run one CMS in each test, or `GOTEST_SHORT=<integer>` to run exactly one project type from the list of project types in the [TestSites array](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/ddevapp_test.go#L43). For example, `GOTEST_SHORT=5 make test TESTARGS="-run TestDdevFullSiteSetup"` will run only `TestDdevFullSiteSetup` against TYPO3.
+Use `GOTEST_SHORT=true` to run one CMS in each test, or `GOTEST_SHORT=<integer>` to run exactly one project type from the list of project types in the [TestSites array](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/ddevapp_test.go#L43). For example, `GOTEST_SHORT=5 make test TESTARGS="-run TestDdevFullSiteSetup"` will run only `TestDdevFullSiteSetup` against TYPO3.
 
 To run a test (in the `cmd` package) against a individually-compiled DDEV binary, set the `DDEV_BINARY_FULLPATH` environment variable, for example `DDEV_BINARY_FULLPATH=$PWD/.gotmp/bin/linux_amd64/ddev make testcmd`.
 
@@ -348,7 +348,7 @@ When preparing your pull request, please use a branch name like `YYYYMMDD_<your_
 
 ### Pull Request Title Guidelines
 
-We have very precise rules over how our PR titles (and thus master-branch commits) are to be formatted. This leads to **more readable messages** that are easy to follow when looking through the **project history**. But also, we use the master-branch Git commit messages to **generate the changelog** for the releases.
+We have very precise rules over how our PR titles (and thus main-branch commits) are to be formatted. This leads to **more readable messages** that are easy to follow when looking through the **project history**. But also, we use the main-branch Git commit messages to **generate the changelog** for the releases.
 
 The pull request title must follow this convention which is based on the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification:
 

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -72,7 +72,7 @@ rm ~/bin/ddev
 
 [Gitpod](https://www.gitpod.io) provides a quick, preconfigured DDEV experience in the browser for testing a PR easily without the need to set up an environment. For any PR you can use the URL `https://gitpod.io/#https://github.com/ddev/ddev/pull/<YOUR-PR>` to open that PR and build it in Gitpod.
 
-It also allows you to work on the DDEV main branch and test modifiying DDEV's source code.
+It also allows you to work on the DDEV `main` branch and test modifying DDEV's source code.
 
 To get started use the button below:
 

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -8,7 +8,7 @@ search:
 
 There are several ways to use DDEV’s latest-committed HEAD version:
 
-* **Download** the latest main branch artifacts from [nightly.link](https://nightly.link/ddev/ddev/workflows/master-build/main). Each of these is built by the CI system, signed, and notarized. Get the one you need and place it in your `$PATH`.
+* **Download** the latest `main` branch artifacts from [nightly.link](https://nightly.link/ddev/ddev/workflows/main-build/main). Each of these is built by the CI system, signed, and notarized. Get the one you need and place it in your `$PATH`.
 * **Homebrew install HEAD**: On macOS and Linux, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD --fetch-HEAD` to get the latest DDEV commit, even if it’s unreleased.
 * **Install via script**: You can download and run the [install_ddev_head.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_head.sh)  script, or run it automatically:
 
@@ -47,7 +47,7 @@ rm ddev-macos-arm64.zip
 
 ![Github Action PR Comment ZIP files](../images/github-action-pr-comment.png)
 
-Tip: If you need a zip-file to try out the "Testing a PR" process, see the [nightly builds](https://nightly.link/ddev/ddev/workflows/master-build/main).
+Tip: If you need a zip-file to try out the "Testing a PR" process, see the [nightly builds](https://nightly.link/ddev/ddev/workflows/main-build/main).
 
 ???warning "macOS and Unsigned Binaries (click me)"
     macOS doesn’t like these downloaded binaries, so you’ll need to bypass the automatic quarantine to use them:
@@ -56,7 +56,7 @@ Tip: If you need a zip-file to try out the "Testing a PR" process, see the [nigh
     xattr -r -d com.apple.quarantine ~/bin/ddev
     ```
 
-    (The binaries on the main branch and the final release binaries _are_ signed.)
+    (The binaries on the `main` branch and the final release binaries _are_ signed.)
 
 Verify the replacement worked by running `ddev -v`. The output should be something like `ddev version v1.23.5-98-g3c93ae87e`, instead of the regular `ddev version v1.23.5`. Valuable commands for debugging are `which -a ddev` and `echo $PATH`.
 
@@ -222,8 +222,8 @@ ampli pull
 ```
 
 Once the changes are ready to be merged, merge the changes made in the new
-branch to the main branch in the Amplitude backend and switch back to the
-main branch:
+branch to the `main` branch in the Amplitude backend and switch back to the
+`main` branch:
 
 ```bash
 ampli checkout main

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -27,7 +27,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 13. Install [winaero tweaker](https://winaero.com/request.php?1796) and “Enable user autologin checkbox”. Set up the machine to [automatically log in on boot](https://www.cnet.com/how-to/automatically-log-in-to-your-windows-10-pc/).  Then run netplwiz, provide the password for the main user, uncheck “require a password to log in”.
 14. Set the `buildkite-agent` service to run as the testbot user and use delayed start: Choose “Automatic, delayed start” and on the “Log On” tab in the services widget it must be set up to log in as the testbot user, so it inherits environment variables and home directory (and can access NFS, has testbot Git config, etc).
 15. `git config --global --add safe.directory '*'`.
-16. Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/master/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
+16. Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/main/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
 17. Run `.buildkite/sanetestbot.sh` to check your work.
 18. Reboot the machine and do a test run. (On Windows, the machine name only takes effect on reboot.)
 19. Verify that `go`, `ddev`, `git-bash` are in the path.
@@ -82,7 +82,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 1. Install Docker Desktop on Windows
 2. In Docker Desktop, enable WSL2 integration with this distro (and this distro only, not default distro).
 3. Install DDEV using the [standard WSL2 Docker Desktop installation](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/#wsl2-docker-desktop-install-script)
-4. Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/master/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
+4. Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/main/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
 5. Run `.buildkite/sanetestbot.sh` to check your work.
 
 ## Windows Setup for WSL2+Docker-Inside Testing
@@ -100,7 +100,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
     ```
 
 4. Install DDEV using the [standard WSL2 Docker CE installation](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/#wsl2-docker-ce-inside-install-script)
-5. Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/master/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
+5. Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/main/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
 6. Run `.buildkite/sanetestbot.sh` to check your work.
 7. In “Advanced Windows Update Settings” enable “Receive updates for other Microsoft products” to make sure you get WSL2 kernel upgrades. Make sure to run Windows Update to get the latest kernel.
 8. Turn off the settings that cause the "windows experience" prompts after new upgrades:

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -7,7 +7,7 @@ search:
 ## Release process and tools
 
 * [GoReleaser Pro](https://goreleaser.com/pro/) is used to do the actual releasing using [.goreleaser.yml](https://github.com/ddev/ddev/blob/main/.goreleaser.yml). GoReleaser Pro is a licensed product that requires separate installation and a license key, which is in the GitHub Workflow configuration and is available in 1Password to DDEV maintainers who need it.
-* The [Master Build/Release GitHub Action](https://github.com/ddev/ddev/blob/main/.github/workflows/master-build.yml) does the actual running of the GoReleaser actions and provides the needed secrets.
+* The [Main Build/Release GitHub Action](https://github.com/ddev/ddev/blob/main/.github/workflows/main-build.yml) does the actual running of the GoReleaser actions and provides the needed secrets.
 
 ## GitHub Actions Required Secrets
 

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -6,8 +6,8 @@ search:
 
 ## Release process and tools
 
-* [GoReleaser Pro](https://goreleaser.com/pro/) is used to do the actual releasing using [.goreleaser.yml](https://github.com/ddev/ddev/blob/master/.goreleaser.yml). GoReleaser Pro is a licensed product that requires separate installation and a license key, which is in the GitHub Workflow configuration and is available in 1Password to DDEV maintainers who need it.
-* The [Master Build/Release GitHub Action](https://github.com/ddev/ddev/blob/master/.github/workflows/master-build.yml) does the actual running of the GoReleaser actions and provides the needed secrets.
+* [GoReleaser Pro](https://goreleaser.com/pro/) is used to do the actual releasing using [.goreleaser.yml](https://github.com/ddev/ddev/blob/main/.goreleaser.yml). GoReleaser Pro is a licensed product that requires separate installation and a license key, which is in the GitHub Workflow configuration and is available in 1Password to DDEV maintainers who need it.
+* The [Master Build/Release GitHub Action](https://github.com/ddev/ddev/blob/main/.github/workflows/master-build.yml) does the actual running of the GoReleaser actions and provides the needed secrets.
 
 ## GitHub Actions Required Secrets
 
@@ -62,11 +62,11 @@ The following “Repository secret” environment variables must be configured i
 ### Prerelease Tasks
 
 * Create and execute a test plan.
-* Make sure [`version-history.md`](https://github.com/ddev/ddev/blob/master/version-history.md) is up to date.
+* Make sure [`version-history.md`](https://github.com/ddev/ddev/blob/main/version-history.md) is up to date.
 * Push the new version of `ddev/ddev-php-base`.
 * Update `ddev/ddev-webserver` to use the new version of `ddev/ddev-php-base` and push it with the proper tag.
 * Make sure the Docker images are all tagged and pushed.
-* Make sure [`pkg/versionconstants/versionconstants.go`](https://github.com/ddev/ddev/blob/master/pkg/versionconstants/versionconstants.go) is all set to point to the new images and tests have been run.
+* Make sure [`pkg/versionconstants/versionconstants.go`](https://github.com/ddev/ddev/blob/main/pkg/versionconstants/versionconstants.go) is all set to point to the new images and tests have been run.
 
 ### Actual Release Creation
 
@@ -95,7 +95,7 @@ If you need to push from a forked PR, you’ll have to do this from your fork (f
 * Visit `https://github.com/ddev/ddev/actions/workflows/push-tagged-image.yml`.
 * Click the “Push tagged image” workflow on the left side of the page.
 * Click the “Run workflow” button in the blue section above the workflow runs.
-* Choose the branch to build from (usually `master`).
+* Choose the branch to build from (usually `main`).
 * Enter the image (`ddev-webserver`, `ddev-php-base`, etc.).
 * Enter the tag that will be used in `pkg/version/version.go`.
 
@@ -107,7 +107,7 @@ While it’s more error-prone, images can be pushed from the command line:
 2. `docker buildx use multi-arch-builder || docker buildx create --name multi-arch-builder --use`.
 3. `cd containers/<image>`.
 4. Before pushing `ddev-webserver`, make sure you’ve pushed a version of `ddev-php-base` and updated `ddev-webserver`’s Dockerfile to use that as a base.
-5. `make push VERSION=<release_version> DOCKER_ARGS=--no-cache` for most of the images. For `ddev-dbserver` it’s `make PUSH=true VERSION=<release_version> DOCKER_ARGS=--no-cache`. There’s a [push-all.sh](https://github.com/ddev/ddev/blob/master/containers/push-all.sh) script to update all of them, but it takes forever.
+5. `make push VERSION=<release_version> DOCKER_ARGS=--no-cache` for most of the images. For `ddev-dbserver` it’s `make PUSH=true VERSION=<release_version> DOCKER_ARGS=--no-cache`. There’s a [push-all.sh](https://github.com/ddev/ddev/blob/main/containers/push-all.sh) script to update all of them, but it takes forever.
 6. `ddev-dbserver` images can be pushed with `make PUSH=true VERSION=<release_version> DOCKER_ARGS=--no-cache` from the `containers/ddev-dbserver` directory.
 
 ## Maintaining `ddev-dbserver` MySQL 5.7 ARM64 Images
@@ -132,7 +132,7 @@ But here are the steps for building:
 
 Homebrew formulas normally update with the release process, so nothing needs to be done.
 
-If you have to temporarily update the Homebrew formulas, you can do that with a commit to <https://github.com/ddev/homebrew-ddev> and <https://github.com/ddev/homebrew-ddev-edge>. The bottles and checksums for macOS (High Sierra) and x86_64_linux are built and pushed to the release page automatically by the release build process (see [bump_homebrew.sh](https://github.com/ddev/ddev/blob/master/.ci-scripts/bump_homebrew.sh)). Test `brew upgrade ddev` both on macOS and Linux and make sure DDEV is the right version and behaves well.
+If you have to temporarily update the Homebrew formulas, you can do that with a commit to <https://github.com/ddev/homebrew-ddev> and <https://github.com/ddev/homebrew-ddev-edge>. The bottles and checksums for macOS (High Sierra) and x86_64_linux are built and pushed to the release page automatically by the release build process (see [bump_homebrew.sh](https://github.com/ddev/ddev/blob/main/.ci-scripts/bump_homebrew.sh)). Test `brew upgrade ddev` both on macOS and Linux and make sure DDEV is the right version and behaves well.
 
 ## Manually Updating Chocolatey
 
@@ -188,7 +188,7 @@ This is done automatically by the release build on a dedicated Windows test runn
 
 ## APT and YUM/RPM Package Management
 
-The Linux `apt` and `yum`/`rpm` packages are built and pushed by the `nfpms` and `furies` sections of the [.goreleaser.yml](https://github.com/ddev/ddev/blob/master/.goreleaser.yml) file.
+The Linux `apt` and `yum`/`rpm` packages are built and pushed by the `nfpms` and `furies` sections of the [.goreleaser.yml](https://github.com/ddev/ddev/blob/main/.goreleaser.yml) file.
 
 * The actual packages are served by [gemfury.com](https://gemfury.com/).
 * The name of the organization in GemFury is `drud`, managed at `https://manage.fury.io/dashboard/drud`.

--- a/docs/content/developers/testing-docs.md
+++ b/docs/content/developers/testing-docs.md
@@ -77,7 +77,7 @@ pyspelling:
 Spelling check passed :)
 ```
 
-If you’ve added a correctly-spelled word that gets flagged, like “Symfony” for example, you’ll need to add it to `.spellcheckwordlist.txt` in the [root of DDEV’s repository](https://github.com/ddev/ddev/blob/master/.spellcheckwordlist.txt).
+If you’ve added a correctly-spelled word that gets flagged, like “Symfony” for example, you’ll need to add it to `.spellcheckwordlist.txt` in the [root of DDEV’s repository](https://github.com/ddev/ddev/blob/main/.spellcheckwordlist.txt).
 
 !!!warning "`pyspelling` and `aspell` required!"
     It’s probably best to install packages locally before attempting to run `make pyspelling`:

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -656,7 +656,7 @@ The Docker image to use for the web server.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | [`ddev/ddev-webserver`](https://hub.docker.com/r/ddev/ddev-webserver) | Specify your own image based on [ddev/ddev-webserver](https://github.com/ddev/ddev/tree/master/containers/ddev-webserver).
+| :octicons-file-directory-16: project | [`ddev/ddev-webserver`](https://hub.docker.com/r/ddev/ddev-webserver) | Specify your own image based on [ddev/ddev-webserver](https://github.com/ddev/ddev/tree/main/containers/ddev-webserver).
 
 !!!warning "Proceed with caution"
     It’s unusual to change this, and we don’t recommend it without Docker experience and a good reason. Typically, this means additions to the existing web image using a `.ddev/web-build/Dockerfile.*`.

--- a/docs/content/users/debugging-profiling/xhprof-profiling.md
+++ b/docs/content/users/debugging-profiling/xhprof-profiling.md
@@ -10,7 +10,7 @@ DDEV has built-in support for [xhprof](https://www.php.net/manual/en/book.xhprof
 * Visit one of the links provided by `ddev xhprof on` and study the results.
 * On the profiler output page, you can drill down to the function that you want to study, or use the graphical “View Full Callgraph” link. Click the column headers to sort by number of runs and inclusive or exclusive wall time, then drill down into the function you want to study and do the same.
 * The runs are erased on [`ddev restart`](../usage/commands.md#restart).
-* If you’re using Apache with a custom `.ddev/apache/apache-site.conf`, you’ll need to make sure it includes `Alias "/xhprof" "/var/xhprof/xhprof_html"` from DDEV’s [default apache-site.conf](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/webserver_config_assets/apache-site-php.conf).
+* If you’re using Apache with a custom `.ddev/apache/apache-site.conf`, you’ll need to make sure it includes `Alias "/xhprof" "/var/xhprof/xhprof_html"` from DDEV’s [default apache-site.conf](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/webserver_config_assets/apache-site-php.conf).
 
 For a tutorial on how to study the various xhprof reports, see the section “How to use XHPROF UI” in [A Guide to Profiling with XHPROF](https://inviqa.com/blog/profiling-xhprof). It takes a little time to get your eyes used to the reporting. (You don’t need to do any of the installation described in that article!)
 

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -189,7 +189,7 @@ yaml_read_files:
 
 then `value1` can be used throughout the `install.yaml` as `{{ example.value1 }}` and it will be replaced with the value `xxx`.
 
-More exotic template-based replacements can be seen in an advanced test [example](https://github.com/ddev/ddev/blob/master/cmd/ddev/cmd/testdata/TestCmdAddonComplex/recipe/install.yaml).
+More exotic template-based replacements can be seen in an advanced test [example](https://github.com/ddev/ddev/blob/main/cmd/ddev/cmd/testdata/TestCmdAddonComplex/recipe/install.yaml).
 
 Go templating resources:
 

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -10,9 +10,9 @@ This involves adding a Bash script to the project in `.ddev/commands/host`, a sp
 
 Example commands in `ddev/commands/*/*.example` can be copied, moved, or symlinked.
 
-For example, [.ddev/commands/host/mysqlworkbench.example](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/global_dotddev_assets/commands/host/mysqlworkbench.example) can be used to add a `ddev mysqlworkbench` command. Rename it from `mysqlworkbench.example` to `mysqlworkbench`. If you’re on macOS or Linux (or some configurations of Windows) you can `cd .ddev/commands/host && ln -s mysqlworkbench.example mysqlworkbench`.
+For example, [.ddev/commands/host/mysqlworkbench.example](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/global_dotddev_assets/commands/host/mysqlworkbench.example) can be used to add a `ddev mysqlworkbench` command. Rename it from `mysqlworkbench.example` to `mysqlworkbench`. If you’re on macOS or Linux (or some configurations of Windows) you can `cd .ddev/commands/host && ln -s mysqlworkbench.example mysqlworkbench`.
 
-The [`ddev mysql`](../usage/commands.md#mysql) runs the `mysql` client inside the `db` container command using this technique. See the [`ddev mysql` command](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/global_dotddev_assets/commands/db/mysql).
+The [`ddev mysql`](../usage/commands.md#mysql) runs the `mysql` client inside the `db` container command using this technique. See the [`ddev mysql` command](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/global_dotddev_assets/commands/db/mysql).
 
 ## Notes for All Command Types
 
@@ -38,7 +38,7 @@ open -a PhpStorm.app ${DDEV_APPROOT}
 
 ## Container Commands
 
-To provide a command which will execute in a container, add a Bash script to `.ddev/commands/<container_name>`, for example, `.ddev/commands/web/mycommand`. The Bash script will be executed inside the named container. For example, see the [several standard DDEV script-based web container commands](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/global_dotddev_assets/commands/web).
+To provide a command which will execute in a container, add a Bash script to `.ddev/commands/<container_name>`, for example, `.ddev/commands/web/mycommand`. The Bash script will be executed inside the named container. For example, see the [several standard DDEV script-based web container commands](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/global_dotddev_assets/commands/web).
 
 You can run commands in custom containers as well as standard DDEV `web` and `db` containers. Use the service name, like `.ddev/commands/solr/<command>`. The only catch with a custom container is that your service must mount `/mnt/ddev-global-cache` like the `web` and `db` containers do; the `volumes` section of `docker-compose.<servicename>.yaml` needs:
 
@@ -67,7 +67,7 @@ Changes to the command files in the global `.ddev` directory need a `ddev start`
 
 ## Shell Command Examples
 
-There are many examples of [global](https://github.com/ddev/ddev/tree/master/pkg/ddevapp/global_dotddev_assets/commands) and [project-level](https://github.com/ddev/ddev/tree/master/pkg/ddevapp/dotddev_assets/commands) custom/shell commands that ship with DDEV you can adapt for your own use. They can be found in your `~/.ddev/commands/*` directories and in your project’s `.ddev/commands/*` directories. There you’ll see how to provide usage, examples, and how to use arguments provided to the commands. For example, the [`xdebug` command](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug) shows simple argument processing and the [launch command](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/global_dotddev_assets/commands/host/launch) demonstrates flag processing.
+There are many examples of [global](https://github.com/ddev/ddev/tree/main/pkg/ddevapp/global_dotddev_assets/commands) and [project-level](https://github.com/ddev/ddev/tree/main/pkg/ddevapp/dotddev_assets/commands) custom/shell commands that ship with DDEV you can adapt for your own use. They can be found in your `~/.ddev/commands/*` directories and in your project’s `.ddev/commands/*` directories. There you’ll see how to provide usage, examples, and how to use arguments provided to the commands. For example, the [`xdebug` command](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug) shows simple argument processing and the [launch command](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/global_dotddev_assets/commands/host/launch) demonstrates flag processing.
 
 ## Command Line Completion
 
@@ -85,7 +85,7 @@ For example:
 
 The autocomplete script should echo the valid arguments as a string separated by line breaks. You don't need to filter the arguments by the last argument string (e.g. if the last argument is `som`, you don't need to filter out any arguments that don't start with `som`). That will be handled for you before the result is given to your shell as completion suggestions.
 
-The web container's [`nvm` autocomplete script](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/nvm) shows how this can be used to forward completion requests to a relevant script in the container.
+The web container's [`nvm` autocomplete script](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/global_dotddev_assets/commands/web/autocomplete/nvm) shows how this can be used to forward completion requests to a relevant script in the container.
 
 ## Environment Variables Provided
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -71,7 +71,7 @@ RUN (apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -
 RUN apt-get remove php${DDEV_PHP_VERSION}-xdebug || true
 RUN pecl install ${extension}
 # Use the standard xdebug.ini from source
-ADD https://raw.githubusercontent.com/ddev/ddev/master/containers/ddev-php-base/ddev-php-files/etc/php/8.2/mods-available/xdebug.ini /etc/php/${DDEV_PHP_VERSION}/mods-available
+ADD https://raw.githubusercontent.com/ddev/ddev/main/containers/ddev-php-base/ddev-php-files/etc/php/8.2/mods-available/xdebug.ini /etc/php/${DDEV_PHP_VERSION}/mods-available
 RUN chmod 666 /etc/php/${DDEV_PHP_VERSION}/mods-available/xdebug.ini
 # ddev xdebug handles enabling module so we don't enable here
 #RUN phpenmod ${extension}

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -20,7 +20,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### Install Script
 
-    The [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) is another option. It downloads, verifies, and sets up the `ddev` executable:
+    The [install script](https://github.com/ddev/ddev/blob/main/scripts/install_ddev.sh) is another option. It downloads, verifies, and sets up the `ddev` executable:
 
     ```bash
     # Download and run the install script
@@ -125,7 +125,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     <!-- we’re using HTML here to customize the #install-script-linux anchor -->
     <h3 id="install-script-linux">Install Script<a class="headerlink" href="#install-script-linux" title="Permanent link">¶</a></h3>
 
-    The [install script](https://github.com/ddev/ddev/blob/master/scripts/install_ddev.sh) is another option. It downloads, verifies, and sets up the `ddev` executable:
+    The [install script](https://github.com/ddev/ddev/blob/main/scripts/install_ddev.sh) is another option. It downloads, verifies, and sets up the `ddev` executable:
 
     ```bash
     # Download and run the install script
@@ -161,16 +161,16 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
       Use `wsl.exe -l -v` to see the versions of the distros you are using they should be v2.
     * WSL2 is supported on Windows 10 and 11.
       All Windows 10/11 editions, including Windows 10 Home support WSL2.
-    * WSL2 offers a faster, smoother experience.  
+    * WSL2 offers a faster, smoother experience.
       It’s vastly more performant, and you’re less likely to have obscure Windows problems.
 
-    * Execute DDEV commands inside WSL2.   
+    * Execute DDEV commands inside WSL2.
       You’ll want to run DDEV commands inside Ubuntu, for example, and never on the Windows side in PowerShell or Git Bash.
-    * Projects should live under the home directory of the Linux filesystem.  
+    * Projects should live under the home directory of the Linux filesystem.
       WSL2’s Linux filesystem (e.g. `/home/<your_username>`) is much faster and has proper permissions, so keep your projects there and **not** in the slower Windows filesystem (`/mnt/c`).
-    * Custom hostnames are managed via the Windows hosts file, not within WSL2.  
+    * Custom hostnames are managed via the Windows hosts file, not within WSL2.
       DDEV attempts to manage custom hostnames via the Windows-side hosts file—usually at `C:\Windows\system32\drivers\etc\hosts`—and it can only do this if it’s installed on the Windows side. (DDEV inside WSL2 uses `ddev.exe` on the Windows side as a proxy to update the Windows hosts file.) If `ddev.exe --version` shows the same version as `ddev --version` you’re all set up. Otherwise, install DDEV on Windows using `choco upgrade -y ddev` or by downloading and running the Windows installer. (The WSL2 scripts below install DDEV on the Windows side, taking care of that for you.) If you frequently run into Windows UAC Escalation, you can calm it down by running `gsudo.exe cache on` and `gsudo.exe config CacheMode auto`, see [gsudo docs](https://github.com/gerardog/gsudo#credentials-cache).
-    * WSL2 is not the same as Docker Desktop’s WSL2 engine.  
+    * WSL2 is not the same as Docker Desktop’s WSL2 engine.
       Using WSL2 to install and run DDEV is not the same as using Docker Desktop’s WSL2 engine, which itself runs in WSL2, but can serve applications running in both traditional Windows and inside WSL2.
 
     The WSL2 install process involves:
@@ -184,10 +184,10 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### WSL2 + Docker CE Inside Install Script
 
-    This technique is our favorite, as it uses the most reliable WSL2 Docker provider (`docker-ce`), which is also free and open-source. 
-    
+    This technique is our favorite, as it uses the most reliable WSL2 Docker provider (`docker-ce`), which is also free and open-source.
+
     This script prepares your default WSL2 Ubuntu distro and doesn’t require Docker Desktop, and you can run the script multiple times without breaking anything.
-        
+
     In all cases:
 
     1. Install WSL2 with an Ubuntu distro.
@@ -199,16 +199,16 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
         * Reboot if required. (Usually required.)
 
-        * Verify that you have an Ubuntu distro set as default by running `wsl.exe -l -v`.  
+        * Verify that you have an Ubuntu distro set as default by running `wsl.exe -l -v`.
           If you have WSL2 but not an Ubuntu distro, install one by running `wsl.exe --install Ubuntu`. If this doesn’t work, see [manual installation](https://docs.microsoft.com/en-us/windows/wsl/install-manual) and [troubleshooting](https://docs.microsoft.com/en-us/windows/wsl/troubleshooting#installation-issues).
 
         * Verify that your Ubuntu default distro is WSL v2 using `wsl -l -v`.
 
-    2. In an administrative PowerShell run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_inside.ps1) by executing:
+    2. In an administrative PowerShell run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_inside.ps1) by executing:
 
         ```powershell
         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-        iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_inside.ps1'))
+        iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_inside.ps1'))
         ```
     3. In *Windows Update Settings* → *Advanced Options* enable *Receive updates for other Microsoft products*. You may want to occasionally run `wsl.exe --update` as well.
 
@@ -217,7 +217,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ### WSL2 + Docker Desktop Install Script
 
     WSL2 with Docker Desktop is a less-favored choice because Docker Desktop may be lightly supported, and has many features not required for use with DDEV that do not add particular value. It is also not free software (although smaller organizations can use it free of charge) and it is not open-source.
-    
+
     The script here prepares your default WSL2 Ubuntu distro for use with Docker Desktop, and you can run the script multiple times without breaking anything.
 
     In all cases:
@@ -229,7 +229,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
         * Verify that you have an Ubuntu distro set as the default default with `wsl -l -v`.
 
-        * If you have WSL2 but not an Ubuntu distro, install one with `wsl --install Ubuntu`.  
+        * If you have WSL2 but not an Ubuntu distro, install one with `wsl --install Ubuntu`.
           If that doesn't work for you, see [manual installation](https://docs.microsoft.com/en-us/windows/wsl/install-manual) and [troubleshooting](https://docs.microsoft.com/en-us/windows/wsl/troubleshooting#installation-issues).
 
         If you prefer to use another Ubuntu distro, install it and set it as default. For example, `wsl --set-default Ubuntu-24.04`.
@@ -239,11 +239,11 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     6. Install Docker Desktop. If you already have Chocolatey, run `choco install -y docker-desktop`. Otherwise [download Docker Desktop from Docker](https://www.docker.com/products/docker-desktop/).
     7. Start Docker Desktop. You should now be able to run `docker ps` in PowerShell or Git Bash.
     8. In *Docker Desktop* → *Settings* → *Resources* → *WSL2 Integration*, verify that Docker Desktop is integrated with your distro.
-    9. In an administrative PowerShell run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_desktop.ps1) by executing:
+    9. In an administrative PowerShell run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1) by executing:
 
         ```powershell
         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-        iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_desktop.ps1'))
+        iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1'))
         ```
 
     Now you can use the "Ubuntu" terminal app or Windows Terminal to access your Ubuntu distro, which has DDEV and Docker Desktop integrated with it.
@@ -338,7 +338,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     4. Save the following link to your bookmark bar: <a href="javascript: if %28 %2Fbitbucket%2F.test %28 window.location.host %29 %20 %29 %20%7B%20paths%3Dwindow.location.pathname.split %28 %22%2F%22 %29 %3B%20repo%3D%5Bwindow.location.origin%2C%20paths%5B1%5D%2C%20paths%5B2%5D%5D.join %28 %22%2F%22 %29 %20%7D%3B%20if %28 %2Fgithub.com%7Cgitlab.com%2F.test %28 window.location.host %29  %29 %20%7Brepo%20%3D%20window.location.href%7D%3B%20if%20 %28 repo %29 %20%7Bwindow.location.href%20%3D%20%22https%3A%2F%2Fgitpod.io%2F%23DDEV_REPO%3D%22%20%2B%20encodeURIComponent %28 repo %29 %20%2B%20%22%2CDDEV_ARTIFACTS%3D%22%20%2B%20encodeURIComponent %28 repo %29 %20%2B%20%22-artifacts%2Fhttps%3A%2F%2Fgithub.com%2Fddev%2Fddev-gitpod-launcher%2F%22%7D%3B">Open in ddev-gitpod</a>.
         It’s easiest to drag the link into your bookmarks. When you’re on a Git repository, click the bookmark to open it with DDEV in Gitpod. It does the same thing as the second option, but it works on non-Chrome browsers and you can use native browser keyboard shortcuts.
 
-    It can be complicated to get private databases and files into Gitpod, so in addition to the launchers, the [`git` provider example](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/git.yaml.example) demonstrates pulling a database and files without complex setup or permissions. This was created explicitly for Gitpod integration, because in Gitpod you typically already have access to private Git repositories, which are a fine place to put a starter database and files. Although [ddev-gitpod-launcher](https://ddev.github.io/ddev-gitpod-launcher/) and the web extension provide the capability, you may want to integrate a Git provider—or one of the [other providers](https://github.com/ddev/ddev/tree/master/pkg/ddevapp/dotddev_assets/providers)—for each project.
+    It can be complicated to get private databases and files into Gitpod, so in addition to the launchers, the [`git` provider example](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/git.yaml.example) demonstrates pulling a database and files without complex setup or permissions. This was created explicitly for Gitpod integration, because in Gitpod you typically already have access to private Git repositories, which are a fine place to put a starter database and files. Although [ddev-gitpod-launcher](https://ddev.github.io/ddev-gitpod-launcher/) and the web extension provide the capability, you may want to integrate a Git provider—or one of the [other providers](https://github.com/ddev/ddev/tree/main/pkg/ddevapp/dotddev_assets/providers)—for each project.
 
 === "Codespaces"
 
@@ -364,16 +364,16 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     <div style="text-align:center;"><img style="max-width:400px;" src="./../../../images/codespaces-setting-up.png" alt="Screenshot of codespace create dialog in a repository on GitHub"></div>
 
-    DDEV is now available within your new codespace instance:  
+    DDEV is now available within your new codespace instance:
 
     <div style="text-align:center;"><img src="./../../../images/codespaces-hello-screen.png" alt=""></div>
 
     Run `ddev config` to [start a new blank project](./../project.md) - or [install a CMS](./../quickstart.md).
-    
+
     Run `ddev start` if there is already a configured DDEV project in your repository.
 
     **Troubleshooting**:
-    
+
     If there are errors after restarting a codespace, use `ddev restart` or `ddev poweroff`.
 
     You can also use the commands
@@ -381,28 +381,28 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     - "Codespaces: Rebuild container"
     - "Codespaces: Full rebuild container" (Beware: database will be deleted)
 
-    via the [Visual Studio Code Command Palette](https://docs.github.com/en/enterprise-cloud@latest/codespaces/codespaces-reference/using-the-vs-code-command-palette-in-codespaces):  
+    via the [Visual Studio Code Command Palette](https://docs.github.com/en/enterprise-cloud@latest/codespaces/codespaces-reference/using-the-vs-code-command-palette-in-codespaces):
 
     - <kbd>⌘</kbd> + <kbd>SHIFT</kbd> + <kbd>P</kbd> on a Mac
     - <kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>P</kbd> on Windows/Linux
     - from the Application Menu, click View > Command Palette (Firefox)
-    
+
     If you need DDEV-specific assistance or have further questions, see [support](./../support.md).
 
-    Your updated `devcontainer.json` file may differ depending on your project, but you should have `install-ddev` in the `features` section. 
+    Your updated `devcontainer.json` file may differ depending on your project, but you should have `install-ddev` in the `features` section.
 
     !!!note "Normal Linux installation also works"
         You can also install DDEV as if it were on any normal [Linux installation](#linux).
 
     ### Docker integration
 
-    DDEV in Codespaces relies on [`docker-in-docker`](https://github.com/devcontainers/features), which is installed by default when you use the image `"mcr.microsoft.com/devcontainers/universal:2"`. Please be aware: GitHub Codespaces and its Docker-integration (docker-in-docker) are relatively new. See [devcontainers/features](https://github.com/devcontainers/features) for general support and issues regarding Docker-support.  
+    DDEV in Codespaces relies on [`docker-in-docker`](https://github.com/devcontainers/features), which is installed by default when you use the image `"mcr.microsoft.com/devcontainers/universal:2"`. Please be aware: GitHub Codespaces and its Docker-integration (docker-in-docker) are relatively new. See [devcontainers/features](https://github.com/devcontainers/features) for general support and issues regarding Docker-support.
 
     ###  DDEV's router is not used
 
-    Since Codespaces handles all the routing, the internal DDEV router will not be used on Codespaces. Therefore config settings like [`web_extra_exposed_ports`](./../configuration/config.md#web_extra_exposed_ports) will have no effect. 
+    Since Codespaces handles all the routing, the internal DDEV router will not be used on Codespaces. Therefore config settings like [`web_extra_exposed_ports`](./../configuration/config.md#web_extra_exposed_ports) will have no effect.
 
-    You can expose ports via the `ports` setting, which is usually not recommended if you work locally due to port conflicts. But you can load these additional Docker compose files only when Codespaces is detected. See [Defining Additional Services](./../extend/custom-compose-files.md#docker-composeyaml-examples) for more information. 
+    You can expose ports via the `ports` setting, which is usually not recommended if you work locally due to port conflicts. But you can load these additional Docker compose files only when Codespaces is detected. See [Defining Additional Services](./../extend/custom-compose-files.md#docker-composeyaml-examples) for more information.
 
     ```yaml
     services:
@@ -414,9 +414,9 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ### Default environment variables
 
     Codespace instances already provide some [default environment values](https://docs.github.com/en/codespaces/developing-in-codespaces/default-environment-variables-for-your-codespace). You can inherit and inject them in your `.ddev/config.yaml`:
-    
+
     ```yaml
-    web_environment: 
+    web_environment:
         - CODESPACES
         - CODESPACE_NAME
         - GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
@@ -424,13 +424,13 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### Advanced usage via devcontainer.json
 
-    A lot more customization is possible via the [`devcontainer.json`-configuration](https://containers.dev/implementors/json_reference/). You can install Visual Studio Code extensions by default or run commands automatically. 
+    A lot more customization is possible via the [`devcontainer.json`-configuration](https://containers.dev/implementors/json_reference/). You can install Visual Studio Code extensions by default or run commands automatically.
 
     #### postCreateCommand
 
     The [`postCreateCommand`](https://containers.dev/implementors/json_reference/) lets you run commands automatically when a new codespace is launched. DDEV commands are available here.
 
-    The event is triggered on: fresh creation, rebuilds and full rebuilds. `ddev poweroff` is used in this example to avoid errors on rebuilds since some Docker containers are kept. 
+    The event is triggered on: fresh creation, rebuilds and full rebuilds. `ddev poweroff` is used in this example to avoid errors on rebuilds since some Docker containers are kept.
 
     You usually want to use a separate bash script to do this, as docker [might not yet be available when the command starts to run](https://github.com/devcontainers/features/issues/780).
 
@@ -456,8 +456,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         },
         "postCreateCommand": "bash .devcontainer/setup_project.sh"
     }
-    ``` 
-    
+    ```
+
     ```bash
     #!/usr/bin/env bash
     set -ex
@@ -481,15 +481,15 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     # start ddev project automatically
     ddev start -y
 
-    # further automated install / setup steps, e.g. 
-    ddev composer install 
+    # further automated install / setup steps, e.g.
+    ddev composer install
     ```
 
-    To check for errors during the `postCreateCommand` action, use the command 
-    
-    - "Codespaces: View creation log” 
-    
-    via the [Visual Studio Code Command Palette](https://docs.github.com/en/enterprise-cloud@latest/codespaces/codespaces-reference/using-the-vs-code-command-palette-in-codespaces):  
+    To check for errors during the `postCreateCommand` action, use the command
+
+    - "Codespaces: View creation log”
+
+    via the [Visual Studio Code Command Palette](https://docs.github.com/en/enterprise-cloud@latest/codespaces/codespaces-reference/using-the-vs-code-command-palette-in-codespaces):
 
     - <kbd>⌘</kbd> + <kbd>SHIFT</kbd> + <kbd>P</kbd> on a Mac
     - <kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>P</kbd> on Windows/Linux

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -157,20 +157,20 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### Important Considerations for WSL2 and DDEV
 
-    * You **must** use WSL2, not WSL version 1.
+    * You **must** use WSL2, not WSL version 1.  
       Use `wsl.exe -l -v` to see the versions of the distros you are using they should be v2.
-    * WSL2 is supported on Windows 10 and 11.
+    * WSL2 is supported on Windows 10 and 11.  
       All Windows 10/11 editions, including Windows 10 Home support WSL2.
-    * WSL2 offers a faster, smoother experience.
+    * WSL2 offers a faster, smoother experience.  
       It’s vastly more performant, and you’re less likely to have obscure Windows problems.
 
-    * Execute DDEV commands inside WSL2.
+    * Execute DDEV commands inside WSL2.  
       You’ll want to run DDEV commands inside Ubuntu, for example, and never on the Windows side in PowerShell or Git Bash.
-    * Projects should live under the home directory of the Linux filesystem.
+    * Projects should live under the home directory of the Linux filesystem.  
       WSL2’s Linux filesystem (e.g. `/home/<your_username>`) is much faster and has proper permissions, so keep your projects there and **not** in the slower Windows filesystem (`/mnt/c`).
-    * Custom hostnames are managed via the Windows hosts file, not within WSL2.
+    * Custom hostnames are managed via the Windows hosts file, not within WSL2.  
       DDEV attempts to manage custom hostnames via the Windows-side hosts file—usually at `C:\Windows\system32\drivers\etc\hosts`—and it can only do this if it’s installed on the Windows side. (DDEV inside WSL2 uses `ddev.exe` on the Windows side as a proxy to update the Windows hosts file.) If `ddev.exe --version` shows the same version as `ddev --version` you’re all set up. Otherwise, install DDEV on Windows using `choco upgrade -y ddev` or by downloading and running the Windows installer. (The WSL2 scripts below install DDEV on the Windows side, taking care of that for you.) If you frequently run into Windows UAC Escalation, you can calm it down by running `gsudo.exe cache on` and `gsudo.exe config CacheMode auto`, see [gsudo docs](https://github.com/gerardog/gsudo#credentials-cache).
-    * WSL2 is not the same as Docker Desktop’s WSL2 engine.
+    * WSL2 is not the same as Docker Desktop’s WSL2 engine.  
       Using WSL2 to install and run DDEV is not the same as using Docker Desktop’s WSL2 engine, which itself runs in WSL2, but can serve applications running in both traditional Windows and inside WSL2.
 
     The WSL2 install process involves:
@@ -193,13 +193,13 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     1. Install WSL2 with an Ubuntu distro.
 
         * Install WSL:
-            ```
+            ```powershell
             wsl --install
             ```
 
         * Reboot if required. (Usually required.)
 
-        * Verify that you have an Ubuntu distro set as default by running `wsl.exe -l -v`.
+        * Verify that you have an Ubuntu distro set as default by running `wsl.exe -l -v`.  
           If you have WSL2 but not an Ubuntu distro, install one by running `wsl.exe --install Ubuntu`. If this doesn’t work, see [manual installation](https://docs.microsoft.com/en-us/windows/wsl/install-manual) and [troubleshooting](https://docs.microsoft.com/en-us/windows/wsl/troubleshooting#installation-issues).
 
         * Verify that your Ubuntu default distro is WSL v2 using `wsl -l -v`.
@@ -229,7 +229,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
         * Verify that you have an Ubuntu distro set as the default default with `wsl -l -v`.
 
-        * If you have WSL2 but not an Ubuntu distro, install one with `wsl --install Ubuntu`.
+        * If you have WSL2 but not an Ubuntu distro, install one with `wsl --install Ubuntu`.  
           If that doesn't work for you, see [manual installation](https://docs.microsoft.com/en-us/windows/wsl/install-manual) and [troubleshooting](https://docs.microsoft.com/en-us/windows/wsl/troubleshooting#installation-issues).
 
         If you prefer to use another Ubuntu distro, install it and set it as default. For example, `wsl --set-default Ubuntu-24.04`.

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -157,7 +157,7 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
         ddev debug mutagen sync list --template "{{ json (index . 0) }}" | docker run -i --rm ddev/ddev-utilities jq -r
         ddev debug mutagen sync monitor <projectname> -l
         ```
-    * You can run the [diagnose_mutagen.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/diagnose_mutagen.sh) script to gather information about Mutagen’s setup. Please share output from it when creating an issue or seeking support.
+    * You can run the [diagnose_mutagen.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/diagnose_mutagen.sh) script to gather information about Mutagen’s setup. Please share output from it when creating an issue or seeking support.
     * Try `ddev poweroff` or `~/.ddev/bin/mutagen daemon stop && ~/.ddev/bin/mutagen daemon start` to restart the Mutagen daemon if you suspect it’s hanging.
     * Use `ddev mutagen reset` if you suspect trouble, and *always* after changing `.ddev/mutagen/mutagen.yml`. This restarts the project’s Mutagen data (Docker volume + Mutagen session) from scratch.
     * `ddev mutagen monitor` can help watch Mutagen behavior. It’s the same as `~/.ddev/bin/mutagen sync monitor <syncname>`.
@@ -259,10 +259,10 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
 
     === "macOS NFS Setup"
 
-        Download, inspect, make executable, and run [macos_ddev_nfs_setup.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/macos_ddev_nfs_setup.sh):
+        Download, inspect, make executable, and run [macos_ddev_nfs_setup.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/macos_ddev_nfs_setup.sh):
 
         ```
-        curl -O https://raw.githubusercontent.com/ddev/ddev/master/scripts/macos_ddev_nfs_setup.sh && chmod +x macos_ddev_nfs_setup.sh && ./macos_ddev_nfs_setup.sh
+        curl -O https://raw.githubusercontent.com/ddev/ddev/main/scripts/macos_ddev_nfs_setup.sh && chmod +x macos_ddev_nfs_setup.sh && ./macos_ddev_nfs_setup.sh
         ```
 
         This one-time setup stops running DDEV projects, adds your home directory to the `/etc/exports` config file that `nfsd` uses, and enables `nfsd` to run on your computer.

--- a/docs/content/users/providers/index.md
+++ b/docs/content/users/providers/index.md
@@ -6,7 +6,7 @@ Hosting provider integration allows connecting with your upstream hosting. `ddev
 
 DDEV provides ready-to-go integrations for Platform.sh, Acquia, and Lagoon in every project, see the .ddev/providers directory. These can be used as is, or they can be modified as you see fit (but remove the `#ddev-generated` line so DDEV doesn't replace them with the defaults).
 
-In addition, each project includes [example recipes](https://github.com/ddev/ddev/tree/master/pkg/ddevapp/dotddev_assets/providers) for Pantheon, Git, local files, and `rsync` in its `.ddev/providers` directory, which you can use and adapt however you’d like.
+In addition, each project includes [example recipes](https://github.com/ddev/ddev/tree/main/pkg/ddevapp/dotddev_assets/providers) for Pantheon, Git, local files, and `rsync` in its `.ddev/providers` directory, which you can use and adapt however you’d like.
 
 DDEV provides the `pull` command with whatever recipes you have configured. For example, `ddev pull platform` is available by default, and `ddev pull pantheon` is available if you have created `.ddev/providers/pantheon.yaml`.
 
@@ -14,16 +14,16 @@ DDEV also provides the `push` command to push database and files to upstream. Th
 
 Each provider recipe is a YAML file that can have whatever name you want. The examples are mostly named after the hosting providers, but they could be named `upstream.yaml` or `live.yaml`, so you could `ddev pull upstream` or `ddev pull live`. If you wanted different upstream environments to pull from, you could name one “prod” and one “dev” and `ddev pull prod` and `ddev pull dev`.
 
-[Recipes](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/) are provided for:
+[Recipes](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/) are provided for:
 
-- [Acquia](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/acquia.yaml)
-- [Git](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/git.yaml.example)
-- [Lagoon](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/lagoon.yaml)
-- [Local files](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) (like Dropbox, for example)
-- [Pantheon](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example)
-- [Platform.sh](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/platform.yaml)
-- [rsync](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/rsync.yaml.example)
-- [Upsun](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/upsun.yaml)
+- [Acquia](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/acquia.yaml)
+- [Git](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/git.yaml.example)
+- [Lagoon](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/lagoon.yaml)
+- [Local files](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) (like Dropbox, for example)
+- [Pantheon](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example)
+- [Platform.sh](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/platform.yaml)
+- [rsync](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/rsync.yaml.example)
+- [Upsun](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/upsun.yaml)
 
 We know you’ll find improvements to these examples and will have lots to contribute for other hosting providers, and we look forward to your contributions as pull requests here or as new add-ons.
 
@@ -31,9 +31,9 @@ Each provider recipe is a file named `<provider>.yaml` and consists of several m
 
 - `environment_variables`: Environment variables will be created in the web container for each of these during pull or push operations. They’re used to provide context (project ID, environment name, etc.) for each of the other stanzas. This stanza is not used in more recent hosting integrations, since providing the environment variables in `config.yaml` or via `ddev pull xxx --environment=VARIABLE=value` is preferred.
 - `db_pull_command`: A script that determines how DDEV should obtain a database. Its job is to create a gzipped database dump in `/var/www/html/.ddev/.downloads/db.sql.gz`. This is optional; if nothing has to be done to obtain the database dump, this step can be omitted.
-- `db_import_command`: (optional) A script that imports the downloaded database. This is for advanced usages like multiple databases. The default behavior only imports a single database into the `db` database. The [localfile example](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) uses this technique.
+- `db_import_command`: (optional) A script that imports the downloaded database. This is for advanced usages like multiple databases. The default behavior only imports a single database into the `db` database. The [localfile example](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) uses this technique.
 - `files_pull_command`: A script that determines how DDEV can get user-generated files from upstream. Its job is to copy the files from upstream to `/var/www/html/.ddev/.downloads/files`. If nothing has to be done to obtain the files, this step can run `true`.
-- `files_import_command`: (optional) A script that imports the downloaded files. There are a number of situations where it’s messy to push a directory of files around, and one can put it directly where it’s needed. The [localfile example](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) uses this technique.
+- `files_import_command`: (optional) A script that imports the downloaded files. There are a number of situations where it’s messy to push a directory of files around, and one can put it directly where it’s needed. The [localfile example](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) uses this technique.
 - `db_push_command`: A script that determines how DDEV should push a database. Its job is to take a gzipped database dump from `/var/www/html/.ddev/.downloads/db.sql.gz` and load it on the hosting provider.
 - `files_push_command`: A script that determines how DDEV push user-generated files to upstream. Its job is to copy the files from the project’s user-files directories (`$DDEV_FILES_DIRS`) to the correct places on the upstream provider.
 
@@ -43,7 +43,7 @@ There are [hooks](../configuration/hooks.md) available to execute commands befor
 
 ## Example Integrations and Hints
 
-- All of the [supplied integrations](https://github.com/ddev/ddev/tree/master/pkg/ddevapp/dotddev_assets/providers) are examples of what you can do.
+- All of the [supplied integrations](https://github.com/ddev/ddev/tree/main/pkg/ddevapp/dotddev_assets/providers) are examples of what you can do.
 - You can name a provider anything you want. For example, an Acquia integration doesn’t have to be named “acquia”, it can be named “upstream”. This is a great technique for [downloading a particular multisite](https://stackoverflow.com/a/68553116/215713).
 
 ## Provider Debugging

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -622,7 +622,7 @@ ddev debug rebuild --all
 
 ### `debug test`
 
-Run diagnostics using the embedded [test script](https://github.com/ddev/ddev/blob/master/cmd/ddev/cmd/scripts/test_ddev.sh).
+Run diagnostics using the embedded [test script](https://github.com/ddev/ddev/blob/main/cmd/ddev/cmd/scripts/test_ddev.sh).
 
 Example:
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -224,7 +224,7 @@ For Debian/Ubuntu/WSL2 with DDEV installed via apt, you can run `sudo apt-get up
 If you’re using Homebrew, first run `brew unlink ddev` to get rid of the version you have there. Then use one of these options:
 
 1. Download the version you want from the [releases page](https://github.com/ddev/ddev/releases) and place it in your `$PATH`.
-2. Use the [install_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh) script with the version number argument. For example, if you want `v1.23.5`, run `curl -fsSL https://ddev.com/install.sh | bash -s v1.23.5`.
+2. Use the [install_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev.sh) script with the version number argument. For example, if you want `v1.23.5`, run `curl -fsSL https://ddev.com/install.sh | bash -s v1.23.5`.
 3. If you want the very latest, unreleased version of DDEV, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD`.
 
 ### Why do I have an old DDEV?

--- a/funding.json
+++ b/funding.json
@@ -24,7 +24,7 @@
     },
     "repositoryUrl": {
       "url": "https://github.com/ddev/ddev",
-      "wellKnown": "https://github.com/ddev/ddev/blob/master/.well-known/funding-manifest-urls"
+      "wellKnown": "https://github.com/ddev/ddev/blob/main/.well-known/funding-manifest-urls"
     },
     "licenses": ["spdx:Apache-2.0"],
     "tags": ["development", "developer-tools", "web-development"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_name: DDEV Docs
 site_url: https://ddev.readthedocs.io/en/stable/
 repo_url: https://github.com/ddev/ddev
 repo_name: ddev/ddev
-edit_uri: blob/master/docs/content
+edit_uri: blob/main/docs/content
 copyright: DDEV Foundation
 extra_javascript:
 - 'assets/jquery-3.5.1.min.js'

--- a/pkg/ddevapp/dotddev_assets/providers/README.txt
+++ b/pkg/ddevapp/dotddev_assets/providers/README.txt
@@ -11,7 +11,7 @@ Hosting provider integration allows connecting with your upstream hosting. `ddev
 
 DDEV provides ready-to-go integrations for Platform.sh, Acquia, and Lagoon in every project, see the .ddev/providers directory. These can be used as is, or they can be modified as you see fit (but remove the `#ddev-generated` line so DDEV doesn't replace them with the defaults).
 
-In addition, each project includes example recipes https://github.com/ddev/ddev/tree/master/pkg/ddevapp/dotddev_assets/providers for Pantheon, Git, local files, and `rsync` in its `.ddev/providers` directory, which you can use and adapt however you’d like.
+In addition, each project includes example recipes https://github.com/ddev/ddev/tree/main/pkg/ddevapp/dotddev_assets/providers for Pantheon, Git, local files, and `rsync` in its `.ddev/providers` directory, which you can use and adapt however you’d like.
 
 DDEV provides the `pull` command with whatever recipes you have configured. For example, `ddev pull platform` is available by default, and `ddev pull pantheon` is available if you have created `.ddev/providers/pantheon.yaml`.
 
@@ -35,9 +35,9 @@ Each provider recipe is a file named `<provider>.yaml` and consists of several m
 
 - `environment_variables`: Environment variables will be created in the web container for each of these during pull or push operations. They’re used to provide context (project ID, environment name, etc.) for each of the other stanzas. This stanza is not used in more recent hosting integrations, since providing the environment variables in `config.yaml` or via `ddev pull xxx --environment=VARIABLE=value` is preferred.
 - `db_pull_command`: A script that determines how DDEV should obtain a database. Its job is to create a gzipped database dump in `/var/www/html/.ddev/.downloads/db.sql.gz`. This is optional; if nothing has to be done to obtain the database dump, this step can be omitted.
-- `db_import_command`: (optional) A script that imports the downloaded database. This is for advanced usages like multiple databases. The default behavior only imports a single database into the `db` database. The [localfile example](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) uses this technique.
+- `db_import_command`: (optional) A script that imports the downloaded database. This is for advanced usages like multiple databases. The default behavior only imports a single database into the `db` database. The [localfile example](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) uses this technique.
 - `files_pull_command`: A script that determines how DDEV can get user-generated files from upstream. Its job is to copy the files from upstream to `/var/www/html/.ddev/.downloads/files`. If nothing has to be done to obtain the files, this step can run `true`.
-- `files_import_command`: (optional) A script that imports the downloaded files. There are a number of situations where it’s messy to push a directory of files around, and one can put it directly where it’s needed. The [localfile example](https://github.com/ddev/ddev/blob/master/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) uses this technique.
+- `files_import_command`: (optional) A script that imports the downloaded files. There are a number of situations where it’s messy to push a directory of files around, and one can put it directly where it’s needed. The [localfile example](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/localfile.yaml.example) uses this technique.
 - `db_push_command`: A script that determines how DDEV should push a database. Its job is to take a gzipped database dump from `/var/www/html/.ddev/.downloads/db.sql.gz` and load it on the hosting provider.
 - `files_push_command`: A script that determines how DDEV push user-generated files to upstream. Its job is to copy the files from the project’s user-files directories (`$DDEV_FILES_DIRS`) to the correct places on the upstream provider.
 
@@ -47,7 +47,7 @@ There are hooks (see https://ddev.readthedocs.io/en/stable/users/configuration/h
 
 ## Example Integrations and Hints
 
-- All of the [supplied integrations](https://github.com/ddev/ddev/tree/master/pkg/ddevapp/dotddev_assets/providers) are examples of what you can do.
+- All of the [supplied integrations](https://github.com/ddev/ddev/tree/main/pkg/ddevapp/dotddev_assets/providers) are examples of what you can do.
 - You can name a provider anything you want. For example, an Acquia integration doesn’t have to be named “acquia”, it can be named “upstream”. This is a great technique for downloading a particular multisite (see https://stackoverflow.com/a/68553116/215713).
 
 ### Provider Debugging

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -21,7 +21,7 @@ for ddev_path in $(which -a ddev | uniq); do
 
     "/usr/local/bin/ddev")
       if [ ! -L /usr/local/bin/ddev ]; then
-        printf "DDEV appears to have been installed with install_ddev.sh, you can run that script again to update.\ncurl -fsSL https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh | bash\n"
+        printf "DDEV appears to have been installed with install_ddev.sh, you can run that script again to update.\ncurl -fsSL https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev.sh | bash\n"
       elif command -v brew; then
         echo "DDEV appears to have been installed with Homebrew, upgrade with 'brew update && brew upgrade ddev'"
       fi

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -193,7 +193,7 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 // TestGetCachedArchive tests download and extraction of archives for test sites
 // to testcache directory.
 func TestGetCachedArchive(t *testing.T) {
-	sourceURL := "https://raw.githubusercontent.com/ddev/ddev/master/.gitignore"
+	sourceURL := "https://raw.githubusercontent.com/ddev/ddev/main/.gitignore"
 	exPath, archPath, err := GetCachedArchive("TestInvalidArchive", "test", "", sourceURL)
 	require.Error(t, err)
 	if err != nil {

--- a/scripts/install_ddev_head.sh
+++ b/scripts/install_ddev_head.sh
@@ -55,7 +55,7 @@ if ! docker --version >/dev/null 2>&1; then
 fi
 
 # Define artifact URLs based on OS and architecture
-ARTIFACTS_BASE_URL="https://nightly.link/${GITHUB_OWNER}/ddev/workflows/master-build/main"
+ARTIFACTS_BASE_URL="https://nightly.link/${GITHUB_OWNER}/ddev/workflows/main-build/main"
 BINARY_ARTIFACT_URL="${ARTIFACTS_BASE_URL}/ddev-${OS}-${ARCH}.zip"
 
 printf "${GREEN}Downloading artifacts for ${OS}_${ARCH}...${RESET}\n"

--- a/scripts/install_ddev_head.sh
+++ b/scripts/install_ddev_head.sh
@@ -55,7 +55,7 @@ if ! docker --version >/dev/null 2>&1; then
 fi
 
 # Define artifact URLs based on OS and architecture
-ARTIFACTS_BASE_URL="https://nightly.link/${GITHUB_OWNER}/ddev/workflows/master-build/master"
+ARTIFACTS_BASE_URL="https://nightly.link/${GITHUB_OWNER}/ddev/workflows/master-build/main"
 BINARY_ARTIFACT_URL="${ARTIFACTS_BASE_URL}/ddev-${OS}-${ARCH}.zip"
 
 printf "${GREEN}Downloading artifacts for ${OS}_${ARCH}...${RESET}\n"

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -7,7 +7,7 @@
 # Run this in an administrative PowerShell window.
 # You can download, inspect, and run this, or run it directly with
 # Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-# iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_desktop.ps1'))
+# iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1'))
 
 #Requires -RunAsAdministrator
 

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -5,7 +5,7 @@
 # Run this in an administrative PowerShell window.
 # You can download, inspect, and run this, or run it directly with
 # Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-# iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev_wsl2_docker_inside.ps1'))
+# iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_inside.ps1'))
 
 #Requires -RunAsAdministrator
 

--- a/winpkg/chocolatey/ddev.nuspec
+++ b/winpkg/chocolatey/ddev.nuspec
@@ -6,13 +6,13 @@
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>ddev</id>
     <version>REPLACE_DDEV_VERSION</version>
-    <packageSourceUrl>https://github.com/ddev/ddev/tree/master/winpkg/chocolatey</packageSourceUrl>
+    <packageSourceUrl>https://github.com/ddev/ddev/tree/main/winpkg/chocolatey</packageSourceUrl>
     <owners>Randy Fay</owners>
 
     <title>ddev (Install)</title>
     <authors>DDEV Foundation</authors>
     <projectUrl>https://github.com/ddev/ddev</projectUrl>
-    <licenseUrl>https://github.com/ddev/ddev/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/ddev/ddev/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <docsUrl>https://ddev.readthedocs.io/en/stable/</docsUrl>
     <bugTrackerUrl>https://github.com/ddev/ddev/issues</bugTrackerUrl>


### PR DESCRIPTION
## The Issue

- #6476

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Replace `master` with `main`.

- [x] run tests here only after `master` is renamed.
- [x] check links on https://ddev.com https://github.com/ddev/ddev.com/pull/306
- [x] update buildkite branch
- [x] update readthedocs branch
- [x] Homebrew works with not updated formula `brew install ddev/ddev/ddev`
- [x] HEAD may have cached repo `brew install --HEAD ddev/ddev/ddev`, needed to clear cache `brew cleanup --prune=all`

## Manual Testing Instructions

Run this for the local repository after renaming the branch:

```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
