### PR TITLE
fix: wrap args with spaces in `ddev exec` with double quotes instead of using raw, for #6930

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -10,6 +10,12 @@ on:
     paths:
       - "docs/content/users/quickstart.md"
       - "docs/tests/**"
+      - "go.*"
+      - "pkg/**"
+      - "cmd/**"
+      - "Makefile"
+      - "vendor/**"
+      - ".github/workflows/quickstart.yml"
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -71,12 +71,13 @@ func TestCmdExec(t *testing.T) {
 	// Test with raw cmd
 	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "--", "ls", "/usr/local")
 	assert.NoError(err)
-	assert.True(strings.HasPrefix(out, "bin\netc\ngames\ninclude"), "expected '%v' to start with 'bin\\netc\\games\\include'", out)
+	assert.True(strings.HasPrefix(out, "bin\netc\ngames\ninclude"), `expected '%v' to start with '%s'`, out, `bin\netc\ngames\ninclude`)
 
 	// Test with raw cmd and bash
 	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "bash", "-c", "ls /usr/local")
 	assert.NoError(err)
-	assert.True(strings.HasPrefix(out, "bin\netc\ngames\ninclude"), "expected '%v' to start with 'bin\\netc\\games\\include'", out)
+	assert.True(strings.HasPrefix(out, "bin\netc\ngames\ninclude"), `expected '%v' to start with '%s'`, out, `bin\netc\games\include`)
+
 
 	// Test sudo
 	out, err = exec.RunHostCommand(DdevBin, "exec", "sudo", "whoami")

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -78,7 +78,6 @@ func TestCmdExec(t *testing.T) {
 	assert.NoError(err)
 	assert.True(strings.HasPrefix(out, "bin\netc\ngames\ninclude"), `expected '%v' to start with '%s'`, out, `bin\netc\games\include`)
 
-
 	// Test sudo
 	out, err = exec.RunHostCommand(DdevBin, "exec", "sudo", "whoami")
 	assert.NoError(err)
@@ -139,11 +138,17 @@ func TestCmdExec(t *testing.T) {
 	// Bash expansion doesn't work with --raw, it's expected
 	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "echo", "$IS_DDEV_PROJECT")
 	assert.NoError(err)
+	// Expect a literal string here instead of a variable
+	// because this is not being run in Bash, i.e., not `docker-compose exec bash -c "command"`,
+	// but `docker-compose exec "command"`
 	assert.Equal("$IS_DDEV_PROJECT", strings.TrimSpace(out))
 
 	// Bash expansion doesn't work with --raw, it's expected (using arg with spaces)
 	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "echo", "$IS_DDEV_PROJECT\n${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}")
 	assert.NoError(err)
+	// Expect a literal string here instead of a variable
+	// because this is not being run in Bash, i.e., not `docker-compose exec bash -c "command"`,
+	// but `docker-compose exec "command"`
 	assert.Equal("$IS_DDEV_PROJECT\n${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}", strings.TrimSpace(out))
 
 	bashPath := util.FindBashPath()

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -116,10 +116,10 @@ func TestCmdExec(t *testing.T) {
 	assert.NoError(err)
 	assert.FileExists(filepath.Join(site.Dir, "echo_args.sh"))
 
-	// Arguments with spaces should not be split
-	out, err = exec.RunHostCommand(DdevBin, "exec", "bash", "echo_args.sh", `string with "quotes" and spaces`, "another string")
+	// Arguments with spaces should not be split, quotes should be preserved
+	out, err = exec.RunHostCommand(DdevBin, "exec", "bash", "echo_args.sh", "string with \"quotes\" and spaces", "another 'quoted' string")
 	assert.NoError(err)
-	assert.Equal("string with \"quotes\" and spaces\nanother string", strings.TrimSpace(out))
+	assert.Equal("string with \"quotes\" and spaces\nanother 'quoted' string", strings.TrimSpace(out))
 
 	// Bash expansion should work
 	out, err = exec.RunHostCommand(DdevBin, "exec", "echo", "$IS_DDEV_PROJECT")
@@ -127,19 +127,19 @@ func TestCmdExec(t *testing.T) {
 	assert.Equal("true", strings.TrimSpace(out))
 
 	// Bash expansion should work (using arg with spaces)
-	out, err = exec.RunHostCommand(DdevBin, "exec", "echo", `$IS_DDEV_PROJECT ${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}`)
+	out, err = exec.RunHostCommand(DdevBin, "exec", "echo", "$IS_DDEV_PROJECT ${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}")
 	assert.NoError(err)
 	assert.Equal("true foobar", strings.TrimSpace(out))
 
 	// Bash expansion doesn't work with --raw, it's expected
-	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "echo", `$IS_DDEV_PROJECT`)
+	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "echo", "$IS_DDEV_PROJECT")
 	assert.NoError(err)
-	assert.Equal(`$IS_DDEV_PROJECT`, strings.TrimSpace(out))
+	assert.Equal("$IS_DDEV_PROJECT", strings.TrimSpace(out))
 
 	// Bash expansion doesn't work with --raw, it's expected (using arg with spaces)
-	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "echo", `$IS_DDEV_PROJECT ${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}`)
+	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "echo", "$IS_DDEV_PROJECT ${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}")
 	assert.NoError(err)
-	assert.Equal(`"$IS_DDEV_PROJECT ${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}"`, strings.TrimSpace(out))
+	assert.Equal("\"$IS_DDEV_PROJECT ${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}\"", strings.TrimSpace(out))
 
 	bashPath := util.FindBashPath()
 	// Make sure we can pipe things into ddev exec and have them work in stdin inside container

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -110,16 +110,16 @@ func TestCmdExec(t *testing.T) {
 	assert.NotEqual("/var/www/html", strings.TrimSpace(out))
 
 	// Create a bash script for testing
-	_, err = exec.RunHostCommand(DdevBin, "exec", "echo 'for i; do echo $i; done' > echo_arg_with_spaces.sh")
+	_, err = exec.RunHostCommand(DdevBin, "exec", "echo 'for i; do echo $i; done' > echo_args.sh")
 	assert.NoError(err)
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
-	assert.FileExists(filepath.Join(site.Dir, "echo_arg_with_spaces.sh"))
+	assert.FileExists(filepath.Join(site.Dir, "echo_args.sh"))
 
 	// Arguments with spaces should not be split
-	out, err = exec.RunHostCommand(DdevBin, "exec", "bash", "echo_arg_with_spaces.sh", "string with spaces")
+	out, err = exec.RunHostCommand(DdevBin, "exec", "bash", "echo_args.sh", `string with "quotes" and spaces`, "another string")
 	assert.NoError(err)
-	assert.Equal("string with spaces", strings.TrimSpace(out))
+	assert.Equal("string with \"quotes\" and spaces\nanother string", strings.TrimSpace(out))
 
 	// Bash expansion should work
 	out, err = exec.RunHostCommand(DdevBin, "exec", "echo", "$IS_DDEV_PROJECT")
@@ -127,7 +127,7 @@ func TestCmdExec(t *testing.T) {
 	assert.Equal("true", strings.TrimSpace(out))
 
 	// Bash expansion should work (using arg with spaces)
-	out, err = exec.RunHostCommand(DdevBin, "exec", "echo", "$IS_DDEV_PROJECT ${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}")
+	out, err = exec.RunHostCommand(DdevBin, "exec", "echo", `$IS_DDEV_PROJECT ${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}`)
 	assert.NoError(err)
 	assert.Equal("true foobar", strings.TrimSpace(out))
 

--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -71,8 +71,12 @@ func TestCmdExec(t *testing.T) {
 	// Test with raw cmd
 	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "--", "ls", "/usr/local")
 	assert.NoError(err)
+	assert.True(strings.HasPrefix(out, "bin\netc\ngames\ninclude"), "expected '%v' to start with 'bin\\netc\\games\\include'", out)
 
-	assert.True(strings.HasPrefix(out, "bin\netc\ngames"), "expected '%v' to start with 'bin\\netc\\games\\include'", out)
+	// Test with raw cmd and bash
+	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "bash", "-c", "ls /usr/local")
+	assert.NoError(err)
+	assert.True(strings.HasPrefix(out, "bin\netc\ngames\ninclude"), "expected '%v' to start with 'bin\\netc\\games\\include'", out)
 
 	// Test sudo
 	out, err = exec.RunHostCommand(DdevBin, "exec", "sudo", "whoami")
@@ -127,9 +131,9 @@ func TestCmdExec(t *testing.T) {
 	assert.Equal("true", strings.TrimSpace(out))
 
 	// Bash expansion should work (using arg with spaces)
-	out, err = exec.RunHostCommand(DdevBin, "exec", "echo", "$IS_DDEV_PROJECT ${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}")
+	out, err = exec.RunHostCommand(DdevBin, "exec", "echo", "$IS_DDEV_PROJECT\n${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}")
 	assert.NoError(err)
-	assert.Equal("true foobar", strings.TrimSpace(out))
+	assert.Equal("true\nfoobar", strings.TrimSpace(out))
 
 	// Bash expansion doesn't work with --raw, it's expected
 	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "echo", "$IS_DDEV_PROJECT")
@@ -137,9 +141,9 @@ func TestCmdExec(t *testing.T) {
 	assert.Equal("$IS_DDEV_PROJECT", strings.TrimSpace(out))
 
 	// Bash expansion doesn't work with --raw, it's expected (using arg with spaces)
-	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "echo", "$IS_DDEV_PROJECT ${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}")
+	out, err = exec.RunHostCommand(DdevBin, "exec", "--raw", "echo", "$IS_DDEV_PROJECT\n${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}")
 	assert.NoError(err)
-	assert.Equal("\"$IS_DDEV_PROJECT ${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}\"", strings.TrimSpace(out))
+	assert.Equal("$IS_DDEV_PROJECT\n${DDEV_NON_EXISTING_TEST_VARIABLE:-foobar}", strings.TrimSpace(out))
 
 	bashPath := util.FindBashPath()
 	// Make sure we can pipe things into ddev exec and have them work in stdin inside container

--- a/docs/tests/civicrm.bats
+++ b/docs/tests/civicrm.bats
@@ -15,7 +15,7 @@ teardown() {
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
-  #ddev config --project-type=php --composer-root=core --upload-dirs=public/media
+  # ddev config --project-type=php --composer-root=core --upload-dirs=public/media
   run ddev config --project-type=php --composer-root=core --upload-dirs=public/media
   assert_success
   # ddev start

--- a/docs/tests/civicrm.bats
+++ b/docs/tests/civicrm.bats
@@ -15,7 +15,7 @@ teardown() {
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
-  # ddev config --project-type=php --composer-root=core --upload-dirs=public/media
+  #ddev config --project-type=php --composer-root=core --upload-dirs=public/media
   run ddev config --project-type=php --composer-root=core --upload-dirs=public/media
   assert_success
   # ddev start


### PR DESCRIPTION
## The Issue

- #6930

After merging the PR above, CiviCRM quickstart failed because the value of `$DDEV_PRIMARY_URL` was not expanded.

```
ddev exec cv core:install --cms-base-url='$DDEV_PRIMARY_URL' ...
...
#   ERROR: (system) cmsBaseUrl: The "cmsBaseUrl" ($DDEV_PRIMARY_URL) is unavailable or malformed. Consider setting it explicitly.
...
```

The use of `ExecRaw` broke variable expansion.

## How This PR Solves The Issue

We can't use `ExecRaw` because variable expansion doesn't work.

I can add `os.ExpandEnv`, but it's not the same as bash expansion:

- https://github.com/golang/go/issues/47187

This means that any existing `ddev exec` code that depends on bash expansion will be broken.

So I reverted this change and added a double quote wrapping, which should be an appropriate solution that still fixes the arguments with spaces.

## Manual Testing Instructions

Using DDEV v1.24.2:
```bash
$ ddev exec echo '$IS_DDEV_PROJECT ${FOO_BAR:-foobar}'
true foobar

$ echo 'for i; do echo $i; done' > issue.sh

$ ddev exec bash issue.sh "string with spaces"
string
with
spaces

$ ddev exec bash issue.sh "string with spaces" --test="a b c"
string
with
spaces
--test=a
b
c

$ ddev exec 'bash issue.sh "string with spaces"'
string with spaces

$ ddev exec "set | grep IS_DDEV_PROJECT"
BASH_EXECUTION_STRING='set -eu && ( set | grep IS_DDEV_PROJECT)'
IS_DDEV_PROJECT=true

$ echo '<?php var_dump($_SERVER["argv"]);' > args.php

$ ddev exec php args.php --option="argument with string"
array(4) {
  [0]=>
  string(8) "args.php"
  [1]=>
  string(17) "--option=argument"
  [2]=>
  string(4) "with"
  [3]=>
  string(6) "string"
}
```

Using DDEV HEAD (which has broken variable expansion when using several args):
```bash
$ ddev exec echo '$IS_DDEV_PROJECT ${FOO_BAR:-foobar}'
$IS_DDEV_PROJECT ${FOO_BAR:-foobar}

$ echo 'for i; do echo $i; done' > issue.sh

$ ddev exec bash issue.sh "string with spaces"
string with spaces

$ ddev exec bash issue.sh "string with spaces" --test="a b c"
string with spaces
--test=a b c

$ ddev exec 'bash issue.sh "string with spaces"'
string with spaces

$ ddev exec "set | grep IS_DDEV_PROJECT"
BASH_EXECUTION_STRING='set -eu && ( set | grep IS_DDEV_PROJECT)'
IS_DDEV_PROJECT=true

$ echo '<?php var_dump($_SERVER["argv"]);' > args.php

$ ddev exec php args.php --option="argument with string"
array(2) {
  [0]=>
  string(8) "args.php"
  [1]=>
  string(29) "--option=argument with string"
}
```

Using this PR:
```bash
$ ddev exec echo '$IS_DDEV_PROJECT ${FOO_BAR:-foobar}'
true foobar

$ echo 'for i; do echo $i; done' > issue.sh

$ ddev exec bash issue.sh "string with spaces"
string with spaces

$ ddev exec bash issue.sh "string with spaces" --test="a b c"
string with spaces
--test=a b c

$ ddev exec 'bash issue.sh "string with spaces"'
string with spaces

$ ddev exec "set | grep IS_DDEV_PROJECT"
BASH_EXECUTION_STRING='set -eu && ( set | grep IS_DDEV_PROJECT)'
IS_DDEV_PROJECT=true

$ echo '<?php var_dump($_SERVER["argv"]);' > args.php

$ ddev exec php args.php --option="argument with string"
array(2) {
  [0]=>
  string(8) "args.php"
  [1]=>
  string(29) "--option=argument with string"
}
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
