### PR TITLE
test: add OpenMage/Magento 1 quickstart test and split it from Magento 2, for #7094

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -757,10 +757,12 @@ ddev magento setup:upgrade
     ```bash
     mkdir my-openmage-site && cd my-openmage-site
     git clone https://github.com/OpenMage/magento-lts .
-    ddev config --project-type=magento --php-version=8.1
+    ddev config --project-type=magento --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
     ddev start
-    # Install openmage and optionally install sample data
-    ddev openmage-install -s -q
+    ddev composer install
+    # Silent OpenMage install with sample data
+    # See `ddev openmage-install -h` for more options
+    ddev openmage-install -q
     # Login using `admin` user and `veryl0ngpassw0rd` password
     ddev launch /admin
     ```

--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+setup() {
+  PROJNAME=magento-lts
+  load 'common-setup'
+  _common_setup
+}
+
+# executed after each test
+teardown() {
+  _common_teardown
+}
+
+@test "OpenMage git based quickstart with $(ddev --version)" {
+  # PROJECT_GIT_URL=https://github.com/OpenMage/magento-lts
+  PROJECT_GIT_URL=https://github.com/OpenMage/magento-lts
+
+  # git clone ${PROJECT_GIT_URL} ${PROJNAME}
+  run git clone ${PROJECT_GIT_URL} ${PROJNAME}
+  assert_success
+
+  # cd magento-lts
+  cd ${PROJNAME} || exit 2
+  assert_success
+
+  # ddev config --project-type=magento --php_version=8.1 --webserver_type=nginx-fpm
+  run ddev config --project-type=magento --php_version=8.1 --webserver_type=nginx-fpm
+  assert_success
+
+  # ddev start -y
+  run ddev start -y
+  assert_success
+
+  # ddev composer install
+  run ddev composer install
+  assert_success
+
+  # ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+
+}

--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -40,4 +40,23 @@ teardown() {
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
 
+  # Install openmage and optionally install sample data
+  ddev openmage-install -s -q
+
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "server: nginx"
+  assert_output --partial "HTTP/2 200"
+  assert_output --partial "set-cookie: om_frontend"
+
+  # Check if the frontend is working
+  run curl -sf https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "2020 OpenMage Demo Store. All Rights Reserved."
+
+  # Check if the admin is working
+  run curl -sf https://${PROJNAME}.ddev.site/index.php/admin/
+  assert_success
+  assert_output --partial "2020 OpenMage Demo Store. All Rights Reserved."
 }

--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -16,7 +16,7 @@ teardown() {
   PROJECT_GIT_URL=https://github.com/OpenMage/magento-lts
 
   # git clone ${PROJECT_GIT_URL} ${PROJNAME}
-  run git clone ${PROJECT_GIT_URL} ${PROJNAME}
+  run git clone --depth=1 ${PROJECT_GIT_URL} ${PROJNAME}
   assert_success
 
   # cd magento-lts

--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -35,13 +35,13 @@ teardown() {
   run ddev composer install
   assert_success
 
+  # Install openmage and optionally install sample data
+  ddev openmage-install -s -q
+
   # ddev launch
   run bash -c "DDEV_DEBUG=true ddev launch"
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
-
-  # Install openmage and optionally install sample data
-  ddev openmage-install -s -q
 
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site

--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -58,5 +58,5 @@ teardown() {
   # Check if the admin is working
   run curl -sf https://${PROJNAME}.ddev.site/index.php/admin/
   assert_success
-  assert_output --partial "2020 OpenMage Demo Store. All Rights Reserved."
+  assert_output --partial "Log into OpenMage Admin Page"
 }

--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  PROJNAME=magento-lts
+  PROJNAME=my-openmage-site
   load 'common-setup'
   _common_setup
 }
@@ -12,33 +12,25 @@ teardown() {
 }
 
 @test "OpenMage git based quickstart with $(ddev --version)" {
-  # PROJECT_GIT_URL=https://github.com/OpenMage/magento-lts
-  PROJECT_GIT_URL=https://github.com/OpenMage/magento-lts
-
-  # git clone ${PROJECT_GIT_URL} ${PROJNAME}
-  run git clone --depth=1 ${PROJECT_GIT_URL} ${PROJNAME}
+  run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
-  # cd magento-lts
-  cd ${PROJNAME} || exit 2
+  run git clone --depth=1 https://github.com/OpenMage/magento-lts .
   assert_success
 
-  # ddev config --project-type=magento --php-version=8.1 --webserver-type=nginx-fpm
-  run ddev config --project-type=magento --php-version=8.1 --webserver-type=nginx-fpm
+  run ddev config --project-type=magento --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
   assert_success
 
-  # ddev start -y
   run ddev start -y
   assert_success
 
-  # ddev composer install
   run ddev composer install
   assert_success
 
-  # Install openmage and optionally install sample data
-  ddev openmage-install -s -q
+  # Silent OpenMage install with sample data
+  ddev openmage-install -q
+  assert_success
 
-  # ddev launch
   run bash -c "DDEV_DEBUG=true ddev launch"
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success

--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -28,7 +28,7 @@ teardown() {
   assert_success
 
   # Silent OpenMage install with sample data
-  ddev openmage-install -q
+  run ddev openmage-install -q
   assert_success
 
   run bash -c "DDEV_DEBUG=true ddev launch"

--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -23,8 +23,8 @@ teardown() {
   cd ${PROJNAME} || exit 2
   assert_success
 
-  # ddev config --project-type=magento --php_version=8.1 --webserver_type=nginx-fpm
-  run ddev config --project-type=magento --php_version=8.1 --webserver_type=nginx-fpm
+  # ddev config --project-type=magento --php-version=8.1 --webserver-type=nginx-fpm
+  run ddev config --project-type=magento --php-version=8.1 --webserver-type=nginx-fpm
   assert_success
 
   # ddev start -y


### PR DESCRIPTION
## The Issue

- #7094 

* Split openmage into its own quickstart
* Use git clone instead of zipball download
* Add quickstart test for it

Rendered updated docs at:

- https://ddev--7091.org.readthedocs.build/en/7091/users/quickstart/#magento-2
- https://ddev--7091.org.readthedocs.build/en/7091/users/quickstart/#openmage

