### PR TITLE
test: Improve WP quickstart and add wordpress bats tests

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -167,6 +167,7 @@ VNC
 VPN
 VPNs
 WAMP
+WP-CLI
 WSL
 WSL2
 WantedBy

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -864,6 +864,9 @@ There are several easy ways to use DDEV with WordPress:
     # Download WordPress
     ddev wp core download
 
+    # Shuffle the salts
+    ddev wp config shuffle-salts
+
     # Launch in browser to finish installation
     ddev launch
 
@@ -914,7 +917,11 @@ There are several easy ways to use DDEV with WordPress:
     ```bash
     git clone https://github.com/example/my-site.git my-wp-site
     cd my-wp-site
-    ddev config
+    ddev config --project-type=wordpress
+    ddev start
+    ddev wp config shuffle-salts
+    ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+    ddev launch wp-admin/
     ```
 
     You’ll see a message like:

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -912,7 +912,8 @@ There are several easy ways to use DDEV with WordPress:
     To get started using DDEV with an existing WordPress project, clone the project’s repository.
 
     ```bash
-    git clone https://github.com/ddev/test-wordpress.git my-wp-site
+    PROJECT_GIT_URL=https://github.com/ddev/test-wordpress.git
+    git clone ${PROJECT_GIT_URL} my-wp-site
     cd my-wp-site
     ddev config --project-type=wordpress
     ddev start

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -915,7 +915,7 @@ There are several easy ways to use DDEV with WordPress:
     To get started using DDEV with an existing WordPress project, clone the project’s repository.
 
     ```bash
-    git clone https://github.com/example/my-site.git my-wp-site
+    git clone https://github.com/ddev/test-wordpress.git my-wp-site
     cd my-wp-site
     ddev config --project-type=wordpress
     ddev start

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -869,7 +869,7 @@ There are several easy ways to use DDEV with WordPress:
 
     # OR use the following installation command
     # (we need to use single quotes to get the primary site URL from `.ddev/config.yaml` as variable)
-    ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+    ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
 
     # Launch WordPress admin dashboard in your browser
     ddev launch wp-admin/

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -869,7 +869,7 @@ There are several easy ways to use DDEV with WordPress:
 
     # OR use the following installation command
     # (we need to use single quotes to get the primary site URL from `.ddev/config.yaml` as variable)
-    ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_email=admin@example.com --prompt=admin_password
+    ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
 
     # Launch WordPress admin dashboard in your browser
     ddev launch wp-admin/
@@ -880,7 +880,7 @@ There are several easy ways to use DDEV with WordPress:
     [Bedrock](https://roots.io/bedrock/) is a modern, Composer-based installation in WordPress:
 
     ```bash
-    mkdir my-wp-bedrock-site && cd my-wp-bedrock-site
+    mkdir my-wp-site && cd my-wp-site
     ddev config --project-type=wordpress --docroot=web
     ddev start
     ddev composer create roots/bedrock

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -864,9 +864,6 @@ There are several easy ways to use DDEV with WordPress:
     # Download WordPress
     ddev wp core download
 
-    # Shuffle the salts
-    ddev wp config shuffle-salts
-
     # Launch in browser to finish installation
     ddev launch
 
@@ -919,7 +916,6 @@ There are several easy ways to use DDEV with WordPress:
     cd my-wp-site
     ddev config --project-type=wordpress
     ddev start
-    ddev wp config shuffle-salts
     ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
     ddev launch wp-admin/
     ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -898,7 +898,12 @@ There are several easy ways to use DDEV with WordPress:
     WP_ENV=development
     ```
 
-    You can then run [`ddev start`](../users/usage/commands.md#start) and [`ddev launch`](../users/usage/commands.md#launch).
+    You can then install the site with WP-CLI and log into the admin interface:
+
+    ```bash
+    ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+    ddev launch wp-admin/
+    ```
 
     For more details, see [Bedrock installation](https://docs.roots.io/bedrock/master/installation/).
 

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -24,6 +24,9 @@ teardown() {
   # ddev wp core download
   run ddev wp core download
   assert_success
+  # ddev wp config shuffle-salts
+  run ddev wp config shuffle-salts
+  assert_success
   # ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   run ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
@@ -94,5 +97,42 @@ teardown() {
   assert_success
   assert_output --partial "location: https://${PROJNAME}.ddev.site/wp/wp-admin/"
   assert_output --partial "link: <https://${PROJNAME}.ddev.site/wp-json/>; rel=\"https://api.w.org/\""
+  assert_output --partial "HTTP/2 302"
+}
+
+@test "WordPress git based quickstart with $(ddev --version)" {
+  # PROJECT_GIT_URL=https://github.com/ddev/test-wordpress.git
+  PROJECT_GIT_URL=https://github.com/ddev/test-wordpress.git
+  # git clone ${PROJECT_GIT_URL} ${PROJNAME}
+  run git clone ${PROJECT_GIT_URL} ${PROJNAME}
+  assert_success
+  # cd my-typo3-site
+  cd ${PROJNAME} || exit 2
+  assert_success
+  # ddev config --project-type=wordpress
+  run ddev config --project-type=wordpress
+  assert_success
+  # ddev start
+  run ddev start
+  assert_success
+  # ddev wp config shuffle-salts
+  run ddev wp config shuffle-salts
+  assert_success
+  # ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  assert_success
+  # ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "link: <https://my-wp-site.ddev.site/wp-json/>; rel=\"https://api.w.org/\""
+  assert_output --partial "HTTP/2 200"
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
+  assert_success
+  assert_output --partial "location: https://my-wp-site.ddev.site/wp-login.php"
   assert_output --partial "HTTP/2 302"
 }

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+setup() {
+  PROJNAME=my-wp-site
+  load 'common-setup'
+  _common_setup
+}
+
+# executed after each test
+teardown() {
+  _common_teardown
+}
+
+@test "WordPress wp-cli based quickstart with $(ddev --version)" {
+  # mkdir my-wp-site && cd my-wp-site
+  run mkdir my-wp-site && cd my-wp-site
+  assert_success
+  # ddev config --project-type=wordpress
+  run ddev config --project-type=wordpress
+  assert_success
+  # ddev start
+  run ddev start
+  assert_success
+  # ddev wp core download
+  run ddev wp core download
+  assert_success
+  # ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  assert_success
+  # ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "link: <https://my-wp-site.ddev.site/wp-json/>; rel=\"https://api.w.org/\""
+  assert_output --partial "HTTP/2 200"
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
+  assert_success
+  assert_output --partial "location: https://my-wp-site.ddev.site/wp-login.php"
+  assert_output --partial "HTTP/2 302"
+}
+
+
+@test "WordPress Bedrock based quickstart with $(ddev --version)" {
+  # mkdir my-wp-site && cd my-wp-site
+  run mkdir my-wp-site && cd my-wp-site
+  assert_success
+  # ddev config --project-type=wordpress --docroot=web
+  run ddev config --project-type=wordpress --docroot=web
+  assert_success
+  # ddev start
+  run ddev start
+  assert_success
+  # ddev composer create roots/bedrock
+  run ddev composer create roots/bedrock
+  assert_success
+  # ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  assert_success
+  # ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "link: <https://my-wp-site.ddev.site/wp-json/>; rel=\"https://api.w.org/\""
+  assert_output --partial "HTTP/2 200"
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
+  assert_success
+  assert_output --partial "location: https://my-wp-site.ddev.site/wp-login.php"
+  assert_output --partial "HTTP/2 302"
+}

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -24,9 +24,6 @@ teardown() {
   # ddev wp core download
   run ddev wp core download
   assert_success
-  # ddev wp config shuffle-salts
-  run ddev wp config shuffle-salts
-  assert_success
   # ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   run ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
@@ -114,9 +111,6 @@ teardown() {
   assert_success
   # ddev start
   run ddev start
-  assert_success
-  # ddev wp config shuffle-salts
-  run ddev wp config shuffle-salts
   assert_success
   # ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   run ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -24,8 +24,8 @@ teardown() {
   # ddev wp core download
   run ddev wp core download
   assert_success
-  # ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
-  run ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  # ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
   # ddev launch
   run bash -c "DDEV_DEBUG=true ddev launch"
@@ -43,7 +43,6 @@ teardown() {
   assert_output --partial "HTTP/2 302"
 }
 
-
 @test "WordPress Bedrock based quickstart with $(ddev --version)" {
   # mkdir my-wp-site && cd my-wp-site
   run mkdir my-wp-site && cd my-wp-site
@@ -57,8 +56,29 @@ teardown() {
   # ddev composer create roots/bedrock
   run ddev composer create roots/bedrock
   assert_success
-  # ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
-  run ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  # cp .env.example .env
+  run cp .env.example .env
+  assert_success
+  # Set database name to db in .env
+  run sed -i "s/DB_NAME='database_name'/DB_NAME='db'/g" .env
+  assert_success
+  # Set database user to db in .env
+  run sed -i "s/DB_USER='database_user'/DB_USER='db'/g" .env
+  assert_success
+  # Set database password to db in .env
+  run sed -i "s/DB_PASSWORD='database_password'/DB_PASSWORD='db'/g" .env
+  assert_success
+  # Set database host to db in .env
+  run sed -i "s/# DB_HOST='localhost'/DB_HOST='db'/g" .env
+  assert_success
+  # Set WP_HOME to ${DDEV_PRIMARY_URL} in .env
+  run sed -i "s/WP_HOME='http:\/\/example.com'/WP_HOME=\"\${DDEV_PRIMARY_URL}\"/g" .env
+  assert_success
+  # Set WP_SITEURL to ${WP_HOME}/wp in .env
+  run sed -i "s/WP_SITEURL=\"\${WP_HOME}\/wp\"/WP_SITEURL=\"\${WP_HOME}\/wp\"/g" .env
+  assert_success
+  # ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
   # ddev launch
   run bash -c "DDEV_DEBUG=true ddev launch"
@@ -67,11 +87,12 @@ teardown() {
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site
   assert_success
-  assert_output --partial "link: <https://my-wp-site.ddev.site/wp-json/>; rel=\"https://api.w.org/\""
+  assert_output --partial "link: <https://${PROJNAME}.ddev.site/wp-json/>; rel=\"https://api.w.org/\""
   assert_output --partial "HTTP/2 200"
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
   assert_success
-  assert_output --partial "location: https://my-wp-site.ddev.site/wp-login.php"
+  assert_output --partial "location: https://${PROJNAME}.ddev.site/wp/wp-admin/"
+  assert_output --partial "link: <https://${PROJNAME}.ddev.site/wp-json/>; rel=\"https://api.w.org/\""
   assert_output --partial "HTTP/2 302"
 }


### PR DESCRIPTION

* adding a bats test for the wp cli quickstart and one for the bedrock quickstart
* Improved docs, rendered at https://ddev--6897.org.readthedocs.build/en/6897/users/quickstart/#wordpress

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
