### PR TITLE
refactor: check for docroot/index.* on start, fixes #7157

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1791,7 +1791,7 @@ func warnMissingDocroot(app *DdevApp) {
 	}
 	docroot := app.GetAbsDocroot(false)
 	if !fileutil.FileExists(docroot) {
-		util.Warning("The project docroot '%s' does not yet exist\n(or `docroot` is misconfigured),\nuntil it exists, you may get a 403 'permission denied' visiting the project in a web browser.\n", docroot)
+		util.WarningWithColor("magenta", "The project docroot '%s' does not yet exist\n(or `docroot` is misconfigured),\nuntil it exists, you may get a 403 'permission denied' visiting the project in a web browser.\n", docroot)
 		return
 	}
 
@@ -1802,7 +1802,7 @@ func warnMissingDocroot(app *DdevApp) {
 		return
 	}
 	if len(matches) == 0 {
-		util.Warning("The index.php or index.html (or index.*) does not yet exist in\n%s\nso you may get 403 errors 'permission denied' from the browser until it does.\n", pattern)
+		util.WarningWithColor("magenta", "The index.php or index.html does not yet exist in\n%s\nso you may get 403 errors 'permission denied' from the browser until it does.\nDon't worry about this if a later action \n(like `ddev composer install`) will create the file.\n", pattern)
 	}
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1785,8 +1785,8 @@ If this seems to be a config issue, update it accordingly.`, app.Name)
 
 // Warn if docroot or docroot/index.* is missing
 func warnMissingDocroot(app *DdevApp) {
-	// No need to warn on generic project type or webserver type; that's the implementor's job
-	if app.Type == nodeps.AppTypeGeneric || app.WebserverType == nodeps.WebserverGeneric {
+	// No need to warn on generic webserver type; that's the implementor's job
+	if app.WebserverType == nodeps.WebserverGeneric {
 		return
 	}
 	docroot := app.GetAbsDocroot(false)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -58,6 +58,16 @@ func Warning(format string, a ...interface{}) {
 	}
 }
 
+// WarningWithColor allows specifying a color for the warning to make it more visible
+func WarningWithColor(color string, format string, a ...interface{}) {
+	format = ColorizeText(format, color)
+	if a != nil {
+		output.UserErr.Warnf(format, a...)
+	} else {
+		output.UserErr.Warn(format)
+	}
+}
+
 // Success will indicate an operation succeeded with colored confirmation text.
 func Success(format string, a ...interface{}) {
 	format = ColorizeText(format, "green")
@@ -302,6 +312,8 @@ func ColorizeText(s string, c string) (out string) {
 	switch c {
 	case "green":
 		out = text.FgGreen.Sprint(s)
+	case "magenta":
+		out = text.FgMagenta.Sprint(s)
 	case "red":
 		out = text.FgRed.Sprint(s)
 	case "yellow":


### PR DESCRIPTION

## The Issue

- #7157

On start, check to see if docroot and index.* exist - or warn. Don't do it on generic webserver_type.

## Manual Testing Instructions

- [ ] Rename or remove docroot, start
- [ ] misconfigure `docroot`, start
- [ ] Check with generic webserver_type, start

## Automated Testing Overview

- nothing added

