### PR TITLE
feat: bind IP to user-defined ports if not set, fixes #6943

### DIFF
--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -102,9 +102,9 @@ func fixupComposeYaml(yamlStr string, app *DdevApp) (map[string]interface{}, err
 		return nil, err
 	}
 
-	dockerIP, _ := dockerutil.GetDockerIP()
+	bindIP, _ := dockerutil.GetDockerIP()
 	if app.BindAllInterfaces {
-		dockerIP = "0.0.0.0"
+		bindIP = "0.0.0.0"
 	}
 
 	// Ensure that some important network properties are not overridden by users
@@ -188,12 +188,12 @@ func fixupComposeYaml(yamlStr string, app *DdevApp) (map[string]interface{}, err
 		// Without this, Docker doesn't add a Docker IP, like this:
 		// ports:
 		//   - 127.0.0.1:3000:3000
-		if dockerIP != "" {
+		if bindIP != "" {
 			if ports, ok := serviceMap["ports"].([]interface{}); ok {
 				for _, port := range ports {
 					if portMap, ok := port.(map[string]interface{}); ok {
 						if _, exists := portMap["host_ip"]; !exists {
-							portMap["host_ip"] = dockerIP
+							portMap["host_ip"] = bindIP
 						}
 					}
 				}

--- a/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.ports.yaml
+++ b/pkg/ddevapp/testdata/TestMultipleComposeFiles/.ddev/docker-compose.ports.yaml
@@ -1,0 +1,5 @@
+services:
+  web:
+    ports:
+      # host_ip (like 127.0.0.1) should be added automatically
+      - ":12345"


### PR DESCRIPTION
## The Issue

- #6943

## How This PR Solves The Issue

Adds Docker IP to the port, but only if the IP is not already set, making it a non-breaking change.

- [x] Add a test

## Manual Testing Instructions

Default config should use `127.0.0.1`:

```
ddev config --bind-all-interfaces=false # default value
printf "services:\n  web:\n    ports:\n      - 12345:12345\n" > .ddev/docker-compose.web.yaml
ddev start

cat .ddev/.ddev-docker-compose-full.yaml | grep -B3 12345
            - host_ip: 127.0.0.1
              mode: ingress
              protocol: tcp
              published: "12345"
              target: 12345
```

`bind-all-interfaces` uses `0.0.0.0`:

```
ddev config --bind-all-interfaces=true
printf "services:\n  web:\n    ports:\n      - 12345:12345\n" > .ddev/docker-compose.web.yaml
ddev start

cat .ddev/.ddev-docker-compose-full.yaml | grep -B3 12345
            - host_ip: 0.0.0.0
              mode: ingress
              protocol: tcp
              published: "12345"
              target: 12345
```

Use default config, but set `0.0.0.0` for this port explicitly, DDEV should respect the user's choice:

```
ddev config --bind-all-interfaces=false
printf "services:\n  web:\n    ports:\n      - 0.0.0.0:12345:12345\n" > .ddev/docker-compose.web.yaml
ddev start

cat .ddev/.ddev-docker-compose-full.yaml | grep -B3 12345
            - host_ip: 0.0.0.0
              mode: ingress
              protocol: tcp
              published: "12345"
              target: 12345
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
