### PR TITLE
test: adding kirby quickstart bats test

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -458,7 +458,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     ddev config --omit-containers=db --webserver-type=apache-fpm
 
     # Spin up the project and install the Kirby Starterkit
-    ddev start -y
+    ddev start
     ddev composer create getkirby/starterkit
 
     # Open the site in your browser
@@ -477,7 +477,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     ddev config --omit-containers=db --webserver-type=apache-fpm
 
     # Spin up the project
-    ddev start -y
+    ddev start
 
     # Open the site in your browser
     ddev launch

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -458,7 +458,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     ddev config --omit-containers=db --webserver-type=apache-fpm
 
     # Spin up the project and install the Kirby Starterkit
-    ddev start
+    ddev start -y
     ddev composer create getkirby/starterkit
 
     # Open the site in your browser
@@ -477,7 +477,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     ddev config --omit-containers=db --webserver-type=apache-fpm
 
     # Spin up the project
-    ddev start
+    ddev start -y
 
     # Open the site in your browser
     ddev launch

--- a/docs/tests/kirby.bats
+++ b/docs/tests/kirby.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+setup() {
+  PROJNAME=my-kirby-site
+  load 'common-setup'
+  _common_setup
+}
+
+# executed after each test
+teardown() {
+  _common_teardown
+}
+
+@test "Kirby new project quickstart with $(ddev --version)" {
+
+  # mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  assert_success
+
+  # ddev config --omit-containers=db --webserver-type=apache-fpm
+  run ddev config --omit-containers=db --webserver-type=apache-fpm
+  assert_success
+
+  # ddev start -y
+  run ddev start -y
+  assert_success
+
+  # ddev composer create getkirby/starterkit
+  run ddev composer create getkirby/starterkit
+  assert_success
+
+  # validate ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "server: Apache"
+  assert_output --partial "HTTP/2 200"
+  run curl -sf https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "<h2><a href=\"https://getkirby.com\">Made with Kirby</a></h2>"
+  assert_output --partial "the file-based CMS that adapts to any project"
+}


### PR DESCRIPTION
… to it

<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue
bats test for the new project quickstart... for existing quickstart there wont be a quickstart necessary imho. it is basically identically to the new project quickstart except the composer create step is missing and an existing codebase is expected


## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
