### PR TITLE
fix: validate docroot instead of using it blindly, fixes #6998

### DIFF
--- a/cmd/ddev/cmd/composer-create.go
+++ b/cmd/ddev/cmd/composer-create.go
@@ -54,7 +54,7 @@ ddev composer create --prefer-dist --no-interaction --no-dev psr/log
 		if status != ddevapp.SiteRunning {
 			err = app.CreateDocroot()
 			if err != nil {
-				util.Failed("Could not create docroot at %s: %v", app.Docroot, err)
+				util.Failed("Could not create docroot at %s: %v", app.GetAbsDocroot(false), err)
 			}
 			err = app.Start()
 			if err != nil {
@@ -475,7 +475,7 @@ func prepareAppForComposer(app *ddevapp.DdevApp) {
 	if !fileutil.IsDirectory(app.GetAbsDocroot(false)) {
 		err := app.CreateDocroot()
 		if err != nil {
-			util.Failed("Could not create docroot at %s: %v", app.Docroot, err)
+			util.Failed("Could not create docroot at %s: %v", app.GetAbsDocroot(false), err)
 		}
 		// Restart the project after creating docroot
 		if err := app.Restart(); err != nil {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -393,7 +393,7 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 		app.Docroot = docrootRelPathArg
 		// Ensure that the docroot exists
 		if err = app.CreateDocroot(); err != nil {
-			util.Failed("Could not create docroot at %s: %v", app.Docroot, err)
+			util.Failed("Could not create docroot at %s: %v", app.GetAbsDocroot(false), err)
 		}
 	} else {
 		app.Docroot = ddevapp.DiscoverDefaultDocroot(app)
@@ -414,10 +414,7 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	}
 
 	detectedApptype := app.DetectAppType()
-	fullPath, pathErr := filepath.Abs(app.Docroot)
-	if pathErr != nil {
-		util.Failed("Failed to get absolute path to Docroot %s: %v", app.Docroot, pathErr)
-	}
+	fullPath := app.GetAbsDocroot(false)
 
 	doUpdate, _ := cmd.Flags().GetBool("update")
 	switch {

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -390,6 +390,9 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 	}
 
 	if cmd.Flags().Changed("docroot") {
+		if err := ddevapp.ValidateDocroot(docrootRelPathArg); err != nil {
+			util.Failed("Failed to validate docroot: %v", err)
+		}
 		app.Docroot = docrootRelPathArg
 		// Ensure that the docroot exists
 		if err = app.CreateDocroot(); err != nil {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -413,14 +413,14 @@ func TestConfigCreateDocroot(t *testing.T) {
 		error       string
 	}{
 		{"empty docroot", "", "", ""},
-		{"dot docroot", ".", "", ""},
-		{"fail for outside approot", "../somewhere-else", "", "is outside the project root"},
-		{"fail for absolute path", "//test", "", "must be relative"},
-		{"dot with slash docroot", "./", "", ""},
-		{"dot with slash and dir docroot", "./test", "test", ""},
+		{"dot docroot", ".", ".", ""},
+		{"fail for outside approot", "../somewhere-else", "", "must remain inside the project"},
+		{"fail for absolute path", "//test", "", "cannot be an absolute path"},
+		{"dot with slash docroot", "./", "./", ""},
+		{"dot with slash and dir docroot", "./test", "./test", ""},
 		{"subdir docroot", "test/dir", "test/dir", ""},
 		{"dir docroot", "test", "test", ""},
-		{"dot with slash and subdir docroot", "./test/dir", "test/dir", ""},
+		{"dot with slash and subdir docroot", "./test/dir", "./test/dir", ""},
 	}
 
 	for _, tc := range testMatrix {

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -515,7 +515,7 @@ func (app *DdevApp) DefaultWorkingDirMap() map[string]string {
 
 // docrootWorkingDir handles the shared case in which the web service working directory is the docroot.
 func docrootWorkingDir(app *DdevApp, defaults map[string]string) map[string]string {
-	defaults["web"] = path.Join("/var/www/html", app.Docroot)
+	defaults["web"] = app.GetAbsDocroot(true)
 
 	return defaults
 }

--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -145,14 +145,14 @@ func getBackdropHooks() []byte {
 // setBackdropSiteSettingsPaths sets the paths to settings.php for templating.
 func setBackdropSiteSettingsPaths(app *DdevApp) {
 	settings := NewBackdropSettings(app)
-	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
+	settingsFileBasePath := app.GetAbsDocroot(false)
 	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, settings.SiteSettings)
 	app.SiteDdevSettingsFile = filepath.Join(settingsFileBasePath, settings.SiteSettingsDdev)
 }
 
 // isBackdropApp returns true if the app is of type "backdrop".
 func isBackdropApp(app *DdevApp) bool {
-	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "core/scripts/backdrop.sh")); err == nil {
+	if _, err := os.Stat(filepath.Join(app.GetAbsDocroot(false), "core/scripts/backdrop.sh")); err == nil {
 		return true
 	}
 	return false

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1487,7 +1487,7 @@ func (app *DdevApp) CreateDocroot() error {
 		return nil
 	}
 	if filepath.IsAbs(app.Docroot) {
-		return fmt.Errorf("docroot %s must be relative", app.Docroot)
+		return fmt.Errorf("docroot '%s' must be relative to project root directory", app.Docroot)
 	}
 	docrootAbsPath := app.GetAbsDocroot(false)
 	// If user provided something like "./some/path", filepath.Rel will convert it to "some/path"
@@ -1548,7 +1548,7 @@ func (app *DdevApp) docrootPrompt() error {
 
 	// Ensure that the docroot exists
 	if err := app.CreateDocroot(); err != nil {
-		return fmt.Errorf("unable to create docroot at %s: %v", app.Docroot, err)
+		return fmt.Errorf("unable to create docroot at '%s': %v", app.GetAbsDocroot(false), err)
 	}
 
 	return nil
@@ -1568,7 +1568,7 @@ func (app *DdevApp) AppTypePrompt() error {
 	detectedAppType := app.DetectAppType()
 
 	// If we found an application type set it and inform the user.
-	util.Success("Found a %s codebase at %s.", detectedAppType, filepath.Join(app.AppRoot, app.Docroot))
+	util.Success("Found a %s codebase at %s.", detectedAppType, app.GetAbsDocroot(false))
 
 	validAppTypes := strings.Join(GetValidAppTypes(), ", ")
 	typePrompt := "Project Type [%s] (%s): "

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1506,6 +1506,9 @@ func (app *DdevApp) CreateDocroot() error {
 	if app.GetDocroot() == "" {
 		return nil
 	}
+	if err := ValidateDocroot(app.GetDocroot()); err != nil {
+		return err
+	}
 	docrootAbsPath := app.GetAbsDocroot(false)
 	if !fileutil.IsDirectory(docrootAbsPath) {
 		if err := os.MkdirAll(docrootAbsPath, 0755); err != nil {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -555,10 +555,7 @@ func (app *DdevApp) ValidateConfig() error {
 
 // ValidateDocroot makes sure we have a usable docroot
 // The docroot must remain inside the project root.
-// TODO: Should this be "validate" or "normalize"???
-// If normalize, it might be able to remove leading /. Probably not.
 func ValidateDocroot(docroot string) error {
-
 	switch {
 	case filepath.IsAbs(docroot):
 		return fmt.Errorf("docroot ('%s') cannot be an absolute path, it must be a relative path from the project root", docroot)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -474,7 +474,7 @@ func (app *DdevApp) AppConfDir() string {
 	return filepath.Join(app.AppRoot, ".ddev")
 }
 
-// GetDocroot returns the docroot path for DDEV app
+// GetDocroot returns the docroot path relative to project root
 func (app DdevApp) GetDocroot() string {
 	return app.Docroot
 }
@@ -2476,7 +2476,7 @@ func (app *DdevApp) DockerEnv() {
 		"DDEV_MAILPIT_HTTP_PORT":   app.GetMailpitHTTPPort(),
 		"DDEV_MAILPIT_HTTPS_PORT":  app.GetMailpitHTTPSPort(),
 		"DDEV_MAILPIT_PORT":        app.GetMailpitHTTPPort(),
-		"DDEV_DOCROOT":             app.Docroot,
+		"DDEV_DOCROOT":             app.GetDocroot(),
 		"DDEV_HOSTNAME":            app.HostName(),
 		"DDEV_UID":                 uidStr,
 		"DDEV_GID":                 gidStr,

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1989,7 +1989,7 @@ func (app *DdevApp) GenerateWebserverConfig() error {
 			}
 		}
 		content := string(c)
-		docroot := path.Join("/var/www/html", app.Docroot)
+		docroot := app.GetAbsDocroot(true)
 		err = fileutil.TemplateStringToFile(content, map[string]interface{}{"Docroot": docroot}, configPath)
 		if err != nil {
 			return err

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -309,7 +309,7 @@ func getDrupalHooks() []byte {
 // for templating.
 func setDrupalSiteSettingsPaths(app *DdevApp) {
 	drupalConfig := NewDrupalSettings(app)
-	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
+	settingsFileBasePath := app.GetAbsDocroot(false)
 	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, drupalConfig.SitePath, drupalConfig.SiteSettings)
 	app.SiteDdevSettingsFile = filepath.Join(settingsFileBasePath, drupalConfig.SitePath, drupalConfig.SiteSettingsDdev)
 }
@@ -326,7 +326,7 @@ func GetDrupalVersion(app *DdevApp) (string, error) {
 		return "7", nil
 	}
 	// Otherwise figure out the version from existing code
-	f := filepath.Join(app.AppRoot, app.Docroot, "core/lib/Drupal.php")
+	f := filepath.Join(app.GetAbsDocroot(false), "core/lib/Drupal.php")
 	hasVersion, matches, err := fileutil.GrepStringInFile(f, `const VERSION = '([0-9]+)`)
 	v := ""
 	if hasVersion {
@@ -337,7 +337,7 @@ func GetDrupalVersion(app *DdevApp) (string, error) {
 
 // isDrupal6App returns true if the app is of type Drupal6
 func isDrupal6App(app *DdevApp) bool {
-	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "misc/ahah.js")); err == nil {
+	if _, err := os.Stat(filepath.Join(app.GetAbsDocroot(false), "misc/ahah.js")); err == nil {
 		return true
 	}
 	return false
@@ -345,7 +345,7 @@ func isDrupal6App(app *DdevApp) bool {
 
 // isDrupal7App returns true if the app is of type drupal7
 func isDrupal7App(app *DdevApp) bool {
-	if _, err := os.Stat(filepath.Join(app.AppRoot, app.Docroot, "misc/ajax.js")); err == nil {
+	if _, err := os.Stat(filepath.Join(app.GetAbsDocroot(false), "misc/ajax.js")); err == nil {
 		return true
 	}
 	return false
@@ -567,8 +567,8 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 	// *inside* the container, allowing mutagen access to it again
 	if app.IsMutagenEnabled() {
 		settingsFiles := []string{
-			filepath.Join(app.Docroot, `sites/default`),
-			filepath.Join(app.Docroot, `sites/default/settings.php`),
+			path.Join(app.GetAbsDocroot(true), `sites/default`),
+			path.Join(app.GetAbsDocroot(true), `sites/default/settings.php`),
 		}
 		_, stderr, err := app.Exec(&ExecOpts{
 			Cmd: fmt.Sprintf(`chmod -f u+w %s`, strings.Join(settingsFiles, " ")),

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -14,7 +14,7 @@ import (
 
 // isMagentoApp returns true if the app is of type magento
 func isMagentoApp(app *DdevApp) bool {
-	ism1, err := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, app.Docroot, "README.md"), `Magento - Long Term Support`)
+	ism1, err := fileutil.FgrepStringInFile(filepath.Join(app.GetAbsDocroot(false), "README.md"), `Magento - Long Term Support`)
 	if err == nil && ism1 {
 		return true
 	}
@@ -23,7 +23,7 @@ func isMagentoApp(app *DdevApp) bool {
 
 // isMagento2App returns true if the app is of type magento2
 func isMagento2App(app *DdevApp) bool {
-	ism2, err := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, app.Docroot, "..", "SECURITY.md"), `https://hackerone.com/`)
+	ism2, err := fileutil.FgrepStringInFile(filepath.Join(app.GetAbsDocroot(false), "..", "SECURITY.md"), `https://hackerone.com/`)
 	if err == nil && ism2 {
 		return true
 	}
@@ -62,9 +62,9 @@ func createMagentoSettingsFile(app *DdevApp) (string, error) {
 	return app.SiteDdevSettingsFile, nil
 }
 
-// setMagentoSiteSettingsPaths sets the paths to settings.php for templating.
+// setMagentoSiteSettingsPaths sets the paths to local.xml for templating.
 func setMagentoSiteSettingsPaths(app *DdevApp) {
-	app.SiteSettingsPath = filepath.Join(app.AppRoot, app.Docroot, "app", "etc", "local.xml")
+	app.SiteSettingsPath = filepath.Join(app.GetAbsDocroot(false), "app", "etc", "local.xml")
 }
 
 // magentoImportFilesAction defines the magento workflow for importing project files.
@@ -154,9 +154,9 @@ func createMagento2SettingsFile(app *DdevApp) (string, error) {
 	return app.SiteDdevSettingsFile, nil
 }
 
-// setMagento2SiteSettingsPaths sets the paths to settings.php for templating.
+// setMagento2SiteSettingsPaths sets the paths to env.php for templating.
 func setMagento2SiteSettingsPaths(app *DdevApp) {
-	app.SiteSettingsPath = filepath.Join(app.AppRoot, app.Docroot, "..", "app", "etc", "env.php")
+	app.SiteSettingsPath = filepath.Join(app.GetAbsDocroot(false), "..", "app", "etc", "env.php")
 }
 
 // magentoConfigOverrideAction is not currently required

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -144,14 +144,14 @@ func setTypo3SiteSettingsPaths(app *DdevApp) {
 		// above. TYPO3 v12 or higher Core Development mono repository is basically a non-composer mode installation
 		// albeit having a composer.json in the project root folder. Set now the correct path and configuration file
 		// names suitable for these setups.
-		settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
+		settingsFileBasePath := app.GetAbsDocroot(false)
 		settingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "system", "settings.php")
 		localSettingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "system", "additional.php")
 	} else if isTypo3LegacyV11OrLower(app) {
 		// Up to TYPO3 v11 configuration files had the same naming and resided in the `docroot/typo3conf/` folder
 		// which dates back to times before composer has been a gamechanger in the PHP ecosystem. TYPO3 Core Development
 		// mono repository shared the same and we do not have to differenciate between composer and legacy mode here.
-		settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
+		settingsFileBasePath := app.GetAbsDocroot(false)
 		settingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "LocalConfiguration.php")
 		localSettingsFilePath = filepath.Join(settingsFileBasePath, "typo3conf", "AdditionalConfiguration.php")
 	} else {
@@ -187,7 +187,7 @@ func isTypo3App(app *DdevApp) bool {
 // which make no difference in the way to detect both variants. TYPO3 Core Development monorepository also shared the
 // same filestem layout. Thus using only a simple docroot/typo3 folder check here and be fine.
 func isTypo3LegacyV11OrLower(app *DdevApp) bool {
-	typo3Folder := filepath.Join(app.AppRoot, app.Docroot, "typo3")
+	typo3Folder := filepath.Join(app.GetAbsDocroot(false), "typo3")
 
 	// Check if the folder exists, fails if a symlink target does not exist.
 	if _, err := os.Stat(typo3Folder); !os.IsNotExist(err) {
@@ -260,7 +260,7 @@ func isTypo3LegacyV12OrHigher(app *DdevApp) bool {
 		return false
 	}
 
-	typo3Folder := filepath.Join(app.AppRoot, app.Docroot, "typo3")
+	typo3Folder := filepath.Join(app.GetAbsDocroot(false), "typo3")
 
 	versionFilePath := filepath.Join(typo3Folder, "sysext", "core", "Classes", "Information", "Typo3Version.php")
 	versionFile, err := fileutil.ReadFileIntoString(versionFilePath)

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -77,7 +77,7 @@ func (app *DdevApp) IsUploadDirsWarningDisabled() bool {
 // on the host or "" if there is none.
 func (app *DdevApp) calculateHostUploadDirFullPath(uploadDir string) string {
 	if uploadDir != "" {
-		return path.Clean(path.Join(app.AppRoot, app.Docroot, uploadDir))
+		return path.Clean(path.Join(app.GetAbsDocroot(false), uploadDir))
 	}
 
 	return ""
@@ -98,7 +98,7 @@ func (app *DdevApp) GetHostUploadDirFullPath() string {
 // directory in container or "" if there is none.
 func (app *DdevApp) calculateContainerUploadDirFullPath(uploadDir string) string {
 	if uploadDir != "" {
-		return path.Clean(path.Join("/var/www/html", app.Docroot, uploadDir))
+		return path.Clean(path.Join(app.GetAbsDocroot(true), uploadDir))
 	}
 
 	return ""

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -239,7 +239,7 @@ func writeWordpressDdevSettingsFile(config *WordpressConfig, filePath string) er
 func setWordpressSiteSettingsPaths(app *DdevApp) {
 	config := NewWordpressConfig(app, "")
 
-	settingsFileBasePath := filepath.Join(app.AppRoot, app.Docroot)
+	settingsFileBasePath := app.GetAbsDocroot(false)
 	app.SiteSettingsPath = filepath.Join(settingsFileBasePath, config.SiteSettings)
 	app.SiteDdevSettingsFile = filepath.Join(settingsFileBasePath, config.SiteSettingsDdev)
 }
@@ -311,7 +311,7 @@ func wordpressImportFilesAction(app *DdevApp, target, importPath, extPath string
 func wordpressGetRelativeAbsPath(app *DdevApp) (string, error) {
 	needle := "wp-settings.php"
 
-	curDirMatches, err := filepath.Glob(filepath.Join(app.AppRoot, app.Docroot, needle))
+	curDirMatches, err := filepath.Glob(filepath.Join(app.GetAbsDocroot(false), needle))
 	if err != nil {
 		return "", err
 	}
@@ -320,7 +320,7 @@ func wordpressGetRelativeAbsPath(app *DdevApp) (string, error) {
 		return "", nil
 	}
 
-	subDirMatches, err := filepath.Glob(filepath.Join(app.AppRoot, app.Docroot, "*", needle))
+	subDirMatches, err := filepath.Glob(filepath.Join(app.GetAbsDocroot(false), "*", needle))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## The Issue

* #6998

## How This PR Solves The Issue

* Validate the docroot to make sure it isn't absolute or start with ..
* I didn't try to update tests
* This now does more validating and less normalizing (it doesn't change the offered docroot)

## Manual Testing Instructions

Try awkward and wrong docroot manually edited in config.yaml
* /web
* ../something
* other?

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
