### PR TITLE
fix: update Drupal 7 settings.ddev.php and settings.php to match Drupal 7.103

### DIFF
--- a/pkg/ddevapp/drupal/drupal7/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal7/settings.ddev.php
@@ -29,6 +29,10 @@ $databases['default']['default']['port'] = $port;
 
 $drupal_hash_salt = '{{ $config.HashSalt }}';
 
+// This will ensure the site can only be accessed through the intended host
+// names. Additional host patterns can be added for custom configurations.
+$conf['trusted_host_patterns'] = ['.*'];
+
 // Enable verbose logging for errors.
 // https://www.drupal.org/docs/7/creating-custom-modules/show-all-errors-while-developing
 $conf['error_level'] = 2;

--- a/pkg/ddevapp/drupal/drupal7/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal7/settings.ddev.php
@@ -29,6 +29,9 @@ $databases['default']['default']['port'] = $port;
 
 $drupal_hash_salt = '{{ $config.HashSalt }}';
 
+// This will prevent Drupal from setting read-only permissions on sites/default.
+$conf['skip_permissions_hardening'] = TRUE;
+
 // This will ensure the site can only be accessed through the intended host
 // names. Additional host patterns can be added for custom configurations.
 $conf['trusted_host_patterns'] = ['.*'];


### PR DESCRIPTION
- Adds new Trusted Host Patterns to eliminate the warning on status report. 
- Adds `skip_permissions_hardening` conf
- Replaces settings.php contents with entire `default.settings.php` file from Drupal 7.103

## The Issue
Mutagen also fails if attempting to modify the settings.ddev.php files after installation if `$conf['skip_permissions_hardening']` is not set to `TRUE`.

Drupal 7 has added many features to the `default.settings.php` including a version of Trusted Host Patterns similar to D10/11 which cause an error on status reports:

 ```
{
  "title": "Trusted Host Settings",
  "value": "Not enabled",
  "description": "The trusted_host_patterns setting is not configured in settings.php. This can  \nlead to security vulnerabilities. It is *highly recommended* that you  \nconfigure this. See Protecting against HTTP HOST Header attacks [1] for more  \ninformation.\n\n[1] https://www.drupal.org/node/1992030\n",
  "severity": "Error",
  "sid": 2
}
```

## How This PR Solves The Issue

This pr introduces the correct settings.php with documentation on the new features and adds the following code to `settings.ddev.php`

```
// This will prevent Drupal from setting read-only permissions on sites/default.
$conf['skip_permissions_hardening'] = TRUE;

// This will ensure the site can only be accessed through the intended host
// names. Additional host patterns can be added for custom configurations.
$conf['trusted_host_patterns'] = ['.*'];
```

## Manual Testing Instructions
Installing Drupal 7 with this configuration should eliminate 
