### PR TITLE
feat: use terminus rsync plugin instead of drush rsync with pantheon provider push, fixes #5215

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1112,6 +1112,14 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 
 	extraWebContent := "\nRUN mkdir -p /home/$username && chown $username /home/$username && chmod 600 /home/$username/.pgpass"
 	extraWebContent = extraWebContent + "\nENV NVM_DIR=/home/$username/.nvm"
+	extraWebContent = extraWebContent + `
+
+### DDEV-injected terminus rsync plugin installation
+USER $username
+RUN terminus self:plugin:install pantheon-systems/terminus-rsync-plugin
+USER root
+
+`
 	if app.NodeJSVersion != nodeps.NodeJSDefault {
 		extraWebContent = extraWebContent + fmt.Sprintf(`
 ENV N_PREFIX=/home/$username/.n

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
@@ -90,4 +90,11 @@ files_push_command:
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     set -eu -o pipefail
     ls ${DDEV_FILES_DIR} >/dev/null # This just refreshes stale NFS if possible
-    drush rsync -y @self:%files @${project}:%files
+    CURRENT_IFS="$IFS"
+    IFS=","
+    FILES_DIR_ARRAY=("${DDEV_FILES_DIRS}")
+    for FILES_DIR in $FILES_DIR_ARRAY
+    do
+      terminus rsync ${FILES_DIR} ${PROJECT}:files -- --progress --update --human-readable
+    done
+    IFS="$CURRENT_IFS"

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
@@ -77,7 +77,6 @@ files_pull_command:
 db_push_command:
   command: |
     set -x   # You can enable bash debugging output by uncommenting
-    ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     set -eu -o pipefail
     pushd /var/www/html/.ddev/.downloads >/dev/null;
     terminus remote:drush ${project} -- sql-drop -y
@@ -87,7 +86,6 @@ db_push_command:
 files_push_command:
   command: |
     set -x   # You can enable bash debugging output by uncommenting
-    ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     set -eu -o pipefail
     ls ${DDEV_FILES_DIR} >/dev/null # This just refreshes stale NFS if possible
     CURRENT_IFS="$IFS"
@@ -95,6 +93,6 @@ files_push_command:
     FILES_DIR_ARRAY=("${DDEV_FILES_DIRS}")
     for FILES_DIR in $FILES_DIR_ARRAY
     do
-      terminus rsync ${FILES_DIR} ${PROJECT}:files -- --progress --update --human-readable
+      terminus rsync ${FILES_DIR} ${project}:files -- --progress --update --human-readable
     done
     IFS="$CURRENT_IFS"

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml.example
@@ -93,6 +93,6 @@ files_push_command:
     FILES_DIR_ARRAY=("${DDEV_FILES_DIRS}")
     for FILES_DIR in $FILES_DIR_ARRAY
     do
-      terminus rsync ${FILES_DIR} ${project}:files -- --progress --update --human-readable
+      terminus rsync ${FILES_DIR} ${PROJECT}:files -- --progress --update --human-readable
     done
     IFS="$CURRENT_IFS"


### PR DESCRIPTION
## The Issue

- #5215

Pantheon integration to use terminus rsync plugin instead of drush rsync.

## How This PR Solves The Issue

This PR alters .webimageBuild/Dockerfile to install the terminus rsync plugin and changes the operations in the Pantheon provider script to use it in replacement of the drush rsync commands.

## Manual Testing Instructions

With a populated test site on Pantheon, configure the site to use ddev, add new files to the site found at sites/default/files, and then perform `ddev push pantheon --skip-db` and assess result.

## Automated Testing Overview

No new automated testing changes.

## Release/Deployment Notes

For ease of integration, this PR should be performed prior to [#4760].