### PR TITLE
test: Run quickstart tests with mutagen enabled [skip buildkite]

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -67,4 +67,6 @@ jobs:
 
       - name: Run quickstart test
         run: |
+          # Use mutagen by default as it may cause different behaviors
+          ddev config global --performance-mode=mutagen
           make quickstart-test

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -69,4 +69,7 @@ jobs:
         run: |
           # Use mutagen by default as it may cause different behaviors
           ddev config global --performance-mode=mutagen
+          # bats refuses ever to exit until all processes started by it
+          # have exited. So we don't want to let bats/ddev start mutagen
+          ddev debug mutagen daemon start || true
           make quickstart-test

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -71,5 +71,8 @@ jobs:
           ddev config global --performance-mode=mutagen
           # bats refuses ever to exit until all processes started by it
           # have exited. So we don't want to let bats/ddev start mutagen
+          # ddev debug download-images makes sure we have mutagen available
+          ddev debug download-images
           ddev debug mutagen daemon start || true
           make quickstart-test
+          ddev poweroff

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -70,9 +70,7 @@ jobs:
           # Use mutagen by default as it may cause different behaviors
           ddev config global --performance-mode=mutagen
           # bats refuses ever to exit until all processes started by it
-          # have exited. So we don't want to let bats/ddev start mutagen
-          # ddev debug download-images makes sure we have mutagen available
-          ddev debug download-images
-          ddev debug mutagen daemon start || true
+          # have exited. So we don't want to let bats/ddev start mutagen daemon
+          mkdir -p ~/tmp/dummystart && pushd ~/tmp/dummystart && ddev config --auto && ddev start -y && popd
           make quickstart-test
           ddev poweroff

--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -1,11 +1,10 @@
 package cmd
 
 import (
-	"runtime"
-
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -24,7 +23,7 @@ var DebugDownloadImagesCmd = &cobra.Command{
 		if err != nil {
 			util.Warning("Unable to download docker-compose: %v", err)
 		}
-		if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 			err = ddevapp.DownloadMutagenIfNeeded()
 			if err != nil {
 				util.Warning("Unable to download Mutagen: %v", err)

--- a/docs/tests/common-setup.bash
+++ b/docs/tests/common-setup.bash
@@ -15,7 +15,5 @@ _common_setup() {
 
 _common_teardown() {
   ddev delete -Oy ${PROJNAME}
-  # Mutagen subprocess running makes bats never exit
-  ddev debug mutagen daemon stop || true
   rm -rf ${tmpdir}
 }

--- a/docs/tests/common-setup.bash
+++ b/docs/tests/common-setup.bash
@@ -15,5 +15,7 @@ _common_setup() {
 
 _common_teardown() {
   ddev delete -Oy ${PROJNAME}
+  # Mutagen subprocess running makes bats never exit
+  ddev debug mutagen daemon stop || true
   rm -rf ${tmpdir}
 }


### PR DESCRIPTION

## The Issue

We've been running quickstarts in a linux workflow, but we might get more information running them with mutagen on. 

We may want to think about running them on macOS, but for now we can enable mutagen here.

## How This PR Solves The Issue

Turn on mutagen for these tests

