### PR TITLE
docs: Add docs about configuring browser for HTTPS certificates

### DIFF
--- a/docs/content/users/install/configuring-browsers.md
+++ b/docs/content/users/install/configuring-browsers.md
@@ -6,19 +6,18 @@ But, because this is a custom Certificate Authority, web browsers produce a "net
 
 To get rid of this warning, you can install the custom root Certificate Authority into the browser.
 
-For default browsers in Linux system it works out of the box using [mkcert](https://github.com/FiloSottile/mkcert) utility. 
+For default browsers in Linux systems, it works out of the box using [mkcert](https://github.com/FiloSottile/mkcert) utility. 
 
-For other operation systems and custom browsers manual steps are needed to fix this.
+For other operating systems and custom browsers manual steps are required to fix this.
 
 ## Adding the DDEV root Certificate Authority into browsers
 
 The concrete steps to install depend on the browser, but generally they are like this:
 
-1. Download the custom DDEV root Certificate Authority certificate [here](#)
-2. Open the browser preferences.
-3. Find the Certificate Manager there.
-4. Click on the "View Certificates" button.
-5. Select the tab "Authorities".
-6. Click to the "Import" button to import a custom authority certificate.
-7. Import the root certificate authority file.
-
+1. Find a directory with the generated root certificate by [mkcert](https://github.com/FiloSottile/mkcert) utility using a command `mkcert -CAROOT` and find there a `rootCA.pem` file. DDEV should generate it during installation. If not - you can generate it manually using `mkcert -install` command.
+2. Open a web browser window and open the browser preferences.
+4. Find the Certificate Manager somewhere in the preferences and open it. Usually it is located in the "Security" section.
+5. Click on the "View Certificates" button.
+6. Select the tab "Authorities".
+7. Click to the "Import" button to import a custom authority certificate.
+8. Import the root certificate authority file.

--- a/docs/content/users/install/configuring-browsers.md
+++ b/docs/content/users/install/configuring-browsers.md
@@ -1,4 +1,5 @@
 # Configuring Browsers for DDEV projects
+
 **Most DDEV users can ignore this page. The standard instructions in DDEV Installation do everything that is needed. These instructions are for unusual browsers or OS environments.**
 DDEV generates SSL certificates to enable local projects to use the HTTPS protocol. It uses a custom root Certificate Authority (CA) to generate SSL certificates for `*.ddev.site` domains.
 

--- a/docs/content/users/install/configuring-browsers.md
+++ b/docs/content/users/install/configuring-browsers.md
@@ -1,5 +1,5 @@
 # Configuring Browsers for DDEV projects
-
+**Most DDEV users can ignore this page. The standard instructions in DDEV Installation do everything that is needed. These instructions are for unusual browsers or OS environments.**
 DDEV generates SSL certificates to enable local projects to use the HTTPS protocol. It uses a custom root Certificate Authority (CA) to generate SSL certificates for `*.ddev.site` domains.
 
 However, since this is a custom CA, web browsers display an ERR_CERT_AUTHORITY_INVALID warning when trying to access a local DDEV site over HTTPS.

--- a/docs/content/users/install/configuring-browsers.md
+++ b/docs/content/users/install/configuring-browsers.md
@@ -1,0 +1,24 @@
+# Configuring Browsers for DDEV projects
+
+DDEV generates SSL certificates to make local projects work natively with HTTPS protocol. It uses a custom root Certificate Authority to generate SSL certificates for `*.ddev.site` domains.
+
+But, because this is a custom Certificate Authority, web browsers produce a "net::ERR_CERT_AUTHORITY_INVALID" warning when you try to open a local DDEV website with HTTPS protocol.
+
+To get rid of this warning, you can install the custom root Certificate Authority into the browser.
+
+For default browsers in Linux system it works out of the box using [mkcert](https://github.com/FiloSottile/mkcert) utility. 
+
+For other operation systems and custom browsers manual steps are needed to fix this.
+
+## Adding the DDEV root Certificate Authority into browsers
+
+The concrete steps to install depend on the browser, but generally they are like this:
+
+1. Download the custom DDEV root Certificate Authority certificate [here](#)
+2. Open the browser preferences.
+3. Find the Certificate Manager there.
+4. Click on the "View Certificates" button.
+5. Select the tab "Authorities".
+6. Click to the "Import" button to import a custom authority cerificate.
+7. Import the root certificate authority file.
+

--- a/docs/content/users/install/configuring-browsers.md
+++ b/docs/content/users/install/configuring-browsers.md
@@ -6,7 +6,7 @@ But, because this is a custom Certificate Authority, web browsers produce a "net
 
 To get rid of this warning, you can install the custom root Certificate Authority into the browser.
 
-For default browsers in Linux systems, it works out of the box using [mkcert](https://github.com/FiloSottile/mkcert) utility. 
+For default browsers in Linux systems, it works out of the box using the [mkcert](https://github.com/FiloSottile/mkcert) utility.
 
 For other operating systems and custom browsers manual steps are required to fix this.
 
@@ -16,8 +16,8 @@ The concrete steps to install depend on the browser, but generally they are like
 
 1. Find a directory with the generated root certificate by [mkcert](https://github.com/FiloSottile/mkcert) utility using a command `mkcert -CAROOT` and find there a `rootCA.pem` file. DDEV should generate it during installation. If not - you can generate it manually using `mkcert -install` command.
 2. Open a web browser window and open the browser preferences.
-4. Find the Certificate Manager somewhere in the preferences and open it. Usually it is located in the "Security" section.
-5. Click on the "View Certificates" button.
-6. Select the tab "Authorities".
-7. Click to the "Import" button to import a custom authority certificate.
-8. Import the root certificate authority file.
+3. Find the Certificate Manager somewhere in the preferences and open it. Usually it is located in the "Security" section.
+4. Click on the "View Certificates" button.
+5. Select the tab "Authorities".
+6. Click to the "Import" button to import a custom authority certificate.
+7. Import the root certificate authority file.

--- a/docs/content/users/install/configuring-browsers.md
+++ b/docs/content/users/install/configuring-browsers.md
@@ -19,6 +19,6 @@ The concrete steps to install depend on the browser, but generally they are like
 3. Find the Certificate Manager there.
 4. Click on the "View Certificates" button.
 5. Select the tab "Authorities".
-6. Click to the "Import" button to import a custom authority cerificate.
+6. Click to the "Import" button to import a custom authority certificate.
 7. Import the root certificate authority file.
 

--- a/docs/content/users/install/configuring-browsers.md
+++ b/docs/content/users/install/configuring-browsers.md
@@ -1,23 +1,29 @@
 # Configuring Browsers for DDEV projects
 
-DDEV generates SSL certificates to make local projects work natively with HTTPS protocol. It uses a custom root Certificate Authority to generate SSL certificates for `*.ddev.site` domains.
+DDEV generates SSL certificates to enable local projects to use the HTTPS protocol. It uses a custom root Certificate Authority (CA) to generate SSL certificates for `*.ddev.site` domains.
 
-But, because this is a custom Certificate Authority, web browsers produce a "net::ERR_CERT_AUTHORITY_INVALID" warning when you try to open a local DDEV website with HTTPS protocol.
+However, since this is a custom CA, web browsers display an ERR_CERT_AUTHORITY_INVALID warning when trying to access a local DDEV site over HTTPS.
 
-To get rid of this warning, you can install the custom root Certificate Authority into the browser.
+To eliminate this warning, you can install the custom root CA into your browser.
 
-For default browsers in Linux systems, it works out of the box using the [mkcert](https://github.com/FiloSottile/mkcert) utility.
+For default browsers, this works automatically using the [mkcert](https://github.com/FiloSottile/mkcert) utility.
 
-For other operating systems and custom browsers manual steps are required to fix this.
+For custom browsers (such as Firefox Developer Edition, Vivaldi, etc.), manual steps may be required.
 
-## Adding the DDEV root Certificate Authority into browsers
+!!!tip "Want to learn more about HTTPS in DDEV?"
+    See [Hostnames and Wildcards and DDEV, Oh My!](https://ddev.com/blog/ddev-name-resolution-wildcards/) for more information on DDEV hostname resolution.
 
-The concrete steps to install depend on the browser, but generally they are like this:
+## Adding the DDEV Root Certificate Authority to Browsers
 
-1. Find a directory with the generated root certificate by [mkcert](https://github.com/FiloSottile/mkcert) utility using a command `mkcert -CAROOT` and find there a `rootCA.pem` file. DDEV should generate it during installation. If not - you can generate it manually using `mkcert -install` command.
-2. Open a web browser window and open the browser preferences.
-3. Find the Certificate Manager somewhere in the preferences and open it. Usually it is located in the "Security" section.
-4. Click on the "View Certificates" button.
-5. Select the tab "Authorities".
-6. Click to the "Import" button to import a custom authority certificate.
-7. Import the root certificate authority file.
+The steps to install the root CA depend on the browser, but they generally follow this process:
+
+1. Use `mkcert -CAROOT` to locate the directory with the generated root certificate. Inside, you should find a `rootCA.pem` file. If it's missing, run `mkcert -install` command.
+2. Open your browser and navigate to the preferences or settings.
+3. Find the Certificate Manager, typically located in the "Security" section of the preferences.
+4. Click the "View Certificates" button.
+5. Go to the "Authorities" tab.
+6. Click the "Import" button to add a custom authority certificate.
+7. Import the `rootCA.pem` file to install the root certificate authority.
+
+!!!note "Still having issues?"
+    Check out [this specific mkcert thread](https://github.com/FiloSottile/mkcert/issues/370) for additional troubleshooting.

--- a/docs/content/users/install/configuring-browsers.md
+++ b/docs/content/users/install/configuring-browsers.md
@@ -1,6 +1,7 @@
 # Configuring Browsers for DDEV projects
 
 **Most DDEV users can ignore this page. The standard instructions in DDEV Installation do everything that is needed. These instructions are for unusual browsers or OS environments.**
+
 DDEV generates SSL certificates to enable local projects to use the HTTPS protocol. It uses a custom root Certificate Authority (CA) to generate SSL certificates for `*.ddev.site` domains.
 
 However, since this is a custom CA, web browsers display an ERR_CERT_AUTHORITY_INVALID warning when trying to access a local DDEV site over HTTPS.

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -18,7 +18,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     mkcert -install
     ```
 
-    Optionally, [configure your browser](configuring-browsers.md).
+    For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
     ### Install Script
 
@@ -29,7 +29,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     curl -fsSL https://ddev.com/install.sh | bash
     ```
 
-    Optionally, [configure your browser](configuring-browsers.md).
+    For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
     ??? "Do you still have an old version after installing or upgrading?"
         If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` executable must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
@@ -69,7 +69,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     mkcert -install
     ```
 
-    Optionally, [configure your browser](configuring-browsers.md).
+    For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
     ??? "Do you still have an old version after installing or upgrading?"
         If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` executable must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
@@ -102,7 +102,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     mkcert -install
     ```
 
-    Optionally, [configure your browser](configuring-browsers.md).
+    For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
     Signed yum repository support will be added in the future.
 
@@ -118,7 +118,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     mkcert -install
     ```
 
-    Optionally, [configure your browser](configuring-browsers.md).
+    For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
     ### Homebrew (AMD64 only)
 
@@ -130,7 +130,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     mkcert -install
     ```
 
-    Optionally, [configure your browser](configuring-browsers.md).
+    For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
     <!-- we’re using HTML here to customize the #install-script-linux anchor -->
     <h3 id="install-script-linux">Install Script<a class="headerlink" href="#install-script-linux" title="Permanent link">¶</a></h3>
@@ -142,7 +142,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     curl -fsSL https://ddev.com/install.sh | bash
     ```
 
-    Optionally, [configure your browser](configuring-browsers.md).
+    For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
     ??? "Need a specific version?"
         Use the `-s` argument to specify a specific stable or prerelease version:
@@ -258,7 +258,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1'))
         ```
 
-    10. Optionally, [configure your browser](configuring-browsers.md).
+    10. For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
     Now you can use the "Ubuntu" terminal app or Windows Terminal to access your Ubuntu distro, which has DDEV and Docker Desktop integrated with it.
 
@@ -293,7 +293,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     13. In WSL2, run `mkcert -install`.
 
-    14. Optionally, [configure your browser](configuring-browsers.md).
+    14. For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
     You have now installed DDEV on WSL2. If you’re using WSL2 for DDEV, remember to run all `ddev` commands inside the WSL2 distro.
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -483,4 +483,4 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
         If you don’t have `mkcert` installed, download the [latest release](https://github.com/FiloSottile/mkcert/releases) for your architecture and `sudo mv <downloaded_file> /usr/local/bin/mkcert && sudo chmod +x /usr/local/bin/mkcert`.
 
-    * Optionally, [configure your browser](configuring-browsers.md).
+    * For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -18,6 +18,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     mkcert -install
     ```
 
+    Optionally, [configure your browser](configuring-browsers.md).
+
     ### Install Script
 
     The [install script](https://github.com/ddev/ddev/blob/main/scripts/install_ddev.sh) is another option. It downloads, verifies, and sets up the `ddev` executable:
@@ -26,6 +28,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     # Download and run the install script
     curl -fsSL https://ddev.com/install.sh | bash
     ```
+
+    Optionally, [configure your browser](configuring-browsers.md).
 
     ??? "Do you still have an old version after installing or upgrading?"
         If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` executable must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
@@ -65,7 +69,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     mkcert -install
     ```
 
-    (Some versions of Firefox (Developer Edition, Flatpak) may need some [extra work](https://github.com/FiloSottile/mkcert/issues/370#issuecomment-1280377305) with `mkcert`, see also [this issue](https://github.com/ddev/ddev/issues/5415).)
+    Optionally, [configure your browser](configuring-browsers.md).
 
     ??? "Do you still have an old version after installing or upgrading?"
         If `ddev --version` still shows an older version than you installed or upgraded to, use `which -a ddev` to find out where another version of the `ddev` executable must be installed. See the ["Why Do I Have An Old DDEV" FAQ](../usage/faq.md#why-do-i-have-an-old-ddev).
@@ -98,6 +102,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     mkcert -install
     ```
 
+    Optionally, [configure your browser](configuring-browsers.md).
+
     Signed yum repository support will be added in the future.
 
     ### Arch Linux
@@ -112,6 +118,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     mkcert -install
     ```
 
+    Optionally, [configure your browser](configuring-browsers.md).
+
     ### Homebrew (AMD64 only)
 
     ```bash
@@ -122,6 +130,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     mkcert -install
     ```
 
+    Optionally, [configure your browser](configuring-browsers.md).
+
     <!-- we’re using HTML here to customize the #install-script-linux anchor -->
     <h3 id="install-script-linux">Install Script<a class="headerlink" href="#install-script-linux" title="Permanent link">¶</a></h3>
 
@@ -131,6 +141,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     # Download and run the install script
     curl -fsSL https://ddev.com/install.sh | bash
     ```
+
+    Optionally, [configure your browser](configuring-browsers.md).
 
     ??? "Need a specific version?"
         Use the `-s` argument to specify a specific stable or prerelease version:
@@ -246,6 +258,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1'))
         ```
 
+    10. Optionally, [configure your browser](configuring-browsers.md).
+
     Now you can use the "Ubuntu" terminal app or Windows Terminal to access your Ubuntu distro, which has DDEV and Docker Desktop integrated with it.
 
     ### WSL2/Docker Desktop Manual Installation
@@ -279,6 +293,8 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     13. In WSL2, run `mkcert -install`.
 
+    14. Optionally, [configure your browser](configuring-browsers.md).
+
     You have now installed DDEV on WSL2. If you’re using WSL2 for DDEV, remember to run all `ddev` commands inside the WSL2 distro.
 
     !!!note "Path to certificates"
@@ -295,21 +311,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     !!!note "Windows Firefox Trusted CA"
 
-        The `mkcert -install` step on Windows isn’t enough for Firefox.
-        You need to add the created root certificate authority to the security configuration yourself:
-
-        * Run `mkcert -install` (you can use the shortcut from the Start Menu for that)
-        * Run `mkcert -CAROOT` to see the local folder used for the newly-created root certificate authority
-        * Open Firefox Preferences (`about:preferences#privacy`)
-        * Enter “certificates” into the search box on the top
-        * Click *View Certificates...*
-        * Select *Authorities* tab
-        * Click to *Import...*
-        * Navigate to the folder where your root certificate authority was stored
-        * Select the `rootCA.pem` file
-        * Click to *Open*
-
-        You should now see your CA under `mkcert development CA`.
+        The `mkcert -install` step on Windows isn’t enough for Firefox. You need to [configure your browser](configuring-browsers.md).
 
 === "Codespaces"
 
@@ -480,3 +482,5 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     * As a one-time initialization, run `mkcert -install`, which may require your `sudo` password.
 
         If you don’t have `mkcert` installed, download the [latest release](https://github.com/FiloSottile/mkcert/releases) for your architecture and `sudo mv <downloaded_file> /usr/local/bin/mkcert && sudo chmod +x /usr/local/bin/mkcert`.
+
+    * Optionally, [configure your browser](configuring-browsers.md).

--- a/docs/content/users/install/index.md
+++ b/docs/content/users/install/index.md
@@ -1,5 +1,5 @@
 # Installation
 
-Whatever system you’re on, you’ll first need to [install a Docker provider](docker-installation.md), then [install DDEV](ddev-installation.md).
+Whatever system you’re on, you’ll first need to [install a Docker provider](docker-installation.md), then [install DDEV](ddev-installation.md), and optionally [configure your browser](configuring-browsers.md).
 
 For the best experience, consider [performance tuning](performance.md) and [enabling shell completion](shell-completion.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
       - users/install/index.md
       - users/install/docker-installation.md
       - users/install/ddev-installation.md
+      - 'Configuring browsers': users/install/configuring-browsers.md
       - 'Upgrading': users/install/ddev-upgrade.md
     - 'Getting Started':
       - users/project.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,7 +156,7 @@ nav:
       - users/install/index.md
       - users/install/docker-installation.md
       - users/install/ddev-installation.md
-      - 'Configuring browsers': users/install/configuring-browsers.md
+      - 'Configuring Browsers': users/install/configuring-browsers.md
       - 'Upgrading': users/install/ddev-upgrade.md
     - 'Getting Started':
       - users/project.md


### PR DESCRIPTION
## The Issue

- #7067

Add documentation about configuring browser for DDEV HTTPS certificates by installing the DDEV root Certificate Authority.

## How This PR Solves The Issue
Add a page with browsers configuring instructions.

## Manual Testing Instructions

https://ddev--7075.org.readthedocs.build/en/7075/users/install/configuring-browsers/

## Automated Testing Overview
Not needed.

## Release/Deployment Notes

Added docs about configuring browser for DDEV HTTPS certificates
