### PR TITLE
fix: add a mutagen sync at the end of the dotenv cmd

### DIFF
--- a/cmd/ddev/cmd/dotenv-set.go
+++ b/cmd/ddev/cmd/dotenv-set.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/ddev/ddev/pkg/output"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/ddev/ddev/pkg/output"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/util"
@@ -19,7 +20,7 @@ var DotEnvSetCmd = &cobra.Command{
 	Use:   "set [file]",
 	Short: "Write values from the command line to a .env file",
 	Long: `Create or update a .env file with values specified via long flags from the command line.
-Flags in the format --env-key=value will be converted to environment variable names 
+Flags in the format --env-key=value will be converted to environment variable names
 like ENV_KEY="value". The .env file should be named .env or .env.<servicename> or .env.<something>
 All environment variables can be used and expanded in .ddev/docker-compose.*.yaml files.
 Provide the path relative to the project root when specifying the file.`,
@@ -102,6 +103,10 @@ ddev dotenv set .ddev/.env.redis --redis-tag 7-bookworm`,
 		var formattedVars []string
 		for _, k := range rawResultKeys {
 			formattedVars = append(formattedVars, fmt.Sprintf(`%s=%v`, k, ddevapp.EscapeEnvFileValue(changedEnvMap[k])))
+		}
+		err = app.MutagenSyncFlush()
+		if err != nil {
+			util.Failed("failed to app.MutagenSyncFlush: %v", err)
 		}
 		friendlyMsg := fmt.Sprintf("Updated %s with:\n\n%s", envFile, strings.Join(formattedVars, "\n"))
 		output.UserOut.WithField("raw", changedEnvMap).Print(friendlyMsg)

--- a/cmd/ddev/cmd/dotenv-set.go
+++ b/cmd/ddev/cmd/dotenv-set.go
@@ -91,6 +91,10 @@ ddev dotenv set .ddev/.env.redis --redis-tag 7-bookworm`,
 			if err := ddevapp.WriteProjectEnvFile(envFile, changedEnvMap, envText); err != nil {
 				util.Failed("Error writing .env file: %v", err)
 			}
+			err = app.MutagenSyncFlush()
+			if err != nil {
+				util.Failed("failed to app.MutagenSyncFlush: %v", err)
+			}
 		}
 
 		// Sort before output, since the map order is not deterministic
@@ -103,10 +107,6 @@ ddev dotenv set .ddev/.env.redis --redis-tag 7-bookworm`,
 		var formattedVars []string
 		for _, k := range rawResultKeys {
 			formattedVars = append(formattedVars, fmt.Sprintf(`%s=%v`, k, ddevapp.EscapeEnvFileValue(changedEnvMap[k])))
-		}
-		err = app.MutagenSyncFlush()
-		if err != nil {
-			util.Failed("failed to app.MutagenSyncFlush: %v", err)
 		}
 		friendlyMsg := fmt.Sprintf("Updated %s with:\n\n%s", envFile, strings.Join(formattedVars, "\n"))
 		output.UserOut.WithField("raw", changedEnvMap).Print(friendlyMsg)

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -449,7 +449,9 @@ func (app *DdevApp) MutagenSyncFlush() error {
 	if !app.IsMutagenEnabled() {
 		return nil
 	}
-
+	if stat, _ := app.SiteStatus(); stat == SiteStopped {
+		return nil
+	}
 	container, err := GetContainer(app, "web")
 	if err != nil {
 		return fmt.Errorf("failed to get web container, err='%v'", err)


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

the problem surfaced during the creation of the sulu bats test. even though the env.local file was correctly created the admin console command was unable to pickup the correct datanbase credentials leading to failing tests on macos in bash and zsh while the tests ran properly on github actions. adding  `ddev mutagen sync` per randys suggestion fixed the problem 
 
```
  run ddev dotenv set .env.local --app-env=dev --database-url="mysql://db:db@db:3306/db?serverVersion=8.0&charset=utf8mb4"
  run ddev mutagen sync
  assert_success
  run ddev exec bin/adminconsole sulu:build dev --no-interaction
```
but instead of adding the mutagen sync statement in the quickstart and the tests it is better to run the mutagen sync within the scope of the command. randy provided the code and i've just quickly done the grunt working setting up the PR. 


- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
