### PR TITLE
build: don't use go 1.24 yet until docker issues resolved, fixes #7051

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21'
+          go-version: '<1.24'
 
       - name: Build DDEV executables
         run: make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 completions mkcert
@@ -160,7 +160,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21'
+          go-version: '<1.24'
 
       - name: restore build-most results from cache
         uses: actions/cache@v4

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21'
+          go-version: '<1.24'
 
       # Find out info about how github is getting the hash
       - run: "git describe --tags --always --dirty"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21'
+          go-version: '<1.24'
 
       - name: Override environment variables for apache-fpm
         if: ${{ matrix.apache-fpm }}


### PR DESCRIPTION

## The Issue

- #7051 

Hopefully this is for a short time, but there have been multiple reports (see #7051) of problems pulling images from go code compiled with go 1.24. We're not having trouble locally, but there's no ready that go v1.23 is not fine.

## How This PR Solves The Issue

Use go 1.23

## Manual Testing Instructions

Review the PR build output to verify that it uses go 1.23*

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
