### PR TITLE
fix: add patch command to hardened prod web image, fixes #6958

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -50,6 +50,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--
     libmagickcore-6.q16-6-extra \
     locales \
     mariadb-client \
+    patch \
     postgresql-client \
     pv \
     python-is-python3 \
@@ -127,7 +128,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     ncurses-bin \
     netcat-traditional \
     openssh-client \
-    patch \
     sudo \
     telnet \
     tree
@@ -251,8 +251,7 @@ RUN apt-get update
 
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
-    blackfire-php \
-    patch
+    blackfire-php
 
 # Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
 RUN rm /etc/apt/sources.list.d/blackfire.list

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -251,7 +251,8 @@ RUN apt-get update
 
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
-    blackfire-php
+    blackfire-php \
+    patch
 
 # Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
 RUN rm /etc/apt/sources.list.d/blackfire.list

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250123_generic_project" // Note that this can be overridden by make
+var WebTag = "20250204_stasadev_patch_hardened" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #6958

## How This PR Solves The Issue

Add `patch` command (which was removed in v1.24.2) to the `ddev/ddev-webserver-prod` Docker image.

## Manual Testing Instructions

```
docker run --rm -it ddev/ddev-webserver-prod:20250204_stasadev_patch_hardened patch --version
```
or
```
ddev config global --use-hardened-images
ddev start
ddev exec patch --version
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
