### PR TITLE
test: Disable link check on freedesktop.org since it will be out for a week

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -26,6 +26,7 @@ ignorePatterns:
   - pattern: "^https://aur.archlinux.org"
   - pattern: "^https://team-ddev.1password.com"
   - pattern: "^https://.*.archive.org"
+  - pattern: "^https://specifications.freedesktop.org"
 aliveStatusCodes:
   - 200
   - 206


### PR DESCRIPTION

## The Issue

- #<issue number>

Currently docs check is failing link to https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html because they're doing a migration and will be down for a week.

## How This PR Solves The Issue

Don't check that link

