### PR TITLE
fix: trim single quotes, double quotes, and spaces from filepath input, fixes #6938

### DIFF
--- a/cmd/ddev/cmd/import-files.go
+++ b/cmd/ddev/cmd/import-files.go
@@ -133,7 +133,7 @@ func promptForFileSource(val *string) {
 	// prompting until something is entered
 	for {
 		fmt.Print("Path to file(s): ")
-		*val = util.GetInput("")
+		*val = util.GetQuotedInput("")
 		if len(*val) > 0 {
 			break
 		}
@@ -150,7 +150,7 @@ func promptForExtractPath(val *string) {
 	// An empty string is acceptable in this case, indicating
 	// no particular extraction path
 	fmt.Print("Archive extraction path: ")
-	*val = util.GetInput("")
+	*val = util.GetQuotedInput("")
 }
 
 func init() {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -736,7 +736,7 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 		output.UserOut.Println("Provide the path to the database you want to import.")
 		fmt.Print("Path to file: ")
 
-		dumpFile = util.GetInput("")
+		dumpFile = util.GetQuotedInput("")
 	}
 
 	if dumpFile != "" {
@@ -746,7 +746,7 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 				output.UserOut.Println("You provided an archive. Do you want to extract from a specific path in your archive? You may leave this blank if you wish to use the full archive contents")
 				fmt.Print("Archive extraction path:")
 
-				extractPath = util.GetInput("")
+				extractPath = util.GetQuotedInput("")
 			} else {
 				return fmt.Errorf("unable to validate import asset %s: %s", dumpFile, err)
 			}

--- a/pkg/util/prompt.go
+++ b/pkg/util/prompt.go
@@ -18,14 +18,26 @@ func SetInputScanner(scanner *bufio.Scanner) {
 func GetInput(defaultValue string) string {
 	inputScanner.Scan()
 	input := inputScanner.Text()
-	value := strings.TrimSpace(input)
 
-	// Check for surrounding single or double quotes and remove them.
-	if len(value) >= 2 && (value[0] == '\'' && value[len(value)-1] == '\'' || value[0] == '"' && value[len(value)-1] == '"') {
-		value = value[1 : len(value)-1]
+	// If the value from the input buffer is blank, then use the default instead.
+	value := strings.TrimSpace(input)
+	if value == "" {
+		value = defaultValue
+	}
+
+	return value
+}
+
+// GetQuotedInput reads input from an input buffer in single or double quotes and returns the result as a string.
+func GetQuotedInput(defaultValue string) string {
+	input := GetInput(defaultValue)
+
+	if len(input) >= 2 && (input[0] == '\'' && input[len(input)-1] == '\'' || input[0] == '"' && input[len(input)-1] == '"') {
+		input = input[1 : len(input)-1]
 	}
 
 	// If the value from the input buffer is blank, then use the default instead.
+	value := strings.TrimSpace(input)
 	if value == "" {
 		value = defaultValue
 	}

--- a/pkg/util/prompt.go
+++ b/pkg/util/prompt.go
@@ -18,9 +18,14 @@ func SetInputScanner(scanner *bufio.Scanner) {
 func GetInput(defaultValue string) string {
 	inputScanner.Scan()
 	input := inputScanner.Text()
+	value := strings.TrimSpace(input)
+
+	// Check for surrounding single or double quotes and remove them.
+	if len(value) >= 2 && (value[0] == '\'' && value[len(value)-1] == '\'' || value[0] == '"' && value[len(value)-1] == '"') {
+		value = value[1 : len(value)-1]
+	}
 
 	// If the value from the input buffer is blank, then use the default instead.
-	value := strings.TrimSpace(input)
 	if value == "" {
 		value = defaultValue
 	}

--- a/pkg/util/prompt.go
+++ b/pkg/util/prompt.go
@@ -32,13 +32,8 @@ func GetInput(defaultValue string) string {
 func GetQuotedInput(defaultValue string) string {
 	input := GetInput(defaultValue)
 
-	// Remove surrounding quotes, but only the closest ones.
-	if len(input) >= 2 && (input[0] == '\'' && input[len(input)-1] == '\'' || input[0] == '"' && input[len(input)-1] == '"') {
-		input = input[1 : len(input)-1]
-	}
-
 	// If the value from the input buffer is blank, then use the default instead.
-	value := strings.TrimSpace(input)
+	value := strings.Trim(input, `"' `)
 	if value == "" {
 		value = defaultValue
 	}

--- a/pkg/util/prompt.go
+++ b/pkg/util/prompt.go
@@ -32,6 +32,7 @@ func GetInput(defaultValue string) string {
 func GetQuotedInput(defaultValue string) string {
 	input := GetInput(defaultValue)
 
+	// Remove surrounding quotes, but only the closest ones.
 	if len(input) >= 2 && (input[0] == '\'' && input[len(input)-1] == '\'' || input[0] == '"' && input[len(input)-1] == '"') {
 		input = input[1 : len(input)-1]
 	}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -43,6 +43,42 @@ func TestGetInput(t *testing.T) {
 	assert.EqualValues(input, result)
 	_ = restoreOutput()
 
+	// GetInput should remove single quotes from start and end
+	input = `'Input"I'WantToSee'`
+	restoreOutput = util.CaptureUserOut()
+	scanner = bufio.NewScanner(strings.NewReader(input))
+	util.SetInputScanner(scanner)
+	result = util.GetInput("nodefault")
+	assert.EqualValues(`Input"I'WantToSee`, result)
+	_ = restoreOutput()
+
+	// GetInput should remove double quotes from start and end
+	input = `"'Input"I'WantToSee"`
+	restoreOutput = util.CaptureUserOut()
+	scanner = bufio.NewScanner(strings.NewReader(input))
+	util.SetInputScanner(scanner)
+	result = util.GetInput("nodefault")
+	assert.EqualValues(`'Input"I'WantToSee`, result)
+	_ = restoreOutput()
+
+	// GetInput should only remove the nearest quotes (checking single quotes)
+	input = `'"InputIWantToSee"'`
+	restoreOutput = util.CaptureUserOut()
+	scanner = bufio.NewScanner(strings.NewReader(input))
+	util.SetInputScanner(scanner)
+	result = util.GetInput("nodefault")
+	assert.EqualValues(`"InputIWantToSee"`, result)
+	_ = restoreOutput()
+
+	// GetInput should only remove the nearest quotes (checking double quotes)
+	input = `"'InputIWantToSee'"`
+	restoreOutput = util.CaptureUserOut()
+	scanner = bufio.NewScanner(strings.NewReader(input))
+	util.SetInputScanner(scanner)
+	result = util.GetInput("nodefault")
+	assert.EqualValues("'InputIWantToSee'", result)
+	_ = restoreOutput()
+
 	// Try Prompt() with a default value which is overridden
 	input = "InputIWantToSee"
 	restoreOutput = util.CaptureUserOut()

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -73,10 +73,8 @@ func TestGetQuotedInput(t *testing.T) {
 		{"Remove single quotes", `'/path/to/file'`, `/path/to/file`},
 		{"Remove double quotes", `"/path/to/file"`, `/path/to/file`},
 		{"Remove spaces", `  /path/to/file  `, `/path/to/file`},
-		{"Remove spaces in single quotes", ` '  /path/to/file ' `, `/path/to/file`},
-		{"Remove spaces in double quotes", ` "  /path/to/file " `, `/path/to/file`},
-		{"Remove only closest quotes (single)", `'"/path/to/file"'`, `"/path/to/file"`},
-		{"Remove only closest quotes (double)", `"'/path/to/file'"`, `'/path/to/file'`},
+		{"Remove all quotes and spaces", `  ''' """ /path/to/file '''  """ `, `/path/to/file`},
+		{"Quotes and spaces are not removed from the middle", `/path/'" to/file`, `/path/'" to/file`},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -43,42 +43,6 @@ func TestGetInput(t *testing.T) {
 	assert.EqualValues(input, result)
 	_ = restoreOutput()
 
-	// GetInput should remove single quotes from start and end
-	input = `'Input"I'WantToSee'`
-	restoreOutput = util.CaptureUserOut()
-	scanner = bufio.NewScanner(strings.NewReader(input))
-	util.SetInputScanner(scanner)
-	result = util.GetInput("nodefault")
-	assert.EqualValues(`Input"I'WantToSee`, result)
-	_ = restoreOutput()
-
-	// GetInput should remove double quotes from start and end
-	input = `"'Input"I'WantToSee"`
-	restoreOutput = util.CaptureUserOut()
-	scanner = bufio.NewScanner(strings.NewReader(input))
-	util.SetInputScanner(scanner)
-	result = util.GetInput("nodefault")
-	assert.EqualValues(`'Input"I'WantToSee`, result)
-	_ = restoreOutput()
-
-	// GetInput should only remove the nearest quotes (checking single quotes)
-	input = `'"InputIWantToSee"'`
-	restoreOutput = util.CaptureUserOut()
-	scanner = bufio.NewScanner(strings.NewReader(input))
-	util.SetInputScanner(scanner)
-	result = util.GetInput("nodefault")
-	assert.EqualValues(`"InputIWantToSee"`, result)
-	_ = restoreOutput()
-
-	// GetInput should only remove the nearest quotes (checking double quotes)
-	input = `"'InputIWantToSee'"`
-	restoreOutput = util.CaptureUserOut()
-	scanner = bufio.NewScanner(strings.NewReader(input))
-	util.SetInputScanner(scanner)
-	result = util.GetInput("nodefault")
-	assert.EqualValues("'InputIWantToSee'", result)
-	_ = restoreOutput()
-
 	// Try Prompt() with a default value which is overridden
 	input = "InputIWantToSee"
 	restoreOutput = util.CaptureUserOut()
@@ -97,6 +61,34 @@ func TestGetInput(t *testing.T) {
 	assert.EqualValues("expected default", result)
 	_ = restoreOutput()
 	println() // Just lets goland find the PASS or FAIL
+}
+
+// TestGetQuotedInput tests GetQuotedInput
+func TestGetQuotedInput(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       string
+		expected    string
+	}{
+		{"Remove single quotes", `'/path/to/file'`, `/path/to/file`},
+		{"Remove double quotes", `"/path/to/file"`, `/path/to/file`},
+		{"Remove spaces", `  /path/to/file  `, `/path/to/file`},
+		{"Remove spaces in single quotes", ` '  /path/to/file ' `, `/path/to/file`},
+		{"Remove spaces in double quotes", ` "  /path/to/file " `, `/path/to/file`},
+		{"Remove only closest quotes (single)", `'"/path/to/file"'`, `"/path/to/file"`},
+		{"Remove only closest quotes (double)", `"'/path/to/file'"`, `'/path/to/file'`},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := asrt.New(t)
+			restoreOutput := util.CaptureUserOut()
+			scanner := bufio.NewScanner(strings.NewReader(tc.input))
+			util.SetInputScanner(scanner)
+			result := util.GetQuotedInput("nodefault")
+			assert.EqualValues(tc.expected, result)
+			_ = restoreOutput()
+		})
+	}
 }
 
 // TestCaptureUserOut ensures capturing of stdout works as expected.


### PR DESCRIPTION
## The Issue

- #6938

## How This PR Solves The Issue

Trims single quotes, double quotes, and spaces from user input where filepath is required.

## Manual Testing Instructions

Before
```
$ ddev import-db
Provide the path to the database you want to import. 
Path to file: 'db.sql.gz'
Error: failed to import database 'db' for php-2023: unable to validate import asset 'db.sql.gz': invalid asset: file not found
```

After:
```
$ ddev import-db
Provide the path to the database you want to import. 
Path to file: 'db.sql.gz'
1.22KiB 0:00:00 [19.2MiB/s] [================================>] 100%            
Successfully imported database 'db' for d11
```

Repeat the same with double quotes.

Before
```
$ ddev import-files
Provide the path to the source directory or archive you wish to import. 
Please note: if the destination directory exists, it will be emptied and replaced with the
import assets specified here.
Path to file(s): 'modules'
Error: failed to import files for d11: invalid asset: file not found
```

After:
```
$ ddev import-files
Provide the path to the source directory or archive you wish to import. 
Please note: if the destination directory exists, it will be emptied and replaced with the
import assets specified here.
Path to file(s): 'modules'
Successfully imported files for d11
```

Repeat the same with double quotes.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
