### PR TITLE
fix: reload app hooks after uninstalling ddev-xhgui add-on, fixes #7144

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -840,6 +840,13 @@ func (app *DdevApp) FixObsolete() {
 		if err != nil {
 			util.Warning("Error removing xhgui add-on: %v", err)
 		}
+		// Reload the hooks because we don't want to run the deleted hooks
+		appCopy, err := NewApp(app.AppRoot, true)
+		if err != nil {
+			util.Warning("Error reloading app hooks after removing xhgui add-on: %v", err)
+		} else {
+			app.Hooks = appCopy.Hooks
+		}
 	}
 }
 


### PR DESCRIPTION
## The Issue

- #7144

```
cp: cannot stat '/var/www/html/.ddev/xhgui_prepend.php': No such file or directory
exit status 1
Task failed: Exec command 'cp /var/www/html/.ddev/xhgui_prepend.php /var/www/html/.ddev/xhprof/xhprof_prepend.php
' in container/service 'web': exit status 1 
A task failure does not mean that DDEV failed, but your hook configuration has a command that failed. 
```

## How This PR Solves The Issue

Reloads the hooks after the add-on is removed.

## Manual Testing Instructions

Using this PR, there should be no error on `ddev start`:

```
ddev stop
ddev add-on get ddev/ddev-xhgui
ddev start
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
