### PR TITLE
fix: DB container: Remove MYSQL_PWD, use ARG in mysql/mariadb Dockerfile, remove OPTIMIZE TABLES, fixes #6886

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -15,11 +15,11 @@ ARG DB_MAJOR_VERSION
 # See https://perconadev.atlassian.net/browse/PXB-3361
 ARG PERCONA_SETUP_URL=https://repo.percona.com/prel/apt/pool/testing/p/percona-release/percona-release_1.0-30.generic_all.deb
 
-ENV LANG=C.UTF-8
-ENV MYSQL_DATABASE=db
-ENV MYSQL_USER=db
-ENV MYSQL_PASSWORD=db
-ENV MYSQL_ROOT_PASSWORD=root
+ARG LANG=C.UTF-8
+ARG MYSQL_DATABASE=db
+ARG MYSQL_USER=db
+ARG MYSQL_PASSWORD=db
+ARG MYSQL_ROOT_PASSWORD=root
 
 SHELL ["/bin/bash", "-c"]
 

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -89,7 +89,7 @@ ADD files /
 # On bitnami-derived images, remove their default config so we get ours
 RUN rm -rf /opt/bitnami/mysql/conf
 
-ENV MYSQL_UNIX_PORT=/var/tmp/mysql.sock
+ARG MYSQL_UNIX_PORT=/var/tmp/mysql.sock
 RUN mkdir -p /var/log /var/tmp/mysqlbase /etc/mysql/conf.d && chmod -R ugo+wx /var/log /var/tmp/mysqlbase /etc/mysql/conf.d
 RUN  ln -sf /tmp/mysqlx.sock ${MYSQL_UNIX_PORT}
 RUN if ! id mysql &>/dev/null ; then useradd -u 112 mysql; fi

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -64,7 +64,6 @@ services:
       - IS_DDEV_PROJECT=true
       - LINES
       - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-db/mysql_history
-      - MYSQL_PWD=db
       - PGDATABASE=db
       - PGHOST=127.0.0.1
       - PGPASSWORD=db
@@ -210,7 +209,6 @@ services:
     - IS_DDEV_PROJECT=true
     - LINES
     - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-web/mysql_history
-    - MYSQL_PWD=db
     - NODE_EXTRA_CA_CERTS=/mnt/ddev-global-cache/mkcert/rootCA.pem
     - npm_config_cache=/mnt/ddev-global-cache/npm
     - PAGER=less -SFX

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2647,42 +2647,7 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to snapshot database, \nyour db container in project %v is not running. \nPlease start the project if you want to snapshot it. \nIf deleting project, you can delete without a snapshot using \n'ddev delete --omit-snapshot --yes', \nwhich will destroy your database", app.Name)
 	}
-
-	// For versions less than 8.0.32, we have to OPTIMIZE TABLES to make xtrabackup work
-	// See https://docs.percona.com/percona-xtrabackup/8.0/em/instant.html and
-	// https://www.percona.com/blog/percona-xtrabackup-8-0-29-and-instant-add-drop-columns/
-	if app.Database.Type == "mysql" && app.Database.Version == nodeps.MySQL80 {
-		stdout, stderr, err := app.Exec(&ExecOpts{
-			Service: "db",
-			Cmd:     `set -eu -o pipefail; MYSQL_PWD=root mysql -e 'SET SQL_NOTES=0'; mysql -N -uroot -e 'SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE TOTAL_ROW_VERSIONS > 0;'`,
-		})
-		if err != nil {
-			util.Warning("Could not check for tables to optimize (mysql 8.0): %v (stdout='%s', stderr='%s')", err, stdout, stderr)
-		} else {
-			stdout = strings.Trim(stdout, "\n\t ")
-			tables := strings.Split(stdout, "\n")
-			// util.Success("tables=%v len(tables)=%d stdout was '%s'", tables, len(tables), stdout)
-			if len(stdout) > 0 && len(tables) > 0 {
-				for _, t := range tables {
-					r := strings.Split(t, `/`)
-					if len(r) != 2 {
-						util.Warning("Unable to get database/table from %s", r)
-						continue
-					}
-					d := r[0]
-					t := r[1]
-					stdout, stderr, err := app.Exec(&ExecOpts{
-						Service: "db",
-						Cmd:     fmt.Sprintf(`set -eu -o pipefail; MYSQL_PWD=root mysql -uroot -D %s -e 'OPTIMIZE TABLES %s';`, d, t),
-					})
-					if err != nil {
-						util.Warning("Unable to optimize table %s (mysql 8.0): %v (stdout='%s', stderr='%s')", t, err, stdout, stderr)
-					}
-				}
-				util.Success("Optimized MySQL 8.0 tables '%s' in preparation for snapshot", strings.Join(tables, `,'`))
-			}
-		}
-	}
+	
 	util.Success("Creating database snapshot %s", snapshotName)
 
 	c := getBackupCommand(app, path.Join(containerSnapshotDir, snapshotFile))

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2647,7 +2647,7 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to snapshot database, \nyour db container in project %v is not running. \nPlease start the project if you want to snapshot it. \nIf deleting project, you can delete without a snapshot using \n'ddev delete --omit-snapshot --yes', \nwhich will destroy your database", app.Name)
 	}
-	
+
 	util.Success("Creating database snapshot %s", snapshotName)
 
 	c := getBackupCommand(app, path.Join(containerSnapshotDir, snapshotFile))

--- a/pkg/ddevapp/hooks_test.go
+++ b/pkg/ddevapp/hooks_test.go
@@ -67,7 +67,7 @@ func TestProcessHooks(t *testing.T) {
 		//{"composer:\n    exec_raw: [licenses, --format=json]", "no-version-set", "Running task: Composer command '[licenses --format=json]' in web container"},
 		{"exec: ls /usr/local/bin", "acli\nbuild_php_extension.sh\ncomposer", "Running task: Exec command 'ls /usr/local/bin'"},
 		{"exec-host: \"echo something\"", "something\n", "Running task: Exec command 'echo something' on the host"},
-		{"exec: echo MYSQL_PWD=${MYSQL_PWD:-}\n    service: db", "MYSQL_PWD=db\n", "Running task: Exec command 'echo MYSQL_PWD=${MYSQL_PWD:-}' in container/service 'db'"},
+		{"exec: echo MYSQL_HISTFILE=${MYSQL_HISTFILE:-}\n    service: db", "MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory", "Running task: Exec command 'echo MYSQL_HISTFILE=${MYSQL_HISTFILE:-}' in container/service 'db'"},
 		{"exec: \"echo TestProcessHooks > /var/www/html/TestProcessHooks-php-version-${DDEV_PHP_VERSION}.txt\"", "", "Running task: Exec command 'echo TestProcessHooks > /var/www/html/TestProcessHooks-php-version-${DDEV_PHP_VERSION}.txt'"},
 		{"exec: \"touch /var/tmp/TestProcessHooks && touch /var/www/html/touch_works_after_and.txt\"", "", "Running task: Exec command 'touch /var/tmp/TestProcessHooks && touch /var/www/html/touch_works_after_and.txt'"},
 		{"exec:\n    exec_raw: [ls, /usr/local]", "bin\netc\ngames\n", "Exec command '[ls /usr/local] (raw)'"},

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "20241223_stasadev_build_warn" // Note that this can be overridden 
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20241223_stasadev_build_warn"
+var BaseDBTag = "20250109_rfay_mysql_db_user"
 
 const TraefikRouterImage = "ddev/ddev-traefik-router:v1.24.1"
 


### PR DESCRIPTION

## The Issue

- #6886 

This doesn't really fix that, I'm not sure there's a fix other than putting `db` as the user back into the .my.cnf, which takes precedence, or changing the passwords so root and db have the same, which would break lots of people.

## How This PR Solves The Issue

- Stop using ENV in the Dockerfile on MYSQL_XXX environment variables so they don't bleed into the container
- Remove MYSQL_PWD from the app_config_yaml, as we should be using the password from .my.cnf
- Minor hook test fixup because of that change.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
