### PR TITLE
docs: Fix pull request title link in pull request template [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- 
   PR titles have very precise rules, please read 
-  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#open-pull-requests
+  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
 -->
 
 ## The Issue


### PR DESCRIPTION

## The Issue

I was looking for the pull request title specs and noticed that our pull request template had an obsolete link.

