### PR TITLE
fix: explicitly ping 127.0.0.1 in Traefik healthcheck to make proxying work, fixes #7044, fixes #6931

### DIFF
--- a/containers/ddev-traefik-router/test/containertest.sh
+++ b/containers/ddev-traefik-router/test/containertest.sh
@@ -63,11 +63,5 @@ if ! containercheck; then
     exit 101
 fi
 
-# Make sure we can access http and https ports successfully (and with valid cert)
-#(curl -s -I http://127.0.0.1:8080 | grep 503) || (echo "Failed to get 503 from nginx-router by default" && exit 102)
-## mkcert is not respected by git-bash curl, so don't try the test on windows.
-#if [ "${OS:-$(uname)}" != "Windows_NT" ]; then
-#    (curl -s -I https://127.0.0.1:8443 | grep 503) || (echo "Failed to get 503 from nginx-router via https by default" && exit 103)
-#fi
 # Make sure internal access to monitor port is working
-docker exec -t $CONTAINER_NAME bash -c 'curl -I http://127.0.0.1:${TRAEFIK_MONITOR_PORT}/ping' || (echo "Failed to run http healthcheck inside container" && exit 104)
+docker exec -t $CONTAINER_NAME bash -c 'traefik healthcheck --ping.entryPoint=ping --entryPoints.ping.address=127.0.0.1:${TRAEFIK_MONITOR_PORT} --ping 2>&1' || (echo "Failed to run http healthcheck inside container" && exit 104)

--- a/containers/ddev-traefik-router/traefik_healthcheck.sh
+++ b/containers/ddev-traefik-router/traefik_healthcheck.sh
@@ -15,7 +15,7 @@ if [ -f /tmp/healthy ]; then
 fi
 
 # If we can now access the traefik ping endpoint, then we're healthy
-check=$(traefik healthcheck --ping --configFile=/mnt/ddev-global-cache/traefik/.static_config.yaml 2>&1)
+check=$(traefik healthcheck --ping.entryPoint=ping --entryPoints.ping.address=127.0.0.1:${TRAEFIK_MONITOR_PORT} --ping 2>&1)
 exit_code=$?
 
 if [ $exit_code -eq 0 ]; then

--- a/containers/ddev-traefik-router/traefik_healthcheck.sh
+++ b/containers/ddev-traefik-router/traefik_healthcheck.sh
@@ -15,6 +15,7 @@ if [ -f /tmp/healthy ]; then
 fi
 
 # If we can now access the traefik ping endpoint, then we're healthy
+# Technique from https://doc.traefik.io/traefik/operations/ping/#entrypoint
 check=$(traefik healthcheck --ping.entryPoint=ping --entryPoints.ping.address=127.0.0.1:${TRAEFIK_MONITOR_PORT} --ping 2>&1)
 exit_code=$?
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -23,7 +23,7 @@ var BaseDBTag = "v1.24.3"
 var TraefikRouterImage = "ddev/ddev-traefik-router"
 
 // TraefikRouterTag is traefik router tag
-var TraefikRouterTag = "v1.24.3"
+var TraefikRouterTag = "20250304_stasadev_traefik_healthcheck"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"


### PR DESCRIPTION
## The Issue

- #7044
- #6931

Caused by the healthcheck change in:

- #6787

## How This PR Solves The Issue

Changes the Traefik healthcheck command to use `127.0.0.1:${TRAEFIK_MONITOR_PORT}` instead of `:${TRAEFIK_MONITOR_PORT}`.

Note: I tried to change it here, but then dashboard doesn't open in the browser:

https://github.com/ddev/ddev/blob/0951e7848b699f83166029aed7f61e27fb462e3c/pkg/ddevapp/traefik_static_config_template.yaml#L43-L45

`http://:10999/ping` doesn't work with proxy.

Traefik source code:

https://github.com/traefik/traefik/blob/fa76ed57d361a4f441a897639005000ec6ab6b1a/cmd/healthcheck/healthcheck.go#L48-L79

```go
return client.Head(protocol + "://" + pingEntryPoint.GetAddress() + path + "ping")
```

## TODO

- [x] Try to understand and recreate what is actually happening to the OP
- [ ] Add to DDEV docs so people know what they have to do to use proxy
  - [ ] What do you have to do to docker?
  - [ ] What do you have to do to system configuration (or similarly, `*_PROXY` environment variables)
- [ ] Move ddev/ddev-proxy-support to rfay account (move it out of official) and update the open issue about that.

## Manual Testing Instructions

Before:
```
$ docker exec -it ddev-router bash -c "traefik healthcheck --ping --configFile=/mnt/ddev-global-cache/traefik/.static_config.yaml 2>&1"
OK: http://:10999/ping
```

```
$ docker inspect --format "{{ json .State.Health }}" ddev-router | docker run -i --rm ddev/ddev-utilities jq -r
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2025-03-04T13:03:27.042700005+02:00",
      "End": "2025-03-04T13:03:27.198244921+02:00",
      "ExitCode": 0,
      "Output": "OK: http://:10999/ping"
    },
    {
      "Start": "2025-03-04T13:03:28.19964313+02:00",
      "End": "2025-03-04T13:04:27.399195246+02:00",
      "ExitCode": 0,
      "Output": "container was previously healthy, so sleeping 59 seconds before continuing healthcheck...  OK: http://:10999/ping"
    }
  ]
}
```

After:

```
$ docker exec -it ddev-router bash -c 'traefik healthcheck --ping.entryPoint=ping --entryPoints.ping.address=127.0.0.1:${TRAEFIK_MONITOR_PORT} --ping 2>&1'
OK: http://127.0.0.1:10999/ping
```

```
$ docker inspect --format "{{ json .State.Health }}" ddev-router | docker run -i --rm ddev/ddev-utilities jq -r
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2025-03-04T13:01:08.793857753+02:00",
      "End": "2025-03-04T13:01:09.025443187+02:00",
      "ExitCode": 0,
      "Output": "OK: http://127.0.0.1:10999/ping"
    },
    {
      "Start": "2025-03-04T13:01:10.026699555+02:00",
      "End": "2025-03-04T13:02:09.210697327+02:00",
      "ExitCode": 0,
      "Output": "container was previously healthy, so sleeping 59 seconds before continuing healthcheck...  OK: http://127.0.0.1:10999/ping"
    }
  ]
}
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
