### PR TITLE
fix: ignore curl error in `Dockerfile.test` for `ddev debug test`

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -91,7 +91,7 @@ function cleanup {
 
 ddev config --project-type=php --docroot=web --disable-upload-dirs-warning || (printf "\n\nPlease run 'ddev debug test' in the root of the existing project where you're having trouble.\n\n" && exit 4)
 
-printf "RUN timeout 30 apt-get update || true\nRUN curl -I https://www.google.com\n" > .ddev/web-build/Dockerfile.test
+printf "RUN timeout 30 apt-get update || true\nRUN curl --connect-timeout 10 --max-time 20 --fail -I https://www.google.com || true\n" > .ddev/web-build/Dockerfile.test
 
 set +eu
 
@@ -242,8 +242,8 @@ host_http_url=$(ddev describe -j | docker run -i --rm ddev/ddev-utilities jq -r 
 http_url=$(ddev describe -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.httpURLs[0]' 2>/dev/null)
 https_url=$(ddev describe -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.httpsURLs[0]' 2>/dev/null)
 
-header "Curl of site from inside container"
-ddev exec curl --fail -I http://127.0.0.1
+header "curl -I of http://127.0.0.1 from inside container"
+ddev exec curl --connect-timeout 10 --max-time 20 --fail -I http://127.0.0.1
 
 if command -v curl >/dev/null; then
   header "curl -I of ${host_http_url} (web container http docker bind port) from outside"
@@ -258,7 +258,7 @@ if command -v curl >/dev/null; then
   header "Full curl of ${https_url} (router https URL) from outside"
   curl --connect-timeout 10 --max-time 20 "${https_url}"
 
-  header "Curl google.com to check internet access and VPN"
+  header "curl -I of https://www.google.com to check internet access and VPN"
   curl --connect-timeout 10 --max-time 20 -I https://www.google.com
 else
   header "curl is not available on the host"


### PR DESCRIPTION
## The Issue

From Discord https://discord.com/channels/664580571770388500/1357034479956262993

When I looked at `ddev debug test` there, I noticed that the test project failed to start because of
```dockerfile
RUN curl -I https://www.google.com
```
Which didn't work under a proxy.
This resulted in a broken project, preventing us from seeing any project-related curl requests.

```
 > [web  8/10] RUN curl -I https://www.google.com:

  0     0    0     0    0     0      0      0 --:--:--  0:02:18 --:--:--     0
139.4 curl: (28) Failed to connect to www.google.com port 443 after 138939 ms: Couldn't connect to server
------
', stderr='failed to solve: process "/bin/bash -c curl -I https://www.google.com" did not complete successfully: exit code: 28'

============= ddev-tryddevproject-15383-web healthcheck run =========
Error response from daemon: No such container: ddev-tryddevproject-15383-web

======== Curl of site from inside container ========
Project is not currently running. Try 'ddev start'.

======== curl -I of null (web container http docker bind port) from outside ========
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 403 Forbidden
```

## How This PR Solves The Issue

- Adds `|| true` for `curl` in the `.ddev/web-build/Dockerfile.test`
- Adds more `curl` timeouts, so it won't wait for so long.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
