### PR TITLE
feat: use docker-compose to parallel download images, fixes #7163

### DIFF
--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -30,20 +28,14 @@ var DebugDownloadImagesCmd = &cobra.Command{
 			}
 		}
 
-		err = ddevapp.PullBaseContainerImages()
+		imagesPulled, err := (&ddevapp.DdevApp{}).PullContainerImages()
 		if err != nil {
-			util.Failed("Failed to PullBaseContainerImages(): %v", err)
+			util.Failed("Failed to PullContainerImages(): %v", err)
 		}
 
-		// Provide at least the default database image
-		dbImage := docker.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion)
-		err = dockerutil.Pull(dbImage)
-		if err != nil {
-			util.Failed("Failed to pull dbImage: %v", err)
+		if imagesPulled {
+			util.Success("Successfully downloaded DDEV images")
 		}
-		util.Debug("Pulled %s", dbImage)
-
-		util.Success("Successfully downloaded DDEV images")
 	},
 }
 

--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -28,9 +28,28 @@ var DebugDownloadImagesCmd = &cobra.Command{
 			}
 		}
 
-		imagesPulled, err := (&ddevapp.DdevApp{}).PullContainerImages()
-		if err != nil {
-			util.Failed("Failed to PullContainerImages(): %v", err)
+		app, err := ddevapp.GetActiveApp("")
+		var imagesPulled bool
+
+		// If we're in a project directory, use the app context
+		if err == nil {
+			util.Success("Downloading images for project '%s'", app.Name)
+
+			app.DockerEnv()
+			if err = app.WriteDockerComposeYAML(); err != nil {
+				util.Failed("Failed to get compose-config: %v", err)
+			}
+
+			imagesPulled, err = app.PullContainerImages()
+			if err != nil {
+				util.Failed("Failed to pull container images: %v", err)
+			}
+		} else {
+			util.Warning("Downloading common images")
+			imagesPulled, err = (&ddevapp.DdevApp{}).PullContainerImages()
+			if err != nil {
+				util.Failed("Failed to pull images: %v", err)
+			}
 		}
 
 		if imagesPulled {


### PR DESCRIPTION
## The Issue

- #7163

DDEV currently preloads all required images via individual docker pull commands. 

## How This PR Solves The Issue

This PR replaces this with a docker compose call, enabling parallel download of multiple images.

## Manual Testing Instructions

Remove DDEV images from local Docker
Run ddev debug download-images

## Automated Testing Overview

-

## Release/Deployment Notes

-
