### PR TITLE
fix: don't wait for one-off containers from PhpStorm, fixes #7146

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -200,6 +200,7 @@ func (app *DdevApp) FindContainerByType(containerType string) (*dockerContainer.
 	labels := map[string]string{
 		"com.ddev.site-name":         app.GetName(),
 		"com.docker.compose.service": containerType,
+		"com.docker.compose.oneoff":  "False",
 	}
 
 	return dockerutil.FindContainerByLabels(labels)
@@ -1736,7 +1737,10 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 	}
 
-	waitLabels := map[string]string{"com.ddev.site-name": app.GetName()}
+	waitLabels := map[string]string{
+		"com.ddev.site-name":        app.GetName(),
+		"com.docker.compose.oneoff": "False",
+	}
 	containersAwaited, err := dockerutil.FindContainersByLabels(waitLabels)
 	if err != nil {
 		return err
@@ -2290,7 +2294,10 @@ func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tailLines
 	var err error
 	// Let people access ddev-router and ddev-ssh-agent logs as well.
 	if service == "ddev-router" || service == "ddev-ssh-agent" {
-		container, err = dockerutil.FindContainerByLabels(map[string]string{"com.docker.compose.service": service})
+		container, err = dockerutil.FindContainerByLabels(map[string]string{
+			"com.docker.compose.service": service,
+			"com.docker.compose.oneoff":  "False",
+		})
 	} else {
 		container, err = app.FindContainerByType(service)
 	}
@@ -2337,7 +2344,10 @@ func (app *DdevApp) CaptureLogs(service string, timestamps bool, tailLines strin
 	var err error
 	// Let people access ddev-router and ddev-ssh-agent logs as well.
 	if service == "ddev-router" || service == "ddev-ssh-agent" {
-		container, err = dockerutil.FindContainerByLabels(map[string]string{"com.docker.compose.service": service})
+		container, err = dockerutil.FindContainerByLabels(map[string]string{
+			"com.docker.compose.service": service,
+			"com.docker.compose.oneoff":  "False",
+		})
 	} else {
 		container, err = app.FindContainerByType(service)
 	}
@@ -2593,7 +2603,8 @@ func (app *DdevApp) WaitForServices() error {
 	output.UserOut.Printf("Waiting for these services to become ready: %v", requiredContainers)
 
 	labels := map[string]string{
-		"com.ddev.site-name": app.GetName(),
+		"com.ddev.site-name":        app.GetName(),
+		"com.docker.compose.oneoff": "False",
 	}
 	waitTime := app.GetMaxContainerWaitTime()
 	_, err := dockerutil.ContainerWait(waitTime, labels)
@@ -2609,6 +2620,7 @@ func (app *DdevApp) Wait(requiredContainers []string) error {
 		labels := map[string]string{
 			"com.ddev.site-name":         app.GetName(),
 			"com.docker.compose.service": containerType,
+			"com.docker.compose.oneoff":  "False",
 		}
 		waitTime := app.GetMaxContainerWaitTime()
 		logOutput, err := dockerutil.ContainerWait(waitTime, labels)
@@ -3170,6 +3182,7 @@ func GetActiveAppRoot(siteName string) (string, error) {
 		labels := map[string]string{
 			"com.ddev.site-name":         siteName,
 			"com.docker.compose.service": "web",
+			"com.docker.compose.oneoff":  "False",
 		}
 
 		webContainer, err := dockerutil.FindContainerByLabels(labels)

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -166,7 +166,10 @@ func StartDdevRouter() error {
 	}
 
 	// Ensure we have a happy router
-	label := map[string]string{"com.docker.compose.service": nodeps.RouterContainer}
+	label := map[string]string{
+		"com.docker.compose.service": nodeps.RouterContainer,
+		"com.docker.compose.oneoff":  "False",
+	}
 	// Normally the router comes right up, but when
 	// it has to do let's encrypt updates, it can take
 	// some time.
@@ -262,6 +265,7 @@ func generateRouterCompose() (string, error) {
 func FindDdevRouter() (*dockerContainer.Summary, error) {
 	containerQuery := map[string]string{
 		"com.docker.compose.service": nodeps.RouterContainer,
+		"com.docker.compose.oneoff":  "False",
 	}
 	container, err := dockerutil.FindContainerByLabels(containerQuery)
 	if err != nil {

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -158,6 +158,7 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 func findDdevSSHAuth() (*dockerContainer.Summary, error) {
 	containerQuery := map[string]string{
 		"com.docker.compose.project": SSHAuthName,
+		"com.docker.compose.oneoff":  "False",
 	}
 
 	container, err := dockerutil.FindContainerByLabels(containerQuery)

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -64,7 +64,10 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 	}
 
 	// ensure we have a happy sshAuth
-	label := map[string]string{"com.docker.compose.project": SSHAuthName}
+	label := map[string]string{
+		"com.docker.compose.project": SSHAuthName,
+		"com.docker.compose.oneoff":  "False",
+	}
 	sshWaitTimeout := 60
 	util.Debug(`Waiting for ddev-ssh-agent to become ready, timeout=%v`, sshWaitTimeout)
 	logOutput, err := dockerutil.ContainerWait(sshWaitTimeout, label)
@@ -183,7 +186,10 @@ func RenderSSHAuthStatus() string {
 // GetSSHAuthStatus outputs sshAuth status and warning if not
 // running or healthy, as applicable.
 func GetSSHAuthStatus() string {
-	label := map[string]string{"com.docker.compose.project": SSHAuthName}
+	label := map[string]string{
+		"com.docker.compose.project": SSHAuthName,
+		"com.docker.compose.oneoff":  "False",
+	}
 	container, err := dockerutil.FindContainerByLabels(label)
 
 	if err != nil {

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -32,6 +32,7 @@ func GetActiveProjects() []*DdevApp {
 	labels := map[string]string{
 		"com.ddev.platform":          "ddev",
 		"com.docker.compose.service": "web",
+		"com.docker.compose.oneoff":  "False",
 	}
 	containers, err := dockerutil.FindContainersByLabels(labels)
 

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -336,6 +336,8 @@ func FindContainersByLabels(labels map[string]string) ([]dockerContainer.Summary
 		}
 		filterList.Add("label", label)
 	}
+	// Don't include one-off containers, e.g. containers created by PhpStorm
+	filterList.Add("label", "com.docker.compose.oneoff=False")
 
 	ctx, client := GetDockerClient()
 	containers, err := client.ContainerList(ctx, dockerContainer.ListOptions{
@@ -345,7 +347,7 @@ func FindContainersByLabels(labels map[string]string) ([]dockerContainer.Summary
 	if err != nil {
 		return nil, err
 	}
-	return filterPhantomContainers(containers), nil
+	return containers, nil
 }
 
 // FindContainersWithLabel returns all containers with the given label
@@ -353,41 +355,18 @@ func FindContainersByLabels(labels map[string]string) ([]dockerContainer.Summary
 func FindContainersWithLabel(label string) ([]dockerContainer.Summary, error) {
 	ctx, client := GetDockerClient()
 	containers, err := client.ContainerList(ctx, dockerContainer.ListOptions{
-		All:     true,
-		Filters: dockerFilters.NewArgs(dockerFilters.KeyValuePair{Key: "label", Value: label}),
+		All: true,
+		Filters: dockerFilters.NewArgs(
+			dockerFilters.KeyValuePair{Key: "label", Value: label},
+			// Don't include one-off containers, e.g. containers created by PhpStorm
+			dockerFilters.KeyValuePair{Key: "label", Value: "com.docker.compose.oneoff=False"},
+		),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return filterPhantomContainers(containers), nil
-}
-
-// filterPhantomContainers removes phantom containers (not created by DDEV) from the provided slice.
-// PhpStorm can create containers based on `.ddev/.ddev-docker-compose-full.yaml` to run tasks,
-// leaving them in an exited state, which breaks `ddev describe`.
-// These containers are automatically removed by `ddev stop`, so filtering them is sufficient.
-func filterPhantomContainers(containers []dockerContainer.Summary) []dockerContainer.Summary {
-	// Map to track containers by com.docker.compose.service label
-	containerMap := make(map[string]dockerContainer.Summary)
-	for _, container := range containers {
-		serviceLabel := container.Labels["com.docker.compose.service"]
-		// Assign a unique key if the service label is empty
-		if serviceLabel == "" {
-			serviceLabel = fmt.Sprintf("no-service-label-%s", container.ID)
-		}
-		_, exists := containerMap[serviceLabel]
-		// If there's no existing container or the container name ends with the service label, prioritize this one
-		if !exists || (len(container.Names) > 0 && strings.HasSuffix(container.Names[0], serviceLabel)) {
-			containerMap[serviceLabel] = container
-		}
-	}
-	// Convert map values back into a slice
-	filteredContainers := make([]dockerContainer.Summary, 0, len(containerMap))
-	for _, container := range containerMap {
-		filteredContainers = append(filteredContainers, container)
-	}
-	return filteredContainers
+	return containers, nil
 }
 
 // FindImagesByLabels takes a map of label names and values and returns any Docker images which match all labels.

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -345,7 +345,7 @@ func FindContainersByLabels(labels map[string]string) ([]dockerContainer.Summary
 	if err != nil {
 		return nil, err
 	}
-	return filterFantomContainers(containers), nil
+	return filterPhantomContainers(containers), nil
 }
 
 // FindContainersWithLabel returns all containers with the given label
@@ -360,14 +360,14 @@ func FindContainersWithLabel(label string) ([]dockerContainer.Summary, error) {
 		return nil, err
 	}
 
-	return filterFantomContainers(containers), nil
+	return filterPhantomContainers(containers), nil
 }
 
-// filterFantomContainers removes fantom containers (not created by DDEV) from the provided slice.
+// filterPhantomContainers removes phantom containers (not created by DDEV) from the provided slice.
 // PhpStorm can create containers based on `.ddev/.ddev-docker-compose-full.yaml` to run tasks,
 // leaving them in an exited state, which breaks `ddev describe`.
 // These containers are automatically removed by `ddev stop`, so filtering them is sufficient.
-func filterFantomContainers(containers []dockerContainer.Summary) []dockerContainer.Summary {
+func filterPhantomContainers(containers []dockerContainer.Summary) []dockerContainer.Summary {
 	// Map to track containers by com.docker.compose.service label
 	containerMap := make(map[string]dockerContainer.Summary)
 	for _, container := range containers {

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -47,7 +47,8 @@ func testMain(m *testing.M) int {
 	_ = os.Setenv("MUTAGEN_DATA_DIRECTORY", globalconfig.GetMutagenDataDirectory())
 
 	labels := map[string]string{
-		"com.ddev.site-name": testContainerName,
+		"com.ddev.site-name":        testContainerName,
+		"com.docker.compose.oneoff": "False",
 	}
 
 	// Prep Docker container for Docker util tests
@@ -90,7 +91,10 @@ func testMain(m *testing.M) int {
 	}()
 
 	log.Printf("ContainerWait at %v", time.Now())
-	out, err := dockerutil.ContainerWait(60, map[string]string{"com.ddev.site-name": testContainerName})
+	out, err := dockerutil.ContainerWait(60, map[string]string{
+		"com.ddev.site-name":        testContainerName,
+		"com.docker.compose.oneoff": "False",
+	})
 	log.Printf("ContainerWait returrned at %v out='%s' err='%v'", time.Now(), out, err)
 
 	if err != nil {
@@ -135,7 +139,8 @@ func TestGetContainerHealth(t *testing.T) {
 	ctx, client := dockerutil.GetDockerClient()
 
 	labels := map[string]string{
-		"com.ddev.site-name": testContainerName,
+		"com.ddev.site-name":        testContainerName,
+		"com.docker.compose.oneoff": "False",
 	}
 
 	t.Cleanup(func() {
@@ -183,7 +188,8 @@ func TestContainerWait(t *testing.T) {
 	assert := asrt.New(t)
 
 	labels := map[string]string{
-		"com.ddev.site-name": testContainerName,
+		"com.ddev.site-name":        testContainerName,
+		"com.docker.compose.oneoff": "False",
 	}
 
 	// We should have `testContainerName' already running, it was started by
@@ -344,7 +350,10 @@ func TestComposeWithStreams(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = dockerutil.ContainerWait(60, map[string]string{"com.ddev.site-name": t.Name()})
+	_, err = dockerutil.ContainerWait(60, map[string]string{
+		"com.ddev.site-name":        t.Name(),
+		"com.docker.compose.oneoff": "False",
+	})
 	if err != nil {
 		logout, _ := exec.RunCommand("docker", []string{"logs", t.Name()})
 		inspectOut, _ := exec.RunCommandPipe("sh", []string{"-c", fmt.Sprintf("docker inspect %s|jq -r '.[0].State.Health.Log'", t.Name())})
@@ -439,7 +448,10 @@ func TestFindContainerByName(t *testing.T) {
 func TestGetContainerEnv(t *testing.T) {
 	assert := asrt.New(t)
 
-	container, err := dockerutil.FindContainerByLabels(map[string]string{"com.ddev.site-name": testContainerName})
+	container, err := dockerutil.FindContainerByLabels(map[string]string{
+		"com.ddev.site-name":        testContainerName,
+		"com.docker.compose.oneoff": "False",
+	})
 	assert.NoError(err)
 	require.NotEmpty(t, container)
 
@@ -502,7 +514,10 @@ func TestRunSimpleContainer(t *testing.T) {
 func TestGetBoundHostPorts(t *testing.T) {
 	assert := asrt.New(t)
 
-	testContainer, err := dockerutil.FindContainerByLabels(map[string]string{"com.ddev.site-name": testContainerName})
+	testContainer, err := dockerutil.FindContainerByLabels(map[string]string{
+		"com.ddev.site-name":        testContainerName,
+		"com.docker.compose.oneoff": "False",
+	})
 	require.NoError(t, err)
 	require.NotNil(t, testContainer)
 	ports, err := dockerutil.GetBoundHostPorts(testContainer.ID)

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -117,7 +117,11 @@ func startTestContainer() (string, error) {
 		"HOTDOG=superior-to-corndog",
 		"POTATO=future-fry",
 		"DDEV_WEBSERVER_TYPE=nginx-fpm",
-	}, nil, "33", false, true, map[string]string{"com.docker.compose.service": "web", "com.ddev.site-name": testContainerName}, portBinding, nil)
+	}, nil, "33", false, true, map[string]string{
+		"com.docker.compose.service": "web",
+		"com.ddev.site-name":         testContainerName,
+		"com.docker.compose.oneoff":  "False",
+	}, portBinding, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## The Issue

- #7146

Related:
- https://github.com/php-perfect/ddev-intellij-plugin/issues/408
- #6125

Possibly related:

- #6085

## How This PR Solves The Issue

Filter them out by looking at the `com.docker.compose.oneoff` label.

I didn't find any documentation on this, but it's well documented in the source code:

- https://github.com/docker/compose/blob/7bedb5a02c8b5f6075806112bc051b3741b609ee/pkg/api/labels.go#L46-L47

```go
// OneoffLabel stores value 'True' for one-off containers created by `compose run`
OneoffLabel = "com.docker.compose.oneoff"
```

- https://github.com/docker/compose/pull/8960/files

```go
api.OneoffLabel: "False", // default, will be overridden by `run` command
```

Containers created by `docker-compose up` have `com.docker.compose.oneoff=False`
Containers created by `docker-compose run` have `com.docker.compose.oneoff=True`

```
$ docker ps -a                                                                          
CONTAINER ID   COMMAND                  CREATED              STATUS                          NAMES
580b7416d304   "composer -V"            About a minute ago   Exited (0) About a minute ago   ddev-d11-web-run-c3134505ca7c
92174a7349a0   "/pre-start.sh"          32 minutes ago       Up 32 minutes (healthy)         ddev-d11-web
```

The created "exited" container has a different name that we can use for comparison.

## Manual Testing Instructions

```
ddev start

~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml run web composer -V

# check for exited container
docker ps -a

# should work
ddev describe

# should show OK for the project
ddev list
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
