### PR TITLE
build: Use some artifacts that we control building windows installer (nsis), fixes #7086

### DIFF
--- a/.ci-scripts/nsis_setup.sh
+++ b/.ci-scripts/nsis_setup.sh
@@ -20,7 +20,7 @@ fi
 NSIS_HOME=$1
 curl -sfL -o /tmp/nsis.zip https://sourceforge.net/projects/nsis/files/NSIS%203/${NSIS_VERSION}/nsis-${NSIS_VERSION}.zip/download && unzip -o -d /tmp/nsistemp /tmp/nsis.zip && sudo mv /tmp/nsistemp/*/* "${NSIS_HOME}" && rm -rf /tmp/nsistemp /tmp/nsis.zip
 curl -sfL -o /tmp/EnVar-Plugin.zip https://github.com/ddev/EnVar/releases/latest/download/EnVar-Plugin.zip && sudo unzip -o -d $"${NSIS_HOME}" /tmp/EnVar-Plugin.zip && rm /tmp/EnVar-Plugin.zip
-curl -sfL -o /tmp/INetC.zip https://github.com/DigitalMediaServer/NSIS-INetC-plugin/releases/latest/download/INetC.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins" /tmp/INetC.zip && rm /tmp/INetC.zip
+curl -sfL -o /tmp/INetC.zip https://github.com/ddev/NSIS-INetC-plugin/releases/latest/download/INetC.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins" /tmp/INetC.zip && rm /tmp/INetC.zip
 curl -sfL -o /tmp/ExecDos.zip https://nsis.sourceforge.io/mediawiki/images/0/0f/ExecDos.zip && sudo unzip -o -d "${NSIS_HOME}" /tmp/ExecDos.zip && rm /tmp/ExecDos.zip
 curl -sfL -o /tmp/NsUnzip.zip https://nsis.sourceforge.io/mediawiki/images/8/88/NsUnzip.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/NsUnzip.zip && rm /tmp/NsUnzip.zip
 curl -sfL -o /tmp/NSISunzU.zip https://nsis.sourceforge.io/mediawiki/images/5/5a/NSISunzU.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/NSISunzU.zip && rm /tmp/NSISunzU.zip

--- a/.ci-scripts/nsis_setup.sh
+++ b/.ci-scripts/nsis_setup.sh
@@ -19,7 +19,7 @@ if [ $1 = "" ]; then
 fi
 NSIS_HOME=$1
 curl -sfL -o /tmp/nsis.zip https://sourceforge.net/projects/nsis/files/NSIS%203/${NSIS_VERSION}/nsis-${NSIS_VERSION}.zip/download && unzip -o -d /tmp/nsistemp /tmp/nsis.zip && sudo mv /tmp/nsistemp/*/* "${NSIS_HOME}" && rm -rf /tmp/nsistemp /tmp/nsis.zip
-curl -sfL -o /tmp/EnVar-Plugin.zip https://github.com/GsNSIS/EnVar/releases/latest/download/EnVar-Plugin.zip && sudo unzip -o -d $"${NSIS_HOME}" /tmp/EnVar-Plugin.zip && rm /tmp/EnVar-Plugin.zip
+curl -sfL -o /tmp/EnVar-Plugin.zip https://github.com/ddev/EnVar/releases/latest/download/EnVar-Plugin.zip && sudo unzip -o -d $"${NSIS_HOME}" /tmp/EnVar-Plugin.zip && rm /tmp/EnVar-Plugin.zip
 curl -sfL -o /tmp/INetC.zip https://github.com/DigitalMediaServer/NSIS-INetC-plugin/releases/latest/download/INetC.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins" /tmp/INetC.zip && rm /tmp/INetC.zip
 curl -sfL -o /tmp/ExecDos.zip https://nsis.sourceforge.io/mediawiki/images/0/0f/ExecDos.zip && sudo unzip -o -d "${NSIS_HOME}" /tmp/ExecDos.zip && rm /tmp/ExecDos.zip
 curl -sfL -o /tmp/NsUnzip.zip https://nsis.sourceforge.io/mediawiki/images/8/88/NsUnzip.zip && sudo unzip -o -d "${NSIS_HOME}/Plugins/x86-unicode" /tmp/NsUnzip.zip && rm /tmp/NsUnzip.zip

--- a/docs/content/developers/scripts/windows_postinstall.sh
+++ b/docs/content/developers/scripts/windows_postinstall.sh
@@ -15,7 +15,7 @@ curl -sSL -o /tmp/nsis-setup.exe https://prdownloads.sourceforge.net/nsis/nsis-$
 /tmp/nsis-setup.exe
 
 # Get the Plugins for NSIS
-curl -fsSL -o /tmp/EnVar-Plugin.zip https://github.com/GsNSIS/EnVar/releases/latest/download/EnVar-Plugin.zip && unzip -o -d "${NSIS_HOME}" /tmp/EnVar-Plugin.zip
+curl -fsSL -o /tmp/EnVar-Plugin.zip https://github.com/ddev/EnVar/releases/latest/download/EnVar-Plugin.zip && unzip -o -d "${NSIS_HOME}" /tmp/EnVar-Plugin.zip
 curl -fsSL -o /tmp/INetC.zip https://github.com/DigitalMediaServer/NSIS-INetC-plugin/releases/latest/download/INetC.zip && unzip -o -d "${NSIS_HOME}/Plugins" /tmp/INetC.zip
 
 echo "You must now add to the system path C:\Program Files (x86)\NSIS\bin, which for some reason is not added by the installer"


### PR DESCRIPTION

## The Issue

- #7086 

We discovered that our NSIS Windows installer build was completely dependent on a couple of repos that probably aren't alive any more, and we have no way to recreate them.

## How This PR Solves The Issue

* Fork the repos
* Unlink the forks
* Recreate the releases
* Change the link in our build code.

## Manual Testing Instructions

* Look at the resultant Windows installer
* Look at the build output

