### PR TITLE
fix: use the DBImg constant instead of the db image name

### DIFF
--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -121,7 +121,7 @@ func deleteDdevImages(deleteAll bool) error {
 					return err
 				}
 			}
-			if strings.HasPrefix(tag, "ddev/ddev-dbserver") && !strings.HasSuffix(tag, keepDBImageTag) && !strings.HasSuffix(tag, keepDBImageTag+"-built") {
+			if strings.HasPrefix(tag, versionconstants.DBImg) && !strings.HasSuffix(tag, keepDBImageTag) && !strings.HasSuffix(tag, keepDBImageTag+"-built") {
 				if err = dockerutil.RemoveImage(tag); err != nil {
 					return err
 				}


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
-->

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->
delete-images.go was using `if strings.HasPrefix(tag, "ddev/ddev-dbserver") ` and as i've learned in https://github.com/ddev/ddev/pull/7036 there are constants to use instead of using the image names.


## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
