### PR TITLE
fix: nginx-site-drupal11.conf wasn't being installed, fixes #6910

### DIFF
--- a/docs/content/developers/project-types.md
+++ b/docs/content/developers/project-types.md
@@ -28,7 +28,7 @@ To add a new project type:
     * `defaultWorkingDirMap` allows the project type to override the project’s [`working_dir`](../users/configuration/config.md#working_dir) (where [`ddev ssh`](../users/usage/commands.md#ssh) and [`ddev exec`](../users/usage/commands.md#exec) start by default). This is mostly not done anymore, as the `working_dir` is typically the project root.
     * `composerCreateAllowedPaths` specifies the paths that can exist in a directory when `ddev composer create` is being used.
 * You’ll likely need templates for settings files, use the Drupal or TYPO3 templates as examples, for example `pkg/ddevapp/drupal` and `pkg/ddevapp/typo3`. Those templates have to be loaded at runtime as well.
-* For a custom nginx config, use `webserver_config_assets/nginx-site-php.conf` as an example.
+* Implement `nginx-site-<project-type>.conf` in `webserver_config_assets`. You can use `webserver_config_assets/nginx-site-php.conf` as a pattern, or something from the upstream project.
 * Upload the project detection file stubs to the `testdata/TestDetectAppType` folder.
 * Add to `appTypes` test slice for `TestConfigOverrideAction` in `ddevapp/apptypes_test.go`.
 * If the project type has a custom command, add it to `global_dotddev_assets/commands/web` folder.

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-cakephp.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-cakephp.conf
@@ -1,4 +1,4 @@
-# ddev php default (PHP project type) config
+# ddev cakephp config
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
@@ -1,0 +1,108 @@
+# ddev drupal11 config
+
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-nginx-configuration
+
+server {
+    listen 80 default_server;
+    listen 443 ssl default_server;
+
+    root {{ .Docroot }};
+
+    ssl_certificate /etc/ssl/certs/master.crt;
+    ssl_certificate_key /etc/ssl/certs/master.key;
+
+    include /etc/nginx/monitoring.conf;
+
+    index index.php index.htm index.html;
+
+    # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+    sendfile off;
+    error_log /dev/stdout info;
+    access_log /var/log/nginx/access.log;
+
+    location / {
+        absolute_redirect off;
+        try_files $uri $uri/ /index.php?$query_string; # For Drupal >= 7
+    }
+
+    location @rewrite {
+        # For D7 and above:
+        # Clean URLs are handled in drupal_environment_initialize().
+        rewrite ^ /index.php;
+    }
+
+    # Handle image styles for Drupal 7+
+    location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+    }
+
+    # pass the PHP scripts to FastCGI server listening on socket
+    location ~ '\.php$|^/update.php' {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php-fpm.sock;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_intercept_errors off;
+        # fastcgi_read_timeout should match max_execution_time in php.ini
+        fastcgi_read_timeout 10m;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTPS $fcgi_https;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
+    }
+
+    # Expire rules for static content
+
+    # Prevent clients from accessing hidden files (starting with a dot)
+    # This is particularly important if you store .htpasswd files in the site hierarchy
+    # Access to `/.well-known/` is allowed.
+    # https://www.mnot.net/blog/2010/04/07/well-known
+    # https://tools.ietf.org/html/rfc5785
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    # Prevent clients from accessing to backup/config/source files
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    ## Regular private file serving (i.e. handled by Drupal).
+    location ^~ /system/files/ {
+        ## For not signaling a 404 in the error log whenever the
+        ## system/files directory is accessed add the line below.
+        ## Note that the 404 is the intended behavior.
+        log_not_found off;
+        access_log off;
+        expires 30d;
+        try_files $uri @rewrite;
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
+    }
+
+    # js and css always loaded
+    location ~* \.(js|css)$ {
+        try_files $uri @rewrite;
+        expires -1;
+        log_not_found off;
+    }
+
+    include /etc/nginx/common.d/*.conf;
+    include /mnt/ddev_config/nginx/*.conf;
+}

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-silverstripe.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-silverstripe.conf
@@ -1,4 +1,4 @@
-# ddev php default (PHP project type) config
+# ddev silverstripe config
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-symfony.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-symfony.conf
@@ -1,4 +1,4 @@
-# ddev php default (PHP project type) config
+# ddev symfony config
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above


### PR DESCRIPTION
## The Issue

- #6910

The correct nginx configuration (.ddev/nginx_full/nginx-site.conf) was not being installed for `drupal11` or `drupal` projects.

I didn't check, but I assume this was a regression in v1.24.0, when we introduced the `drupal11` project type.

## How This PR Solves The Issue

Provide the nginx config.

## Manual Testing Instructions

`ddev start` in a `drupal11` or `drupal` project and inspect .ddev/nginx_full/nginx-site.conf

## Automated Testing Overview

- [x] This still needs test coverage for this situation. Just looking at the nginx-site.conf after start may be adequate.
- [x] Test in TestPHPWebserverType can probably detect problems with this
- [x] Look at the docs for adding a project type and make sure the nginx config is there.
- [x] Make sure the `drupal` project type is working correctly
