### PR TITLE
feat: support prepend.Dockerfile* files for multi-stage builds

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -106,12 +106,12 @@ For certain use cases, you might need to add directives very early on the Docker
 * `.ddev/db-build/pre.Dockerfile.*`
 * `.ddev/db-build/pre.Dockerfile`
 
-Finally, to support [Multi-stage builds](https://docs.docker.com/build/building/multi-stage/), you can use `stage.` variants that are inserted *before* everything else, *on top* of the generated Dockerfile.
+Finally, to support [Multi-stage builds](https://docs.docker.com/build/building/multi-stage/) and other more complex use cases, you can use `prepend.` variants that are inserted *before* everything else, *on top* of the generated Dockerfile.
 
-* `.ddev/web-build/stage.Dockerfile.*`
-* `.ddev/web-build/stage.Dockerfile`
-* `.ddev/db-build/stage.Dockerfile.*`
-* `.ddev/db-build/stage.Dockerfile`
+* `.ddev/web-build/prepend.Dockerfile.*`
+* `.ddev/web-build/prepend.Dockerfile`
+* `.ddev/db-build/prepend.Dockerfile.*`
+* `.ddev/db-build/prepend.Dockerfile`
 
 Multi-stage builds are useful to anyone who has struggled to optimize Dockerfiles while keeping them easy to read and maintain.
 
@@ -151,14 +151,14 @@ RUN chmod -R ugo+rw $COMPOSER_HOME
 ENV COMPOSER_HOME=""
 ```
 
-An example [Multi-stage](https://docs.docker.com/build/building/multi-stage/) web image could have a  `.ddev/web-build/stage.Dockerfile`:
+An example [Multi-stage](https://docs.docker.com/build/building/multi-stage/) web image could have a  `.ddev/web-build/prepend.Dockerfile`:
 
 ```dockerfile
-# We must declare the build enviroment variables we want to use on stage.Dockerfile
+# We must declare the build enviroment variables we want to use on prepend.Dockerfile
 ARG BASE_IMAGE="scratch"
 FROM $BASE_IMAGE AS build-stage-go
 
-# We must declare the build enviroment variables we want to use on stage.Dockerfile
+# We must declare the build enviroment variables we want to use on prepend.Dockerfile
 ARG uid
 ARG gid
 
@@ -193,8 +193,8 @@ The following environment variables are available for the web Dockerfile to use 
 * `$TARGETOS`: The build target operating system (always `linux`)
 * `$TARGETPLATFORM`: `linux/amd64` or `linux/arm64` depending on the machine it's been executed on
 
-!!!warning "These variables won't be automatically available on `stage.Dockerfile*` variants"
-    If you need to use any of these variables you will need to manually add them to your `stage.Dockerfile*` files using [ARG](https://docs.docker.com/reference/dockerfile/#arg) instructions.
+!!!warning "These variables won't be automatically available on `prepend.Dockerfile*` variants"
+    If you need to use any of these variables you will need to manually add them to your `prepend.Dockerfile*` files using [ARG](https://docs.docker.com/reference/dockerfile/#arg) instructions.
 
 For example, a Dockerfile might want to build an extension for the configured PHP version like this using `$DDEV_PHP_VERSION` to specify the proper version:
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -99,12 +99,19 @@ For more complex requirements, you can add:
 
 These files’ content will be inserted into the constructed Dockerfile for each image. They are inserted *after* most of the rest of the things that are done to build the image, and are done in alphabetical order, so `Dockerfile` is inserted first, followed by `Dockerfile.*` in alphabetical order.
 
-For certain use cases, you might need to add directives very early on the Dockerfile like proxy settings or SSL termination. You can use `pre.` variants for this that are inserted *before* everything else:
+For certain use cases, you might need to add directives very early on the Dockerfile like proxy settings or SSL termination. You can use `pre.` variants for this that are inserted *before* what DDEV adds to build the image:
 
 * `.ddev/web-build/pre.Dockerfile.*`
 * `.ddev/web-build/pre.Dockerfile`
 * `.ddev/db-build/pre.Dockerfile.*`
 * `.ddev/db-build/pre.Dockerfile`
+
+Finally, to support [Multi-stage builds](https://docs.docker.com/build/building/multi-stage/), you can use `stage.` variants for this that are inserted *before* everything else, *on top* of the generated Dockerfile.
+
+* `.ddev/web-build/stage.Dockerfile.*`
+* `.ddev/web-build/stage.Dockerfile`
+* `.ddev/db-build/stage.Dockerfile.*`
+* `.ddev/db-build/stage.Dockerfile`
 
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with [`ddev debug rebuild`](../usage/commands.md#debug-rebuild). `ddev debug rebuild` is also great because it shows you the entire process of the build for debugging.
 
@@ -156,6 +163,9 @@ The following environment variables are available for the web Dockerfile to use 
 * `$TARGETARCH`: The build target architecture, like `arm64` or `amd64`
 * `$TARGETOS`: The build target operating system (always `linux`)
 * `$TARGETPLATFORM`: `linux/amd64` or `linux/arm64` depending on the machine it's been executed on
+
+!!!warning "These variables won't be automatically available on `stage.Dockerfile*` variants"
+    If you need to use any of these variables you will need to manually add them to your `stage.Dockerfile*` files using [ARG](https://docs.docker.com/reference/dockerfile/#arg) instructions.
 
 For example, a Dockerfile might want to build an extension for the configured PHP version like this using `$DDEV_PHP_VERSION` to specify the proper version:
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -106,7 +106,7 @@ For certain use cases, you might need to add directives very early on the Docker
 * `.ddev/db-build/pre.Dockerfile.*`
 * `.ddev/db-build/pre.Dockerfile`
 
-Finally, to support [Multi-stage builds](https://docs.docker.com/build/building/multi-stage/), you can use `stage.` variants for this that are inserted *before* everything else, *on top* of the generated Dockerfile.
+Finally, to support [Multi-stage builds](https://docs.docker.com/build/building/multi-stage/), you can use `stage.` variants that are inserted *before* everything else, *on top* of the generated Dockerfile.
 
 * `.ddev/web-build/stage.Dockerfile.*`
 * `.ddev/web-build/stage.Dockerfile`

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -178,7 +178,6 @@ And then a `Dockerfile`:
 COPY --from=build-stage-go /usr/local/go /usr/local
 ```
 
-
 **Remember that the Dockerfile is building a Docker image that will be used later with DDEV.** At the time the Dockerfile is executing, your code is not mounted and the container is not running, the image is being built. So for example, an `npm install` in `/var/www/html` will not do anything to your project because the code is not there at image building time.
 
 ### Build Time Environment Variables

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -164,9 +164,9 @@ ARG gid
 
 # install go
 RUN set -eux; \
-    GO_VERSION=1.24.1; \
+    GO_VERSION=$(curl -fsSL "https://go.dev/dl/?mode=json" | jq -r ".[0].version"); \
     AARCH=$(dpkg --print-architecture); \
-    wget -q https://go.dev/dl/go${GO_VERSION}.linux-${AARCH}.tar.gz -O go.tar.gz; \
+    wget -q https://go.dev/dl/${GO_VERSION}.linux-${AARCH}.tar.gz -O go.tar.gz; \
     tar -C /usr/local -xzf go.tar.gz; \
     rm go.tar.gz;
 ```

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -154,11 +154,12 @@ ENV COMPOSER_HOME=""
 An example [Multi-stage](https://docs.docker.com/build/building/multi-stage/) web image could have a  `.ddev/web-build/prepend.Dockerfile`:
 
 ```dockerfile
-# We must declare the build enviroment variables we want to use on prepend.Dockerfile
+# If we want to use any of the build time environment variables injected by ddev
+# on the prepend.Dockerfile* variants we need to manually declare them to make
+# them available using the ARG instruction.
 ARG BASE_IMAGE="scratch"
 FROM $BASE_IMAGE AS build-stage-go
 
-# We must declare the build enviroment variables we want to use on prepend.Dockerfile
 ARG uid
 ARG gid
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1258,7 +1258,7 @@ func WriteBuildDockerfile(app *DdevApp, fullpath string, userDockerfilePath stri
 	contents := `
 #ddev-generated - Do not modify this file; your modifications will be overwritten.
 `
-	// If there are user prepend.Dockerfile.* files, insert their contents
+	// If there are user prepend.Dockerfile* files, insert their contents
 	if userDockerfilePath != "" {
 		files, err := filepath.Glob(filepath.Join(userDockerfilePath, "prepend.Dockerfile*"))
 		if err != nil {
@@ -1777,7 +1777,7 @@ func validateHookYAML(source []byte) error {
 
 // isNotDockerfileContextFile returns true if the given file is NOT a Dockerfile context file
 // We consider files in the .ddev/web-build and .ddev/db-build directory to be context files
-// excluding /Dockerfile*, /pre.Dockerfile*, /prepend.Dockerfile.* and /README.txt
+// excluding /Dockerfile*, /pre.Dockerfile*, /prepend.Dockerfile* and /README.txt
 func isNotDockerfileContextFile(userDockerfilePath string, file string) (bool, error) {
 	// Directories are always context.
 	if fileutil.IsDirectory(file) {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1252,7 +1252,29 @@ func WriteBuildDockerfile(app *DdevApp, fullpath string, userDockerfilePath stri
 	// Normal starting content is the arg and base image
 	contents := `
 #ddev-generated - Do not modify this file; your modifications will be overwritten.
+`
+	// If there are user stage.Dockerfile.* files, insert their contents
+	if userDockerfilePath != "" {
+		files, err := filepath.Glob(filepath.Join(userDockerfilePath, "stage.Dockerfile.*"))
+		if err != nil {
+			return err
+		}
 
+		for _, file := range files {
+			// Skip example files
+			if strings.HasSuffix(file, ".example") {
+				continue
+			}
+			userContents, err := fileutil.ReadFileIntoString(file)
+			if err != nil {
+				return err
+			}
+
+			contents = contents + "\n\n### From user Dockerfile " + file + ":\n" + userContents
+		}
+	}
+
+	contents = contents + `
 ### DDEV-injected base Dockerfile contents
 ARG BASE_IMAGE="scratch"
 FROM $BASE_IMAGE

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -720,7 +720,10 @@ func (app *DdevApp) CheckCustomConfig() {
 			util.CheckErr(err)
 			preDockerFiles, err := filepath.Glob(filepath.Join(customDockerPath, "pre.Dockerfile*"))
 			util.CheckErr(err)
+			stageDockerFiles, err := filepath.Glob(filepath.Join(customDockerPath, "stage.Dockerfile*"))
+			util.CheckErr(err)
 			dockerFiles = append(dockerFiles, preDockerFiles...)
+			dockerFiles = append(dockerFiles, stageDockerFiles...)
 			dockerFiles = slices.DeleteFunc(dockerFiles, func(s string) bool {
 				return strings.HasSuffix(s, ".example")
 			})
@@ -1772,7 +1775,7 @@ func validateHookYAML(source []byte) error {
 
 // isNotDockerfileContextFile returns true if the given file is NOT a Dockerfile context file
 // We consider files in the .ddev/web-build and .ddev/db-build directory to be context files
-// excluding /Dockerfile*, /pre.Dockerfile*, and /README.txt
+// excluding /Dockerfile*, /pre.Dockerfile*, /stage.Dockerfile.* and /README.txt
 func isNotDockerfileContextFile(userDockerfilePath string, file string) (bool, error) {
 	// Directories are always context.
 	if fileutil.IsDirectory(file) {
@@ -1789,7 +1792,7 @@ func isNotDockerfileContextFile(userDockerfilePath string, file string) (bool, e
 	}
 	filename := filepath.Base(file)
 	// Return true for not context Dockerfiles
-	if strings.HasPrefix(filename, "Dockerfile") || strings.HasPrefix(filename, "pre.Dockerfile") {
+	if strings.HasPrefix(filename, "Dockerfile") || strings.HasPrefix(filename, "pre.Dockerfile") || strings.HasPrefix(filename, "stage.Dockerfile") {
 		return true, nil
 	}
 	// Return true for not context README.txt if it is managed by DDEV

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1258,7 +1258,7 @@ func WriteBuildDockerfile(app *DdevApp, fullpath string, userDockerfilePath stri
 `
 	// If there are user stage.Dockerfile.* files, insert their contents
 	if userDockerfilePath != "" {
-		files, err := filepath.Glob(filepath.Join(userDockerfilePath, "stage.Dockerfile.*"))
+		files, err := filepath.Glob(filepath.Join(userDockerfilePath, "stage.Dockerfile*"))
 		if err != nil {
 			return err
 		}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1350,15 +1350,15 @@ RUN touch /var/tmp/`+"added-by-"+item+"-test4.txt"))
 RUN rm /var/tmp/`+"added-by-"+item+"-test4.txt"))
 		assert.NoError(err)
 
-		// Testing stage.Dockerfile* with a simple multi-stage build
-		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/stage.Dockerfile"), []byte(`
+		// Testing prepend.Dockerfile* with a simple multi-stage build
+		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/prepend.Dockerfile"), []byte(`
 ARG BASE_IMAGE="scratch"
 FROM $BASE_IMAGE AS stage
 `+
 			`RUN touch /var/tmp/`+"added-by-"+item+"-stage.txt"+`
 			 RUN touch /var/tmp/`+"added-by-"+item+"-stage-other.txt"))
 		assert.NoError(err)
-		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/stage.Dockerfile.test5"), []byte(`
+		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/prepend.Dockerfile.test5"), []byte(`
 ARG BASE_IMAGE="scratch"
 FROM $BASE_IMAGE AS test5
 `+
@@ -1452,8 +1452,8 @@ RUN mkdir -p "/var/tmp/my-arch-info-is-${TARGETOS}-${TARGETARCH}-${TARGETPLATFOR
 		assert.Error(err)
 
 		// Dockerfiles should not be copied
-		assert.NoFileExists(app.GetConfigPath("." + item + "imageBuild/stage.Dockerfile"))
-		assert.NoFileExists(app.GetConfigPath("." + item + "imageBuild/stage.Dockerfile.test5"))
+		assert.NoFileExists(app.GetConfigPath("." + item + "imageBuild/prepend.Dockerfile"))
+		assert.NoFileExists(app.GetConfigPath("." + item + "imageBuild/prepend.Dockerfile.test5"))
 		assert.NoFileExists(app.GetConfigPath("." + item + "imageBuild/Dockerfile.test5"))
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: item,

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1337,8 +1337,8 @@ RUN touch /var/tmp/`+"added-by-"+item+"-test2.txt"))
 		assert.NoError(err)
 
 		// Testing pre.Dockerfile.*
-		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/pre.Dockerfile.test3"), []byte(`
-RUN touch /var/tmp/`+"added-by-"+item+"-test3.txt"))
+		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/pre.Dockerfile"), []byte(`
+RUN touch /var/tmp/`+"added-by-"+item+"-pre.txt"))
 		assert.NoError(err)
 
 		// Testing that pre comes before post, we create a file on pre and remove
@@ -1350,7 +1350,14 @@ RUN touch /var/tmp/`+"added-by-"+item+"-test4.txt"))
 RUN rm /var/tmp/`+"added-by-"+item+"-test4.txt"))
 		assert.NoError(err)
 
-		// Testing stage.Dockerfile.* with a simple multi-stage build
+		// Testing stage.Dockerfile* with a simple multi-stage build
+		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/stage.Dockerfile"), []byte(`
+ARG BASE_IMAGE="scratch"
+FROM $BASE_IMAGE AS stage
+`+
+			`RUN touch /var/tmp/`+"added-by-"+item+"-stage.txt"+`
+			 RUN touch /var/tmp/`+"added-by-"+item+"-stage-other.txt"))
+		assert.NoError(err)
 		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/stage.Dockerfile.test5"), []byte(`
 ARG BASE_IMAGE="scratch"
 FROM $BASE_IMAGE AS test5
@@ -1359,6 +1366,7 @@ FROM $BASE_IMAGE AS test5
 		assert.NoError(err)
 
 		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test5"), []byte(`
+COPY --from=stage /var/tmp/`+"added-by-"+item+"-stage.txt /var/tmp/"+"added-by-"+item+"-stage.txt"+`
 COPY --from=test5 /var/tmp/`+"added-by-"+item+"-test5.txt /var/tmp/"+"added-by-"+item+"-test5.txt"))
 		assert.NoError(err)
 	}
@@ -1421,10 +1429,10 @@ RUN mkdir -p "/var/tmp/my-arch-info-is-${TARGETOS}-${TARGETARCH}-${TARGETPLATFOR
 		assert.NoError(err)
 
 		// Dockerfiles should not be copied
-		assert.NoFileExists(app.GetConfigPath("." + item + "imageBuild/pre.Dockerfile.test3"))
+		assert.NoFileExists(app.GetConfigPath("." + item + "imageBuild/pre.Dockerfile"))
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: item,
-			Cmd:     "ls /var/tmp/added-by-" + item + "-test3.txt >/dev/null",
+			Cmd:     "ls /var/tmp/added-by-" + item + "-pre.txt >/dev/null",
 		})
 		assert.NoError(err)
 
@@ -1444,13 +1452,26 @@ RUN mkdir -p "/var/tmp/my-arch-info-is-${TARGETOS}-${TARGETARCH}-${TARGETPLATFOR
 		assert.Error(err)
 
 		// Dockerfiles should not be copied
+		assert.NoFileExists(app.GetConfigPath("." + item + "imageBuild/stage.Dockerfile"))
 		assert.NoFileExists(app.GetConfigPath("." + item + "imageBuild/stage.Dockerfile.test5"))
 		assert.NoFileExists(app.GetConfigPath("." + item + "imageBuild/Dockerfile.test5"))
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
+			Service: item,
+			Cmd:     "ls /var/tmp/added-by-" + item + "-stage.txt >/dev/null",
+		})
+		assert.NoError(err)
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: item,
 			Cmd:     "ls /var/tmp/added-by-" + item + "-test5.txt >/dev/null",
 		})
 		assert.NoError(err)
+		// stage-other.txt should not be present as it was only touched by the build stage,
+		// but not copied on the final image
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
+			Service: item,
+			Cmd:     "ls /var/tmp/added-by-" + item + "-stage-other.txt 2>/dev/null",
+		})
+		assert.Error(err)
 	}
 
 	// Dockerfiles should not be copied

--- a/pkg/ddevapp/dotddev_assets/db-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/db-build/README.txt
@@ -4,7 +4,7 @@ Files in this directory will be used to customize the dbimage, you can add:
 * .ddev/db-build/Dockerfile
 * .ddev/db-build/Dockerfile.*
 
-Additionally, you can use `pre.` variants that are inserted before what DDEV adds :
+Additionally, you can use `pre.` variants that are inserted before what DDEV adds:
 
 * .ddev/db-build/pre.Dockerfile
 * .ddev/db-build/pre.Dockerfile.*

--- a/pkg/ddevapp/dotddev_assets/db-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/db-build/README.txt
@@ -9,11 +9,12 @@ Additionally, you can use `pre.` variants that are inserted before what DDEV add
 * .ddev/db-build/pre.Dockerfile
 * .ddev/db-build/pre.Dockerfile.*
 
-Finally, you can also use `stage.` variants that are inserted on top of the Dockerfile allowing for Multi-stage builds:
-See https://docs.docker.com/build/building/multi-stage/
+Finally, you can also use `prepend.` variants that are inserted on top of the Dockerfile allowing for Multi-stage builds and other more complex use cases:
 
-* .ddev/db-build/stage.Dockerfile
-* .ddev/db-build/stage.Dockerfile.*
+* .ddev/db-build/prepend.Dockerfile
+* .ddev/db-build/prepend.Dockerfile.*
+
+See https://docs.docker.com/build/building/multi-stage/
 
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.dbimageBuild/Dockerfile`. You can force a rebuild with `ddev debug rebuild -s db`.
 

--- a/pkg/ddevapp/dotddev_assets/db-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/db-build/README.txt
@@ -4,10 +4,16 @@ Files in this directory will be used to customize the dbimage, you can add:
 * .ddev/db-build/Dockerfile
 * .ddev/db-build/Dockerfile.*
 
-Additionally, you can use `pre.` variants that are inserted before everything else:
+Additionally, you can use `pre.` variants that are inserted before what DDEV adds :
 
 * .ddev/db-build/pre.Dockerfile
 * .ddev/db-build/pre.Dockerfile.*
+
+Finally, you can also use `stage.` variants that are inserted on top of the Dockerfile allowing for Multi-stage builds:
+See https://docs.docker.com/build/building/multi-stage/
+
+* .ddev/db-build/stage.Dockerfile
+* .ddev/db-build/stage.Dockerfile.*
 
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.dbimageBuild/Dockerfile`. You can force a rebuild with `ddev debug rebuild -s db`.
 

--- a/pkg/ddevapp/dotddev_assets/web-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/web-build/README.txt
@@ -4,10 +4,16 @@ Files in this directory will be used to customize the webimage, you can add:
 * .ddev/web-build/Dockerfile
 * .ddev/web-build/Dockerfile.*
 
-Additionally, you can use `pre.` variants that are inserted before everything else:
+Additionally, you can use `pre.` variants that are inserted before what DDEV adds :
 
 * .ddev/web-build/pre.Dockerfile
 * .ddev/web-build/pre.Dockerfile.*
+
+Finally, you can also use `stage.` variants that are inserted on top of the Dockerfile allowing for Multi-stage builds:
+See https://docs.docker.com/build/building/multi-stage/
+
+* .ddev/web-build/stage.Dockerfile
+* .ddev/web-build/stage.Dockerfile.*
 
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with `ddev debug rebuild -s web`.
 

--- a/pkg/ddevapp/dotddev_assets/web-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/web-build/README.txt
@@ -4,7 +4,7 @@ Files in this directory will be used to customize the webimage, you can add:
 * .ddev/web-build/Dockerfile
 * .ddev/web-build/Dockerfile.*
 
-Additionally, you can use `pre.` variants that are inserted before what DDEV adds :
+Additionally, you can use `pre.` variants that are inserted before what DDEV adds:
 
 * .ddev/web-build/pre.Dockerfile
 * .ddev/web-build/pre.Dockerfile.*

--- a/pkg/ddevapp/dotddev_assets/web-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/web-build/README.txt
@@ -9,11 +9,12 @@ Additionally, you can use `pre.` variants that are inserted before what DDEV add
 * .ddev/web-build/pre.Dockerfile
 * .ddev/web-build/pre.Dockerfile.*
 
-Finally, you can also use `stage.` variants that are inserted on top of the Dockerfile allowing for Multi-stage builds:
-See https://docs.docker.com/build/building/multi-stage/
+Finally, you can also use `prepend.` variants that are inserted on top of the Dockerfile allowing for Multi-stage builds and other more complex use cases:
 
-* .ddev/web-build/stage.Dockerfile
-* .ddev/web-build/stage.Dockerfile.*
+* .ddev/web-build/prepend.Dockerfile
+* .ddev/web-build/prepend.Dockerfile.*
+
+See https://docs.docker.com/build/building/multi-stage/
 
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with `ddev debug rebuild -s web`.
 


### PR DESCRIPTION
## The issue

We can customize the default Dockerfile by adding appending stuff to the end (through `Dockerfile* variants`), and by injecting something before ddev own customizations, but still in between ddev's own Dockerfile (through `pre.Dockerfile*` variants). But we cannot add anything before everything else, limiting other customization like being able to define other build stages. 

## How This PR Solves The Issue

It adds a new `prepend.Dockerfile*` variant that gets added on top of everything before anything added by ddev.

## Manual Testing Instructions

1. create a `.ddev/web-build/prepend.Dockerfile.pr-7071` with:

```dockerfile
# If we want to use any of the build time environment variables injected by ddev 
# on the prepend.Dockerfile* variants we need to manually declare them to make 
# them available using the ARG instruction.
ARG BASE_IMAGE
FROM $BASE_IMAGE AS build-stage-go

ARG uid
ARG gid

# install go
RUN set -eux; \
    GO_VERSION=$(curl -fsSL "https://go.dev/dl/?mode=json" | jq -r ".[0].version"); \
    AARCH=$(dpkg --print-architecture); \
    wget -q https://go.dev/dl/${GO_VERSION}.linux-${AARCH}.tar.gz -O go.tar.gz; \
    tar -C /usr/local -xzf go.tar.gz; \
    rm go.tar.gz;
```

2. Create a `.ddev/web-build/Dockerfile.pr-7071` with:

```dockerfile
# Copy entire go directory from the build stage defined above.
COPY --from=build-stage-go /usr/local/go /usr/local
```

3. Run `ddev start` and it should build without error.
4. Check that both files are reported as custom web-build configurations:

```
Using custom web-build configuration: [
	/tmp/gotest/.ddev/web-build/prepend.Dockerfile.pr-7071
	/tmp/gotest/.ddev/web-build/Dockerfile.pr-7071
] 
```

5. Run `ddev exec go version` and verify the command runs ok and you got the latest go version. 

## Automated Testing Overview

This verifies that that the all of the variants work by doing a simple build stage that creates a file and then it copies it over. It tests both `prepend.Dockerfile` and `prepend.Dockerfile.*`

## Release/Deployment Notes

It affects nothing.

## Additional context

Most important docs for review: https://ddev--7071.org.readthedocs.build/en/7071/users/extend/customizing-images/#adding-extra-dockerfiles-for-webimage-and-dbimage

This is a follow up for a discord thread: https://discord.com/channels/664580571770388500/1349036904015855636

The reasoning behind this is having a way to, if needed/wanted for any reason, be able to feed to ddev Dockefile build stages. This can help in splitting out big modifications of Dockerfiles into their own stages.

The change to ddev code is super simple actually, just adds any `stage.Dockerfile.*` that's get added before EVERYTHING in the current Dockerfile, allowing you to do whatever you want there.

While I am still working through a test project that uses this successfully, initial test works just fine and I think you can gather what we can do with this.

i.e.

```
#ddev-generated - Do not modify this file; your modifications will be overwritten.


### From user Dockerfile /Users/ariel/Sites/work/dockerfile-stage/.ddev/web-build/stage.Dockerfile.pimp-my-shell.ahoy:
#ddev-generated

ARG BASE_IMAGE="scratch"
FROM $BASE_IMAGE AS pimp-my-shell-ahoy

# ahoy
RUN set -eux; \
    AHOY_VERSION=2.2.0; \
    AARCH=$(dpkg --print-architecture); \
    wget -q https://github.com/ahoy-cli/ahoy/releases/download/v${AHOY_VERSION}/ahoy-bin-linux-${AARCH} -O - > /usr/local/bin/ahoy; \
    chmod +x /usr/local/bin/ahoy;


### From user Dockerfile /Users/ariel/Sites/work/dockerfile-stage/.ddev/web-build/stage.Dockerfile.pimpi-my-shell.kitty:
#ddev-generated

ARG BASE_IMAGE="scratch"
FROM $BASE_IMAGE AS pimp-my-shell-kitty

# kitty-terminfo from directoy from their GitHub repo @ master
RUN set -eux; \
    KITTY_VERSION=0.40.0; \
    url="https://github.com/kovidgoyal/kitty/raw/refs/tags/v${KITTY_VERSION}/terminfo/x/xterm-kitty"; \
    mkdir -p /usr/share/terminfo/x; \
    cd /usr/share/terminfo/x; \
    wget -q "${url}";
```

This is the first part of the `.webImageBuild`'s Dockerfile where it concatenates `stage.Dockerfile.pimpi-my-shell.ahoy` and `stage.Dockerfile.pimpi-my-shell.kitty`.

Further below I also have a `Dockerfile.pimp-my-shell` that does:

```
COPY --from=pimp-my-shell-ahoy /usr/local/bin/ahoy /usr/local/bin/ahoy
COPY --from=pimp-my-shell-kitty /usr/share/terminfo/x/xterm-kitty /usr/share/terminfo/x/xterm-kitty
```

Changing something in the ahoy stage, doesn't bust the kitty stage cache. The COPY entries gets busted in order (the first one that get busted busts the others, but the COPY performance is negible. 

> [!NOTE]
> At first I was trying to support more logic, like adding all of the ARGs or auto detect FROM statements to see if I should add the FROM base image but then I figured I was getting too complex into something that's inherently complex and if one would want to use this, he should cover anything what's required in this part of the dockerfile.

Docs: https://ddev--7071.org.readthedocs.build/en/7071/users/extend/customizing-images/#adding-extra-dockerfiles-for-webimage-and-dbimage