### PR TITLE
test: contao quickstart bats test

### DIFF
--- a/docs/tests/contao.bats
+++ b/docs/tests/contao.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+setup() {
+  PROJNAME=my-contao-site
+  load 'common-setup'
+  _common_setup
+}
+
+# executed after each test
+teardown() {
+  _common_teardown
+}
+
+@test "Contao Composer quickstart with $(ddev --version)" {
+  # mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  assert_success
+  # ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+  run ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+  assert_success
+  # ddev composer create contao/managed-edition:5.3
+  run ddev composer create contao/managed-edition:5.3
+  assert_success
+  # Set DATABASE_URL and MAILER_DSN in .env.local
+  # ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
+  run ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
+  assert_success
+  # Create the database
+  # ddev exec contao-console contao:migrate --no-interaction
+  run ddev exec contao-console contao:migrate --no-interaction
+  assert_success
+  # Create backend user
+  # ddev exec contao-console contao:user:create --username=admin --name=Administrator --email=admin@example.com --language=en --password=Password123 --admin
+  run ddev exec contao-console contao:user:create --username=admin --name=Administrator --email=admin@example.com --language=en --password=Password123 --admin
+  assert_success
+  # ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch contao"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site/contao/login
+  assert_success
+  assert_output --partial "HTTP/2 200"
+}
+
+@test "Contao Manager quickstart with $(ddev --version)" {
+  # mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  assert_success
+  run ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+  assert_success
+  # set DATABASE_URL and MAILER_DSN in .env.local
+  # ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
+  run ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
+  assert_success
+  # ddev start
+  run ddev start
+  assert_success
+  # ddev exec "wget -O public/contao-manager.phar.php https://download.contao.org/contao-manager/stable/contao-manager.phar"
+  run ddev exec "wget -O public/contao-manager.phar.php https://download.contao.org/contao-manager/stable/contao-manager.phar"
+  assert_success
+  # ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch contao-manager.phar.php"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site/contao-manager.phar.php"
+  assert_success
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site/contao-manager.phar.php
+  assert_success
+  assert_output --partial "HTTP/2 302"
+  assert_output --partial "location: /contao-manager.phar.php/"
+}

--- a/docs/tests/contao.bats
+++ b/docs/tests/contao.bats
@@ -35,7 +35,7 @@ teardown() {
   assert_success
   # ddev launch
   run bash -c "DDEV_DEBUG=true ddev launch contao"
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site/contao"
   assert_success
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site/contao/login

--- a/docs/tests/contao.bats
+++ b/docs/tests/contao.bats
@@ -18,6 +18,9 @@ teardown() {
   # ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
   run ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
   assert_success
+  # ddev start -y
+  run ddev start -y
+  assert_success
   # ddev composer create contao/managed-edition:5.3
   run ddev composer create contao/managed-edition:5.3
   assert_success
@@ -53,8 +56,8 @@ teardown() {
   # ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
   run ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
   assert_success
-  # ddev start
-  run ddev start
+  # ddev start -y
+  run ddev start -y
   assert_success
   # ddev exec "wget -O public/contao-manager.phar.php https://download.contao.org/contao-manager/stable/contao-manager.phar"
   run ddev exec "wget -O public/contao-manager.phar.php https://download.contao.org/contao-manager/stable/contao-manager.phar"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

Initial draft of bats tests for contao. the first test for composer fails on the following step `run ddev exec contao-console contao:migrate --no-interaction` when running the test locally (https://gist.github.com/rpkoller/4d4f09f6971db12d4f7cbd4d2ba4a7bf). I've created the PR already to test it with tmate in github action as well per the suggestion of @rfay (otherwise i wouldnt have considered pushing a PR at this point yet)

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
