### PR TITLE
fix: don't override `generic` type in `ddev config --update`, fixes #7035

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -308,7 +308,7 @@ func init() {
 	ConfigCommand.Flags().Bool("disable-upload-dirs-warning", true, `Disable warnings about upload-dirs not being set when using performance-mode=mutagen.`)
 	ConfigCommand.Flags().StringVar(&ddevVersionConstraint, "ddev-version-constraint", "", `Specify a ddev version constraint to validate ddev against.`)
 	ConfigCommand.Flags().Bool("corepack-enable", true, `Do 'corepack enable' to enable latest yarn/pnpm'`)
-	ConfigCommand.Flags().Bool("update", false, `Update project settings based on detection and project-type overrides`)
+	ConfigCommand.Flags().Bool("update", false, `Update project settings based on detection and project-type overrides (except for 'generic' type)`)
 
 	RootCmd.AddCommand(ConfigCommand)
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -295,7 +295,8 @@ ddev config
 # on every question in `ddev config`
 ddev config --auto
 
-## Detect docroot, project type, and expected defaults for an existing project
+# Detect docroot, project type (except for `generic` type),
+# and expected defaults for an existing project
 ddev config --update
 
 # Configure a Drupal project with a `web` document root

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -397,6 +397,10 @@ func (app *DdevApp) SetApptypeSettingsPaths() {
 // DetectAppType calls each apptype's detector until it finds a match,
 // or returns 'php' as a last resort.
 func (app *DdevApp) DetectAppType() string {
+	// `generic` type should not be overridden
+	if app.Type == nodeps.AppTypeGeneric {
+		return app.Type
+	}
 	var keys []string
 	for k := range appTypeMatrix {
 		keys = append(keys, k)

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -49,6 +49,11 @@ func TestDetectAppType(t *testing.T) {
 
 		foundType := app.DetectAppType()
 		require.EqualValues(t, appType, foundType)
+
+		// `generic` type should not be overridden
+		app.Type = nodeps.AppTypeGeneric
+		foundType = app.DetectAppType()
+		require.EqualValues(t, nodeps.AppTypeGeneric, foundType)
 	}
 }
 


### PR DESCRIPTION
## The Issue

- #7035

## How This PR Solves The Issue

Ignores the app type detection for the `generic` type.

## Manual Testing Instructions

Follow any quickstart https://ddev.readthedocs.io/en/stable/users/quickstart/ and run:

```
ddev config --project-type=generic

# update should not change the project type
ddev config --update
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
