### PR TITLE
fix: handle args with spaces in `ddev exec`, don't panic about invalid syntax in `exec_raw`, fixes #5865

### DIFF
--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -49,10 +49,11 @@ ddev exec --raw -- ls -lR`,
 			Tty:     true,
 		}
 
+		// If they've chosen raw, use the actual passed values.
 		// If there are multiple arguments, treat them as a raw command.
 		// This avoids splitting quoted strings with spaces into separate arguments.
 		// Also, retrieve and preserve the current $PATH to ensure the environment is consistent.
-		if len(args) > 1 {
+		if cmd.Flag("raw").Changed || len(args) > 1 {
 			var env []string
 			path, _, err := app.Exec(&ddevapp.ExecOpts{
 				Service: serviceType,
@@ -78,7 +79,6 @@ func init() {
 	DdevExecCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Defines the service to connect to. [e.g. web, db]")
 	DdevExecCmd.Flags().StringVarP(&execDirArg, "dir", "d", "", "Defines the execution directory within the container")
 	DdevExecCmd.Flags().Bool("raw", true, "Use raw exec (do not interpret with Bash inside container)")
-	_ = DdevExecCmd.Flags().MarkHidden("raw")
 	// This requires flags for exec to be specified prior to any arguments, allowing for
 	// flags to be ignored by cobra for commands that are to be executed in a container.
 	DdevExecCmd.Flags().SetInterspersed(false)

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -99,13 +99,10 @@ func TestCmdExec(t *testing.T) {
 
 	assert.FileExists(filepath.Join(site.Dir, "TestCmdExec-touch-all-in-one.txt"))
 
-	_, err = exec.RunHostCommand(DdevBin, "exec", "true", "&&", "touch", "/var/www/html/TestCmdExec-touch-separate-args.txt")
+	// Complex commands with spaces should also work, even without the --raw flag
+	out, err = exec.RunHostCommand(DdevBin, "exec", "bash", "-c", "for i; do echo $i; done", "_", "string with spaces")
 	assert.NoError(err)
-
-	err = app.MutagenSyncFlush()
-	assert.NoError(err)
-
-	assert.FileExists(filepath.Join(site.Dir, "TestCmdExec-touch-separate-args.txt"))
+	assert.Equal("string with spaces", strings.TrimSpace(out))
 
 	bashPath := util.FindBashPath()
 	// Make sure we can pipe things into ddev exec and have them work in stdin inside container

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -99,6 +99,16 @@ func TestCmdExec(t *testing.T) {
 
 	assert.FileExists(filepath.Join(site.Dir, "TestCmdExec-touch-all-in-one.txt"))
 
+	// Checking how '&&' works in Bash
+	bash := util.FindBashPath()
+	out, err = exec.RunHostCommand(bash, "-c", fmt.Sprintf("%s exec 'true && pwd'", DdevBin))
+	assert.NoError(err)
+	assert.Equal("/var/www/html", strings.TrimSpace(out))
+
+	out, err = exec.RunHostCommand(bash, "-c", fmt.Sprintf("%s exec true && pwd", DdevBin))
+	assert.NoError(err)
+	assert.NotEqual("/var/www/html", strings.TrimSpace(out))
+
 	// Complex commands with spaces should also work, even without the --raw flag
 	out, err = exec.RunHostCommand(DdevBin, "exec", "bash", "-c", "for i; do echo $i; done", "_", "string with spaces")
 	assert.NoError(err)

--- a/pkg/ddevapp/task.go
+++ b/pkg/ddevapp/task.go
@@ -132,9 +132,9 @@ func NewTask(app *DdevApp, ytask YAMLTask) Task {
 
 		// Handle the new-style `composer: [install]`
 		if v, ok := ytask["exec_raw"]; ok {
-			raw, err := util.InterfaceSliceToStringSlice(v.([]interface{}))
+			raw, err := util.InterfaceSliceToStringSlice(v)
 			if err != nil {
-				util.Warning("Invalid composer/exec_raw value, not executing it: %v", e)
+				util.Warning("Invalid composer/exec_raw value, not executing it: %v", err)
 				return nil
 			}
 
@@ -152,9 +152,9 @@ func NewTask(app *DdevApp, ytask YAMLTask) Task {
 		}
 
 		if v, ok := ytask["exec_raw"]; ok {
-			raw, err := util.InterfaceSliceToStringSlice(v.([]interface{}))
+			raw, err := util.InterfaceSliceToStringSlice(v)
 			if err != nil {
-				util.Warning("Invalid exec/exec_raw value, not executing it: %v", e)
+				util.Warning("Invalid exec/exec_raw value, not executing it: %v", err)
 				return nil
 			}
 
@@ -164,7 +164,7 @@ func NewTask(app *DdevApp, ytask YAMLTask) Task {
 			}
 			return t
 		}
-		util.Warning("Invalid exec_raw value, not executing it: %v", e)
+		util.Warning("Invalid exec/exec_raw value, not executing it: %v", e)
 
 	} else if e, ok = ytask["exec"]; ok {
 		if v, ok := e.(string); ok {

--- a/pkg/ddevapp/task.go
+++ b/pkg/ddevapp/task.go
@@ -117,15 +117,15 @@ func (c ComposerTask) GetDescription() string {
 // we need using the yaml description of the task.
 // Returns a task (of various types) or nil
 func NewTask(app *DdevApp, ytask YAMLTask) Task {
-	if e, ok := ytask["exec-host"]; ok {
-		if v, ok := e.(string); ok {
+	if value, ok := ytask["exec-host"]; ok {
+		if v, ok := value.(string); ok {
 			t := ExecHostTask{app: app, exec: v}
 			return t
 		}
-		util.Warning("Invalid exec-host value, not executing it: %v", e)
-	} else if e, ok = ytask["composer"]; ok {
+		util.Warning("Invalid exec-host value, not executing it: %v", value)
+	} else if value, ok = ytask["composer"]; ok {
 		// Handle the old-style `composer: install`
-		if v, ok := e.(string); ok {
+		if v, ok := value.(string); ok {
 			t := ComposerTask{app: app, execRaw: strings.Split(v, " ")}
 			return t
 		}
@@ -141,9 +141,9 @@ func NewTask(app *DdevApp, ytask YAMLTask) Task {
 			t := ComposerTask{app: app, execRaw: raw}
 			return t
 		}
-		util.Warning("Invalid Composer value, not executing it: %v", e)
-	} else if e, ok = ytask["exec"]; ok {
-		if v, ok := e.(string); ok {
+		util.Warning("Invalid Composer value, not executing it: %v", value)
+	} else if value, ok = ytask["exec"]; ok {
+		if v, ok := value.(string); ok {
 			t := ExecTask{app: app, exec: v}
 			if t.service, ok = ytask["service"].(string); !ok {
 				t.service = nodeps.WebContainer
@@ -164,7 +164,7 @@ func NewTask(app *DdevApp, ytask YAMLTask) Task {
 			}
 			return t
 		}
-		util.Warning("Invalid exec/exec_raw value, not executing it: %v", e)
+		util.Warning("Invalid exec/exec_raw value, not executing it: %v", value)
 	}
 	return nil
 }

--- a/pkg/ddevapp/task.go
+++ b/pkg/ddevapp/task.go
@@ -165,16 +165,6 @@ func NewTask(app *DdevApp, ytask YAMLTask) Task {
 			return t
 		}
 		util.Warning("Invalid exec/exec_raw value, not executing it: %v", e)
-
-	} else if e, ok = ytask["exec"]; ok {
-		if v, ok := e.(string); ok {
-			t := ExecTask{app: app, exec: v}
-			if t.service, ok = ytask["service"].(string); !ok {
-				t.service = nodeps.WebContainer
-			}
-			return t
-		}
-		util.Warning("Invalid exec value, not executing it: %v", e)
 	}
 	return nil
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -324,16 +324,21 @@ func Killall(processName string) {
 }
 
 // InterfaceSliceToStringSlice converts a slice of interfaces to a slice of strings
-func InterfaceSliceToStringSlice(v []interface{}) ([]string, error) {
-	raw := make([]string, len(v))
-	for i := range v {
-		if s, ok := v[i].(string); ok {
-			raw[i] = s
-		} else {
-			return nil, fmt.Errorf("%v is not a string", v[i])
+func InterfaceSliceToStringSlice(input interface{}) ([]string, error) {
+	switch v := input.(type) {
+	case []interface{}:
+		raw := make([]string, len(v))
+		for i := range v {
+			if s, ok := v[i].(string); ok {
+				raw[i] = s
+			} else {
+				return nil, fmt.Errorf("%v is not a string", v[i])
+			}
 		}
+		return raw, nil
+	default:
+		return nil, fmt.Errorf("unexpected type: %T", input)
 	}
-	return raw, nil
 }
 
 // SliceToUniqueSlice processes a slice of string to make sure there are no duplicates


### PR DESCRIPTION
## The Issue

- #5865
- #3603

## How This PR Solves The Issue

Uses the same technique I tried in:

- #6627

But this time I fixed the command with pipes `ddev exec "set | grep IS_DDEV_PROJECT"`

TODO:

- ~~I marked the `--raw` flag hidden. Mark it deprecated, remove it from the docs?~~
- ~~Remove `--raw` from tests~~
- ~~Check the hooks, maybe we can get rid of `exec_raw`~~

Edit: I decided not to remove the `--raw` flag, this PR simply runs `ddev exec` with *multiple* (2+) arguments, as it could be run using `ddev exec --raw`.

---

And it fixes panic for the wrong syntax on `ddev start` (this is indirectly related to `exec`, so I decided to fix it here):

```yaml
hooks:
    post-start:
        - exec:
          exec_raw: ls -la # the command should look like this [ls, la]
```

```
$ ddev start
...
panic: interface conversion: interface {} is string, not []interface {}
...
```

## Manual Testing Instructions

Using DDEV v1.24.2:
```bash
$ echo 'for i; do echo $i; done' > issue.sh

$ ddev exec bash issue.sh "string with spaces"
string
with
spaces

$ ddev exec bash issue.sh "string with spaces" --test="a b c"
string
with
spaces
--test=a
b
c

$ ddev exec 'bash issue.sh "string with spaces"'
string with spaces

$ ddev exec "set | grep IS_DDEV_PROJECT"
BASH_EXECUTION_STRING='set -eu && ( set | grep IS_DDEV_PROJECT)'
IS_DDEV_PROJECT=true

$ echo '<?php var_dump($_SERVER["argv"]);' > args.php

$ ddev exec php args.php --option="argument with string"
array(4) {
  [0]=>
  string(8) "args.php"
  [1]=>
  string(17) "--option=argument"
  [2]=>
  string(4) "with"
  [3]=>
  string(6) "string"
}
```

Using this PR:
```bash
$ echo 'for i; do echo $i; done' > issue.sh

$ ddev exec bash issue.sh "string with spaces"
string with spaces

$ ddev exec bash issue.sh "string with spaces" --test="a b c"
string with spaces
--test=a b c

$ ddev exec 'bash issue.sh "string with spaces"'
string with spaces

$ ddev exec "set | grep IS_DDEV_PROJECT"
BASH_EXECUTION_STRING='set -eu && ( set | grep IS_DDEV_PROJECT)'
IS_DDEV_PROJECT=true

$ echo '<?php var_dump($_SERVER["argv"]);' > args.php

$ ddev exec php args.php --option="argument with string"
array(2) {
  [0]=>
  string(8) "args.php"
  [1]=>
  string(29) "--option=argument with string"
}
```

Additionally check `ddev start` with this hook (it shouldn't panic):

```yaml
hooks:
    post-start:
        - exec:
          exec_raw: ls -la # the command should look like this [ls, la]
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
