### PR TITLE
feat: change php-fpm setting 'decorate_workers_output' to 'no'

### DIFF
--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.3/fpm/pool.d/www.conf
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.3/fpm/pool.d/www.conf
@@ -361,6 +361,13 @@ pm.status_path = /phpstatus
 ; Default Value: no
 catch_workers_output = yes
 
+; Decorate worker output with prefix and suffix containing information about
+; the child that writes to the log and if stdout or stderr is used as well as
+; log level and time. This options is used only if catch_workers_output is yes.
+; Settings to "no" will output data as written to the stdout or stderr.
+; Default value: yes
+decorate_workers_output = no
+
 ; Clear environment in FPM workers
 ; Prevents arbitrary environment variables from reaching FPM worker processes
 ; by clearing the environment in workers before env vars specified in this

--- a/containers/ddev-php-base/ddev-php-files/etc/php/7.4/fpm/pool.d/www.conf
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/7.4/fpm/pool.d/www.conf
@@ -361,6 +361,13 @@ pm.status_path = /phpstatus
 ; Default Value: no
 catch_workers_output = yes
 
+; Decorate worker output with prefix and suffix containing information about
+; the child that writes to the log and if stdout or stderr is used as well as
+; log level and time. This options is used only if catch_workers_output is yes.
+; Settings to "no" will output data as written to the stdout or stderr.
+; Default value: yes
+decorate_workers_output = no
+
 ; Clear environment in FPM workers
 ; Prevents arbitrary environment variables from reaching FPM worker processes
 ; by clearing the environment in workers before env vars specified in this

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.0/fpm/pool.d/www.conf
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.0/fpm/pool.d/www.conf
@@ -361,6 +361,13 @@ pm.status_path = /phpstatus
 ; Default Value: no
 catch_workers_output = yes
 
+; Decorate worker output with prefix and suffix containing information about
+; the child that writes to the log and if stdout or stderr is used as well as
+; log level and time. This options is used only if catch_workers_output is yes.
+; Settings to "no" will output data as written to the stdout or stderr.
+; Default value: yes
+decorate_workers_output = no
+
 ; Clear environment in FPM workers
 ; Prevents arbitrary environment variables from reaching FPM worker processes
 ; by clearing the environment in workers before env vars specified in this

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.1/fpm/pool.d/www.conf
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.1/fpm/pool.d/www.conf
@@ -361,6 +361,13 @@ pm.status_path = /phpstatus
 ; Default Value: no
 catch_workers_output = yes
 
+; Decorate worker output with prefix and suffix containing information about
+; the child that writes to the log and if stdout or stderr is used as well as
+; log level and time. This options is used only if catch_workers_output is yes.
+; Settings to "no" will output data as written to the stdout or stderr.
+; Default value: yes
+decorate_workers_output = no
+
 ; Clear environment in FPM workers
 ; Prevents arbitrary environment variables from reaching FPM worker processes
 ; by clearing the environment in workers before env vars specified in this

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/pool.d/www.conf
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.2/fpm/pool.d/www.conf
@@ -361,6 +361,13 @@ pm.status_path = /phpstatus
 ; Default Value: no
 catch_workers_output = yes
 
+; Decorate worker output with prefix and suffix containing information about
+; the child that writes to the log and if stdout or stderr is used as well as
+; log level and time. This options is used only if catch_workers_output is yes.
+; Settings to "no" will output data as written to the stdout or stderr.
+; Default value: yes
+decorate_workers_output = no
+
 ; Clear environment in FPM workers
 ; Prevents arbitrary environment variables from reaching FPM worker processes
 ; by clearing the environment in workers before env vars specified in this

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.3/fpm/pool.d/www.conf
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.3/fpm/pool.d/www.conf
@@ -436,7 +436,7 @@ catch_workers_output = yes
 ; log level and time. This options is used only if catch_workers_output is yes.
 ; Settings to "no" will output data as written to the stdout or stderr.
 ; Default value: yes
-;decorate_workers_output = no
+decorate_workers_output = no
 
 ; Clear environment in FPM workers
 ; Prevents arbitrary environment variables from reaching FPM worker processes

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.4/fpm/pool.d/www.conf
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.4/fpm/pool.d/www.conf
@@ -436,7 +436,7 @@ catch_workers_output = yes
 ; log level and time. This options is used only if catch_workers_output is yes.
 ; Settings to "no" will output data as written to the stdout or stderr.
 ; Default value: yes
-;decorate_workers_output = no
+decorate_workers_output = no
 
 ; Clear environment in FPM workers
 ; Prevents arbitrary environment variables from reaching FPM worker processes

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20250208_stasadev_xdebug AS ddev-webserver-base
+FROM ddev/ddev-php-base:20250207_atomicptr_decorate_fpm AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "Verify required binaries are installed in normal image" {
     if [ "${IS_HARDENED}" == "true" ]; then skip "Skipping because IS_HARDENED==true"; fi
-    COMMANDS="composer ddev drush8 git magerun magerun2 mkcert mysql mysqladmin mysqldump node npm platform sudo symfony terminus wp"
+    COMMANDS="composer ddev drush8 git magerun magerun2 mkcert mysql mysqladmin mysqldump node npm patch platform sudo symfony terminus wp"
     for item in $COMMANDS; do
 #      echo "# looking for $item" >&3
       docker exec $CONTAINER_NAME bash -c "command -v $item >/dev/null"

--- a/containers/ddev-webserver/tests/ddev-webserver/project_type.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/project_type.bats
@@ -18,9 +18,3 @@ setup() {
 		docker exec -t $CONTAINER_NAME bash -c 'if [ -d  ~/.drush/commands/backdrop ] ; then echo "Found unexpected backdrop drush commands"; exit 107; fi'
   fi
 }
-
-@test "verify that both nginx logs and fpm logs are being tailed ($project_type)" {
-    curl --fail 127.0.0.1:$HOST_HTTP_PORT/test/fatal.php
-	docker logs $CONTAINER_NAME 2>&1 | grep "WARNING:.* said into stderr:.*fatal.php on line " >/dev/null
-	docker logs $CONTAINER_NAME 2>&1 | grep "FastCGI sent in stderr: .PHP message: PHP Fatal error:" >/dev/null
-}

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250208_stasadev_xdebug" // Note that this can be overridden by make
+var WebTag = "20250207_atomicptr_decorate_fpm" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

<!-- Provide a brief description of the issue. -->

By default php-fpm outputs logs like this:

```
[06-Feb-2025 12:04:23] WARNING: [pool www] child 1554 said into stderr: "{"message":"Matched route \"app_admin_schedule_index\".","context":{"route":"app_admin_schedule_index","route_parameters":{"_route":"app_admin_schedule_index","_controller":"App\\Controller\\Admin\\Event\\EventScheduleController::index","event":"2"},"request_uri":"https://myapp.ddev.site/admin/event/2/schedule/template","method":"GET"},"level":200,"level_name":"INFO","channel":"request","datetime":"2025-02-06T12:04:23.926697+01:00","extra":{}}"
[06-Feb-2025 12:04:23] WARNING: [pool www] child 1554 said into stderr: "{"message":"Uncaught PHP Exception Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException: \"\"App\\Entity\\Event\" object not found by \"Symfony\\Bridge\\Doctrine\\ArgumentResolver\\EntityValueResolver\".\" at EntityValueResolver.php line 76","context":{"exception":{"class":"Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException","message":"\"App\\Entity\\Event\" object not found by \"Symfony\\Bridge\\Doctrine\\ArgumentResolver\\EntityValueResolver\".","code":0,"file":"/var/www/html/vendor/symfony/doctrine-bridge/ArgumentResolver/EntityValueResolver.php:76"}},"level":400,"level_name":"ERROR","channel":"request","datetime":"2025-02-06T12:04:23.944647+01:00","extra":{}}"
[06-Feb-2025 12:04:33] WARNING: [pool www] child 1555 said into stderr: "{"message":"Matched route \"app_admin\".","context":{"route":"app_admin","route_parameters":{"_route":"app_admin","_controller":"App\\Controller\\Admin\\IndexController::index"},"request_uri":"https://myapp.ddev.site/admin","method":"GET"},"level":200,"level_name":"INFO","channel":"request","datetime":"2025-02-06T12:04:33.840382+01:00","extra":{}}"
```

the problem here being the extra bits that php-fpm adds "[06-Feb-2025 12:04:23] WARNING: [pool www] child 1554 said into stderr: ..."

Which is for local development not only pretty unhelpful (esp considering most frameworks add custom decorations anyway) but also hinders JSON logging (which I for instance would like to parse / filter)

## How This PR Solves The Issue

This PR resolves this issue by disabling the option to decorate outputs, which is also the default in the official PHP docker images ( See: https://github.com/docker-library/php/blob/master/8.4/alpine3.21/fpm/Dockerfile#L239 )

> decorate_workers_output [bool](https://www.php.net/manual/en/language.types.boolean.php)
Enable the output decoration for workers output when [catch_workers_output](https://www.php.net/manual/en/install.fpm.configuration.php#catch-workers-output) is enabled. Default value: yes. Available as of PHP 7.3.0.

From: https://www.php.net/manual/en/install.fpm.configuration.php

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

This should not affect anything except for the default output in `ddev logs` when using an \*-fpm php image