### PR TITLE
fix: make sure mutagen agents file is fresh on upgrade, add shasum testing, test shasum for mutagen+docker-compose

### DIFF
--- a/cmd/ddev/cmd/addon-get.go
+++ b/cmd/ddev/cmd/addon-get.go
@@ -130,10 +130,10 @@ ddev add-on get /path/to/tarball.tar.gz
 				argType = "tarball"
 			}
 			extractedDir, cleanup, err = archive.DownloadAndExtractTarball(tarballURL, true)
+			defer cleanup()
 			if err != nil {
 				util.Failed("Unable to download %v: %v", sourceRepoArg, err)
 			}
-			defer cleanup()
 		}
 
 		// 20220811: Don't auto-start because it auto-creates the wrong database in some situations, leading to a

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -492,9 +492,6 @@ func DownloadAndExtractTarball(url string, removeTopLevel bool) (string, func(),
 		return "", nil, fmt.Errorf("unable to download %v: %v", url, err)
 	}
 	extractedDir, cleanup, err := ExtractTarballWithCleanup(tarball, removeTopLevel)
-	if err != nil {
-		_ = os.RemoveAll(extractedDir)
-	}
 	return extractedDir, cleanup, err
 }
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -487,7 +487,7 @@ func DownloadAndExtractTarball(url string, removeTopLevel bool) (string, func(),
 		_ = os.Remove(tarball)
 	}()
 
-	err = util.DownloadFile(tarball, url, true)
+	err = util.DownloadFile(tarball, url, true, "")
 	if err != nil {
 		return "", nil, fmt.Errorf("unable to download %v: %v", url, err)
 	}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -492,6 +492,9 @@ func DownloadAndExtractTarball(url string, removeTopLevel bool) (string, func(),
 		return "", nil, fmt.Errorf("unable to download %v: %v", url, err)
 	}
 	extractedDir, cleanup, err := ExtractTarballWithCleanup(tarball, removeTopLevel)
+	if err != nil {
+		_ = os.RemoveAll(extractedDir)
+	}
 	return extractedDir, cleanup, err
 }
 

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -159,14 +159,13 @@ func TestExtractTarballWithCleanup(t *testing.T) {
 
 // TestDownloadAndExtractTarball tests DownloadAndExtractTarball
 func TestDownloadAndExtractTarball(t *testing.T) {
-	assert := asrt.New(t)
-
 	testTarball := "https://github.com/ddev/ddev-drupal-solr/archive/refs/tags/v1.2.3.tar.gz"
 
 	dir, cleanup, err := archive.DownloadAndExtractTarball(testTarball, true)
+	defer cleanup()
 	require.NoError(t, err)
-	assert.DirExists(dir)
-	assert.FileExists(path.Join(dir, "install.yaml"))
+	require.DirExists(t, dir)
+	require.FileExists(t, path.Join(dir, "install.yaml"))
 	cleanup()
-	assert.NoDirExists(dir)
+	require.NoDirExists(t, dir)
 }

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -528,13 +528,19 @@ func DownloadMutagen() error {
 	mutagenURL := fmt.Sprintf("https://github.com/mutagen-io/mutagen/releases/download/v%s/mutagen_%s_v%s.tar.gz", versionconstants.RequiredMutagenVersion, flavor, versionconstants.RequiredMutagenVersion)
 	util.Debug("Downloading %s to %s...", mutagenURL, destFile)
 
-	// Remove the existing file. This may help on macOS to prevent the Gatekeeper's
+	// Remove the existing mutagen files. This may help on macOS to prevent the Gatekeeper's
 	// caching bug from confusing with a previously downloaded file?
 	// Discussion in https://github.com/mutagen-io/mutagen/issues/290#issuecomment-906612749
-	_ = os.Remove(globalconfig.GetMutagenPath())
+	err := fileutil.RemoveFilesMatchingGlob(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen*"))
+	if err != nil {
+		return fmt.Errorf("Unable to remove mutagen files: %v", err)
+	}
 
-	_ = os.MkdirAll(globalMutagenDir, 0777)
-	err := util.DownloadFile(destFile, mutagenURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"))
+	err = os.MkdirAll(globalMutagenDir, 0777)
+	if err != nil {
+		return errors.Errorf("Unable to create directory %s: %v", globalMutagenDir, err)
+	}
+	err = util.DownloadFile(destFile, mutagenURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"))
 	if err != nil {
 		return err
 	}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -526,6 +526,7 @@ func DownloadMutagen() error {
 	globalMutagenDir := filepath.Dir(globalconfig.GetMutagenPath())
 	destFile := filepath.Join(globalMutagenDir, "mutagen.tgz")
 	mutagenURL := fmt.Sprintf("https://github.com/mutagen-io/mutagen/releases/download/v%s/mutagen_%s_v%s.tar.gz", versionconstants.RequiredMutagenVersion, flavor, versionconstants.RequiredMutagenVersion)
+	shasumFileURL := fmt.Sprintf("https://github.com/mutagen-io/mutagen/releases/download/v%s/SHA256SUMS", versionconstants.RequiredMutagenVersion)
 	util.Debug("Downloading %s to %s...", mutagenURL, destFile)
 
 	// Remove the existing mutagen files. This may help on macOS to prevent the Gatekeeper's
@@ -540,8 +541,10 @@ func DownloadMutagen() error {
 	if err != nil {
 		return errors.Errorf("Unable to create directory %s: %v", globalMutagenDir, err)
 	}
-	err = util.DownloadFile(destFile, mutagenURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"), "")
+	err = util.DownloadFile(destFile, mutagenURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"), shasumFileURL)
 	if err != nil {
+		_ = fileutil.RemoveFilesMatchingGlob(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen*"))
+		_ = os.Remove(destFile)
 		return err
 	}
 	output.UserOut.Printf("Download complete.")

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -540,7 +540,7 @@ func DownloadMutagen() error {
 	if err != nil {
 		return errors.Errorf("Unable to create directory %s: %v", globalMutagenDir, err)
 	}
-	err = util.DownloadFile(destFile, mutagenURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"))
+	err = util.DownloadFile(destFile, mutagenURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"), "")
 	if err != nil {
 		return err
 	}

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -13,7 +13,7 @@ import (
 
 var DdevBin = "ddev"
 
-// TestDockerComposeDownload
+// TestDockerComposeDownload verifies that we can download a particular docker-compose version
 func TestDockerComposeDownload(t *testing.T) {
 	assert := asrt.New(t)
 	var err error
@@ -50,7 +50,7 @@ func TestDockerComposeDownload(t *testing.T) {
 	assert.NoError(err)
 	assert.False(downloaded)
 
-	for _, v := range []string{"v2.18.0"} {
+	for _, v := range []string{"v2.32.4"} {
 		globalconfig.DockerComposeVersion = ""
 		globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = v
 		downloaded, err = dockerutil.DownloadDockerComposeIfNeeded()

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1594,7 +1594,7 @@ func DownloadDockerCompose() error {
 	_ = os.Remove(destFile)
 
 	_ = os.MkdirAll(globalBinDir, 0777)
-	err = util.DownloadFile(destFile, composeURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"))
+	err = util.DownloadFile(destFile, composeURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"), "")
 	if err != nil {
 		return err
 	}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1585,7 +1585,7 @@ func DownloadDockerCompose() error {
 	globalBinDir := globalconfig.GetDDEVBinDir()
 	destFile, _ := globalconfig.GetDockerComposePath()
 
-	composeURL, err := dockerComposeDownloadLink()
+	composeURL, shasumURL, err := dockerComposeDownloadLink()
 	if err != nil {
 		return err
 	}
@@ -1594,7 +1594,7 @@ func DownloadDockerCompose() error {
 	_ = os.Remove(destFile)
 
 	_ = os.MkdirAll(globalBinDir, 0777)
-	err = util.DownloadFile(destFile, composeURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"), "")
+	err = util.DownloadFile(destFile, composeURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"), shasumURL)
 	if err != nil {
 		return err
 	}
@@ -1611,26 +1611,8 @@ func DownloadDockerCompose() error {
 	return nil
 }
 
-func dockerComposeDownloadLink() (string, error) {
-	v := globalconfig.GetRequiredDockerComposeVersion()
-	if len(v) < 3 {
-		return "", fmt.Errorf("required docker-compose version is invalid: %v", v)
-	}
-	baseVersion := v[1:2]
-
-	switch baseVersion {
-	case "2":
-		return dockerComposeDownloadLinkV2()
-	}
-	return "", fmt.Errorf("invalid docker-compose base version %s", v)
-}
-
-// dockerComposeDownloadLinkV2 downlods compose v1 downloads like
-//   https://github.com/docker/compose/releases/download/v2.2.1/docker-compose-darwin-aarch64
-//   https://github.com/docker/compose/releases/download/v2.2.1/docker-compose-darwin-x86_64
-//   https://github.com/docker/compose/releases/download/v2.2.1/docker-compose-windows-x86_64.exe
-
-func dockerComposeDownloadLinkV2() (string, error) {
+// dockerComposeDownloadLink returns the URL and SHASUM-file link for docker-compose
+func dockerComposeDownloadLink() (composeURL string, shasumURL string, err error) {
 	arch := runtime.GOARCH
 
 	switch arch {
@@ -1639,14 +1621,16 @@ func dockerComposeDownloadLinkV2() (string, error) {
 	case "amd64":
 		arch = "x86_64"
 	default:
-		return "", fmt.Errorf("only ARM64 and AMD64 architectures are supported for docker-compose v2, not %s", arch)
+		return "", "", fmt.Errorf("only ARM64 and AMD64 architectures are supported for docker-compose, not %s", arch)
 	}
 	flavor := runtime.GOOS + "-" + arch
-	ComposeURL := fmt.Sprintf("https://github.com/docker/compose/releases/download/%s/docker-compose-%s", globalconfig.GetRequiredDockerComposeVersion(), flavor)
+	composerURL := fmt.Sprintf("https://github.com/docker/compose/releases/download/%s/docker-compose-%s", globalconfig.GetRequiredDockerComposeVersion(), flavor)
 	if runtime.GOOS == "windows" {
-		ComposeURL = ComposeURL + ".exe"
+		composerURL = composerURL + ".exe"
 	}
-	return ComposeURL, nil
+	shasumURL = fmt.Sprintf("https://github.com/docker/compose/releases/download/%s/checksums.txt", globalconfig.GetRequiredDockerComposeVersion(), flavor)
+
+	return composerURL, shasumURL, nil
 }
 
 // IsDockerDesktop detects if running on Docker Desktop

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1628,7 +1628,7 @@ func dockerComposeDownloadLink() (composeURL string, shasumURL string, err error
 	if runtime.GOOS == "windows" {
 		composerURL = composerURL + ".exe"
 	}
-	shasumURL = fmt.Sprintf("https://github.com/docker/compose/releases/download/%s/checksums.txt", globalconfig.GetRequiredDockerComposeVersion(), flavor)
+	shasumURL = fmt.Sprintf("https://github.com/docker/compose/releases/download/%s/checksums.txt", globalconfig.GetRequiredDockerComposeVersion())
 
 	return composerURL, shasumURL, nil
 }

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1596,6 +1596,7 @@ func DownloadDockerCompose() error {
 	_ = os.MkdirAll(globalBinDir, 0777)
 	err = util.DownloadFile(destFile, composeURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"), shasumURL)
 	if err != nil {
+		_ = os.Remove(destFile)
 		return err
 	}
 	output.UserOut.Printf("Download complete.")

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"io/fs"
 	"os"
@@ -405,6 +406,28 @@ func RemoveContents(dir string) error {
 			return err
 		}
 	}
+	return nil
+}
+
+// RemoveFilesMatchingGlob removes all files matching a given glob pattern.
+// It does nothing if the directory does not exist.
+func RemoveFilesMatchingGlob(pattern string) error {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return errors.Errorf("Error finding files matching %s: %v", pattern, err)
+	}
+
+	// If no matches, just return (e.g., directory might not exist)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	for _, match := range matches {
+		if err := os.Remove(match); err != nil {
+			return errors.Errorf("Unable to remove file %s: %v", match, err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -408,7 +408,7 @@ func GetCachedArchive(_, _, internalExtractionPath, sourceURL string) (string, s
 	if aErr != nil {
 		output.UserOut.Printf("Downloading %s", sourceURL)
 
-		err := util.DownloadFile(archiveFullPath, sourceURL, false)
+		err := util.DownloadFile(archiveFullPath, sourceURL, false, "")
 		if err != nil {
 			_ = os.RemoveAll(archiveFullPath)
 			return extractPath, archiveFullPath, fmt.Errorf("failed to download url=%s into %s, err=%v", sourceURL, archiveFullPath, err)

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -16,7 +16,7 @@ import (
 )
 
 // DownloadFile retrieves a file.
-func DownloadFile(destPath string, url string, progressBar bool) (err error) {
+func DownloadFile(destPath string, url string, progressBar bool, shaSumURL string) (err error) {
 	if output.JSONOutput || !term.IsTerminal(int(os.Stdin.Fd())) {
 		progressBar = false
 	}

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -102,7 +102,7 @@ func DownloadFile(destPath string, url string, progressBar bool, shaSumURL strin
 			if fileRemoveErr != nil {
 				msg += fmt.Sprintf("\nAlso failed to remove file %s: %v", destPath, fileRemoveErr)
 			}
-			return fmt.Errorf(msg)
+			return errors.New(msg)
 		}
 	}
 

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -89,11 +89,13 @@ func DownloadFile(destPath string, url string, progressBar bool, shaSumURL strin
 		}
 
 		if matchedSHA == "" {
+			_ = os.Remove(destPath)
 			return fmt.Errorf("no matching SHA256 found for %s in shaSum file", baseName)
 		}
 
 		actualSHA := fmt.Sprintf("%x", hasher.Sum(nil))
 		if actualSHA != matchedSHA {
+			_ = os.Remove(destPath)
 			return fmt.Errorf("SHA256 mismatch: expected %s, got %s", matchedSHA, actualSHA)
 		}
 	}

--- a/pkg/util/network_test.go
+++ b/pkg/util/network_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -39,6 +40,13 @@ func TestDownloadFile(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		content, err := os.ReadFile(dest)
+		if err != nil {
+			t.Fatalf("failed to read downloaded file: %v", err)
+		}
+		if string(content) != testData {
+			t.Fatalf("file content mismatch: got %q, want %q", content, testData)
+		}
 	})
 
 	t.Run("correct shasum", func(t *testing.T) {
@@ -47,6 +55,13 @@ func TestDownloadFile(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		content, err := os.ReadFile(dest)
+		if err != nil {
+			t.Fatalf("failed to read downloaded file: %v", err)
+		}
+		if string(content) != testData {
+			t.Fatalf("file content mismatch: got %q, want %q", content, testData)
+		}
 	})
 
 	t.Run("incorrect shasum", func(t *testing.T) {
@@ -54,6 +69,9 @@ func TestDownloadFile(t *testing.T) {
 		err := DownloadFile(dest, ts.URL+"/"+fileName, false, ts.URL+"/badsha256sums.txt")
 		if err == nil || err.Error() == "" {
 			t.Fatal("expected SHA256 mismatch error, got nil")
+		}
+		if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+			t.Fatalf("expected file %s to be deleted after sha mismatch, but it exists", dest)
 		}
 	})
 }

--- a/pkg/util/network_test.go
+++ b/pkg/util/network_test.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+// TestDownloadFile tests downloading a file with no sha, good sha, bad sha
+func TestDownloadFile(t *testing.T) {
+	testData := "hello world\n"
+	sum := fmt.Sprintf("%x", sha256.Sum256([]byte(testData)))
+	fileName := "testfile.txt"
+
+	// HTTP test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + fileName:
+			io.WriteString(w, testData)
+		case "/sha256sums.txt":
+			fmt.Fprintf(w, "%s *%s\n", sum, fileName)
+		case "/badsha256sums.txt":
+			fmt.Fprintf(w, "%s *%s\n", "deadbeef", fileName)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+
+	t.Run("no shasum", func(t *testing.T) {
+		dest := filepath.Join(tmpDir, "plain.txt")
+		err := DownloadFile(dest, ts.URL+"/"+fileName, false, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("correct shasum", func(t *testing.T) {
+		dest := filepath.Join(tmpDir, "verified.txt")
+		err := DownloadFile(dest, ts.URL+"/"+fileName, false, ts.URL+"/sha256sums.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("incorrect shasum", func(t *testing.T) {
+		dest := filepath.Join(tmpDir, "bad.txt")
+		err := DownloadFile(dest, ts.URL+"/"+fileName, false, ts.URL+"/badsha256sums.txt")
+		if err == nil || err.Error() == "" {
+			t.Fatal("expected SHA256 mismatch error, got nil")
+		}
+	})
+}

--- a/pkg/util/network_test.go
+++ b/pkg/util/network_test.go
@@ -21,7 +21,7 @@ func TestDownloadFile(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/" + fileName:
-			io.WriteString(w, testData)
+			_, _ = io.WriteString(w, testData)
 		case "/sha256sums.txt":
 			fmt.Fprintf(w, "%s *%s\n", sum, fileName)
 		case "/badsha256sums.txt":


### PR DESCRIPTION
## The Issue

Discord: https://discord.com/channels/664580571770388500/1349663367178096650/1349755537377722520

A user upgraded to DDEV v1.24.3 and somehow got a bad version of the mutagen-agents.tar.gz which did not contain the linux agents.

```
rfay@rfay-mba-m4:~/Downloads/bin.bak$ tar -vtzf mutagen-agents.tar.gz
-rwxr-xr-x  0 0      0     9511958 Feb 24 15:34 aix_ppc64
-rwxr-xr-x  0 0      0     8176880 Feb 24 15:34 darwin_amd64
-rwxr-xr-x  0 0      0     7892416 Feb 24 15:34 darwin_arm64
-rwxr-xr-x  0 0      0     7848088 Feb 24 15:35 dragonfly_amd64
-rwxr-xr-x  0 0      0     7528610 Feb 24 15:35 freebsd_386
```

They did say they might have had internet troubles at the time, but I don't know how we could be untarring an agents file and getting different results.

## TODO

- [x] Check SHA256SUMS or checksums.txt on download
- [x] Check checksums.txt on docker-compose download as well
- [x] util.DownloadFile() now takes an optional arg for SHASUM file
- [x] If shasum validation fails, downloaded file is deleted.
- [x] Add TestRemoveFilesMatchingGlob
- [x] Add TestDownloadFile
- [x] Simplify docker-compose download logic (no longer needs to look for v1, etc.)

## How This PR Solves The Issue

This probably doesn't actually solve the issue, but at the very least we should make sure that we can't have an old or bad mutagen-agents.tar.gz file (or docker-compose, etc.)


## Manual Testing Instructions

- [ ] With mutagen enabled, `ddev poweroff` and remove the ~/.ddev/bin/mutagen* , then `ddev start`.
- [ ] With mutagen enabled, `ddev poweroff` and untar a previous mutagen version into ~/.ddev/bin - you should get the new version successfully
- [ ] For extra credit, step through and verify the deletion.

## Automated Testing Overview

- [x] Added fileutil.TestRemoveFilesMatchingGlob()
- [x] TestDownloadFile

