### PR TITLE
fix: show router errors on `ddev list` and `ddev describe`, for #6980

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -233,6 +233,15 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 		if len(bindInfo) > 0 {
 			t.AppendRow(table.Row{"Network", "", strings.Join(bindInfo, "\n")})
 		}
+		if !ddevapp.IsRouterDisabled(app) {
+			// If there is a problem with the router, add it to the table
+			routerStatus, errorInfo := ddevapp.RenderRouterStatus()
+			if errorInfo != "" {
+				t.AppendFooter(table.Row{
+					"Router", routerStatus, text.WrapSoft(errorInfo, int(urlPortWidth)),
+				})
+			}
+		}
 	}
 
 	t.Render()

--- a/pkg/ddevapp/list.go
+++ b/pkg/ddevapp/list.go
@@ -74,13 +74,17 @@ func List(settings ListCommandSettings) {
 			if routerStatus == SiteStopped {
 				routerURL = ""
 			}
-			extendedRouterStatus := RenderRouterStatus()
+			location := fileutil.ShortHomeJoin(globalconfig.GetGlobalDdevDirLocation())
+			extendedRouterStatus, errorInfo := RenderRouterStatus()
+			if errorInfo != "" {
+				location = text.WrapSoft(errorInfo, 35)
+			}
 			routerType := globalconfig.DdevGlobalConfig.Router
 			if len(types.GetValidRouterTypes()) < 2 {
 				routerType = ""
 			}
 			t.AppendFooter(table.Row{
-				"Router", extendedRouterStatus, fileutil.ShortHomeJoin(globalconfig.GetGlobalDdevDirLocation()), routerURL, routerType},
+				"Router", extendedRouterStatus, location, routerURL, routerType},
 			)
 			t.Render()
 			output.UserOut.WithField("raw", appDescs).Print(out.String())


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/6980#issuecomment-2664268292

Run `ddev list --continuous`, open a new terminal and run `ddev start`

Look at `ddev list --continuous` (but this is not an error!):

![image](https://github.com/user-attachments/assets/fc5d6122-3409-4140-a4cf-2e1f4f27cc2d)

In a couple of seconds:

![image](https://github.com/user-attachments/assets/62c970df-599c-4649-a63b-d22d1dc86d0c)

Run `docker exec -it ddev-router bash -c "killall traefik"` in a new terminal.

Look at `ddev list --continuous` (it's ugly):

![image](https://github.com/user-attachments/assets/b771a4c5-206c-48c9-83ad-317f68113f26)

## How This PR Solves The Issue

- Makes the `ddev list` output fancier
- Adds router error to `ddev describe` output because people don't always notice the output from `ddev start`, so give them a second chance to see if there is a problem with router on `ddev describe`.

## Manual Testing Instructions

Run `ddev list --continuous`, open a new terminal and run `ddev start`

Look at `ddev list --continuous`:

![image](https://github.com/user-attachments/assets/82a5bbc8-20cc-4059-b704-0a02e4dda297)

In a couple of seconds:

![image](https://github.com/user-attachments/assets/8f8554a8-8e32-4b94-97f9-2b91bb65325b)

Run `docker exec -it ddev-router bash -c "killall traefik"` in a new terminal.

Look at `ddev list --continuous`:

![image](https://github.com/user-attachments/assets/fbe4b196-b8cf-4020-b2ce-40002ecdfd60)

Run `ddev describe` (new footer that will only be displayed in case of an error with the router):

![image](https://github.com/user-attachments/assets/021fcd98-824e-48a2-b12e-cbee0d14bc06)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
