### PR TITLE
build: skip testing with buildkite if diff is not from that branch

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -166,9 +166,14 @@ fi
 
 # If this is a PR and the diff doesn't have code, skip it
 set -x
-if [ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ] && ( ! git diff --name-only refs/remotes/origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-} | egrep "^(\.buildkite|Makefile|pkg|cmd|vendor|go\.)" >/dev/null ); then
-  echo "Skipping buildkite build since no code changes found"
-  exit 0
+if [ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ]; then
+  # Find the merge base between the PR branch and the base branch
+  MERGE_BASE=$(git merge-base HEAD refs/remotes/origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-})
+  # Check if there are any changes in the specified directories or files since the merge base
+  if ! git diff --name-only $MERGE_BASE | egrep "^(\.buildkite|Makefile|pkg|cmd|vendor|go\.)" >/dev/null; then
+    echo "Skipping buildkite build since no code changes found"
+    exit 0
+  fi
 fi
 
 # Run any testbot maintenance that may need to be done


### PR DESCRIPTION
## The Issue

I wondered why buildkite tests were run for:

- #7061

## How This PR Solves The Issue

Buildkite's skip logic works well when you're always up to date, but not when you're pushing commits without rebasing.

Affected PRs are PRs for documentation.

This PR uses the base merge commit instead of the latest HEAD to compare changes, which helps reduce the carbon footprint.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
