### PR TITLE
fix: db warning on `config --update` should only be shown for default db type

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -440,7 +440,7 @@ func drupalConfigOverrideAction(app *DdevApp) error {
 	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
 		if dbType, err := app.GetExistingDBType(); err == nil && dbType == "" {
 			app.Database = DatabaseDefault
-		} else if app.Database != DatabaseDefault && drupalVersion >= 8 {
+		} else if app.Database.Type == DatabaseDefault.Type && app.Database != DatabaseDefault && drupalVersion >= 8 {
 			defaultType := DatabaseDefault.Type + ":" + DatabaseDefault.Version
 			util.Warning("Default database type is %s, but the current actual database type is %s, you may want to migrate with 'ddev debug migrate-database %s'.", defaultType, dbType, defaultType)
 		}


### PR DESCRIPTION
## The Issue

@rfay noticed this:

```
$ ddev config --update
You are reconfiguring the project at /home/stas/code/ddev-quickstarts/d11.
The existing configuration will be updated and replaced.
Auto-updating project configuration because update is requested.
Configuring a 'drupal11' project with docroot 'web' at '/home/stas/code/ddev-quickstarts/d11/web'
Default database type is mariadb:10.11, but the current actual database type is postgres:16, you may want to migrate with 'ddev debug migrate-database mariadb:10.11'.
Configuration complete. You may now run 'ddev start'.
```

Where:
```
Default database type is mariadb:10.11, but the current actual database type is postgres:16, you may want to migrate with 'ddev debug migrate-database mariadb:10.11'.
```

We should not suggest changing the database unless it is MariaDB.

## How This PR Solves The Issue

Adds check for the database type.

## Manual Testing Instructions

Using Drupal quickstart https://ddev.readthedocs.io/en/stable/users/quickstart/#drupal

Should NOT show a warning about db:
```
ddev delete -Oy
ddev config --database=postgres:16
ddev start
ddev config --update
You are reconfiguring the project at /home/stas/code/ddev-quickstarts/d11.
The existing configuration will be updated and replaced.
Auto-updating project configuration because update is requested.
Configuring a 'drupal11' project with docroot 'web' at '/home/stas/code/ddev-quickstarts/d11/web'
Configuration complete. You may now run 'ddev start'.
```

Should show a warning about db:

```
ddev delete -Oy
ddev config --database=mariadb:10.3
ddev start
ddev config --update
You are reconfiguring the project at /home/stas/code/ddev-quickstarts/d11.
The existing configuration will be updated and replaced.
Auto-updating project configuration because update is requested.
Configuring a 'drupal11' project with docroot 'web' at '/home/stas/code/ddev-quickstarts/d11/web'
Default database type is mariadb:10.11, but the current actual database type is mariadb:10.3, you may want to migrate with 'ddev debug migrate-database mariadb:10.11'.
Configuration complete. You may now run 'ddev start'.
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
