### PR TITLE
build: remove <1.24 constraint for go, for #7057

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.23'
+          check-latest: true
 
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -83,7 +83,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21'
+          go-version: '>=1.23'
 
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -74,6 +74,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.23'
+          check-latest: true
 
       - name: Build and test container ${{ matrix.containers }}
         run: |

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21'
+          go-version: '>=1.23'
 
       - name: Build and test container ${{ matrix.containers }}
         run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21'
+          go-version: '>=1.23'
 
       - name: Add Homebrew to PATH
         run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21'
+          go-version: '>=1.23'
 
       # Fails if something is wrong with the dependencies
       - name: Verify Go Modules

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '>=1.23'
+          check-latest: true
 
       - name: Add Homebrew to PATH
         run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
@@ -65,6 +66,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '>=1.23'
+          check-latest: true
 
       # Fails if something is wrong with the dependencies
       - name: Verify Go Modules

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '<1.24'
+          go-version: '>=1.23'
 
       - name: Build DDEV executables
         run: make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 completions mkcert
@@ -160,7 +160,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: '<1.24'
+          go-version: '>=1.23'
 
       - name: restore build-most results from cache
         uses: actions/cache@v4

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.23'
+          check-latest: true
 
       - name: Build DDEV executables
         run: make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 completions mkcert
@@ -161,6 +162,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.23'
+          check-latest: true
 
       - name: restore build-most results from cache
         uses: actions/cache@v4

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -53,6 +53,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.23'
+          check-latest: true
 
       # Find out info about how github is getting the hash
       - run: "git describe --tags --always --dirty"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '<1.24'
+          go-version: '>=1.23'
 
       # Find out info about how github is getting the hash
       - run: "git describe --tags --always --dirty"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,6 +125,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.23'
+          check-latest: true
 
       - name: Override environment variables for apache-fpm
         if: ${{ matrix.apache-fpm }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '<1.24'
+          go-version: '>=1.23'
 
       - name: Override environment variables for apache-fpm
         if: ${{ matrix.apache-fpm }}


### PR DESCRIPTION
## The Issue

- #7057
- https://github.com/moby/moby/issues/49513

## How This PR Solves The Issue

Upstream has a fix for go, which is already included in Arch Linux. (I'm already using it.)

The bug only affected Linux with kernel 6.11+

And I don't think DDEV has ever been affected by this bug seen in Docker.

---

I used `go-version: '>=1.23'` everywhere because this is what we have in `go.mod`:

https://github.com/ddev/ddev/blob/19a3e5fb27ca1793c4d2c4a809816b3245cd75dd/go.mod#L85

---

Adding `check-latest: true`, because it still used `go1.23.7` from cache.

## Manual Testing Instructions

Not needed.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
