### PR TITLE
refactor: Hide ddev debug capabilities, fixes #7174

### DIFF
--- a/cmd/ddev/cmd/debug-capabilities.go
+++ b/cmd/ddev/cmd/debug-capabilities.go
@@ -11,7 +11,7 @@ import (
 var DebugCapabilitiesCmd = &cobra.Command{
 	Use:        "capabilities",
 	Short:      "Show capabilities of this version of DDEV",
-	Deprecated: "ddev debug capabilities is no longer maintained and may be removed in a future release. Use ddev_version_constraint to specify versions of DDEV instead. https://ddev.readthedocs.io/en/stable/users/configuration/config/#ddev_version_constraint\n",
+	Deprecated: "\nddev debug capabilities is no longer maintained \nand may be removed in a future release.\nUse ddev_version_constraint to specify versions of DDEV instead. \nhttps://ddev.readthedocs.io/en/stable/users/configuration/config/#ddev_version_constraint\n\n",
 	Hidden:     true,
 	Run: func(_ *cobra.Command, _ []string) {
 		capabilities := []string{

--- a/cmd/ddev/cmd/debug-capabilities.go
+++ b/cmd/ddev/cmd/debug-capabilities.go
@@ -9,8 +9,10 @@ import (
 
 // DebugCapabilitiesCmd implements the ddev debug capabilities command
 var DebugCapabilitiesCmd = &cobra.Command{
-	Use:   "capabilities",
-	Short: "Show capabilities of this version of DDEV",
+	Use:        "capabilities",
+	Short:      "Show capabilities of this version of DDEV",
+	Deprecated: "ddev debug capabilities is no longer maintained and may be removed in a future release. Use ddev_version_constraint to specify versions of DDEV instead. https://ddev.readthedocs.io/en/stable/users/configuration/config/#ddev_version_constraint\n",
+	Hidden:     true,
 	Run: func(_ *cobra.Command, _ []string) {
 		capabilities := []string{
 			"multiple-dockerfiles",

--- a/cmd/ddev/cmd/debug-capabilities_test.go
+++ b/cmd/ddev/cmd/debug-capabilities_test.go
@@ -17,6 +17,7 @@ func TestDebugCapabilitiesCmd(t *testing.T) {
 	out, err := exec.RunHostCommand(DdevBin, "debug", "capabilities")
 	assert.NoError(err)
 	assert.Contains(out, "multiple-dockerfiles")
+	assert.Contains(out, "is deprecated")
 
 	out, err = exec.RunHostCommandSeparateStreams(DdevBin, "debug", "-j", "capabilities")
 	assert.NoError(err)

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -430,20 +430,6 @@ ddev dbeaver
 
 A collection of debugging commands, often useful for [troubleshooting](troubleshooting.md).
 
-### `debug capabilities`
-
-Show capabilities of this version of DDEV.
-
-Example:
-
-```shell
-# List capabilities of the current project
-ddev debug capabilities
-
-# List capabilities of `my-project`
-ddev debug capabilities my-project
-```
-
 ### `debug cd`
 
 Uses shell built-in `cd` to change to a project directory. For example, `ddevcd some-project` will change directories to the project root of the project named `some-project`.


### PR DESCRIPTION

## The Issue

- #7174

`ddev debug capabilities` is no longer maintained or useful

## How This PR Solves The Issue

Hide it. Deprecate it. Remove from docs.

## Manual Testing Instructions

- [ ] `ddev debug capabilities` should work but show deprecation notice
- [ ] `ddev debug` should not show it
- [ ] `ddev debug capabilities -h` should show the deprecation notice

