### PR TITLE
feat: show config.*.y*ml on ddev start

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -745,7 +745,7 @@ func (app *DdevApp) CheckCustomConfig() {
 		util.CheckErr(err)
 		if len(entrypointFiles) > 0 {
 			printableFiles, _ := util.ArrayToReadableOutput(entrypointFiles)
-			util.Warning("Using custom config.*.yaml configuration: %v", printableFiles)
+			util.Warning("Using custom config.*.y*ml configuration: %v", printableFiles)
 			customConfig = true
 		}
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -739,6 +739,17 @@ func (app *DdevApp) CheckCustomConfig() {
 		}
 	}
 
+	configPath := filepath.Join(ddevDir, "")
+	if _, err := os.Stat(configPath); err == nil {
+		entrypointFiles, err := filepath.Glob(filepath.Join(configPath, "config.*.y*ml"))
+		util.CheckErr(err)
+		if len(entrypointFiles) > 0 {
+			printableFiles, _ := util.ArrayToReadableOutput(entrypointFiles)
+			util.Warning("Using custom config.*.yaml configuration: %v", printableFiles)
+			customConfig = true
+		}
+	}
+
 	if customConfig {
 		util.Warning("Custom configuration is updated on restart.\nIf you don't see your custom configuration taking effect, run 'ddev restart'.")
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -741,11 +741,11 @@ func (app *DdevApp) CheckCustomConfig() {
 
 	configPath := filepath.Join(ddevDir, "")
 	if _, err := os.Stat(configPath); err == nil {
-		entrypointFiles, err := filepath.Glob(filepath.Join(configPath, "config.*.y*ml"))
+		configFiles, err := filepath.Glob(filepath.Join(configPath, "config.*.y*ml"))
 		util.CheckErr(err)
-		if len(entrypointFiles) > 0 {
-			printableFiles, _ := util.ArrayToReadableOutput(entrypointFiles)
-			util.Warning("Using custom config.*.y*ml configuration: %v", printableFiles)
+		if len(configFiles) > 0 {
+			printableFiles, _ := util.ArrayToReadableOutput(configFiles)
+			util.Warning("Using custom config.*.yaml configuration: %v", printableFiles)
 			customConfig = true
 		}
 	}


### PR DESCRIPTION
I liked how custom configurations are now output and I realize I was missing `config.*.y*ml` files to see what is there and it what order so I thought it a nice addition to add config files as well to the report:

```
Using custom MySQL configuration: [
  ./.ddev/mysql/acquia.cnf
] 
Using custom PHP configuration: [
  ./.ddev/php/cc9.ini
] 
Using custom web-build configuration: [
  ./.ddev/web-build/Dockerfile
  ./.ddev/web-build/Dockerfile.pimp-my-shell
] 
Using custom web-entrypoint.d configuration: [
  ./.ddev/web-entrypoint.d/readme-nodedeps.sh
] 
Using custom config.*.yaml configuration: [
  ./.ddev/config.pimp-my-shell.yaml
  ./.ddev/config.readme.yaml
  ./.ddev/config.selenium-standalone-chrome.yaml
  ./.ddev/config.~overrides.yaml
] 
Custom configuration is updated on restart.
If you don't see your custom configuration taking effect, run 'ddev restart'. 
```

Curious thing:

```
Using custom config.*.yaml configuration: [
  ./.ddev/config.pimp-my-shell.yaml
  ./.ddev/config.readme.yaml
  ./.ddev/config.selenium-standalone-chrome.yaml
  ./.ddev/config.~overrides.yaml
] 
```

I use `config.~overrides.yaml` so that it loads last, but VS code sorts it differently:

<img width="318" alt="Screenshot 2025-03-14 at 13 04 16" src="https://github.com/user-attachments/assets/45c01f33-7af0-4e1d-97c1-b556e62accd7" />

Not sublime though 🤷🏻 
