### PR TITLE
docs: add Backdrop-specific config considerations.

### DIFF
--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -34,6 +34,14 @@ This environment variable is set `true` by default in DDEV’s environment, and 
 
 ## CMS-Specific Help and Techniques
 
+### Backdrop Specifics
+
+#### Configuration considerations
+
+By default, Backdrop stores both active and staging configuration in the filesystem. In this case, if you are updating the database (either from a live site, or reloading while working locally) it can be important to also refresh the active configuration directory to make sure your database structure is in line with what your configuration is describing. 
+
+Backdrop also allows you to store your active configuration in the database ([as of Backdrop 1.28.0](https://docs.backdropcms.org/change-records/swappable-config-storage)), which can be simpler while developing locally, especially if you are making use of DDEV's snapshot feature. In this case, the database and the active configuration are effectively bundled and refreshing the database also refreshes the active configuration.
+
 ### Drupal Specifics
 
 #### Drupal Settings Files

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -42,6 +42,13 @@ By default, Backdrop stores both active and staging configuration in the filesys
 
 Backdrop also allows you to store your active configuration in the database ([as of Backdrop 1.28.0](https://docs.backdropcms.org/change-records/swappable-config-storage)), which can be simpler while developing locally, especially if you are making use of DDEV's snapshot feature. In this case, the database and the active configuration are effectively bundled and refreshing the database also refreshes the active configuration.
 
+#### Command line tool
+
+Backdrop's command line tool, [Bee](https://github.com/backdrop-contrib/bee), can be included in a DDEV local using this command:
+```php
+ddev add-on get backdrop-ops/ddev-backdrop-bee
+```
+
 ### Drupal Specifics
 
 #### Drupal Settings Files

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -38,16 +38,9 @@ This environment variable is set `true` by default in DDEV’s environment, and 
 
 #### Configuration considerations
 
-By default, Backdrop stores both active and staging configuration in the filesystem. In this case, if you are updating the database (either from a live site, or reloading while working locally) it can be important to also refresh the active configuration directory to make sure your database structure is in line with what your configuration is describing. 
+By default, Backdrop stores both active and staging configuration in the filesystem. In this case, if you are updating the database (either from a live site, or reloading while working locally) it can be important to also refresh the active configuration directory to make sure your database structure is in line with what your configuration is describing.
 
 Backdrop also allows you to store your active configuration in the database ([as of Backdrop 1.28.0](https://docs.backdropcms.org/change-records/swappable-config-storage)), which can be simpler while developing locally, especially if you are making use of DDEV's snapshot feature. In this case, the database and the active configuration are effectively bundled and refreshing the database also refreshes the active configuration.
-
-#### Command line tool
-
-Backdrop's command line tool, [Bee](https://github.com/backdrop-contrib/bee), can be included in a DDEV local using this command:
-```php
-ddev add-on get backdrop-ops/ddev-backdrop-bee
-```
 
 ### Drupal Specifics
 


### PR DESCRIPTION
## The Issue

Backdrop's config storage options can be confusing with local development, so it would be good to have a short description of the options as discussed in https://github.com/ddev/ddev/pull/7014#issuecomment-2677157148

As well, it is worth mentioning Backdrop's command line tool, `bee`. 

Review rendered at https://ddev--7037.org.readthedocs.build/en/7037/users/usage/cms-settings/#backdrop-specifics