### PR TITLE
fix: delete third-party built images on `ddev delete`

### DIFF
--- a/cmd/ddev/cmd/delete_test.go
+++ b/cmd/ddev/cmd/delete_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/ddev/ddev/pkg/ddevapp"
+	ddevImages "github.com/ddev/ddev/pkg/docker"
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDeleteCmd ensures that `ddev delete` removes expected data
+func TestDeleteCmd(t *testing.T) {
+	assert := asrt.New(t)
+
+	origDir, _ := os.Getwd()
+	site := TestSites[0]
+	err := os.Chdir(site.Dir)
+	require.NoError(t, err)
+	app, err := ddevapp.GetActiveApp("")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		out, err := exec.RunHostCommand(DdevBin, "add-on", "remove", "busybox")
+		assert.NoError(err, "output='%s'", out)
+		out, err = exec.RunHostCommand(DdevBin, "delete", "-Oy", site.Name)
+		assert.NoError(err, "output='%s'", out)
+		// And register the project again in the global list for other tests
+		out, err = exec.RunHostCommand(DdevBin, "config", "--auto")
+		assert.NoError(err, "output='%s'", out)
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+	})
+
+	out, err := exec.RunHostCommand(DdevBin, "add-on", "get", filepath.Join(origDir, "testdata", t.Name(), "busybox"))
+	require.NoError(t, err, "out=%s", out)
+
+	out, err = exec.RunHostCommand(DdevBin, "start", "-y")
+	require.NoError(t, err, "out=%s", out)
+
+	out, err = exec.RunHostCommand(DdevBin, "delete", "-Oy", app.Name)
+	require.NoError(t, err, "unable to ddev restart: %v, output='%s'", err, out)
+
+	// Check that volumes are deleted
+	vols := []string{
+		app.GetMariaDBVolumeName(),
+		app.GetPostgresVolumeName(),
+	}
+	if app.IsMutagenEnabled() {
+		vols = append(vols, ddevapp.GetMutagenVolumeName(app))
+	}
+	if globalconfig.DdevGlobalConfig.NoBindMounts {
+		vols = append(vols, app.Name+"-ddev-config")
+	}
+	for _, volName := range vols {
+		assert.Contains(out, fmt.Sprintf("Volume %s for project %s was deleted", volName, app.Name))
+		assert.False(dockerutil.VolumeExists(volName))
+	}
+	assert.Contains(out, "Deleting third-party persistent volume third-party-tmp-busybox-volume")
+
+	// Check that images are deleted
+	imgs := []string{
+		"ddev-" + strings.ToLower(app.Name) + "-busybox:latest",
+		app.GetDBImage() + "-" + app.Name + "-built",
+		ddevImages.GetWebImage() + "-" + app.Name + "-built",
+	}
+	for _, img := range imgs {
+		assert.Contains(out, fmt.Sprintf("Image %s for project %s was deleted", img, app.Name))
+	}
+
+	labels := map[string]string{
+		"com.docker.compose.project": app.GetComposeProjectName(),
+	}
+	images, err := dockerutil.FindImagesByLabels(labels, false)
+	require.NoError(t, err)
+	assert.Len(images, 0)
+}

--- a/cmd/ddev/cmd/delete_test.go
+++ b/cmd/ddev/cmd/delete_test.go
@@ -39,13 +39,13 @@ func TestDeleteCmd(t *testing.T) {
 	})
 
 	out, err := exec.RunHostCommand(DdevBin, "add-on", "get", filepath.Join(origDir, "testdata", t.Name(), "busybox"))
-	require.NoError(t, err, "out=%s", out)
+	require.NoError(t, err, "failed to add-on get, out=%s, err=%v", out, err)
 
 	out, err = exec.RunHostCommand(DdevBin, "start", "-y")
-	require.NoError(t, err, "out=%s", out)
+	require.NoError(t, err, "failed to start, out=%s, err=%v", out, err)
 
 	out, err = exec.RunHostCommand(DdevBin, "delete", "-Oy", app.Name)
-	require.NoError(t, err, "unable to ddev restart: %v, output='%s'", err, out)
+	require.NoError(t, err, "failed to delete, out=%s, err=%v", out, err)
 
 	// Check that volumes are deleted
 	vols := []string{

--- a/cmd/ddev/cmd/testdata/TestDeleteCmd/busybox/busybox/Dockerfile
+++ b/cmd/ddev/cmd/testdata/TestDeleteCmd/busybox/busybox/Dockerfile
@@ -1,0 +1,2 @@
+#ddev-generated
+FROM busybox:stable

--- a/cmd/ddev/cmd/testdata/TestDeleteCmd/busybox/docker-compose.busybox.yaml
+++ b/cmd/ddev/cmd/testdata/TestDeleteCmd/busybox/docker-compose.busybox.yaml
@@ -1,0 +1,20 @@
+#ddev-generated
+services:
+  busybox:
+    container_name: ddev-${DDEV_SITENAME}-busybox
+    build:
+      context: busybox
+    command: tail -f /dev/null
+    restart: "no"
+    # These labels ensure this service is discoverable by ddev.
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    volumes:
+      - ".:/mnt/ddev_config"
+      - "ddev-global-cache:/mnt/ddev-global-cache"
+      - "busybox:/tmp"
+
+volumes:
+  busybox:
+    name: third-party-tmp-busybox-volume

--- a/cmd/ddev/cmd/testdata/TestDeleteCmd/busybox/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestDeleteCmd/busybox/install.yaml
@@ -1,0 +1,6 @@
+#ddev-generated
+name: busybox
+
+project_files:
+  - docker-compose.busybox.yaml
+  - busybox/Dockerfile

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2928,20 +2928,18 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 			vols = append(vols, app.Name+"-ddev-config")
 		}
 		for _, volName := range vols {
-			err = dockerutil.RemoveVolume(volName)
-			if err != nil {
-				util.Warning("Could not remove volume %s: %v", volName, err)
-			} else {
-				util.Success("Volume %s for project %s was deleted", volName, app.Name)
+			if dockerutil.VolumeExists(volName) {
+				err = dockerutil.RemoveVolume(volName)
+				if err != nil {
+					util.Warning("Could not remove volume %s: %v", volName, err)
+				} else {
+					util.Success("Volume %s for project %s was deleted", volName, app.Name)
+				}
 			}
 		}
 		deleteServiceVolumes(app)
+		deleteImages(app)
 
-		dbBuilt := app.GetDBImage() + "-" + app.Name + "-built"
-		_ = dockerutil.RemoveImage(dbBuilt)
-
-		webBuilt := ddevImages.GetWebImage() + "-" + app.Name + "-built"
-		_ = dockerutil.RemoveImage(webBuilt)
 		util.Success("Project %s was deleted. Your code and configuration are unchanged.", app.Name)
 	}
 
@@ -2981,6 +2979,30 @@ func deleteServiceVolumes(app *DdevApp) {
 			}
 		}
 	}
+}
+
+// deleteImages finds all the app images created by docker-compose and removes them.
+func deleteImages(app *DdevApp) {
+	labels := map[string]string{
+		"com.docker.compose.project": app.GetComposeProjectName(),
+	}
+	images, err := dockerutil.FindImagesByLabels(labels, false)
+	if err != nil {
+		util.Warning("Could not find images for project %s: %v", app.Name, err)
+	}
+	for _, img := range images {
+		_ = dockerutil.RemoveImage(img.ID)
+		if err != nil {
+			util.Warning("Could not remove image %s: %v", strings.Join(img.RepoTags, ", "), err)
+		} else {
+			util.Success("Image %s for project %s was deleted", strings.Join(img.RepoTags, ", "), app.Name)
+		}
+	}
+	// These images should already be deleted, but just in case, delete these two by name
+	dbBuilt := app.GetDBImage() + "-" + app.Name + "-built"
+	_ = dockerutil.RemoveImage(dbBuilt)
+	webBuilt := ddevImages.GetWebImage() + "-" + app.Name + "-built"
+	_ = dockerutil.RemoveImage(webBuilt)
 }
 
 // RemoveGlobalProjectInfo deletes the project from DdevProjectList


### PR DESCRIPTION
## The Issue

@rpkoller noticed that if you have an add-on and that add-on has its own `Dockerfile`, the create image is not deleted on `ddev delete -Oy`

It should remove created `ddev-<project-name>-solr` image, which is not removed in v1.24.3:

```
ddev add-on get ddev/ddev-solr
ddev start
ddev delete -Oy

# image is not removed
$ docker images | grep solr
ddev-d11-solr
```

## How This PR Solves The Issue

- Goes through each image with `com.docker.compose.project=<project-name>` label and removes it.
- Doesn't say `Volume ... was deleted` if that volume is already removed.
- Adds test coverage for `ddev delete`

## Manual Testing Instructions

```
ddev add-on get ddev/ddev-solr
ddev start
```

And
```
$ ddev delete -Oy
 Container ddev-d11-db  Stopped 
 Container ddev-d11-web  Stopped 
 Container ddev-d11-solr  Stopped 
 Container ddev-d11-web  Stopped 
 Container ddev-d11-db  Stopped 
 Container ddev-d11-db  Removed 
 Container ddev-d11-web  Removed 
 Container ddev-d11-solr  Stopped 
 Container ddev-d11-solr  Removed 
 Network ddev-d11_default  Removed 
Volume d11-mariadb for project d11 was deleted 
Volume d11-postgres for project d11 was deleted 
Deleting third-party persistent volume ddev-d11_solr 
Image ddev-d11-solr:latest for project d11 was deleted 
Image ddev/ddev-webserver:20250307_rfay_xhgui-d11-built for project d11 was deleted 
Image ddev/ddev-dbserver-mysql-8.0:v1.24.3-d11-built for project d11 was deleted 
Project d11 was deleted. Your code and configuration are unchanged.
```

If I run it once more (No repeating for `Volume ... was deleted`):
```
$ ddev delete -Oy
Project d11 was deleted. Your code and configuration are unchanged.
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
