### PR TITLE
docs: add DevDb tip to database management documentation

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -37,6 +37,7 @@ CRM
 DBeaver
 DDEV's
 DDEV
+DevDb
 DHCP
 DKIM
 DNS

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -65,6 +65,8 @@ The PostgreSQL database container includes normal `pg` commands like `pg_dump`.
 
 If you’d like to use a GUI database client, you’ll need the right connection details and there may even be a command to launch it for you:
 
+!!!tip "If you’re using VS Code or any of its forks (Cursor, Windsurf, etc.)" You can use [DevDb]([url](https://marketplace.visualstudio.com/items?itemName=damms005.devdb)) extension to access your database right inside the IDE.
+
 * phpMyAdmin, formerly built into DDEV core, can be installed by running `ddev add-on get ddev/ddev-phpmyadmin`.
 * Adminer can be installed with `ddev add-on get ddev/ddev-adminer`
 * The [`ddev describe`](../usage/commands.md#describe) command displays the `Host:` details you’ll need to connect to the `db` container externally, for example if you're using an on-host database browser like SequelAce.

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -74,7 +74,7 @@ If you’d like to use a GUI database client, you’ll need the right connection
     * Choose a static [`host_db_port`](../configuration/config.md#host_db_port) setting for your project. For example `host_db_port: 59002` (each project’s database port should be different if you’re running more than one project at a time). Use [`ddev start`](../usage/commands.md#start) for it to take effect.
     * Use the “database” tool to create a source from “localhost”, with the proper type `mysql` or `postgresql` and the port you chose, username `db` + password `db`.
     * Explore away!
-* If you're working with VS Code or any of its forks (Cursor, Windsurf, etc.), the [DevDb](https://marketplace.visualstudio.com/items?itemName=damms005.devdb) lets you access your database directly inside the editor.
+* VS Code or any of its forks (Cursor, Windsurf, etc.) has [DevDb](https://marketplace.visualstudio.com/items?itemName=damms005.devdb), an extension that lets you access your database directly inside the editor.
 * There’s a sample custom command that will run the free MySQL Workbench on macOS, Windows or Linux. To use it, run:
     * `cp ~/.ddev/commands/host/mysqlworkbench.example ~/.ddev/commands/host/mysqlworkbench`
     * `ddev mysqlworkbench`

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -65,7 +65,8 @@ The PostgreSQL database container includes normal `pg` commands like `pg_dump`.
 
 If you’d like to use a GUI database client, you’ll need the right connection details and there may even be a command to launch it for you:
 
-!!!tip "If you’re using VS Code or any of its forks (Cursor, Windsurf, etc.)" You can use [DevDb]([url](https://marketplace.visualstudio.com/items?itemName=damms005.devdb)) extension to access your database right inside the IDE.
+!!!tip "If you’re using VS Code or any of its forks (Cursor, Windsurf, etc.)"
+    You can use the [DevDb](https://marketplace.visualstudio.com/items?itemName=damms005.devdb) extension to access your database right inside the IDE.
 
 * phpMyAdmin, formerly built into DDEV core, can be installed by running `ddev add-on get ddev/ddev-phpmyadmin`.
 * Adminer can be installed with `ddev add-on get ddev/ddev-adminer`

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -77,6 +77,7 @@ If you’d like to use a GUI database client, you’ll need the right connection
     * Choose a static [`host_db_port`](../configuration/config.md#host_db_port) setting for your project. For example `host_db_port: 59002` (each project’s database port should be different if you’re running more than one project at a time). Use [`ddev start`](../usage/commands.md#start) for it to take effect.
     * Use the “database” tool to create a source from “localhost”, with the proper type `mysql` or `postgresql` and the port you chose, username `db` + password `db`.
     * Explore away!
+* If you’re using VS Code or any of its forks (Cursor, Windsurf, etc.), you can use the [DevDb](https://marketplace.visualstudio.com/items?itemName=damms005.devdb) extension to access your database right inside the IDE.
 * There’s a sample custom command that will run the free MySQL Workbench on macOS, Windows or Linux. To use it, run:
     * `cp ~/.ddev/commands/host/mysqlworkbench.example ~/.ddev/commands/host/mysqlworkbench`
     * `ddev mysqlworkbench`

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -77,7 +77,7 @@ If you’d like to use a GUI database client, you’ll need the right connection
     * Choose a static [`host_db_port`](../configuration/config.md#host_db_port) setting for your project. For example `host_db_port: 59002` (each project’s database port should be different if you’re running more than one project at a time). Use [`ddev start`](../usage/commands.md#start) for it to take effect.
     * Use the “database” tool to create a source from “localhost”, with the proper type `mysql` or `postgresql` and the port you chose, username `db` + password `db`.
     * Explore away!
-* If you’re using VS Code or any of its forks (Cursor, Windsurf, etc.), you can use the [DevDb](https://marketplace.visualstudio.com/items?itemName=damms005.devdb) extension to access your database right inside the IDE.
+* If you're working with VS Code or any of its forks (Cursor, Windsurf, etc.), the [DevDb](https://marketplace.visualstudio.com/items?itemName=damms005.devdb) lets you access your database directly inside the editor.
 * There’s a sample custom command that will run the free MySQL Workbench on macOS, Windows or Linux. To use it, run:
     * `cp ~/.ddev/commands/host/mysqlworkbench.example ~/.ddev/commands/host/mysqlworkbench`
     * `ddev mysqlworkbench`

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -65,9 +65,6 @@ The PostgreSQL database container includes normal `pg` commands like `pg_dump`.
 
 If you’d like to use a GUI database client, you’ll need the right connection details and there may even be a command to launch it for you:
 
-!!!tip "If you’re using VS Code or any of its forks (Cursor, Windsurf, etc.)"
-    You can use the [DevDb](https://marketplace.visualstudio.com/items?itemName=damms005.devdb) extension to access your database right inside the IDE.
-
 * phpMyAdmin, formerly built into DDEV core, can be installed by running `ddev add-on get ddev/ddev-phpmyadmin`.
 * Adminer can be installed with `ddev add-on get ddev/ddev-adminer`
 * The [`ddev describe`](../usage/commands.md#describe) command displays the `Host:` details you’ll need to connect to the `db` container externally, for example if you're using an on-host database browser like SequelAce.


### PR DESCRIPTION
This PR adds DevDb tip to database management documentation

https://ddev--7084.org.readthedocs.build/en/7084/users/usage/database-management/#database-guis