### PR TITLE
build: remove custom Xdebug 3.4.1

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -56,9 +56,6 @@ ARG XDEBUG_MODE=off
 ### See https://github.com/ddev/ddev/issues/6159
 RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
 RUN /usr/local/bin/build_php_extension.sh "php8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
-### Bump the Xdebug version to 3.4.1 because of https://bugs.xdebug.org/view.php?id=2307
-RUN /usr/local/bin/build_php_extension.sh "php8.3" "xdebug" "3.4.1" "/usr/lib/php/20230831/xdebug.so"
-RUN /usr/local/bin/build_php_extension.sh "php8.4" "xdebug" "3.4.1" "/usr/lib/php/20240924/xdebug.so"
 #END ddev-php-extension-build
 
 ### ---------------------------ddev-php-base--------------------------------------
@@ -120,11 +117,9 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/ru
 ### The dates from /usr/lib/php/YYYYMMDD/ represent PHP API versions https://unix.stackexchange.com/a/591771
 SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]
 ARG XDEBUG_MODE=off
-RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug php8.3-xdebug php8.4-xdebug
+RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug
 COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
 COPY --from=ddev-php-extension-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
-COPY --from=ddev-php-extension-build /usr/lib/php/20230831/xdebug.so /usr/lib/php/20230831/xdebug.so
-COPY --from=ddev-php-extension-build /usr/lib/php/20240924/xdebug.so /usr/lib/php/20240924/xdebug.so
 #END ddev-php-extension-build
 RUN phpdismod xhprof xdebug
 RUN apt-get -qq autoremove -y

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -19,9 +19,6 @@ done
 
 RUN ls -l /usr/sbin/dpkg-split /usr/sbin/dpkg-deb /usr/sbin/tar /usr/sbin/rm
 
-# This curl -I is debugging for intermittent failures on https://github.com/oerdnj/deb.sury.org/issues/2046
-RUN curl -s -I https://packages.sury.org/php/
-
 RUN apt-get -qq update
 RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     apt-transport-https \
@@ -40,6 +37,9 @@ RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
     | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
 RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
 http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
+
+# This curl -I is debugging for intermittent failures on https://github.com/oerdnj/deb.sury.org/issues/2046
+RUN curl -s -I https://packages.sury.org/php/
 
 RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
     dpkg -i /tmp/debsuryorg-archive-keyring.deb

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:v1.24.2 AS ddev-webserver-base
+FROM ddev/ddev-php-base:20250208_stasadev_xdebug AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250206_vever001_switch_apache_mpm" // Note that this can be overridden by make
+var WebTag = "20250208_stasadev_xdebug" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

I wanted to build an image for another PR, but got this error on `ddev-php-base` build (from https://github.com/ddev/ddev/commit/daaea4053f2ac7bf3dcdf4cdb1a385f1f9ef7a8e):

```
 > [linux/amd64 base  6/15] RUN curl -s -I https://packages.sury.org/php/:
0.048 /bin/bash: line 1: curl: command not found
```

## How This PR Solves The Issue

- Reverts https://github.com/ddev/ddev/commit/daaea4053f2ac7bf3dcdf4cdb1a385f1f9ef7a8e
- While I'm here, remove Xdebug 3.4.1 custom build

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
