### PR TITLE
test: allow a margin of +2 for ephemeral port checks due to flakiness

### DIFF
--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -251,13 +251,18 @@ func TestUseEphemeralPort(t *testing.T) {
 		require.NotEqual(t, targetHTTPPort, app.GetPrimaryRouterHTTPPort())
 		require.NotEqual(t, targetHTTPSPort, app.GetPrimaryRouterHTTPSPort())
 
+		// Allow a margin of +2 for ephemeral port checks due to flakiness
 		actualHTTPPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPPort())
 		require.NoError(t, err)
+		require.Condition(t, func() bool {
+			return actualHTTPPort >= expectedEphemeralHTTPPort && actualHTTPPort <= expectedEphemeralHTTPPort+2
+		}, "HTTP port must be between %d and %d, got %d", expectedEphemeralHTTPPort, expectedEphemeralHTTPPort+2, actualHTTPPort)
+
 		actualHTTPSPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPSPort())
 		require.NoError(t, err)
-		// Allow a margin of +/- 1 for ephemeral port checks
-		require.InDelta(t, expectedEphemeralHTTPPort, actualHTTPPort, 1)
-		require.InDelta(t, expectedEphemeralHTTPSPort, actualHTTPSPort, 1)
+		require.Condition(t, func() bool {
+			return actualHTTPSPort >= expectedEphemeralHTTPSPort && actualHTTPSPort <= expectedEphemeralHTTPSPort+2
+		}, "HTTPS port must be between %d and %d, got %d", expectedEphemeralHTTPSPort, expectedEphemeralHTTPSPort+2, actualHTTPSPort)
 
 		// Make sure that both http and https URLs have proper content
 		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), testString, 0)

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -1,7 +1,6 @@
 package ddevapp_test
 
 import (
-	"fmt"
 	"math/rand"
 	"net"
 	"os"
@@ -252,8 +251,13 @@ func TestUseEphemeralPort(t *testing.T) {
 		require.NotEqual(t, targetHTTPPort, app.GetPrimaryRouterHTTPPort())
 		require.NotEqual(t, targetHTTPSPort, app.GetPrimaryRouterHTTPSPort())
 
-		require.Equal(t, fmt.Sprint(expectedEphemeralHTTPPort), app.GetPrimaryRouterHTTPPort())
-		require.Equal(t, fmt.Sprint(expectedEphemeralHTTPSPort), app.GetPrimaryRouterHTTPSPort())
+		actualHTTPPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPPort())
+		require.NoError(t, err)
+		actualHTTPSPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPSPort())
+		require.NoError(t, err)
+		// Allow a margin of +/- 1 for ephemeral port checks
+		require.InDelta(t, expectedEphemeralHTTPPort, actualHTTPPort, 1)
+		require.InDelta(t, expectedEphemeralHTTPSPort, actualHTTPSPort, 1)
 
 		// Make sure that both http and https URLs have proper content
 		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), testString, 0)


### PR DESCRIPTION
## The Issue

`TestUseEphemeralPort` fails from time to time, in this case it didn't use 33003 port (probably it was busy), which broke the test:

https://github.com/ddev/ddev/actions/runs/13180515366/job/36789882879

```
Port 28080 is busy, using 33000 instead, see https://ddev.com/s/port-conflict
2025-02-06T15:30:21.859 GetAvailableRouterPort(): proposedPort 28443 is not available, epheneralPort=33001 is available, use it
Port 28443 is busy, using 33001 instead, see https://ddev.com/s/port-conflict
2025-02-06T15:30:21.86 GetAvailableRouterPort(): proposedPort 8025 is not available, epheneralPort=33002 is available, use it
Port 8025 is busy, using 33002 instead, see https://ddev.com/s/port-conflict
2025-02-06T15:30:21.86 GetAvailableRouterPort(): proposedPort 8026 is not available, epheneralPort=33004 is available, use it
Port 8026 is busy, using 33004 instead, see https://ddev.com/s/port-conflict
...
2025-02-06T15:30:52.923 ddev-router is ready
    router_test.go:255: 
        	Error Trace:	/home/runner/work/ddev/ddev/pkg/ddevapp/router_test.go:255
        	Error:      	Not equal: 
        	            	expected: "33004"
        	            	actual  : "33005"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-33004
        	            	+33005
        	Test:       	TestUseEphemeralPort
```

## How This PR Solves The Issue

Allows a margin of +2 port number during check. If this doesn't help we can increase the margin.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
