### PR TITLE
docs: update Craft CMS quickstart, for #7107

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -628,7 +628,7 @@ export MAGENTO_HOSTNAME=my-magento2-site
 mkdir ${MAGENTO_HOSTNAME} && cd ${MAGENTO_HOSTNAME}
 ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
 ddev add-on get ddev/ddev-elasticsearch
-ddev start -y
+ddev start
 ddev composer create --repository https://repo.magento.com/ magento/project-community-edition
 rm -f app/etc/env.php
 
@@ -866,7 +866,7 @@ If you have any questions there is lots of help in the [DDEV thread in the Proce
     ```bash
     mkdir my-shopware-site && cd my-shopware-site
     ddev config --project-type=shopware6 --docroot=public
-    ddev start -y
+    ddev start
     ddev composer create shopware/production:^v6.5
     # If it asks `Do you want to include Docker configuration from recipes?`
     # answer `x`, as we're using DDEV for this rather than its recipes.

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -172,14 +172,16 @@ Environment variables will be automatically added to your `.env` file to simplif
 
     # Boot the project and install the starter project:
     ddev start
-    ddev composer create craftcms/craft
+    ddev composer create --no-scripts craftcms/craft
     ddev craft install/craft \
         --username=admin \
-        --password=password123 \
-        --email=admin@mail.com \
+        --password=Password123 \
+        --email=admin@example.com \
         --site-name='$DDEV_PROJECT' \
         --language=en \
         --site-url='$DDEV_PRIMARY_URL'
+
+    # Login using `admin` user and `Password123` password
     ddev launch
     ```
 

--- a/docs/tests/craftcms.bats
+++ b/docs/tests/craftcms.bats
@@ -29,9 +29,9 @@ teardown() {
 
   run ddev craft install/craft \
     --username=admin \
-    --password=password123 \
+    --password=Password123 \
     --email=admin@example.com \
-    --site-name=${PROJNAME} \
+    --site-name='$DDEV_PROJECT' \
     --language=en \
     --site-url='$DDEV_PRIMARY_URL'
   assert_success

--- a/docs/tests/craftcms.bats
+++ b/docs/tests/craftcms.bats
@@ -11,20 +11,16 @@ teardown() {
   _common_teardown
 }
 @test "Craft CMS New Projects quickstart with $(ddev --version)" {
-  # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
-  # ddev config --project-type=craftcms --docroot=web
   run ddev config --project-type=craftcms --docroot=web
   assert_success
 
-  # ddev start -y
   run ddev start -y
   assert_success
 
-  # ddev composer create craftcms/craft
-  run ddev composer create -y --no-scripts craftcms/craft
+  run ddev composer create --no-scripts craftcms/craft
   assert_success
 
   run ddev craft install/craft \


### PR DESCRIPTION
## The Issue

I didn't review this before it was merged:

- #7107 

Related:

- #6246
- https://dev.to/mandrasch/install-craft-cms-v5-alpha-with-one-command-via-ddev-4ne5

## How This PR Solves The Issue

- Makes the quickstart for Craft CMS non-interactive.
- Removes not needed comments from Craft CMS quickstart.
- Removes not needed `-y` flag.

## Manual Testing Instructions

https://ddev--7160.org.readthedocs.build/en/7160/users/quickstart/#craft-cms

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
