### PR TITLE
docs: Stop checking stopwords 'just' and 'simply' [skip ci]

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -39,12 +39,5 @@
         "web[- ]?site(s)?"
       ]
     },
-    "stop-words": {
-      "defaultWords": false,
-      "words": [
-        ["just"],
-        ["simply"]
-      ],
-    }
   }
 }


### PR DESCRIPTION

## The Issue

The stopword setup for "just" and "simply" aren't helpful. Remove them.

## How This PR Solves The Issue

Adjust .textlintrc

