### PR TITLE
fix: sanitize `~/.ddev/project_list.yaml`, fixes #7132

### DIFF
--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -520,6 +520,14 @@ func ReadProjectList() error {
 		return err
 	}
 
+	// Sanitize the project list
+	for name, project := range DdevProjectList {
+		if project == nil || project.AppRoot == "" {
+			logrus.Warningf("Project '%s' in global project list has incomplete configuration and has been ignored.", name)
+			delete(DdevProjectList, name)
+		}
+	}
+
 	// Clean up the deprecated DdevGlobalConfig.ProjectList if it not nil,
 	// but only if the new one DdevProjectList is not nil (for safe migration).
 	if DdevGlobalConfig.ProjectList != nil && DdevProjectList != nil {


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #7132

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

- Checks for `nil`
- Checks for `approot`

## Manual Testing Instructions

Remove `approot` line in:

```
$ cat ~/.ddev/project_list.yaml
d11:
    approot: /home/stas/code/ddev-quickstarts/d11
```

```
$ ddev start d11                
WARN[0000] Project 'd11' in global project list has incomplete configuration and has been ignored. 
Failed to start project(s): could not find requested project 'd11', you may need to use "ddev start" to add it to the project catalog
```

---

Rename `approot` line in:

```
$ cat ~/.ddev/project_list.yaml
d11:
    approot_test: /home/stas/code/ddev-quickstarts/d11
```

```
$ ddev start d11
WARN[0000] Project 'd11' in global project list has incomplete configuration and has been ignored. 
Failed to start project(s): could not find requested project 'd11', you may need to use "ddev start" to add it to the project catalog
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
