### PR TITLE
docs: Update quickstart.md for Drupal CMS, remove --stability="RC"

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -232,7 +232,7 @@ The legacy type `drupal` will be interpreted as the latest stable version of Dru
     ```bash
     mkdir my-drupal-cms && cd my-drupal-cms
     ddev config --project-type=drupal11 --docroot=web
-    ddev composer create --stability="RC" drupal/cms
+    ddev composer create drupal/cms
     ddev launch
     ```
 


### PR DESCRIPTION
## The Issue

Drupal CMS 1.0 is out (https://new.drupal.org/download), `--stability="RC"` can be removed from quick start docs.

Tested it myself just yet, worked.

## How This PR Solves The Issue

- remove `--stability="RC"` from install command

## Manual Testing Instructions

Test

```bash
mkdir my-drupal-cms && cd my-drupal-cms
ddev config --project-type=drupal11 --docroot=web
ddev composer create drupal/cms
ddev launch
```

## Automated Testing Overview

None

## Release/Deployment Notes

