### PR TITLE
docs: add quickstart tip on running Symfony Web Debug Toolbar with Apache

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1009,6 +1009,13 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev exec symfony server:log
     ```
 
+!!!tip "Web Debug Toolbar support for Apache (`apache-fpm`)"
+    
+    ```bash
+    ddev composer require symfony/apache-pack
+    # When asked to execute the recipe, choose "yes" with "y"
+    ```
+
 ## TYPO3
 
 === "Composer"


### PR DESCRIPTION
This PR adds a quickstart tip to the documentation on how to fix the issue of not being able to use the Symfony Web Debug Toolbar when the Apache web server is used (`webserver_type` in `.ddev/config.yaml` is set to `apache-fpm`).

![symf-deb-tool](https://github.com/user-attachments/assets/35d171a3-208f-4171-bc95-7d49df31905c)

The Web Debug Toolbar needs support through `.htaccess` in order to find the appropriate Symfony profiler routes.

This support is added by including the official Symfony Apache pack through Composer: https://packagist.org/packages/symfony/apache-pack

```bash
ddev composer require symfony/apache-pack
```

