### PR TITLE
build: stop installing chocolatey, fixes #6636, fixes #6344 [skip buildkite]

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -5,7 +5,7 @@ See the [installation instructions](https://github.com/ddev/ddev/blob/main/docs/
 - macOS or Linux Homebrew: `brew upgrade ddev`
 - Linux or macOS via script (an unusual and nonstandard approach):
 `curl https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev.sh | bash`
-- Windows: Download the ddev_windows_installer above or `choco upgrade ddev` (on Intel/AMD64 systems)
+- Windows: Download and run the ddev_windows_installer above.
 
 And anywhere, you can download the tarball or zipball, un-tar or un-zip it, and place the executable in your path where it belongs.
 

--- a/Makefile
+++ b/Makefile
@@ -231,12 +231,12 @@ windows_sign_binaries: $(GOTMP)/bin/windows_amd64/ddev.exe $(GOTMP)/bin/windows_
 	ls -l .gotmp/bin/windows_arm64
 	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing arm64 ddev.exe, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows arm64 binaries..." && signtool sign -fd SHA256 ".gotmp/bin/windows_arm64/ddev.exe" ".gotmp/bin/windows_arm64/mkcert.exe" ".gotmp/bin/windows_arm64/ddev_gen_autocomplete.exe"; fi
 
-$(GOTMP)/bin/windows_amd64/ddev_windows_amd64_installer.exe: windows_sign_binaries $(GOTMP)/bin/windows_amd64/sudo_license.txt $(GOTMP)/bin/windows_amd64/mkcert_license.txt winpkg/ddev.nsi
+$(GOTMP)/bin/windows_amd64/ddev_windows_amd64_installer.exe: windows_sign_binaries $(GOTMP)/bin/windows_amd64/gsudo_license.txt $(GOTMP)/bin/windows_amd64/mkcert_license.txt winpkg/ddev.nsi
 	@makensis -DTARGET_ARCH=amd64 -DVERSION=$(VERSION) winpkg/ddev.nsi  # brew install makensis, apt-get install nsis, or install on Windows
 	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing amd64 $@, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows installer amd64 binary..." && signtool sign -fd SHA256 "$@"; fi
 	$(SHASUM) $@ >$@.sha256.txt
 
-$(GOTMP)/bin/windows_arm64/ddev_windows_arm64_installer.exe: windows_sign_binaries $(GOTMP)/bin/windows_arm64/sudo_license.txt $(GOTMP)/bin/windows_arm64/mkcert_license.txt winpkg/ddev.nsi
+$(GOTMP)/bin/windows_arm64/ddev_windows_arm64_installer.exe: windows_sign_binaries $(GOTMP)/bin/windows_arm64/gsudo_license.txt $(GOTMP)/bin/windows_arm64/mkcert_license.txt winpkg/ddev.nsi
 	@makensis -DTARGET_ARCH=arm64 -DVERSION=$(VERSION) winpkg/ddev.nsi  # brew install makensis, apt-get install nsis, or install on Windows
 	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing arm64 $@, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows installer arm64 binary..." && signtool sign -fd SHA256 "$@"; fi
 	$(SHASUM) $@ >$@.sha256.txt
@@ -265,13 +265,13 @@ $(GOTMP)/bin/windows_arm64/mkcert.exe $(GOTMP)/bin/windows_arm64/mkcert_license.
 	curl --fail -JL -S --retry 5 --retry-delay 5 --retry-connrefused -s -o $(GOTMP)/bin/windows_arm64/mkcert.exe "https://dl.filippo.io/mkcert/latest?for=windows/arm64"
 	curl --fail -sSL --retry 5 --retry-delay 5 --retry-connrefused -o $(GOTMP)/bin/windows_arm64/mkcert_license.txt -O https://raw.githubusercontent.com/FiloSottile/mkcert/master/LICENSE
 
-$(GOTMP)/bin/windows_amd64/sudo_license.txt:
+$(GOTMP)/bin/windows_amd64/gsudo_license.txt:
 	set -x
-	curl --fail -sSL --retry 5 --retry-delay 5 --retry-connrefused -o "$(GOTMP)/bin/windows_amd64/sudo_license.txt" "https://raw.githubusercontent.com/gerardog/gsudo/master/LICENSE.txt"
+	curl --fail -sSL --retry 5 --retry-delay 5 --retry-connrefused -o "$(GOTMP)/bin/windows_amd64/gsudo_license.txt" "https://raw.githubusercontent.com/gerardog/gsudo/master/LICENSE.txt"
 
-$(GOTMP)/bin/windows_arm64/sudo_license.txt:
+$(GOTMP)/bin/windows_arm64/gsudo_license.txt:
 	set -x
-	curl --fail -sSL --retry 5 --retry-delay 5 --retry-connrefused -o "$(GOTMP)/bin/windows_arm64/sudo_license.txt" "https://raw.githubusercontent.com/gerardog/gsudo/master/LICENSE.txt"
+	curl --fail -sSL --retry 5 --retry-delay 5 --retry-connrefused -o "$(GOTMP)/bin/windows_arm64/gsudo_license.txt" "https://raw.githubusercontent.com/gerardog/gsudo/master/LICENSE.txt"
 
 # Best to install golangci-lint locally with "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.31.0"
 golangci-lint:

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -233,7 +233,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     In all cases:
 
-    4. Install WSL2 with an Ubuntu distro. On a system without WSL2, run:
+    1. Install WSL2 with an Ubuntu distro. On a system without WSL2, run:
         ```powershell
         wsl --install
         ```
@@ -245,19 +245,19 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
         If you prefer to use another Ubuntu distro, install it and set it as default. For example, `wsl --set-default Ubuntu-24.04`.
 
-    5. In *Windows Update Settings* → *Advanced Options* enable *Receive updates for other Microsoft products*. You may want to occasionally run `wsl.exe --update` as well.
+    2. In *Windows Update Settings* → *Advanced Options* enable *Receive updates for other Microsoft products*. You may want to occasionally run `wsl.exe --update` as well.
 
-    6. Install Docker Desktop. Download [Docker Desktop from Docker](https://www.docker.com/products/docker-desktop/).
-    7. Start Docker Desktop. You should now be able to run `docker ps` in PowerShell or Git Bash.
-    8. In *Docker Desktop* → *Settings* → *Resources* → *WSL2 Integration*, verify that Docker Desktop is integrated with your distro.
-    9. Open a non-administrative PowerShell terminal. However, if the commands below don't work (e.g. "the system cannot find all the information required"), you may need to reboot or open a new Powershell terminal before trying again.  Run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1) by executing:
+    3. Install Docker Desktop. Download [Docker Desktop from Docker](https://www.docker.com/products/docker-desktop/).
+    4. Start Docker Desktop. You should now be able to run `docker ps` in PowerShell or Git Bash.
+    5. In *Docker Desktop* → *Settings* → *Resources* → *WSL2 Integration*, verify that Docker Desktop is integrated with your distro.
+    6. Open a non-administrative PowerShell terminal. However, if the commands below don't work (e.g. "the system cannot find all the information required"), you may need to reboot or open a new Powershell terminal before trying again.  Run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1) by executing:
 
         ```powershell
         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
         iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1'))
         ```
 
-    10. For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
+    7. For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
     Now you can use the "Ubuntu" terminal app or Windows Terminal to access your Ubuntu distro, which has DDEV and Docker Desktop integrated with it.
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -265,16 +265,16 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     You can manually step through the process the install script attempts to automate:
     1. Download and run the [Windows-side installer](https://github.com/ddev/ddev/releases) (used for hosts-file management only).
-    3. In an administrative PowerShell, run `mkcert -install` and follow the prompt to install the Certificate Authority.
-    4. In an administrative PowerShell, run `$env:CAROOT="$(mkcert -CAROOT)"; setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }`. This will set WSL2 to use the Certificate Authority installed on the Windows side. In some cases it takes a reboot to work correctly.
-    5. In administrative PowerShell, run `wsl --install`. This will install WSL2 and Ubuntu for you. Reboot when this is done.
-    6. **Docker Desktop for Windows:** If you already have the latest Docker Desktop, configure it in the General Settings to use the WSL2-based engine. Otherwise install the latest Docker Desktop for Windows and select the WSL2-based engine (not legacy Hyper-V) when installing. Download the installer from [docker.com](https://www.docker.com/products/docker-desktop/).  Start Docker. It may prompt you to log out and log in again, or reboot.
-    7. Go to Docker Desktop’s *Settings* → *Resources* → *WSL integration* → *enable integration for your distro*. Now `docker` commands will be available from within your WSL2 distro.
-    8. Double-check in PowerShell: `wsl -l -v` should show three distros, and your Ubuntu should be the default. All three should be WSL version 2.
-    9. Double-check in Ubuntu (or your distro): `echo $CAROOT` should show something like `/mnt/c/Users/<you>/AppData/Local/mkcert`
-    10. Check that Docker is working inside Ubuntu (or your distro) by running `docker ps`.
-    11. Open the WSL2 terminal, for example `Ubuntu` from the Windows start menu.
-    12. Install DDEV:
+    2. In an administrative PowerShell, run `mkcert -install` and follow the prompt to install the Certificate Authority.
+    3. In an administrative PowerShell, run `$env:CAROOT="$(mkcert -CAROOT)"; setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }`. This will set WSL2 to use the Certificate Authority installed on the Windows side. In some cases it takes a reboot to work correctly.
+    4. In administrative PowerShell, run `wsl --install`. This will install WSL2 and Ubuntu for you. Reboot when this is done.
+    5. **Docker Desktop for Windows:** If you already have the latest Docker Desktop, configure it in the General Settings to use the WSL2-based engine. Otherwise install the latest Docker Desktop for Windows and select the WSL2-based engine (not legacy Hyper-V) when installing. Download the installer from [docker.com](https://www.docker.com/products/docker-desktop/).  Start Docker. It may prompt you to log out and log in again, or reboot.
+    6. Go to Docker Desktop’s *Settings* → *Resources* → *WSL integration* → *enable integration for your distro*. Now `docker` commands will be available from within your WSL2 distro.
+    7. Double-check in PowerShell: `wsl -l -v` should show three distros, and your Ubuntu should be the default. All three should be WSL version 2.
+    8. Double-check in Ubuntu (or your distro): `echo $CAROOT` should show something like `/mnt/c/Users/<you>/AppData/Local/mkcert`
+    9. Check that Docker is working inside Ubuntu (or your distro) by running `docker ps`.
+    10. Open the WSL2 terminal, for example `Ubuntu` from the Windows start menu.
+    11. Install DDEV:
 
         ```bash
         sudo apt-get update && sudo apt-get install -y curl
@@ -284,9 +284,9 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         sudo apt-get update && sudo apt-get install -y ddev
         ```
 
-    13. In WSL2, run `mkcert -install`.
+    12. In WSL2, run `mkcert -install`.
 
-    14. For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
+    13. For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
     You have now installed DDEV on WSL2. If you’re using WSL2 for DDEV, remember to run all `ddev` commands inside the WSL2 distro.
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -216,7 +216,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
         * Verify that your Ubuntu default distro is WSL v2 using `wsl -l -v`.
 
-    2. In an administrative PowerShell run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_inside.ps1) by executing:
+    2. Open a non-administrative PowerShell terminal. However, if it doesn't work (e.g. "the system cannot find all the information required"), try with an Administrator one (possibly after a reboot) as it may be necessary on some systems.  Run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_inside.ps1) by executing:
 
         ```powershell
         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
@@ -251,7 +251,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     6. Install Docker Desktop. If you already have Chocolatey, run `choco install -y docker-desktop`. Otherwise [download Docker Desktop from Docker](https://www.docker.com/products/docker-desktop/).
     7. Start Docker Desktop. You should now be able to run `docker ps` in PowerShell or Git Bash.
     8. In *Docker Desktop* → *Settings* → *Resources* → *WSL2 Integration*, verify that Docker Desktop is integrated with your distro.
-    9. In an administrative PowerShell run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1) by executing:
+    9. Open a non-administrative PowerShell terminal. However, if it doesn't work (e.g. "the system cannot find all the information required"), try with an Administrator one (possibly after a reboot) as it may be necessary on some systems.  Run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1) by executing:
 
         ```powershell
         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -181,13 +181,12 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     * Projects should live under the home directory of the Linux filesystem.  
       WSL2’s Linux filesystem (e.g. `/home/<your_username>`) is much faster and has proper permissions, so keep your projects there and **not** in the slower Windows filesystem (`/mnt/c`).
     * Custom hostnames are managed via the Windows hosts file, not within WSL2.  
-      DDEV attempts to manage custom hostnames via the Windows-side hosts file—usually at `C:\Windows\system32\drivers\etc\hosts`—and it can only do this if it’s installed on the Windows side. (DDEV inside WSL2 uses `ddev.exe` on the Windows side as a proxy to update the Windows hosts file.) If `ddev.exe --version` shows the same version as `ddev --version` you’re all set up. Otherwise, install DDEV on Windows using `choco upgrade -y ddev` or by downloading and running the Windows installer. (The WSL2 scripts below install DDEV on the Windows side, taking care of that for you.) If you frequently run into Windows UAC Escalation, you can calm it down by running `gsudo.exe cache on` and `gsudo.exe config CacheMode auto`, see [gsudo docs](https://github.com/gerardog/gsudo#credentials-cache).
+      DDEV attempts to manage custom hostnames via the Windows-side hosts file—usually at `C:\Windows\system32\drivers\etc\hosts`—and it can only do this if it’s installed on the Windows side. (DDEV inside WSL2 uses `ddev.exe` on the Windows side as a proxy to update the Windows hosts file.) If `ddev.exe --version` shows the same version as `ddev --version` you’re all set up. Otherwise, install DDEV on Windows by downloading and running the Windows installer. (The WSL2 scripts below install DDEV on the Windows side, taking care of that for you.) If you frequently run into Windows UAC Escalation, you can calm it down by running `gsudo.exe cache on` and `gsudo.exe config CacheMode auto`, see [gsudo docs](https://github.com/gerardog/gsudo#credentials-cache).
     * WSL2 is not the same as Docker Desktop’s WSL2 engine.  
       Using WSL2 to install and run DDEV is not the same as using Docker Desktop’s WSL2 engine, which itself runs in WSL2, but can serve applications running in both traditional Windows and inside WSL2.
 
     The WSL2 install process involves:
 
-    * Installing Chocolatey package manager (optional).
     * One time initialization of mkcert.
     * Installing WSL2 and installing a distro like Ubuntu.
     * Optionally installing Docker Desktop for Windows and enabling WSL2 integration with the distro (if you're using the Docker Desktop approach).
@@ -248,7 +247,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     5. In *Windows Update Settings* → *Advanced Options* enable *Receive updates for other Microsoft products*. You may want to occasionally run `wsl.exe --update` as well.
 
-    6. Install Docker Desktop. If you already have Chocolatey, run `choco install -y docker-desktop`. Otherwise [download Docker Desktop from Docker](https://www.docker.com/products/docker-desktop/).
+    6. Install Docker Desktop. Download [Docker Desktop from Docker](https://www.docker.com/products/docker-desktop/).
     7. Start Docker Desktop. You should now be able to run `docker ps` in PowerShell or Git Bash.
     8. In *Docker Desktop* → *Settings* → *Resources* → *WSL2 Integration*, verify that Docker Desktop is integrated with your distro.
     9. Open a non-administrative PowerShell terminal. However, if the commands below don't work (e.g. "the system cannot find all the information required"), you may need to reboot or open a new Powershell terminal before trying again.  Run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1) by executing:
@@ -265,17 +264,11 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ### WSL2/Docker Desktop Manual Installation
 
     You can manually step through the process the install script attempts to automate:
-
-    1. Install [Chocolatey](https://chocolatey.org/install):
-        ```powershell
-        Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-        iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))`
-        ```
-    2. In an administrative PowerShell, run `choco install -y ddev mkcert`.
+    1. Download and run the [Windows-side installer](https://github.com/ddev/ddev/releases) (used for hosts-file management only).
     3. In an administrative PowerShell, run `mkcert -install` and follow the prompt to install the Certificate Authority.
     4. In an administrative PowerShell, run `$env:CAROOT="$(mkcert -CAROOT)"; setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }`. This will set WSL2 to use the Certificate Authority installed on the Windows side. In some cases it takes a reboot to work correctly.
     5. In administrative PowerShell, run `wsl --install`. This will install WSL2 and Ubuntu for you. Reboot when this is done.
-    6. **Docker Desktop for Windows:** If you already have the latest Docker Desktop, configure it in the General Settings to use the WSL2-based engine. Otherwise install the latest Docker Desktop for Windows and select the WSL2-based engine (not legacy Hyper-V) when installing. Install with Chocolatey by running `choco install docker-desktop`, or download the installer from [desktop.docker.com](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe).  Start Docker. It may prompt you to log out and log in again, or reboot.
+    6. **Docker Desktop for Windows:** If you already have the latest Docker Desktop, configure it in the General Settings to use the WSL2-based engine. Otherwise install the latest Docker Desktop for Windows and select the WSL2-based engine (not legacy Hyper-V) when installing. Download the installer from [docker.com](https://www.docker.com/products/docker-desktop/).  Start Docker. It may prompt you to log out and log in again, or reboot.
     7. Go to Docker Desktop’s *Settings* → *Resources* → *WSL integration* → *enable integration for your distro*. Now `docker` commands will be available from within your WSL2 distro.
     8. Double-check in PowerShell: `wsl -l -v` should show three distros, and your Ubuntu should be the default. All three should be WSL version 2.
     9. Double-check in Ubuntu (or your distro): `echo $CAROOT` should show something like `/mnt/c/Users/<you>/AppData/Local/mkcert`
@@ -302,12 +295,11 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ### Traditional Windows
 
-    If you must use traditional Windows, then Docker Desktop is your only choice of a Docker provider. DDEV is supported in this configuration but it's not as performant as the WSL2 options.
+    If you must use traditional Windows, then Docker Desktop is your only choice of a Docker provider. DDEV is supported in this configuration but it may not be as performant as the WSL2 options.
 
-    * We recommend using [Chocolatey](https://chocolatey.org/). Once installed, you can run `choco install ddev docker-desktop git` from an administrative shell. You can upgrade by running `ddev poweroff && choco upgrade ddev`.
     * Each [DDEV release](https://github.com/ddev/ddev/releases) includes Windows installers for AMD64 and ARM64 Windows (`ddev_windows_<architecture>_installer.<version>.exe`). After running that, you can open a new Git Bash, PowerShell, or cmd.exe window and start using DDEV.
 
-    Most people interact with DDEV on traditional Windows using Git Bash, part of the [Windows Git suite](https://git-scm.com/download/win). Although DDEV does work with cmd.exe and PowerShell, it's more at home in Bash. You can install Git Bash with Chocolatey by running `choco install -y git`.
+    Most people interact with DDEV on traditional Windows using Git Bash, part of the [Windows Git suite](https://git-scm.com/download/win). Although DDEV does work with cmd.exe and PowerShell, it's more at home in Bash.
 
     !!!note "Windows Firefox Trusted CA"
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -216,7 +216,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
         * Verify that your Ubuntu default distro is WSL v2 using `wsl -l -v`.
 
-    2. Open a non-administrative PowerShell terminal. However, if it doesn't work (e.g. "the system cannot find all the information required"), try with an Administrator one (possibly after a reboot) as it may be necessary on some systems.  Run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_inside.ps1) by executing:
+    2. Open a non-administrative PowerShell terminal. However, if the commands below don't work (e.g. "the system cannot find all the information required"), you may need to reboot or open a new Powershell terminal before trying again.  Run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_inside.ps1) by executing:
 
         ```powershell
         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
@@ -251,7 +251,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     6. Install Docker Desktop. If you already have Chocolatey, run `choco install -y docker-desktop`. Otherwise [download Docker Desktop from Docker](https://www.docker.com/products/docker-desktop/).
     7. Start Docker Desktop. You should now be able to run `docker ps` in PowerShell or Git Bash.
     8. In *Docker Desktop* → *Settings* → *Resources* → *WSL2 Integration*, verify that Docker Desktop is integrated with your distro.
-    9. Open a non-administrative PowerShell terminal. However, if it doesn't work (e.g. "the system cannot find all the information required"), try with an Administrator one (possibly after a reboot) as it may be necessary on some systems.  Run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1) by executing:
+    9. Open a non-administrative PowerShell terminal. However, if the commands below don't work (e.g. "the system cannot find all the information required"), you may need to reboot or open a new Powershell terminal before trying again.  Run [this PowerShell script](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1) by executing:
 
         ```powershell
         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;

--- a/docs/content/users/install/ddev-upgrade.md
+++ b/docs/content/users/install/ddev-upgrade.md
@@ -85,15 +85,6 @@ Installing and upgrading DDEV are nearly the same thing, because you're upgradin
 
     ### Traditional Windows
 
-    #### Chocolatey (only on Intel machines)
-
-    ```bash
-    # Turn off DDEV and upgrade it
-    ddev poweroff && choco upgrade ddev
-    ```
-
-    #### Installer
-
     Download and run the Windows installer (for your architecture, most often AMD64) for the latest [DDEV release](https://github.com/ddev/ddev/releases) (`ddev_windows_<architecture>_installer.<version>.exe`).
 
 === "Codespaces"

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -119,7 +119,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     ### Docker Desktop for Windows
 
-    Docker Desktop for Windows can be downloaded via [Chocolatey](https://chocolatey.org/install) with `choco install docker-desktop` or it can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has extensive automated testing with DDEV, and works with DDEV both on traditional Windows and in WSL2.
+    Docker Desktop for Windows can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). DDEV has extensive automated testing using Docker Desktop, and Docker Desktop with DDEV works both on traditional Windows and in WSL2.
 
     See [WSL2 DDEV Installation](ddev-installation.md#wsl2-docker-desktop-install-script) for help installing DDEV with Docker Desktop on WSL2.
 

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -35,7 +35,7 @@ if (-not(wsl -e docker ps) ) {
 }
 $ErrorActionPreference = "Stop"
 
-# Install DDEV on Windows to manipulate the local hosts file.  (Also requires mkcert & sudo; see below.)
+# Install DDEV on Windows to manipulate the host OS's hosts file.
 $TempDir = $env:TEMP
 $DdevInstallerPath = Join-Path $TempDir "ddev-installer.exe"
 # TODO: To always fetch the latest EXE (e.g. https://github.com/<OWNER>/<REPO>/releases/latest/download/myprogram.exe),
@@ -46,29 +46,6 @@ Invoke-WebRequest `
     -OutFile $DdevInstallerPath
 Start-Process $DdevInstallerPath -Wait
 Remove-Item $DdevInstallerPath
-
-# Install mkcert for Windows.
-$ExecutablesDirectoryPath = Join-Path $env:ProgramFiles "mkcert"
-if (!(Test-Path $ExecutablesDirectoryPath)) {
-    New-Item -ItemType Directory -Path $ExecutablesDirectoryPath | Out-Null
-}
-$existingPath = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" -Name PATH).Path
-if ($existingPath -notlike "*$ExecutablesDirectoryPath*") {
-    $newPath = $existingPath + ";" + $ExecutablesDirectoryPath
-    Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" -Name PATH -Value $newPath
-    $env:Path = $env:Path + ";" + $ExecutablesDirectoryPath
-}
-$MkcertBinaryPath = Join-Path $ExecutablesDirectoryPath "mkcert.exe"
-    # Because this is an external dependency, pin the release so we're not implicitly trusting their branch forever.
-Invoke-WebRequest `
-    -Uri "https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-windows-amd64.exe" `
-    -OutFile $MkcertBinaryPath
-
-# Install Sudo for Windows.
-Set-ExecutionPolicy RemoteSigned -scope Process
-[Net.ServicePointManager]::SecurityProtocol = 'Tls12'
-# Because this is an external dependency, pin the release so we're not implicitly trusting their branch forever.
-iwr -UseBasicParsing https://raw.githubusercontent.com/gerardog/gsudo/v2.6.0/installgsudo.ps1 | iex
 
 mkcert -install
 $env:CAROOT="$(mkcert -CAROOT)"

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -88,7 +88,7 @@ try {
     Write-Error "Could not download the installer from $downloadUrl. Details: $_"
     exit 1
 }
-Start-Process $DdevInstallerPath -ArgumentList "/S", "/C" -Wait
+Start-Process $DdevInstallerPath -ArgumentList "/S", -Wait
 Remove-Item $DdevInstallerPath
 Write-Host "DDEV installation complete."
 

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -70,9 +70,18 @@ $tagName = $json.tag_name
 Write-Host "The latest $GitHubOwner/$RepoName version is $tagName."
 # Because the published artifact includes the version in its name, we have to insert $tagName into the filename.
 $downloadUrl = "https://github.com/$GitHubOwner/$RepoName/releases/download/$tagName/ddev_windows_${architectureForInstaller}_installer.${tagName}.exe"
-Write-Host "Downloading from $downloadUrl..."
 $TempDir = $env:TEMP
 $DdevInstallerPath = Join-Path $TempDir "ddev-installer.exe"
+if (Test-Path $DdevInstallerPath) {
+    Write-Host "Deleting old installer at $DdevInstallerPath..."
+    try {
+        Remove-Item $DdevInstallerPath -Force
+    } catch {
+        Write-Error "Could not delete the old installer $DdevInstallerPath.  Please delete it manually, and then try again."
+        exit 1
+    }
+}
+Write-Host "Downloading from $downloadUrl..."
 try {
     Invoke-WebRequest -Uri $downloadUrl -OutFile $DdevInstallerPath
 } catch {

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -69,18 +69,11 @@ $json = $response.Content | ConvertFrom-Json
 $tagName = $json.tag_name
 Write-Host "The latest $GitHubOwner/$RepoName version is $tagName."
 # Because the published artifact includes the version in its name, we have to insert $tagName into the filename.
-$downloadUrl = "https://github.com/$GitHubOwner/$RepoName/releases/download/$tagName/ddev_windows_${architectureForInstaller}_installer.${tagName}.exe"
+$installerFilename = "ddev_windows_${architectureForInstaller}_installer.${tagName}.exe"
+$downloadUrl = "https://github.com/$GitHubOwner/$RepoName/releases/download/$tagName/$installerFilename"
 $TempDir = $env:TEMP
-$DdevInstallerPath = Join-Path $TempDir "ddev-installer.exe"
-if (Test-Path $DdevInstallerPath) {
-    Write-Host "Deleting old installer at $DdevInstallerPath..."
-    try {
-        Remove-Item $DdevInstallerPath -Force
-    } catch {
-        Write-Error "Could not delete the old installer $DdevInstallerPath.  Please delete it manually, and then try again."
-        exit 1
-    }
-}
+$DdevInstallerPath = Join-Path $TempDir ([guid]::NewGuid().ToString() + "_" + $installerFilename)
+
 Write-Host "Downloading from $downloadUrl..."
 try {
     Invoke-WebRequest -Uri $downloadUrl -OutFile $DdevInstallerPath

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -96,7 +96,7 @@ $env:PATH += ";C:\Program Files\DDEV"
 
 Write-Host "DDEV installation complete."
 
-mkcert -install
+mkcert.exe -install
 $env:CAROOT="$(mkcert -CAROOT)"
 setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -96,8 +96,8 @@ $env:PATH += ";C:\Program Files\DDEV"
 
 Write-Host "DDEV installation complete."
 
-mkcert.exe -install
-$env:CAROOT="$(mkcert -CAROOT)"
+& "C:\Program Files\DDEV\mkcert.exe" -install
+$env:CAROOT = & "C:\Program Files\DDEV\mkcert.exe" -CAROOT
 setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
 wsl -u root -e bash -c "apt-get update && apt-get install -y curl"

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -92,7 +92,6 @@ try {
     exit 1
 }
 Start-Process $DdevInstallerPath -ArgumentList "/S", -Wait
-Remove-Item $DdevInstallerPath
 Write-Host "DDEV installation complete."
 
 mkcert -install

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -92,6 +92,8 @@ try {
     exit 1
 }
 Start-Process $DdevInstallerPath -ArgumentList "/S", -Wait
+$env:PATH += ";C:\Program Files\DDEV"
+
 Write-Host "DDEV installation complete."
 
 mkcert -install

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -82,7 +82,7 @@ try {
     Write-Error "Could not download the installer from $downloadUrl. Details: $_"
     exit 1
 }
-Start-Process $DdevInstallerPath -Wait
+Start-Process $DdevInstallerPath -ArgumentList "/S", "/C" -Wait
 Remove-Item $DdevInstallerPath
 Write-Host "DDEV installation complete."
 

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -58,6 +58,16 @@ Write-Host "Detected OS architecture: $realArchitecture; using DDEV installer: $
 $GitHubOwner = "ddev"
 $RepoName    = "ddev"
 # Get the latest release JSON from the GitHub API endpoint.
+
+# Delete existing old installers
+Get-ChildItem -Path $env:TEMP -Filter "ddev_windows_*_installer.*.exe" -ErrorAction SilentlyContinue | ForEach-Object {
+    try {
+        Remove-Item $_.FullName -Force -ErrorAction Stop
+    } catch {
+        Write-Warning "Could not delete old installer file $($_.FullName): $_"
+    }
+}
+
 $apiUrl = "https://api.github.com/repos/$GitHubOwner/$RepoName/releases/latest"
 try {
     $response = Invoke-WebRequest -Headers @{ Accept = 'application/json' } -Uri $apiUrl

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -24,7 +24,7 @@ if (-not(Compare-Object "root" (wsl -e whoami)) ) {
     throw "The default user in your distro seems to be root. Please configure an ordinary default user"
 }
 if (-not(Get-Command docker 2>&1 ) -Or -Not(docker ps ) ) {
-    throw "\n\ndocker does not seem to be installed yet, or Docker Desktop is not running. Please install it or start it. For example, choco install -y docker-desktop"
+    throw "\n\ndocker does not seem to be installed yet, or Docker Desktop is not running. Please install it or start it."
 }
 
 if (-not(wsl -e docker ps) ) {

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -4,12 +4,9 @@
 # done manually.
 # It requires that Docker Desktop is installed and running, and that it has integration enabled with the Ubuntu
 # distro, which is the default behavior.
-# Run this in an administrative PowerShell window.
 # You can download, inspect, and run this, or run it directly with
 # Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
 # iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1'))
-
-#Requires -RunAsAdministrator
 
 # Make sure wsl is installed and working
 if (-not(wsl -l -v)) {

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -31,14 +31,22 @@ if (wsl bash -c "test -d /mnt/wsl/docker-desktop >/dev/null 2>&1" ) {
 $ErrorActionPreference = "Stop"
 
 # Install DDEV on Windows to manipulate the host OS's hosts file.
+$GitHubOwner = "ddev"
+$RepoName    = "ddev"
+# Get the latest release JSON from the GitHub API endpoint.
+$apiUrl = "https://api.github.com/repos/$GitHubOwner/$RepoName/releases/latest"
+$response = Invoke-WebRequest -UseBasicParsing `
+    -Headers @{ Accept = 'application/json' } `
+    -Uri $apiUrl
+$json = $response.Content | ConvertFrom-Json
+$tagName = $json.tag_name
+Write-Host "The latest $GitHubOwner/$RepoName version is $tagName."
+# Because the published artifact includes the version in its name, we have to insert $tagName into the filename.
+$downloadUrl = "https://github.com/$GitHubOwner/$RepoName/releases/download/$tagName/ddev_windows_amd64_installer.$tagName.exe"
+Write-Host "Downloading from $downloadUrl..."
 $TempDir = $env:TEMP
 $DdevInstallerPath = Join-Path $TempDir "ddev-installer.exe"
-# TODO: To always fetch the latest EXE (e.g. https://github.com/<OWNER>/<REPO>/releases/latest/download/myprogram.exe),
-# there can't be version numbers in the file name so we need to remove the version number from the release artefact.
-# Until then, we can simply fetch the installer from the latest release, which we'll hardcode.
-Invoke-WebRequest `
-    -Uri "https://github.com/ddev/ddev/releases/download/v1.24.3/ddev_windows_amd64_installer.v1.24.3.exe" `
-    -OutFile $DdevInstallerPath
+Invoke-WebRequest -Uri $downloadUrl -OutFile $DdevInstallerPath
 Start-Process $DdevInstallerPath -Wait
 Remove-Item $DdevInstallerPath
 

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -30,7 +30,7 @@ if (wsl bash -c "test -d /mnt/wsl/docker-desktop >/dev/null 2>&1" ) {
 }
 $ErrorActionPreference = "Stop"
 
-# Install DDEV on Windows to manipulate the local hosts file.  (Also requires mkcert & sudo; see below.)
+# Install DDEV on Windows to manipulate the host OS's hosts file.
 $TempDir = $env:TEMP
 $DdevInstallerPath = Join-Path $TempDir "ddev-installer.exe"
 # TODO: To always fetch the latest EXE (e.g. https://github.com/<OWNER>/<REPO>/releases/latest/download/myprogram.exe),
@@ -41,29 +41,6 @@ Invoke-WebRequest `
     -OutFile $DdevInstallerPath
 Start-Process $DdevInstallerPath -Wait
 Remove-Item $DdevInstallerPath
-
-# Install mkcert for Windows.
-$ExecutablesDirectoryPath = Join-Path $env:ProgramFiles "mkcert"
-if (!(Test-Path $ExecutablesDirectoryPath)) {
-    New-Item -ItemType Directory -Path $ExecutablesDirectoryPath | Out-Null
-}
-$existingPath = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" -Name PATH).Path
-if ($existingPath -notlike "*$ExecutablesDirectoryPath*") {
-    $newPath = $existingPath + ";" + $ExecutablesDirectoryPath
-    Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" -Name PATH -Value $newPath
-    $env:Path = $env:Path + ";" + $ExecutablesDirectoryPath
-}
-$MkcertBinaryPath = Join-Path $ExecutablesDirectoryPath "mkcert.exe"
-    # Because this is an external dependency, pin the release so we're not implicitly trusting their branch forever.
-Invoke-WebRequest `
-    -Uri "https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-windows-amd64.exe" `
-    -OutFile $MkcertBinaryPath
-
-# Install Sudo for Windows.
-Set-ExecutionPolicy RemoteSigned -scope Process
-[Net.ServicePointManager]::SecurityProtocol = 'Tls12'
-# Because this is an external dependency, pin the release so we're not implicitly trusting their branch forever.
-iwr -UseBasicParsing https://raw.githubusercontent.com/gerardog/gsudo/v2.6.0/installgsudo.ps1 | iex
 
 mkcert -install
 $env:CAROOT="$(mkcert -CAROOT)"

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -30,25 +30,56 @@ if (wsl bash -c "test -d /mnt/wsl/docker-desktop >/dev/null 2>&1" ) {
 }
 $ErrorActionPreference = "Stop"
 
+# Determine the architecture we're running on to fetch the correct installer.
+$realArchitecture = $env:PROCESSOR_ARCHITEW6432
+if (-not $realArchitecture) {
+    $realArchitecture = $env:PROCESSOR_ARCHITECTURE
+}
+switch ($realArchitecture) {
+    "AMD64" {
+        $architectureForInstaller = "amd64"
+    }
+    "ARM64" {
+        $architectureForInstaller = "arm64"
+    }
+    "x86" {
+        Write-Error "Error: x86 Windows detected, which is not supported."
+        exit 1
+    }
+    Default {
+        $architectureForInstaller = "amd64"
+    }
+}
+Write-Host "Detected OS architecture: $realArchitecture; using DDEV installer: $architectureForInstaller"
+
 # Install DDEV on Windows to manipulate the host OS's hosts file.
 $GitHubOwner = "ddev"
 $RepoName    = "ddev"
 # Get the latest release JSON from the GitHub API endpoint.
 $apiUrl = "https://api.github.com/repos/$GitHubOwner/$RepoName/releases/latest"
-$response = Invoke-WebRequest -UseBasicParsing `
-    -Headers @{ Accept = 'application/json' } `
-    -Uri $apiUrl
+try {
+    $response = Invoke-WebRequest -Headers @{ Accept = 'application/json' } -Uri $apiUrl
+} catch {
+    Write-Error "Could not fetch latest release info from $apiUrl. Details: $_"
+    exit 1
+}
 $json = $response.Content | ConvertFrom-Json
 $tagName = $json.tag_name
 Write-Host "The latest $GitHubOwner/$RepoName version is $tagName."
 # Because the published artifact includes the version in its name, we have to insert $tagName into the filename.
-$downloadUrl = "https://github.com/$GitHubOwner/$RepoName/releases/download/$tagName/ddev_windows_amd64_installer.$tagName.exe"
+$downloadUrl = "https://github.com/$GitHubOwner/$RepoName/releases/download/$tagName/ddev_windows_${architectureForInstaller}_installer.${tagName}.exe"
 Write-Host "Downloading from $downloadUrl..."
 $TempDir = $env:TEMP
 $DdevInstallerPath = Join-Path $TempDir "ddev-installer.exe"
-Invoke-WebRequest -Uri $downloadUrl -OutFile $DdevInstallerPath
+try {
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $DdevInstallerPath
+} catch {
+    Write-Error "Could not download the installer from $downloadUrl. Details: $_"
+    exit 1
+}
 Start-Process $DdevInstallerPath -Wait
 Remove-Item $DdevInstallerPath
+Write-Host "DDEV installation complete."
 
 mkcert -install
 $env:CAROOT="$(mkcert -CAROOT)"

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -24,13 +24,6 @@ if (-not (wsl -e bash -c "env | grep WSL_INTEROP=")) {
 if (-not(Compare-Object "root" (wsl -e whoami)) ) {
     throw "The default user in your distro seems to be root. Please configure an ordinary default user"
 }
-# Install Chocolatey if needed
-if (-not (Get-Command "choco" -errorAction SilentlyContinue))
-{
-    "Chocolatey does not appear to be installed yet, installing"
-    $ErrorActionPreference = "Stop"
-    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-}
 
 if (wsl bash -c "test -d /mnt/wsl/docker-desktop >/dev/null 2>&1" ) {
     throw "Docker Desktop integration is enabled with the default distro and it must but turned off."

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -64,18 +64,11 @@ $json = $response.Content | ConvertFrom-Json
 $tagName = $json.tag_name
 Write-Host "The latest $GitHubOwner/$RepoName version is $tagName."
 # Because the published artifact includes the version in its name, we have to insert $tagName into the filename.
-$downloadUrl = "https://github.com/$GitHubOwner/$RepoName/releases/download/$tagName/ddev_windows_${architectureForInstaller}_installer.${tagName}.exe"
+$installerFilename = "ddev_windows_${architectureForInstaller}_installer.${tagName}.exe"
+$downloadUrl = "https://github.com/$GitHubOwner/$RepoName/releases/download/$tagName/$installerFilename"
 $TempDir = $env:TEMP
-$DdevInstallerPath = Join-Path $TempDir "ddev-installer.exe"
-if (Test-Path $DdevInstallerPath) {
-    Write-Host "Deleting old installer at $DdevInstallerPath..."
-    try {
-        Remove-Item $DdevInstallerPath -Force
-    } catch {
-        Write-Error "Could not delete the old installer $DdevInstallerPath.  Please delete it manually, and then try again."
-        exit 1
-    }
-}
+$DdevInstallerPath = Join-Path $TempDir ([guid]::NewGuid().ToString() + "_" + $installerFilename)
+
 Write-Host "Downloading from $downloadUrl..."
 try {
     Invoke-WebRequest -Uri $downloadUrl -OutFile $DdevInstallerPath

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -90,8 +90,8 @@ $env:PATH += ";C:\Program Files\DDEV"
 
 Write-Host "DDEV installation complete."
 
-mkcert.exe -install
-$env:CAROOT="$(mkcert -CAROOT)"
+& "C:\Program Files\DDEV\mkcert.exe" -install
+$env:CAROOT = & "C:\Program Files\DDEV\mkcert.exe" -CAROOT
 setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
 wsl -u root bash -c "apt-get remove -y -qq docker docker-engine docker.io containerd runc >/dev/null 2>&1"

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -49,6 +49,15 @@ switch ($realArchitecture) {
 }
 Write-Host "Detected OS architecture: $realArchitecture; using DDEV installer: $architectureForInstaller"
 
+# Cleanup old installers
+Get-ChildItem -Path $env:TEMP -Filter "ddev_windows_*_installer.*.exe" -ErrorAction SilentlyContinue | ForEach-Object {
+    try {
+        Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
+    } catch {
+        # Intentionally silent
+    }
+}
+
 # Install DDEV on Windows to manipulate the host OS's hosts file.
 $GitHubOwner = "ddev"
 $RepoName    = "ddev"

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -77,7 +77,7 @@ try {
     Write-Error "Could not download the installer from $downloadUrl. Details: $_"
     exit 1
 }
-Start-Process $DdevInstallerPath -Wait
+Start-Process $DdevInstallerPath -ArgumentList "/S", "/C" -Wait
 Remove-Item $DdevInstallerPath
 Write-Host "DDEV installation complete."
 

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -90,8 +90,20 @@ $env:PATH += ";C:\Program Files\DDEV"
 
 Write-Host "DDEV installation complete."
 
-& "C:\Program Files\DDEV\mkcert.exe" -install
-$env:CAROOT = & "C:\Program Files\DDEV\mkcert.exe" -CAROOT
+$mkcertPath = "C:\Program Files\DDEV\mkcert.exe"
+$maxWait = 10
+$waited = 0
+while (-not (Test-Path $mkcertPath) -and $waited -lt $maxWait) {
+    Start-Sleep -Seconds 1
+    $waited++
+}
+if (-not (Test-Path $mkcertPath)) {
+    Write-Error "mkcert.exe did not appear at $mkcertPath after waiting $maxWait seconds"
+    exit 1
+}
+
+& $mkcertPath -install
+$env:CAROOT = & $mkcertPath -CAROOT
 setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
 wsl -u root bash -c "apt-get remove -y -qq docker docker-engine docker.io containerd runc >/dev/null 2>&1"

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -83,7 +83,7 @@ try {
     Write-Error "Could not download the installer from $downloadUrl. Details: $_"
     exit 1
 }
-Start-Process $DdevInstallerPath -ArgumentList "/S", "/C" -Wait
+Start-Process $DdevInstallerPath -ArgumentList "/S", -Wait
 Remove-Item $DdevInstallerPath
 Write-Host "DDEV installation complete."
 

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -86,7 +86,6 @@ try {
     exit 1
 }
 Start-Process $DdevInstallerPath -ArgumentList "/S", -Wait
-Remove-Item $DdevInstallerPath
 Write-Host "DDEV installation complete."
 
 mkcert -install

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -2,12 +2,9 @@
 # an Ubuntu WSL2 instance for use with DDEV and docker-ce installed inside WSL2.
 # It requires that an Ubuntu wsl2 distro be installed already, preferably with `wsl --install`, but it can also be
 # done manually.
-# Run this in an administrative PowerShell window.
 # You can download, inspect, and run this, or run it directly with
 # Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
 # iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_inside.ps1'))
-
-#Requires -RunAsAdministrator
 
 # Make sure wsl is installed and working
 if (-not(wsl -l -v)) {

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -86,6 +86,8 @@ try {
     exit 1
 }
 Start-Process $DdevInstallerPath -ArgumentList "/S", -Wait
+$env:PATH += ";C:\Program Files\DDEV"
+
 Write-Host "DDEV installation complete."
 
 mkcert -install

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -65,9 +65,18 @@ $tagName = $json.tag_name
 Write-Host "The latest $GitHubOwner/$RepoName version is $tagName."
 # Because the published artifact includes the version in its name, we have to insert $tagName into the filename.
 $downloadUrl = "https://github.com/$GitHubOwner/$RepoName/releases/download/$tagName/ddev_windows_${architectureForInstaller}_installer.${tagName}.exe"
-Write-Host "Downloading from $downloadUrl..."
 $TempDir = $env:TEMP
 $DdevInstallerPath = Join-Path $TempDir "ddev-installer.exe"
+if (Test-Path $DdevInstallerPath) {
+    Write-Host "Deleting old installer at $DdevInstallerPath..."
+    try {
+        Remove-Item $DdevInstallerPath -Force
+    } catch {
+        Write-Error "Could not delete the old installer $DdevInstallerPath.  Please delete it manually, and then try again."
+        exit 1
+    }
+}
+Write-Host "Downloading from $downloadUrl..."
 try {
     Invoke-WebRequest -Uri $downloadUrl -OutFile $DdevInstallerPath
 } catch {

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -90,7 +90,7 @@ $env:PATH += ";C:\Program Files\DDEV"
 
 Write-Host "DDEV installation complete."
 
-mkcert -install
+mkcert.exe -install
 $env:CAROOT="$(mkcert -CAROOT)"
 setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -136,10 +136,7 @@ InstType "Minimal"
 /**
  * Local macros
  */
-Var ChocolateyMode
-!macro _Chocolatey _a _b _t _f
-  !insertmacro _== $ChocolateyMode `1` `${_t}` `${_f}`
-!macroend
+
 !define Chocolatey `"" Chocolatey ""`
 
 /**
@@ -498,32 +495,29 @@ SectionGroup /e "mkcert"
    * mkcert application install
    */
   Section "mkcert" SecMkcert
-    ; Install in non choco mode only
-    ${IfNot} ${Chocolatey}
-      SectionIn 1 2
-      SetOutPath "$INSTDIR"
-      SetOverwrite try
+    SectionIn 1 2
+    SetOutPath "$INSTDIR"
+    SetOverwrite try
 
-      ; Copy files
-      File "..\.gotmp\bin\windows_${TARGET_ARCH}\mkcert.exe"
-      File "..\.gotmp\bin\windows_${TARGET_ARCH}\mkcert_license.txt"
+    ; Copy files
+    File "..\.gotmp\bin\windows_${TARGET_ARCH}\mkcert.exe"
+    File "..\.gotmp\bin\windows_${TARGET_ARCH}\mkcert_license.txt"
 
-      ; Install icons
-      SetOutPath "$INSTDIR\Icons"
-      SetOverwrite try
-      File /oname=ca-install.ico "graphics\ca-install.ico"
-      File /oname=ca-uninstall.ico "graphics\ca-uninstall.ico"
+    ; Install icons
+    SetOutPath "$INSTDIR\Icons"
+    SetOverwrite try
+    File /oname=ca-install.ico "graphics\ca-install.ico"
+    File /oname=ca-uninstall.ico "graphics\ca-uninstall.ico"
 
-      ; Shortcuts
-      CreateShortcut "$INSTDIR\mkcert install.lnk" "$INSTDIR\mkcert.exe" "-install" "$INSTDIR\Icons\ca-install.ico"
-      CreateShortcut "$INSTDIR\mkcert uninstall.lnk" "$INSTDIR\mkcert.exe" "-uninstall" "$INSTDIR\Icons\ca-uninstall.ico"
+    ; Shortcuts
+    CreateShortcut "$INSTDIR\mkcert install.lnk" "$INSTDIR\mkcert.exe" "-install" "$INSTDIR\Icons\ca-install.ico"
+    CreateShortcut "$INSTDIR\mkcert uninstall.lnk" "$INSTDIR\mkcert.exe" "-uninstall" "$INSTDIR\Icons\ca-uninstall.ico"
 
-      !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
-      CreateDirectory "$SMPROGRAMS\$ICONS_GROUP\mkcert"
-      CreateShortCut "$SMPROGRAMS\$ICONS_GROUP\mkcert\mkcert install trusted https.lnk" "$INSTDIR\mkcert install.lnk"
-      CreateShortCut "$SMPROGRAMS\$ICONS_GROUP\mkcert\mkcert uninstall trusted https.lnk" "$INSTDIR\mkcert uninstall.lnk"
-      !insertmacro MUI_STARTMENU_WRITE_END
-    ${EndIf}
+    !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+    CreateDirectory "$SMPROGRAMS\$ICONS_GROUP\mkcert"
+    CreateShortCut "$SMPROGRAMS\$ICONS_GROUP\mkcert\mkcert install trusted https.lnk" "$INSTDIR\mkcert install.lnk"
+    CreateShortCut "$SMPROGRAMS\$ICONS_GROUP\mkcert\mkcert uninstall trusted https.lnk" "$INSTDIR\mkcert uninstall.lnk"
+    !insertmacro MUI_STARTMENU_WRITE_END
   SectionEnd
 
   /**
@@ -712,16 +706,6 @@ Function .onInit
 
   ; Initialize global variables
   StrCpy $mkcertSetup ""
-
-  ; Check parameters
-  ${GetParameters} $R0
-  ClearErrors
-  ${GetOptions} $R0 "/C" $0
-  ${IfNot} ${Errors}
-    StrCpy $ChocolateyMode "1"
-  ${Else}
-    StrCpy $ChocolateyMode "0"
-  ${EndIf}
 
 FunctionEnd
 

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -193,7 +193,7 @@ Caption "${PRODUCT_NAME_FULL} ${PRODUCT_VERSION} $InstallerModeCaption"
 !define MUI_PAGE_HEADER_SUBTEXT "Please review the license terms before installing sudo."
 !define MUI_PAGE_CUSTOMFUNCTION_PRE sudoLicPre
 !define MUI_PAGE_CUSTOMFUNCTION_LEAVE sudoLicLeave
-!insertmacro MUI_PAGE_LICENSE "..\.gotmp\bin\windows_${TARGET_ARCH}\sudo_license.txt"
+!insertmacro MUI_PAGE_LICENSE "..\.gotmp\bin\windows_${TARGET_ARCH}\gsudo_license.txt"
 
 ; Components page
 Var MkcertSetup
@@ -893,7 +893,7 @@ Section Uninstall
   Delete "$INSTDIR\mkcert_license.txt"
   Delete "$INSTDIR\mkcert.exe"
 
-  Delete "$INSTDIR\sudo_license.txt"
+  Delete "$INSTDIR\gsudo_license.txt"
   Delete "$INSTDIR\${GSUDO_SETUP}"
 
   Delete "$INSTDIR\license.txt"

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -136,7 +136,9 @@ InstType "Minimal"
 /**
  * Local macros
  */
-
+!macro _Chocolatey _a _b _t _f
+  !insertmacro _== $ChocolateyMode `1` `${_t}` `${_f}`
+!macroend
 !define Chocolatey `"" Chocolatey ""`
 
 /**
@@ -524,9 +526,8 @@ SectionGroup /e "mkcert"
    * mkcert setup
    */
   Section "Setup mkcert" SecMkcertSetup
-    ; Install in non silent and choco mode only
-    ${IfNot} ${Silent}
-    ${AndIfNot} ${Chocolatey}
+    ; Install in non choco mode only
+    ${IfNot} ${Chocolatey}
       MessageBox MB_ICONINFORMATION|MB_OK "Now running mkcert to enable trusted https. Please accept the mkcert dialog box that may follow."
 
       ; Run setup

--- a/winpkg/ddev.nsi
+++ b/winpkg/ddev.nsi
@@ -136,6 +136,7 @@ InstType "Minimal"
 /**
  * Local macros
  */
+Var ChocolateyMode
 !macro _Chocolatey _a _b _t _f
   !insertmacro _== $ChocolateyMode `1` `${_t}` `${_f}`
 !macroend


### PR DESCRIPTION
## The Issue

- #6636 
- #6344 (I think this is the final fix for Windows ARM64, stopping use of Choco)

We no longer need Chocolatey when installing inside WSL so let's remove it to prevent side effects that users are running into.

## How This PR Solves The Issue

It removes the unnecessary dependency.

## Manual Testing Instructions

1. Run the script to install DDEV.
1. Ensure that there are no errors caused by Chocolatey not being installed.
1. Ensure that DDEV works.

## Automated Testing Overview

TBD

## Release/Deployment Notes

TBD