### PR TITLE
build: bump images to v1.24.4 for release, and docker-compose to v2.34.0, fixes #7131

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -2,7 +2,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:v1.24.3 AS ddev-webserver-base
+FROM ddev/ddev-php-base:v1.24.4 AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,25 +11,25 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250331_stasadev_xhgui_php-profiler" // Note that this can be overridden by make
+var WebTag = "v1.24.4" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.24.3"
+var BaseDBTag = "v1.24.4"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"
 
 // TraefikRouterTag is traefik router tag
-var TraefikRouterTag = "20250318_stasadev_proxy_load_balancer_alias"
+var TraefikRouterTag = "v1.24.4"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.24.3"
+var SSHAuthTag = "v1.24.4"
 
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"
@@ -38,7 +38,7 @@ var BusyboxImage = "busybox:stable"
 var XhguiImage = "ddev/ddev-xhgui"
 
 // XhguiTag is xhgui tag
-var XhguiTag = "20250328_stasadev_xhgui_0.23.x"
+var XhguiTag = "v1.24.4"
 
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities"
@@ -51,4 +51,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.18.1"
 
-const RequiredDockerComposeVersionDefault = "v2.33.1"
+const RequiredDockerComposeVersionDefault = "v2.34.0"


### PR DESCRIPTION
## The Issue

It's time for v1.24.4 release mostly because of:

- #7069

## How This PR Solves The Issue

- Bumps Docker images to v1.24.4
- Bumps `docker-compose` to [v2.34.0](https://github.com/docker/compose/releases/tag/v2.34.0)

XHGui image should be rebuilt if we decide to pull:

- [x] #7161

Add release notes for:

- [x] #7131

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
