### PR TITLE
build: put both git and ssh in both webserver images, fixes #7054

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get install -y postgresql-common && /usr/share/postgresql-common/pgdg/ap
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
     bash-completion \
     gettext \
+    git \
     graphviz \
     less \
     libcap2-bin \
@@ -49,6 +50,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--
     libmagickcore-6.q16-6-extra \
     locales \
     mariadb-client \
+    openssh-client \
     patch \
     postgresql-client \
     pv \
@@ -116,7 +118,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     blackfire \
     blackfire-php \
     fontconfig \
-    git \
     iproute2 \
     iputils-ping \
     jq \
@@ -124,7 +125,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--for
     nano \
     ncurses-bin \
     netcat-traditional \
-    openssh-client \
     sudo \
     telnet \
     tree

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -9,7 +9,7 @@ setup() {
 
 @test "Verify required binaries are installed in normal image" {
     if [ "${IS_HARDENED}" == "true" ]; then skip "Skipping because IS_HARDENED==true"; fi
-    COMMANDS="composer ddev drush8 git magerun magerun2 mkcert mysql mysqladmin mysqldump node npm patch platform sudo symfony terminus wp"
+    COMMANDS="composer ddev drush8 git magerun magerun2 mkcert mysql mysqladmin mysqldump node npm patch platform ssh sudo symfony terminus wp"
     for item in $COMMANDS; do
 #      echo "# looking for $item" >&3
       docker exec $CONTAINER_NAME bash -c "command -v $item >/dev/null"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.24.3" // Note that this can be overridden by make
+var WebTag = "20250307_rfay_add_hardened_ssh" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

- #7054

Make sure both git and ssh client are in both ddev-webserver and ddev-webserver-prod

## Manual Testing Instructions

```
docker run -it --rm ddev/ddev-webserver:20250307_rfay_add_hardened_ssh git --version
docker run -it --rm ddev/ddev-webserver-prod:20250307_rfay_add_hardened_ssh git --version
docker run -it --rm ddev/ddev-webserver:20250307_rfay_add_hardened_ssh ssh -V
docker run -it --rm ddev/ddev-webserver-prod:20250307_rfay_add_hardened_ssh ssh -V

## Automated Testing Overview

I did add a check for git and ssh in the image. It doesn't specifically check hardened though.

