### PR TITLE
docs: Improvements to Zscaler instructions, fixes #7209, fixes #7211 [skip buildkite]

### DIFF
--- a/docs/content/users/usage/networking.md
+++ b/docs/content/users/usage/networking.md
@@ -99,9 +99,9 @@ The standard approach:
 4. If you're using Node.js/npm make it trust both the DDEV `mkcert` CA and your corporate CA by combining the two into a single file and then making the environment variable `NODE_EXTRA_CA_CERTS` point to that file. Add a post-start hook to concatenate the required files into the needed `/usr/local/share/ca-certificates/node_ca_certs.pem`. For example, in a `.ddev/config.vpn.yaml` add `post-start` hook:
 
     ```yaml
-   hooks:
-     post-start:
-       - exec: "cat /mnt/ddev-global-cache/mkcert/rootCA.pem /usr/local/share/ca-certificates/mycorp-ca.crt > /usr/local/share/ca-certificates/node_ca_certs.pem"
+    hooks:
+      post-start:
+        - exec: "cat /mnt/ddev-global-cache/mkcert/rootCA.pem /usr/local/share/ca-certificates/mycorp-ca.crt > /usr/local/share/ca-certificates/node_ca_certs.pem"
     ```
 
 5. Run:
@@ -111,7 +111,7 @@ The standard approach:
     ddev exec curl -I https://www.google.com
     # ✅ Expect: HTTP/2 200
     # ❌ If not trusted: curl: (60) SSL certificate problem
-   ddev npm install
+    ddev npm install
     ```
 
     You should see a `200 OK` response if the CA is trusted correctly.

--- a/docs/content/users/usage/networking.md
+++ b/docs/content/users/usage/networking.md
@@ -88,7 +88,7 @@ The standard approach:
 
 1. Export the corporate CA certificate (`.crt`) as described in the section below.
 2. Place the `.crt` file in your `.ddev/web-build` directory.
-3. Add a `Dockerfile.vpn` like this:
+3. Add a `.ddev/web-build/pre.Dockerfile.vpn` like this:
 
     ```Dockerfile
     COPY mycorp-ca.crt /usr/local/share/ca-certificates/

--- a/docs/content/users/usage/networking.md
+++ b/docs/content/users/usage/networking.md
@@ -118,6 +118,9 @@ The standard approach:
 
 This method works across all OS platforms and all Docker providers, because you're explicitly modifying the container's certificate store.
 
+!!!note "Clear or recreate buildx contexts"
+    In testing, we found that an old `docker buildx` context can make all of the `ddev start` builds fail in this situation. We had to remove buildx contexts (`docker buildx ls` and `docker buildx rm <context>` may help, or removing the `~/.docker/buildx` directory.)
+
 ---
 
 ### 🔍 Where to Get the Corporate CA Certificate


### PR DESCRIPTION
## The Issue

- #7209
- https://github.com/ddev/ddev/issues/7211


Related:
* https://github.com/ddev/ddev/issues/4032
* https://github.com/ddev/ddev/pull/4049 (has test situation)

Needed improvements in 
- [x] Usage with MySQL client - use pre.Dockerfile.vpn instead of Dockerfile.VPN
- [x]  Add the CA to db container as well
- [x] Add generated/concatenated NODE_EXTRA_CA_CERTS (WIP)
- [x] Clear buildx cache or use new builder, etc

Rendered at https://ddev--7212.org.readthedocs.build/en/7212/users/usage/networking/#corporate-packet-inspection-vpns-including-zscaler-and-global-protect