### PR TITLE
fix: disable xdebug trigger for xdebug and xhprof status checks, fixes #6191, fixes php-perfect/ddev-intellij-plugin#414

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
@@ -18,7 +18,7 @@ xdebug_version=$(php --version | awk '/Xdebug v/ {print $3}')
 get_xdebug_status() {
     case ${xdebug_version} in
     v3*)
-      status=$(php -r 'echo ini_get("xdebug.mode");' 2>/dev/null)
+      status=$(php -d xdebug.start_with_request=no -r 'echo ini_get("xdebug.mode");' 2>/dev/null)
       if [[ "${status}" =~ .*"debug".* ]]; then
         echo "1"
       else
@@ -26,7 +26,7 @@ get_xdebug_status() {
       fi
       ;;
     v2*)
-      echo $(php -r 'echo ini_get("xdebug.remote_enable");')
+      echo $(php -d xdebug.remote_autostart=0 -r 'echo ini_get("xdebug.remote_enable");')
       ;;
     *)
       echo "0"

--- a/pkg/ddevapp/xhprof_xhgui.go
+++ b/pkg/ddevapp/xhprof_xhgui.go
@@ -118,6 +118,7 @@ func XHProfDisable(app *DdevApp) error {
 func XHProfStatus(app *DdevApp) (status bool, err error) {
 	out, _, err := app.Exec(&ExecOpts{
 		Cmd: `php -r 'echo extension_loaded("xhprof");'`,
+		Env: []string{"XDEBUG_MODE=off"},
 	})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## The Issue

- #6191
- php-perfect/ddev-intellij-plugin#414

When xdebug is enabled, DDEV internal executions of PHP code are not excluded from debugging, causing unexpected debugging connections in the IDE.

## How This PR Solves The Issue

- Add flags to disable xdebug connections for status checks of xdebug itself, works for xdebug 2 and 3.
- Add ENV to disable xdebug for status checks of xhprof, works only for xdebug 3.
For xdebug 2 support, we'd first need to figure out the xdebug version. Seeing as the composer command also implements the xdebug 3 only solution, this is what I went with here as well.

## Manual Testing Instructions

Setup:
Take any ddev project, can also be a completely new and blank one
ddev config global --xhprof-mode=xhgui
ddev start
ddev xdebug on
Enable xdebug listen in PhpStorm

Test the following commands. Running either causes a debug connection in the IDE with DDEV 1.24.4 that looks like the screenshot, while no longer creating one with this version:
ddev xdebug status
ddev describe
![image](https://github.com/user-attachments/assets/857bfda1-d30f-431f-a4d3-32c3922829dd)

ddev describe is called by the PhpStorm plugin in regular intervals to watch the project's status, so stopping debugging connections from happening here resolves php-perfect/ddev-intellij-plugin#414

## Automated Testing Overview

Might be useful. That the changes don't break existing functionality is already covered by existing tests. What isn't tested, is that they remove the xdebug connection attempt.

## Release/Deployment Notes

No change for deployment, the commands behave as before, minus the debugging connections.
