### PR TITLE
build: remove Xdebug 3.2.2 builds for php8.1 and php8.2

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -1,4 +1,4 @@
-### ---------------------------base--------------------------------------
+### ---------------------------------base-----------------------------------------
 ### Build the base Debian image that will be used in every other image
 FROM debian:bookworm-slim AS base
 ARG TARGETPLATFORM
@@ -46,17 +46,16 @@ RUN curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/deb
 RUN rm -f /tmp/debsuryorg-archive-keyring.deb && \
     echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 RUN apt-get -qq update
-#END base
+### -------------------------------END base---------------------------------------
 
-### ---------------------------ddev-php-extension-build--------------------------------------
-FROM base AS ddev-php-extension-build
-SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]
-ARG XDEBUG_MODE=off
-### Xdebug compile specific version because 3.3 is not fully reliable
-### See https://github.com/ddev/ddev/issues/6159
-RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
-RUN /usr/local/bin/build_php_extension.sh "php8.2" "xdebug" "3.2.2" "/usr/lib/php/20220829/xdebug.so"
-#END ddev-php-extension-build
+### ------------------------ddev-php-extension-build------------------------------
+### Uncomment the lines below to enable custom PHP extension builds:
+#FROM base AS ddev-php-extension-build
+#SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]
+### Use this section to add PHP extensions that need to be built manually.
+### Example: The following line installs Xdebug version 3.2.2 for PHP 8.1:
+#RUN /usr/local/bin/build_php_extension.sh "php8.1" "xdebug" "3.2.2" "/usr/lib/php/20210902/xdebug.so"
+### -----------------------END ddev-php-extension-build---------------------------
 
 ### ---------------------------ddev-php-base--------------------------------------
 ### Build ddev-php-base, which is the base for ddev-php-prod and ddev-webserver-*
@@ -113,14 +112,15 @@ RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/ru
     chmod ugo+rx /usr/local/bin/* && \
     ln -sf /usr/sbin/php-fpm${PHP_DEFAULT_VERSION} /usr/sbin/php-fpm
 
-### ---------------------------ddev-php-extension-build--------------------------------------
-### The dates from /usr/lib/php/YYYYMMDD/ represent PHP API versions https://unix.stackexchange.com/a/591771
-SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]
-ARG XDEBUG_MODE=off
-RUN apt-get -qq remove -y php8.1-xdebug php8.2-xdebug
-COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
-COPY --from=ddev-php-extension-build /usr/lib/php/20220829/xdebug.so /usr/lib/php/20220829/xdebug.so
-#END ddev-php-extension-build
+### ------------------------ddev-php-extension-build------------------------------
+### Remove any existing PHP extensions that will be replaced by custom-built versions:
+#RUN apt-get -qq remove -y php8.1-xdebug
+### After building the custom extensions, copy them from the multi-stage build:
+### Note: The dates in /usr/lib/php/YYYYMMDD/ represent PHP API versions.
+### For more info, see: https://unix.stackexchange.com/a/591771
+#COPY --from=ddev-php-extension-build /usr/lib/php/20210902/xdebug.so /usr/lib/php/20210902/xdebug.so
+### -----------------------END ddev-php-extension-build---------------------------
+
 RUN phpdismod xhprof xdebug
 RUN apt-get -qq autoremove -y
 RUN curl -L --fail -o /usr/local/bin/composer -sSL https://getcomposer.org/composer-stable.phar && chmod ugo+wx /usr/local/bin/composer
@@ -139,7 +139,7 @@ RUN apt-get -qq autoremove && apt-get -qq clean -y && rm -rf /var/lib/apt/lists/
 RUN ln -sf /usr/sbin/php-fpm${DDEV_PHP_VERSION} /usr/sbin/php-fpm
 RUN mkdir -p /run/php && chown -R www-data:www-data /run
 RUN chmod 777 /var/lib/php/sessions
-#END ddev-php-base
+### -------------------------END ddev-php-base------------------------------------
 
 ### ---------------------------ddev-php-prod--------------------------------------
 ### Build ddev-php-prod from ddev-php-base as a single layer
@@ -150,4 +150,4 @@ SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]
 COPY --from=ddev-php-base / /
 EXPOSE 8080 8585
 CMD ["/usr/sbin/php-fpm", "-F"]
-#END ddev-php-prod
+### -------------------------END ddev-php-prod------------------------------------

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -1,9 +1,8 @@
-
-### ---------------------------ddev-webserver-base--------------------------------------
+### ---------------------------ddev-webserver-base--------------------------------
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20250207_atomicptr_decorate_fpm AS ddev-webserver-base
+FROM ddev/ddev-php-base:20250211_stasadev_remove_pecl_xdebug AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -99,10 +98,9 @@ RUN mkdir -p /usr/local/sqlite3-drupal11 && cd /usr/local/sqlite3-drupal11 && \
     wget https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
     wget https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb
 
-# END ddev-webserver-base
+### -------------------------END ddev-webserver-base------------------------------
 
-
-### ---------------------------ddev-webserver-dev-base--------------------------------------
+### -------------------------ddev-webserver-dev-base------------------------------
 ### Build ddev-webserver-dev-base from ddev-webserver-base
 FROM ddev-webserver-base AS ddev-webserver-dev-base
 SHELL ["/bin/bash", "-eu", "-o", "pipefail", "-c"]
@@ -112,8 +110,7 @@ ENV PHP_DEFAULT_VERSION="8.3"
 
 RUN curl -s --fail https://packages.blackfire.io/gpg.key > /usr/share/keyrings/blackfire-archive-keyring.asc
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/blackfire-archive-keyring.asc] http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
-RUN apt-get update
-
+RUN apt-get -qq update
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
     blackfire \
@@ -205,9 +202,9 @@ CMD ["/start.sh"]
 RUN apt-get -qq clean -y && rm -rf /var/lib/apt/lists/* /tmp/*
 RUN update-alternatives --set php /usr/bin/php${PHP_DEFAULT_VERSION}
 
-#END ddev-webserver-dev-base
+### -------------------------END ddev-webserver-dev-base--------------------------
 
-### ---------------------------ddev-webserver--------------------------------------
+### -----------------------------ddev-webserver-----------------------------------
 ### This could be known as ddev-webserver-dev as it's development-env targeted
 ### But for historical reasons, it's just ddev-webserver
 ### Build ddev-webserver by turning ddev-webserver-dev-base into one layer
@@ -232,9 +229,9 @@ ENV PLATFORMSH_CLI_UPDATES_CHECK=0
 COPY --from=ddev-webserver-dev-base / /
 HEALTHCHECK --interval=1s --retries=120 --timeout=120s --start-period=120s CMD ["/healthcheck.sh"]
 CMD ["/start.sh"]
-#END ddev-webserver
+### ----------------------------END ddev-webserver--------------------------------
 
-### ---------------------------ddev-webserver-prod-base--------------------------------------
+### -------------------------ddev-webserver-prod-base-----------------------------
 ### Build ddev-webserver-prod-base from ddev-webserver-base
 ### This image is aimed at actual hardened production environments
 FROM ddev-webserver-base AS ddev-webserver-prod-base
@@ -247,8 +244,7 @@ ARG TARGETARCH
 
 RUN curl -s --fail https://packages.blackfire.io/gpg.key > /usr/share/keyrings/blackfire-archive-keyring.asc
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/blackfire-archive-keyring.asc] http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
-RUN apt-get update
-
+RUN apt-get -qq update
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
     blackfire-php
@@ -300,9 +296,9 @@ CMD ["/start.sh"]
 RUN apt-get -qq clean -y && rm -rf /var/lib/apt/lists/* /tmp/*
 RUN update-alternatives --set php /usr/bin/php${PHP_DEFAULT_VERSION}
 
-#END ddev-webserver-prod-base
+### -----------------------END ddev-webserver-prod-base---------------------------
 
-### ---------------------------ddev-webserver-prod--------------------------------------
+### ---------------------------ddev-webserver-prod--------------------------------
 ### Build ddev-webserver-prod, the hardened version of ddev-webserver-base
 ### (Withut dev features, single layer)
 FROM scratch AS ddev-webserver-prod
@@ -324,4 +320,4 @@ ENV PLATFORMSH_CLI_UPDATES_CHECK=0
 COPY --from=ddev-webserver-prod-base / /
 HEALTHCHECK --interval=1s --retries=120 --timeout=120s --start-period=120s CMD ["/healthcheck.sh"]
 CMD ["/start.sh"]
-#END ddev-webserver-prod
+### -------------------------END ddev-webserver-prod------------------------------

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250207_atomicptr_decorate_fpm" // Note that this can be overridden by make
+var WebTag = "20250211_stasadev_remove_pecl_xdebug" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

From Discord https://discord.com/channels/664580571770388500/1338908217094180935

A user experienced an issue with PHP 8.2 and Xdebug 3.2.2 when debugging was enabled.

Some time ago, we reverted Xdebug from 3.3.x to 3.2.2 in:

- #6181

## How This PR Solves The Issue

Xdebug 3.4.1 is now available for PHP 8.1 and PHP 8.2.

Given that some time has passed, it's time to switch to the newer versions.

This PR removes the custom PECL Xdebug builds for the mentioned PHP versions.

## Manual Testing Instructions

It should show Xdebug 3.4.1:
```
$ ddev start
$ ddev xdebug

$ ddev exec php8.1 -v
PHP 8.1.31 (cli) (built: Nov 21 2024 10:26:13) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.31, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.31, Copyright (c), by Zend Technologies
    with Xdebug v3.4.1, Copyright (c) 2002-2025, by Derick Rethans

ddev exec php8.2 -v
PHP 8.2.27 (cli) (built: Dec 24 2024 06:13:38) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.27, Copyright (c) Zend Technologies
    with Zend OPcache v8.2.27, Copyright (c), by Zend Technologies
    with Xdebug v3.4.1, Copyright (c) 2002-2025, by Derick Rethans
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
