### PR TITLE
feat: add MutagenSync annotation for custom commands, for #7053

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -203,7 +203,7 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 
 		// Run the command with mutagen sync or not
 		mutagenSync := false
-		if val, ok := directives["NutagenSync"]; ok {
+		if val, ok := directives["MutagenSync"]; ok {
 			if val == "true" {
 				mutagenSync = true
 			}

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -492,7 +492,9 @@ func makeContainerCmd(app *ddevapp.DdevApp, fullPath, name, service string, exec
 		}
 		app.DockerEnv()
 
-		runMutagenSync(app, mutagenSync)
+		if service == "web" {
+			runMutagenSync(app, mutagenSync)
+		}
 
 		osArgs := []string{}
 		if len(os.Args) > 2 {
@@ -519,7 +521,9 @@ func makeContainerCmd(app *ddevapp.DdevApp, fullPath, name, service string, exec
 			util.Failed("Failed to run %s %v: %v", name, strings.Join(osArgs, " "), err)
 		}
 
-		runMutagenSync(app, mutagenSync)
+		if service == "web" {
+			runMutagenSync(app, mutagenSync)
+		}
 	}
 }
 
@@ -561,11 +565,11 @@ func findDirectivesInScriptCommand(script string) map[string]string {
 }
 
 func runMutagenSync(app *ddevapp.DdevApp, mutagenSync bool) {
-	if mutagenSync {
+	if mutagenSync && app.IsMutagenEnabled() {
 		if status, _ := app.SiteStatus(); status == ddevapp.SiteRunning {
 			err := app.MutagenSyncFlush()
 			if err != nil {
-				util.Warning("failed to app.MutagenSyncFlush: %v", err)
+				util.Warning("Could not flush Mutagen: %v", err)
 			}
 		}
 	}

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -565,7 +565,7 @@ func runMutagenSync(app *ddevapp.DdevApp, mutagenSync bool) {
 		if status, _ := app.SiteStatus(); status == ddevapp.SiteRunning {
 			err := app.MutagenSyncFlush()
 			if err != nil {
-				util.Failed("failed to app.MutagenSyncFlush: %v", err)
+				util.Warning("failed to app.MutagenSyncFlush: %v", err)
 			}
 		}
 	}

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -296,7 +296,7 @@ Example: `## ExecRaw: true`
 
 Use `MutagenSync: true` to ensure [Mutagen](../install/performance.md#mutagen) sync runs before and after the command (where Mutagen is enabled and the project is running).
 
-We recommend using this annotation if your command can modify, add, or remove files in the project directory.
+We recommend using this annotation if your `host` or `web` command can modify, add, or remove files in the project directory.
 
 ## Known Windows Issues
 

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -294,7 +294,7 @@ Example: `## ExecRaw: true`
 
 ### `MutagenSync` Annotation
 
-Use `MutagenSync: true` to ensure [Mutagen](../install/performance.md#mutagen) sync runs before and after the command.
+Use `MutagenSync: true` to ensure [Mutagen](../install/performance.md#mutagen) sync runs before and after the command (where Mutagen is enabled and the project is running).
 
 We recommend using this annotation if your command can modify, add, or remove files in the project directory.
 

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -296,7 +296,7 @@ Example: `## ExecRaw: true`
 
 Use `MutagenSync: true` to ensure [Mutagen](../install/performance.md#mutagen) sync runs before and after the command.
 
-We recommend using this annotation if your command modifies, adds, or removes files in the project directory.
+We recommend using this annotation if your command can modify, add, or remove files in the project directory.
 
 ## Known Windows Issues
 

--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -288,9 +288,15 @@ Use `ExecRaw: true` to pass command arguments directly to the container as-is.
 
 For example, when `ExecRaw` is true, `ddev yarn --help` returns the help for `yarn`, not DDEV's help for the `ddev yarn` command.
 
-We recommend  using this annotation for all container commands. The default behavior is retained to avoid breaking existing commands.
+We recommend using this annotation for all container commands. The default behavior is retained to avoid breaking existing commands.
 
 Example: `## ExecRaw: true`
+
+### `MutagenSync` Annotation
+
+Use `MutagenSync: true` to ensure [Mutagen](../install/performance.md#mutagen) sync runs before and after the command.
+
+We recommend using this annotation if your command modifies, adds, or removes files in the project directory.
 
 ## Known Windows Issues
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/artisan
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/artisan
@@ -7,5 +7,6 @@
 ## Aliases: art
 ## ProjectTypes: laravel
 ## ExecRaw: true
+## MutagenSync: true
 
 php ./artisan "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/cake
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/cake
@@ -6,6 +6,7 @@
 ## Example: "ddev cake bake" or "ddev cake cache clear_all"
 ## ProjectTypes: cakephp
 ## ExecRaw: true
+## MutagenSync: true
 
 php ./bin/cake.php "$@"
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/console
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/console
@@ -6,6 +6,7 @@
 ## Example: "ddev console about" or "ddev console doctrine:schema:update --dump-sql"
 ## ProjectTypes: symfony
 ## ExecRaw: true
+## MutagenSync: true
 
 if [ ! -f bin/console ]; then
   echo 'bin/console does not exist in your project root directory.'

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/craft
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/craft
@@ -6,6 +6,7 @@
 ## Example: "ddev craft db/backup" or "ddev craft db/backup ./my-backups" (see https://craftcms.com/docs/4.x/console-commands.html)
 ## ProjectTypes: craftcms,php
 ## ExecRaw: true
+## MutagenSync: true
 
 if [ "${DDEV_PROJECT_TYPE}" != "craftcms" ]; then
     echo "The craft command is only available in the craftcms project type. You can update this in your project's config file, followed by restarting the DDEV project."

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/drush
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/drush
@@ -7,6 +7,7 @@
 ## Aliases: dr
 ## ProjectTypes: drupal,drupal11,drupal10,drupal9,drupal8,drupal7,backdrop
 ## ExecRaw: true
+## MutagenSync: true
 
 # Ignore anything we find in the mounted global commands
 PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/magento
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/magento
@@ -6,6 +6,7 @@
 ## Example: "ddev magento list" or "ddev magento maintenance:enable" or "ddev magento sampledata:reset"
 ## ProjectTypes: magento2
 ## ExecRaw: true
+## MutagenSync: true
 
 if [ ! -f bin/magento ]; then
   echo 'bin/magento does not exist in your project root directory.'

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/npm
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/npm
@@ -5,5 +5,6 @@
 ## Example: "ddev npm install" or "ddev npm update"
 ## ExecRaw: true
 ## HostWorkingDir: true
+## MutagenSync: true
 
 npm "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/nvm
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/nvm
@@ -5,5 +5,6 @@
 ## Usage: nvm [flags] [args]
 ## Example: "ddev nvm install 6"
 ## ExecRaw: true
+## MutagenSync: true
 
 nvm "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/nvm
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/nvm
@@ -5,6 +5,5 @@
 ## Usage: nvm [flags] [args]
 ## Example: "ddev nvm install 6"
 ## ExecRaw: true
-## MutagenSync: true
 
 nvm "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/php
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/php
@@ -5,5 +5,6 @@
 ## Usage: php [flags] [args]
 ## Example: "ddev php --version"
 ## ExecRaw: true
+## MutagenSync: true
 
 php "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/sake
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/sake
@@ -6,6 +6,7 @@
 ## Example: "ddev sake dev/build" or "ddev sake dev/tasks"
 ## ProjectTypes: silverstripe
 ## ExecRaw: true
+## MutagenSync: true
 
 # Ignore anything we find in the mounted global commands
 PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/typo3
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/typo3
@@ -8,6 +8,7 @@
 ## Example: "ddev typo3 site:list" or "ddev typo3 list" or "ddev typo3 extension:list"
 ## ProjectTypes: typo3
 ## ExecRaw: true
+## MutagenSync: true
 
 # Ignore anything we find in the mounted global commands
 PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/wp
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/wp
@@ -5,6 +5,7 @@
 ## Example: "ddev wp core version" or "ddev wp plugin install user-switching --activate"
 ## ProjectTypes: wordpress
 ## ExecRaw: true
+## MutagenSync: true
 
 # Ignore anything we find in the mounted global commands
 PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/yarn
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/yarn
@@ -6,5 +6,6 @@
 ## Example: "ddev yarn install" or "ddev yarn add learna" or "ddev yarn --cwd web/core add learna"
 ## ExecRaw: true
 ## HostWorkingDir: true
+## MutagenSync: true
 
 yarn "$@"


### PR DESCRIPTION
## The Issue

- #7053
- https://github.com/backdrop-ops/ddev-backdrop-bee/pull/8

We need to have a way to run `ddev mutagen sync` automatically.

## How This PR Solves The Issue

Adds `## MutagenSync: true` annotation.

I added it to the most of our bundled `web` commands.
(I'm not 100% sure of the changes I've made, but I think we'll be able to figure out where we need `MutagenSync` or not in the review.)

## Manual Testing Instructions

```
ddev config global --performance-mode=mutagen
```

And:

```
mkdir my-backdrop-site && cd my-backdrop-site
ddev config --project-type=backdrop
ddev add-on get backdrop-ops/ddev-backdrop-bee
ddev start
ddev bee download-core
ddev bee si --username=admin --password=admin --db-name=db --db-user=db --db-pass=db --db-host=db --auto
ddev launch
```

Mutagen Sync should run before and after each of `ddev bee` commands:

```
$ DDEV_VERBOSE=true DDEV_DEBUG=true ddev bee status 2>&1 | grep 'Mutagen sync status'
2025-03-19T20:10:53.005 Mutagen sync status my-backdrop-site in MutagenSyncFlush(): status='ok', short='watching', err='<nil>'
2025-03-19T20:10:53.698 Mutagen sync status my-backdrop-site in MutagenSyncFlush(): status='ok', short='watching', err='<nil>'
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
