### PR TITLE
docs: change code refs to include info about Backdrop config storage options, fixes #7013

### DIFF
--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -161,7 +161,7 @@ func isBackdropApp(app *DdevApp) bool {
 // backdropPostImportDBAction emits a warning about moving configuration into place
 // appropriately in order for Backdrop to function properly.
 func backdropPostImportDBAction(_ *DdevApp) error {
-	util.Warning("Backdrop sites require your config JSON files to be located in your site's \"active\" configuration directory. Please refer to the Backdrop documentation (https://docs.backdropcms.org/documentation/deploying-a-backdrop-site) for more information about this process.")
+	util.Warning("Backdrop sites store your config JSON files in your site's \"active\" configuration directory by default, although you also have the option to store it in the database. Please refer to the Backdrop documentation (https://docs.backdropcms.org/documentation/deploying-a-backdrop-site) for more information about this process.")
 	return nil
 }
 


### PR DESCRIPTION
## The Issue

- #7013

DDEV provides helpful information regarding Backdrop's config after importing a database. As of Backdrop 1.28.0, this information is slightly outdated so I'd like to update it.

## How This PR Solves The Issue

Minor touch to adjust language slightly and give additional context about config storage options.

## Manual Testing Instructions

    1. Spin up a Backdrop site.
    2. Export the database.
    3. Import the database.
    4. Read the message that DDEV provides.

## Automated Testing Overview

No additional tests needed as it's just a minor text adjustment.

## Release/Deployment Notes

n/a