### PR TITLE
build: go back to normal blackfire packaging, fixes #6078

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -129,9 +129,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     telnet \
     tree
 
-# Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
-RUN rm /etc/apt/sources.list.d/blackfire.list
-
 RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=${TARGETPLATFORM}" && chmod +x /usr/local/bin/mkcert
 
 # blackfire user by default is set up with /dev/null as homedir, and 999 as uid, which
@@ -246,11 +243,9 @@ RUN curl -s --fail https://packages.blackfire.io/gpg.key > /usr/share/keyrings/b
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/blackfire-archive-keyring.asc] http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
 RUN apt-get -qq update
 
+# Blackfire outputs errors about not having systemd, but they do no harm to our usage
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
-    blackfire-php
-
-# Remove blackfire from apt sources, because we pin to a specific version, see https://github.com/ddev/ddev/issues/6078
-RUN rm /etc/apt/sources.list.d/blackfire.list
+    blackfire-php 2>/dev/null
 
 RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=${TARGETPLATFORM}" && chmod +x /usr/local/bin/mkcert
 

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/apt/preferences.d/blackfire
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/apt/preferences.d/blackfire
@@ -1,6 +1,0 @@
-# 2024-04-10: blackfire upgrade was broken per https://github.com/ddev/ddev/issues/6078
-# Pinned to current installed version
-Package: blackfire
-Version: 2:2.26.1
-Pin: version 2:2.26.1
-Pin-Priority: 1001

--- a/docs/content/users/debugging-profiling/blackfire-profiling.md
+++ b/docs/content/users/debugging-profiling/blackfire-profiling.md
@@ -37,6 +37,6 @@ The Blackfire CLI is built into the web container, so you don’t need to instal
 
 * `ddev blackfire on` and `ddev blackfire off`
 * [`ddev exec blackfire curl https://<yoursite>.ddev.site`](../usage/commands.md#exec)
-* `ddev exec blackfire drush st`
+* `ddev exec blackfire run drush st`
 * `ddev exec blackfire curl https://<yoursite>.ddev.site`
 * [`ddev ssh`](../usage/commands.md#ssh) and use the Blackfire CLI as described in [Profiling HTTP Requests with the CLI](https://blackfire.io/docs/profiling-cookbooks/profiling-http-via-cli).

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250211_stasadev_remove_pecl_xdebug" // Note that this can be overridden by make
+var WebTag = "20250213_rfay_blackfire" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

* #6978 
* https://github.com/ddev/ddev/issues/6078

Blackfire installation was completely failing due to systemd.

They seem to have fixed that in the meantime, meaning that the `apt-get install` only screams bloody murder, but actually succeeds with a zero exit code.

## How This PR Solves The Issue

* Remove the pin
* Remove the removal of the /etc/apt/sources.list.d/blackfire.list
* Push the image
* Add specification of the image in versionconstants.go

## Manual Testing Instructions

Try using blackfire using the keys we have available in 1password

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
