### PR TITLE
fix: make `ddev config` work with project name from `config.*.yaml`, fixes #7060

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -343,12 +343,9 @@ func getConfigApp(_ string) *ddevapp.DdevApp {
 	if err != nil {
 		util.Failed("Could not create a new config: %v", err)
 	}
-	// If the project name is changed to something else in the config overrides, update it here.
-	appWithOverrides, err := ddevapp.NewApp(appRoot, true)
-	if err != nil {
-		util.Failed("Could not create a new config: %v", err)
+	if err = app.RespectConfigNameOverride(); err != nil {
+		util.Failed("Could not check for name override: %v", err)
 	}
-	app.Name = appWithOverrides.Name
 	return app
 }
 

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -343,8 +343,8 @@ func getConfigApp(_ string) *ddevapp.DdevApp {
 	if err != nil {
 		util.Failed("Could not create a new config: %v", err)
 	}
-	if err = app.RespectConfigNameOverride(); err != nil {
-		util.Failed("Could not check for name override: %v", err)
+	if hasConfigNameOverride, newName := app.HasConfigNameOverride(); hasConfigNameOverride {
+		app.Name = newName
 	}
 	return app
 }

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -343,6 +343,12 @@ func getConfigApp(_ string) *ddevapp.DdevApp {
 	if err != nil {
 		util.Failed("Could not create a new config: %v", err)
 	}
+	// If the project name is changed to something else in the config overrides, update it here.
+	appWithOverrides, err := ddevapp.NewApp(appRoot, true)
+	if err != nil {
+		util.Failed("Could not create a new config: %v", err)
+	}
+	app.Name = appWithOverrides.Name
 	return app
 }
 

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -918,13 +918,12 @@ func TestRespectConfigNameOverride(t *testing.T) {
 	err = os.MkdirAll(filepath.Join(tmpDir, ".ddev"), 0777)
 	require.NoError(t, err)
 	configFile := filepath.Join(tmpDir, ".ddev/config.yaml")
-	configFileLocal := filepath.Join(tmpDir, ".ddev/config.local.yaml")
 	_, err = os.Create(configFile)
 	require.NoError(t, err)
 
 	// Create an override for the project name
 	projectNameOverride := projectName + "-override"
-	err = os.WriteFile(configFileLocal, []byte(`name: `+projectNameOverride), 0644)
+	err = os.WriteFile(filepath.Join(tmpDir, ".ddev/config.local.yaml"), []byte(`name: `+projectNameOverride), 0644)
 	require.NoError(t, err)
 
 	out, err := exec.RunHostCommand(DdevBin, "config", "--auto")
@@ -932,17 +931,10 @@ func TestRespectConfigNameOverride(t *testing.T) {
 
 	configContents, err := os.ReadFile(configFile)
 	require.NoError(t, err, "Unable to read '%s'", configFile)
-	configLocalContents, err := os.ReadFile(configFileLocal)
-	require.NoError(t, err, "Unable to read '%s'", configFileLocal)
 
 	app := &ddevapp.DdevApp{}
 	err = yaml.Unmarshal(configContents, app)
 	require.NoError(t, err, "Could not unmarshal '%s'", configFile)
-	// app.Name inside .ddev/config.yaml should be empty
-	require.Equal(t, "", app.Name)
 
-	err = yaml.Unmarshal(configLocalContents, app)
-	require.NoError(t, err, "Could not unmarshal '%s'", configFileLocal)
-	// app.Name inside .ddev/config.local.yaml should have the expected value
 	require.Equal(t, projectNameOverride, app.Name)
 }

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -889,8 +889,9 @@ func TestDrupalAppTypeUsage(t *testing.T) {
 	require.Equal(t, nodeps.AppTypeDrupalLatestStable, app.Type)
 }
 
-// TestRespectConfigNameOverride tests that `ddev config` respects name override from `.ddev/config.*.yaml` files
-func TestRespectConfigNameOverride(t *testing.T) {
+// TestHasConfigNameOverride tests that `ddev config` has name override from `.ddev/config.*.yaml` files
+// and new name is not written to .ddev/config.yaml
+func TestHasConfigNameOverride(t *testing.T) {
 	assert := asrt.New(t)
 
 	projectName := strings.ToLower(t.Name())
@@ -918,12 +919,13 @@ func TestRespectConfigNameOverride(t *testing.T) {
 	err = os.MkdirAll(filepath.Join(tmpDir, ".ddev"), 0777)
 	require.NoError(t, err)
 	configFile := filepath.Join(tmpDir, ".ddev/config.yaml")
+	configFileLocal := filepath.Join(tmpDir, ".ddev/config.local.yaml")
 	_, err = os.Create(configFile)
 	require.NoError(t, err)
 
 	// Create an override for the project name
 	projectNameOverride := projectName + "-override"
-	err = os.WriteFile(filepath.Join(tmpDir, ".ddev/config.local.yaml"), []byte(`name: `+projectNameOverride), 0644)
+	err = os.WriteFile(configFileLocal, []byte(`name: `+projectNameOverride), 0644)
 	require.NoError(t, err)
 
 	out, err := exec.RunHostCommand(DdevBin, "config", "--auto")
@@ -931,10 +933,19 @@ func TestRespectConfigNameOverride(t *testing.T) {
 
 	configContents, err := os.ReadFile(configFile)
 	require.NoError(t, err, "Unable to read '%s'", configFile)
+	configLocalContents, err := os.ReadFile(configFileLocal)
+	require.NoError(t, err, "Unable to read '%s'", configFileLocal)
 
 	app := &ddevapp.DdevApp{}
 	err = yaml.Unmarshal(configContents, app)
 	require.NoError(t, err, "Could not unmarshal '%s'", configFile)
 
+	// app.Name inside .ddev/config.yaml should be empty
+	require.Equal(t, "", app.Name)
+
+	err = yaml.Unmarshal(configLocalContents, app)
+	require.NoError(t, err, "Could not unmarshal '%s'", configFileLocal)
+
+	// app.Name inside .ddev/config.local.yaml should have the expected value
 	require.Equal(t, projectNameOverride, app.Name)
 }

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -889,8 +889,8 @@ func TestDrupalAppTypeUsage(t *testing.T) {
 	require.Equal(t, nodeps.AppTypeDrupalLatestStable, app.Type)
 }
 
-// TestConfigRespectNameOverride tests that `ddev config` respects name override from `.ddev/config.*.yaml` files
-func TestConfigRespectNameOverride(t *testing.T) {
+// TestRespectConfigNameOverride tests that `ddev config` respects name override from `.ddev/config.*.yaml` files
+func TestRespectConfigNameOverride(t *testing.T) {
 	assert := asrt.New(t)
 
 	projectName := strings.ToLower(t.Name())
@@ -918,12 +918,13 @@ func TestConfigRespectNameOverride(t *testing.T) {
 	err = os.MkdirAll(filepath.Join(tmpDir, ".ddev"), 0777)
 	require.NoError(t, err)
 	configFile := filepath.Join(tmpDir, ".ddev/config.yaml")
+	configFileLocal := filepath.Join(tmpDir, ".ddev/config.local.yaml")
 	_, err = os.Create(configFile)
 	require.NoError(t, err)
 
 	// Create an override for the project name
 	projectNameOverride := projectName + "-override"
-	err = os.WriteFile(filepath.Join(tmpDir, ".ddev/config.local.yaml"), []byte(`name: `+projectNameOverride), 0644)
+	err = os.WriteFile(configFileLocal, []byte(`name: `+projectNameOverride), 0644)
 	require.NoError(t, err)
 
 	out, err := exec.RunHostCommand(DdevBin, "config", "--auto")
@@ -931,10 +932,17 @@ func TestConfigRespectNameOverride(t *testing.T) {
 
 	configContents, err := os.ReadFile(configFile)
 	require.NoError(t, err, "Unable to read '%s'", configFile)
+	configLocalContents, err := os.ReadFile(configFileLocal)
+	require.NoError(t, err, "Unable to read '%s'", configFileLocal)
 
 	app := &ddevapp.DdevApp{}
 	err = yaml.Unmarshal(configContents, app)
 	require.NoError(t, err, "Could not unmarshal '%s'", configFile)
+	// app.Name inside .ddev/config.yaml should be empty
+	require.Equal(t, "", app.Name)
 
+	err = yaml.Unmarshal(configLocalContents, app)
+	require.NoError(t, err, "Could not unmarshal '%s'", configFileLocal)
+	// app.Name inside .ddev/config.local.yaml should have the expected value
 	require.Equal(t, projectNameOverride, app.Name)
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -194,11 +194,6 @@ func (app *DdevApp) WriteConfig() error {
 
 	// Work against a copy of the DdevApp, since we don't want to actually change it.
 	appcopy := *app
-	appcopyName := appcopy.Name
-
-	if appcopy.OmitName {
-		appcopy.Name = ""
-	}
 
 	// Only set the images on write if non-default values have been specified.
 	if appcopy.WebImage == docker.GetWebImage() {
@@ -267,7 +262,7 @@ func (app *DdevApp) WriteConfig() error {
 	}
 
 	// The .ddev directory may still need to be populated, especially in tests
-	err = PopulateExamplesCommandsHomeadditions(appcopyName)
+	err = PopulateExamplesCommandsHomeadditions(appcopy.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -195,6 +195,11 @@ func (app *DdevApp) WriteConfig() error {
 	// Work against a copy of the DdevApp, since we don't want to actually change it.
 	appcopy := *app
 
+	// If the app name has been changed, then remove it from the main config.yaml file.
+	if hasConfigNameOverride, _ := app.HasConfigNameOverride(); hasConfigNameOverride {
+		appcopy.Name = ""
+	}
+
 	// Only set the images on write if non-default values have been specified.
 	if appcopy.WebImage == docker.GetWebImage() {
 		appcopy.WebImage = ""
@@ -262,7 +267,7 @@ func (app *DdevApp) WriteConfig() error {
 	}
 
 	// The .ddev directory may still need to be populated, especially in tests
-	err = PopulateExamplesCommandsHomeadditions(appcopy.Name)
+	err = PopulateExamplesCommandsHomeadditions(app.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -194,6 +194,11 @@ func (app *DdevApp) WriteConfig() error {
 
 	// Work against a copy of the DdevApp, since we don't want to actually change it.
 	appcopy := *app
+	appcopyName := appcopy.Name
+
+	if appcopy.OmitName {
+		appcopy.Name = ""
+	}
 
 	// Only set the images on write if non-default values have been specified.
 	if appcopy.WebImage == docker.GetWebImage() {
@@ -262,7 +267,7 @@ func (app *DdevApp) WriteConfig() error {
 	}
 
 	// The .ddev directory may still need to be populated, especially in tests
-	err = PopulateExamplesCommandsHomeadditions(appcopy.Name)
+	err = PopulateExamplesCommandsHomeadditions(appcopyName)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -81,8 +81,7 @@ type WebExtraDaemon struct {
 // DdevApp is the struct that represents a DDEV app, mostly its config
 // from config.yaml.
 type DdevApp struct {
-	Name                      string                 `yaml:"name,omitempty"`
-	OmitName                  bool                   `yaml:"-"`
+	Name                      string                 `yaml:"name"`
 	Type                      string                 `yaml:"type"`
 	AppRoot                   string                 `yaml:"-"`
 	Docroot                   string                 `yaml:"docroot"`
@@ -3434,7 +3433,6 @@ func (app *DdevApp) GetMinimalContainerTimeout() string {
 }
 
 // RespectConfigNameOverride checks if the app name should be different and updates app.Name
-// In this case, we don't want to write the name to the .ddev/config.yaml
 func (app *DdevApp) RespectConfigNameOverride() error {
 	appWithOverrides, err := NewApp(app.GetAppRoot(), true)
 	if err != nil {
@@ -3442,7 +3440,6 @@ func (app *DdevApp) RespectConfigNameOverride() error {
 	}
 	if appWithOverrides.Name != app.Name {
 		app.Name = appWithOverrides.Name
-		app.OmitName = true
 	}
 	return nil
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -81,7 +81,8 @@ type WebExtraDaemon struct {
 // DdevApp is the struct that represents a DDEV app, mostly its config
 // from config.yaml.
 type DdevApp struct {
-	Name                      string                 `yaml:"name"`
+	Name                      string                 `yaml:"name,omitempty"`
+	OmitName                  bool                   `yaml:"-"`
 	Type                      string                 `yaml:"type"`
 	AppRoot                   string                 `yaml:"-"`
 	Docroot                   string                 `yaml:"docroot"`
@@ -3430,6 +3431,20 @@ func (app *DdevApp) GetMinimalContainerTimeout() string {
 		minimalTimeout = nodeps.DefaultDefaultContainerTimeout
 	}
 	return minimalTimeout
+}
+
+// RespectConfigNameOverride checks if the app name should be different and updates app.Name
+// In this case, we don't want to write the name to the .ddev/config.yaml
+func (app *DdevApp) RespectConfigNameOverride() error {
+	appWithOverrides, err := NewApp(app.GetAppRoot(), true)
+	if err != nil {
+		return err
+	}
+	if appWithOverrides.Name != app.Name {
+		app.Name = appWithOverrides.Name
+		app.OmitName = true
+	}
+	return nil
 }
 
 // genericImportFilesAction defines the workflow for importing project files.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -81,7 +81,7 @@ type WebExtraDaemon struct {
 // DdevApp is the struct that represents a DDEV app, mostly its config
 // from config.yaml.
 type DdevApp struct {
-	Name                      string                 `yaml:"name"`
+	Name                      string                 `yaml:"name,omitempty"`
 	Type                      string                 `yaml:"type"`
 	AppRoot                   string                 `yaml:"-"`
 	Docroot                   string                 `yaml:"docroot"`
@@ -3432,16 +3432,22 @@ func (app *DdevApp) GetMinimalContainerTimeout() string {
 	return minimalTimeout
 }
 
-// RespectConfigNameOverride checks if the app name should be different and updates app.Name
-func (app *DdevApp) RespectConfigNameOverride() error {
-	appWithOverrides, err := NewApp(app.GetAppRoot(), true)
-	if err != nil {
-		return err
+// HasConfigNameOverride checks if the app name should be different,
+// returns true if the app name has been changed along with the new app name.
+func (app *DdevApp) HasConfigNameOverride() (bool, string) {
+	newApp := DdevApp{ConfigPath: app.ConfigPath}
+	if _, err := newApp.ReadConfig(false); err != nil {
+		return false, app.Name
 	}
-	if appWithOverrides.Name != app.Name {
-		app.Name = appWithOverrides.Name
+	name := newApp.Name
+	if _, err := newApp.ReadConfig(true); err != nil {
+		return false, app.Name
 	}
-	return nil
+	nameWithOverrides := newApp.Name
+	if name != nameWithOverrides {
+		return true, nameWithOverrides
+	}
+	return false, app.Name
 }
 
 // genericImportFilesAction defines the workflow for importing project files.

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -6,6 +6,8 @@ const ConfigInstructions = `
 
 # name: <projectname> # Name of the project, automatically provides
 #   http://projectname.ddev.site and https://projectname.ddev.site
+# If the name is omitted, the project will take the name of the enclosing directory,
+# which is useful if you want to have a copy of the project side by side with this one.
 
 # type: <projecttype>  # backdrop, cakephp, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
 # See https://ddev.readthedocs.io/en/stable/users/quickstart/ for more


### PR DESCRIPTION
## The Issue

- #7060

```
mkdir foo && cd foo
ddev config --omit-containers=db
ddev delete -Oy

# remove name
sed -i '1d' .ddev/config.yaml

# set a different name
echo "name: bar" > .ddev/config.local.yaml

ddev start
Starting bar...

ddev stop

ddev config --auto
this project root '/home/stas/code/ddev/foo' already contains a project named 'bar'. You may want to remove the existing project with "ddev stop --unlist bar"

ddev stop --unlist bar

# this adds "name: foo" to .ddev/config.yaml
ddev config --webserver-type apache-fpm

ddev start
Starting bar...
```

So you need to unlist the project before running `ddev config` to make it work.

But it must simply work with the `name` we already have from `.ddev/config.local.yaml`

## How This PR Solves The Issue

- Sets app name to the appropriate value, so it won't throw an error.
- Doesn't write the `name` to `.ddev/config.yaml` if you already have it in `.ddev/config.*.yaml`.

## Manual Testing Instructions

```
mkdir foo && cd foo
ddev config --omit-containers=db
ddev delete -Oy

# remove name
sed -i '1d' .ddev/config.yaml

# set a different name
echo "name: bar" > .ddev/config.local.yaml

ddev start
Starting bar...

ddev stop

ddev config --auto
You are reconfiguring the project at /home/stas/code/ddev/foo.
The existing configuration will be updated and replaced.
Configuring a 'php' project named 'bar' with docroot '' at '/home/stas/code/ddev/foo'.
For full details use 'ddev describe'.
Configuration complete. You may now run 'ddev start'.
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
