### PR TITLE
fix: support TYPO3 v14 nginx configuration, fixes #6944

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1122,19 +1122,19 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev exec touch public/FIRST_INSTALL
     
     ddev typo3 setup \
-    --admin-user-password="Demo123*" \
-    --driver=mysqli \
-    --create-site=https://${PROJECT_NAME}.ddev.site \
-    --server-type=other \
-    --dbname=db \
-    --username=db \
-    --password=db \
-    --port=3306 \
-    --host=db \
-    --admin-username=admin \
-    --admin-email=admin@example.com \
-    --project-name="demo TYPO3 site" \
-    --force
+        --admin-user-password="Demo123*" \
+        --driver=mysqli \
+        --create-site=https://${PROJECT_NAME}.ddev.site \
+        --server-type=other \
+        --dbname=db \
+        --username=db \
+        --password=db \
+        --port=3306 \
+        --host=db \
+        --admin-username=admin \
+        --admin-email=admin@example.com \
+        --project-name="demo TYPO3 site" \
+        --force
 
     ddev launch /typo3/
     # Log in with credentials above, admin/Demo123*

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1105,6 +1105,35 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev launch /typo3/install.php
     ```
 
+=== "ddev typo3 setup"
+
+    ```bash
+    PROJECT_NAME=my-typo3-site
+    mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
+    ddev config --project-type=typo3 --docroot=public --php-version=8.3
+    ddev start
+    ddev composer create-project typo3/cms-base-distribution 
+    ddev exec touch public/FIRST_INSTALL
+    
+    ddev typo3 setup \
+    --admin-user-password="Demo123*" \
+    --driver=mysqli \
+    --create-site=https://${PROJECT_NAME}.ddev.site \
+    --server-type=other \
+    --dbname=db \
+    --username=db \
+    --password=db \
+    --port=3306 \
+    --host=db \
+    --admin-username=admin \
+    --admin-email=admin@example.com \
+    --project-name="demo TYPO3 site" \
+    --force
+
+    ddev launch /typo3/
+    # Log in with credentials above, admin/Demo123*
+    ```
+
 ## WordPress
 
 There are several easy ways to use DDEV with WordPress:

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1085,7 +1085,8 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 === "Composer"
 
     ```bash
-    mkdir my-typo3-site && cd my-typo3-site
+    PROJECT_NAME=my-typo3-site
+    mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
     ddev config --project-type=typo3 --docroot=public --php-version=8.3
     ddev start
     ddev composer create-project "typo3/cms-base-distribution"
@@ -1095,9 +1096,14 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 
 === "Git Clone"
 
+    This example uses a clone of a test repository, `github.com/ddev/test-typo3.git`. 
+    Replace that with your git repository.
+
     ```bash
-    git clone https://github.com/ddev/test-typo3.git my-typo3-site
-    cd my-typo3-site
+    PROJECT_GIT_URL=https://github.com/ddev/test-typo3.git
+    PROJECT_NAME=my-typo3-site
+    mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
+    git clone ${PROJECT_GIT_REPOSITORY} .
     ddev config --project-type=typo3 --docroot=public --php-version=8.3
     ddev start
     ddev composer install

--- a/docs/tests/common-setup.bash
+++ b/docs/tests/common-setup.bash
@@ -11,10 +11,10 @@ _common_setup() {
     export DDEV_NO_INSTRUMENTATION=true
     export DDEV_NONINTERACTIVE=true
     mkdir -p ${tmpdir} && cd ${tmpdir} || exit 1
-    ddev delete -Oy ${PROJNAME:-notset}
+    ddev delete -Oy ${PROJNAME:-notset} >/dev/null
 }
 
 _common_teardown() {
-  ddev delete -Oy ${PROJNAME}
+  ddev delete -Oy ${PROJNAME} >/dev/null
   rm -rf ${tmpdir}
 }

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -189,8 +189,6 @@ teardown() {
   run ddev restart -y
   assert_success
 
-  sleep 2
-
   run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/ \| grep "Welcome to a default website made with"
   assert_success
   run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
@@ -199,6 +197,7 @@ teardown() {
   # Now try it with /admin as the BE entrypoint
   echo '$GLOBALS["TYPO3_CONF_VARS"]["BE"]["entryPoint"] = "/admin";' >> config/system/additional.php
   assert_success
+  # Sync it into the container immediately
   run ddev mutagen sync
   assert_success
 

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -12,8 +12,8 @@ teardown() {
 }
 
 @test "TYPO3 composer based quickstart with $(ddev --version)" {
-  PROJECT_NAME=my-typo3-site
-  run mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
+  PROJNAME=my-typo3-site
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
   run ddev config --project-type=typo3 --docroot=public --php-version=8.3
   assert_success
@@ -35,7 +35,7 @@ teardown() {
 
 @test "TYPO3 git based quickstart with $(ddev --version)" {
   PROJECT_GIT_URL=https://github.com/ddev/test-typo3.git
-  PROJECT_NAME=my-typo3-site
+  PROJNAME=my-typo3-site
   run git clone ${PROJECT_GIT_URL} ${PROJNAME}
   assert_success
   # cd my-typo3-site
@@ -108,8 +108,8 @@ teardown() {
 
 # bats test_tags=typo3-setup,t3v13
 @test "TYPO3 v13 'ddev typo3 setup' composer test with $(ddev --version)" {
-  PROJECT_NAME=my-typo3-site
-  run mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
+  PROJNAME=my-typo3-site
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run ddev config --project-type=typo3 --docroot=public --php-version=8.3
@@ -127,7 +127,7 @@ teardown() {
   run ddev typo3 setup \
     --admin-user-password="Demo123*" \
     --driver=mysqli \
-    --create-site=https://${PROJECT_NAME}.ddev.site \
+    --create-site=https://${PROJNAME}.ddev.site \
     --server-type=other \
     --dbname=db \
     --username=db \
@@ -140,9 +140,9 @@ teardown() {
     --force
   assert_success
 
-  run bats_pipe curl -sfL https://${PROJECT_NAME}.ddev.site/ \| grep "Welcome to a default website made with"
+  run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/ \| grep "Welcome to a default website made with"
   assert_success
-  run bats_pipe curl s-sfL https://${PROJECT_NAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
+  run bats_pipe curl s-sfL https://${PROJNAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
   assert_success
 }
 
@@ -150,8 +150,8 @@ teardown() {
 # to ensure compatibility with upcoming v14
 # bats test_tags=typo3-setup,t3v14
 @test "TYPO3 v14 DEV 'ddev typo3 setup' composer test with $(ddev --version)" {
-  PROJECT_NAME=my-typo3-site
-  run mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
+  PROJNAME=my-typo3-site
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
   run git clone https://github.com/TYPO3/TYPO3.CMS.BaseDistribution.git .
@@ -172,7 +172,7 @@ teardown() {
   run ddev typo3 setup \
     --admin-user-password="Demo123*" \
     --driver=mysqli \
-    --create-site=https://${PROJECT_NAME}.ddev.site \
+    --create-site=https://${PROJNAME}.ddev.site \
     --server-type=other \
     --dbname=db \
     --username=db \
@@ -189,21 +189,24 @@ teardown() {
   run ddev restart -y
   assert_success
 
-  run bats_pipe curl -sfL https://${PROJECT_NAME}.ddev.site/ \| grep "Welcome to a default website made with"
+  ddev mutagen sync
+  sleep 2
+
+  run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/ \| grep "Welcome to a default website made with"
   assert_success
-  run bats_pipe curl -sfL https://${PROJECT_NAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
+  run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
   assert_success
 
   # Now try it with /admin as the BE entrypoint
   echo '$GLOBALS["TYPO3_CONF_VARS"]["BE"]["entryPoint"] = "/admin";' >> config/system/additional.php
   run ddev mutagen sync
-  assert_success
-
-  run curl -If https://${PROJECT_NAME}.ddev.site/typo3/
+  sleep 2
+  
+  run curl -If https://${PROJNAME}.ddev.site/typo3/
   assert_failure
-  run curl -If https://${PROJECT_NAME}.ddev.site/admin/
+  run curl -If https://${PROJNAME}.ddev.site/admin/
   assert_success
 
-  run bats_pipe curl -sfL https://${PROJECT_NAME}.ddev.site/admin/ \| grep "TYPO3 CMS Login:"
+  run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/admin/ \| grep "TYPO3 CMS Login:"
   assert_success
 }

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -146,6 +146,8 @@ teardown() {
   assert_success
 }
 
+# This test is for the future, when we have a v14 quickstart. For now, it's
+# to ensure compatibility with upcoming v14
 # bats test_tags=typo3-setup,t3v14
 @test "TYPO3 v14 DEV 'ddev typo3 setup' composer test with $(ddev --version)" {
   PROJECT_NAME=my-typo3-site
@@ -194,6 +196,8 @@ teardown() {
 
   # Now try it with /admin as the BE entrypoint
   echo '$GLOBALS["TYPO3_CONF_VARS"]["BE"]["entryPoint"] = "/admin";' >> config/system/additional.php
+  run ddev mutagen sync
+  assert_success
 
   run curl -If https://${PROJECT_NAME}.ddev.site/typo3/
   assert_failure

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -191,8 +191,12 @@ teardown() {
     --force
   assert_success
 
-  run curl -sfL https://${PROJECT_NAME}.ddev.site/ | grep "Welcome to a default website made with"
+  # Restart to get the additional.php settings in there
+  run ddev restart -y
   assert_success
-  run curl s-sfL https://${PROJECT_NAME}.ddev.site/typo3/ | grep "TYPO3 CMS Login:"
+
+  run bats_pipe curl -sfL https://${PROJECT_NAME}.ddev.site/ \| grep "Welcome to a default website made with"
+  assert_success
+  run bats_pipe curl s-sfL https://${PROJECT_NAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
   assert_success
 }

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -112,7 +112,8 @@ teardown() {
   assert_success
 }
 
-@test "TYPO3 v13 `ddev typo3 setup` composer test with $(ddev --version)" {
+# bats test_tags=typo3-setup
+@test "TYPO3 v13 'ddev typo3 setup' composer test with $(ddev --version)" {
   PROJECT_NAME=my-typo3-site
   run mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
   assert_success
@@ -152,7 +153,8 @@ teardown() {
   assert_success
 }
 
-@test "TYPO3 v14 DEV `ddev typo3 setup` composer test with $(ddev --version)" {
+# bats test_tags=typo3-setup,t3v14
+@test "TYPO3 v14 DEV 'ddev typo3 setup' composer test with $(ddev --version)" {
   PROJECT_NAME=my-typo3-site
   run mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
   assert_success

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -189,6 +189,10 @@ teardown() {
   run ddev restart -y
   assert_success
 
+  # I don't understand why this would be necessary
+  run ddev exec killall -USR2 php-fpm
+  assert_success
+
   run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/ \| grep "Welcome to a default website made with"
   assert_success
   run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -12,22 +12,17 @@ teardown() {
 }
 
 @test "TYPO3 composer based quickstart with $(ddev --version)" {
-  # mkdir my-typo3-site && cd my-typo3-site
-  run mkdir my-typo3-site && cd my-typo3-site
+  PROJECT_NAME=my-typo3-site
+  run mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
   assert_success
-  # ddev config --project-type=typo3 --docroot=public --php-version=8.3
   run ddev config --project-type=typo3 --docroot=public --php-version=8.3
   assert_success
-  # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create-project "typo3/cms-base-distribution"
   run ddev composer create-project "typo3/cms-base-distribution"
   assert_success
-  # ddev exec touch public/FIRST_INSTALL
   run ddev exec touch public/FIRST_INSTALL
   assert_success
-  # ddev launch
   run bash -c "DDEV_DEBUG=true ddev launch"
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
@@ -39,9 +34,8 @@ teardown() {
 }
 
 @test "TYPO3 git based quickstart with $(ddev --version)" {
-  # PROJECT_GIT_URL=https://github.com/ddev/test-typo3.git
   PROJECT_GIT_URL=https://github.com/ddev/test-typo3.git
-  # git clone ${PROJECT_GIT_URL} ${PROJNAME}
+  PROJECT_NAME=my-typo3-site
   run git clone ${PROJECT_GIT_URL} ${PROJNAME}
   assert_success
   # cd my-typo3-site

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -71,10 +71,10 @@ teardown() {
   run ddev config --project-type=typo3 --docroot=public --php-version=8.3 --xhprof-mode=xhgui
   assert_success
 
-  run ddev start -y
+  run ddev start -y >/dev/null
   assert_success
 
-  run ddev composer create-project typo3/cms-base-distribution
+  run ddev composer create-project typo3/cms-base-distribution >/dev/null
   assert_success
 
   run ddev exec touch public/FIRST_INSTALL
@@ -115,10 +115,10 @@ teardown() {
   run ddev config --project-type=typo3 --docroot=public --php-version=8.3
   assert_success
 
-  run ddev start -y
+  run ddev start -y >/dev/null
   assert_success
 
-  run ddev composer create-project typo3/cms-base-distribution
+  run ddev composer create-project typo3/cms-base-distribution >/dev/null
   assert_success
 
   run ddev exec touch public/FIRST_INSTALL
@@ -160,10 +160,10 @@ teardown() {
   run ddev config --project-type=typo3 --docroot=public --php-version=8.3
   assert_success
 
-  run ddev start -y
+  run ddev start -y >/dev/null
   assert_success
 
-  run ddev composer install
+  run ddev composer install >/dev/null
   assert_success
 
   run ddev exec touch public/FIRST_INSTALL

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -115,7 +115,7 @@ teardown() {
 # bats test_tags=typo3-setup,t3v13
 @test "TYPO3 v13 'ddev typo3 setup' composer test with $(ddev --version)" {
   PROJECT_NAME=my-typo3-site
-  run mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
+  run mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
   assert_success
 
   run ddev config --project-type=typo3 --docroot=public --php-version=8.3
@@ -130,7 +130,6 @@ teardown() {
   run ddev exec touch public/FIRST_INSTALL
   assert_success
 
-  # Profile site
   run ddev typo3 setup \
     --admin-user-password="Demo123*" \
     --driver=mysqli \
@@ -156,7 +155,7 @@ teardown() {
 # bats test_tags=typo3-setup,t3v14
 @test "TYPO3 v14 DEV 'ddev typo3 setup' composer test with $(ddev --version)" {
   PROJECT_NAME=my-typo3-site
-  run mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
+  run mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
   assert_success
 
   run git clone https://github.com/TYPO3/TYPO3.CMS.BaseDistribution.git .
@@ -174,7 +173,6 @@ teardown() {
   run ddev exec touch public/FIRST_INSTALL
   assert_success
 
-  # Profile site
   run ddev typo3 setup \
     --admin-user-password="Demo123*" \
     --driver=mysqli \

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -111,3 +111,86 @@ teardown() {
   run ddev exec "curl -s xhgui:80 | grep -q '<a href=\"/?server_name=${PROJNAME}.ddev.site\">'"
   assert_success
 }
+
+@test "TYPO3 v13 `ddev typo3 setup` composer test with $(ddev --version)" {
+  PROJECT_NAME=my-typo3-site
+  run mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
+  assert_success
+
+  run ddev config --project-type=typo3 --docroot=public --php-version=8.3
+  assert_success
+
+  run ddev start -y
+  assert_success
+
+  run ddev composer create-project typo3/cms-base-distribution
+  assert_success
+
+  run ddev exec touch public/FIRST_INSTALL
+  assert_success
+
+  # Profile site
+  run ddev typo3 setup \
+    --admin-user-password="Demo123*" \
+    --driver=mysqli \
+    --create-site=https://${PROJECT_NAME}.ddev.site \
+    --server-type=other \
+    --dbname=db \
+    --username=db \
+    --password=db \
+    --port=3306 \
+    --host=db \
+    --admin-username=admin \
+    --admin-email=admin@example.com \
+    --project-name="demo TYPO3 site" \
+    --force
+  assert_success
+
+  run curl -sfL https://${PROJECT_NAME}.ddev.site/ | grep "Welcome to a default website made with"
+  assert_success
+  run curl s-sfL https://${PROJECT_NAME}.ddev.site/typo3/ | grep "TYPO3 CMS Login:"
+  assert_success
+}
+
+@test "TYPO3 v14 DEV `ddev typo3 setup` composer test with $(ddev --version)" {
+  PROJECT_NAME=my-typo3-site
+  run mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
+  assert_success
+
+  run git clone https://github.com/TYPO3/TYPO3.CMS.BaseDistribution.git .
+  assert_success
+
+  run ddev config --project-type=typo3 --docroot=public --php-version=8.3
+  assert_success
+
+  run ddev start -y
+  assert_success
+
+  run ddev composer install
+  assert_success
+
+  run ddev exec touch public/FIRST_INSTALL
+  assert_success
+
+  # Profile site
+  run ddev typo3 setup \
+    --admin-user-password="Demo123*" \
+    --driver=mysqli \
+    --create-site=https://${PROJECT_NAME}.ddev.site \
+    --server-type=other \
+    --dbname=db \
+    --username=db \
+    --password=db \
+    --port=3306 \
+    --host=db \
+    --admin-username=admin \
+    --admin-email=admin@example.com \
+    --project-name="demo TYPO3 site" \
+    --force
+  assert_success
+
+  run curl -sfL https://${PROJECT_NAME}.ddev.site/ | grep "Welcome to a default website made with"
+  assert_success
+  run curl s-sfL https://${PROJECT_NAME}.ddev.site/typo3/ | grep "TYPO3 CMS Login:"
+  assert_success
+}

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -112,7 +112,7 @@ teardown() {
   assert_success
 }
 
-# bats test_tags=typo3-setup
+# bats test_tags=typo3-setup,t3v13
 @test "TYPO3 v13 'ddev typo3 setup' composer test with $(ddev --version)" {
   PROJECT_NAME=my-typo3-site
   run mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
@@ -147,9 +147,9 @@ teardown() {
     --force
   assert_success
 
-  run curl -sfL https://${PROJECT_NAME}.ddev.site/ | grep "Welcome to a default website made with"
+  run bats_pipe curl -sfL https://${PROJECT_NAME}.ddev.site/ \| grep "Welcome to a default website made with"
   assert_success
-  run curl s-sfL https://${PROJECT_NAME}.ddev.site/typo3/ | grep "TYPO3 CMS Login:"
+  run bats_pipe curl s-sfL https://${PROJECT_NAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
   assert_success
 }
 

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -197,6 +197,17 @@ teardown() {
 
   run bats_pipe curl -sfL https://${PROJECT_NAME}.ddev.site/ \| grep "Welcome to a default website made with"
   assert_success
-  run bats_pipe curl s-sfL https://${PROJECT_NAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
+  run bats_pipe curl -sfL https://${PROJECT_NAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
+  assert_success
+
+  # Now try it with /admin as the BE entrypoint
+  echo '$GLOBALS["TYPO3_CONF_VARS"]["BE"]["entryPoint"] = "/admin";' >> config/system/additional.php
+
+  run curl -If https://${PROJECT_NAME}.ddev.site/typo3/
+  assert_failure
+  run curl -If https://${PROJECT_NAME}.ddev.site/admin/
+  assert_success
+
+  run bats_pipe curl -sfL https://${PROJECT_NAME}.ddev.site/admin/ \| grep "TYPO3 CMS Login:"
   assert_success
 }

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -190,8 +190,7 @@ teardown() {
   assert_success
 
   # I don't understand why this would be necessary
-  run ddev exec killall -USR2 php-fpm
-  assert_success
+  sleep 2
 
   run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/ \| grep "Welcome to a default website made with"
   assert_success

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -74,7 +74,6 @@ server {
         try_files $uri $typo3_fallback_target$is_args$args;
     }
 
-
     # pass the PHP scripts to FastCGI server listening on socket
     location ~ \.php$ {
         try_files $uri =404;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -12,6 +12,12 @@ map $http_accept $webp_suffix {
     "~*webp"  ".webp";
 }
 
+# Try both pre-v14 in /typo3 and also v14+ location (/index.php)
+map $document_root/typo3/index.php $typo3_fallback_target {
+    default /typo3/index.php;
+    "~*" /index.php;
+}
+
 server {
     listen 80 default_server;
     listen 443 ssl default_server;
@@ -65,9 +71,9 @@ server {
 
     location /typo3/ {
         absolute_redirect off;
-        # Try both pre-v14 in /typo3 and also v14+ location (/index.php)
-        try_files $uri /typo3/index.php$is_args$args /index.php$is_args$args;
+        try_files $uri $typo3_fallback_target$is_args$args;
     }
+
 
     # pass the PHP scripts to FastCGI server listening on socket
     location ~ \.php$ {

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -65,7 +65,8 @@ server {
 
     location /typo3/ {
         absolute_redirect off;
-        try_files $uri /typo3/index.php$is_args$args;
+        # Try both pre-v14 in /typo3 and also v14+ location (/index.php)
+        try_files $uri /typo3/index.php$is_args$args /index.php$is_args$args;
     }
 
     # pass the PHP scripts to FastCGI server listening on socket


### PR DESCRIPTION
## The Issue

- #6944

TYPO3 docroot setup is changing.

TYPO3 v14 LTS is still a year away (April 2026), but v14 will appear in a few months.

## How This PR Solves The Issue

Use nginx config that will support older and newer TYPO3.

## Manual Testing Instructions

- [x] Test TYPO3 quickstart with v13
- [x] Test TYPO3 quickstart with TYPO3 v14 (instructions below)
- [x] New quickstart (ddev typo3 setup) at https://ddev--7230.org.readthedocs.build/en/7230/users/quickstart/#typo3
- [x] Take a look at the new quickstart tests

