### PR TITLE
fix: correct status color formatting in `ddev describe` and `ddev list`

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1059,6 +1059,7 @@ func (app *DdevApp) SiteStatus() (string, string) {
 			siteStatusDesc += serviceName + ": " + status + "\n"
 		}
 	}
+	siteStatusDesc = strings.TrimSpace(siteStatusDesc)
 
 	// Base the siteStatus on web container. Then override it if others are not the same.
 	if siteStatusDesc == "" {
@@ -3400,7 +3401,7 @@ func FormatSiteStatus(status string) string {
 	switch {
 	case strings.Contains(status, SitePaused):
 		formattedStatus = util.ColorizeText(formattedStatus, "yellow")
-	case strings.Contains(status, SiteStopped) || strings.Contains(status, SiteDirMissing) || strings.Contains(status, SiteConfigMissing):
+	case slices.Contains([]string{SiteStopped, SiteDirMissing, SiteConfigMissing, SiteUnhealthy, "exited"}, status):
 		formattedStatus = util.ColorizeText(formattedStatus, "red")
 	default:
 		formattedStatus = util.ColorizeText(formattedStatus, "green")


### PR DESCRIPTION
## The Issue

I've noticed that we're not showing some status colors correctly.

## How This PR Solves The Issue

Fixes it.

## Manual Testing Instructions

```
ddev add-on get ddev/ddev-memcached
ddev restart
ddev exec -s memcached kill 1
ddev describe
```

Before:

![image](https://github.com/user-attachments/assets/c0e8e3dc-514a-42bf-b86b-2fcff32e356f)

After:

![image](https://github.com/user-attachments/assets/26b386e1-dea9-455b-89b2-6ffa009d6a48)

---

```
ddev exec -s db kill 1
ddev list
```

Before:

![image](https://github.com/user-attachments/assets/9831c22b-cf75-493f-b172-77ecc18a0079)

After:

![image](https://github.com/user-attachments/assets/d1a30d2d-b5b8-4b43-a105-099c089ebbdb)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
