### PR TITLE
test: figure out why buildkite tests are running for quickstart bats tests

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -165,12 +165,11 @@ if [[ ${BUILDKITE_MESSAGE:-} == *"[skip buildkite]"* ]] || [[ ${BUILDKITE_MESSAG
 fi
 
 # If this is a PR and the diff doesn't have code, skip it
-if [ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ] && ! git diff --name-only refs/remotes/origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-} | egrep "^(\.buildkite|Makefile|pkg|cmd|vendor|go\.)" >/dev/null; then
+set -x
+if [ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ] && ( ! git diff --name-only refs/remotes/origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-} | egrep "^(\.buildkite|Makefile|pkg|cmd|vendor|go\.)" >/dev/null ); then
   echo "Skipping buildkite build since no code changes found"
   exit 0
 fi
-
-set -x
 
 # Run any testbot maintenance that may need to be done
 echo "--- running testbot_maintenance.sh"


### PR DESCRIPTION

## The Issue

Recent bats quickstart tests (which are in docs directory) have been running on buildkite, wasting millions of CPU cycles.

## How This PR Solves The Issue

* Try to make the skip in test.sh a bit more explicit
* Move the `set -x` so maybe we can see what happened.

