### PR TITLE
feat: add `go-version` to `ddev version`, fixes #7021

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,6 +27,7 @@ func GetVersionInfo() map[string]string {
 	versionInfo["DDEV version"] = versionconstants.DdevVersion
 	versionInfo["cgo_enabled"] = strconv.FormatInt(versionconstants.CGOEnabled, 10)
 	versionInfo["global-ddev-dir"] = globalconfig.GetGlobalDdevDir()
+	versionInfo["go_version"] = runtime.Version()
 	versionInfo["web"] = docker.GetWebImage()
 	versionInfo["db"] = docker.GetDBImage(nodeps.MariaDB, "")
 	versionInfo["router"] = docker.GetRouterImage()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,7 +27,7 @@ func GetVersionInfo() map[string]string {
 	versionInfo["DDEV version"] = versionconstants.DdevVersion
 	versionInfo["cgo_enabled"] = strconv.FormatInt(versionconstants.CGOEnabled, 10)
 	versionInfo["global-ddev-dir"] = globalconfig.GetGlobalDdevDir()
-	versionInfo["go_version"] = runtime.Version()
+	versionInfo["go-version"] = runtime.Version()
 	versionInfo["web"] = docker.GetWebImage()
 	versionInfo["db"] = docker.GetDBImage(nodeps.MariaDB, "")
 	versionInfo["router"] = docker.GetRouterImage()

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -33,7 +33,7 @@ func TestGetVersionInfo(t *testing.T) {
 	assert.Contains(v["web"], versionconstants.WebTag)
 	assert.Contains(v["db"], versionconstants.DBImg)
 	assert.Contains(v["db"], nodeps.MariaDBDefaultVersion)
-	assert.Equal(runtime.Version(), v["go_version"])
+	assert.Equal(runtime.Version(), v["go-version"])
 	assert.Equal(runtime.GOOS, v["os"])
 	assert.Equal(versionconstants.BUILDINFO, v["build info"])
 	assert.NotEmpty(v["docker"])

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -33,6 +33,7 @@ func TestGetVersionInfo(t *testing.T) {
 	assert.Contains(v["web"], versionconstants.WebTag)
 	assert.Contains(v["db"], versionconstants.DBImg)
 	assert.Contains(v["db"], nodeps.MariaDBDefaultVersion)
+	assert.Equal(runtime.Version(), v["go_version"])
 	assert.Equal(runtime.GOOS, v["os"])
 	assert.Equal(versionconstants.BUILDINFO, v["build info"])
 	assert.NotEmpty(v["docker"])


### PR DESCRIPTION
## The Issue

- #7021

## How This PR Solves The Issue

Adds the Go version that was used in the DDEV build.

## Manual Testing Instructions

```
$ ddev version
 ITEM             VALUE                                    
 DDEV version     v1.24.3-1-g9337adae4                     
 architecture     amd64                                    
 cgo_enabled      0                                        
 db               ddev/ddev-dbserver-mariadb-10.11:v1.24.3 
 ddev-ssh-agent   ddev/ddev-ssh-agent:v1.24.3              
 docker           28.0.1                                   
 docker-api       1.48                                     
 docker-compose   v2.33.1                                  
 docker-platform  linux-docker                             
 global-ddev-dir  /home/stas/.ddev                         
 go-version       go1.23.6                                 <= added this
 mutagen          0.18.1                                   
 os               linux                                    
 router           ddev/ddev-traefik-router:v1.24.3         
 web              ddev/ddev-webserver:v1.24.3
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
