### PR TITLE
feat: make generic webserver work with ephemeral ports

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -206,6 +206,8 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 			}
 			t.AppendRow(table.Row{"Mailpit", "", fmt.Sprintf("Mailpit: %s\nLaunch: ddev mailpit", mailpitURL)})
 
+			ddevapp.SyncGenericWebserverPortsWithRouterPorts(app)
+
 			//WebExtraExposedPorts stanza
 			for _, extraPort := range app.WebExtraExposedPorts {
 				if app.CanUseHTTPOnly() {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1244,8 +1244,13 @@ func (app *DdevApp) Start() error {
 	app.RouterHTTPSPort = app.GetPrimaryRouterHTTPSPort()
 	app.MailpitHTTPPort = app.GetMailpitHTTPPort()
 	app.MailpitHTTPSPort = app.GetMailpitHTTPSPort()
+
+	AssignRouterPortsToGenericWebserverPorts(app)
+
 	portsToCheck := []*string{&app.RouterHTTPPort, &app.RouterHTTPSPort, &app.MailpitHTTPPort, &app.MailpitHTTPSPort}
 	GetEphemeralPortsIfNeeded(portsToCheck, true)
+
+	SyncGenericWebserverPortsWithRouterPorts(app)
 
 	app.DockerEnv()
 	dockerutil.EnsureDdevNetwork()

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -530,3 +530,25 @@ func GetEphemeralPortsIfNeeded(ports []*string, verbose bool) {
 		}
 	}
 }
+
+// AssignRouterPortsToGenericWebserverPorts assigns the router ports to the generic webserver.
+// If it's a generic webserver, use the first pair of exposed ports as router ports.
+func AssignRouterPortsToGenericWebserverPorts(app *DdevApp) {
+	if app.WebserverType == nodeps.WebserverGeneric && len(app.WebExtraExposedPorts) > 0 {
+		app.RouterHTTPPort = strconv.Itoa(app.WebExtraExposedPorts[0].HTTPPort)
+		app.RouterHTTPSPort = strconv.Itoa(app.WebExtraExposedPorts[0].HTTPSPort)
+	}
+}
+
+// SyncGenericWebserverPortsWithRouterPorts syncs the generic webserver ports with the router ports.
+// If the used ephemeral router ports are different, the first pair webserver ports should be updated.
+func SyncGenericWebserverPortsWithRouterPorts(app *DdevApp) {
+	if app.WebserverType == nodeps.WebserverGeneric && len(app.WebExtraExposedPorts) > 0 {
+		if httpPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPPort()); err == nil {
+			app.WebExtraExposedPorts[0].HTTPPort = httpPort
+		}
+		if httpsPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPSPort()); err == nil {
+			app.WebExtraExposedPorts[0].HTTPSPort = httpsPort
+		}
+	}
+}


### PR DESCRIPTION
## The Issue

While working on #7152, I discovered that ephemeral ports don't work properly with the `generic` webserver.

Using svetlekit quickstart https://ddev.readthedocs.io/en/stable/users/quickstart/#nodejs

```
$ ddev poweroff

# leave it running
$ docker run -it --rm -p 80:80 -p 443:443 busybox sh

$ ddev start
Starting my-sveltekit-site... 
Port 80 is busy, using 33000 instead, see https://ddev.com/s/port-conflict 
Port 443 is busy, using 33001 instead, see https://ddev.com/s/port-conflict 
Building project images....
Project images built in 2s. 
 Network ddev-my-sveltekit-site_default  Created 
 Container ddev-my-sveltekit-site-web  Created 
 Container ddev-my-sveltekit-site-db  Created 
 Container ddev-my-sveltekit-site-db  Started 
 Container ddev-my-sveltekit-site-web  Started 
Waiting for containers to become ready: [web db] 
Starting web_extra_daemons... 
Starting ddev-router if necessary... 
Failed to start my-sveltekit-site: unable to listen on required ports, port 443 is already in use,
Troubleshooting suggestions at https://ddev.readthedocs.io/en/stable/users/usage/troubleshooting/#unable-listen
```

When there is nothing to expose, and default ports are busy, DDEV says that it tries to use router ports (which is not true):

```
$ ddev poweroff

# leave it running
$ docker run -it --rm -p 80:80 -p 443:443 busybox sh

$ mkdir generic-no-ports && cd generic-no-ports
$ ddev config --webserver-type=generic
$ ddev start
Starting generic-no-ports...
Port 80 is busy, using 33000 instead, see https://ddev.com/s/port-conflict 
Port 443 is busy, using 33001 instead, see https://ddev.com/s/port-conflict
...

# why say "port is busy", if nothing is running there
```

## How This PR Solves The Issue

- Makes generic webserver work when default ports (80, 443) are busy. The first port pair from `web_extra_exposed_ports` is used.
- Shows correct values in `ddev describe` for `generic`.

## Manual Testing Instructions

Run this, leave it running:

```
docker run -it --rm -p 80:80 -p 443:443 busybox sh
```

---

Open another terminal and try svetlekit quickstart https://ddev.readthedocs.io/en/stable/users/quickstart/#nodejs

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
