### PR TITLE
feat: allow YAML for custom command annotations, fixes #2638

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/artisan
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/artisan
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
 #ddev-generated
-## Description: Run artisan CLI inside the web container
-## Usage: artisan [flags] [args]
-## Example: "ddev artisan list" or "ddev artisan cache:clear"
-## Aliases: art
-## ProjectTypes: laravel
-## ExecRaw: true
-## MutagenSync: true
+<<'###YAML_ANNOTATIONS'
+description: "Run artisan CLI inside the web container"
+usage: "artisan [flags] [args]"
+example: '"ddev artisan list" or "ddev artisan cache:clear"'
+aliases:
+  - "art"
+projectTypes:
+  - "laravel"
+execRaw: true
+mutagenSync: true
+###YAML_ANNOTATIONS
 
 php ./artisan "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/blackfire
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/blackfire
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 
 #ddev-generated: Remove this line to take over this script
-## Description: Enable or disable blackfire.io profiling
-## Usage: blackfire start|stop|on|off|enable|disable|true|false|status
-## Example: "ddev blackfire" (default is "on"), "ddev blackfire off", "ddev blackfire on", "ddev blackfire status"
-## ExecRaw: false
-## Flags: []
-## AutocompleteTerms: ["start","stop","on","off","enable","disable","status"]
+<<'###YAML_ANNOTATIONS'
+description: "Enable or disable blackfire.io profiling"
+usage: "blackfire start|stop|on|off|enable|disable|true|false|status"
+example: '"ddev blackfire" (default is "on"), "ddev blackfire off", "ddev blackfire on", "ddev blackfire status"'
+execRaw: false
+autocompleteTerms:
+  - "start"
+  - "stop"
+  - "on"
+  - "off"
+  - "enable"
+  - "disable"
+  - "status"
+###YAML_ANNOTATIONS
 
 function enable {
   if [ -z ${BLACKFIRE_SERVER_ID} ] || [ -z ${BLACKFIRE_SERVER_TOKEN} ]; then

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/cake
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/cake
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
 #ddev-generated
-## Description: Run cake CLI inside the web container
-## Usage: cake [subcommand] [flags] [args]
-## Example: "ddev cake bake" or "ddev cake cache clear_all"
-## ProjectTypes: cakephp
-## ExecRaw: true
-## MutagenSync: true
+<<'###YAML_ANNOTATIONS'
+description: "Run cake CLI inside the web container"
+usage: "cake [subcommand] [flags] [args]"
+example: '"ddev cake bake" or "ddev cake cache clear_all"'
+projectTypes:
+  - "cakephp"
+execRaw: true
+mutagenSync: true
+###YAML_ANNOTATIONS
 
 php ./bin/cake.php "$@"
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/console
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/console
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 #ddev-generated
-## Description: Run symfony console inside the web container
-## Usage: console [flags] [args]
-## Example: "ddev console about" or "ddev console doctrine:schema:update --dump-sql"
-## ProjectTypes: symfony
-## ExecRaw: true
-## MutagenSync: true
+<<'###YAML_ANNOTATIONS'
+description: "Run symfony console inside the web container"
+usage: "console [flags] [args]"
+example: '"ddev console about" or "ddev console doctrine:schema:update --dump-sql"'
+projectTypes:
+  - "symfony"
+execRaw: true
+mutagenSync: true
+###YAML_ANNOTATIONS
 
 if [ ! -f bin/console ]; then
   echo 'bin/console does not exist in your project root directory.'

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/craft
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/craft
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
 #ddev-generated
-## Description: Run Craft CMS command inside the web container
-## Usage: craft [flags] [args]
-## Example: "ddev craft db/backup" or "ddev craft db/backup ./my-backups" (see https://craftcms.com/docs/4.x/console-commands.html)
-## ProjectTypes: craftcms,php
-## ExecRaw: true
-## MutagenSync: true
+<<'###YAML_ANNOTATIONS'
+description: "Run Craft CMS command inside the web container"
+usage: "craft [flags] [args]"
+example: '"ddev craft db/backup" or "ddev craft db/backup ./my-backups" (see https://craftcms.com/docs/4.x/console-commands.html)'
+projectTypes:
+  - "craftcms"
+  - "php"
+execRaw: true
+mutagenSync: true
+###YAML_ANNOTATIONS
 
 if [ "${DDEV_PROJECT_TYPE}" != "craftcms" ]; then
     echo "The craft command is only available in the craftcms project type. You can update this in your project's config file, followed by restarting the DDEV project."

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
-## #ddev-generated
-## Description: Enable or disable xdebug
-## Usage: xdebug on|off|enable|disable|true|false|toggle|status
-## Example: "ddev xdebug" (default is "on"), "ddev xdebug off", "ddev xdebug on", "ddev xdebug toggle", "ddev xdebug status"
-## ExecRaw: false
-## Flags: []
-## AutocompleteTerms: ["on","off","enable","disable","toggle","status"]
+#ddev-generated
+<<'###YAML_ANNOTATIONS'
+description: "This is a test to see if it works."
+usage: "xdebug test on|off etc"
+example: '"ddev xdebug" (default is "on"), "ddev xdebug off", "ddev xdebug on", "ddev xdebug toggle", "ddev xdebug status"'
+execRaw: false
+autocompleteTerms:
+  - "on"
+  - "off"
+  - "enable"
+  - "disable"
+  - "toggle"
+  - "status"
+###YAML_ANNOTATIONS
 
 if [ $# -eq 0 ] ; then
   enable_xdebug


### PR DESCRIPTION
## The Issue

- #2638

Annotations for custom commands (especially for flags) can get pretty long since they have to be on a single line.
Allowing annotations to be defined in YAML would resolve this and give clear syntax rules that DDEV doesn't have to define or maintain.

## How This PR Solves The Issue

Allows defining for custom commands in YAML

## Manual Testing Instructions

Create a custom command
Instead of using the `## Annotation: Value` syntax, use the following syntax:

```text
<<'###YAML_ANNOTATIONS'
annotation: value
###YAML_ANNOTATIONS
```

for example:

```text
<<'###YAML_ANNOTATIONS'
description: "A description for the command"
usage: "command-name [flags] [args]"
aliases:
  - "command-alias"
  - "my-command"
projectTypes:
  - "laravel"
  - "php"
execRaw: true
mutagenSync: true
###YAML_ANNOTATIONS
```

## Automated Testing Overview

Will be written after I have a good sense that the general approach is acceptable

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
The old syntax will still work, but should be considered deprecated.
In a future major release, the old syntax should be removed.

## Remaining tasks:

1. [ ] Confirm the general approach
2. [ ] Make sure flags work
3. [ ] Any other "todo" comments currently added in the PR
4. [ ] Update all commands included with DDEV
5. [ ] Update docs
6. [ ] Add tests for the new format

## Outstanding questions:

1. Is this a good way to delimit the start and end of the YAML command content?
1. Should the YAML format accept keys with both capital and lower case first characters (if `yaml.unmarshal` allows that)?
    - If `yaml.unmarshal` dictates it must be one or the other, should it accept upper-case or lower-case?
1. Should the documentation list both syntaxes or just the new YAML syntax?
    - If both, how should that look? e.g. show YAML as default but then "before x.y.z use `<old syntax>`"?
1. If a command uses the old syntax, should a warning or message of some sort be output to the terminal? (I would suggest no)