### PR TITLE
test: improve `ddev debug test`

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -179,7 +179,7 @@ echo "
   3. To remove all containers and images (it doesn't remove your data):
     \`\`\`
     ddev poweroff
-    docker rm -f \$(docker ps -aq)
+    docker rm -f \$(docker ps -aq) || true
     docker rmi -f \$(docker images -q)
     \`\`\`
     (DDEV images will be downloaded again on 'ddev start')"

--- a/pkg/amplitude/amplitude.go
+++ b/pkg/amplitude/amplitude.go
@@ -140,7 +140,7 @@ func Clean() {
 
 // CheckSetUp shows a warning to the user if the API key is not available.
 func CheckSetUp() {
-	if !output.JSONOutput && globalconfig.DdevGlobalConfig.InstrumentationOptIn && versionconstants.AmplitudeAPIKey == "" {
+	if !output.JSONOutput && globalconfig.DdevGlobalConfig.InstrumentationOptIn && !globalconfig.DdevNoInstrumentation && versionconstants.AmplitudeAPIKey == "" {
 		util.Warning("Instrumentation is opted in, but AmplitudeAPIKey is not available. This usually means you have a locally-built ddev binary or one from a PR build. It's not an error. Please report it if you're using an official release build.")
 	}
 }


### PR DESCRIPTION
## The Issue

- `ddev debug test` creates test project, which is probably included to instrumentation
- `curl` on host runs without explicit timeout

## How This PR Solves The Issue

- Adds `export DDEV_NO_INSTRUMENTATION=true` inside the script.
- Runs `DOCKER_HOST="" docker context ls` with empty DOCKER_HOST (because it always shown as a warning, but we set this variable ourselves in DDEV).
- Fixes `printf` warnings shown to me in the IDE.
- Adds `docker system df` output with tips how to clean it.
- Do not show warning about instrumentation in `ddev version` if `DDEV_NO_INSTRUMENTATION=true`.
- Adds `curl --connect-timeout 10 --max-time 20` on the host to prevent people from using `^C`.

## Manual Testing Instructions

Run `ddev debug test`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
