### PR TITLE
build: autoload Python and Node deps from Makefile with direnv [skip ci]

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# This file is used by `direnv` to install all Python and Node dependencies
+# specified in the Makefile into the virtual env located in the `.gotmp/env` directory.
+
+# Steps to set up:
+# 1. Install direnv: https://direnv.net/docs/installation.html
+# 2. Hook direnv into your shell: https://direnv.net/docs/hook.html
+# 3. Create the global config: https://github.com/direnv/direnv/blob/master/man/direnv.toml.1.md
+#    where `~/workspace/ddev/.envrc` is the path to this file.
+#    (Alternatively, `.envrc` file can be loaded with `direnv allow .`)
+#    $ cat ~/.config/direnv/direnv.toml
+#    [global]
+#    hide_env_diff = true
+#    [whitelist]
+#    exact = ["~/workspace/ddev/.envrc"]
+# 4. After setting this up, when you `cd` into this directory, all required tools
+#    will automatically be installed in .gotmp/env and sourced.
+# 5. To update tools, run `make clean`, then `cd` out of and back into this directory.
+
+PYTHON_ENV=.gotmp/env/python
+NODE_ENV=.gotmp/env/node
+
+if ! command -v python >/dev/null 2>&1 && ! command -v python3 >/dev/null 2>&1; then
+    echo "Python is not available."
+    exit 1
+fi
+
+if [[ ! -f "${PYTHON_ENV}/bin/activate" ]]; then
+    echo "Initializing python venv..."
+    python -m venv "${PYTHON_ENV}" || python3 -m venv "${PYTHON_ENV}"
+fi
+
+source "${PYTHON_ENV}/bin/activate"
+
+if [[ ! -f "${NODE_ENV}/bin/activate" ]]; then
+    echo "Initializing python nodeenv..."
+    pip install nodeenv
+    nodeenv --node=lts --prebuilt "${NODE_ENV}"
+fi
+
+source "${NODE_ENV}/bin/activate"
+
+if [[ ! -f "${PYTHON_ENV}/bin/mkdocs" ]]; then\
+    echo "Installing mkdocs..."
+    pip install -r docs/mkdocs-pip-requirements
+fi
+
+if [[ ! -f "${PYTHON_ENV}/bin/pyspelling" ]]; then
+    echo "Installing pyspelling..."
+    pip install pyspelling pymdown-extensions
+fi
+
+if [[ ! -f "${NODE_ENV}/bin/markdownlint" ]]; then
+    echo "Installing markdownlint..."
+    npm install -g markdownlint-cli
+fi
+
+if [[ ! -f "${NODE_ENV}/bin/linkspector" ]]; then
+    echo "Installing linkspector..."
+    npm install -g @umbrelladocs/linkspector
+fi
+
+if [[ ! -f "${NODE_ENV}/bin/textlint" ]]; then
+    echo "Installing textlint..."
+    npm install -g textlint \
+        textlint-filter-rule-comments \
+        textlint-rule-no-todo \
+        textlint-rule-stop-words \
+        textlint-rule-terminology
+fi

--- a/.envrc
+++ b/.envrc
@@ -15,7 +15,7 @@
 #    [whitelist]
 #    exact = ["~/workspace/ddev/.envrc"]
 # 4. After setting this up, when you `cd` into this directory, all required tools
-#    will automatically be installed in .gotmp/env and sourced.
+#    will automatically be installed in `.gotmp/env` and sourced.
 # 5. To update tools, run `make clean`, then `cd` out of and back into this directory.
 
 PYTHON_ENV=.gotmp/env/python
@@ -41,7 +41,7 @@ fi
 
 source "${NODE_ENV}/bin/activate"
 
-if [[ ! -f "${PYTHON_ENV}/bin/mkdocs" ]]; then\
+if [[ ! -f "${PYTHON_ENV}/bin/mkdocs" ]]; then
     echo "Installing mkdocs..."
     pip install -r docs/mkdocs-pip-requirements
 fi

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ markdownlint:
 	if command -v markdownlint >/dev/null 2>&1 ; then \
 		$$CMD; \
 	else \
-		echo "Skipping markdownlint as not installed"; \
+		echo "Skipping markdownlint as not installed (see .envrc file)"; \
 	fi
 
 # Install mkdocs locally using
@@ -155,7 +155,7 @@ mkdocs:
 	if command -v mkdocs >/dev/null 2>&1; then \
 		$$CMD ; \
 	else \
-		echo "Not running mkdocs because it's not installed"; \
+		echo "Not running mkdocs because it's not installed (see .envrc file)"; \
 	fi
 
 # To see what the docs will look like, you can use `make mkdocs-serve`
@@ -165,7 +165,7 @@ mkdocs-serve:
 	@if command -v mkdocs >/dev/null ; then \
 		mkdocs serve; \
 	else \
-		echo "mkdocs is not installed." && exit 2; \
+		echo "mkdocs is not installed (see .envrc file)" && exit 2; \
 	fi; \
 
 # Install linkspector locally with "sudo npm install -g @umbrelladocs/linkspector"
@@ -174,10 +174,10 @@ linkspector:
 	@if command -v linkspector >/dev/null 2>&1; then \
 		linkspector check; \
 	else \
-		echo "Not running linkspector because it's not installed"; \
+		echo "Not running linkspector because it's not installed (see .envrc file)"; \
 	fi
 
-# Best to install pyspelling locally with "sudo -H pip3 install pyspelling pymdown-extensions". Also requries aspell, `sudo apt-get install aspell"
+# Best to install pyspelling locally with "sudo -H pip3 install pyspelling pymdown-extensions". Also requires aspell, `sudo apt-get install aspell"
 pyspelling:
 	@echo "pyspelling: "
 	@CMD="pyspelling --config .spellcheck.yml"; \
@@ -185,7 +185,7 @@ pyspelling:
 	if command -v pyspelling >/dev/null 2>&1 ; then \
 		$$CMD; \
 	else \
-		echo "Not running pyspelling because it's not installed"; \
+		echo "Not running pyspelling because it's not installed (see .envrc file)"; \
 	fi
 
 # Install textlint locally with `npm install -g textlint textlint-filter-rule-comments textlint-rule-no-todo textlint-rule-stop-words textlint-rule-terminology`
@@ -196,7 +196,7 @@ textlint:
 	if command -v textlint >/dev/null 2>&1 ; then \
 		$$CMD; \
 	else \
-		echo "textlint is not installed"; \
+		echo "textlint is not installed (see .envrc file)"; \
 	fi
 
 darwin_amd64_signed: $(GOTMP)/bin/darwin_amd64/ddev
@@ -297,7 +297,7 @@ version:
 clean: bin-clean
 
 bin-clean:
-	@rm -rf bin
+	@rm -rf bin .cache
 	$(shell if [ -d $(GOTMP) ]; then chmod -R u+w $(GOTMP) && rm -rf $(GOTMP); fi )
 
 # print-ANYVAR prints the expanded variable


### PR DESCRIPTION
## The Issue

The [Makefile](https://github.com/ddev/ddev/blob/main/Makefile) suggests installing some tools globally, but it is better to install them in an isolated environment, accessible only within DDEV directory.

## How This PR Solves The Issue

Adds a config file for `direnv` tool, that will autoinstall everything needed.

It is completely optional and not necessary, but I find it easy to use.

## Manual Testing Instructions

1. Install direnv: https://direnv.net/docs/installation.html
2. Hook direnv into your shell: https://direnv.net/docs/hook.html
3. Create the global config: https://github.com/direnv/direnv/blob/master/man/direnv.toml.1.md
    where `~/workspace/ddev/.envrc` is the path to this file.
    (Alternatively, `.envrc` file can be loaded with `direnv allow .`)
    ```  
    $ cat ~/.config/direnv/direnv.toml
    [global]
    hide_env_diff = true
    [whitelist]
    exact = ["~/workspace/ddev/.envrc"]
	```
4. After setting this up, when you `cd` into this directory, all required tools
    will automatically be installed in .gotmp/env and sourced.
5. To update tools, run `make clean`, then `cd` out of and back into this directory.

Example of use:
```
$ eval "$(direnv hook bash)" # sourced in ~/.bashrc
$ cd ~/workspace/ddev
direnv: loading ~/workspace/ddev/.envrc
$ mkdocs -V
mkdocs, version 1.6.1 from /home/stas/workspace/ddev/.gotmp/env/python/lib/python3.13/site-packages/mkdocs (Python 3.13)
$ cd ..
$ mkdocs -V
bash: mkdocs: command not found
$ cd ddev
direnv: loading ~/workspace/ddev/.envrc
$ make mkdocs
mkdocs: 
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /tmp/mkdocsbuild
INFO    -  Documentation built in 6.60 seconds
```

The following message can be disabled with `export DIRENV_LOG_FORMAT=`
```
direnv: loading ~/workspace/ddev/.envrc
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
