### PR TITLE
test: make lima/colima tests work after lima 1.0.4

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -44,6 +44,10 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
   echo "starting docker context situation:"
   docker context ls
 
+  # For Lima and Colima, as of Lima 1.0.4, having orbstack running
+  # makes lima fail, see https://github.com/lima-vm/lima/issues/3145#issuecomment-2613728408
+  orb stop || true
+
   # Now start the docker provider we want
   case ${DOCKER_TYPE:=none} in
     "colima")

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -46,7 +46,8 @@ if [ "${OSTYPE%%[0-9]*}" = "darwin" ]; then
 
   # For Lima and Colima, as of Lima 1.0.4, having orbstack running
   # makes lima fail, see https://github.com/lima-vm/lima/issues/3145#issuecomment-2613728408
-  orb stop || true
+  command -v orb 2>/dev/null && echo "Stopping orbstack" && (nohup orb stop &)
+  sleep 3 # Since we backgrounded orb stop, make sure it completes
 
   # Now start the docker provider we want
   case ${DOCKER_TYPE:=none} in


### PR DESCRIPTION

## The Issue

- https://github.com/lima-vm/lima/issues/3145#issuecomment-2613728408

All our lima and colima tests are failing after Lima 1.0.4. This seems to be because orbstack was still running and it tries to take some action on the docker.sock, even though it's not the correct docker.sock.

## How This PR Solves The Issue

Stop orbstack before running anything else

