### PR TITLE
build: run golangci-lint only for changed code in PRs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -50,6 +50,8 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
+          # Check code only for the changed lines for PRs
+          only-new-issues: ${{ github.event_name == 'pull_request' && true || false }}
           args: --timeout=30m --disable-all --enable=gofmt --enable=govet --enable=revive --enable=errcheck --enable=staticcheck --enable=ineffassign
 
   check_modules:


### PR DESCRIPTION
## The Issue

Sometimes `golangci-lint` introduces new rules that break our tests. This affects the people who contribute to DDEV because these errors show up in their PRs. Usually, we deal with this by doing a hotfix PR, merging it, and then rebasing other people's PRs.

## How This PR Solves The Issue

Runs `golangci-lint` in the PR only for the actually modified code, the full check will still be done on the main branch.

I got the idea from #6953, where I tested the same thing for `linkspector`.

## Manual Testing Instructions

I tested this PR on `ddev-test`. It works!

Log from this PR https://github.com/ddev/ddev/actions/runs/13081600537/job/36506164694?pr=6954

```
run golangci-lint
  only new issues on pull_request: /tmp/tmp-1924-DYZkqY0KDaC0/pull.patch
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
