### PR TITLE
fix: show correct ephemeral router ports in `ddev describe`, make generic webserver work with ephemeral ports

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -206,6 +206,8 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 			}
 			t.AppendRow(table.Row{"Mailpit", "", fmt.Sprintf("Mailpit: %s\nLaunch: ddev mailpit", mailpitURL)})
 
+			ddevapp.SyncGenericWebserverPortsWithRouterPorts(app)
+
 			//WebExtraExposedPorts stanza
 			for _, extraPort := range app.WebExtraExposedPorts {
 				if app.CanUseHTTPOnly() {

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -514,7 +514,7 @@ func GetAvailableRouterPort(proposedPort string, minPort, maxPort int) (string, 
 	return proposedPort, strconv.Itoa(ephemeralPort), true
 }
 
-// GetEphemeralPortsIfNeeded() replaces the provided ports with an ephemeral version if they need it.
+// GetEphemeralPortsIfNeeded replaces the provided ports with an ephemeral version if they need it.
 func GetEphemeralPortsIfNeeded(ports []*string, verbose bool) {
 	for _, port := range ports {
 		proposedPort, replacementPort, portChangeRequired := GetAvailableRouterPort(*port, MinEphemeralPort, MaxEphemeralPort)
@@ -523,6 +523,28 @@ func GetEphemeralPortsIfNeeded(ports []*string, verbose bool) {
 			if verbose {
 				output.UserOut.Printf("Port %s is busy, using %s instead, see %s", proposedPort, replacementPort, "https://ddev.com/s/port-conflict")
 			}
+		}
+	}
+}
+
+// AssignRouterPortsToGenericWebserverPorts assigns the router ports to the generic webserver.
+// If it's a generic webserver, use the first pair of exposed ports as router ports.
+func AssignRouterPortsToGenericWebserverPorts(app *DdevApp) {
+	if app.WebserverType == nodeps.WebserverGeneric && len(app.WebExtraExposedPorts) > 0 {
+		app.RouterHTTPPort = strconv.Itoa(app.WebExtraExposedPorts[0].HTTPPort)
+		app.RouterHTTPSPort = strconv.Itoa(app.WebExtraExposedPorts[0].HTTPSPort)
+	}
+}
+
+// SyncGenericWebserverPortsWithRouterPorts syncs the generic webserver ports with the router ports.
+// If the used ephemeral router ports are different, the first pair webserver ports should be updated.
+func SyncGenericWebserverPortsWithRouterPorts(app *DdevApp) {
+	if app.WebserverType == nodeps.WebserverGeneric && len(app.WebExtraExposedPorts) > 0 {
+		if httpPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPPort()); err == nil {
+			app.WebExtraExposedPorts[0].HTTPPort = httpPort
+		}
+		if httpsPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPSPort()); err == nil {
+			app.WebExtraExposedPorts[0].HTTPSPort = httpsPort
 		}
 	}
 }


### PR DESCRIPTION
## The Issue

From https://discord.com/channels/664580571770388500/1352433228966789150

`ddev describe` shows incorrect project URL, without the correct ephemeral port.

Caused by changes to `ddevapp.go` in:

- #6935

To reproduce:

```
$ ddev poweroff

# leave it running
$ docker run -it --rm -p 80:80 -p 443:443 busybox sh

# in another terminal window
$ ddev start
Starting d11... 
Port 80 is busy, using 33000 instead, see https://ddev.com/s/port-conflict 
Port 443 is busy, using 33001 instead, see https://ddev.com/s/port-conflict
...
Your project can be reached at https://d11.ddev.site:33001

# describe doesn't show https://d11.ddev.site:33001 and http://d11.ddev.site:33000
$ ddev describe
...
├──────────────┼──────┼─────────────────────────────────────────────────┤
│ Project URLs │      │ https://127.0.0.1:33151, http://127.0.0.1:33150 │
└──────────────┴──────┴─────────────────────────────────────────────────┘

$ ddev describe -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.httpURLs'
[
  "http://127.0.0.1:33150"
]

$ ddev describe -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.httpsURLs'
[
  "https://127.0.0.1:33151"
]
```

Additionally:

I noticed that `generic` webserver tries to use ephemeral ports, but fails:

Using svetlekit quickstart https://ddev.readthedocs.io/en/stable/users/quickstart/#nodejs

```
$ ddev poweroff

# leave it running
$ docker run -it --rm -p 80:80 -p 443:443 busybox sh

$ ddev start
Starting my-sveltekit-site... 
Port 80 is busy, using 33000 instead, see https://ddev.com/s/port-conflict 
Port 443 is busy, using 33001 instead, see https://ddev.com/s/port-conflict 
Building project images....
Project images built in 2s. 
 Network ddev-my-sveltekit-site_default  Created 
 Container ddev-my-sveltekit-site-web  Created 
 Container ddev-my-sveltekit-site-db  Created 
 Container ddev-my-sveltekit-site-db  Started 
 Container ddev-my-sveltekit-site-web  Started 
Waiting for containers to become ready: [web db] 
Starting web_extra_daemons... 
Starting ddev-router if necessary... 
Failed to start my-sveltekit-site: unable to listen on required ports, port 443 is already in use,
Troubleshooting suggestions at https://ddev.readthedocs.io/en/stable/users/usage/troubleshooting/#unable-listen
```

When there is nothing to expose, and default ports are busy, DDEV says that it tries to use router ports (which is not true):

```
$ ddev poweroff

# leave it running
$ docker run -it --rm -p 80:80 -p 443:443 busybox sh

$ mkdir generic-no-ports && cd generic-no-ports
$ ddev config --webserver-type=generic
$ ddev start
Starting generic-no-ports...
Port 80 is busy, using 33000 instead, see https://ddev.com/s/port-conflict 
Port 443 is busy, using 33001 instead, see https://ddev.com/s/port-conflict
...

# why say "port is busy", if nothing is running there
```

## How This PR Solves The Issue

- Refactors `GetPrimaryRouterHTTPPort` and `GetPrimaryRouterHTTPSPort` to use correct values.
- Makes generic webserver work when default ports (80, 443) are busy.
- Show correct values in `ddev describe` for usual webserver and `generic` one.

## Manual Testing Instructions

Repeat my three examples:

1. describe should show `https://d11.ddev.site:33001` and `http://d11.ddev.site:33000`
2. svetlekit quickstart show start on ephemeral ports, and `ddev describe` should show correct URLs
3. generic webserver without ports shouldn't say "Port X is busy, using Y"

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
