### PR TITLE
fix: use correct autoloader for XHGui php-profiler, preinstall it in ddev-webserver, fixes #7170

### DIFF
--- a/cmd/ddev/cmd/xhgui.go
+++ b/cmd/ddev/cmd/xhgui.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/heredoc"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
@@ -35,6 +36,10 @@ var DdevXHGuiCmd = &cobra.Command{
 		}
 
 		app.DockerEnv()
+
+		if globalconfig.DdevGlobalConfig.UseHardenedImages {
+			util.Failed("XHGui is not available with use-hardened-images.")
+		}
 
 		status, _ := app.SiteStatus()
 		if status != ddevapp.SiteRunning {

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -179,6 +179,11 @@ RUN chmod -fR ugo+w /usr/sbin /usr/bin /etc/nginx /var/cache/nginx /var/lib/ngin
 
 RUN mkdir -p /var/xhprof && curl --fail  -o /tmp/xhprof.tgz -sSL https://pecl.php.net/get/xhprof && tar -zxf /tmp/xhprof.tgz --strip-components=1 -C /var/xhprof && chmod 777 /var/xhprof/xhprof_html && rm /tmp/xhprof.tgz
 
+# Install https://github.com/perftools/php-profiler for XHGui
+RUN COMPOSER_HOME=/tmp/composer composer global require perftools/php-profiler --dev && \
+    mv /tmp/composer/vendor/perftools/php-profiler /usr/local/xhgui.collector/php-profiler && \
+    rm -rf /tmp/composer
+
 RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && \
     chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log
 

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -182,7 +182,8 @@ RUN mkdir -p /var/xhprof && curl --fail  -o /tmp/xhprof.tgz -sSL https://pecl.ph
 # Install https://github.com/perftools/php-profiler for XHGui
 RUN COMPOSER_HOME=/tmp/composer composer global require perftools/php-profiler --dev && \
     mv /tmp/composer/vendor/perftools/php-profiler /usr/local/xhgui.collector/php-profiler && \
-    rm -rf /tmp/composer
+    rm -rf /tmp/composer && \
+    chmod -R ugo+rw /usr/local/xhgui.collector
 
 RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && \
     chmod 666 /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/xhprof/xhprof_prepend.php
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/xhprof/xhprof_prepend.php
@@ -3,13 +3,12 @@
 // It invokes the xhgui collector by default.
 // However, if xhprof_mode=prepend in DDEV the .ddev/xhprof/xhprof_prepend.php will
 // be mounted on top of it.
-$homeDir = getenv('HOME');
-$globalAutoload = $homeDir . '/.composer/vendor/autoload.php';
-if (file_exists($globalAutoload)) {
-    require_once $globalAutoload;
-    // echo "Global autoloader loaded successfully from: $globalAutoload\n";
+$phpProfilerAutoload = '/usr/local/xhgui.collector/php-profiler/autoload.php';
+if (file_exists($phpProfilerAutoload)) {
+    require_once $phpProfilerAutoload;
+    // echo "php-profiler autoloader loaded successfully from: $phpProfilerAutoload\n";
 } else {
-    error_log("Global autoloader not found at: $globalAutoload");
+    error_log("php-profiler autoloader not found at: $phpProfilerAutoload");
 }
 
 $collector_php = "/usr/local/xhgui.collector/xhgui.collector.php";

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -4,7 +4,6 @@
 # bats tests/ddev-webserver/php_webserver.bats
 
 @test "http and https phpstatus access work inside and outside container for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
-    docker exec -t ${CONTAINER_NAME} composer global require perftools/php-profiler
     curl -sSL --fail http://127.0.0.1:$HOST_HTTP_PORT/test/phptest.php
     if [ "${OS:-$(uname)}" != "Windows_NT" ] ; then
         # TODO: Why doesn't this work on Windows?

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -69,3 +69,45 @@ teardown() {
   assert_output --partial "content-security-policy: default-src 'self'; script-src 'self'"
   assert_output --partial "HTTP/2 200"
 }
+
+@test "TYPO3 XHGui composer test with $(ddev --version)" {
+  run mkdir my-typo3-site && cd my-typo3-site
+  assert_success
+
+  run ddev config --project-type=typo3 --docroot=public --php-version=8.3 --xhprof-mode=xhgui
+  assert_success
+
+  run ddev start -y
+  assert_success
+
+  run ddev composer create typo3/cms-base-distribution
+  assert_success
+
+  run ddev exec touch public/FIRST_INSTALL
+  assert_success
+
+  run ddev xhgui on
+  assert_success
+  assert_output --partial "Started optional compose profiles"
+  assert_output --partial "xhgui"
+
+  # Ensure there's no profiling data link
+  run ddev exec "curl -s xhgui:80 | grep -q '<a href=\"/?server_name=${PROJNAME}.ddev.site\">'"
+  assert_failure
+
+  # Profile site
+  run curl -sfI https://${PROJNAME}.ddev.site/typo3/install.php
+  assert_success
+  assert_output --partial "HTTP/2 200"
+
+  run curl -sf https://${PROJNAME}.ddev.site/typo3/install.php
+  assert_success
+  assert_output --partial "Installing TYPO3 CMS"
+
+  # wait for XHGui
+  sleep 5
+
+  # Ensure there a profiling data link
+  run ddev exec "curl -s xhgui:80 | grep -q '<a href=\"/?server_name=${PROJNAME}.ddev.site\">'"
+  assert_success
+}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1113,15 +1113,6 @@ ENV N_PREFIX=/home/$username/.n
 ENV N_INSTALL_VERSION="%s"
 `, app.NodeJSVersion)
 	}
-	// TODO: I would rather put this in the ddev-webserver image but...
-	// - We don't know the username yet there, so would have to put in /usr/local/composer
-	// - /usr/local/composer would then have to be set as COMPOSER_HOME
-	// - We could set the permissions here so people could use it
-	// - BUT... we don't know the PHP version until runtime.
-	// - Oh, but we don't know the PHP version here yet because it's not runtime yet.
-	// - Maybe this can be done or checked by `ddev xhgui` ?
-	// Add php-profiler for xhgui
-	extraWebContent = extraWebContent + "\nUSER ${username}\nRUN composer global require perftools/php-profiler --dev\nUSER root\n"
 	if app.CorepackEnable {
 		extraWebContent = extraWebContent + "\nRUN corepack enable"
 	}

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250307_rfay_xhgui" // Note that this can be overridden by make
+var WebTag = "20250331_stasadev_xhgui_php-profiler" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #7170

The problem with TYPO3 can be solved by making only the following change:

```diff
-$globalAutoload = $homeDir . '/.composer/vendor/autoload.php';
+$globalAutoload = $homeDir . '/.composer/vendor/perftools/php-profiler/autoloader.php';
```

The above is recommended by the upstream https://github.com/perftools/php-profiler#autoloader

Global `~/.composer/vendor/autoload.php` affected TYPO3 files, which was wrong.

## How This PR Solves The Issue

- We don't care about PHP version, [perftools/php-profiler](https://packagist.org/packages/perftools/php-profiler) can be used with `php: ^5.3.0 || ^7.0 || ^8.0`
- Previous usage of `ddev composer global require` is tricky and can break Composer for our users. We don't need to have global `composer.json` and use its autoloader, I moved the php-profiler to `/usr/local/xhgui.collector/php-profiler`.
- Creates an actual test that fails on DDEV HEAD.
- Don't allow to run `ddev xhgui` with hardened images (because we don't install the required files there).

## Manual Testing Instructions

See the issue.

Follow https://ddev.readthedocs.io/en/stable/users/quickstart/#typo3

And run:

```
ddev xhgui
ddev launch
```

Don't see this:

![image](https://github.com/user-attachments/assets/e4849b47-04ad-456e-a675-095c4a01f2a6)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
