### PR TITLE
docs: ignore mutagen links in linkspector

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -7,7 +7,7 @@ ignorePatterns:
   - pattern: "https://www.drupal.org/forum/"
   - pattern: "https://www.drupal.org/join-slack"
   - pattern: "https://www.php.net/manual/"
-  - pattern: "https://www.drupaleasy.com/blogs/ultimike/2019/06/sharing-your-ddev-local-site-public-url-using-ddev-share-and-ngrok"
+  - pattern: "https://www.drupaleasy.com"
   - pattern: "https://blackfire.io"
   - pattern: "https://www.blackfire.io"
   - pattern: "https://nightly.link/ddev/ddev/workflows/main-build/main"
@@ -26,6 +26,7 @@ ignorePatterns:
   - pattern: "https://team-ddev.1password.com"
   - pattern: "https://web.archive.org"
   - pattern: "https://specifications.freedesktop.org"
+  - pattern: "https://mutagen.io"
 aliveStatusCodes:
   - 200
   - 206


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/actions/runs/13957940211/job/39112163537#step:10:344

```
Pattern exceeds maximum safe length: https://www.drupaleasy.com/blogs/ultimike/2019/06/...
  message:"Cannot reach https://mutagen.io/documentation/synchronization/symbolic-links. Status: 403" location:{path:"docs/content/users/usage/troubleshooting.md" range:{start:{line:345 column:180} end:{line:345 column:259}}} severity:ERROR source:{name:"linkspector" url:"https://github.com/UmbrellaDocs/linkspector"}
```

## How This PR Solves The Issue

- Ignores `https://mutagen.io`
- Shortens the pattern for `https://www.drupaleasy.com`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
