### PR TITLE
fix: XHGui launch command support custom ports, fixes #7181

### DIFF
--- a/cmd/ddev/cmd/xhgui_test.go
+++ b/cmd/ddev/cmd/xhgui_test.go
@@ -64,7 +64,12 @@ func TestCmdXHGui(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Now hit xhgui UI
-	xhguiURL := app.GetXHGuiURL()
+	desc, err := app.Describe(true)
+	require.NoError(t, err)
+	require.NotNil(t, desc["xhgui_url"])
+	require.NotNil(t, desc["xhgui_https_url"])
+	xhguiURL := desc["xhgui_https_url"].(string)
+
 	out, _, err = testcommon.GetLocalHTTPResponse(t, xhguiURL, 2)
 	require.NoError(t, err)
 	// Output should contain at least one run

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -231,6 +231,8 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 	}
 	appDesc["mailpit_https_url"] = "https://" + app.GetHostname() + ":" + app.GetMailpitHTTPSPort()
 	appDesc["mailpit_url"] = "http://" + app.GetHostname() + ":" + app.GetMailpitHTTPPort()
+	appDesc["xhgui_https_url"] = "https://" + app.GetHostname() + ":" + app.GetXHGuiHTTPSPort()
+	appDesc["xhgui_url"] = "http://" + app.GetHostname() + ":" + app.GetXHGuiHTTPPort()
 	appDesc["router_disabled"] = IsRouterDisabled(app)
 	appDesc["primary_url"] = app.GetPrimaryURL()
 	appDesc["type"] = app.GetType()

--- a/pkg/ddevapp/xhprof_xhgui.go
+++ b/pkg/ddevapp/xhprof_xhgui.go
@@ -71,15 +71,21 @@ func IsXHGuiContainerRunning(app *DdevApp) bool {
 func (app *DdevApp) GetXHGuiURL() string {
 	var xhguiURL string
 
-	// If router enabled, use primary URL with regular port
 	if !IsRouterDisabled(app) {
-		baseURL := app.GetPrimaryURL()
-		xhguiURL = baseURL + ":" + app.GetXHGuiPort()
-	} else if app.HostXHGuiPort != "" {
-		// Otherwise, if host_xhgui_port is set, use that to build URL
+		var desc, _ = app.Describe(true)
+
+		if _, ok := desc["xhgui_url"]; ok {
+			xhguiURL = desc["xhgui_url"].(string)
+		}
+		if _, ok := desc["xhgui_https_url"]; ok && !app.CanUseHTTPOnly() {
+			xhguiURL = desc["xhgui_https_url"].(string)
+		}
+	} else {
+		// If router is not enabled, use docker IP with regular port
 		ip, _ := dockerutil.GetDockerIP()
 		xhguiURL = fmt.Sprintf("http://%s:%s", ip, app.HostXHGuiPort)
 	}
+
 	return xhguiURL
 }
 


### PR DESCRIPTION
## The Issue

- #7181 


## How This PR Solves The Issue

This PR move the logic of building the xhgui url into the describe method, just like mailpit.

## Manual Testing Instructions

- ddev config global --router-http-port=8080 --router-https-port=8443
- ddev restart
- ddev xhgui launch

The launch should now work instead of throwing an error.

## Automated Testing Overview

Automated test has been updated to validate values are properly filled in by the describe method.
