### PR TITLE
fix: bump mutagen to 0.18.1, fixes #7015

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -39,6 +39,6 @@ var BUILDINFO = "BUILDINFO should have new info"
 // MutagenVersion is filled with the version we find for Mutagen in use
 var MutagenVersion = ""
 
-const RequiredMutagenVersion = "0.18.0"
+const RequiredMutagenVersion = "0.18.1"
 
 const RequiredDockerComposeVersionDefault = "v2.32.4"


### PR DESCRIPTION
## The Issue

* #7015

Mutagen 0.18.0 doesn't work at all with Docker 28.0.0

@xenoscopic diagnosed and immediately responded with a new release, thanks!

## How This PR Solves The Issue

Bump mutagen to 0.18.1

## Manual Testing Instructions

Try it out with mutagen.

## Release/Deployment Notes

- [ ] After this gets pulled, we need to upgrade colima and lima on runners to use 27.0.0