### PR TITLE
fix: don't panic when running project in not allowed location, fixes #6925

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -75,10 +75,8 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 		app.AppRoot = appRoot
 	}
 
-	if RunValidateConfig {
-		if err := HasAllowedLocation(app); err != nil {
-			return app, err
-		}
+	if err := HasAllowedLocation(app); err != nil {
+		return app, err
 	}
 
 	if _, err := os.Stat(app.AppRoot); err != nil {
@@ -1385,6 +1383,10 @@ func WriteImageDockerfile(fullpath string, contents []byte) error {
 
 // HasAllowedLocation returns an error if the project location is not recommended
 func HasAllowedLocation(app *DdevApp) error {
+	// Do not run this check if we want to delete the project.
+	if !RunValidateConfig {
+		return nil
+	}
 	homeDir, _ := os.UserHomeDir()
 	if app.AppRoot == homeDir || app.AppRoot == filepath.Dir(globalconfig.GetGlobalDdevDir()) {
 		return fmt.Errorf("a project is not allowed in your home directory (%v)", app.AppRoot)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1417,7 +1417,7 @@ func HasAllowedLocation(app *DdevApp) error {
 		// Do not allow 'ddev config' in any parent directory of any project
 		rel, err = filepath.Rel(app.AppRoot, project.AppRoot)
 		if err == nil && !strings.HasPrefix(rel, "..") {
-			return fmt.Errorf("a project is not allowed in %s because another project exists in the subdirectory %s\nUnlist this project with 'cd \"%s\" && ddev stop --unlist'\nOr run 'ddev stop --unlist' for all projects in the subdirectories of this project directory", app.AppRoot, project.AppRoot, app.AppRoot)
+			return fmt.Errorf("a project is not allowed in %s because another project exists in the subdirectory %s\nUnlist this project (if it exists) with 'cd \"%s\" && ddev stop --unlist'\nOr run 'ddev stop --unlist' for all projects in the subdirectories of this project directory", app.AppRoot, project.AppRoot, app.AppRoot)
 		}
 	}
 	return nil

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1398,7 +1398,7 @@ func HasAllowedLocation(app *DdevApp) error {
 		return fmt.Errorf("a project is not allowed in your global config directory (%v)", app.AppRoot)
 	}
 	if fileutil.FileExists(filepath.Join(app.AppRoot, "cmd/ddev/main.go")) && fileutil.FileExists(filepath.Join(app.AppRoot, "cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go")) {
-		return fmt.Errorf("a project is not allowed in the directory used for DDEV development (%v)", app.AppRoot)
+		return fmt.Errorf("a project cannot be created in the DDEV source code (%v)", app.AppRoot)
 	}
 	projectMap := globalconfig.GetGlobalProjectList()
 	projectList := make([]*globalconfig.ProjectInfo, 0, len(projectMap))

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1406,11 +1406,13 @@ func HasAllowedLocation(app *DdevApp) error {
 		projectList = append(projectList, project)
 	}
 	// Sort the projects by AppRoot in reverse alphabetical order,
-	// so deeper-level projects (longer paths) take precedence
+	// this ensures that subdirectory projects are checked first.
 	sort.Slice(projectList, func(i, j int) bool {
 		return projectList[i].AppRoot > projectList[j].AppRoot
 	})
 	for _, project := range projectList {
+		// Without sorting, a parent directory might be matched first,
+		// causing the function to return without checking the project in the subdirectory.
 		if app.AppRoot == project.AppRoot {
 			return nil
 		}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -87,26 +87,26 @@ func TestConfigHasAllowedLocation(t *testing.T) {
 	tmpDir, _ := os.UserHomeDir()
 	_, err := ddevapp.NewApp(tmpDir, false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", tmpDir)
-	assert.Contains(err.Error(), "is not allowed in your home directory")
+	require.Contains(t, err.Error(), "is not allowed in your home directory")
 
 	// Make sure we're not allowed to config in the parent directory of the home directory.
 	tmpDir = filepath.Dir(tmpDir)
 	_, err = ddevapp.NewApp(tmpDir, false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", tmpDir)
-	assert.Contains(err.Error(), "is not allowed in the parent directory of your home directory")
+	require.Contains(t, err.Error(), "is not allowed in the parent directory of your home directory")
 
 	// Make sure we're not allowed to config in global config directory.
 	tmpDir = globalconfig.GetGlobalDdevDir()
 	_, err = ddevapp.NewApp(tmpDir, false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", tmpDir)
-	assert.Contains(err.Error(), "is not allowed in your global config directory")
+	require.Contains(t, err.Error(), "is not allowed in your global config directory")
 
 	// Make sure we're not allowed to config in the root of ddev/ddev project itself.
 	// origDir is "pkg/ddevapp", we need to go two levels up.
 	tmpDir = filepath.Dir(filepath.Dir(origDir))
 	_, err = ddevapp.NewApp(tmpDir, false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", tmpDir)
-	assert.Contains(err.Error(), "is not allowed in the directory used for DDEV development")
+	require.Contains(t, err.Error(), "cannot be created in the DDEV source code")
 
 	_ = os.Chdir(origDir)
 
@@ -144,15 +144,15 @@ func TestConfigHasAllowedLocation(t *testing.T) {
 	// Checking the project parent directory here
 	_, err = ddevapp.NewApp(filepath.Dir(tmpDir), false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", filepath.Dir(tmpDir))
-	assert.Contains(err.Error(), "is not allowed")
-	assert.Contains(err.Error(), "because another project exists in the subdirectory")
+	require.Contains(t, err.Error(), "is not allowed")
+	require.Contains(t, err.Error(), "because another project exists in the subdirectory")
 
 	// Make sure we're not allowed to config in any project parent directory
 	// Checking parent directory of the project parent directory here
 	_, err = ddevapp.NewApp(filepath.Dir(filepath.Dir(tmpDir)), false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", filepath.Dir(filepath.Dir(tmpDir)))
-	assert.Contains(err.Error(), "is not allowed")
-	assert.Contains(err.Error(), "because another project exists in the subdirectory")
+	require.Contains(t, err.Error(), "is not allowed")
+	require.Contains(t, err.Error(), "because another project exists in the subdirectory")
 }
 
 // TestAllowedAppType tests the IsValidAppType function.

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -87,26 +87,26 @@ func TestConfigHasAllowedLocation(t *testing.T) {
 	tmpDir, _ := os.UserHomeDir()
 	_, err := ddevapp.NewApp(tmpDir, false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", tmpDir)
-	assert.Contains(err.Error(), "'ddev config' is not allowed in your home directory")
+	assert.Contains(err.Error(), "is not allowed in your home directory")
 
 	// Make sure we're not allowed to config in the parent directory of the home directory.
 	tmpDir = filepath.Dir(tmpDir)
 	_, err = ddevapp.NewApp(tmpDir, false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", tmpDir)
-	assert.Contains(err.Error(), "'ddev config' is not allowed in the parent directory of your home directory")
+	assert.Contains(err.Error(), "is not allowed in the parent directory of your home directory")
 
 	// Make sure we're not allowed to config in global config directory.
 	tmpDir = globalconfig.GetGlobalDdevDir()
 	_, err = ddevapp.NewApp(tmpDir, false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", tmpDir)
-	assert.Contains(err.Error(), "'ddev config' is not allowed in your global config directory")
+	assert.Contains(err.Error(), "is not allowed in your global config directory")
 
 	// Make sure we're not allowed to config in the root of ddev/ddev project itself.
 	// origDir is "pkg/ddevapp", we need to go two levels up.
 	tmpDir = filepath.Dir(filepath.Dir(origDir))
 	_, err = ddevapp.NewApp(tmpDir, false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", tmpDir)
-	assert.Contains(err.Error(), "'ddev config' is not allowed in the directory used for DDEV development")
+	assert.Contains(err.Error(), "is not allowed in the directory used for DDEV development")
 
 	_ = os.Chdir(origDir)
 
@@ -144,15 +144,15 @@ func TestConfigHasAllowedLocation(t *testing.T) {
 	// Checking the project parent directory here
 	_, err = ddevapp.NewApp(filepath.Dir(tmpDir), false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", filepath.Dir(tmpDir))
-	assert.Contains(err.Error(), "'ddev config' is not allowed")
-	assert.Contains(err.Error(), "because a project exists in the subdirectory")
+	assert.Contains(err.Error(), "is not allowed")
+	assert.Contains(err.Error(), "because another project exists in the subdirectory")
 
 	// Make sure we're not allowed to config in any project parent directory
 	// Checking parent directory of the project parent directory here
 	_, err = ddevapp.NewApp(filepath.Dir(filepath.Dir(tmpDir)), false)
 	require.Error(t, err, "'ddev config' must not be allowed in %s", filepath.Dir(filepath.Dir(tmpDir)))
-	assert.Contains(err.Error(), "'ddev config' is not allowed")
-	assert.Contains(err.Error(), "because a project exists in the subdirectory")
+	assert.Contains(err.Error(), "is not allowed")
+	assert.Contains(err.Error(), "because another project exists in the subdirectory")
 }
 
 // TestAllowedAppType tests the IsValidAppType function.


### PR DESCRIPTION
## The Issue

- #6925

The problem is that when you upgrade from DDEV v1.24.1 to v1.24.2 and have a *running* project in a not allowed place, you will see panic:

```
$ ddev poweroff
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xa67cf8]

goroutine 1 [running]:
github.com/ddev/ddev/pkg/ddevapp.GetActiveProjects()
        /home/runner/work/ddev/ddev/pkg/ddevapp/utils.go:51 +0x238
...
```

---

The change was made in:

- #6852

Previously, the code was:

https://github.com/ddev/ddev/blob/4936e6958fec52fff844df64f2650db6148348d3/pkg/ddevapp/config.go#L79C1-L81C3

```go
if appRoot == filepath.Dir(globalconfig.GetGlobalDdevDir()) || app.AppRoot == homeDir {
	return nil, fmt.Errorf("ddev config is not useful in your home directory (%s)", homeDir)
}
```

and now it is:

https://github.com/ddev/ddev/blob/8cded44666ff3dab8b2132feac34aa25795030af/pkg/ddevapp/config.go#L78-L80

As you can see, it used to return `nil`, so theoretically there was panic all this time, I just added a new condition that triggered it.

## How This PR Solves The Issue

Fixes panic by returning `app` instead of nothing.

## Manual Testing Instructions

To reproduce:

Using DDEV v1.24.1, create a project at not allowed location, and start it:

```
mkdir -p ~/workspace && cd ~/workspace
mkdir good && cd good && ddev config --auto
cd ~/workspace
ddev config --auto
ddev start
```

Upgrade DDEV to v1.24.2 and run `ddev list`, see panic.

Then run `ddev list` using this PR (without doing `ddev poweroff`) the forbidden project will show up in the list (without a warning, because the project is in the *running* state).

Run `ddev poweroff`, and see the warning in `ddev list`:

```
$ ddev list
Something went wrong with /home/stas/workspace: project is not allowed in /home/stas/workspace because another project exists in the subdirectory /home/stas/workspace/good
Unlist this project (if it exists) with 'cd "/home/stas/workspace" && ddev stop --unlist'
Or run 'ddev stop --unlist' for all projects in the subdirectories of this project directory
...
```

Run the recommended command:
```
Unlist this project (if it exists) with 'cd "/home/stas/workspace" && ddev stop --unlist'
```

`ddev list` should not show any warnings.

And `ddev start` won't be possible:
```
$ ddev start
Failed to start project(s): a project is not allowed in /home/stas/workspace because another project exists in the subdirectory /home/stas/workspace/good
Unlist this project (if it exists) with 'cd "/home/stas/workspace" && ddev stop --unlist'
Or run 'ddev stop --unlist' for all projects in the subdirectories of this project directory
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
