### PR TITLE
build: push tagged images with ubuntu 22.04 [skip ci]

### DIFF
--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   push-tagged-dbimage:
     name: "push tagged dbimage"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         dbtype: [mariadb_5.5, mariadb_10.0, mariadb_10.1, mariadb_10.2, mariadb_10.3, mariadb_10.4, mariadb_10.5, mariadb_10.6, mariadb_10.7, mariadb_10.8, mariadb_10.11, mariadb_11.4, mysql_5.5, mysql_5.6, mysql_5.7, mysql_8.0, mysql_8.4]

--- a/.github/workflows/push-tagged-image.yml
+++ b/.github/workflows/push-tagged-image.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   push-tagged-image:
     name: "push tagged image"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Load 1password secret(s)


### PR DESCRIPTION

## The Issue

* https://github.com/docker/setup-qemu-action/issues/198
* https://github.com/tonistiigi/binfmt/issues/240
* https://github.com/atomvm/AtomVM/pull/1530

It seems that there's a problem with qemu on Ubuntu 24.04 currently, so I'm unable to push-tagged-image because of segfaults on apt install

## How This PR Solves The Issue

Go to 22.04 for now.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
