### PR TITLE
docs: Update quickstart.md to remove Drupal CMS zip file instructions

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -241,15 +241,6 @@ Read more about customizing the environment and persisting configuration in [Pro
     ddev launch
     ```
 
-    or use the ZIP file download technique:
-
-    ```bash
-    curl -o my-drupal-site.zip -fL https://www.drupal.org/download-latest/cms
-    unzip my-drupal-site.zip && rm -f my-drupal-site.zip
-    cd drupal-cms
-    ./launch-drupal-cms.sh
-    ```
-
     Read more about: [Drupal CMS](https://new.drupal.org/drupal-cms) & [Documentation](https://new.drupal.org/docs/drupal-cms)
 
 === "Drupal 10"

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -127,33 +127,3 @@ teardown() {
   assert_output --partial "HTTP/2 302"
   assert_output --partial "x-generator: Drupal 11 (https://www.drupal.org)"
 }
-
-@test "Drupal CMS zip file quickstart with $(ddev --version)" {
-  skip "Skipping until script doesn't erroneously create a -1 on project name"
-  # curl -o my-drupal-site.zip -fL https://www.drupal.org/download-latest/cms
-  run curl -o my-drupal-site.zip -fL https://www.drupal.org/download-latest/cms
-  assert_success
-  # unzip my-drupal-cms-zip.zip && rm -f my-drupal-cms-zip.zip
-  run unzip my-drupal-site.zip && rm -f my-drupal-site.zip
-  assert_success
-  # mv drupal-cms my-drupal-site
-  # (Not contained in quickstart but necessary to use PROJNAME in this test )
-  run mv drupal-cms my-drupal-site
-  assert_success
-  # Change directory
-  cd ${tmpdir}/${PROJNAME}
-  assert_success
-  # execute launch script
-  run bash -c "DDEV_DEBUG=true ./launch-drupal-cms.sh"
-  assert_success
-  # ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch"
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
-  assert_success
-  # validate running project
-  run curl -sfI https://${PROJNAME}.ddev.site
-  assert_success
-  assert_output --partial "location: /core/install.php"
-  assert_output --partial "HTTP/2 302"
-  assert_output --partial "x-generator: Drupal 11 (https://www.drupal.org)"
-}


### PR DESCRIPTION
## The Issue
The `launch-drupal-cms.sh` script mentioned in the docs is removed from Drupal CMS 1.1.0, which releases tomorrow. We should remove all mention of it from DDEV's docs as well.

## How This PR Solves The Issue

## Manual Testing Instructions
N/A

## Automated Testing Overview
N/A

## Release/Deployment Notes
N/A