### PR TITLE
fix: Improve the output of ArrayToReadableOutput

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -360,12 +360,17 @@ func SliceToUniqueSlice(inSlice *[]string) []string {
 	return newSlice
 }
 
-// ArrayToReadableOutput generates a printable list of files in a readable way
-func ArrayToReadableOutput(slice []string) (response string, err error) {
+// ArrayToReadableOutput generates a printable list of items in a readable way
+func ArrayToReadableOutput(slice []string) (string, error) {
 	if len(slice) == 0 {
 		return "", fmt.Errorf("empty slice")
 	}
-	return "[\n\t" + strings.Join(slice, "\n\t") + "\n]", nil
+	var b strings.Builder
+	b.WriteString("\n")
+	for _, item := range slice {
+		b.WriteString("  - " + item + "\n")
+	}
+	return b.String(), nil
 }
 
 // WindowsPathToCygwinPath changes C:/path/to/something to //c/path/to/something


### PR DESCRIPTION

## The Issue

I've long been annoyed by the output of ArrayToReadableOuput, think we can do better

## How This PR Solves The Issue

Old config override notification:

```
Using custom nginx configuration in /home/rfay/workspace/d11/.ddev/nginx_full/nginx-site.conf
Using custom PHP configuration: [
        /home/rfay/workspace/d11/.ddev/php/xxx.ini
]
Using custom web-build configuration: [
        /home/rfay/workspace/d11/.ddev/web-build/Dockerfile.nothing
        /home/rfay/workspace/d11/.ddev/web-build/Dockerfile.nothing2
]
```

New config override notification:

```
rfay@ubuntu-len:~/workspace/d11$ ddev start
Starting d11...
Using custom PHP configuration:
  - /home/rfay/workspace/d11/.ddev/php/xxx.ini

Using custom web-build configuration:
  - /home/rfay/workspace/d11/.ddev/web-build/Dockerfile.nothing
  - /home/rfay/workspace/d11/.ddev/web-build/Dockerfile.nothing2
```

Old startup failure notification:

```
Waiting for containers to become ready: [web db]
Failed waiting for web/db containers to become ready: web container failed: log=, err=ddev-d11-web container is unhealthy, log=
Troubleshoot this with these commands:
[
        ddev logs -s web
        docker logs ddev-d11-web
        docker inspect --format "{{ json .State.Health }}" ddev-d11-web | docker run -i --rm ddev/ddev-utilities jq -r
]
```

New startup failure notification:

```
Waiting for containers to become ready: [web db]
Failed waiting for web/db containers to become ready: web container failed: log=, err=ddev-d11-web container is unhealthy, log=
Troubleshoot this with these commands:

  - ddev logs -s web
  - docker logs ddev-d11-web
  - docker inspect --format "{{ json .State.Health }}" ddev-d11-web | docker run -i --rm ddev/ddev-utilities jq -r
```

## Manual Testing Instructions

- [ ] Add some config override and see what happens.
- [ ] You can break the startup by adding "xxx;" to .ddev/nginx_full/nginx-site.conf in the `server` section and removing #ddev-generated.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
