### PR TITLE
docs: use ddev composer create-project everywhere, fixes #6920

### DIFF
--- a/cmd/ddev/cmd/composer-create-project.go
+++ b/cmd/ddev/cmd/composer-create-project.go
@@ -506,8 +506,7 @@ var ComposerCreateCmd = &cobra.Command{
 	Short:              `Use "ddev composer create-project" instead`,
 	DisableFlagParsing: true,
 	Hidden:             true,
-	// TODO: make it deprecated when we switch to "create-project" in our quickstarts
-	//Deprecated:         `use "create-project" instead`,
+	Deprecated:         `please start using the identical "ddev composer create-project" instead`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ComposerCreateProjectCmd.Run(cmd, args)
 	},

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -68,7 +68,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
     mkdir my-cakephp-site && cd my-cakephp-site
     ddev config --project-type=cakephp --docroot=webroot
     ddev start
-    ddev composer create --prefer-dist --no-interaction cakephp/app:~5.0
+    ddev composer create-project --prefer-dist --no-interaction cakephp/app:~5.0
     ddev launch
     ```
 
@@ -118,7 +118,7 @@ Further information on the DDEV procedure can also be found in the [Contao docum
     ```bash
     mkdir my-contao-site && cd my-contao-site
     ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
-    ddev composer create contao/managed-edition:5.3
+    ddev composer create-project contao/managed-edition:5.3
 
     # Set DATABASE_URL and MAILER_DSN in .env.local
     ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
@@ -177,7 +177,7 @@ Environment variables will be automatically added to your `.env` file to simplif
 
     # Boot the project and install the starter project:
     ddev start
-    ddev composer create --no-scripts craftcms/craft
+    ddev composer create-project --no-scripts craftcms/craft
     ddev craft install/craft \
         --username=admin \
         --password=Password123 \
@@ -190,7 +190,7 @@ Environment variables will be automatically added to your `.env` file to simplif
     ddev launch
     ```
 
-    Third-party starter projects can by used the same way—substitute the package name when running `ddev composer create`.
+    Third-party starter projects can by used the same way—substitute the package name when running `ddev composer create-project`.
 
 === "Existing projects"
 
@@ -235,7 +235,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal11 --docroot=web
     ddev start
-    ddev composer create drupal/recommended-project:^11
+    ddev composer create-project drupal/recommended-project:^11
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
     ddev launch
@@ -251,7 +251,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal11 --docroot=web
     ddev start
-    ddev composer create drupal/cms
+    ddev composer create-project drupal/cms
     ddev launch
     ```
 
@@ -263,7 +263,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal10 --docroot=web
     ddev start
-    ddev composer create drupal/recommended-project:^10
+    ddev composer create-project drupal/recommended-project:^10
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
     ddev launch
@@ -370,7 +370,7 @@ RUN mv frankenphp /usr/local/bin/
 RUN mkdir -p /usr/local/etc && ln -s /etc/php/${DDEV_PHP_VERSION}/fpm /usr/local/etc/php
 DOCKERFILEEND
 
-ddev composer create drupal/recommended-project
+ddev composer create-project drupal/recommended-project
 ddev composer require drush/drush
 ddev restart
 ddev drush site:install demo_umami --account-name=admin --account-pass=admin -y
@@ -387,7 +387,7 @@ ddev launch $(ddev drush uli)
     mkdir my-grav-site && cd my-grav-site
     ddev config --omit-containers=db
     ddev start
-    ddev composer create getgrav/grav
+    ddev composer create-project getgrav/grav
     ddev exec gpm install admin -y
     ddev launch
     ```
@@ -428,7 +428,7 @@ Install [Ibexa DXP](https://www.ibexa.co) OSS Edition.
 mkdir my-ibexa-site && cd my-ibexa-site
 ddev config --project-type=php --docroot=public --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
 ddev start
-ddev composer create ibexa/oss-skeleton
+ddev composer create-project ibexa/oss-skeleton
 ddev exec console ibexa:install
 ddev exec console ibexa:graphql:generate-schema
 ddev launch /admin/login
@@ -458,7 +458,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
 
 === "New projects"
 
-    Create a new Kirby CMS project from the official [Starterkit](https://github.com/getkirby/starterkit) using DDEV’s [`composer create` command](../users/usage/commands.md#composer):
+    Create a new Kirby CMS project from the official [Starterkit](https://github.com/getkirby/starterkit) using DDEV’s [`composer create-project` command](../users/usage/commands.md#composer):
 
     ```bash
     # Create a new project directory and navigate into it
@@ -469,7 +469,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
 
     # Spin up the project and install the Kirby Starterkit
     ddev start
-    ddev composer create getkirby/starterkit
+    ddev composer create-project getkirby/starterkit
 
     # Open the site in your browser
     ddev launch
@@ -510,7 +510,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     mkdir my-laravel-site && cd my-laravel-site
     ddev config --project-type=laravel --docroot=public
     ddev start
-    ddev composer create "laravel/laravel:^12"
+    ddev composer create-project "laravel/laravel:^12"
     ddev launch
     ```
 
@@ -522,7 +522,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     mkdir my-laravel-site && cd my-laravel-site
     ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
     ddev start
-    ddev composer create "laravel/laravel:^12"
+    ddev composer create-project "laravel/laravel:^12"
     ddev launch
     ```
 
@@ -634,7 +634,7 @@ mkdir ${MAGENTO_HOSTNAME} && cd ${MAGENTO_HOSTNAME}
 ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
 ddev add-on get ddev/ddev-opensearch
 ddev start
-ddev composer create --repository https://repo.magento.com/ magento/project-community-edition
+ddev composer create-project --repository https://repo.magento.com/ magento/project-community-edition
 rm -f app/etc/env.php
 
 ddev magento setup:install --base-url="https://${MAGENTO_HOSTNAME}.ddev.site/" \
@@ -671,7 +671,7 @@ ddev magento setup:upgrade
     mkdir my-moodle-site && cd my-moodle-site
     ddev config --composer-root=public --docroot=public --webserver-type=apache-fpm
     ddev start
-    ddev composer create moodle/moodle
+    ddev composer create-project moodle/moodle
     ddev exec 'php public/admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
     ddev launch /login
     ```
@@ -816,7 +816,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
     ddev config --project-type=php --docroot=public --webimage-extra-packages='php${DDEV_PHP_VERSION}-amqp'
 
     ddev start
-    ddev composer create pimcore/skeleton
+    ddev composer create-project pimcore/skeleton
     ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin --no-interaction
     echo "web_extra_daemons:
       - name: consumer
@@ -848,7 +848,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     mkdir my-processwire-site && cd my-processwire-site
     ddev config --project-type=php --webserver-type=apache-fpm
     ddev start
-    ddev composer create "processwire/processwire:^3"
+    ddev composer create-project "processwire/processwire:^3"
     ddev launch
     ```
 
@@ -891,13 +891,13 @@ If you have any questions there is lots of help in the [DDEV thread in the Proce
 
 === "Composer"
 
-    Though you can set up a Shopware 6 environment many ways, we recommend the following technique. DDEV creates a `.env.local` file for you by default; if you already have one DDEV adds necessary information to it. When `ddev composer create` asks if you want to include Docker configuration, answer `x`, as this approach does not use their Docker configuration.
+    Though you can set up a Shopware 6 environment many ways, we recommend the following technique. DDEV creates a `.env.local` file for you by default; if you already have one DDEV adds necessary information to it. When `ddev composer create-project` asks if you want to include Docker configuration, answer `x`, as this approach does not use their Docker configuration.
 
     ```bash
     mkdir my-shopware-site && cd my-shopware-site
     ddev config --project-type=shopware6 --docroot=public
     ddev start
-    ddev composer create shopware/production:^v6.5
+    ddev composer create-project shopware/production:^v6.5
     # If it asks `Do you want to include Docker configuration from recipes?`
     # answer `x`, as we're using DDEV for this rather than its recipes.
     ddev exec console system:install --basic-setup
@@ -919,7 +919,7 @@ Use a new or existing Composer project, or clone a Git repository.
     mkdir my-silverstripe-site && cd my-silverstripe-site
     ddev config --project-type=silverstripe --docroot=public
     ddev start
-    ddev composer create --prefer-dist silverstripe/installer
+    ddev composer create-project --prefer-dist silverstripe/installer
     ddev sake dev/build flush=all
     ddev launch /admin
     ```
@@ -955,7 +955,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
     ```bash
     mkdir my-statamic-site && cd my-statamic-site
     ddev config --project-type=laravel --docroot=public
-    ddev composer create --prefer-dist statamic/statamic
+    ddev composer create-project --prefer-dist statamic/statamic
     ddev php please make:user admin@example.com --password=admin1234 --super --no-interaction
     ddev launch /cp
     ```
@@ -977,7 +977,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
 mkdir my-sulu-site && cd my-sulu-site
 ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0
 ddev start
-ddev composer create sulu/skeleton
+ddev composer create-project sulu/skeleton
 ```
 
 Create your default webspace configuration `mv config/webspaces/website.xml config/webspaces/my-sulu-site.xml` and adjust the values for `<name>` and `<key>` so that they are matching your project:
@@ -1035,7 +1035,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     mkdir my-symfony-site && cd my-symfony-site
     ddev config --project-type=symfony --docroot=public
     ddev start
-    ddev composer create symfony/skeleton
+    ddev composer create-project symfony/skeleton
     ddev composer require webapp
     # When it asks if you want to include docker configuration, say "no" with "x"
     ddev launch
@@ -1088,7 +1088,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     mkdir my-typo3-site && cd my-typo3-site
     ddev config --project-type=typo3 --docroot=public --php-version=8.3
     ddev start
-    ddev composer create "typo3/cms-base-distribution"
+    ddev composer create-project "typo3/cms-base-distribution"
     ddev exec touch public/FIRST_INSTALL
     ddev launch /typo3/install.php
     ```
@@ -1143,7 +1143,7 @@ There are several easy ways to use DDEV with WordPress:
     mkdir my-wp-site && cd my-wp-site
     ddev config --project-type=wordpress --docroot=web
     ddev start
-    ddev composer create roots/bedrock
+    ddev composer create-project roots/bedrock
     ```
 
     Rename the file `.env.example` to `.env` in the project root and make the following adjustments:

--- a/docs/tests/cakephp.bats
+++ b/docs/tests/cakephp.bats
@@ -24,8 +24,8 @@ teardown() {
   run ddev start -y
   assert_success
 
-  # ddev composer create --prefer-dist --no-interaction cakephp/app:~5.0
-  run ddev composer create --prefer-dist --no-interaction cakephp/app:~5.0
+  # ddev composer create-project --prefer-dist --no-interaction cakephp/app:~5.0
+  run ddev composer create-project --prefer-dist --no-interaction cakephp/app:~5.0
   assert_success
 
   # validate ddev launch

--- a/docs/tests/contao.bats
+++ b/docs/tests/contao.bats
@@ -21,8 +21,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create contao/managed-edition:5.3
-  run ddev composer create contao/managed-edition:5.3
+  # ddev composer create-project contao/managed-edition:5.3
+  run ddev composer create-project contao/managed-edition:5.3
   assert_success
   # Set DATABASE_URL and MAILER_DSN in .env.local
   # ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025

--- a/docs/tests/craftcms.bats
+++ b/docs/tests/craftcms.bats
@@ -20,7 +20,7 @@ teardown() {
   run ddev start -y
   assert_success
 
-  run ddev composer create --no-scripts craftcms/craft
+  run ddev composer create-project --no-scripts craftcms/craft
   assert_success
 
   run ddev craft install/craft \

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -21,8 +21,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create drupal/recommended-project:^11
-  run ddev composer create drupal/recommended-project:^11
+  # ddev composer create-project drupal/recommended-project:^11
+  run ddev composer create-project drupal/recommended-project:^11
   assert_success
   # ddev composer require drush/drush
   run ddev composer require drush/drush
@@ -51,8 +51,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create drupal/recommended-project:^10
-  run ddev composer create drupal/recommended-project:^10
+  # ddev composer create-project drupal/recommended-project:^10
+  run ddev composer create-project drupal/recommended-project:^10
   assert_success
   # ddev composer require drush/drush
   run ddev composer require drush/drush
@@ -113,8 +113,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create drupal/cms
-  run ddev composer create drupal/cms
+  # ddev composer create-project drupal/cms
+  run ddev composer create-project drupal/cms
   assert_success
   # Run Drush site install to set up the site
   run ddev drush si --account-name=admin --account-pass=admin -y

--- a/docs/tests/frankenphp.bats
+++ b/docs/tests/frankenphp.bats
@@ -41,7 +41,7 @@ RUN mkdir -p /usr/local/etc && ln -s /etc/php/${DDEV_PHP_VERSION}/fpm /usr/local
 DOCKERFILEEND
   assert_success
 
-  run ddev composer create drupal/recommended-project
+  run ddev composer create-project drupal/recommended-project
   assert_success
   run ddev composer require drush/drush
   assert_success

--- a/docs/tests/grav.bats
+++ b/docs/tests/grav.bats
@@ -21,8 +21,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create getgrav/grav
-  run ddev composer create getgrav/grav
+  # ddev composer create-project getgrav/grav
+  run ddev composer create-project getgrav/grav
   assert_success
   # ddev exec gpm install admin -y
   run ddev exec gpm install admin -y

--- a/docs/tests/ibexa.bats
+++ b/docs/tests/ibexa.bats
@@ -21,8 +21,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create ibexa/oss-skeleton
-  run ddev composer create ibexa/oss-skeleton
+  # ddev composer create-project ibexa/oss-skeleton
+  run ddev composer create-project ibexa/oss-skeleton
   assert_success
   # ddev exec console ibexa:install
   run ddev exec console ibexa:install

--- a/docs/tests/kirby.bats
+++ b/docs/tests/kirby.bats
@@ -25,8 +25,8 @@ teardown() {
   run ddev start -y
   assert_success
 
-  # ddev composer create getkirby/starterkit
-  run ddev composer create getkirby/starterkit
+  # ddev composer create-project getkirby/starterkit
+  run ddev composer create-project getkirby/starterkit
   assert_success
 
   # validate ddev launch

--- a/docs/tests/laravel.bats
+++ b/docs/tests/laravel.bats
@@ -21,7 +21,7 @@ teardown() {
   run ddev start -y
   assert_success
 
-  run ddev composer create "laravel/laravel:^12"
+  run ddev composer create-project "laravel/laravel:^12"
   assert_success
 
   DDEV_DEBUG=true run ddev launch
@@ -53,7 +53,7 @@ teardown() {
   run ddev start -y
   assert_success
 
-  run ddev composer create "laravel/laravel:^12"
+  run ddev composer create-project "laravel/laravel:^12"
   assert_success
 
   DDEV_DEBUG=true run ddev launch

--- a/docs/tests/magento2.bats
+++ b/docs/tests/magento2.bats
@@ -47,8 +47,8 @@ EOF
   run ddev start -y
   assert_success
 
-  # ddev composer create --repository https://repo.magento.com/ magento/project-community-edition
-  run ddev composer create --repository https://repo.magento.com/ magento/project-community-edition
+  # ddev composer create-project --repository https://repo.magento.com/ magento/project-community-edition
+  run ddev composer create-project --repository https://repo.magento.com/ magento/project-community-edition
   assert_success
 
     # Copy the auth.json into var/composer_home for the deploying the sample data sep

--- a/docs/tests/moodle.bats
+++ b/docs/tests/moodle.bats
@@ -21,8 +21,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create moodle/moodle
-  run ddev composer create moodle/moodle
+  # ddev composer create-project moodle/moodle
+  run ddev composer create-project moodle/moodle
   assert_success
   # ddev exec 'php public/admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
   run ddev exec 'php public/admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'

--- a/docs/tests/pimcore.bats
+++ b/docs/tests/pimcore.bats
@@ -21,8 +21,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create pimcore/skeleton
-  run ddev composer create pimcore/skeleton
+  # ddev composer create-project pimcore/skeleton
+  run ddev composer create-project pimcore/skeleton
   assert_success
   # ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin --no-interaction
   run ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin --no-interaction

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -48,8 +48,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create "processwire/processwire:^3"
-  run ddev composer create "processwire/processwire:^3"
+  # ddev composer create-project "processwire/processwire:^3"
+  run ddev composer create-project "processwire/processwire:^3"
   # ddev launch
   run bash -c "DDEV_DEBUG=true ddev launch"
   assert_output "FULLURL https://${PROJNAME}.ddev.site"

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -21,8 +21,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev . echo x | ddev composer create shopware/production:^v6.5
-  run ddev . echo x | ddev composer create shopware/production:^v6.5
+  # ddev . echo x | ddev composer create-project shopware/production:^v6.5
+  run ddev . echo x | ddev composer create-project shopware/production:^v6.5
   # ddev exec console system:install --basic-setup
   run ddev exec console system:install --basic-setup
   assert_success

--- a/docs/tests/silverstripe.bats
+++ b/docs/tests/silverstripe.bats
@@ -25,7 +25,7 @@ teardown() {
   assert_success
 
   # ddev sake dev/build flush=all
-  run ddev composer create --prefer-dist silverstripe/installer
+  run ddev composer create-project --prefer-dist silverstripe/installer
   assert_success
 
   # ddev sake dev/build flush=all

--- a/docs/tests/statamic.bats
+++ b/docs/tests/statamic.bats
@@ -20,8 +20,8 @@ teardown() {
   run ddev config --project-type=laravel --docroot=public
   assert_success
 
-  # ddev composer create --prefer-dist statamic/statamic
-  run ddev composer create --prefer-dist statamic/statamic
+  # ddev composer create-project --prefer-dist statamic/statamic
+  run ddev composer create-project --prefer-dist statamic/statamic
   assert_success
 
   # fill out the interactive form

--- a/docs/tests/sulu.bats
+++ b/docs/tests/sulu.bats
@@ -21,8 +21,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create sulu/skeleton
-  run ddev composer create sulu/skeleton
+  # ddev composer create-project sulu/skeleton
+  run ddev composer create-project sulu/skeleton
   assert_success
   # export SULU_PROJECT_NAME="My Sulu Site"
   export SULU_PROJECT_NAME="My Sulu Site"

--- a/docs/tests/symfony.bats
+++ b/docs/tests/symfony.bats
@@ -24,8 +24,8 @@ teardown() {
   run ddev start -y
   assert_success
 
-  # ddev composer create symfony/skeleton
-  run ddev composer create symfony/skeleton
+  # ddev composer create-project symfony/skeleton
+  run ddev composer create-project symfony/skeleton
   assert_success
 
   # bash -c 'printf "x\n" | ddev composer require webapp'

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -21,8 +21,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create "typo3/cms-base-distribution"
-  run ddev composer create "typo3/cms-base-distribution"
+  # ddev composer create-project "typo3/cms-base-distribution"
+  run ddev composer create-project "typo3/cms-base-distribution"
   assert_success
   # ddev exec touch public/FIRST_INSTALL
   run ddev exec touch public/FIRST_INSTALL
@@ -80,7 +80,7 @@ teardown() {
   run ddev start -y
   assert_success
 
-  run ddev composer create typo3/cms-base-distribution
+  run ddev composer create-project typo3/cms-base-distribution
   assert_success
 
   run ddev exec touch public/FIRST_INSTALL

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -53,8 +53,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create roots/bedrock
-  run ddev composer create roots/bedrock
+  # ddev composer create-project roots/bedrock
+  run ddev composer create-project roots/bedrock
   assert_success
   # cp .env.example .env
   run cp .env.example .env


### PR DESCRIPTION
## The Issue

- #6920

@stasadev finally got `ddev composer create-project` sorted out to be identical to `composer create-project` so we don't need the one-off `ddev composer create` any more. 

## How This PR Solves The Issue

Update docs and CMS quickstart tests

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
