### PR TITLE
feat: add DDEV_APPROOT variable to web container and updates documentation, fixes #7198

### DIFF
--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -120,6 +120,7 @@ A number of environment variables are provided to these command scripts. These a
 
 Useful variables for container scripts are:
 
+* `DDEV_APPROOT`: Absolute path to the project files within the web container
 * `DDEV_DOCROOT`: Relative path from approot to docroot
 * `DDEV_FILES_DIR`: *Deprecated*, first directory of user-uploaded files
 * `DDEV_FILES_DIRS`: Comma-separated list of directories of user-uploaded files

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -182,7 +182,7 @@ services:
     - COREPACK_ENABLE_DOWNLOAD_PROMPT=0
     - COREPACK_HOME=/mnt/ddev-global-cache/corepack
     - DOCROOT=${DDEV_DOCROOT}
-    - DDEV_APPROOT="/var/www/html"
+    - DDEV_APPROOT=/var/www/html
     - DDEV_COMPOSER_ROOT
     - DDEV_DATABASE
     - DDEV_DOCROOT

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -182,6 +182,7 @@ services:
     - COREPACK_ENABLE_DOWNLOAD_PROMPT=0
     - COREPACK_HOME=/mnt/ddev-global-cache/corepack
     - DOCROOT=${DDEV_DOCROOT}
+    - DDEV_APPROOT="/var/www/html"
     - DDEV_COMPOSER_ROOT
     - DDEV_DATABASE
     - DDEV_DOCROOT


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #7198 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Adds the variable to the web container.

## Manual Testing Instructions

```
ddev ssh
echo $DDEV_APPROOT
```

You should see "/var/www/html" as the output (without the quotes of course)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
