### PR TITLE
test: bats tests for expression engine and adjustments to its quickstart

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -302,7 +302,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     mkdir my-ee-site && cd my-ee-site
     # Download the zip archive for ExpressionEngine at https://github.com/ExpressionEngine/ExpressionEngine/releases/latest unarchive and move its content into the root of the my-ee-site directory
     ddev config --database=mysql:8.0
-    ddev start
+    ddev start -y
     ddev launch /admin.php # Open installation wizard in browser
     ```
 
@@ -315,14 +315,13 @@ Read more about customizing the environment and persisting configuration in [Pro
     Follow these steps based on the [ExpressionEngine Git Repository README.md](https://github.com/ExpressionEngine/ExpressionEngine#how-to-install):
 
     ```bash
-    git clone https://github.com/ExpressionEngine/ExpressionEngine my-ee-site # for example
-    cd my-ee-site
-    ddev config # Accept the defaults
-    ddev start
+    mkdir my-ee-site && cd my-ee-site
+    git clone https://github.com/ExpressionEngine/ExpressionEngine .
+    ddev config --database=mysql:8.0
+    ddev start -y
     ddev composer install
     touch system/user/config/config.php
     echo "EE_INSTALL_MODE=TRUE" >.env.php
-    ddev start
     ddev launch /admin.php  # Open installation wizard in browser
     ```
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -303,7 +303,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     curl -o ee.zip -L $(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
     unzip ee.zip && rm -f ee.zip
     ddev config --database=mysql:8.0
-    ddev start -y
+    ddev start
     ddev launch /admin.php # Open installation wizard in browser
     ```
 
@@ -319,7 +319,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     mkdir my-ee-site && cd my-ee-site
     git clone https://github.com/ExpressionEngine/ExpressionEngine .
     ddev config --database=mysql:8.0
-    ddev start -y
+    ddev start
     ddev composer install
     touch system/user/config/config.php
     echo "EE_INSTALL_MODE=TRUE" >.env.php

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -300,7 +300,8 @@ Read more about customizing the environment and persisting configuration in [Pro
 
     ```bash
     mkdir my-ee-site && cd my-ee-site
-    # Download the zip archive for ExpressionEngine at https://github.com/ExpressionEngine/ExpressionEngine/releases/latest unarchive and move its content into the root of the my-ee-site directory
+    curl -o ee.zip -L $(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
+    unzip ee.zip && rm -f ee.zip
     ddev config --database=mysql:8.0
     ddev start -y
     ddev launch /admin.php # Open installation wizard in browser

--- a/docs/tests/ee.bats
+++ b/docs/tests/ee.bats
@@ -72,8 +72,8 @@ teardown() {
   assert_success
 
   # echo "EE_INSTALL_MODE=TRUE" >.env.php
-  run echo "EE_INSTALL_MODE=TRUE" >.env.php
-  assert_success
+  echo "EE_INSTALL_MODE=TRUE" >.env.php
+  assert_file_exist .env.php
 
   # validate ddev launch
   run bash -c "DDEV_DEBUG=true ddev launch /admin.php"

--- a/docs/tests/ee.bats
+++ b/docs/tests/ee.bats
@@ -16,18 +16,12 @@ teardown() {
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
-  # Download the latest version of the ExpressionEngine zip file from GitHub
-  LATEST_RELEASE=$(curl -fsSL -H 'Accept: application/json' https://github.com/ExpressionEngine/ExpressionEngine/releases/latest || (printf "${RED}Failed to get find latest release${RESET}\n" >/dev/stderr && exit 107))
-  LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
-  VERSION=$LATEST_VERSION
-  if [ $# -ge 1 ]; then
-    VERSION=$1
-  fi
-  run curl -LJO https://github.com/ExpressionEngine/ExpressionEngine/releases/download/$VERSION/ExpressionEngine$VERSION.zip
+  # Download the latest version of Expression Engine
+  run curl -o ee.zip -L $(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
   assert_success
 
-  # Unzip and move the extracted assets to the parent root
-  run unzip -o ./ExpressionEngine$VERSION.zip && rm -f ExpressionEngine$VERSION.zip && shopt -s dotglob 2>/dev/null || setopt dotglob && mv -f ./ExpressionEngine$VERSION/* . && shopt -u dotglob 2>/dev/null || unsetopt dotglob && rm -rf ExpressionEngine$VERSION
+  # unzip ee.zip && rm -f ee.zip
+  run unzip ee.zip && rm -f ee.zip
   assert_success
 
   # ddev config --database=mysql:8.0

--- a/docs/tests/ee.bats
+++ b/docs/tests/ee.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+
+setup() {
+  PROJNAME=my-ee-site
+  load 'common-setup'
+  _common_setup
+}
+
+# executed after each test
+teardown() {
+  _common_teardown
+}
+
+@test "Expression Engine Zip File Download quickstart with $(ddev --version)" {
+  # mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  assert_success
+
+  # Download the latest version of the ExpressionEngine zip file from GitHub
+  LATEST_RELEASE=$(curl -fsSL -H 'Accept: application/json' https://github.com/ExpressionEngine/ExpressionEngine/releases/latest || (printf "${RED}Failed to get find latest release${RESET}\n" >/dev/stderr && exit 107))
+  LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+  VERSION=$LATEST_VERSION
+  if [ $# -ge 1 ]; then
+    VERSION=$1
+  fi
+  run curl -LJO https://github.com/ExpressionEngine/ExpressionEngine/releases/download/$VERSION/ExpressionEngine$VERSION.zip
+  assert_success
+
+  # Unzip and move the extracted assets to the parent root
+  run unzip -o ./ExpressionEngine$VERSION.zip && rm -f ExpressionEngine$VERSION.zip && shopt -s dotglob 2>/dev/null || setopt dotglob && mv -f ./ExpressionEngine$VERSION/* . && shopt -u dotglob 2>/dev/null || unsetopt dotglob && rm -rf ExpressionEngine$VERSION
+  assert_success
+
+  # ddev config --database=mysql:8.0
+  run ddev config --database=mysql:8.0
+  assert_success
+
+  # ddev start -y
+  run ddev start -y
+  assert_success
+
+  # validate ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch /admin.php"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site/admin.php"
+  assert_success
+    # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site/admin.php
+  assert_success
+  assert_output --partial "server: nginx"
+  assert_output --partial "HTTP/2 200"
+  run curl -sf https://${PROJNAME}.ddev.site/admin.php
+  assert_success
+  assert_output --partial "<title>Install ExpressionEngine"
+}
+
+@test "Expression Engine Git Clone quickstart with $(ddev --version)" {
+  # mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  assert_success
+
+  # git clone --depth=1 https://github.com/ExpressionEngine/ExpressionEngine my-ee-site
+  run git clone --depth=1 https://github.com/ExpressionEngine/ExpressionEngine .
+  assert_success
+
+  # ddev config --auto
+  run ddev config --database=mysql:8.0
+  assert_success
+
+  # ddev start -y
+  run ddev start -y
+  assert_success
+
+  # ddev composer install
+  run ddev composer install
+  assert_success
+
+  # touch system/user/config/config.php
+  run touch system/user/config/config.php
+  assert_success
+
+  # echo "EE_INSTALL_MODE=TRUE" >.env.php
+  run echo "EE_INSTALL_MODE=TRUE" >.env.php
+  assert_success
+
+  # validate ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch /admin.php"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site/admin.php"
+  assert_success
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site/admin.php
+  assert_success
+  assert_output --partial "server: nginx"
+  assert_output --partial "HTTP/2 200"
+  run curl -sf https://${PROJNAME}.ddev.site/admin.php
+  assert_success
+  assert_output --partial "<title>Install ExpressionEngine"
+}


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue
i'Ve made a few adjustments to the quickstart. added `-y`to `ddev start`to keep it in line with the tests. for the config i'Ve added `--database=mysql:8.0`to the git based install. so far it was only for the zip based. and i've adjusted the git based quickstart. before we had git clone and then the cd. but that caused problems with the bats test. i now took the road of creating a test dir change into it and then git clone into the dir. that works. 

and as already noted via discord to randy and stas for the zip based approach i'Ve used the snippets used for backdrop. there i noticed that i ran into warning and error moving the expanded zip assets to the parent root. i found a way to fix it and to make things pass locally. i was using shell options. but that needs a through examination and lets also see if the tests pass on github actions as well. 


## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
