### PR TITLE
fix: add check for app in `ddev debug test` and run it from approot

### DIFF
--- a/cmd/ddev/cmd/debug-test.go
+++ b/cmd/ddev/cmd/debug-test.go
@@ -23,11 +23,20 @@ var DebugTestCmdCmd = &cobra.Command{
 		if len(args) != 0 {
 			util.Failed("This command takes no additional arguments")
 		}
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed(err.Error())
+		}
+		err = os.Chdir(app.AppRoot)
+		if err != nil {
+			util.Failed("Unable to change directory to project root %s: %v", app.AppRoot, err)
+		}
+
 		tmpDir := os.TempDir()
 		outputFilename := filepath.Join(tmpDir, "ddev-debug-test.txt")
 		outputFilename = filepath.ToSlash(outputFilename)
 		bashPath := util.FindBashPath()
-		err := fileutil.CopyEmbedAssets(bundledAssets, "scripts", tmpDir, nil)
+		err = fileutil.CopyEmbedAssets(bundledAssets, "scripts", tmpDir, nil)
 		if err != nil {
 			util.Failed("Failed to copy test_ddev.sh to %s: %v", tmpDir, err)
 		}


### PR DESCRIPTION
## The Issue

- https://drupal.slack.com/archives/C5TQRQZRR/p1741801391372109

User ran `ddev debug test` from the project subdirectory (there was misunderstanding with initial `ddev config`, that was run in `~/www` instead of `~/www/drupal-test-01`). And the result of running it in `~/www/drupal-test-01` is:

```
Output file written to:
/tmp/ddev-debug-test.txt
file:///tmp/ddev-debug-test.txt
Please provide the file for support in Discord or the issue queue.
Failed running test_ddev.sh: exit status 1
. You can run it manually with `curl -sL -O https://raw.githubusercontent.com/ddev/ddev/main/cmd/ddev/cmd/scripts/test_ddev.sh && bash test_ddev.sh`
```

I noticed the same error when you run `ddev debug test` outside of any project.

## How This PR Solves The Issue

Adds check for active project.
Runs `cd` to approot before running script.

## Manual Testing Instructions

Run `ddev debug test` in different locations:
- outside of a project (should show an error immediately, and not try to run `ddev debug test`)
- in project root (should work as before)
- in project subdirectory (should work)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
