### PR TITLE
test: symfony bats tests

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1000,7 +1000,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ```bash
     mkdir my-symfony-site && cd my-symfony-site
     ddev config --project-type=symfony --docroot=public
-    ddev start -y
+    ddev start
     ddev composer create symfony/skeleton
     ddev composer require webapp
     # When it asks if you want to include docker configuration, say "no" with "x"
@@ -1012,7 +1012,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ```bash
     mkdir my-symfony-site && cd my-symfony-site
     ddev config --project-type=symfony --docroot=public
-    ddev start -y
+    ddev start
     ddev exec symfony check:requirements
     ddev exec symfony new temp --version="7.1.*" --webapp
     # 'symfony new' can't install in the current directory right away,

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1000,6 +1000,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ```bash
     mkdir my-symfony-site && cd my-symfony-site
     ddev config --project-type=symfony --docroot=public
+    ddev start -y
     ddev composer create symfony/skeleton
     ddev composer require webapp
     # When it asks if you want to include docker configuration, say "no" with "x"
@@ -1011,7 +1012,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ```bash
     mkdir my-symfony-site && cd my-symfony-site
     ddev config --project-type=symfony --docroot=public
-    ddev start
+    ddev start -y
     ddev exec symfony check:requirements
     ddev exec symfony new temp --version="7.1.*" --webapp
     # 'symfony new' can't install in the current directory right away,

--- a/docs/tests/symfony.bats
+++ b/docs/tests/symfony.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+setup() {
+  PROJNAME=my-symfony-site
+  load 'common-setup'
+  _common_setup
+}
+
+# executed after each test
+teardown() {
+  _common_teardown
+}
+
+@test "Symfony Composer quickstart with $(ddev --version)" {
+  # mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  assert_success
+
+  # config --project-type=symfony --docroot=public
+  run ddev config --project-type=symfony --docroot=public
+  assert_success
+
+  # ddev start -y
+  run ddev start -y
+  assert_success
+
+  # ddev composer create symfony/skeleton
+  run ddev composer create symfony/skeleton
+  assert_success
+
+  # bash -c 'printf "x\n" | ddev composer require webapp'
+  run bash -c 'printf "x\n" | ddev composer require webapp'
+  assert_success
+
+  # validate ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+  # validate running project
+  run curl -sf https://${PROJNAME}.ddev.site/index.php
+  assert_success
+  assert_output --partial "You are seeing this page because the homepage URL is not configured and"
+}
+
+@test "Symfony CLI quickstart with $(ddev --version)" {
+  # mkdir ${PROJNAME} && cd ${PROJNAME}
+  run mkdir ${PROJNAME} && cd ${PROJNAME}
+  assert_success
+
+  # ddev config --project-type=symfony --docroot=public
+  run ddev config --project-type=symfony --docroot=public
+  assert_success
+
+  # ddev start -y
+  run ddev start -y
+  assert_success
+
+  # ddev exec symfony check:requirements
+  run ddev exec symfony check:requirements
+  assert_success
+
+  # ddev exec symfony new temp --version="7.1.*" --webapp
+  run ddev exec symfony new temp --version="7.1.*" --webapp
+  assert_success
+
+  # ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'
+  run ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'
+  assert_success
+
+  # validate ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+}

--- a/docs/tests/symfony.bats
+++ b/docs/tests/symfony.bats
@@ -37,9 +37,9 @@ teardown() {
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
   # validate running project
-  run curl -sf https://${PROJNAME}.ddev.site/index.php
-  assert_success
-  assert_output --partial "You are seeing this page because the homepage URL is not configured and"
+  #run curl -sf https://${PROJNAME}.ddev.site/index.php
+  #assert_success
+  #assert_output --partial "You are seeing this page because the homepage URL is not configured and"
 }
 
 @test "Symfony CLI quickstart with $(ddev --version)" {

--- a/docs/tests/symfony.bats
+++ b/docs/tests/symfony.bats
@@ -36,10 +36,16 @@ teardown() {
   run bash -c "DDEV_DEBUG=true ddev launch"
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
+
   # validate running project
-  #run curl -sf https://${PROJNAME}.ddev.site/index.php
-  #assert_success
-  #assert_output --partial "You are seeing this page because the homepage URL is not configured and"
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_output --partial "server: nginx"
+  assert_output --partial "HTTP/2 404"
+  run curl https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "<title>Welcome to Symfony!</title>"
+  assert_output --partial "You are seeing this page because the homepage URL is not configured and"
+  assert_output --partial "<a target=\"_blank\" href=\"https://symfony.com/community#interact\">Follow Symfony</a>"
 }
 
 @test "Symfony CLI quickstart with $(ddev --version)" {
@@ -71,4 +77,14 @@ teardown() {
   run bash -c "DDEV_DEBUG=true ddev launch"
   assert_output "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
+
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_output --partial "server: nginx"
+  assert_output --partial "HTTP/2 404"
+  run curl https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "<title>Welcome to Symfony!</title>"
+  assert_output --partial "You are seeing this page because the homepage URL is not configured and"
+  assert_output --partial "<a target=\"_blank\" href=\"https://symfony.com/community#interact\">Follow Symfony</a>"
 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

bats tests for the symfony composer and the symfony cli quickstart. also made small adjustments to the quickstarts. 

only nagging point, at the moment it is only possible to check ddev launch. it is impossible to check the install with curl. the default page that is shown is not an actual page but rather a "virtual" on... the webprofiler in the footer bar shows a 404 and curl returns no output. so uncertain how to reliably and more thoroughly check for a successful install. am a bit out of ideas and dont know symfony well enough. only idea would be if it is possible to create a page with symfony cli if that is possible and then check that page and route as a proof that symfony was properly set up. but i only found the manual set up of a page and that entailed several steps that also required code snippets. 

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
