### PR TITLE
fix: delete traefik images based on the pattern used for ddev-dbserver and use constants for targeting, fixes #6326

### DIFF
--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -121,7 +121,7 @@ func deleteDdevImages(deleteAll bool) error {
 					return err
 				}
 			}
-			if strings.HasPrefix(tag, "ddev/ddev-dbserver") && !strings.HasSuffix(tag, keepDBImageTag) && !strings.HasSuffix(tag, keepDBImageTag+"-built") {
+			if strings.HasPrefix(tag, versionconstants.DBImg) && !strings.HasSuffix(tag, keepDBImageTag) && !strings.HasSuffix(tag, keepDBImageTag+"-built") {
 				if err = dockerutil.RemoveImage(tag); err != nil {
 					return err
 				}

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -126,9 +126,8 @@ func deleteDdevImages(deleteAll bool) error {
 					return err
 				}
 			}
-			// TODO: Verify the functionality here. May not work since GetRouterImage() returns full image spec
 			// If a routerImage, but doesn't match our routerimage, delete it
-			if strings.HasPrefix(tag, ddevImages.GetRouterImage()) && !strings.HasPrefix(tag, routerimage) {
+			if strings.HasPrefix(tag, "ddev/ddev-traefik-router") && !strings.HasPrefix(tag, routerimage) {
 				if err = dockerutil.RemoveImage(tag); err != nil {
 					return err
 				}

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -127,7 +127,7 @@ func deleteDdevImages(deleteAll bool) error {
 				}
 			}
 			// If a routerImage, but doesn't match our routerimage, delete it
-			if strings.HasPrefix(tag, "ddev/ddev-traefik-router") && !strings.HasPrefix(tag, routerimage) {
+			if strings.HasPrefix(tag, versionconstants.TraefikRouterImage) && !strings.HasPrefix(tag, routerimage) {
 				if err = dockerutil.RemoveImage(tag); err != nil {
 					return err
 				}

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -45,5 +45,5 @@ func GetSSHAuthImage() string {
 
 // GetRouterImage returns the router image:tag reference
 func GetRouterImage() string {
-	return versionconstants.TraefikRouterImage
+	return fmt.Sprintf("%s:%s", versionconstants.TraefikRouterImage, versionconstants.TraefikRouterTag)
 }

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -19,7 +19,11 @@ var DBImg = "ddev/ddev-dbserver"
 // BaseDBTag is the main tag, DBTag is constructed from it
 var BaseDBTag = "v1.24.3"
 
-const TraefikRouterImage = "ddev/ddev-traefik-router:v1.24.3"
+// TraefikRouterImage is image for router
+var TraefikRouterImage = "ddev/ddev-traefik-router"
+
+// TraefikRouterTag is traefik router tag
+var TraefikRouterTag = "v1.24.3"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"


### PR DESCRIPTION
## The Issue

- #6326

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue
The PR addresses two details. first it fixes #6326 by applying the same pattern used for db images. i've addressed the suggestion by @stasadev using constants instead of the image name. talking of constant i've also did a small cosmetic fix and use now also a constant for addressing the db images instead of the image name. now every if clause in the for loop uses constants instead of image names

## Manual Testing Instructions

```
docker pull ddev/ddev-ssh-agent:v1.24.2
docker pull ddev/ddev-traefik-router:v1.24.2

docker images | grep v1.24.2
ddev/ddev-traefik-router                  v1.24.2                        01f41d37afe2   6 weeks ago     229MB
ddev/ddev-ssh-agent                       v1.24.2                        bd674e56e923   6 weeks ago     136MB

ddev delete images

docker images | grep v1.24.2
(nothing)
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
