### PR TITLE
fix: check snapshot name for valid characters, fixes #6955

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"slices"
 	"sort"
@@ -2652,6 +2653,10 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 	if snapshotName == "" {
 		t := time.Now()
 		snapshotName = app.Name + "_" + t.Format("20060102150405")
+	}
+
+	if !regexp.MustCompile(`^[\w-]+$`).MatchString(snapshotName) {
+		return "", fmt.Errorf("invalid snapshot name '%s': it may only contain letters, numbers, hyphens, and underscores", snapshotName)
 	}
 
 	snapshotFile := snapshotName + "-" + app.Database.Type + "_" + app.Database.Version + ".gz"

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2655,8 +2655,8 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 		snapshotName = app.Name + "_" + t.Format("20060102150405")
 	}
 
-	if !regexp.MustCompile(`^[\w-]+$`).MatchString(snapshotName) {
-		return "", fmt.Errorf("invalid snapshot name '%s': it may only contain letters, numbers, hyphens, and underscores", snapshotName)
+	if !regexp.MustCompile(`^[\w-.]+$`).MatchString(snapshotName) {
+		return "", fmt.Errorf("invalid snapshot name '%s': it may only contain letters, numbers, hyphens, periods, and underscores", snapshotName)
 	}
 
 	snapshotFile := snapshotName + "-" + app.Database.Type + "_" + app.Database.Version + ".gz"

--- a/pkg/ddevapp/snapshot_test.go
+++ b/pkg/ddevapp/snapshot_test.go
@@ -198,6 +198,19 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	_, err = app.Snapshot("d7testerTest1")
 	assert.Error(err)
 
+	// Name should contain only allowed characters
+	_, err = app.Snapshot(`name with spaces`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid snapshot name")
+
+	_, err = app.Snapshot(`single'quotes`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid snapshot name")
+
+	_, err = app.Snapshot(`double"quotes`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid snapshot name")
+
 	err = app.ImportDB(d7testerTest2Dump, "", false, false, "db")
 	assert.NoError(err, "Failed to app.ImportDB path: %s err: %v", d7testerTest2Dump, err)
 


### PR DESCRIPTION
## The Issue

- #6955

## How This PR Solves The Issue

Checks if the snapshot title contains letters, numbers, hyphens, or underscores.

Instead, we could escape or replace incorrect characters, but the validation is simpler.

## Manual Testing Instructions

```
ddev snapshot --name="with spaces"
Failed to snapshot d11: invalid snapshot name 'with spaces': it may only contain letters, numbers, hyphens, periods, and underscores
```

```
ddev snapshot --name="single'quotes"
Failed to snapshot d11: invalid snapshot name 'single'quotes': it may only contain letters, numbers, hyphens, periods, and underscores
```

```
ddev snapshot --name="double\"quotes"
Failed to snapshot d11: invalid snapshot name 'double"quotes': it may only contain letters, numbers, hyphens, periods, and underscores
```

```
ddev snapshot --name="my_snapshot-123-test.name"
Creating database snapshot my_snapshot-123-test.name
Created database snapshot my_snapshot-123-test.name 
Restore this snapshot with 'ddev snapshot restore my_snapshot-123-test.name'
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
