### PR TITLE
feat: backdrop add bee to quickstart

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -60,8 +60,6 @@ fi
 if [ "$DDEV_PROJECT_TYPE" = "backdrop" ] ; then
     # Start can be executed when the container is already running.
     mkdir -p ~/.drush/commands && ln -sf /var/tmp/backdrop_drush_commands ~/.drush/commands/backdrop
-    # Add Bee CLI add-on.
-    ddev add-on get backdrop-ops/ddev-backdrop-bee
 fi
 
 if [ "${DDEV_PROJECT_TYPE}" = "drupal6" ] || [ "${DDEV_PROJECT_TYPE}" = "drupal7" ] || [ "${DDEV_PROJECT_TYPE}" = "backdrop" ]; then

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -60,6 +60,8 @@ fi
 if [ "$DDEV_PROJECT_TYPE" = "backdrop" ] ; then
     # Start can be executed when the container is already running.
     mkdir -p ~/.drush/commands && ln -sf /var/tmp/backdrop_drush_commands ~/.drush/commands/backdrop
+    # Add Bee CLI add-on.
+    ddev add-on get backdrop-ops/ddev-backdrop-bee
 fi
 
 if [ "${DDEV_PROJECT_TYPE}" = "drupal6" ] || [ "${DDEV_PROJECT_TYPE}" = "drupal7" ] || [ "${DDEV_PROJECT_TYPE}" = "backdrop" ]; then

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -17,6 +17,8 @@ To get started with [Backdrop](https://backdropcms.org), clone the project repos
     mv backdrop/* my-backdrop-site/ && rm -rf backdrop
     cd my-backdrop-site
     ddev config --project-type=backdrop
+    # Add the Bee CLI add-on.
+    ddev add-on get backdrop-ops/ddev-backdrop-bee
     ddev start
     ddev launch
     ```
@@ -35,6 +37,9 @@ To get started with [Backdrop](https://backdropcms.org), clone the project repos
 
     # Set up the DDEV environment:
     ddev config --project-type=backdrop
+
+    # Add the Bee CLI add-on.
+    ddev add-on get backdrop-ops/ddev-backdrop-bee
 
     # Start the project
     ddev start
@@ -157,7 +162,7 @@ Further information on the DDEV procedure can also be found in the [Contao docum
 Start a new [Craft CMS](https://craftcms.com) project or retrofit an existing one.
 
 !!!tip "Compatibility with Craft CMS 3"
-    The `craftcms` project type is best with Craft CMS 4+, which is more opinionated about some settings. If you are using Craft CMS 3 or earlier, you may want to use the `php` project type and [manage settings yourself](https://github.com/ddev/ddev/issues/4650).
+The `craftcms` project type is best with Craft CMS 4+, which is more opinionated about some settings. If you are using Craft CMS 3 or earlier, you may want to use the `php` project type and [manage settings yourself](https://github.com/ddev/ddev/issues/4650).
 
 Environment variables will be automatically added to your `.env` file to simplify the first boot of a project. For _new_ installations, this means the default URL and database connection settings displayed during installation can be used without modification. If _existing_ projects expect environment variables to be named in a particular way, you are welcome to rename them.
 
@@ -218,7 +223,7 @@ In order for `ddev craft` to work when Craft is installed in a subdirectory, you
 Read more about customizing the environment and persisting configuration in [Providing Custom Environment Variables to a Container](./extend/customization-extendibility.md#environment-variables-for-containers-and-services).
 
 !!!tip "Installing Craft"
-    Read more about installing Craft in the [official documentation](https://craftcms.com/docs).
+Read more about installing Craft in the [official documentation](https://craftcms.com/docs).
 
 ## Drupal
 
@@ -399,7 +404,7 @@ ddev launch $(ddev drush uli)
     ```
 
 !!!tip "How to update?"
-    Upgrade Grave core:
+Upgrade Grave core:
 
     ```bash
     ddev exec gpm selfupgrade -f
@@ -487,7 +492,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     ```
 
 !!!tip "Installing Kirby"
-    Read more about developing your Kirby project with DDEV in our [extensive DDEV guide](https://getkirby.com/docs/cookbook/setup/ddev).
+Read more about developing your Kirby project with DDEV in our [extensive DDEV guide](https://getkirby.com/docs/cookbook/setup/ddev).
 
 ## Laravel
 
@@ -588,7 +593,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ```
 
 !!!tip "Add Vite support?"
-    Since Laravel v9.19, Vite is included as the default [asset bundler](https://laravel.com/docs/vite). There are small tweaks needed in order to use it: [Working with Vite in DDEV - Laravel](https://ddev.com/blog/working-with-vite-in-ddev/#laravel).
+Since Laravel v9.19, Vite is included as the default [asset bundler](https://laravel.com/docs/vite). There are small tweaks needed in order to use it: [Working with Vite in DDEV - Laravel](https://ddev.com/blog/working-with-vite-in-ddev/#laravel).
 
 ## Magento 2
 
@@ -927,6 +932,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
     ddev php please make:user admin@example.com --password=admin1234 --super --no-interaction
     ddev launch /cp
     ```
+
 === "Git Clone"
 
     ```bash
@@ -972,7 +978,7 @@ ddev exec "sed -i -e 's|<name>.*</name>|<name>${SULU_PROJECT_NAME}</name>|g' -e 
 ```
 
 !!!warning "Caution"
-    Changing the `<key>` for a webspace later on causes problems. It is recommended to decide on the value for the key before the database is build in the next step.
+Changing the `<key>` for a webspace later on causes problems. It is recommended to decide on the value for the key before the database is build in the next step.
 
 Now build the database. Building with the `dev` argument adds the user `admin` with the password `admin` to your project.
 
@@ -985,7 +991,7 @@ ddev launch /admin
 ```
 
 !!!tip
-    If you don't want to add an admin user use the `prod` argument instead
+If you don't want to add an admin user use the `prod` argument instead
 
     ```bash
     ddev execute bin/adminconsole sulu:build prod
@@ -1042,7 +1048,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ```
 
 !!!tip "Consuming Messages (Running the Worker)"
-    Edit `.ddev/config.yaml` in your project directory and uncomment `post-start` hook to see `messenger:consume` command logs, and run:
+Edit `.ddev/config.yaml` in your project directory and uncomment `post-start` hook to see `messenger:consume` command logs, and run:
 
     ```bash
     ddev exec symfony server:log

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -18,11 +18,6 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
     ddev start
     # Download Backdrop core
     ddev bee download-core
-    ```
-
-    After all the files are downloaded, create a new user and launch the site:
-
-    ```bash
     # Create admin user
     ddev bee si --username=admin --password=Password123 --db-name=db --db-user=db --db-pass=db --db-host=db --auto
     # Login using `admin` user and `Password123` password

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -162,7 +162,7 @@ Further information on the DDEV procedure can also be found in the [Contao docum
 Start a new [Craft CMS](https://craftcms.com) project or retrofit an existing one.
 
 !!!tip "Compatibility with Craft CMS 3"
-The `craftcms` project type is best with Craft CMS 4+, which is more opinionated about some settings. If you are using Craft CMS 3 or earlier, you may want to use the `php` project type and [manage settings yourself](https://github.com/ddev/ddev/issues/4650).
+    The `craftcms` project type is best with Craft CMS 4+, which is more opinionated about some settings. If you are using Craft CMS 3 or earlier, you may want to use the `php` project type and [manage settings yourself](https://github.com/ddev/ddev/issues/4650).
 
 Environment variables will be automatically added to your `.env` file to simplify the first boot of a project. For _new_ installations, this means the default URL and database connection settings displayed during installation can be used without modification. If _existing_ projects expect environment variables to be named in a particular way, you are welcome to rename them.
 
@@ -223,7 +223,7 @@ In order for `ddev craft` to work when Craft is installed in a subdirectory, you
 Read more about customizing the environment and persisting configuration in [Providing Custom Environment Variables to a Container](./extend/customization-extendibility.md#environment-variables-for-containers-and-services).
 
 !!!tip "Installing Craft"
-Read more about installing Craft in the [official documentation](https://craftcms.com/docs).
+    Read more about installing Craft in the [official documentation](https://craftcms.com/docs).
 
 ## Drupal
 
@@ -404,7 +404,7 @@ ddev launch $(ddev drush uli)
     ```
 
 !!!tip "How to update?"
-Upgrade Grave core:
+    Upgrade Grave core:
 
     ```bash
     ddev exec gpm selfupgrade -f
@@ -492,7 +492,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     ```
 
 !!!tip "Installing Kirby"
-Read more about developing your Kirby project with DDEV in our [extensive DDEV guide](https://getkirby.com/docs/cookbook/setup/ddev).
+    Read more about developing your Kirby project with DDEV in our [extensive DDEV guide](https://getkirby.com/docs/cookbook/setup/ddev).
 
 ## Laravel
 
@@ -593,7 +593,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ```
 
 !!!tip "Add Vite support?"
-Since Laravel v9.19, Vite is included as the default [asset bundler](https://laravel.com/docs/vite). There are small tweaks needed in order to use it: [Working with Vite in DDEV - Laravel](https://ddev.com/blog/working-with-vite-in-ddev/#laravel).
+    Since Laravel v9.19, Vite is included as the default [asset bundler](https://laravel.com/docs/vite). There are small tweaks needed in order to use it: [Working with Vite in DDEV - Laravel](https://ddev.com/blog/working-with-vite-in-ddev/#laravel).
 
 ## Magento 2
 
@@ -978,7 +978,7 @@ ddev exec "sed -i -e 's|<name>.*</name>|<name>${SULU_PROJECT_NAME}</name>|g' -e 
 ```
 
 !!!warning "Caution"
-Changing the `<key>` for a webspace later on causes problems. It is recommended to decide on the value for the key before the database is build in the next step.
+    Changing the `<key>` for a webspace later on causes problems. It is recommended to decide on the value for the key before the database is build in the next step.
 
 Now build the database. Building with the `dev` argument adds the user `admin` with the password `admin` to your project.
 
@@ -991,7 +991,7 @@ ddev launch /admin
 ```
 
 !!!tip
-If you don't want to add an admin user use the `prod` argument instead
+    If you don't want to add an admin user use the `prod` argument instead
 
     ```bash
     ddev execute bin/adminconsole sulu:build prod
@@ -1048,7 +1048,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ```
 
 !!!tip "Consuming Messages (Running the Worker)"
-Edit `.ddev/config.yaml` in your project directory and uncomment `post-start` hook to see `messenger:consume` command logs, and run:
+    Edit `.ddev/config.yaml` in your project directory and uncomment `post-start` hook to see `messenger:consume` command logs, and run:
 
     ```bash
     ddev exec symfony server:log
@@ -1066,7 +1066,6 @@ Edit `.ddev/config.yaml` in your project directory and uncomment `post-start` ho
     ddev exec touch public/FIRST_INSTALL
     ddev launch /typo3/install.php
     ```
-
 === "Git Clone"
 
     ```bash

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -6,20 +6,23 @@ Before proceeding, make sure your installation of DDEV is up to date. In a new a
 
 ## Backdrop
 
-To get started with [Backdrop](https://backdropcms.org), clone the project repository and navigate to the project directory.
+You can start a new [Backdrop](https://backdropcms.org) project or configure an existing one.
 
 === "New projects"
 
     ```bash
-    mkdir my-backdrop-site
-    curl -LJO https://github.com/backdrop/backdrop/releases/latest/download/backdrop.zip
-    unzip backdrop.zip && rm -f backdrop.zip
-    mv backdrop/* my-backdrop-site/ && rm -rf backdrop
-    cd my-backdrop-site
+    mkdir my-backdrop-site && cd my-backdrop-site
     ddev config --project-type=backdrop
-    # Add the Bee CLI add-on.
+    # Add the official Bee CLI add-on
     ddev add-on get backdrop-ops/ddev-backdrop-bee
     ddev start
+    # Download Backdrop core
+    ddev bee download-core
+    # Sync files between host and container (only if Mutagen is enabled)
+    ddev mutagen sync
+    # Create admin user
+    ddev bee si --username=admin --password=Password123 --db-name=db --db-user=db --db-pass=db --db-host=db --auto
+    # Login using `admin` user and `Password123` password
     ddev launch
     ```
 
@@ -29,16 +32,15 @@ To get started with [Backdrop](https://backdropcms.org), clone the project repos
 
 
     ```bash
-    # Clone an existing repository (or navigate to a local project directory):
-    # Set PROJECT_GIT_URL to your project's git URL.
-    PROJECT_GIT_URL=https://github.com/ddev/test-backdrop.git
-    git clone ${PROJECT_GIT_URL} my-backdrop-site
-    cd my-backdrop-site
+    mkdir my-backdrop-site && cd my-backdrop-site
+
+    # Use your own repository URL, this is an example
+    git clone https://github.com/ddev/test-backdrop.git .
 
     # Set up the DDEV environment:
     ddev config --project-type=backdrop
 
-    # Add the Bee CLI add-on.
+    # Add the official Bee CLI add-on
     ddev add-on get backdrop-ops/ddev-backdrop-bee
 
     # Start the project

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -932,7 +932,6 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
     ddev php please make:user admin@example.com --password=admin1234 --super --no-interaction
     ddev launch /cp
     ```
-
 === "Git Clone"
 
     ```bash
@@ -1066,6 +1065,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev exec touch public/FIRST_INSTALL
     ddev launch /typo3/install.php
     ```
+
 === "Git Clone"
 
     ```bash

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -18,8 +18,11 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
     ddev start
     # Download Backdrop core
     ddev bee download-core
-    # Sync files between host and container (only if Mutagen is enabled)
-    ddev mutagen sync
+    ```
+
+    After all the files are downloaded, create a new user and launch the site:
+
+    ```bash
     # Create admin user
     ddev bee si --username=admin --password=Password123 --db-name=db --db-user=db --db-pass=db --db-host=db --auto
     # Login using `admin` user and `Password123` password

--- a/docs/tests/backdrop.bats
+++ b/docs/tests/backdrop.bats
@@ -12,66 +12,77 @@ teardown() {
 }
 
 @test "backdrop new-project quickstart with $(ddev --version)" {
-  # mkdir my-backdrop-site && cd my-backdrop-site
-  run mkdir -p ${PROJNAME}
+  run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
-  # curl -LJO https://github.com/backdrop/backdrop/releases/latest/download/backdrop.zip
-  run curl -LJO https://github.com/backdrop/backdrop/releases/latest/download/backdrop.zip
-  assert_success
-  # unzip -o backdrop.zip && rm -f backdrop.zip
-  run unzip -o backdrop.zip && rm -f backdrop.zip
-  assert_success
-  # mv backdrop/* my-backdrop-site/ && rm -rf backdrop
-  run mv backdrop/* my-backdrop-site/ && rm -rf backdrop
-  assert_success
-  # cd ${PROJNAME}
-  cd ${PROJNAME}
-  assert_success
-  # ddev config --project-type=backdrop
+
   run ddev config --project-type=backdrop
   assert_success
-  # ddev start -y
+
+  # Add the official Bee CLI add-on
+  run ddev add-on get backdrop-ops/ddev-backdrop-bee
+  assert_success
+
   run ddev start -y
   assert_success
-  # ddev launch
+
+  # Download Backdrop core
+  run ddev bee download-core
+  assert_success
+
+  # Sync files between host and container (only if Mutagen is enabled)
+  run ddev mutagen sync
+  assert_success
+
+  # Create admin user
+  run ddev bee si --username=admin --password=Password123 --db-name=db --db-user=db --db-pass=db --db-host=db --auto
+  assert_success
+
   run bash -c "DDEV_DEBUG=true ddev launch"
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site
   assert_success
-  assert_output --partial "location: https://${PROJNAME}.ddev.site/core/install.php"
-  assert_output --partial "HTTP/2 302"
+  assert_output --partial "HTTP/2 200"
+  run curl -sf https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "Welcome to My Backdrop Site!"
 }
 
 @test "backdrop existing project with $(ddev --version)" {
-  # PROJECT_GIT_URL=https://github.com/ddev/test-backdrop.git
-  PROJECT_GIT_URL=https://github.com/ddev/test-backdrop.git
-  # git clone ${PROJECT_GIT_URL} my-backdrop-site
-  run git clone ${PROJECT_GIT_URL} ${PROJNAME}
+  run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
-  # cd my-backdrop-site
-  cd ${PROJNAME} || exit 2
+
+  run git clone https://github.com/ddev/test-backdrop.git .
   assert_success
-  # ddev config --project-type=backdrop
+
   run ddev config --project-type=backdrop
   assert_success
-  # ddev start -y
+
+  # Add the official Bee CLI add-on
+  run ddev add-on get backdrop-ops/ddev-backdrop-bee
+  assert_success
+
   run ddev start -y
   assert_success
+
   run curl -fLO https://github.com/ddev/test-backdrop/releases/download/1.29.2/db.sql.gz
   assert_success
-  # ddev import-db --file=/path/to/db.sql.gz
+
   run ddev import-db --file=db.sql.gz
   assert_success
+
   run curl -fLO https://github.com/ddev/test-backdrop/releases/download/1.29.2/files.tgz
   assert_success
-  # ddev import-files --source=/path/to/files.tar.gz
+
   run ddev import-files --source=files.tgz
-  # ddev launch
+  assert_success
+
   run bash -c "DDEV_DEBUG=true ddev launch"
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
+
+  # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site
   assert_success
   assert_output --partial "HTTP/2 200"

--- a/docs/tests/backdrop.bats
+++ b/docs/tests/backdrop.bats
@@ -19,7 +19,8 @@ teardown() {
   assert_success
 
   # Add the official Bee CLI add-on
-  run ddev add-on get backdrop-ops/ddev-backdrop-bee
+  # TODO: run ddev add-on get backdrop-ops/ddev-backdrop-bee
+  run ddev add-on get https://github.com/stasadev/ddev-backdrop-bee/tarball/20250319_stasadev_host_command
   assert_success
 
   run ddev start -y
@@ -27,10 +28,6 @@ teardown() {
 
   # Download Backdrop core
   run ddev bee download-core
-  assert_success
-
-  # Sync files between host and container (only if Mutagen is enabled)
-  run ddev mutagen sync
   assert_success
 
   # Create admin user

--- a/docs/tests/backdrop.bats
+++ b/docs/tests/backdrop.bats
@@ -19,8 +19,7 @@ teardown() {
   assert_success
 
   # Add the official Bee CLI add-on
-  # TODO: run ddev add-on get backdrop-ops/ddev-backdrop-bee
-  run ddev add-on get https://github.com/stasadev/ddev-backdrop-bee/tarball/20250319_stasadev_host_command
+  run ddev add-on get backdrop-ops/ddev-backdrop-bee
   assert_success
 
   run ddev start -y


### PR DESCRIPTION
## The Issue

In an earlier PR, I was going to add instructions on how to install the Bee CLI add-on for Backdrop. It was suggested that it might be more useful to include it by default in the Backdrop Quickstart.

## How This PR Solves The Issue

I'm not 100% sure that what I've done will work or is the right place for it, but I found a spot where it was doing some Drush-related processing and added the `ddev addon get` line there.

## Manual Testing Instructions

Run instructions from https://ddev--7053.org.readthedocs.build/en/7053/users/quickstart/#backdrop