### PR TITLE
fix: add ddev_nointeractive to common-setup.bash (per @stasadev)

### DIFF
--- a/docs/tests/common-setup.bash
+++ b/docs/tests/common-setup.bash
@@ -9,6 +9,7 @@ _common_setup() {
     mkdir -p ~/tmp
     tmpdir=$(mktemp -d ~/tmp/${PROJNAME}.XXXXXX)
     export DDEV_NO_INSTRUMENTATION=true
+    export DDEV_NONINTERACTIVE=true
     mkdir -p ${tmpdir} && cd ${tmpdir} || exit 1
     ddev delete -Oy ${PROJNAME:-notset}
 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue
@stasadev suggested in todays discussion adding 
```
export DDEV_NONINTERACTIVE=true
export DDEV_NO_INSTRUMENTATION=true
```
to the common-setup.bash. turned out DDEV_NO_INSTRUMENTATION was already there but this PR is adding the second eng variable alongside. 

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
