### PR TITLE
fix: unset JAVA_HOME to prevent mkcert hang

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2436,6 +2436,10 @@ func (app *DdevApp) DockerEnv() {
 		dbFamily = "postgres"
 	}
 
+	// JAVA_HOME is not useful to us and can make `mkcert` fail when set wrong
+	// see https://stackoverflow.com/questions/78865612/ddev-mkcert-install-fails-or-hangs-when-java-home-misconfigured
+	_ = os.Unsetenv("JAVA_HOME")
+
 	envVars := map[string]string{
 		// The compose project name can no longer contain dots; must be lower-case
 		"COMPOSE_PROJECT_NAME":           app.GetComposeProjectName(),


### PR DESCRIPTION
## The Issue

In very occasional cases, JAVA_HOME may be set incorrectly, leading to failure or hang of the `mkcert` command, which is used to create trusted certs. Examples in https://stackoverflow.com/questions/78865612/ddev-mkcert-install-fails-or-hangs-when-java-home-misconfigured

## How This PR Solves The Issue

Disables `mkcert` if `JAVA_HOME` is incorrect.
`mkcert` fails to run if `JAVA_HOME` is set, and `$JAVA_HOME/lib/security/cacerts` or `$JAVA_HOME/jre/lib/security/cacerts` is not found.

## Manual Testing Instructions

Set JAVA_HOME to something that causes failure. Try `ddev start`, it should work with this PR, and fail with v1.24.2:

```
export JAVA_HOME=/usr
ddev start
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
