### PR TITLE
docs: Add ProcessWire to the Quickstart List

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -43,14 +43,14 @@ jobs:
       - name: Install Docker and deps (Linux)
         run: ./.github/workflows/linux-setup.sh
 
-      - name: Load 1password secret(s) magento2 etc
-        uses: 1password/load-secrets-action@v2
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.TESTS_SERVICE_ACCOUNT_TOKEN }}"
-          MAGENTO2_PUBLIC_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/public_access_key"
-          MAGENTO2_PRIVATE_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/private_access_key"
+#      - name: Load 1password secret(s) magento2 etc
+#        uses: 1password/load-secrets-action@v2
+#        with:
+#          export-env: true
+#        env:
+#          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.TESTS_SERVICE_ACCOUNT_TOKEN }}"
+#          MAGENTO2_PUBLIC_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/public_access_key"
+#          MAGENTO2_PRIVATE_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/private_access_key"
 
       - name: Setup tmate session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -127,6 +127,7 @@ PathMaps
 PhpStorm
 PhpStorm's
 PowerShell
+ProcessWire
 Pull
 Quickstart
 RabbitMQ

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -648,8 +648,9 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
 
     ```bash
     mkdir my-processwire-site && cd my-processwire-site
-    ddev config --webserver-type=apache-fpm
-    ddev composer create processwire/processwire:^3
+    ddev config --project-type=php --webserver-type=apache-fpm
+    ddev start
+    ddev composer create "processwire/processwire:^3"
     ddev launch
     ```
     

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -147,7 +147,7 @@ Further information on the DDEV procedure can also be found in the [Contao docum
 === "Demo Website"
 
     The [Contao demo website](https://demo.contao.org/) is maintained for the currently supported Contao versions and can be [optionally installed](https://github.com/contao/contao-demo).
-    Via the Contao Manager you can simply select this option during the first installation.
+    Via the Contao Manager you can select this option during the first installation.
 
 ## Craft CMS
 
@@ -675,7 +675,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     - DB Pass = `db`
     - DB Host = `db` (not `localhost`!)
 - Compatibility Check
-    - Simply hit refresh if you get a warning about `Apache mod_rewrite`
+    - Hit refresh if you get a warning about `Apache mod_rewrite`
 - Mutagen `upload_dirs` warning
     - If you get a warning about missing `upload_dirs` when using Mutagen, add the following lines to your ddev config after ProcessWire has been installed (not earlier, otherwise it will break the installer!):
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -673,22 +673,16 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     - DB Name = `db`
     - DB User = `db`
     - DB Pass = `db`
-    - DB Host = `db` (not `localhost`!)
+    - DB Host = `db` (**not** `localhost`!)
 - Compatibility Check
     - Hit refresh if you get a warning about `Apache mod_rewrite`
-- Mutagen `upload_dirs` warning
-    - If you get a warning about missing `upload_dirs` when using Mutagen, add the following lines to your ddev config after ProcessWire has been installed (not earlier, otherwise it will break the installer!):
+- **After installation,** configure `upload_dirs` to specify where user-generated files are managed by Processwire:
 
-```yaml
-upload_dirs:
-  - site/assets/files
-```
-
-Enjoy!
-
-If you have any questions head over to the dedicated DDEV thread in the ProcessWire forum:
-
-- https://processwire.com/talk/topic/27433-using-ddev-for-local-processwire-development-tips-tricks/
+  ```
+  ddev config --upload-dirs=sites/assets/files`.
+  ```
+  
+If you have any questions there is lots of help in the [DDEV thread in the ProcessWire forum](https://processwire.com/talk/topic/27433-using-ddev-for-local-processwire-development-tips-tricks/).
 
 ## Shopware
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -644,25 +644,50 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
 To get started with [ProcessWire](https://processwire.com/), create a new directory and use composer to require the desired version.
 
-=== "MAIN Branch"
+=== "Composer"
 
     ```bash
     mkdir my-processwire-site && cd my-processwire-site
-    curl -LJO https://github.com/processwire/processwire/archive/master.zip
-    unzip ./processwire-master.zip && rm -f processwire-master.zip && mv -f ./processwire-master/{.,}* . ; rm -rf processwire-master
     ddev config --webserver-type=apache-fpm
-    ddev start && ddev launch
+    ddev composer create processwire/processwire:^3
+    ddev launch
     ```
-
-=== "DEV Branch"
+    
+=== "Git"
 
     ```bash
     mkdir my-processwire-site && cd my-processwire-site
-    curl -LJO https://github.com/processwire/processwire/archive/dev.zip
-    unzip ./processwire-dev.zip && rm -f processwire-dev.zip && mv -f ./processwire-dev/{.,}* . ; rm -rf processwire-dev
+
+    # clone the main branch (stable release) in the current directory
+    git clone https://github.com/processwire/processwire.git .
+
+    # clone the dev branch (latest features) in the current directory
+    # git clone -b dev https://github.com/processwire/processwire.git .
+    
     ddev config --webserver-type=apache-fpm
-    ddev start && ddev launch
+    ddev start
+    ddev launch
     ```
+
+- When the installation wizard prompts for database settings, enter the following:
+    - DB Name = `db`
+    - DB User = `db`
+    - DB Pass = `db`
+    - DB Host = `db` (not `localhost`!)
+- Compatibility Check
+    - Simply hit refresh if you get a warning about `Apache mod_rewrite`
+- Mutagen `upload_dirs` warning
+    - If you get a warning about missing `upload_dirs` when using Mutagen, add the following lines to your ddev config after ProcessWire has been installed (not earlier, otherwise it will break the installer!):
+
+```yaml
+upload_dirs:
+  - site/assets/files
+```
+
+Enjoy!
+
+If you have any questions head over to the dedicated DDEV thread in the ProcessWire forum:
+- https://processwire.com/talk/topic/27433-using-ddev-for-local-processwire-development-tips-tricks/
 
 ## Shopware
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -642,9 +642,9 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
 ## ProcessWire
 
-To get started with [ProcessWire](https://processwire.com/), create a new directory and use the Zip file download, composer, or Git checkout to build. These instructions are adapted from [ProcessWire Install Documentation](https://processwire.com/docs/start/install/new/#installing-processwire).
+To get started with [ProcessWire](https://processwire.com/), create a new directory and use the ZIP file download, composer, or Git checkout to build. These instructions are adapted from [ProcessWire Install Documentation](https://processwire.com/docs/start/install/new/#installing-processwire).
 
-=== "Zip File"
+=== "ZIP File"
 
     ```bash
     mkdir my-processwire-site && cd my-processwire-site
@@ -695,7 +695,7 @@ If you get a warning about "Apache mod_rewrite" during the compatibility check, 
 **After installation,** configure `upload_dirs` to specify where user-generated files are managed by Processwire:
 
     ```
-    ddev config --upload-dirs=sites/assets/files` && ddev restart
+    ddev config --upload-dirs=sites/assets/files && ddev restart
     ```
   
 If you have any questions there is lots of help in the [DDEV thread in the ProcessWire forum](https://processwire.com/talk/topic/27433-using-ddev-for-local-processwire-development-tips-tricks/).

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -687,6 +687,7 @@ upload_dirs:
 Enjoy!
 
 If you have any questions head over to the dedicated DDEV thread in the ProcessWire forum:
+
 - https://processwire.com/talk/topic/27433-using-ddev-for-local-processwire-development-tips-tricks/
 
 ## Shopware

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -671,19 +671,19 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     ```
 
 - When the installation wizard prompts for database settings, enter the following:
-    - DB Name = `db`
-    - DB User = `db`
-    - DB Pass = `db`
-    - DB Host = `db` (**not** `localhost`!)
-    - DB Charset = `utf8mb4`
-    - DB Engine = `InnoDB`
+    - `DB Name` = `db`
+    - `DB User` = `db`
+    - `DB Pass` = `db`
+    - `DB Host` = `db` (**not** `localhost`!)
+    - `DB Charset` = `utf8mb4`
+    - `DB Engine` = `InnoDB`
 - Compatibility Check
     - Hit refresh if you get a warning about `Apache mod_rewrite`
 - **After installation,** configure `upload_dirs` to specify where user-generated files are managed by Processwire:
 
-  ```
-  ddev config --upload-dirs=sites/assets/files`.
-  ```
+    ```
+    ddev config --upload-dirs=sites/assets/files` && ddev restart
+    ```
   
 If you have any questions there is lots of help in the [DDEV thread in the ProcessWire forum](https://processwire.com/talk/topic/27433-using-ddev-for-local-processwire-development-tips-tricks/).
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -642,7 +642,18 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
 ## ProcessWire
 
-To get started with [ProcessWire](https://processwire.com/), create a new directory and use composer to require the desired version.
+To get started with [ProcessWire](https://processwire.com/), create a new directory and use the Zip file download, composer, or Git checkout to build. These instructions are adapted from [ProcessWire Install Documentation](https://processwire.com/docs/start/install/new/#installing-processwire).
+
+=== "Zip File"
+
+    ```bash
+    mkdir my-processwire-site && cd my-processwire-site
+    curl -LJOf https://github.com/processwire/processwire/archive/master.zip
+    unzip processwire-master.zip && rm -f processwire-master.zip && mv processwire-master/* . && mv processwire-master/.* . 2>/dev/null && rm -rf processwire-master
+    ddev config --project-type=php --webserver-type=apache-fpm
+    ddev start
+    ddev launch
+    ```
 
 === "Composer"
 
@@ -670,16 +681,18 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     ddev launch
     ```
 
-- When the installation wizard prompts for database settings, enter the following:
-    - `DB Name` = `db`
-    - `DB User` = `db`
-    - `DB Pass` = `db`
-    - `DB Host` = `db` (**not** `localhost`!)
-    - `DB Charset` = `utf8mb4`
-    - `DB Engine` = `InnoDB`
-- Compatibility Check
-    - Hit refresh if you get a warning about `Apache mod_rewrite`
-- **After installation,** configure `upload_dirs` to specify where user-generated files are managed by Processwire:
+When the installation wizard prompts for database settings, enter:
+
+- `DB Name` = `db`
+- `DB User` = `db`
+- `DB Pass` = `db`
+- `DB Host` = `db` (**not** `localhost`!)
+- `DB Charset` = `utf8mb4`
+- `DB Engine` = `InnoDB`
+
+If you get a warning about "Apache mod_rewrite" during the compatibility check, Click "refresh".
+
+**After installation,** configure `upload_dirs` to specify where user-generated files are managed by Processwire:
 
     ```
     ddev config --upload-dirs=sites/assets/files` && ddev restart

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -642,7 +642,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     
 ## ProcessWire
 
-To get started with [ProcessWire](https://processwire.com/), clone the project repository and navigate to the project directory.
+To get started with [ProcessWire](https://processwire.com/), create a new directory and use composer to require the desired version.
 
 === "MAIN Branch"
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -639,6 +639,30 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ddev restart
     ddev launch /admin
     ```
+    
+## ProcessWire
+
+To get started with [ProcessWire](https://processwire.com/), clone the project repository and navigate to the project directory.
+
+=== "MAIN Branch"
+
+    ```bash
+    mkdir my-processwire-site && cd my-processwire-site
+    curl -LJO https://github.com/processwire/processwire/archive/master.zip
+    unzip ./processwire-master.zip && rm -f processwire-master.zip && mv -f ./processwire-master/{.,}* . ; rm -rf processwire-master
+    ddev config --webserver-type=apache-fpm
+    ddev start && ddev launch
+    ```
+
+=== "DEV Branch"
+
+    ```bash
+    mkdir my-processwire-site && cd my-processwire-site
+    curl -LJO https://github.com/processwire/processwire/archive/dev.zip
+    unzip ./processwire-dev.zip && rm -f processwire-dev.zip && mv -f ./processwire-dev/{.,}* . ; rm -rf processwire-dev
+    ddev config --webserver-type=apache-fpm
+    ddev start && ddev launch
+    ```
 
 ## Shopware
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -639,7 +639,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ddev restart
     ddev launch /admin
     ```
-    
+
 ## ProcessWire
 
 To get started with [ProcessWire](https://processwire.com/), create a new directory and use composer to require the desired version.
@@ -652,8 +652,8 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     ddev start
     ddev composer create "processwire/processwire:^3"
     ddev launch
-    ```
-    
+    ``` 
+
 === "Git"
 
     ```bash
@@ -675,6 +675,8 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     - DB User = `db`
     - DB Pass = `db`
     - DB Host = `db` (**not** `localhost`!)
+    - DB Charset = `utf8mb4`
+    - DB Engine = `InnoDB`
 - Compatibility Check
     - Hit refresh if you get a warning about `Apache mod_rewrite`
 - **After installation,** configure `upload_dirs` to specify where user-generated files are managed by Processwire:

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -658,10 +658,10 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     ```bash
     mkdir my-processwire-site && cd my-processwire-site
 
-    # clone the main branch (stable release) in the current directory
+    # clone the main branch (stable release) into the current directory
     git clone https://github.com/processwire/processwire.git .
 
-    # clone the dev branch (latest features) in the current directory
+    # clone the dev branch (latest features) into the current directory
     # git clone -b dev https://github.com/processwire/processwire.git .
     
     ddev config --webserver-type=apache-fpm

--- a/docs/tests/backdrop.bats
+++ b/docs/tests/backdrop.bats
@@ -25,7 +25,7 @@ teardown() {
   run ddev config --project-type=backdrop
   assert_success
   # ddev start
-  run ddev start
+  run ddev start -y
   assert_success
   # ddev launch
   run bash -c "DDEV_DEBUG=true ddev launch"
@@ -51,7 +51,7 @@ teardown() {
   run ddev config --project-type=backdrop
   assert_success
   # ddev start
-  run ddev start
+  run ddev start -y
   assert_success
   run curl -fLO https://github.com/ddev/test-backdrop/releases/download/1.29.2/db.sql.gz
   assert_success

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+setup() {
+  PROJNAME=my-processwire-site
+  load 'common-setup'
+  _common_setup
+}
+
+# executed after each test
+teardown() {
+  _common_teardown
+}
+
+@test "processwire composer with $(ddev --version)" {
+  # mkdir my-processwire-site && cd my-processwire-site
+  run mkdir -p my-processwire-site && cd my-processwire-site
+  assert_success
+  # ddev config --project-type=php --webserver-type=apache-fpm
+  run ddev config --project-type=php --webserver-type=apache-fpm
+  assert_success
+  # ddev start
+  run ddev start -y
+  assert_success
+  # ddev composer create "processwire/processwire:^3"
+  run ddev composer create "processwire/processwire:^3"
+  # ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "server: Apache"
+}

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -31,4 +31,7 @@ teardown() {
   run curl -sfI https://${PROJNAME}.ddev.site
   assert_success
   assert_output --partial "server: Apache"
+  run curl -sf https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "This tool will guide you through the installation process."
 }

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -58,6 +58,7 @@ teardown() {
   run curl -sfI https://${PROJNAME}.ddev.site
   assert_success
   assert_output --partial "server: Apache"
+  assert_output --partial "HTTP/2 200"
   run curl -sf https://${PROJNAME}.ddev.site
   assert_success
   assert_output --partial "This tool will guide you through the installation process."

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -11,6 +11,33 @@ teardown() {
   _common_teardown
 }
 
+@test "processwire zipball with $(ddev --version)" {
+  # mkdir my-processwire-site && cd my-processwire-site
+  run mkdir -p my-processwire-site && cd my-processwire-site
+  assert_success
+  run curl -LJOf https://github.com/processwire/processwire/archive/master.zip
+  assert_success
+  run unzip processwire-master.zip && rm -f processwire-master.zip && mv processwire-master/* . && mv processwire-master/.* . 2>/dev/null && rm -rf processwire-master
+  assert_success
+  # ddev config --project-type=php --webserver-type=apache-fpm
+  run ddev config --project-type=php --webserver-type=apache-fpm
+  assert_success
+  # ddev start
+  run ddev start -y
+  assert_success
+  # ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "server: Apache"
+  run curl -sf https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "This tool will guide you through the installation process."
+}
+
 @test "processwire composer with $(ddev --version)" {
   # mkdir my-processwire-site && cd my-processwire-site
   run mkdir -p my-processwire-site && cd my-processwire-site


### PR DESCRIPTION

## The Issue

Add Processwire CMS to quickstarts

## How This PR Solves The Issue

* Add the quickstart
* Add the automated test

## Manual Testing Instructions

Review rendered docs at https://ddev--6879.org.readthedocs.build/en/6879/users/quickstart/#processwire

* Step through both types of quickstart and make sure they work right
* Review the automated test and make sure it properly tests the quickstart

## Automated Testing Overview

Added processwire.bats.

