### PR TITLE
fix: remove XHGui volume for `/run/nginx`, for #7069

### DIFF
--- a/containers/ddev-xhgui/Dockerfile
+++ b/containers/ddev-xhgui/Dockerfile
@@ -1,4 +1,20 @@
-FROM xhgui/xhgui:0.21 AS ddev-xhgui
+FROM xhgui/xhgui:0.21 AS xhgui-docker
+
+FROM alpine:3.15 AS ddev-xhgui
+
+### --------------------------------xhgui-docker----------------------------------
+### XHGui Docker image creates a volume for /run/nginx, which we want to remove.
+### We copy all files from xhgui/xhgui, and set ENV, WORKDIR, CMD, EXPOSE.
+### Source https://github.com/perftools/xhgui/blob/0.21.x/Dockerfile
+COPY --from=xhgui-docker / /
+ENV PHP_INI_DIR=/etc/php7
+ARG APPDIR=/var/www/xhgui
+ARG WEBROOT=$APPDIR/webroot
+WORKDIR $APPDIR
+RUN mkdir -p /run/nginx
+CMD ["sh", "-c", "nginx && exec php-fpm"]
+EXPOSE 80
+### ------------------------------END xhgui-docker--------------------------------
 
 RUN apk add bash curl
 ADD /var /var

--- a/containers/ddev-xhgui/Dockerfile
+++ b/containers/ddev-xhgui/Dockerfile
@@ -1,6 +1,6 @@
 FROM xhgui/xhgui:0.21 AS xhgui-docker
 
-FROM alpine:3.15 AS ddev-xhgui
+FROM scratch AS ddev-xhgui
 
 ### --------------------------------xhgui-docker----------------------------------
 ### XHGui Docker image creates a volume for /run/nginx, which we want to remove.

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -349,7 +349,3 @@ volumes:
     external: true
 
   {{ end }}{{/* end if and .MutagenEnabled (not .NoProjectMount) */}}
-  {{- if eq .XHProfMode "xhgui" }}
-  run_nginx:
-    name: "{{ .Name }}_xhgui_run_nginx"
-  {{ end }}

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -278,10 +278,6 @@ services:
     ports:
       - "{{ $.DockerIP }}:{{ .HostXHGuiPort }}:{{ .XHGuiPort }}"
     {{- end }}
-    {{- if eq .XHProfMode "xhgui" }}
-    volumes:
-      - run_nginx:/run/nginx
-    {{- end }}
 
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -38,7 +38,7 @@ var BusyboxImage = "busybox:stable"
 var XhguiImage = "ddev/ddev-xhgui"
 
 // XhguiTag is xhgui tag
-var XhguiTag = "20250307_rfay_xhgui"
+var XhguiTag = "20250325_stasadev_xhgui_volume"
 
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities"


### PR DESCRIPTION
## The Issue

- #7069
- https://github.com/perftools/xhgui/issues/505

XHGui creates a volume in the [Dockerfile](https://github.com/perftools/xhgui/blob/cec362839f001a7f2f7f681abbcadbe0a26a400b/Dockerfile#L108):

```dockerfile
VOLUME "/run/nginx"
```

Related:

- https://github.com/moby/buildkit/issues/4802#issuecomment-2182544924
- https://github.com/moby/moby/issues/3465#issuecomment-2179958180

## How This PR Solves The Issue

Overrides the parent Dockerfile using this technique:

- https://stackoverflow.com/questions/44020785/remove-a-volume-in-a-dockerfile/78645904

## Manual Testing Instructions

```
# check and remove all xhgui and anonymous volumes
docker volume ls

ddev start
ddev xhgui

# check it again, it should not create any new volumes
docker volume ls
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
