### PR TITLE
fix: remove obsolete references to non-traefik router

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -630,33 +630,31 @@ func (app *DdevApp) CheckCustomConfig() {
 		customConfig = true
 	}
 
-	if globalconfig.DdevGlobalConfig.IsTraefikRouter() {
-		traefikGlobalConfigPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "traefik")
-		if _, err := os.Stat(traefikGlobalConfigPath); err == nil {
-			traefikGlobalFiles, err := filepath.Glob(filepath.Join(traefikGlobalConfigPath, "static_config.*.yaml"))
-			util.CheckErr(err)
-			if len(traefikGlobalFiles) > 0 {
-				printableFiles, _ := util.ArrayToReadableOutput(traefikGlobalFiles)
-				util.Warning("Using custom global Traefik configuration (use `docker logs ddev-router` for troubleshooting): %v", printableFiles)
-				customConfig = true
+	traefikGlobalConfigPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "traefik")
+	if _, err := os.Stat(traefikGlobalConfigPath); err == nil {
+		traefikGlobalFiles, err := filepath.Glob(filepath.Join(traefikGlobalConfigPath, "static_config.*.yaml"))
+		util.CheckErr(err)
+		if len(traefikGlobalFiles) > 0 {
+			printableFiles, _ := util.ArrayToReadableOutput(traefikGlobalFiles)
+			util.Warning("Using custom global Traefik configuration (use `docker logs ddev-router` for troubleshooting): %v", printableFiles)
+			customConfig = true
+		}
+	}
+	traefikConfigPath := filepath.Join(ddevDir, "traefik/config")
+	if _, err := os.Stat(traefikConfigPath); err == nil {
+		traefikFiles, err := filepath.Glob(filepath.Join(traefikConfigPath, "*.yaml"))
+		util.CheckErr(err)
+		var customTraefikFiles []string
+		for _, traefikFile := range traefikFiles {
+			sigFound, _ = fileutil.FgrepStringInFile(traefikFile, nodeps.DdevFileSignature)
+			if !sigFound {
+				customTraefikFiles = append(customTraefikFiles, traefikFile)
 			}
 		}
-		traefikConfigPath := filepath.Join(ddevDir, "traefik/config")
-		if _, err := os.Stat(traefikConfigPath); err == nil {
-			traefikFiles, err := filepath.Glob(filepath.Join(traefikConfigPath, "*.yaml"))
-			util.CheckErr(err)
-			var customTraefikFiles []string
-			for _, traefikFile := range traefikFiles {
-				sigFound, _ = fileutil.FgrepStringInFile(traefikFile, nodeps.DdevFileSignature)
-				if !sigFound {
-					customTraefikFiles = append(customTraefikFiles, traefikFile)
-				}
-			}
-			if len(customTraefikFiles) > 0 {
-				printableFiles, _ := util.ArrayToReadableOutput(customTraefikFiles)
-				util.Warning("Using custom Traefik configuration (use `docker logs ddev-router` for troubleshooting): %v", printableFiles)
-				customConfig = true
-			}
+		if len(customTraefikFiles) > 0 {
+			printableFiles, _ := util.ArrayToReadableOutput(customTraefikFiles)
+			util.Warning("Using custom Traefik configuration (use `docker logs ddev-router` for troubleshooting): %v", printableFiles)
+			customConfig = true
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2846,11 +2846,13 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 		}
 	}
 
-	_, _, err = app.Exec(&ExecOpts{
-		Cmd: fmt.Sprintf("rm -f /mnt/ddev-global-cache/traefik/*/%s.{yaml,crt,key}", app.Name),
-	})
-	if err != nil {
-		util.Warning("Unable to clean up Traefik configuration: %v", err)
+	if status == SiteRunning {
+		_, _, err = app.Exec(&ExecOpts{
+			Cmd: fmt.Sprintf("rm -f /mnt/ddev-global-cache/traefik/*/%s.{yaml,crt,key}", app.Name),
+		})
+		if err != nil {
+			util.Warning("Unable to clean up Traefik configuration: %v", err)
+		}
 	}
 
 	// Clean up ddev-global-cache

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1587,18 +1587,14 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 
 		// If TLS supported and using Traefik, create cert/key and push into ddev-global-cache/traefik
-		if globalconfig.DdevGlobalConfig.IsTraefikRouter() {
-			err = configureTraefikForApp(app)
-			if err != nil {
-				return err
-			}
+		err = configureTraefikForApp(app)
+		if err != nil {
+			return err
 		}
 
 		// Push custom certs
-		targetSubdir := "custom_certs"
-		if globalconfig.DdevGlobalConfig.IsTraefikRouter() {
-			targetSubdir = path.Join("traefik", "certs")
-		}
+		targetSubdir := path.Join("traefik", "certs")
+
 		certPath := app.GetConfigPath("custom_certs")
 		uid, _, _ := util.GetContainerUIDGid()
 		if fileutil.FileExists(certPath) && globalconfig.DdevGlobalConfig.MkcertCARoot != "" {
@@ -2850,14 +2846,13 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 		}
 	}
 
-	if globalconfig.DdevGlobalConfig.IsTraefikRouter() && status == SiteRunning {
-		_, _, err = app.Exec(&ExecOpts{
-			Cmd: fmt.Sprintf("rm -f /mnt/ddev-global-cache/traefik/*/%s.{yaml,crt,key}", app.Name),
-		})
-		if err != nil {
-			util.Warning("Unable to clean up Traefik configuration: %v", err)
-		}
+	_, _, err = app.Exec(&ExecOpts{
+		Cmd: fmt.Sprintf("rm -f /mnt/ddev-global-cache/traefik/*/%s.{yaml,crt,key}", app.Name),
+	})
+	if err != nil {
+		util.Warning("Unable to clean up Traefik configuration: %v", err)
 	}
+
 	// Clean up ddev-global-cache
 	if removeData {
 		c := fmt.Sprintf("rm -rf /mnt/ddev-global-cache/*/%s-{web,db} /mnt/ddev-global-cache/traefik/*/%s.{yaml,crt,key}", app.Name, app.Name)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -4399,10 +4399,8 @@ func TestCustomCerts(t *testing.T) {
 	// mkcert --cert-file d9composer.ddev.site.crt --key-file d9composer.ddev.site.key d9composer.ddev.site
 	// For Traefik generation, it's app.Name,
 	// mkcert --cert-file d9.crt --key-file d9.key d9.ddev.site
-	baseCertName := app.GetHostname()
-	if globalconfig.DdevGlobalConfig.IsTraefikRouter() {
-		baseCertName = app.Name
-	}
+	baseCertName := app.Name
+
 	stdout, err = exec.RunHostCommand("mkcert", "--cert-file", filepath.Join(certDir, baseCertName+".crt"), "--key-file", filepath.Join(certDir, baseCertName+".key"), app.GetHostname())
 	require.NoError(t, err, "mkcert command failed, stdout=%s", stdout)
 

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -146,11 +146,9 @@ func StartDdevRouter() error {
 	if err != nil {
 		return err
 	}
-	if globalconfig.DdevGlobalConfig.IsTraefikRouter() {
-		err = PushGlobalTraefikConfig()
-		if err != nil {
-			return fmt.Errorf("failed to push global Traefik config: %v", err)
-		}
+	err = PushGlobalTraefikConfig()
+	if err != nil {
+		return fmt.Errorf("failed to push global Traefik config: %v", err)
 	}
 
 	err = CheckRouterPorts()

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -2,13 +2,11 @@ services:
   ddev-router:
     image: {{ .router_image }}
 
-    {{ if eq .Router "traefik" }}
     # Prevent zombie container
     init: true
     command:
       - --configFile=/mnt/ddev-global-cache/traefik/.static_config.yaml
     user: {{ .UID }}:{{ .GID }}
-    {{ end }}
 
     networks:
       - ddev_default
@@ -16,17 +14,12 @@ services:
     ports: {{ $dockerIP := .dockerIP }}{{ if not .router_bind_all_interfaces }}{{ range $port := .ports }}
       - "{{ $dockerIP }}:{{ $port }}:{{ $port }}"{{ end }}{{ else }}{{ range $port := .ports }}
       - "{{ $port }}:{{ $port }}"{{ end }}{{ end }}
-      {{ if eq .Router "traefik" }}
       # Traefik router; configured in static config as entrypoint
       - "{{ if not .router_bind_all_interfaces }}{{ $dockerIP }}:{{ end }}{{.TraefikMonitorPort}}:{{.TraefikMonitorPort}}"
-      {{ end }}
     labels:
       # For cleanup on ddev poweroff
       com.ddev.site-name: ""
     volumes:
-      {{ if ne .Router "traefik" }}
-      - /var/run/docker.sock:/tmp/docker.sock:ro
-      {{ end }}
       - ddev-global-cache:/mnt/ddev-global-cache:rw
       {{ if .letsencrypt }}
       - ddev-router-letsencrypt:/etc/letsencrypt:rw
@@ -40,9 +33,7 @@ services:
       - TZ={{ .Timezone }}
     restart: "no"
     healthcheck:
-      {{ if eq .Router "traefik" }}
       test: "/healthcheck.sh"
-      {{ end }}
       interval: 1s
       retries: 120
       start_period: 120s

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -513,9 +513,6 @@ func (app *DdevApp) GetRelativeWorkingDirectory() string {
 func (app *DdevApp) HasCustomCert() bool {
 	customCertsPath := app.GetConfigPath("custom_certs")
 	certFileName := fmt.Sprintf("%s.crt", app.Name)
-	if !globalconfig.DdevGlobalConfig.IsTraefikRouter() {
-		certFileName = fmt.Sprintf("%s.crt", app.GetHostname())
-	}
 	return fileutil.FileExists(filepath.Join(customCertsPath, certFileName))
 }
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -849,11 +849,6 @@ func IsInternetActive() bool {
 	return active
 }
 
-// IsTraefikRouter returns true if the router is Traefik
-func (c *GlobalConfig) IsTraefikRouter() bool {
-	return c.Router == types.RouterTypeTraefik
-}
-
 // DockerComposeVersion is filled with the version we find for docker-compose
 var DockerComposeVersion = ""
 
@@ -876,9 +871,7 @@ func GetRequiredDockerComposeVersion() string {
 // GetRouterURL Return the Traefik router URL
 func GetRouterURL() string {
 	routerURL := ""
-	// Until we figure out how to configure this, use static value
-	if DdevGlobalConfig.IsTraefikRouter() {
-		routerURL = "http://127.0.0.1:" + DdevGlobalConfig.TraefikMonitorPort
-	}
+	routerURL = "http://127.0.0.1:" + DdevGlobalConfig.TraefikMonitorPort
+
 	return routerURL
 }


### PR DESCRIPTION

## The Issue

I happened to notice that we had some code checking for traefik/non-traefik routers, and since that's obsolete, it's better to remove.

Review carefully, but this should have no impact.

