### PR TITLE
fix: add timeout for netutil::IsPortActive check for WSL2 with "mirrored networking mode" as opposed to default "NAT mode", fixes #6245

### DIFF
--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/util"

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -21,7 +21,7 @@ func IsPortActive(port string) bool {
 		return false
 	}
 
-	conn, err := net.Dial("tcp", dockerIP+":"+port)
+	conn, err := net.DialTimeout("tcp", dockerIP+":"+port, 1*time.Second)
 
 	// If we were able to connect, something is listening on the port.
 	if err == nil {


### PR DESCRIPTION
## The Issue

- #6245

WSL2 with networkingMode=mirrored seems to break port checks, as there is no response for the dial attempt and ddevs netutil IsPortActive waits around 5 minutes for each port to check when starting a project. This makes it quite unusable. The windows team seems not able to fix it in a reasonable time so im proposing this simple change as a workaround. 

## How This PR Solves The Issue
Instead of waiting 5 minutes for each port check on WSL2 (mirrored networking mode), it waits for .2 second max per check.  The timeout approach is only used on WSL2, and it's possible that in NAT mode it doesn't hit it anyway, but if it did it should be no more than about 1s total added to `ddev start`.

## Manual Testing Instructions

- [ ] Use `export DDEV_DEBUG=true` to get more info about what it's doing
- [ ] Test `ddev poweroff && ddev start -y` on non-WSL2 to verify behavior
- [ ] Test `ddev poweroff && ddev start -y` on WSL2 in NAT mode
- [ ] Test `ddev poweroff && ddev start -y` on WSL2 in mirrored mode

Note that the delay in mirrored mode happens only when the port is *not* occupied, which is what's superbly annoying about this. It happens to new users or first start. 

To occupy ports manually, consider `docker run -it --rm -p 80 -p 443 busybox sh`, which occupies 80 and 443, a common situation. In that situation it should *not* time out on 80/443, but rather it finds them occupied.

## Automated Testing Overview

We may want to consider putting one of our WSL2 test runners into mirrored mode after this goes into HEAD.

