### PR TITLE
feat: normalize docroot usage in `ddev config`

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -389,14 +389,13 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 		util.Failed(err.Error())
 	}
 
-	// Ensure that the docroot exists
-	if docrootRelPathArg != "" {
+	if cmd.Flags().Changed("docroot") {
 		app.Docroot = docrootRelPathArg
+		// Ensure that the docroot exists
 		if err = app.CreateDocroot(); err != nil {
 			util.Failed("Could not create docroot at %s: %v", app.Docroot, err)
 		}
-		util.Success("Created docroot directory at %s", app.GetAbsDocroot(false))
-	} else if !cmd.Flags().Changed("docroot") {
+	} else {
 		app.Docroot = ddevapp.DiscoverDefaultDocroot(app)
 	}
 

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -386,7 +386,7 @@ func TestConfigSetValues(t *testing.T) {
 		{"empty docroot", "", "", ""},
 		{"dot docroot", ".", "", ""},
 		{"fail for outside approot", "..", "", "is outside the project root"},
-		{"fail for absolute path outside approot", "/test", "", "is outside the project root"},
+		{"fail for absolute path outside approot", "//test", "", "is outside the project root"},
 		{"ok for absolute path inside approot", tmpDir, "", ""},
 		{"dot with slash docroot", "./", "", ""},
 		{"dot with slash and dir docroot", "./test", "test", ""},

--- a/docs/content/developers/quickstart-maintenance.md
+++ b/docs/content/developers/quickstart-maintenance.md
@@ -27,7 +27,7 @@ In general:
 1. Add a link to the upstream installation or "Getting Started" web page, so people can know where the instructions are coming from.
 2. Use `mkdir my-<projecttype>-site && cd my-<projecttype>-site` as the opener. (There are places like Magento 2 where the project name must be used later in the recipe, in those cases, use an environment variable, like `PROJECT_NAME=my-<projecttype>-site`.)
 3. Composer-based recipes are preferable, unless the project does not use or prefer composer.
-4. If your project type does not yet appear in the DDEV documentation, your PR should add the name to the [.spellcheckwordlist.txt](https://github.com/ddev/ddev/blob/main/.spellcheckwordlist.txt) so it can pass the spellcheck test.
+4. If your project type does not yet appear in the DDEV documentation, your PR should add the name to the [.spellcheckwordlist.txt](https://github.com/ddev/ddev/blob/main/.spellcheckwordlist.txt) so it can pass the spell check test.
 5. If your project installation requires providing an administrative username and/or password, make sure to indicate clearly in the instructions what it is.
 6. If your project type includes folders that accept public files (such as images), for example, `public/media`, make sure to add them to the [config](../users/configuration/config.md#upload_dirs) command:
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1481,6 +1481,36 @@ func AvailablePHPDocrootLocations() []string {
 	}
 }
 
+// CreateDocroot normalizes the docroot path and creates it for DDEV app if it doesn't exist
+func (app *DdevApp) CreateDocroot() error {
+	if app.Docroot == "" {
+		return nil
+	}
+	docrootAbsPath := ""
+	if filepath.IsAbs(app.Docroot) {
+		docrootAbsPath = app.Docroot
+	} else {
+		docrootAbsPath = app.GetAbsDocroot(false)
+	}
+	// If user provided something like "./some/path", filepath.Rel will convert it to "some/path"
+	relPath, err := filepath.Rel(app.GetAbsAppRoot(false), docrootAbsPath)
+	if err != nil || strings.HasPrefix(relPath, "..") {
+		return fmt.Errorf("the provided docroot %s is outside the project root", app.Docroot)
+	}
+	if relPath == "." {
+		relPath = ""
+	}
+	// Normalize docroot
+	app.Docroot = relPath
+	if !fileutil.IsDirectory(docrootAbsPath) {
+		if err := os.MkdirAll(docrootAbsPath, 0755); err != nil {
+			return err
+		}
+		util.Success("Created docroot at %s", docrootAbsPath)
+	}
+	return nil
+}
+
 // DiscoverDefaultDocroot returns the default docroot directory.
 func DiscoverDefaultDocroot(app *DdevApp) string {
 	// Provide use the app.Docroot as the default docroot option.
@@ -1505,31 +1535,22 @@ func (app *DdevApp) docrootPrompt() error {
 
 	// Determine the document root.
 	output.UserOut.Printf("\nThe docroot is the directory from which your site is served.\nThis is a relative path from your project root at %s\n", app.AppRoot)
-	output.UserOut.Printf("Leave docroot empty (hit <RETURN>) to use the location shown in parentheses.\nOr specify a custom path if your index.php is in a different directory.\n")
+	output.UserOut.Printf("Leave docroot empty (hit <RETURN>) to use the location shown in parentheses.\nOr specify a custom path if your index.php is in a different directory.\nOr use '.' (a dot) to explicitly set it to the project root.\n")
 	var docrootPrompt = "Docroot Location"
 	var defaultDocroot = DiscoverDefaultDocroot(app)
 	// If there is a default docroot, display it in the prompt.
 	if defaultDocroot != "" {
 		docrootPrompt = fmt.Sprintf("%s (%s)", docrootPrompt, defaultDocroot)
-	} else if cd, _ := os.Getwd(); cd == filepath.Join(app.AppRoot, defaultDocroot) {
-		// Preserve the case where the docroot is the current directory
-		docrootPrompt = fmt.Sprintf("%s (current directory)", docrootPrompt)
 	} else {
-		// Explicitly state 'project root' when in a subdirectory
 		docrootPrompt = fmt.Sprintf("%s (project root)", docrootPrompt)
 	}
 
 	fmt.Print(docrootPrompt + ": ")
-	app.Docroot = util.GetInput(defaultDocroot)
+	app.Docroot = util.GetQuotedInput(defaultDocroot)
 
-	// Ensure the docroot exists. If it doesn't, prompt the user to verify they entered it correctly.
-	fullPath := filepath.Join(app.AppRoot, app.Docroot)
-	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-		if err = os.MkdirAll(fullPath, 0755); err != nil {
-			return fmt.Errorf("unable to create docroot: %v", err)
-		}
-
-		util.Success("Created docroot at %s.", fullPath)
+	// Ensure that the docroot exists
+	if err := app.CreateDocroot(); err != nil {
+		return fmt.Errorf("unable to create docroot at %s: %v", app.Docroot, err)
 	}
 
 	return nil

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1501,7 +1501,7 @@ func (app *DdevApp) CreateDocroot() error {
 		relPath = ""
 	}
 	// Normalize docroot
-	app.Docroot = relPath
+	app.Docroot = util.WindowsPathToCygwinPath(relPath)
 	if !fileutil.IsDirectory(docrootAbsPath) {
 		if err := os.MkdirAll(docrootAbsPath, 0755); err != nil {
 			return err

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1486,16 +1486,14 @@ func (app *DdevApp) CreateDocroot() error {
 	if app.Docroot == "" {
 		return nil
 	}
-	docrootAbsPath := ""
 	if filepath.IsAbs(app.Docroot) {
-		docrootAbsPath = app.Docroot
-	} else {
-		docrootAbsPath = app.GetAbsDocroot(false)
+		return fmt.Errorf("docroot %s must be relative", app.Docroot)
 	}
+	docrootAbsPath := app.GetAbsDocroot(false)
 	// If user provided something like "./some/path", filepath.Rel will convert it to "some/path"
 	relPath, err := filepath.Rel(app.GetAbsAppRoot(false), docrootAbsPath)
 	if err != nil || strings.HasPrefix(relPath, "..") {
-		return fmt.Errorf("the provided docroot %s is outside the project root", app.Docroot)
+		return fmt.Errorf("docroot %s is outside the project root", app.Docroot)
 	}
 	if relPath == "." {
 		relPath = ""

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -489,22 +489,6 @@ func (app DdevApp) GetAbsDocroot(inContainer bool) string {
 	return filepath.Join(app.GetAbsAppRoot(false), app.GetDocroot())
 }
 
-// CreateDocroot creates the docroot directory for DDEV app if it doesn't exist
-func (app DdevApp) CreateDocroot() error {
-	if app.Docroot == "" {
-		return nil
-	}
-	docrootAbsPath, err := filepath.Abs(app.Docroot)
-	if err != nil {
-		return err
-	}
-	if !fileutil.IsDirectory(docrootAbsPath) {
-		err := os.MkdirAll(docrootAbsPath, 0755)
-		return err
-	}
-	return nil
-}
-
 // GetAbsAppRoot returns the absolute path to the project root on the host or if
 // inContainer is set to true in the container.
 func (app DdevApp) GetAbsAppRoot(inContainer bool) string {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -368,7 +368,7 @@ func ArrayToReadableOutput(slice []string) (response string, err error) {
 // Sadly, if we have a Windows drive name, it has to be converted from C:/ to //c for Win10Home/Docker toolbox
 func WindowsPathToCygwinPath(windowsPath string) string {
 	windowsPath = filepath.ToSlash(windowsPath)
-	if string(windowsPath[1]) == ":" {
+	if len(windowsPath) >= 2 && string(windowsPath[1]) == ":" {
 		drive := strings.ToLower(string(windowsPath[0]))
 		windowsPath = "/" + drive + windowsPath[2:]
 	}


### PR DESCRIPTION
## The Issue

```
# set docroot to some value
ddev config --docroot=web

# try to unset it with this command, which won't work
ddev config --docroot=""

# works, but sets docroot to dot, not empty string
ddev config --docroot=.

# and try absolute path, which should not be possible (it fails, but the error should not come from os.Mkdir)
ddev config --docroot="/test"
Could not create docroot at /test: the provided docroot /test is outside the project root

# and this one works, but it shouldn't work
ddev config --docroot="/tmp"
```

## How This PR Solves The Issue

- Normalizes docroot in `CreateDocroot` function.
- Accepts quoted input for docroot in `ddev config` (because we accept path here).
- Adds a test.

## Manual Testing Instructions

```
ddev config --docroot=web
ddev debug configyaml | grep docroot # docroot: web

ddev config --docroot=""
ddev debug configyaml | grep docroot # should return nothing

ddev config --docroot="."
ddev debug configyaml | grep docroot # should return nothing

ddev config --docroot="./"
ddev debug configyaml | grep docroot # should return nothing

ddev config --docroot="/test"
Could not create docroot at /test: the provided docroot /test is outside the project root

ddev config --docroot="/tmp"
Could not create docroot at /tmp: the provided docroot /tmp is outside the project root

# repeat the above with interactive input for docroot:
ddev config
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
