### PR TITLE
fix: Use fast checkpoint during postgresql backup, fixes #7098

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2791,7 +2791,7 @@ func getBackupCommand(app *DdevApp, targetFile string) string {
 	case app.Database.Type == nodeps.MySQL:
 		c = fmt.Sprintf(`xtrabackup --backup --stream=xbstream --user=root --password=root --socket=/var/tmp/mysql.sock  2>/tmp/snapshot_%s.log | gzip > "%s"`, path.Base(targetFile), targetFile)
 	case app.Database.Type == nodeps.Postgres:
-		c = fmt.Sprintf("rm -rf /var/tmp/pgbackup && pg_basebackup -D /var/tmp/pgbackup 2>/tmp/snapshot_%s.log && tar -czf %s -C /var/tmp/pgbackup/ .", path.Base(targetFile), targetFile)
+		c = fmt.Sprintf("rm -rf /var/tmp/pgbackup && pg_basebackup -c fast -D /var/tmp/pgbackup 2>/tmp/snapshot_%s.log && tar -czf %s -C /var/tmp/pgbackup/ .", path.Base(targetFile), targetFile)
 	}
 	return c
 }


### PR DESCRIPTION
## The Issue

- #7098

During backup of postgresql, the export might be blocked for up to 5 minutes. This happens when the postgres checkpoint is being triggered. Since the checkpoint_timeout is set to 5 minutes, and postgres by default spreads out the writes across most of the timeout time, that's the maximum duration the backup might hang for.

## How This PR Solves The Issue

Add `-c fast` during backup, which instructs postgres to immediately perform the checkpoint at maximum speed, instead of spreading the writes out.

Documentation:
Checkpoints: https://www.postgresql.org/docs/17/wal-configuration.html
Backup flags: https://www.postgresql.org/docs/17/app-pgbasebackup.html

## Manual Testing Instructions

```
mkdir d11
cd d11
ddev config --project-type=drupal11 --docroot=web --database postgres:16
ddev composer create-project drupal/recommended-project
ddev composer require drush/drush
ddev drush si -y demo_umami --account-pass=admin
ddev snapshot --name=postgresdummp
```

## Automated Testing Overview

none

## Release/Deployment Notes

none
