### PR TITLE
docs: fix minor typo in the Grav quickstart

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -406,7 +406,7 @@ ddev launch $(ddev drush uli)
     ```
 
 !!!tip "How to update?"
-    Upgrade Grave core:
+    Upgrade Grav core:
 
     ```bash
     ddev exec gpm selfupgrade -f


### PR DESCRIPTION
Minor correction of a typo "Grave" -> "Grav"