### PR TITLE
docs: add MySQL 8.4 to supported databases

### DIFF
--- a/docs/content/users/extend/database-types.md
+++ b/docs/content/users/extend/database-types.md
@@ -5,7 +5,7 @@ DDEV supports many versions of the MariaDB, MySQL, and PostgreSQL database serve
 The following database types are currently supported:
 
 - MariaDB 5.5-10.8, 10.11, and 11.4
-- MySQL 5.5-8.0
+- MySQL 5.5-8.4
 - Postgres 9-17
 
 The default database type is MariaDB, and the default version is currently 10.11.


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

Reflecting blog post https://ddev.com/blog/database-improvements/, I've updated this page to show DDEV supports MySQL 8.4.