### PR TITLE
docs: Remove gitpod/drupalpod from docs, for #6891 [skip buildkite]

### DIFF
--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -147,7 +147,6 @@ jobs:
             }, 'Download the artifacts for this pull request:\n');
 
             body += `\n\nSee [Testing a PR](https://ddev.readthedocs.io/en/latest/developers/building-contributing/#testing-a-pr).`;
-            body += `\n\n[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber})`;
             const codespacesLink = prRef && prRepoId
               ? `https://github.com/codespaces/new?ref=${prRef}&repo=${prRepoId}`
               : `https://github.com/codespaces/new/${context.repo.owner}/${context.repo.repo}`;

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -319,7 +319,6 @@ dotfiles
 dropdown
 drupal
 drupalize
-drupalpod
 drush
 dumpfile
 ef

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ---
 
 ![project is maintained](https://img.shields.io/maintenance/yes/2025.svg)
-[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/ddev/ddev) <a href="https://github.com/codespaces/new/ddev/ddev"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
+<a href="https://github.com/codespaces/new/ddev/ddev"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
 
 DDEV is an open-source tool for running local web development environments for PHP and Node.js, ready in minutes. Its powerful, flexible per-project environment configurations can be extended, version controlled, and shared. DDEV allows development teams to adopt a consistent Docker workflow without the complexities of bespoke configuration.
 
@@ -35,7 +35,7 @@ See “How can I contribute to DDEV?” in the [FAQ](https://ddev.readthedocs.io
 
 ## Get Started
 
-1. **Check [System Requirements](https://ddev.readthedocs.io/):** macOS (Intel and Apple Silicon), Windows 10/11, WSL2, Linux, [Gitpod](https://www.gitpod.io), and [GitHub Codespaces](https://github.com/codespaces).
+1. **Check [System Requirements](https://ddev.readthedocs.io/):** macOS (Intel and Apple Silicon), Windows 10/11, WSL2, Linux, and [GitHub Codespaces](https://github.com/codespaces).
 2. **Install a [Docker provider and DDEV](https://ddev.readthedocs.io/en/stable/users/install/)**.
 3. **Try a [CMS Quick Start Guide](https://ddev.readthedocs.io/en/stable/users/quickstart/)**.
 

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -18,7 +18,6 @@ There are several ways to use DDEV’s latest-committed HEAD version:
     ```
 
 * **Build manually**: If you have normal build tools like `make` and `go` installed, you can check out the code and run `make`.
-* **Gitpod** You can use the latest build by visiting DDEV on [Gitpod](https://gitpod.io/#https://github.com/ddev/ddev).
 
 ## Testing a PR
 
@@ -97,59 +96,6 @@ After you’re done testing, you can delete your downloaded executable, restart 
 rm ~/bin/ddev
 ```
 
-## Open in Gitpod
-
-[Gitpod](https://www.gitpod.io) provides a quick, preconfigured DDEV experience in the browser for testing a PR easily without the need to set up an environment. For any PR you can use the URL `https://gitpod.io/#https://github.com/ddev/ddev/pull/<YOUR-PR>` to open that PR and build it in Gitpod.
-
-It also allows you to work on the DDEV `main` branch and test modifying DDEV's source code.
-
-To get started use the button below:
-
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ddev/ddev)
-
-For a simple test, edit `cmd/ddev/cmd/start.go` and change the line
-
-```go
-output.UserOut.Printf("Starting %s...", project.GetName())
-```
-
-to
-
-```go
-output.UserOut.Printf("Let's gooooo ... %s...", project.GetName())
-```
-
-Compile and install your new modified DDEV version:
-
-```bash
-cd /workspace/ddev/
-make
-```
-
-The command `ddev -v` now will output something like `ddev version v1.23.5-98-g3c93ae87e-dirty`. The version will stay the same for all compilations until you make a commit.
-
-A Gitpod dummy project for is provided by default in `/workspace/d10simple` to test your changes:
-
-```bash
-cd /workspace/d10simple/
-ddev start
-```
-
-If you want to create a new project or use your own project, you will need to delete the dummy project to free up reserved host ports by running `ddev delete -Oy d10simple`.
-
-Afterwards you can run [`ddev config`](../users/usage/commands.md#config) as usual:
-
-```bash
-cd /workspace/
-mkdir my-new-project/
-cd my-new-project/
-ddev config
-```
-
-If you want to use an existing web project, also check it out into `/workspace/<yourproject>` and use it as usual.
-
-The things you’re familiar with work normally, except that `ddev-router` does not run.
-
 ## Making Changes to DDEV Images
 
 If you need to make a change to one of the DDEV images, it will need to be built with a specific tag that’s updated in `pkg/versionconstants/versionconstants.go`.
@@ -169,8 +115,6 @@ make
 ```
 
 `ddev version` should show you that you are using the correct webtag, and [`ddev start`](../users/usage/commands.md#start) will show it.
-
-It’s easiest to do this using Gitpod (see above) because Gitpod already has `docker buildx` all set up for you and the built DDEV binary is in the `$PATH`.
 
 ## Docker Image Changes
 

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -137,7 +137,7 @@ Normally the release process does okay with pushing to Chocolatey, but at times 
 
 Note that if an existing approved release is being updated you have to have a new version. So for example, if `v1.21.3` failed, you'll need to work with `v1.21.3.1`, so `make chocolatey VERSION=v1.21.3.1` below.
 
-* Open up Gitpod, <https://gitpod.io/#https://github.com/ddev/ddev> and
+* Open up GitHub Codespaces and
 
 ```bash
 cd /workspace/ddev

--- a/docs/content/developers/writing-style-guide.md
+++ b/docs/content/developers/writing-style-guide.md
@@ -204,7 +204,6 @@ Use backticks to differentiate between a product and command, like DDEV vs. `dde
 | Git | git
 | Git Bash | git bash
 | GitHub or `github` | Github
-| Gitpod or `gitpod` | Gitpod.io, GitPod
 | GoLand | Goland
 | Google | google
 | Homebrew | homebrew

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -81,13 +81,13 @@ These environments can be extended, version controlled, and shared, so you can t
     2. Install [DDEV for Linux](users/install/ddev-installation.md#linux).
     3. Launch your [first project](users/project.md) and start developing. 🚀
 
-=== "Gitpod & Codespaces"
+=== "GitHub Codespaces"
 
-    ### Gitpod and GitHub Codespaces
+    ### GitHub Codespaces
 
-    With [Gitpod](https://www.gitpod.io) and [GitHub Codespaces](https://github.com/features/codespaces) you don’t install anything; you only need a browser and an internet connection.
+    With [GitHub Codespaces](https://github.com/features/codespaces) you don’t install anything; you only need a browser and an internet connection.
 
     **Next steps:**
 
-    1. Install DDEV within [Gitpod](users/install/ddev-installation.md#gitpod) or [GitHub Codespaces](users/install/ddev-installation.md#github-codespaces).
+    1. Install DDEV within [GitHub Codespaces](users/install/ddev-installation.md#github-codespaces).
     2. Launch your [first project](users/project.md) and start developing. 🚀

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -311,35 +311,6 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
         You should now see your CA under `mkcert development CA`.
 
-=== "Gitpod"
-
-    ## Gitpod
-
-    Choose any of the following methods to launch your project with [Gitpod](https://www.gitpod.io):
-
-    1. Add a [.gitpod.yml](https://www.gitpod.io/docs/references/gitpod-yml) to your project that installs DDEV and starts your project. The easy way to do this is with the excellent [ddev-gitpod-setup](https://github.com/tyler36/ddev-gitpod-setup) add-on. `ddev get tyler36/ddev-gitpod-setup` and add it to your git repository, push it, and then open it. You can even do all of this right on gitpod by opening your repository, doing the `ddev get` there and then pushing it back and restarting.
-    2. [Open any repository](https://www.gitpod.io/docs/getting-started) using Gitpod and run the following:
-        ```bash
-        # Add DDEV’s GPG key to your keyring
-        curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/ddev.gpg > /dev/null
-
-        # Add DDEV releases to your package repository
-        echo "deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
-
-
-        # Update package information and install DDEV
-        sudo apt-get update && sudo apt-get install -y ddev
-        ```
-
-        * You can install your web app there, or import a database.
-        * You may want to implement one of the `ddev pull` provider integrations to pull from a hosting provider or an upstream source.
-    3. Use the [ddev-gitpod-launcher](https://ddev.github.io/ddev-gitpod-launcher/) form to launch a repository.
-        You’ll provide a source repository and click a button to open a newly-established environment. You can specify a companion artifacts repository and automatically load `db.sql.gz` and `files.tgz` from it. (More details in the [repository’s README](https://github.com/ddev/ddev-gitpod-launcher/blob/main/README.md).)
-    4. Save the following link to your bookmark bar: <a href="javascript: if %28 %2Fbitbucket%2F.test %28 window.location.host %29 %20 %29 %20%7B%20paths%3Dwindow.location.pathname.split %28 %22%2F%22 %29 %3B%20repo%3D%5Bwindow.location.origin%2C%20paths%5B1%5D%2C%20paths%5B2%5D%5D.join %28 %22%2F%22 %29 %20%7D%3B%20if %28 %2Fgithub.com%7Cgitlab.com%2F.test %28 window.location.host %29  %29 %20%7Brepo%20%3D%20window.location.href%7D%3B%20if%20 %28 repo %29 %20%7Bwindow.location.href%20%3D%20%22https%3A%2F%2Fgitpod.io%2F%23DDEV_REPO%3D%22%20%2B%20encodeURIComponent %28 repo %29 %20%2B%20%22%2CDDEV_ARTIFACTS%3D%22%20%2B%20encodeURIComponent %28 repo %29 %20%2B%20%22-artifacts%2Fhttps%3A%2F%2Fgithub.com%2Fddev%2Fddev-gitpod-launcher%2F%22%7D%3B">Open in ddev-gitpod</a>.
-        It’s easiest to drag the link into your bookmarks. When you’re on a Git repository, click the bookmark to open it with DDEV in Gitpod. It does the same thing as the second option, but it works on non-Chrome browsers and you can use native browser keyboard shortcuts.
-
-    It can be complicated to get private databases and files into Gitpod, so in addition to the launchers, the [`git` provider example](https://github.com/ddev/ddev/blob/main/pkg/ddevapp/dotddev_assets/providers/git.yaml.example) demonstrates pulling a database and files without complex setup or permissions. This was created explicitly for Gitpod integration, because in Gitpod you typically already have access to private Git repositories, which are a fine place to put a starter database and files. Although [ddev-gitpod-launcher](https://ddev.github.io/ddev-gitpod-launcher/) and the web extension provide the capability, you may want to integrate a Git provider—or one of the [other providers](https://github.com/ddev/ddev/tree/main/pkg/ddevapp/dotddev_assets/providers)—for each project.
-
 === "Codespaces"
 
     ## GitHub Codespaces

--- a/docs/content/users/install/ddev-upgrade.md
+++ b/docs/content/users/install/ddev-upgrade.md
@@ -96,15 +96,6 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     Download and run the Windows installer (for your architecture, most often AMD64) for the latest [DDEV release](https://github.com/ddev/ddev/releases) (`ddev_windows_<architecture>_installer.<version>.exe`).
 
-=== "Gitpod"
-
-    ## Gitpod
-
-    ```bash
-    # Update package information and all packages including DDEV
-    sudo apt-get update && sudo apt-get upgrade -y
-    ```
-
 === "Codespaces"
 
     ## GitHub Codespaces

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -121,12 +121,6 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     See [WSL2 DDEV Installation](ddev-installation.md#wsl2-docker-desktop-install-script) for help installing DDEV with Docker Desktop on WSL2.
 
-=== "Gitpod"
-
-    ## Gitpod
-
-    With [Gitpod](https://www.gitpod.io) you don’t have to install anything at all. Docker is all set up for you.
-
 === "Codespaces"
 
     ## GitHub Codespaces

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -2,7 +2,7 @@
 
 DDEV is continually focused on quick project startup and fast responses to its web requests. DDEV’s performance is mostly an issue of how Docker runs on your workstation.
 
-On Linux, including Windows WSL2 and Gitpod, Docker is fast. Most people are happy with Linux performance and don’t need to change anything.
+On Linux, including Windows WSL2, Docker is fast. Most people are happy with Linux performance and don’t need to change anything.
 
 On macOS and Windows with Docker Desktop, allocated resources and mounted filesystem performance can be significant bottlenecks. Taking a bit of time to optimize your setup can yield massive performance gains.
 

--- a/docs/content/users/topics/sharing.md
+++ b/docs/content/users/topics/sharing.md
@@ -69,6 +69,6 @@ DDEV’s web container also exposes an HTTP port directly, in addition to the no
 * Make sure your firewall allows access to the port on your host machine.
 * If you’re using WordPress or Magento 2 you’ll need to change the base URL as described in the [`ddev share`](../usage/commands.md#share) instructions above.
 * Each project on your computer must use different ports or you’ll have port conflicts, and you can’t typically use ports 80 or 443 because `ddev-router` is already using those for normal routing.
-* If you don’t want to run `ddev-router` at all, you can omit it globally with `ddev config global --omit-containers=ddev-router`. This is a specialty thing to do when you don’t need the reverse proxy, as for [DrupalPod](https://github.com/shaal/DrupalPod) or other [Gitpod](https://www.gitpod.io/) applications.
+* If you don’t want to run `ddev-router` at all, you can omit it globally with `ddev config global --omit-containers=ddev-router`. This is a specialty thing to do when you don’t need the reverse proxy.
 
 Computers and mobile devices on your local network should now be able to access port 8080, on the (example) host address 192.168.5.23, so `http://192.168.5.23:8080` You’ll probably want to use the HTTP URL; your coworker’s browser will not trust the developer TLS certificate you’re using.


### PR DESCRIPTION

## The Issue

- #6891 

This is the docs section of the removal.

## How This PR Solves The Issue

* Remove docs
* Remove the helper on PRs

