### PR TITLE
[test] don't load 1password secrets if not available [skip buildkite]

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -49,15 +49,16 @@ jobs:
       - name: Install Docker and deps (Linux)
         run: ./.github/workflows/linux-setup.sh
 
-# The magento secrets don't yet work on forked PR, and magento quickstart not done
-#      - name: Load 1password secret(s) magento2 etc
-#        uses: 1password/load-secrets-action@v2
-#        with:
-#          export-env: true
-#        env:
-#          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.TESTS_SERVICE_ACCOUNT_TOKEN }}"
-#          MAGENTO2_PUBLIC_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/public_access_key"
-#          MAGENTO2_PRIVATE_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/private_access_key"
+      # 1password secrets are not available on forked PRs and some other PRs
+      - name: Load 1password secret(s) magento2 etc if available
+        if: ${{ secrets.TESTS_SERVICE_ACCOUNT_TOKEN != '' }}
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.TESTS_SERVICE_ACCOUNT_TOKEN }}"
+          MAGENTO2_PUBLIC_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/public_access_key"
+          MAGENTO2_PRIVATE_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/private_access_key"
 
       - name: Setup tmate session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,6 +168,7 @@ jobs:
         if: ${{ matrix.pull-push-test-platforms }}
 
       - name: Load 1password secret(s) for push-pull-test-platforms
+        if: ${{ matrix.pull-push-test-platforms && secrets.TESTS_SERVICE_ACCOUNT_TOKEN != '' }}
         uses: 1password/load-secrets-action@v2
         with:
           export-env: true
@@ -181,7 +182,6 @@ jobs:
           DDEV_PANTHEON_SSH_KEY: "op://test-secrets/DDEV_PANTHEON_SSH_KEY/private key?ssh-format=openssh"
           DDEV_PLATFORM_API_TOKEN: "op://test-secrets/DDEV_PLATFORM_API_TOKEN/credential"
           DDEV_UPSUN_API_TOKEN: "op://test-secrets/DDEV_UPSUN_API_TOKEN/credential"
-        if: ${{ matrix.pull-push-test-platforms && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner) }}
 
       - name: Override environment variables for plain nginx-fpm
         if: ${{ matrix.webserver == 'nginx-fpm' }}


### PR DESCRIPTION
## The Issue

Dependabot PRs and some forked PRs fail in some places where they could continue without secrets.

Instead, this PR attempts to check if the base `secrets.TESTS_SERVICE_ACCOUNT_TOKEN` is available, and if it is not, then proceed without loading 1password secrets.

I'm not sure this PR will actually use the changes added here, but recreated this on upstream to give it the best chance to see.