### PR TITLE
fix: improve error message for invalid env flag, fixes #6949

### DIFF
--- a/cmd/ddev/cmd/dotenv_test.go
+++ b/cmd/ddev/cmd/dotenv_test.go
@@ -81,11 +81,11 @@ func TestCmdDotEnvGetAndSet(t *testing.T) {
 
 	out, err = exec.RunHostCommand(DdevBin, "dotenv", "set", envFile, "--TEST", "custom value")
 	require.Error(t, err, "out=%s", out)
-	require.Contains(t, out, "the flag must be lowercase and start with a letter")
+	require.Contains(t, out, "the flag must consist of lowercase letters, numbers, and hyphens")
 
 	out, err = exec.RunHostCommand(DdevBin, "dotenv", "set", envFile, "--1test", "custom value")
 	require.Error(t, err, "out=%s", out)
-	require.Contains(t, out, "the flag must be lowercase and start with a letter")
+	require.Contains(t, out, "the flag must consist of lowercase letters, numbers, and hyphens")
 
 	out, err = exec.RunHostCommand(DdevBin, "dotenv", "get", envFile, "--test-value", "--test-value-2")
 	require.Error(t, err, "out=%s", out)

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -124,7 +124,7 @@ func GetUnknownFlags(cmd *cobra.Command) (map[string]string, error) {
 		if !flagRegex.MatchString(arg) {
 			// Fail if the value is not a valid flag
 			if strings.HasPrefix(arg, "-") {
-				return unknownFlags, fmt.Errorf("the flag must be lowercase and start with a letter, but received %s", arg)
+				return unknownFlags, fmt.Errorf("the flag must consist of lowercase letters, numbers, and hyphens, and it must start with a letter, but received %s", arg)
 			}
 			// Skip if the value is not a flag, but an argument
 			continue


### PR DESCRIPTION
## The Issue

- #6949 

## How This PR Solves The Issue

Changes the error message to make it clearer what is allowed.

## Manual Testing Instructions

```
$ ddev dotenv set .env --test_flag=foobar
Error reading command flags: the flag must consist of lowercase letters, numbers, and hyphens, and it must start with a letter, but received --test_flag=foobar
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
