### PR TITLE
feat: override `PAGER` with `DDEV_PAGER` env variable, for #6842

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -71,7 +71,7 @@ services:
       - POSTGRES_PASSWORD=db
       - POSTGRES_USER=db
       - POSTGRES_DB=db
-      - PAGER=less -SFX
+      - PAGER=${DDEV_PAGER-less -SFX}
       - TZ={{ .Timezone }}
       - USER={{ .Username }}
     command: ${DDEV_DB_CONTAINER_COMMAND}
@@ -211,7 +211,7 @@ services:
     - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-web/mysql_history
     - NODE_EXTRA_CA_CERTS=/mnt/ddev-global-cache/mkcert/rootCA.pem
     - npm_config_cache=/mnt/ddev-global-cache/npm
-    - PAGER=less -SFX
+    - PAGER=${DDEV_PAGER-less -SFX}
     - PGDATABASE=db
     - PGHOST=db
     - PGPASSWORD=db


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/6842#issuecomment-2590294868

We don't have a quick and easy way to override `PAGER` variable in the `web` and `db` containers.

## How This PR Solves The Issue

Adds an optional environment variable `DDEV_PAGER`.

I'm unsure where to add information about DDEV_PAGER in the docs (should we?).
The section on [Environment Variables Provided](https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/#environment-variables-provided) is not the right place, as it covers variables inside the container, whereas `DDEV_PAGER` is used outside the container.

## Manual Testing Instructions

```
ddev start
ddev exec 'echo $PAGER'
less -SFX
```

```
export DDEV_PAGER=less
ddev start
ddev exec 'echo $PAGER'
less
```

```
export DDEV_PAGER=
ddev start
ddev exec 'echo $PAGER'
<empty>
```

```
unset DDEV_PAGER
ddev start
ddev exec 'echo $PAGER'
less -SFX
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
