### PR TITLE
fix: make linkspector ignorePatterns work properly, for #6951

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,32 +1,31 @@
 dirs:
   - docs/content
 ignorePatterns:
-  # Ignore internal mkdocs links
-  - pattern: '^(?!https?://)'
-  - pattern: '^https?://127.0.0.1'
-  - pattern: '^https://www.drupal.org/(u|project|about|forum|slack|join-slack)'
-  - pattern: "^https://deb.sury.org"
-  - pattern: "^https://nssm.cc/"
-  - pattern: "^https://www.php.net/manual/"
-  - pattern: "^https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok"
-  - pattern: "^https://.*blackfire.io"
-  - pattern: "^https://twitter.com/search"
-  - pattern: "^https://www.cyberciti.biz/"
-  - pattern: "^https://nightly.link/ddev/ddev/workflows/main-build/main"
-  - pattern: "^https://github.com/ddev/maintainer-info"
-  - pattern: "^https://buildkite.com/organizations/ddev"
-  - pattern: "^https://github.com/orgs/ddev"
-  - pattern: "^https://github.com/watching"
-  - pattern: "^https://newmonitor.thefays.us/icingaweb2"
-  - pattern: "^https://analytics.amplitude.com"
-  - pattern: "^https://(meta.stackoverflow|stackoverflow|superuser).com/"
-  - pattern: "^https://packages.debian.org/stable/"
-  - pattern: "^https://symfony.com"
-  - pattern: "^https://community.chocolatey.org"
-  - pattern: "^https://aur.archlinux.org"
-  - pattern: "^https://team-ddev.1password.com"
-  - pattern: "^https://.*.archive.org"
-  - pattern: "^https://specifications.freedesktop.org"
+  # Ignore internal anchors that are already handled by mkdocs
+  - pattern: ".md#"
+  - pattern: "https://www.drupal.org/project/"
+  - pattern: "https://www.drupal.org/forum/"
+  - pattern: "https://www.drupal.org/join-slack"
+  - pattern: "https://www.php.net/manual/"
+  - pattern: "https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok"
+  - pattern: "https://blackfire.io"
+  - pattern: "https://www.blackfire.io"
+  - pattern: "https://nightly.link/ddev/ddev/workflows/main-build/main"
+  - pattern: "https://github.com/ddev/maintainer-info"
+  - pattern: "https://buildkite.com/organizations/ddev"
+  - pattern: "https://github.com/orgs/ddev"
+  - pattern: "https://github.com/watching"
+  - pattern: "https://newmonitor.thefays.us/icingaweb2"
+  - pattern: "https://analytics.amplitude.com"
+  - pattern: "https://stackoverflow.com"
+  - pattern: "https://meta.stackoverflow.com"
+  - pattern: "https://superuser.com"
+  - pattern: "https://symfony.com"
+  - pattern: "https://community.chocolatey.org"
+  - pattern: "https://aur.archlinux.org"
+  - pattern: "https://team-ddev.1password.com"
+  - pattern: "https://web.archive.org"
+  - pattern: "https://specifications.freedesktop.org"
 aliveStatusCodes:
   - 200
   - 206


### PR DESCRIPTION
## The Issue

From https://github.com/ddev/ddev/actions/runs/13953802513/job/39059819024?pr=7124

```
 message:"Cannot reach ../install/performance.md#mutagen. Status: 404 Cannot find section: #mutagen in file: /home/runner/work/ddev/ddev/docs/content/users/install/performance.md." location:
```

Related:

- #6951

## How This PR Solves The Issue

Our linkspector `ignorePatterns` never worked, we didn't see any errors only because we didn't touch the existing links. (And our action for linkspector used reviewdog, that check *only* for modified links.)

I tested it locally with `make linkspector` and I almost gave up trying to make any regex work. (It just didn't work.)

Finally, I removed all regex related symbols, and it started working properly. 

I removed unused patterns.

And including this pattern `".md#"` made linkspector ignore local links.

## Manual Testing Instructions

Run locally:
```
make linkspector
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
