### PR TITLE
test: Quickstart tests for TYPO3 quickstart 

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - "docs/content/users/quickstart.md"
+      - "docs/tests/**"
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -830,7 +830,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev start
     ddev composer create "typo3/cms-base-distribution"
     ddev exec touch public/FIRST_INSTALL
-    ddev launch
+    ddev launch /typo3/install.php
     ```
 
 === "Git Clone"
@@ -842,7 +842,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev start
     ddev composer install
     ddev exec touch public/FIRST_INSTALL
-    ddev launch
+    ddev launch /typo3/install.php
     ```
 
 ## WordPress

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -839,8 +839,8 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     git clone https://github.com/example/example-site my-typo3-site
     cd my-typo3-site
     ddev config --project-type=typo3 --docroot=public --php-version=8.3
+    ddev start
     ddev composer install
-    ddev restart
     ddev exec touch public/FIRST_INSTALL
     ddev launch
     ```

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -37,3 +37,36 @@ teardown() {
   assert_output --partial "location: /typo3/install.php"
   assert_output --partial "HTTP/2 302"
 }
+
+@test "TYPO3 git based quickstart with $(ddev --version)" {
+  skip
+  # PROJECT_GIT_URL=https://github.com/ddev/test-typo3.git
+  PROJECT_GIT_URL=https://github.com/ddev/test-typo3.git
+  # git clone ${PROJECT_GIT_URL} ${PROJNAME}
+  run git clone ${PROJECT_GIT_URL} ${PROJNAME}
+  assert_success
+  # cd my-typo3-site
+  cd ${PROJNAME} || exit 2
+  assert_success
+  # ddev config --project-type=typo3 --docroot=public --php-version=8.3
+  run ddev config --project-type=typo3 --docroot=public --php-version=8.3
+  assert_success
+  # ddev start
+  run ddev start
+  assert_success
+  # ddev composer install
+  run ddev composer install
+  assert_success
+  # ddev exec touch public/FIRST_INSTALL
+  run ddev exec touch public/FIRST_INSTALL
+  assert_success
+  # ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "location: /typo3/install.php"
+  assert_output --partial "HTTP/2 302"
+}

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -61,11 +61,11 @@ teardown() {
   assert_success
   # ddev launch
   run bash -c "DDEV_DEBUG=true ddev launch"
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project
-  run curl -sfI https://${PROJNAME}.ddev.site
+  run curl -sfI https://${PROJNAME}.ddev.site/typo3/install.php
   assert_success
-  assert_output --partial "location: /typo3/install.php"
-  assert_output --partial "HTTP/2 302"
+  assert_output --partial "content-security-policy: default-src 'self'; script-src 'self'"
+  assert_output --partial "HTTP/2 200"
 }

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+setup() {
+  PROJNAME=my-typo3-site
+  load 'common-setup'
+  _common_setup
+}
+
+# executed after each test
+teardown() {
+  _common_teardown
+}
+
+@test "TYPO3 composer based quickstart with $(ddev --version)" {
+  # mkdir my-typo3-site && cd my-typo3-site
+  run mkdir my-typo3-site && cd my-typo3-site
+  assert_success
+  # ddev config --project-type=typo3 --docroot=public --php-version=8.3
+  run ddev config --project-type=typo3 --docroot=public --php-version=8.3
+  assert_success
+  # ddev start
+  run ddev start
+  assert_success
+  # ddev composer create "typo3/cms-base-distribution"
+  run ddev composer create "typo3/cms-base-distribution"
+  assert_success
+  # ddev exec touch public/FIRST_INSTALL
+  run ddev exec touch public/FIRST_INSTALL
+  assert_success
+  # ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "location: /typo3/install.php"
+  assert_output --partial "HTTP/2 302"
+}

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -39,7 +39,6 @@ teardown() {
 }
 
 @test "TYPO3 git based quickstart with $(ddev --version)" {
-  skip
   # PROJECT_GIT_URL=https://github.com/ddev/test-typo3.git
   PROJECT_GIT_URL=https://github.com/ddev/test-typo3.git
   # git clone ${PROJECT_GIT_URL} ${PROJNAME}


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

Initial draft for the composer based quickstart for setting up TYPO3. tested locally and it is working fine. the second available quickstart is missing so far for this PR since there is no github repo for a typo3  test install yet as far as i can see. 

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
