### PR TITLE
test: prepare for magento2 quickstarts by providing composer secrets [skip ci]

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -43,6 +43,15 @@ jobs:
       - name: Install Docker and deps (Linux)
         run: ./.github/workflows/linux-setup.sh
 
+      - name: Load 1password secret(s) magento2 etc
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.TESTS_SERVICE_ACCOUNT_TOKEN }}"
+          MAGENTO2_PUBLIC_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/public_access_key"
+          MAGENTO2_PRIVATE_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/private_access_key"
+
       - name: Setup tmate session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
         uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION

## The Issue

We'll be preparing more quickstart automated tests (thanks @rpkoller )

The Magento 2 tests require a composer secret set.

## How This PR Solves The Issue

Provide the necessary secrets in that test

## Manual Testing Instructions

- [x] Manually run the test workflow using tmate and verify that the access keys are in the environment.

