### PR TITLE
Update Magento 2 Quickstart for 2.4.8 Requirements

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -631,15 +631,17 @@ Normal details of a Composer build for Magento 2 are on the [Magento 2 site](htt
 ```bash
 export MAGENTO_HOSTNAME=my-magento2-site
 mkdir ${MAGENTO_HOSTNAME} && cd ${MAGENTO_HOSTNAME}
-ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
-ddev add-on get ddev/ddev-elasticsearch
+# Configure DDEV for Magento 2 with PHP 8.4
+ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management --php-version=8.4
+# Magento >=2.4.8 requires OpenSearch
+ddev add-on get ddev/ddev-opensearch
 ddev start
 ddev composer create --repository https://repo.magento.com/ magento/project-community-edition
 rm -f app/etc/env.php
 
 ddev magento setup:install --base-url="https://${MAGENTO_HOSTNAME}.ddev.site/" \
     --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db \
-    --elasticsearch-host=elasticsearch --search-engine=elasticsearch7 --elasticsearch-port=9200 \
+    --search-engine=opensearch --opensearch-host=opensearch --opensearch-port=9200 \
     --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
     --admin-user=admin --admin-password=Password123 --language=en_US
 
@@ -658,7 +660,7 @@ The admin login URL is specified by `frontName` in `app/etc/env.php`.
 
 You may want to add the [Magento 2 Sample Data](https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/next-steps/sample-data/composer-packages.html) with:
 
-```
+```bash
 ddev magento sampledata:deploy
 ddev magento setup:upgrade
 ```

--- a/docs/tests/magento2.bats
+++ b/docs/tests/magento2.bats
@@ -16,19 +16,19 @@ teardown() {
   if [ "${MAGENTO2_PUBLIC_ACCESS_KEY}" = "" ]; then
     skip "MAGENTO_PUBLIC_ACCESS_KEY not provided (forked PR)"
   fi
-  
+
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
-  # ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
-  run ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
+  # ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management --php-version=8.4
+  run ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management --php-version=8.4
   assert_success
 
   # mkdir -p .ddev/homeadditions/.composer
   mkdir -p ./.ddev/homeadditions/.composer
 
   # add the env variable credentials to auth.json
-  cat <<EOF > .ddev/homeadditions/.composer/auth.json
+  cat <<EOF >.ddev/homeadditions/.composer/auth.json
 {
     "http-basic": {
         "repo.magento.com": {
@@ -39,8 +39,8 @@ teardown() {
 }
 EOF
 
-  # ddev add-on get ddev/ddev-elasticsearch
-  run ddev add-on get ddev/ddev-elasticsearch
+  # ddev add-on get ddev/ddev-opensearch
+  run ddev add-on get ddev/ddev-opensearch
   assert_success
 
   # ddev start -y
@@ -57,10 +57,10 @@ EOF
 
   # magento setup:install
   run ddev magento setup:install --base-url="https://${PROJNAME}.ddev.site/" \
-      --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db \
-      --elasticsearch-host=elasticsearch --search-engine=elasticsearch7 --elasticsearch-port=9200 \
-      --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
-      --admin-user=admin --admin-password=Password123 --language=en_US
+    --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db \
+    --search-engine=opensearch --opensearch-host=opensearch --opensearch-port=9200 \
+    --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
+    --admin-user=admin --admin-password=Password123 --language=en_US
   assert_success
 
   # ddev magento deploy:mode:set developer


### PR DESCRIPTION
## The Issue

The Magento 2 quickstart documentation needs alignment with the requirements specified for the recently released Magento 2.4.8 (released April 8, 2025).

## How This PR Solves The Issue

This PR updates the Magento 2 quickstart guide to align with the official Magento 2.4.8 requirements by:
1.  Setting the default PHP version in the `ddev config` command example to 8.4, compatible with Magento 2.4.8.
2.  Replacing the `ddev/ddev-elasticsearch` add-on instruction with `ddev/ddev-opensearch`, as required by Magento 2.4.8.
3.  Modifying the `ddev magento setup:install` command example to use the correct OpenSearch parameters (`--search-engine=opensearch`, `--opensearch-host`, `--opensearch-port`).

## Manual Testing Instructions

1.  Follow the steps outlined in the updated Magento 2 quickstart section of `docs/content/users/quickstart.md`.
here a oneliner for ease of testing: 
```bash
export MAGENTO_HOSTNAME=magento248 && \
mkdir ${MAGENTO_HOSTNAME} && \
cd ${MAGENTO_HOSTNAME} && \
ddev config --project-type=magento2 \
  --docroot=pub \
  --upload-dirs=media \
  --disable-settings-management \
  --php-version=8.4 && \
ddev add-on get ddev/ddev-opensearch && \
ddev start && \
ddev composer create --repository https://repo.magento.com/ magento/project-community-edition && \
rm -f app/etc/env.php && \
ddev magento setup:install \
  --base-url="https://${MAGENTO_HOSTNAME}.ddev.site/" \
  --cleanup-database \
  --db-host=db \
  --db-name=db \
  --db-user=db \
  --db-password=db \
  --search-engine=opensearch \
  --opensearch-host=opensearch \
  --opensearch-port=9200 \
  --admin-firstname=Magento \
  --admin-lastname=User \
  --admin-email=user@example.com \
  --admin-user=admin \
  --admin-password=Password123 \
  --language=en_US && \
ddev magento deploy:mode:set developer && \
ddev magento module:disable Magento_TwoFactorAuth Magento_AdminAdobeImsTwoFactorAuth && \
ddev config --disable-settings-management=false && \
ddev magento setup:config:set --backend-frontname="admin_ddev" --no-interaction && \
ddev launch /admin_ddev
```
3.  Verify that a new Magento 2 project can be successfully created and installed using DDEV configured with PHP 8.4 and OpenSearch, following the updated guide.
4.  Confirm that the Magento admin area (`/admin_ddev` by default) is accessible after installation.

## Automated Testing Overview

No automated tests are added or modified by this PR as it only involves changes to documentation files.

## Release/Deployment Notes

This is a documentation-only change and has no impact on DDEV's codebase or deployment procedures.