### PR TITLE
docs: Improve windows buildkite setup workflow

### DIFF
--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -3,7 +3,7 @@
 # Check a testbot or test environment to make sure it's likely to be sane.
 # We should add to this script whenever a testbot fails and we can figure out why.
 
-MIN_DDEV_VERSION=v1.11.0
+MIN_DDEV_VERSION=v1.24.0
 
 set -o errexit
 set -o pipefail

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -15,7 +15,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 5. In admin PowerShell, download and run [windows_buildkite_start.ps1](scripts/windows_buildkite_start.ps1) with `curl <url> -O windows_buildkite_start.ps1`.
 6. Install items as needed; `git`, `jq`, `mysql-cli`, `golang`, `make` are only required for a traditional Windows test machine. `choco install -y git jq  mysql-cli golang make mkcert netcat zip`.
 7. After restart, in **administrative** Git Bash window, `Rename-Computer <testbot-win10(home|pro)-<description>-1` and then `export BUILDKITE_AGENT_TOKEN=<token>`.
-8. (Traditional Windows test runner only): Download and run [`windows_buildkite-testmachine_setup.sh`](scripts/windows_buildkite_setup.sh).
+8. (Traditional Windows test runner only): Download and run [windows_buildkite_setup.sh](scripts/windows_buildkite_setup.sh).
 9. (Traditional Windows test runner only): Download and run [windows_postinstall.sh](scripts/windows_postinstall.sh).
 10. Launch Docker. It may require you to take further actions.
     * Check "Start Docker Desktop when you sign in"

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -10,12 +10,13 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 
 1. Create the user “testbot” on the machine. Use the password for `ddevtestbot@gmail.com`, available in 1Password.
 2. In admin PowerShell, `wsl --install`.
-3. Install [Docker Desktop for Windows](https://www.docker.com/products/docker-desktop/)
+3. Install [Docker Desktop for Windows](https://docs.docker.com/desktop/release-notes/) (from the release notes page, which is best maintained)
 4. In admin PowerShell, `Set-ExecutionPolicy -Scope "CurrentUser" -ExecutionPolicy "RemoteSigned"`.
 5. In admin PowerShell, download and run [windows_buildkite_start.ps1](scripts/windows_buildkite_start.ps1) with `curl <url> -O windows_buildkite_start.ps1`.
+6. Install items as needed; `git`, `jq`, `mysql-cli`, `golang`, `make` are only required for a traditional Windows test machine. `choco install -y git jq  mysql-cli golang make mkcert netcat zip`.
 6. After restart, in **administrative** Git Bash window, `Rename-Computer <testbot-win10(home|pro)-<description>-1` and then `export BUILDKITE_AGENT_TOKEN=<token>`.
-7. Now download and run [`windows_buildkite-testmachine_setup.sh`](scripts/windows_buildkite_setup.sh).
-8. Download and run [windows_postinstall.sh](scripts/windows_postinstall.sh).
+7. (Traditional Windows test runner only): Download and run [`windows_buildkite-testmachine_setup.sh`](scripts/windows_buildkite_setup.sh).
+8. (Traditional Windows test runner only): Download and run [windows_postinstall.sh](scripts/windows_postinstall.sh).
 9. Launch Docker. It may require you to take further actions.
    * Check "Launch on login"
    * Check "Add the *.docker.internal names to the host's /etc/hosts file"

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -35,10 +35,12 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 20. In “Advanced Windows Update Settings” enable “Receive updates for other Microsoft products” to make sure you get WSL2 kernel upgrades. Make sure to run Windows Update to get the latest kernel.
 21. Turn off the settings that cause the "windows experience" prompts after new upgrades:
 ![disable_windows_experience](../images/disable_windows_experience.png)
+22. In PowerShell: `wsl.exe --update`. Watch for the escalation to complete, it may require escalation.
+
 
 ## Both Docker Desktop/WSL2 and Docker-ce/WSL2
 
-1. The Ubuntu distro should be set up with the user `buildkite-agent`
+1. The Ubuntu distro should be set up with the user `buildkite-agent` and the password used for `ddevtestbot@gmail.com`.
 2. (Optionally if hostname is not same as appropriate hostname for WSL2) set the hostname in `/etc/wsl.conf` in the network section, for example:
 
     ```
@@ -48,22 +50,8 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 
 3. Log into Chrome with the user `ddevtestbot@gmail.com` and enable Chrome Remote Desktop.
 4. Windows Terminal should be installed. Set "Ubuntu" (or this distro) as the default and have it start on Windows startup. Enable "copy on select" in behaviors.
-12. Configure buildkite agent in /etc/buildkite-agent:
-     * `tags="os=wsl2,architecture=amd64,dockertype=dockerforwindows"`
-     * token="xxx"
-13. `sudo systemctl enable buildkite-agent && sudo systemctl start buildkite-agent`
-14. In PowerShell: `wsl.exe --update`. Watch for the escalation to complete, it may require escalation.
-15. Open WSL2 and check out [ddev/ddev](https://github.com/ddev/ddev).
-16. As root user (`sudo -s`), add sudo capability with `echo "ALL ALL=NOPASSWD: ALL" >/etc/sudoers.d/all && chmod 440 /etc/sudoers.d/all`.
-17. `git config --global --add safe.directory '*'`
-18. `echo "capath=/etc/ssl/certs/" >>~/.curlrc`
-19. `nc.exe -L -p 9003` on Windows to trigger and allow Windows Defender.
-20. Run `ngrok authtoken <token>` with token for free account.
-21. Install [winaero tweaker](https://winaero.com/request.php?1796) and “Enable user autologin checkbox”. Set up the machine to [automatically log in on boot](https://www.cnet.com/how-to/automatically-log-in-to-your-windows-10-pc/).  Then run netplwiz, provide the password for the main user, uncheck “require a password to log in”.
-22. In “Advanced Windows Update Settings” enable “Receive updates for other Microsoft products” to make sure you get WSL2 kernel upgrades. Make sure to run Windows Update to get the latest kernel.
-23. Turn off the `System` -> `Notifications` -> `Additional settings` that cause the "Windows experience" prompts after upgrades:
-    ![disable_windows_experience](../images/disable_windows_experience.png)
-24. Edit the `~/.wslconfig` on Windows to add appropriate WSL2 memory allocation and `autoMemoryReclaim`
+5. `nc.exe -L -p 9003` on Windows to trigger and allow Windows Defender.
+6. Optionally edit the `~/.wslconfig` on Windows to add appropriate WSL2 memory allocation and `autoMemoryReclaim`
 
     ```
     memory=12GB
@@ -73,11 +61,16 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 
 ## Windows Setup for WSL2+Docker Desktop
 
-1. Install Docker Desktop on Windows
-2. In Docker Desktop, enable WSL2 integration with this distro (and this distro only, not default distro).
-3. Install DDEV using the [standard WSL2 Docker Desktop installation](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/#wsl2-docker-desktop-install-script)
-4. Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/main/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
-5. Run `.buildkite/sanetestbot.sh` to check your work.
+1. Stop Docker Desktop so it doesn't panic when the Ubuntu distro exits for reboot.
+2. In the Ubuntu distro:
+   1. `export BUILDKITE_AGENT_TOKEN=<token>` with the token from 1Password `BUILDKITE_AGENT_TOKEN`.
+   2. `export BUILDKITE_DOCKER_TYPE=dockerforwindows` or `export BUILDKITE_DOCKER_TYPE=wsl2`
+   3. Optionally `export NGROK_TOKEN=<token>` with the `NGROK_TOKEN` from 1Password ngrok.com `nopaid` account.
+   4. Run the script [wsl2-test-runner-setup.sh](scripts/wsl2-test-runner-setup.sh) in the Ubuntu distro.
+3. Restart the distro with `wsl.exe -t Ubuntu` and then restart it by opening the Ubuntu window.
+4. Start Docker Desktop.
+4. In `~/workspace/ddev/.buildkite`, run `./testbot_maintenance.sh`.
+5. In `~/workspace/ddev/.buildkite`, run `./sanetestbot.sh` to check your work.
 
 ## Windows Setup for WSL2+Docker-Inside Testing
 

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -14,29 +14,28 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 4. In admin PowerShell, `Set-ExecutionPolicy -Scope "CurrentUser" -ExecutionPolicy "RemoteSigned"`.
 5. In admin PowerShell, download and run [windows_buildkite_start.ps1](scripts/windows_buildkite_start.ps1) with `curl <url> -O windows_buildkite_start.ps1`.
 6. Install items as needed; `git`, `jq`, `mysql-cli`, `golang`, `make` are only required for a traditional Windows test machine. `choco install -y git jq  mysql-cli golang make mkcert netcat zip`.
-6. After restart, in **administrative** Git Bash window, `Rename-Computer <testbot-win10(home|pro)-<description>-1` and then `export BUILDKITE_AGENT_TOKEN=<token>`.
-7. (Traditional Windows test runner only): Download and run [`windows_buildkite-testmachine_setup.sh`](scripts/windows_buildkite_setup.sh).
-8. (Traditional Windows test runner only): Download and run [windows_postinstall.sh](scripts/windows_postinstall.sh).
-9. Launch Docker. It may require you to take further actions.
-   * Check "Start Docker Desktop when you sign in"
-   * Check "Add the *.docker.internal names to the host's /etc/hosts file"
-   * Uncheck "SBOM Indexing"
-   * Under "Resources" uncheck "Resource Saver"
-10. Log into Chrome with the user `ddevtestbot@gmail.com` and enable Chrome Remote Desktop.
-11. (Traditional Windows test runner only): Enable gd, fileinfo, and curl extensions in `/c/tools/php*/php.ini`.
-12. Set the “Sleep after time” setting in settings to never.
-13. Install [winaero tweaker](https://winaero.com/request.php?1796) and “Enable user autologin checkbox”. Set up the machine to [automatically log in on boot](https://www.cnet.com/how-to/automatically-log-in-to-your-windows-10-pc/).  Then run netplwiz, provide the password for the main user, uncheck “require a password to log in”.
-14. (Traditional Windows test runner only): Set the `buildkite-agent` service to run as the testbot user and use delayed start: Choose “Automatic, delayed start” and on the “Log On” tab in the services widget it must be set up to log in as the testbot user, so it inherits environment variables and home directory (and can access NFS, has testbot Git config, etc).
-15. (Traditional Windows test runner only): `git config --global --add safe.directory '*'`.
-16. (Traditional Windows test runner only): Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/main/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
-17. (Traditional Windows test runner only): Run `.buildkite/sanetestbot.sh` to check your work.
-18. (Traditional Windows test runner only): Reboot the machine and do a test run. (On Windows, the machine name only takes effect on reboot.)
-19. (Traditional Windows test runner only): Verify that `go`, `ddev`, `git-bash` are in the path.
-20. In “Advanced Windows Update Settings” enable “Receive updates for other Microsoft products” to make sure you get WSL2 kernel upgrades. Make sure to run Windows Update to get the latest kernel.
-21. Turn off the settings that cause the "windows experience" prompts after new upgrades:
+7. After restart, in **administrative** Git Bash window, `Rename-Computer <testbot-win10(home|pro)-<description>-1` and then `export BUILDKITE_AGENT_TOKEN=<token>`.
+8. (Traditional Windows test runner only): Download and run [`windows_buildkite-testmachine_setup.sh`](scripts/windows_buildkite_setup.sh).
+9. (Traditional Windows test runner only): Download and run [windows_postinstall.sh](scripts/windows_postinstall.sh).
+10. Launch Docker. It may require you to take further actions.
+    * Check "Start Docker Desktop when you sign in"
+    * Check "Add the *.docker.internal names to the host's /etc/hosts file"
+    * Uncheck "SBOM Indexing"
+    * Under "Resources" uncheck "Resource Saver"
+11. Log into Chrome with the user `ddevtestbot@gmail.com` and enable Chrome Remote Desktop.
+12. (Traditional Windows test runner only): Enable gd, fileinfo, and curl extensions in `/c/tools/php*/php.ini`.
+13. Set the “Sleep after time” setting in settings to never.
+14. Install [winaero tweaker](https://winaero.com/request.php?1796) and “Enable user autologin checkbox”. Set up the machine to [automatically log in on boot](https://www.cnet.com/how-to/automatically-log-in-to-your-windows-10-pc/).  Then run netplwiz, provide the password for the main user, uncheck “require a password to log in”.
+15. (Traditional Windows test runner only): Set the `buildkite-agent` service to run as the testbot user and use delayed start: Choose “Automatic, delayed start” and on the “Log On” tab in the services widget it must be set up to log in as the testbot user, so it inherits environment variables and home directory (and can access NFS, has testbot Git config, etc).
+16. (Traditional Windows test runner only): `git config --global --add safe.directory '*'`.
+17. (Traditional Windows test runner only): Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/main/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
+18. (Traditional Windows test runner only): Run `.buildkite/sanetestbot.sh` to check your work.
+19. (Traditional Windows test runner only): Reboot the machine and do a test run. (On Windows, the machine name only takes effect on reboot.)
+20. (Traditional Windows test runner only): Verify that `go`, `ddev`, `git-bash` are in the path.
+21. In “Advanced Windows Update Settings” enable “Receive updates for other Microsoft products” to make sure you get WSL2 kernel upgrades. Make sure to run Windows Update to get the latest kernel.
+22. Turn off the settings that cause the "windows experience" prompts after new upgrades:
 ![disable_windows_experience](../images/disable_windows_experience.png)
-22. In PowerShell: `wsl.exe --update`. Watch for the escalation to complete, it may require escalation.
-
+23. In PowerShell: `wsl.exe --update`. Watch for the escalation to complete, it may require escalation.
 
 ## Both Docker Desktop/WSL2 and Docker-ce/WSL2
 
@@ -69,8 +68,8 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
    4. Run the script [wsl2-test-runner-setup.sh](scripts/wsl2-test-runner-setup.sh) in the Ubuntu distro.
 3. Restart the distro with `wsl.exe -t Ubuntu` and then restart it by opening the Ubuntu window.
 4. Start Docker Desktop.
-4. In `~/workspace/ddev/.buildkite`, run `./testbot_maintenance.sh`.
-5. In `~/workspace/ddev/.buildkite`, run `./sanetestbot.sh` to check your work.
+5. In `~/workspace/ddev/.buildkite`, run `./testbot_maintenance.sh`.
+6. In `~/workspace/ddev/.buildkite`, run `./sanetestbot.sh` to check your work.
 
 ## Windows Setup for WSL2+Docker-Inside Testing
 
@@ -97,11 +96,9 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 
 1. Icinga Director web UI, configure the host on `newmonitor.thefays.us`, normally making a copy of an existing identical item.
 2. Deploy the new host using Icinga Director.
-3. On the WSL2 Ubuntu instance, install needed packages: `sudo apt-get update && sudo apt-get install -y etckeeper icinga2 monitoring-plugins-contrib nagios-plugins`
-4. Add `nagios` to the `docker` group in `/etc/group`.
-5. `sudo icinga2 node wizard` to configure the agent, see [docs](https://icinga.com/docs/icinga-2/latest/doc/06-distributed-monitoring/#agentsatellite-setup-on-linux)
-6. Restart `sudo systemctl restart icinga2`
-7. On `newmonitor.thefays.us` edit `/usr/local/bin/check_buildkite_agents.sh` to include the hostname of the new instance.
+3. `sudo icinga2 node wizard` to configure the agent, see [docs](https://icinga.com/docs/icinga-2/latest/doc/06-distributed-monitoring/#agentsatellite-setup-on-linux)
+4. Restart `sudo systemctl restart icinga2`
+5. On `newmonitor.thefays.us` edit `/usr/local/bin/check_buildkite_agents.sh` to include the hostname of the new instance.
 
 ## macOS Docker Desktop Test Agent Setup (Intel and Apple Silicon)
 

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -10,7 +10,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 
 1. Create the user “testbot” on the machine. Use the password for `ddevtestbot@gmail.com`, available in 1Password.
 2. In admin PowerShell, `wsl --install`.
-3. Install [Docker Desktop for Windows](https://docs.docker.com/desktop/release-notes/) (from the release notes page, which is best maintained)
+3. (WSL2/Docker Desktop and traditional Windows only): Install [Docker Desktop for Windows](https://docs.docker.com/desktop/release-notes/) (from the release notes page, which is best maintained)
 4. In admin PowerShell, `Set-ExecutionPolicy -Scope "CurrentUser" -ExecutionPolicy "RemoteSigned"`.
 5. In admin PowerShell, download and run [windows_buildkite_start.ps1](scripts/windows_buildkite_start.ps1) with `curl <url> -O windows_buildkite_start.ps1`.
 6. Install items as needed; `git`, `jq`, `mysql-cli`, `golang`, `make` are only required for a traditional Windows test machine. `choco install -y git jq  mysql-cli golang make mkcert netcat zip`.
@@ -18,20 +18,20 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 7. (Traditional Windows test runner only): Download and run [`windows_buildkite-testmachine_setup.sh`](scripts/windows_buildkite_setup.sh).
 8. (Traditional Windows test runner only): Download and run [windows_postinstall.sh](scripts/windows_postinstall.sh).
 9. Launch Docker. It may require you to take further actions.
-   * Check "Launch on login"
+   * Check "Start Docker Desktop when you sign in"
    * Check "Add the *.docker.internal names to the host's /etc/hosts file"
    * Uncheck "SBOM Indexing"
    * Under "Resources" uncheck "Resource Saver"
 10. Log into Chrome with the user `ddevtestbot@gmail.com` and enable Chrome Remote Desktop.
-11. Enable gd, fileinfo, and curl extensions in `/c/tools/php*/php.ini`.
+11. (Traditional Windows test runner only): Enable gd, fileinfo, and curl extensions in `/c/tools/php*/php.ini`.
 12. Set the “Sleep after time” setting in settings to never.
 13. Install [winaero tweaker](https://winaero.com/request.php?1796) and “Enable user autologin checkbox”. Set up the machine to [automatically log in on boot](https://www.cnet.com/how-to/automatically-log-in-to-your-windows-10-pc/).  Then run netplwiz, provide the password for the main user, uncheck “require a password to log in”.
-14. Set the `buildkite-agent` service to run as the testbot user and use delayed start: Choose “Automatic, delayed start” and on the “Log On” tab in the services widget it must be set up to log in as the testbot user, so it inherits environment variables and home directory (and can access NFS, has testbot Git config, etc).
-15. `git config --global --add safe.directory '*'`.
-16. Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/main/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
-17. Run `.buildkite/sanetestbot.sh` to check your work.
-18. Reboot the machine and do a test run. (On Windows, the machine name only takes effect on reboot.)
-19. Verify that `go`, `ddev`, `git-bash` are in the path.
+14. (Traditional Windows test runner only): Set the `buildkite-agent` service to run as the testbot user and use delayed start: Choose “Automatic, delayed start” and on the “Log On” tab in the services widget it must be set up to log in as the testbot user, so it inherits environment variables and home directory (and can access NFS, has testbot Git config, etc).
+15. (Traditional Windows test runner only): `git config --global --add safe.directory '*'`.
+16. (Traditional Windows test runner only): Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/main/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
+17. (Traditional Windows test runner only): Run `.buildkite/sanetestbot.sh` to check your work.
+18. (Traditional Windows test runner only): Reboot the machine and do a test run. (On Windows, the machine name only takes effect on reboot.)
+19. (Traditional Windows test runner only): Verify that `go`, `ddev`, `git-bash` are in the path.
 20. In “Advanced Windows Update Settings” enable “Receive updates for other Microsoft products” to make sure you get WSL2 kernel upgrades. Make sure to run Windows Update to get the latest kernel.
 21. Turn off the settings that cause the "windows experience" prompts after new upgrades:
 ![disable_windows_experience](../images/disable_windows_experience.png)

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -39,7 +39,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 ## Both Docker Desktop/WSL2 and Docker-ce/WSL2
 
 1. The Ubuntu distro should be set up with the user `buildkite-agent`
-2. Set the hostname in `/etc/wsl.conf` in the network section, for example:
+2. (Optionally if hostname is not same as appropriate hostname for WSL2) set the hostname in `/etc/wsl.conf` in the network section, for example:
 
     ```
     [network]
@@ -48,13 +48,6 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 
 3. Log into Chrome with the user `ddevtestbot@gmail.com` and enable Chrome Remote Desktop.
 4. Windows Terminal should be installed. Set "Ubuntu" (or this distro) as the default and have it start on Windows startup. Enable "copy on select" in behaviors.
-5. `sudo apt update && sudo apt install -y apt-transport-https autojump build-essential ca-certificates curl dirmngr etckeeper expect git gnupg icinga2 jq libcurl4-gnutls-dev libnss3-tools lsb-release mariadb-client nagios-plugins postgresql-client unzip vim zip`
-6. `sudo snap install --classic go`
-7. Install `ngrok` with the [`linux apt` technique](https://ngrok.com/download).
-8. `curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg`
-9. `echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list`
-10. `sudo apt-get update && sudo apt-get install -y buildkite-agent`
-11. Change `buildkite-agent` home directory to `/var/lib/buildkite-agent`: `sudo usermod -d /var/lib/buildkite-agent buildkite-agent`
 12. Configure buildkite agent in /etc/buildkite-agent:
      * `tags="os=wsl2,architecture=amd64,dockertype=dockerforwindows"`
      * token="xxx"

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -40,17 +40,18 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 ## Both Docker Desktop/WSL2 and Docker-ce/WSL2
 
 1. The Ubuntu distro should be set up with the user `buildkite-agent` and the password used for `ddevtestbot@gmail.com`.
-2. (Optionally if hostname is not same as appropriate hostname for WSL2) set the hostname in `/etc/wsl.conf` in the network section, for example:
+2. Stop Docker Desktop if it is running.
+3. (Optionally if hostname is not same as appropriate hostname for WSL2) set the hostname in `/etc/wsl.conf` in the network section, for example:
 
     ```
     [network]
     hostname=tb-wsl-16-dockerce
     ```
 
-3. Log into Chrome with the user `ddevtestbot@gmail.com` and enable Chrome Remote Desktop.
-4. Windows Terminal should be installed. Set "Ubuntu" (or this distro) as the default and have it start on Windows startup. Enable "copy on select" in behaviors.
-5. `nc.exe -L -p 9003` on Windows to trigger and allow Windows Defender.
-6. Optionally edit the `~/.wslconfig` on Windows to add appropriate WSL2 memory allocation and `autoMemoryReclaim`
+4. Log into Chrome with the user `ddevtestbot@gmail.com` and enable Chrome Remote Desktop.
+5. Windows Terminal should be installed. Set "Ubuntu" (or this distro) as the default and have it start on Windows startup. Enable "copy on select" in behaviors.
+6. `nc.exe -L -p 9003` on Windows to trigger and allow Windows Defender.
+7. Optionally edit the `~/.wslconfig` on Windows to add appropriate WSL2 memory allocation and `autoMemoryReclaim`
 
     ```
     memory=12GB
@@ -58,39 +59,15 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
     autoMemoryReclaim=dropcache
     ```
 
-## Windows Setup for WSL2+Docker Desktop
-
-1. Stop Docker Desktop so it doesn't panic when the Ubuntu distro exits for reboot.
-2. In the Ubuntu distro:
-   1. `export BUILDKITE_AGENT_TOKEN=<token>` with the token from 1Password `BUILDKITE_AGENT_TOKEN`.
-   2. `export BUILDKITE_DOCKER_TYPE=dockerforwindows` or `export BUILDKITE_DOCKER_TYPE=wsl2`
-   3. Optionally `export NGROK_TOKEN=<token>` with the `NGROK_TOKEN` from 1Password ngrok.com `nopaid` account.
-   4. Run the script [wsl2-test-runner-setup.sh](scripts/wsl2-test-runner-setup.sh) in the Ubuntu distro.
-3. Restart the distro with `wsl.exe -t Ubuntu` and then restart it by opening the Ubuntu window.
-4. Start Docker Desktop.
-5. In `~/workspace/ddev/.buildkite`, run `./testbot_maintenance.sh`.
-6. In `~/workspace/ddev/.buildkite`, run `./sanetestbot.sh` to check your work.
-
-## Windows Setup for WSL2+Docker-Inside Testing
-
-1. Make sure Docker Desktop is not integrated with this distro.
-2. Remove any entries (especially `host.docker.internal`) that Docker Desktop might have added in `C:\Windows\system32\drivers\etc\hosts`.
-3. Install Docker and basics in WSL2:
-
-    ```bash
-    sudo mkdir -p /etc/apt/keyrings
-    sudo mkdir -p /etc/apt/keyrings && sudo rm -f /etc/apt/keyrings/docker.gpg && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli etckeeper containerd.io docker-compose-plugin
-    sudo usermod -aG docker $USER
-    ```
-
-4. Install DDEV using the [standard WSL2 Docker CE installation](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/#wsl2-docker-ce-inside-install-script)
-5. Manually run `testbot_maintenance.sh`, `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/main/.buildkite/testbot_maintenance.sh && bash testbot_maintenance.sh`.
-6. Run `.buildkite/sanetestbot.sh` to check your work.
-7. In “Advanced Windows Update Settings” enable “Receive updates for other Microsoft products” to make sure you get WSL2 kernel upgrades. Make sure to run Windows Update to get the latest kernel.
-8. Turn off the settings that cause the "windows experience" prompts after new upgrades:
-   ![disable_windows_experience](../images/disable_windows_experience.png)
+8. In the Ubuntu distro:
+    1. `export BUILDKITE_AGENT_TOKEN=<token>` with the token from 1Password `BUILDKITE_AGENT_TOKEN`.
+    2. `export BUILDKITE_DOCKER_TYPE=dockerforwindows` or `export BUILDKITE_DOCKER_TYPE=wsl2`
+    3. Optionally `export NGROK_TOKEN=<token>` with the `NGROK_TOKEN` from 1Password ngrok.com `nopaid` account.
+    4. Run the script [wsl2-test-runner-setup.sh](scripts/wsl2-test-runner-setup.sh) in the Ubuntu distro.
+9. Restart the distro with `wsl.exe -t Ubuntu` and then restart it by opening the Ubuntu window.
+10. If using Docker Desktop, start Docker Desktop.
+11. In `~/workspace/ddev/.buildkite`, run `./testbot_maintenance.sh`.
+12. In `~/workspace/ddev/.buildkite`, run `./sanetestbot.sh` to check your work.
 
 ## Icinga2 monitoring setup for WSL2 instances
 

--- a/docs/content/developers/scripts/windows_buildkite_setup.sh
+++ b/docs/content/developers/scripts/windows_buildkite_setup.sh
@@ -40,5 +40,3 @@ nssm.exe status buildkite-agent || true
 
 # Get firewall set up with a single run
 winpty docker run -it --rm -p 80 busybox:stable ls
-
-bash "/c/Program Files/ddev/windows_ddev_nfs_setup.sh"

--- a/docs/content/developers/scripts/windows_buildkite_start.ps1
+++ b/docs/content/developers/scripts/windows_buildkite_start.ps1
@@ -2,9 +2,6 @@
 # Chocolatey
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
-# Install required items using chocolatey
-choco install -y composer ddev git jq  mysql-cli golang GoogleChrome make mkcert netcat nodejs zip
-
 net localgroup docker-users /add
 net localgroup docker-users testbot /add
 

--- a/docs/content/developers/scripts/wsl2-test-runner-setup.sh
+++ b/docs/content/developers/scripts/wsl2-test-runner-setup.sh
@@ -3,11 +3,26 @@
 # This sets up an Ubuntu distro to be a test runner for WSL2
 # Run this inside a working WSL2 Ubuntu Distro
 
+# REQUIRED environment variable: BUILDKITE_AGENT_TOKEN
+# REQUIRED environment variable: BUILDKITE_DOCKER_TYPE (dockerforwindows or wsl2)
+# OPTIONAL environment variable: NGROK_TOKEN if ngrok will be run
+
 set -eu -o pipefail
 
-sudo apt update && sudo apt upgrade -y
-sudo apt install -y apt-transport-https autojump build-essential ca-certificates curl dirmngr etckeeper expect git gnupg icinga2 jq libcurl4-gnutls-dev libnss3-tools lsb-release mariadb-client nagios-plugins postgresql-client unzip vim zip
+# BUILDKITE_AGENT_TOKEN must be set
+if [ "${BUILDKITE_AGENT_TOKEN:-}" = "" ]; then
+  echo "BUILDKITE_AGENT_TOKEN must be set, export BUILDKITE_AGENT_TOKEN=token" && exit 1
+fi
 
+# BUILDKITE_DOCKER_TYPE must be set
+if [ "${BUILDKITE_DOCKER_TYPE:-}" = "" ]; then
+  echo "BUILDKITE_DOCKER_TYPE must be set to dockerforwindows or wsl2, export BUILDKITE_DOCKER_TYPE=dockerforwindows" && exit 2
+fi
+
+sudo apt-get update -qq >/dev/null && sudo apt-get upgrade -qq -y >/dev/null
+sudo apt-get install -qq -y apt-transport-https autojump bats build-essential ca-certificates ccache clang curl dirmngr etckeeper expect git gnupg htop icinga2 jq libcurl4-gnutls-dev libnss3-tools lsb-release mariadb-client mkcert nagios-plugins postgresql-client unzip vim wslu xdg-utils zip >/dev/null
+
+# golang
 sudo snap install --classic go
 
 # ngrok
@@ -15,13 +30,51 @@ curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc \
   | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null \
   && echo "deb https://ngrok-agent.s3.amazonaws.com buster main" \
   | sudo tee /etc/apt/sources.list.d/ngrok.list \
-  && sudo apt update \
-  && sudo apt install ngrok
+  && sudo apt-get update >/dev/null \
+  && sudo apt-get install -y ngrok >/dev/null
+
+# ddev
+sudo rm -f /etc/apt/keyrings/ddev.gpg
+sudo bash -c "rm -f /etc/apt/keyrings/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/ddev.gpg > /dev/null"
+sudo bash -c 'echo deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
+sudo apt-get -qq update >/dev/null && sudo apt-get install -qq -y ddev >/dev/null
 
 # Buildkite-agent
 curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
-sudo apt-get update && sudo apt-get install -y buildkite-agent
-sudo usermod -d /var/lib/buildkite-agent buildkite-agent
+sudo apt-get update >/dev/null && sudo apt-get install -y buildkite-agent >/dev/null
 
+# Edit the config file. Does not need sudo because buildkite-agent owns the file
+sed -i "s/^token=.*/token=\"$BUILDKITE_AGENT_TOKEN\"/" /etc/buildkite-agent/buildkite-agent.cfg
+echo "tags=\"os=wsl2,architecture=amd64,dockertype=${BUILDKITE_DOCKER_TYPE:-}\"" >> /etc/buildkite-agent/buildkite-agent.cfg
 
+sudo systemctl enable buildkite-agent
+
+# Check out ddev
+mkdir ~/workspace && pushd ~/workspace && git clone -o upstream https://github.com/ddev/ddev && popd
+
+# Setup sudo
+(echo "ALL ALL=NOPASSWD: ALL" | sudo tee /etc/sudoers.d/all) && sudo chmod 440 /etc/sudoers.d/all
+
+# git global confnig (safe.directory)
+git config --global --add safe.directory '*'
+
+# curl setup to respect mkcert
+echo "capath=/etc/ssl/certs/" >>~/.curlrc
+
+# Optionally set up ngrok token
+if [ "${NGROK_TOKEN:-}" != "" ]; then
+  ngrok authtoken ${NGROK_TOKEN:-}
+else
+  echo "NGROK_TOKEN not set so not doing ngrok authtoken"
+fi
+
+mkcert -install
+
+echo "In the editor, change the home directory of buildkite-agent to /var/lib/buildkite-agent"
+echo "Press any key to continue..."
+read x
+sudo vipw || true
+sudo systemctl start buildkite-agent
+
+echo "Now reboot the distro with 'wsl.exe -t Ubuntu' and restart it"

--- a/docs/content/developers/scripts/wsl2-test-runner-setup.sh
+++ b/docs/content/developers/scripts/wsl2-test-runner-setup.sh
@@ -62,9 +62,6 @@ echo "tags=\"os=wsl2,architecture=amd64,dockertype=${BUILDKITE_DOCKER_TYPE:-}\""
 
 sudo systemctl enable buildkite-agent
 
-# Check out ddev
-mkdir ~/workspace && pushd ~/workspace && git clone -o upstream https://github.com/ddev/ddev && popd
-
 # Setup sudo
 (echo "ALL ALL=NOPASSWD: ALL" | sudo tee /etc/sudoers.d/all) && sudo chmod 440 /etc/sudoers.d/all
 
@@ -90,6 +87,13 @@ sudo vipw || true
 sudo systemctl start buildkite-agent
 
 # nagios for icinga2 needs to be in docker group
+if ! getent group docker > /dev/null; then
+    sudo groupadd docker
+fi
 sudo usermod -aG docker nagios
+sudo usermod -aG docker buildkite-agent
+
+# Check out ddev code for later use
+mkdir -p /var/lib/buildkite-agent/workspace && pushd /var/lib/buildkite-agent/workspace && git clone -o upstream https://github.com/ddev/ddev && popd
 
 echo "Now reboot the distro with 'wsl.exe -t Ubuntu' and restart it"

--- a/docs/content/developers/scripts/wsl2-test-runner-setup.sh
+++ b/docs/content/developers/scripts/wsl2-test-runner-setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# This sets up an Ubuntu distro to be a test runner for WSL2
+# Run this inside a working WSL2 Ubuntu Distro
+
+set -eu -o pipefail
+
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y apt-transport-https autojump build-essential ca-certificates curl dirmngr etckeeper expect git gnupg icinga2 jq libcurl4-gnutls-dev libnss3-tools lsb-release mariadb-client nagios-plugins postgresql-client unzip vim zip
+
+sudo snap install --classic go
+
+# ngrok
+curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc \
+  | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null \
+  && echo "deb https://ngrok-agent.s3.amazonaws.com buster main" \
+  | sudo tee /etc/apt/sources.list.d/ngrok.list \
+  && sudo apt update \
+  && sudo apt install ngrok
+
+# Buildkite-agent
+curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
+sudo apt-get update && sudo apt-get install -y buildkite-agent
+sudo usermod -d /var/lib/buildkite-agent buildkite-agent
+
+

--- a/docs/content/developers/scripts/wsl2-test-runner-setup.sh
+++ b/docs/content/developers/scripts/wsl2-test-runner-setup.sh
@@ -20,7 +20,7 @@ if [ "${BUILDKITE_DOCKER_TYPE:-}" = "" ]; then
 fi
 
 sudo apt-get update -qq >/dev/null && sudo apt-get upgrade -qq -y >/dev/null
-sudo apt-get install -qq -y apt-transport-https autojump bats build-essential ca-certificates ccache clang curl dirmngr etckeeper expect git gnupg htop icinga2 jq libcurl4-gnutls-dev libnss3-tools lsb-release mariadb-client mkcert nagios-plugins postgresql-client unzip vim wslu xdg-utils zip >/dev/null
+sudo apt-get install -qq -y apt-transport-https autojump bats build-essential ca-certificates ccache clang curl dirmngr etckeeper expect git gnupg htop icinga2 jq libcurl4-gnutls-dev libnss3-tools lsb-release mariadb-client mkcert monitoring-plugins-contrib nagios-plugins postgresql-client unzip vim wslu xdg-utils zip >/dev/null
 
 # golang
 sudo snap install --classic go
@@ -76,5 +76,8 @@ echo "Press any key to continue..."
 read x
 sudo vipw || true
 sudo systemctl start buildkite-agent
+
+# nagios for icinga2 needs to be in docker group
+sudo usermod -aG docker nagios
 
 echo "Now reboot the distro with 'wsl.exe -t Ubuntu' and restart it"


### PR DESCRIPTION
## The Issue

Improving WSL2 Docker Desktop setup instructions for buildkite. Developer only.

Rendered docs at https://ddev--6889.org.readthedocs.build/en/6889/developers/buildkite-testmachine-setup/#windows-test-agent-setup

I haven't tested the script for WSL2/docker-ce, but tested for Docker Desktop several times, should be ok. 

This simplifies the setup of a WSL2 test runner quite a lot
