### PR TITLE
build: bump docker-compose to 2.32.4

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -41,4 +41,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.18.0"
 
-const RequiredDockerComposeVersionDefault = "v2.31.0"
+const RequiredDockerComposeVersionDefault = "v2.32.4"


### PR DESCRIPTION

## The Issue

We're preparing for a release and docker-compose 2.32.4 is out, https://github.com/docker/compose/releases/tag/v2.32.4

Bump it