### PR TITLE
build: run linkspector on the main branch, for #6860

### DIFF
--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -53,7 +53,7 @@ jobs:
         uses: umbrelladocs/action-linkspector@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
+          reporter: github-check
           fail_on_error: true
           # Check links only in the added lines for PRs, but check everything otherwise
           filter_mode: ${{ github.event_name == 'pull_request' && 'added' || 'nofilter' }}


### PR DESCRIPTION
## The Issue

- #6860

I noticed that linkspector doesn't run for main branch:
https://github.com/ddev/ddev/actions/runs/13079915327/job/36500915400
```
 Running linkspector with reviewdog :dog: ...
  reviewdog: this is not PullRequest build.
```

## How This PR Solves The Issue

Changes the reporter to make it check for broken links on the main branch as well.

## Manual Testing Instructions

I tested it on `ddev-test`.

In addition, I confirmed that `filter_mode: ${{ github.event_name == 'pull_request' && 'added' || 'nofilter' }}` allows us to check only for changed links.

This means that if some link somewhere in the project is broken, and PR didn't touch it, then it won't be reported (the error will be shown only on the main branch build).

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
