### PR TITLE
test: add force flag to the remove cmd and a fixed dl link to the latest version of Drupal CMS

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -243,7 +243,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     ```bash
     CMS_VERSION=1.0.0
     curl -o my-drupal-site.zip -fL https://ftp.drupal.org/files/projects/cms-${CMS_VERSION}.zip
-    unzip my-drupal-site.zip && rm my-drupal-site.zip
+    unzip my-drupal-site.zip && rm -f my-drupal-site.zip
     cd drupal-cms
     ./launch-drupal-cms.sh
     ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -241,8 +241,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     or use the ZIP file download technique:
 
     ```bash
-    CMS_VERSION=1.0.0
-    curl -o my-drupal-site.zip -fL https://ftp.drupal.org/files/projects/cms-${CMS_VERSION}.zip
+    curl -o my-drupal-site.zip -fL https://www.drupal.org/download-latest/cms
     unzip my-drupal-site.zip && rm -f my-drupal-site.zip
     cd drupal-cms
     ./launch-drupal-cms.sh

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -130,10 +130,8 @@ teardown() {
 
 @test "Drupal CMS zip file quickstart with $(ddev --version)" {
   skip "Skipping until script doesn't erroneously create a -1 on project name"
-  # CMS_VERSION=1.0.0
-  CMS_VERSION=1.0.0
   # curl -o my-drupal-site.zip -fL https://ftp.drupal.org/files/projects/cms-1.0.0-${CMS_VERSION}.zip
-  run curl -o my-drupal-site.zip -fL https://ftp.drupal.org/files/projects/cms-${CMS_VERSION}.zip
+  run curl -o my-drupal-site.zip -fL https://www.drupal.org/download-latest/cms
   assert_success
   # unzip my-drupal-cms-zip.zip && rm my-drupal-cms-zip.zip
   run unzip my-drupal-site.zip && rm -f my-drupal-site.zip

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -136,7 +136,7 @@ teardown() {
   run curl -o my-drupal-site.zip -fL https://ftp.drupal.org/files/projects/cms-${CMS_VERSION}.zip
   assert_success
   # unzip my-drupal-cms-zip.zip && rm my-drupal-cms-zip.zip
-  run unzip my-drupal-site.zip && rm my-drupal-site.zip
+  run unzip my-drupal-site.zip && rm -f my-drupal-site.zip
   assert_success
   # mv drupal-cms my-drupal-site
   # (Not contained in quickstart but necessary to use PROJNAME in this test )

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -133,7 +133,7 @@ teardown() {
   # curl -o my-drupal-site.zip -fL https://www.drupal.org/download-latest/cms
   run curl -o my-drupal-site.zip -fL https://www.drupal.org/download-latest/cms
   assert_success
-  # unzip my-drupal-cms-zip.zip && rm my-drupal-cms-zip.zip
+  # unzip my-drupal-cms-zip.zip && rm -f my-drupal-cms-zip.zip
   run unzip my-drupal-site.zip && rm -f my-drupal-site.zip
   assert_success
   # mv drupal-cms my-drupal-site

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -130,7 +130,7 @@ teardown() {
 
 @test "Drupal CMS zip file quickstart with $(ddev --version)" {
   skip "Skipping until script doesn't erroneously create a -1 on project name"
-  # curl -o my-drupal-site.zip -fL https://ftp.drupal.org/files/projects/cms-1.0.0-${CMS_VERSION}.zip
+  # curl -o my-drupal-site.zip -fL https://www.drupal.org/download-latest/cms
   run curl -o my-drupal-site.zip -fL https://www.drupal.org/download-latest/cms
   assert_success
   # unzip my-drupal-cms-zip.zip && rm my-drupal-cms-zip.zip


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->
(*disclaimer: did something stupid and pushed some changes to the branch for this PR, instead of the branch i created for it. :( but since both changes are about drupal CMS i rescoped this issue now.) 

this PR introduces two changes: 

1. per the request of @stasadev a small adjustment to the drupal cms quickstart and bats test adding the force flag to avoid option confirmation for people who activated that. plus the rest of the quickstarts are using that flag on remove operations as well. 

2. added a fixed link for the latest version of drupal cms zip file to the quickstart and test. got added to drupal cms in https://www.drupal.org/project/drupalorg/issues/3500098

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
