### PR TITLE
fix: allow `ddev config` for existing parent projects, fixes #6937

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1418,6 +1418,10 @@ func HasAllowedLocation(app *DdevApp) error {
 		if app.AppRoot == project.AppRoot {
 			return nil
 		}
+		// If this is an existing project, allow it
+		if fileutil.FileExists(app.GetConfigPath("config.yaml")) {
+			return nil
+		}
 		// Do not allow 'ddev config' in any parent directory of any project
 		rel, err = filepath.Rel(app.AppRoot, project.AppRoot)
 		if err == nil && !strings.HasPrefix(rel, "..") {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1402,6 +1402,11 @@ func HasAllowedLocation(app *DdevApp) error {
 	if fileutil.FileExists(filepath.Join(app.AppRoot, "cmd/ddev/main.go")) && fileutil.FileExists(filepath.Join(app.AppRoot, "cmd/ddev_gen_autocomplete/ddev_gen_autocomplete.go")) {
 		return fmt.Errorf("a project cannot be created in the DDEV source code (%v)", app.AppRoot)
 	}
+	// If this is an existing project, allow it.
+	if fileutil.FileExists(app.GetConfigPath("config.yaml")) {
+		return nil
+	}
+	// Check all projects if they are located in the subdirectories of the project we are in.
 	projectMap := globalconfig.GetGlobalProjectList()
 	projectList := make([]*globalconfig.ProjectInfo, 0, len(projectMap))
 	for _, project := range projectMap {
@@ -1416,10 +1421,6 @@ func HasAllowedLocation(app *DdevApp) error {
 		// Without sorting, a parent directory might be matched first,
 		// causing the function to return without checking the project in the subdirectory.
 		if app.AppRoot == project.AppRoot {
-			return nil
-		}
-		// If this is an existing project, allow it
-		if fileutil.FileExists(app.GetConfigPath("config.yaml")) {
 			return nil
 		}
 		// Do not allow 'ddev config' in any parent directory of any project


### PR DESCRIPTION
## The Issue

- #6937

## How This PR Solves The Issue

If users have existing projects in a forbidden place, let them run `ddev config` there.

## Manual Testing Instructions

```
$ mkdir -p ~/workspace/parent/subfolder/child/anotherdir

# create project in the child dir
$ cd ~/workspace/parent/subfolder/child && ddev config --auto
Creating a new DDEV project config in the current directory (/home/stas/workspace/parent/subfolder/child) 
Once completed, your configuration will be written to /home/stas/workspace/parent/subfolder/child/.ddev/config.yaml
 
Configuring a 'php' project named 'child' with docroot '' at '/home/stas/workspace/parent/subfolder/child'.
For full details use 'ddev describe'. 
Configuration complete. You may now run 'ddev start'.

# create project in the parent dir doesn't work as expected
$ cd ~/workspace/parent && ddev config --auto
Could not create a new config: a project is not allowed in /home/stas/workspace/parent because another project exists in the subdirectory /home/stas/workspace/parent/subfolder/child
Unlist this project (if it exists) with 'cd "/home/stas/workspace/parent" && ddev stop --unlist'
Or run 'ddev stop --unlist' for all projects in the subdirectories of this project directory

# create dummy config file for parent
$ mkdir -p ~/workspace/parent/.ddev && touch ~/workspace/parent/.ddev/config.yaml

# create project in the parent dir works
$ cd ~/workspace/parent && ddev config --auto
You are reconfiguring the project at /home/stas/workspace/parent.
The existing configuration will be updated and replaced.
Configuring a 'php' project named 'parent' with docroot '' at '/home/stas/workspace/parent'.
For full details use 'ddev describe'.
Configuration complete. You may now run 'ddev start'.

# reconfiguring in the parent/subfolder belongs to the parent project
$ cd ~/workspace/parent/subfolder && ddev config --auto
You are reconfiguring the project at /home/stas/workspace/parent.
The existing configuration will be updated and replaced.
Configuring a 'php' project named 'parent' with docroot '' at '/home/stas/workspace/parent'.
For full details use 'ddev describe'.
Configuration complete. You may now run 'ddev start'.

# reconfiguring in the parent/subfolder/child/anotherdir belongs to the child project
$ cd ~/workspace/parent/subfolder/child/anotherdir && ddev config --auto
You are reconfiguring the project at /home/stas/workspace/parent/subfolder/child.
The existing configuration will be updated and replaced.
Configuring a 'php' project named 'child' with docroot '' at '/home/stas/workspace/parent/subfolder/child'.
For full details use 'ddev describe'.
Configuration complete. You may now run 'ddev start'.

# should show both projects, parent and child
$ ddev list
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
