### PR TITLE
fix: make `DDEV_PAGER` optional, update docs for `PAGER`, fixes #7032

### DIFF
--- a/docs/content/users/extend/in-container-configuration.md
+++ b/docs/content/users/extend/in-container-configuration.md
@@ -16,7 +16,7 @@ Usage examples:
 * If you use Git inside the container, you may want to symlink your `~/.gitconfig` into `~/.ddev/homeadditions` or the project’s `.ddev/homeadditions` so that in-container `git` commands use whatever username and email you’ve configured on your host machine. For example, `ln -s ~/.gitconfig ~/.ddev/homeadditions/.gitconfig`.
 * If you use SSH inside the container and want to use your `.ssh/config`, consider `mkdir -p ~/.ddev/homeadditions/.ssh && ln -s ~/.ssh/config ~/.ddev/homeadditions/.ssh/config`. Some people will be able to symlink their entire `.ssh` directory, `ln -s ~/.ssh ~/.ddev/homeadditions/.ssh`. If you provide your own `.ssh/config` though, please make sure it includes these lines:
 
-    ```
+    ```text
     UserKnownHostsFile=/home/.ssh-agent/known_hosts
     StrictHostKeyChecking=accept-new
     ```
@@ -27,6 +27,14 @@ Usage examples:
 * If you have a favorite `.bashrc`, copy it into either the global or project `homeadditions`.
 * If you like the traditional `ll` Bash alias for `ls -l`, add a `.ddev/homeadditions/.bash_aliases` with these contents:
 
-    ```
+    ```bash
     alias ll="ls -lhA"
     ```
+
+## Using `PAGER` Inside Containers
+
+To set the `PAGER` variable in the `web` and `db` containers across all projects, define the `DDEV_PAGER` environment variable in your shell configuration file (e.g., `~/.bashrc` or `~/.zshrc`), outside of DDEV, for example:
+
+```bash
+export DDEV_PAGER="less -SFXR"
+```

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -71,7 +71,9 @@ services:
       - POSTGRES_PASSWORD=db
       - POSTGRES_USER=db
       - POSTGRES_DB=db
-      - PAGER=${DDEV_PAGER-less -SFX}
+      {{- if ne (env "DDEV_PAGER") "" }}
+      - PAGER=${DDEV_PAGER}
+      {{- end }}
       - TZ={{ .Timezone }}
       - USER={{ .Username }}
     command: ${DDEV_DB_CONTAINER_COMMAND}
@@ -225,7 +227,9 @@ services:
     - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-web/mysql_history
     - NODE_EXTRA_CA_CERTS=/mnt/ddev-global-cache/mkcert/rootCA.pem
     - npm_config_cache=/mnt/ddev-global-cache/npm
-    - PAGER=${DDEV_PAGER-less -SFX}
+    {{- if ne (env "DDEV_PAGER") "" }}
+    - PAGER=${DDEV_PAGER}
+    {{- end }}
     - PGDATABASE=db
     - PGHOST=db
     - PGPASSWORD=db


### PR DESCRIPTION
## The Issue

- #6842
- #7032

## How This PR Solves The Issue

- Reads `DDEV_PAGER` from environment outside of DDEV.
- Doesn't set `DDEV_PAGER` value by default.
- Updates documentation.

## Manual Testing Instructions

See https://ddev--7138.org.readthedocs.build/en/7138/users/extend/in-container-configuration/#using-pager-inside-containers

```
export DDEV_PAGER="less -SFXR"
ddev start
ddev exec 'echo $PAGER'
less -SFXR
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
