### PR TITLE
docs: add a note about rootless mode, show context in ddev debug test

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -132,6 +132,9 @@ if [ ${OSTYPE%-*} != "linux" ] && [ "$docker_platform" = "docker-desktop" ]; the
   echo -n "Docker Desktop Version: " && docker_desktop_version && echo
 fi
 echo "docker version: " && docker version
+echo
+echo "docker context: " && docker context ls
+echo
 printf "\nDOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM:-notset}\n"
 
 case $docker_platform in

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -98,7 +98,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     * [binaries](https://docs.docker.com/install/linux/docker-ce/binaries/)
 
 
-    Linux installation **absolutely** requires adding your Linux user to the `docker` group, and configuring the Docker daemon to start at boot. See [Post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).
+    Linux installation **absolutely** requires adding your Linux user to the `docker` group, and configuring the Docker daemon to start at boot. Don't install rootless mode, it is not supported by DDEV. See [Post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).
 
     !!!warning "Don’t `sudo` with `docker` or `ddev`"
         Don’t use `sudo` with the `docker` command. If you find yourself needing it, you haven’t finished the installation. You also shouldn’t use `sudo` with `ddev` unless it’s specifically for the [`ddev hostname`](../usage/commands.md#hostname) command.


### PR DESCRIPTION
## The Issue

From Discord https://discord.com/channels/664580571770388500/1343957710604992573

## How This PR Solves The Issue

It's good to see all available contexts in `ddev debug test`.
Say explicitly that rootless mode is not supported.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
