### PR TITLE
test: adjust openmage bats test assertions to the now available demo content

### DIFF
--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -45,7 +45,8 @@ teardown() {
   # Check if the frontend is working
   run curl -sf https://${PROJNAME}.ddev.site
   assert_success
-  assert_output --partial "2020 OpenMage Demo Store. All Rights Reserved."
+  assert_output --partial "<title>Madison Island</title>"
+  assert_output --partial "<meta name=\"keywords\" content=\"Magento, Varien, E-commerce\" />"
 
   # Check if the admin is working
   run curl -sf https://${PROJNAME}.ddev.site/index.php/admin/


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #7091

<!-- Provide a brief description of the issue. -->

according to randy tests were failing on main for the openmage bats test. turn out the assertion testing the frontend was failing the test. well turns out the fix by stas got already merged https://github.com/OpenMage/magento-lts/pull/4720 and due to the fact the test and quickstart is using `git clone https://github.com/OpenMage/magento-lts .`the fix was already available that way the demo site is completely different: 

![Screenshot 2025-03-19 at 22 17 26](https://github.com/user-attachments/assets/17c710df-e473-4074-8082-7f235f2cb0eb)

adjusted the assertion to the now working demo content. only question is is it a good idea to recommend a quickstart that is living on the edge aka the head for openmage?  ( a good thing in case of the bug but in the long run for less technical folks getting in touch with openmage for the first time i am unsure) 

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
