### PR TITLE
build: bump images to v1.24.2 for release

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -56,6 +56,9 @@ ARG XDEBUG_MODE=off
 ### See https://github.com/ddev/ddev/issues/6159
 RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
+### Bump the Xdebug version to 3.4.1 because of https://bugs.xdebug.org/view.php?id=2307
+RUN /usr/local/bin/build_php_extension.sh "php8.3" "xdebug" "3.4.1" "/usr/lib/php/20230831/xdebug.so"
+RUN /usr/local/bin/build_php_extension.sh "php8.4" "xdebug" "3.4.1" "/usr/lib/php/20240924/xdebug.so"
 #END ddev-php-extension-build
 
 ### ---------------------------ddev-php-base--------------------------------------
@@ -117,9 +120,11 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/ru
 ### The dates from /usr/lib/php/YYYYMMDD/ represent PHP API versions https://unix.stackexchange.com/a/591771
 SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]
 ARG XDEBUG_MODE=off
-RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug
+RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug php8.3-xdebug php8.4-xdebug
 COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
 COPY --from=ddev-php-extension-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
+COPY --from=ddev-php-extension-build /usr/lib/php/20230831/xdebug.so /usr/lib/php/20230831/xdebug.so
+COPY --from=ddev-php-extension-build /usr/lib/php/20240924/xdebug.so /usr/lib/php/20240924/xdebug.so
 #END ddev-php-extension-build
 RUN phpdismod xhprof xdebug
 RUN apt-get -qq autoremove -y

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:v1.24.1 AS ddev-webserver-base
+FROM ddev/ddev-php-base:v1.24.2 AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,21 +11,21 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250115_ddev_in_container" // Note that this can be overridden by make
+var WebTag = "v1.24.2" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20250109_rfay_mysql_db_user"
+var BaseDBTag = "v1.24.2"
 
-const TraefikRouterImage = "ddev/ddev-traefik-router:v1.24.1"
+const TraefikRouterImage = "ddev/ddev-traefik-router:v1.24.2"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "20241223_stasadev_build_warn"
+var SSHAuthTag = "v1.24.2"
 
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"


### PR DESCRIPTION
## The Issue

It's time for v1.24.2 release.

## How This PR Solves The Issue

Bumps Docker images.

Bumps Xdebug to 3.4.1 for PHP 8.3 and 8.4 because of https://bugs.xdebug.org/view.php?id=2307

## Manual Testing Instructions

```
$ ddev start

$ ddev xdebug
Enabled xdebug

$ ddev exec php8.3 -v
PHP 8.3.16 (cli) (built: Jan 19 2025 13:29:20) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.3.16, Copyright (c) Zend Technologies
    with Zend OPcache v8.3.16, Copyright (c), by Zend Technologies
    with Xdebug v3.4.1, Copyright (c) 2002-2025, by Derick Rethans

$ ddev exec php8.4 -v
PHP 8.4.3 (cli) (built: Jan 19 2025 18:22:53) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.4.3, Copyright (c) Zend Technologies
    with Zend OPcache v8.4.3, Copyright (c), by Zend Technologies
    with Xdebug v3.4.1, Copyright (c) 2002-2025, by Derick Rethans
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
