### PR TITLE
fix: provide a dummy ddev command inside container, allow web commands there, fixes #6574

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/commandline-addons.bashrc
@@ -5,13 +5,24 @@ case ":$PATH:" in
     # Otherwise, add it.
     *) PATH="$HOME/bin:$PATH" ;;
 esac
-# Add /var/www/html/bin as the last item to the $PATH.
+# Add /var/www/html/bin as the next-to-last item to the $PATH.
 case ":$PATH:" in
     # If the item is already in $PATH, don't add it again.
     *":/var/www/html/bin:"*) ;;
     # Otherwise, add it.
     *) PATH="$PATH:/var/www/html/bin" ;;
 esac
+
+# Add /mnt/ddev-global-cache/global-commands/web as the last item to the $PATH.
+# This allows commands that weren't found elsewhere to be executed. For example, `xdebug on`
+# can be used inside web container
+case ":$PATH:" in
+    # If the item is already in $PATH, don't add it again.
+    *":/mnt/ddev-global-cache/global-commands/web:"*) ;;
+    # Otherwise, add it.
+    *) PATH="$PATH:/mnt/ddev-global-cache/global-commands/web" ;;
+esac
+
 # And don't forget to export the new $PATH.
 export PATH
 

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/ddev
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/ddev
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Imitation/replacement for `ddev` inside the web container
+# Partial functionality
+
+set -eu -o pipefail
+
+printf "You executed 'ddev $*' inside the web container\nbut many DDEV commands are not available.\n"
+
+if [ $# -ge 1 ] && command -v "$1" >/dev/null 2>&1; then
+  printf "\nHowever, you may be able to use just the command '$*'\n".
+fi

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/ddev
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/ddev
@@ -8,5 +8,5 @@ set -eu -o pipefail
 printf "You executed 'ddev $*' inside the web container\nbut many DDEV commands are not available.\n"
 
 if [ $# -ge 1 ] && command -v "$1" >/dev/null 2>&1; then
-  printf "\nHowever, you may be able to use just the command '$*'\n".
+  printf "\nHowever, you may be able to use a command like:\n\n$*\n".
 fi

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/ddev
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/ddev
@@ -8,5 +8,5 @@ set -eu -o pipefail
 printf "You executed 'ddev $*' inside the web container\nbut many DDEV commands are not available.\n"
 
 if [ $# -ge 1 ] && command -v "$1" >/dev/null 2>&1; then
-  printf "\nHowever, you may be able to use a command like:\n\n$*\n".
+  printf "\nHowever, you may be able to use a command like:\n\n$*\n"
 fi

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "Verify required binaries are installed in normal image" {
     if [ "${IS_HARDENED}" == "true" ]; then skip "Skipping because IS_HARDENED==true"; fi
-    COMMANDS="composer ddev drush8 git magerun magerun2 mkcert mysql mysqladmin mysqldump node npm platform sudo symfony terminus wp xdebug xhprof"
+    COMMANDS="composer ddev drush8 git magerun magerun2 mkcert mysql mysqladmin mysqldump node npm platform sudo symfony terminus wp"
     for item in $COMMANDS; do
 #      echo "# looking for $item" >&3
       docker exec $CONTAINER_NAME bash -c "command -v $item >/dev/null"

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "Verify required binaries are installed in normal image" {
     if [ "${IS_HARDENED}" == "true" ]; then skip "Skipping because IS_HARDENED==true"; fi
-    COMMANDS="composer drush8 git magerun magerun2 mkcert mysql mysqladmin mysqldump node npm platform sudo symfony terminus wp"
+    COMMANDS="composer ddev drush8 git magerun magerun2 mkcert mysql mysqladmin mysqldump node npm platform sudo symfony terminus wp xdebug xhprof"
     for item in $COMMANDS; do
 #      echo "# looking for $item" >&3
       docker exec $CONTAINER_NAME bash -c "command -v $item >/dev/null"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/drush
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/drush
@@ -8,6 +8,9 @@
 ## ProjectTypes: drupal,drupal11,drupal10,drupal9,drupal8,drupal7,backdrop
 ## ExecRaw: true
 
+# Ignore anything we find in the mounted global commands
+PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
+
 if ! command -v drush >/dev/null; then
   echo "drush is not available. You may need to 'ddev composer require drush/drush'"
   exit 1

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/pint
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/pint
@@ -3,8 +3,11 @@
 #ddev-generated
 ## Description: Run Pint inside the web container
 ## Usage: pint [flags] [args]
-## Example: "ddev pint --dirty" for fixing your current changes lint errors or "ddev pint --test app/Models" for only analyzing your models without autofix. 
+## Example: "ddev pint --dirty" for fixing your current changes lint errors or "ddev pint --test app/Models" for only analyzing your models without autofix.
 ## ProjectTypes: laravel
+
+# Ignore anything we find in the mounted global commands
+PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
 
 if ! command -v pint >/dev/null; then
   echo "pint is not available. You may need to 'ddev composer require laravel/pint'"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/sake
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/sake
@@ -7,5 +7,8 @@
 ## ProjectTypes: silverstripe
 ## ExecRaw: true
 
+# Ignore anything we find in the mounted global commands
+PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
+
 sake "$@"
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/typo3
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/typo3
@@ -9,4 +9,7 @@
 ## ProjectTypes: typo3
 ## ExecRaw: true
 
+# Ignore anything we find in the mounted global commands
+PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
+
 typo3 "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/wp
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/wp
@@ -6,4 +6,7 @@
 ## ProjectTypes: wordpress
 ## ExecRaw: true
 
+# Ignore anything we find in the mounted global commands
+PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
+
 wp "$@"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20241223_stasadev_build_warn" // Note that this can be overridden by make
+var WebTag = "20250115_ddev_in_container" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

- #6574 

* People who work inside the web container like in the @ultimike technique often type `ddev <whatever>` and waste their keystrokes.
* Some commands like `xdebug on` would be useful inside the web container, and they're already there.

## How This PR Solves The Issue

Add a simple `ddev` command. Works when things are available and when not available:

```
rfay@d11-web:/var/www/html$ ddev
You executed 'ddev ' inside the web container
but many DDEV commands are not available.
```

```
rfay@d11-web:/var/www/html$ ddev drush cr
You executed 'ddev drush cr' inside the web container
but many DDEV commands are not available.

However, you may be able to use just the command 'drush cr'
```

Also, specially for @ultimike :

```
rfay@d11-web:/var/www/html$ xdebug on
Enabled xdebug
rfay@d11-web:/var/www/html$ xdebug off
Disabled xdebug
rfay@d11-web:/var/www/html$ xhprof on
Enabled xhprof.
After each web request or CLI process you can see all runs, most recent first, at
https://d11.ddev.site/xhprof
```

## Manual Testing Instructions

* Try using `ddev` inside `ddev ssh`
* try using some various things like `xdebug on`

## Automated Testing Overview

* Added check for xdebug and such in web container tests

## Release/Deployment Notes

It's possible this needs note in docs or release, but maybe better to just have people discover it?
