### PR TITLE
fix: remove refreshenv from WSL2 install scripts, fixes #7024 [skip ci]

### DIFF
--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -62,6 +62,4 @@ if (-not(wsl -e docker ps)) {
 }
 wsl -u root -e bash -c "touch /etc/wsl.conf && if ! fgrep '[boot]' /etc/wsl.conf >/dev/null; then printf '\n[boot]\nsystemd=true\n' >>/etc/wsl.conf; fi"
 
-refreshenv
-
 wsl ddev version

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -58,14 +58,11 @@ wsl bash -c 'sudo usermod -aG docker $USER'
 
 wsl bash -c 'echo CAROOT=$CAROOT'
 wsl -u root mkcert -install
-wsl -u root service docker start
 if (-not(wsl -e docker ps)) {
     throw "docker does not seem to be working inside the WSL2 distro yet. "
 }
 # If docker desktop was previously set up, the .docker can break normal use of docker client.
 wsl rm -rf ~/.docker
-
-refreshenv
 
 wsl -u root -e bash -c "touch /etc/wsl.conf && if ! fgrep '[boot]' /etc/wsl.conf >/dev/null; then printf '\n[boot]\nsystemd=true\n' >>/etc/wsl.conf; fi"
 


### PR DESCRIPTION

## The Issue

* #7024 

In some new Windows 11 versions, `wmic.exe` is either not installed or not in the PATH.
It's also part of a deprecated subsystem.

## How This PR Solves The Issue

* Remove the `refreshenv` that happened to call this from the two WSL2 install scripts
* Since WSL2 now uses systemd, there's no need for the `system service docker start` that was in there.

## Manual Testing Instructions

Use a fresh clean Ubuntu as the default WSL2.
Install in both contexts (docker-ce and Docker Desktop), with `wmic` out of the path, as described in the issue.

## Automated Testing Overview

There is no testing for this.

