### PR TITLE
test: add yes flag to ddev start cmd

### DIFF
--- a/docs/tests/backdrop.bats
+++ b/docs/tests/backdrop.bats
@@ -24,7 +24,7 @@ teardown() {
   # ddev config --project-type=backdrop
   run ddev config --project-type=backdrop
   assert_success
-  # ddev start
+  # ddev start -y
   run ddev start -y
   assert_success
   # ddev launch
@@ -50,7 +50,7 @@ teardown() {
   # ddev config --project-type=backdrop
   run ddev config --project-type=backdrop
   assert_success
-  # ddev start
+  # ddev start -y
   run ddev start -y
   assert_success
   run curl -fLO https://github.com/ddev/test-backdrop/releases/download/1.29.2/db.sql.gz

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -18,8 +18,8 @@ teardown() {
   # ddev config --project-type=drupal11 --docroot=web
   run ddev config --project-type=drupal11 --docroot=web
   assert_success
-  # ddev start
-  run ddev start
+  # ddev start -y
+  run ddev start -y
   assert_success
   # ddev composer create drupal/recommended-project:^11
   run ddev composer create drupal/recommended-project:^11
@@ -48,8 +48,8 @@ teardown() {
   # ddev config --project-type=drupal10 --docroot=web
   run ddev config --project-type=drupal10 --docroot=web
   assert_success
-  # ddev start
-  run ddev start
+  # ddev start -y
+  run ddev start -y
   assert_success
   # ddev composer create drupal/recommended-project:^10
   run ddev composer create drupal/recommended-project:^10
@@ -83,8 +83,8 @@ teardown() {
   # ddev config --project-type=drupal11 --docroot=web
   run ddev config --project-type=drupal11 --docroot=web
   assert_success
-  # ddev start
-  run ddev start
+  # ddev start -y
+  run ddev start -y
   assert_success
   # ddev composer install
   run ddev composer install
@@ -110,8 +110,8 @@ teardown() {
   # ddev config --project-type=drupal11 --docroot=web
   run ddev config --project-type=drupal11 --docroot=web
   assert_success
-  # ddev start
-  run ddev start
+  # ddev start -y
+  run ddev start -y
   assert_success
   # ddev composer create drupal/cms
   run ddev composer create drupal/cms

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -22,7 +22,7 @@ teardown() {
   # ddev config --project-type=php --webserver-type=apache-fpm
   run ddev config --project-type=php --webserver-type=apache-fpm
   assert_success
-  # ddev start
+  # ddev start -y
   run ddev start -y
   assert_success
   # ddev launch
@@ -45,7 +45,7 @@ teardown() {
   # ddev config --project-type=php --webserver-type=apache-fpm
   run ddev config --project-type=php --webserver-type=apache-fpm
   assert_success
-  # ddev start
+  # ddev start -y
   run ddev start -y
   assert_success
   # ddev composer create "processwire/processwire:^3"

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -18,8 +18,8 @@ teardown() {
   # ddev config --project-type=typo3 --docroot=public --php-version=8.3
   run ddev config --project-type=typo3 --docroot=public --php-version=8.3
   assert_success
-  # ddev start
-  run ddev start
+  # ddev start -y
+  run ddev start -y
   assert_success
   # ddev composer create "typo3/cms-base-distribution"
   run ddev composer create "typo3/cms-base-distribution"
@@ -50,8 +50,8 @@ teardown() {
   # ddev config --project-type=typo3 --docroot=public --php-version=8.3
   run ddev config --project-type=typo3 --docroot=public --php-version=8.3
   assert_success
-  # ddev start
-  run ddev start
+  # ddev start -y
+  run ddev start -y
   assert_success
   # ddev composer install
   run ddev composer install

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -18,8 +18,8 @@ teardown() {
   # ddev config --project-type=wordpress
   run ddev config --project-type=wordpress
   assert_success
-  # ddev start
-  run ddev start
+  # ddev start -y
+  run ddev start -y
   assert_success
   # ddev wp core download
   run ddev wp core download
@@ -50,8 +50,8 @@ teardown() {
   # ddev config --project-type=wordpress --docroot=web
   run ddev config --project-type=wordpress --docroot=web
   assert_success
-  # ddev start
-  run ddev start
+  # ddev start -y
+  run ddev start -y
   assert_success
   # ddev composer create roots/bedrock
   run ddev composer create roots/bedrock
@@ -109,8 +109,8 @@ teardown() {
   # ddev config --project-type=wordpress
   run ddev config --project-type=wordpress
   assert_success
-  # ddev start
-  run ddev start
+  # ddev start -y
+  run ddev start -y
   assert_success
   # ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   run ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

ddev start and or ddev restart was missing the yes flag on several bats tests. without a test is stuck on the new version of ddev prompt and could never proceed

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
