### PR TITLE
build: switch to official percona release for xtrabackup, fixes #6963

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -11,9 +11,7 @@ ARG BASE_IMAGE
 ARG DB_TYPE
 ARG DB_MAJOR_VERSION
 
-#TODO: 2024-12-07: Currently the "testing" repository, change to the real one when they release
-# See https://perconadev.atlassian.net/browse/PXB-3361
-ARG PERCONA_SETUP_URL=https://repo.percona.com/prel/apt/pool/testing/p/percona-release/percona-release_1.0-30.generic_all.deb
+ARG PERCONA_SETUP_URL=https://repo.percona.com/apt/percona-release_latest.generic_all.deb
 
 ARG LANG=C.UTF-8
 ARG MYSQL_DATABASE=db

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "v1.24.4" // Note that this can be overridden by make
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.24.4"
+var BaseDBTag = "20250207_rfay_use_regular_xtrabackup"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION

## The Issue

- #6963 

It looks like percona updated repositories finally.

## How This PR Solves The Issue

Use the official technique.

