### PR TITLE
fix: nginx.conf should let index.php handle 404 errors for media files

### DIFF
--- a/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
@@ -1,4 +1,5 @@
 # ddev backdrop config
+# https://github.com/perusio/drupal-with-nginx
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
@@ -1,4 +1,6 @@
 # ddev backdrop config
+# https://www.drupal.org/project/drupal/issues/2937161
+# https://www.drupal.org/project/drupal/issues/3336659
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
@@ -1,5 +1,5 @@
 # ddev backdrop config
-# https://github.com/perusio/drupal-with-nginx
+# https://docs.backdropcms.org/documentation/system-requirements#web-server-details
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
@@ -1,6 +1,4 @@
 # ddev backdrop config
-# https://www.drupal.org/project/drupal/issues/2937161
-# https://www.drupal.org/project/drupal/issues/3336659
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-cakephp.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-cakephp.conf
@@ -1,4 +1,5 @@
 # ddev cakephp config
+# https://book.cakephp.org/5/en/installation.html#nginx
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
@@ -1,4 +1,5 @@
 # ddev craftcms config
+# https://github.com/nystudio107/nginx-craft
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal.conf
@@ -1,4 +1,6 @@
 # ddev drupal config (drupal8+)
+# https://www.drupal.org/project/drupal/issues/2937161
+# https://www.drupal.org/project/drupal/issues/3336659
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal.conf
@@ -1,4 +1,5 @@
-# ddev drupal config (drupal8+)
+# ddev drupal config (obsolete), should point to latest stable drupal version
+# This should no longer be in use.
 # https://www.drupal.org/project/drupal/issues/2937161
 # https://www.drupal.org/project/drupal/issues/3336659
 

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
@@ -1,4 +1,6 @@
 # ddev drupal10 config
+# https://www.drupal.org/project/drupal/issues/2937161
+# https://www.drupal.org/project/drupal/issues/3336659
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
@@ -1,4 +1,6 @@
 # ddev drupal11 config
+# https://www.drupal.org/project/drupal/issues/2937161
+# https://www.drupal.org/project/drupal/issues/3336659
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
@@ -1,6 +1,4 @@
 # ddev drupal6 config
-# https://www.drupal.org/project/drupal/issues/2937161
-# https://www.drupal.org/project/drupal/issues/3336659
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
@@ -1,4 +1,6 @@
 # ddev drupal6 config
+# https://www.drupal.org/project/drupal/issues/2937161
+# https://www.drupal.org/project/drupal/issues/3336659
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
@@ -1,4 +1,5 @@
 # ddev drupal6 config
+# https://github.com/perusio/drupal-with-nginx
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
@@ -1,4 +1,6 @@
 # ddev drupal7 config
+# https://www.drupal.org/project/drupal/issues/2937161
+# https://www.drupal.org/project/drupal/issues/3336659
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
@@ -1,4 +1,5 @@
 # ddev drupal7 config
+# https://github.com/perusio/drupal-with-nginx
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
@@ -1,6 +1,4 @@
 # ddev drupal7 config
-# https://www.drupal.org/project/drupal/issues/2937161
-# https://www.drupal.org/project/drupal/issues/3336659
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
@@ -1,4 +1,7 @@
 # ddev drupal8 config
+# https://www.drupal.org/project/drupal/issues/2937161
+# https://www.drupal.org/project/drupal/issues/3336659
+
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above
 # and ddev will respect it and won't overwrite the file.

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
@@ -1,4 +1,6 @@
 # ddev drupal9 config
+# https://www.drupal.org/project/drupal/issues/2937161
+# https://www.drupal.org/project/drupal/issues/3336659
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
@@ -1,4 +1,5 @@
 # ddev laravel config
+# https://laravel.com/docs/deployment#nginx
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above
@@ -55,17 +56,6 @@ server {
         fastcgi_pass_header "X-Accel-Expires";
         fastcgi_pass_header "X-Accel-Limit-Rate";
         fastcgi_pass_header "X-Accel-Redirect";
-    }
-
-    # Expire rules for static content
-
-    # Media: images, icons, video, audio, HTC
-    # Ignore "/img" path for Glide in Statamic CMS.
-    # See https://github.com/ddev/ddev/issues/6774, https://github.com/statamic/cms/issues/10053
-    location ~* ^(?!\/img\/).*\.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
-        expires 1M;
-        access_log off;
-        add_header Cache-Control "public";
     }
 
     # Prevent clients from accessing hidden files (starting with a dot)

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
@@ -1,4 +1,6 @@
 # ddev magento config
+# https://devdocs-openmage.org/guides/m1x/install/nginx.html
+# https://gist.github.com/gwillem/cd5ae6845fa33aa0d481
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
@@ -73,6 +73,7 @@ server {
         expires 1M;
         access_log off;
         add_header Cache-Control "public";
+        try_files $uri /index.php$is_args$args;
     }
 
     # Prevent clients from accessing hidden files (starting with a dot)

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
@@ -1,4 +1,5 @@
 # ddev magento2 config
+# https://github.com/magento/magento2/blob/2.4-develop/nginx.conf.sample
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
@@ -58,15 +58,6 @@ server {
         fastcgi_pass_header "X-Accel-Redirect";
     }
 
-    # Expire rules for static content
-
-    # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
-        expires 1M;
-        access_log off;
-        add_header Cache-Control "public";
-    }
-
     # Prevent clients from accessing hidden files (starting with a dot)
     # This is particularly important if you store .htpasswd files in the site hierarchy
     # Access to `/.well-known/` is allowed.

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
@@ -1,4 +1,5 @@
 # ddev shopware6 config
+# https://developer.shopware.com/docs/resources/references/config-reference/server/nginx.html
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
@@ -90,6 +90,7 @@ server {
         expires 1M;
         access_log off;
         add_header Cache-Control "public";
+        try_files $uri /index.php$is_args$args;
     }
 
     # Prevent clients from accessing hidden files (starting with a dot)

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-silverstripe.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-silverstripe.conf
@@ -1,4 +1,5 @@
 # ddev silverstripe config
+# https://docs.silverstripe.org/en/3/getting_started/installation/how_to/configure_nginx/
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-symfony.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-symfony.conf
@@ -1,4 +1,5 @@
 # ddev symfony config
+# https://symfony.com/doc/current/setup/web_server_configuration.html#nginx
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -1,4 +1,5 @@
 # ddev typo3 config
+# https://docs.typo3.org/p/lochmueller/staticfilecache/main/en-us/Configuration/Nginx.html
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above
@@ -89,15 +90,6 @@ server {
         fastcgi_pass_header "X-Accel-Expires";
         fastcgi_pass_header "X-Accel-Limit-Rate";
         fastcgi_pass_header "X-Accel-Redirect";
-    }
-
-    # Expire rules for static content
-
-    # Media: images, icons, video, audio, HTC
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
-        expires 1M;
-        access_log off;
-        add_header Cache-Control "public";
     }
 
     # Compressing resource files will save bandwidth and so improve loading speed especially for users

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
@@ -1,4 +1,5 @@
 # ddev wordpress config
+# https://developer.wordpress.org/advanced-administration/server/web-server/nginx/
 
 #ddev-generated
 # If you want to take over this file and customize it, remove the line above
@@ -90,6 +91,7 @@ server {
     location ~* \.(jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
         expires max;
         log_not_found off;
+        try_files $uri /index.php$is_args$args;
     }
     location ~* \.(js|css)$ {
         expires -1;

--- a/pkg/ddevapp/webserver_config_assets/nginx_second_docroot_example-site-php.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx_second_docroot_example-site-php.conf
@@ -64,6 +64,7 @@ server {
     # Expire rules for static content
     # Media: images, icons, video, audio, HTC
     location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
+        try_files $uri @rewrite;
         expires 1M;
         access_log off;
         add_header Cache-Control "public";


### PR DESCRIPTION
## The Issue

Media stanza in `nginx.conf` doesn't work as expected in some cases:

| Framework | 404 `.png` handled by | 404 `.txt` handled by | Description |
| --------- | -------------- | ----------- |  ----------- |
| Shopware6 | nginx (this PR: app) | app | without PR `.png` is handled by nginx (this is wrong) |
| Magento1 | nginx (this PR: app) | app | has the same problem as Shopware6 |
| Magento2 | nginx (this PR: app) | app | has the same problem as Shopware6 |
| Typo3 | nginx (this PR: app) | app | has the same problem as Shopware6 |
| Wordpress | nginx (this PR: app) | app | has the same problem as Shopware6 |
| Laravel | app | app | has `error_page 404 /index.php;` |
| Symfony | app | app | because nginx doesn't have `Media` stanza |
| Drupal | app | app | Media stanza has `try_files $uri @rewrite;` |

## How This PR Solves The Issue

- Adds links to upstream nginx files.
- Updates Shopware6, Magento1 and Wordpress nginx.conf with `try_files`.
- Removes Media stanza from Laravel, Magento2 and Typo3 (because upstream doesn't have it.)

## Manual Testing Instructions

Try quickstarts for Shopware6, Magento1, Typo3, Wordpress, Laravel

The below pages should show the same 404 from the app:

```
ddev launch /test/image.png
ddev launch /test/some.txt
```

Expected result (404 page from app):

![image](https://github.com/user-attachments/assets/e5ba5c1a-c2dd-4ec8-90e2-d933bd045427)

Unexpected result (404 page from nginx):

![image](https://github.com/user-attachments/assets/49a0a125-42dc-4142-9358-8d35690c1bda)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

