### PR TITLE
fix: the `#ddev-description` stanza in add-on install actions not showing if it's the first line

### DIFF
--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -146,7 +146,7 @@ func ProcessAddonAction(action string, dict map[string]interface{}, bashPath str
 
 // GetAddonDdevDescription returns what follows #ddev-description: in any line in action
 func GetAddonDdevDescription(action string) string {
-	descLines := nodeps.GrepStringInBuffer(action, `[\r\n]+#ddev-description:.*[\r\n]+`)
+	descLines := nodeps.GrepStringInBuffer(action, `[\r\n]*#ddev-description:.*[\r\n]+`)
 	if len(descLines) > 0 {
 		d := strings.Split(descLines[0], ":")
 		if len(d) > 1 {


### PR DESCRIPTION
I just noticed that my [add-on's post install actions](https://github.com/hanoii/ddev-pimp-my-shell/blob/637a873275cff867d82b48e707644df0f1854905/install.yaml#L21-L54) were not showing the `#ddev-description` as I was used to.

I looked at the code and found that the regex was not finding it if the stanza was right next to `- |`. One more newline and it was picked up.

I added an extra newline on the last commit of that file, but trying it with the latest release of the add-on show showcase the issue.