### PR TITLE
build: bump images to v1.24.3 for release, and docker-compose to v2.33.1

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -2,7 +2,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20250211_stasadev_remove_pecl_xdebug AS ddev-webserver-base
+FROM ddev/ddev-php-base:v1.24.3 AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,21 +11,21 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250213_rfay_blackfire" // Note that this can be overridden by make
+var WebTag = "v1.24.3" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.24.2"
+var BaseDBTag = "v1.24.3"
 
-const TraefikRouterImage = "ddev/ddev-traefik-router:v1.24.2"
+const TraefikRouterImage = "ddev/ddev-traefik-router:v1.24.3"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.24.2"
+var SSHAuthTag = "v1.24.3"
 
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"
@@ -41,4 +41,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.18.1"
 
-const RequiredDockerComposeVersionDefault = "v2.32.4"
+const RequiredDockerComposeVersionDefault = "v2.33.1"


### PR DESCRIPTION
## The Issue

It's time for v1.24.3 release mostly because of:

- #7015

## How This PR Solves The Issue

- Bumps Docker images to v1.24.3
	Not every image build worked, I used [this workaround](https://github.com/actions/runner-images/issues/11561#issuecomment-2678571978):
    ```yaml
    - name: Set up QEMU
      uses: docker/setup-qemu-action@v3
      with:
        image: tonistiigi/binfmt:qemu-v7.0.0-28
	````
- Bumps `docker-compose` to [v2.33.1](https://github.com/docker/compose/releases/tag/v2.33.1)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
