### PR TITLE
build: fix new mkdocs failure on git

### DIFF
--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -16,6 +16,14 @@ on:
       - ".readthedocs.yaml"
       - ".github/workflows/**"
 
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate set "debug_enabled"'
+        type: boolean
+        required: false
+        default: false
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -37,6 +45,13 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        
+      - name: Setup tmate session
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+
       - name: Spellcheck
         uses: rojopolis/spellcheck-github-actions@v0
       - name: Install textlint

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,10 +76,7 @@ plugins:
 - minify:
     minify_html: true
 - git-revision-date-localized:
-#    enable_creation_date: true
-#- git-committers:
-#    repository: https://github.com/ddev/ddev
-#    token: !ENV GH_TOKEN
+    fallback_to_build_date: true
 
 # Fail the entire build if the validation fails
 strict: true


### PR DESCRIPTION

## The Issue

mkdocs builds are failing, and docscheck builds are failing.

I'm not sure this has anything to do with us, but we might as well solve the complaint

> WARNING -  [git-revision-date-localized-plugin] Unable to find a git directory and/or git is not installed. To ignore this error, set option 'fallback_to_build_date: true'

In addition, we didn't have tmate set up for the docscheck workflow.

## How This PR Solves The Issue

