### PR TITLE
fix: remove noise from `docker-compose` on build and reformat `ddev start` output, for #6905

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1491,9 +1491,14 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	// Build extra layers on web and db images if necessary
-	output.UserOut.Printf("Building project images...")
+	fmt.Print("Building project images...")
 	buildDurationStart := util.ElapsedDuration(time.Now())
 	progress := "plain"
+	// Add a new line to display the debug output
+	// on the next line after "Building project images..."
+	if globalconfig.DdevDebug {
+		output.UserOut.Debugln()
+	}
 	util.Debug("Executing docker-compose -f %s build --progress=%s", app.DockerComposeFullRenderedYAMLPath(), progress)
 	out, stderr, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
 		ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1491,14 +1491,20 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	// Build extra layers on web and db images if necessary
-	fmt.Print("Building project images...")
+	if output.JSONOutput {
+		output.UserOut.Printf("Building project images...")
+	} else {
+		// Using fmt.Print to avoid a newline, as output.UserOut.Printf adds one by default.
+		// See https://github.com/sirupsen/logrus/issues/167
+		// We want the progress dots to appear on the same line.
+		fmt.Print("Building project images...")
+		// Print a newline before util.Debug below
+		if globalconfig.DdevDebug {
+			output.UserOut.Debugln()
+		}
+	}
 	buildDurationStart := util.ElapsedDuration(time.Now())
 	progress := "plain"
-	// Add a new line to display the debug output
-	// on the next line after "Building project images..."
-	if globalconfig.DdevDebug {
-		output.UserOut.Debugln()
-	}
 	util.Debug("Executing docker-compose -f %s build --progress=%s", app.DockerComposeFullRenderedYAMLPath(), progress)
 	out, stderr, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
 		ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1615,7 +1615,18 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		if !mounted {
 			util.Failed("Mutagen Docker volume is not mounted. Please use `ddev restart`")
 		}
-		output.UserOut.Printf("Starting Mutagen sync process...")
+		if output.JSONOutput {
+			output.UserOut.Printf("Starting Mutagen sync process...")
+		} else {
+			// Using fmt.Print to avoid a newline, as output.UserOut.Printf adds one by default.
+			// See https://github.com/sirupsen/logrus/issues/167
+			// We want the progress dots to appear on the same line.
+			fmt.Print("Starting Mutagen sync process...")
+			// Print a newline before util.Debug below
+			if globalconfig.DdevDebug {
+				output.UserOut.Debugln()
+			}
+		}
 		mutagenDuration := util.ElapsedDuration(time.Now())
 
 		err = SetMutagenVolumeOwnership(app)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1736,7 +1736,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	if err != nil {
 		return err
 	}
-	containerNames := dockerutil.GetContainerNames(containersAwaited, []string{GetContainerName(app, "web"), GetContainerName(app, "db")})
+	containerNames := dockerutil.GetContainerNames(containersAwaited, []string{GetContainerName(app, "web"), GetContainerName(app, "db")}, "ddev-"+app.Name+"-")
 	if len(containerNames) > 0 {
 		output.UserOut.Printf("Waiting %ds for additional project containers %v to become ready...", app.GetMaxContainerWaitTime(), containerNames)
 	}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -284,6 +284,7 @@ func CreateOrResumeMutagenSync(app *DdevApp) error {
 		select {
 		// Complete when the MutagenSyncFlush() completes
 		case err = <-flushErr:
+			_, _ = fmt.Fprintln(os.Stderr)
 			return err
 		case outputComing = <-firstOutputReceived:
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -727,7 +727,7 @@ func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
 	// Container (or Volume) ... Creating or Created or Stopping or Starting or Removing
 	// Container Stopped or Created
 	// No resource found to remove (when doing a stop and no project exists)
-	ignoreRegex := "(^ *(Network|Container|Volume|Service) .* (Creat|Start|Stopp|Remov|Build|Buil)(ing|t)$|^Container .*(Stopp|Creat)(ed|ing)$|Warning: No resource found to remove|Pulling fs layer|Waiting|Downloading|Extracting|Verifying Checksum|Download complete|Pull complete)"
+	ignoreRegex := "(^ *(Network|Container|Volume|Service) .* (Creat|Start|Stopp|Remov|Build|Buil)(ing|t)$|.* Built$|^Container .*(Stopp|Creat)(ed|ing)$|Warning: No resource found to remove|Pulling fs layer|Waiting|Downloading|Extracting|Verifying Checksum|Download complete|Pull complete)"
 	downRE, err := regexp.Compile(ignoreRegex)
 	if err != nil {
 		util.Warning("Failed to compile regex %v: %v", ignoreRegex, err)

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1928,8 +1928,9 @@ func GetLiveDockerComposeVersion() (string, error) {
 }
 
 // GetContainerNames takes an array of Container
-// and returns an array of strings with container names
-func GetContainerNames(containers []dockerTypes.Container, excludeContainerNames []string) []string {
+// and returns an array of strings with container names.
+// Use removePrefix to get short container names.
+func GetContainerNames(containers []dockerTypes.Container, excludeContainerNames []string, removePrefix string) []string {
 	var names []string
 	for _, container := range containers {
 		if len(container.Names) == 0 {
@@ -1938,6 +1939,9 @@ func GetContainerNames(containers []dockerTypes.Container, excludeContainerNames
 		name := container.Names[0][1:] // Trimming the leading '/' from the container name
 		if slices.Contains(excludeContainerNames, name) {
 			continue
+		}
+		if removePrefix != "" {
+			name = strings.TrimPrefix(name, removePrefix)
 		}
 		names = append(names, name)
 	}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -93,6 +93,7 @@ func ShowDots() chan bool {
 		for {
 			select {
 			case <-done:
+				_, _ = fmt.Fprintln(os.Stderr)
 				return
 			default:
 				_, _ = fmt.Fprintf(os.Stderr, ".")


### PR DESCRIPTION
## The Issue

@rpkoller pointed out that we have some strange output on `ddev start`:

```
Building project images... 
. db  Built 
 web  Built 
Project images built in 1s.
```

Previously it looked like this:

```
Building project images... 
.Project images built in 1s.
```

This noise was added with:

- #6905

## How This PR Solves The Issue

1. Removes the noise.
2. Changes the output from:
	```
	Building project images...
	........Project images built in 8s.

    Starting Mutagen sync process...
    ........Mutagen sync flush completed in 8s.
	```
	to:
	```
	Building project images...........
	Project images built in 8s.

    Starting Mutagen sync process...........
    Mutagen sync flush completed in 8s.
	```

3. We use short names here:
	```
	Waiting for containers to become ready: [web db]
	```
	but not here:
	```
	Waiting 120s for additional project containers [ddev-d11-redis ddev-d11-varnish] to become ready...
	```
	Change it to:
	```
	Waiting 120s for additional project containers [redis varnish] to become ready...
	```

## Manual Testing Instructions

Run `ddev debug rebuild`

Or

```
ddev config --webimage-extra-packages=vim
ddev add-on get ddev/ddev-redis
ddev start
...
Building project images.............
Project images built in 11s.
...
Waiting for containers to become ready: [web db]
...
Waiting 120s for additional project containers [redis] to become ready...
...
```


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
