### PR TITLE
refactor: Use `.ddev/.env.web` for Craft CMS DDEV settings, fixes #7233

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -98,10 +98,10 @@ func init() {
 		},
 
 		nodeps.AppTypeCraftCms: {
+			settingsCreator:      createCraftCMSDotEnv,
 			importFilesAction:    craftCmsImportFilesAction,
 			appTypeDetect:        isCraftCmsApp,
 			configOverrideAction: craftCmsConfigOverrideAction,
-			postStartAction:      craftCmsPostStartAction,
 		},
 
 		nodeps.AppTypeDrupal6: {

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -100,6 +100,7 @@ func init() {
 		nodeps.AppTypeCraftCms: {
 			settingsCreator:      createCraftCMSDotEnv,
 			importFilesAction:    craftCmsImportFilesAction,
+			appTypeSettingsPaths: setCraftCMSDotFileLocation,
 			appTypeDetect:        isCraftCmsApp,
 			configOverrideAction: craftCmsConfigOverrideAction,
 		},

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -98,7 +98,7 @@ func init() {
 		},
 
 		nodeps.AppTypeCraftCms: {
-			settingsCreator:      createCraftCMSDotEnv,
+			settingsCreator:      updateCraftCMSDotEnv,
 			importFilesAction:    craftCmsImportFilesAction,
 			appTypeSettingsPaths: setCraftCMSDotFileLocation,
 			appTypeDetect:        isCraftCmsApp,

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -2,6 +2,7 @@ package ddevapp
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -100,7 +101,8 @@ func updateCraftCMSDotEnv(app *DdevApp) (string, error) {
 
 	// Read existing env file
 	_, existingEnvText, err := ReadProjectEnvFile(envFilePath)
-	if err != nil {
+	// If envFilePath doesn't exist, that's not really an error, continue
+	if !os.IsNotExist(err) {
 		return "", err
 	}
 

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -62,7 +62,7 @@ func craftCmsImportFilesAction(app *DdevApp, uploadDir, importPath, extPath stri
 }
 
 // Set up the .ddev/.env.web file for ddev
-func createCraftCMSDotEnv(app *DdevApp) (string, error) {
+func updateCraftCMSDotEnv(app *DdevApp) (string, error) {
 	// If settings management is disabled, do nothing
 	if app.DisableSettingsManagement {
 		return "", nil
@@ -85,7 +85,7 @@ func createCraftCMSDotEnv(app *DdevApp) (string, error) {
 		port = "5432"
 	}
 
-	envMap := map[string]string{
+	newCraftEnvMap := map[string]string{
 		"CRAFT_DB_DRIVER":       driver,
 		"CRAFT_DB_SERVER":       "db",
 		"CRAFT_DB_PORT":         port,
@@ -98,7 +98,13 @@ func createCraftCMSDotEnv(app *DdevApp) (string, error) {
 		"PRIMARY_SITE_URL":      app.GetPrimaryURL(),
 	}
 
-	err := WriteProjectEnvFile(envFilePath, envMap, "")
+	// Read existing env file
+	_, existingEnvText, err := ReadProjectEnvFile(envFilePath)
+	if err != nil {
+		return "", err
+	}
+
+	err = WriteProjectEnvFile(envFilePath, newCraftEnvMap, existingEnvText)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -102,7 +102,7 @@ func updateCraftCMSDotEnv(app *DdevApp) (string, error) {
 	// Read existing env file
 	_, existingEnvText, err := ReadProjectEnvFile(envFilePath)
 	// If envFilePath doesn't exist, that's not really an error, continue
-	if !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(err) {
 		return "", err
 	}
 

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -78,7 +78,7 @@ func craftCmsPostStartAction(app *DdevApp) error {
 	}
 
 	// If the .env file doesn't exist, try to create it by copying .env.example to .env
-	envFilePath := filepath.Join(app.AppRoot, app.ComposerRoot, ".env")
+	envFilePath := app.GetConfigPath(".env.web")
 	if !fileutil.FileExists(envFilePath) {
 		var exampleEnvFilePaths = []string{".env.example", ".env.example.dev"}
 		for _, envFileName := range exampleEnvFilePaths {
@@ -101,7 +101,7 @@ func craftCmsPostStartAction(app *DdevApp) error {
 	// Read in the .env file
 	envMap, envText, err := ReadProjectEnvFile(envFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("unable to read .env file: %v", err)
+		return fmt.Errorf("unable to read %s: %v", envFilePath, err)
 	}
 
 	port := "3306"

--- a/pkg/ddevapp/craftcms.go
+++ b/pkg/ddevapp/craftcms.go
@@ -63,17 +63,17 @@ func craftCmsImportFilesAction(app *DdevApp, uploadDir, importPath, extPath stri
 }
 
 // Set up the .env file for ddev
-func craftCmsPostStartAction(app *DdevApp) error {
+func createCraftCMSDotEnv(app *DdevApp) (string, error) {
 	// If settings management is disabled, do nothing
 	if app.DisableSettingsManagement {
-		return nil
+		return "", nil
 	}
 
 	// Check version is v4 or higher or warn user about app type mismatch.
 	if !isCraftCms4orHigher(app) {
 		util.Warning("It looks like the installed Craft CMS is lower than version 4 where it's recommended to use project type `php` or disable settings management with `ddev config --disable-settings-management`")
 		if !util.Confirm("Would you like to stop here, not do the automatic configuration and change project type?") {
-			return nil
+			return "", nil
 		}
 	}
 
@@ -89,19 +89,19 @@ func craftCmsPostStartAction(app *DdevApp) error {
 				if err != nil {
 					util.Error(fmt.Sprintf("Error copying %s to .env", exampleEnvFilePath))
 
-					return err
+					return "", err
 				}
 			}
 		}
 	}
 	// If the .env file *still* doesn't exist, return early
 	if !fileutil.FileExists(envFilePath) {
-		return nil
+		return "", nil
 	}
 	// Read in the .env file
 	envMap, envText, err := ReadProjectEnvFile(envFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("unable to read %s: %v", envFilePath, err)
+		return "", fmt.Errorf("unable to read %s: %v", envFilePath, err)
 	}
 
 	port := "3306"
@@ -143,10 +143,10 @@ func craftCmsPostStartAction(app *DdevApp) error {
 
 	err = WriteProjectEnvFile(envFilePath, envMap, envText)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return "", nil
 }
 
 func craftCmsConfigOverrideAction(app *DdevApp) error {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2312,7 +2312,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		assert.NoError(err)
 
 		switch app.Type {
-		case nodeps.AppTypeShopware6, nodeps.AppTypeSymfony:
+		case nodeps.AppTypeCraftCms, nodeps.AppTypeShopware6, nodeps.AppTypeSymfony:
 			// Skip the check for the above types because they use app.SiteSettingsPath differently
 		default:
 			assert.Equal(filepath.Dir(settingsLocation), filepath.Dir(app.SiteSettingsPath))

--- a/pkg/ddevapp/envfile.go
+++ b/pkg/ddevapp/envfile.go
@@ -26,7 +26,7 @@ func ReadProjectEnvFile(envFilePath string) (envMap map[string]string, envText s
 }
 
 // WriteProjectEnvFile writes the passed envText into the envFilePath .env file
-// with all items in envMap changed in envText there
+// changing items in envMap changed in envText there
 func WriteProjectEnvFile(envFilePath string, envMap map[string]string, envText string) error {
 	for k, v := range envMap {
 		v = EscapeEnvFileValue(v)

--- a/pkg/ddevapp/envfile.go
+++ b/pkg/ddevapp/envfile.go
@@ -11,6 +11,10 @@ import (
 
 // ReadProjectEnvFile reads the .env in the project root into a envText and envMap
 // The map has the envFile content, but without comments
+// returns
+// - envMap (map of items found)
+// - envText (plain text unaltered of existing env file
+// - error/nil
 func ReadProjectEnvFile(envFilePath string) (envMap map[string]string, envText string, err error) {
 	// envFilePath := filepath.Join(app.AppRoot, ".env")
 	envText, _ = fileutil.ReadFileIntoString(envFilePath)
@@ -21,10 +25,9 @@ func ReadProjectEnvFile(envFilePath string) (envMap map[string]string, envText s
 	return envMap, envText, err
 }
 
-// WriteProjectEnvFile writes the passed envText into the project-root .env file
+// WriteProjectEnvFile writes the passed envText into the envFilePath .env file
 // with all items in envMap changed in envText there
 func WriteProjectEnvFile(envFilePath string, envMap map[string]string, envText string) error {
-	// envFilePath := filepath.Join(app.AppRoot, ".env")
 	for k, v := range envMap {
 		v = EscapeEnvFileValue(v)
 		// If the item is already in envText, use regex to replace it


### PR DESCRIPTION
## The Issue

- #7233

Craft CMS settings for DDEV would be better in the .ddev namespace

## How This PR Solves The Issue

Move DB settings and the like into .ddev/.env.web. Could be improved with better naming, see
* #7235 

## TODO

- [x] Changes to Craft CMS quickstart doc?
- [x] Figure out how to make this backward-compatible. Warn people about project-level .env if it contains things?
- [x] Add `#ddev-generated` to the generated file if we can. Previously we couldn't, but with this approach we mostly should be able to.


## Manual Testing Instructions

Use the [DDEV Craft CMS Quickstart](https://ddev.readthedocs.io/en/stable/users/quickstart/#craft-cms)

Note that the `composer create-project craftcms/craft` absolutely insists on creating a project-level .env with these values. It takes the correct values as default that have already been set by the .ddev/.env.web, but then they're place in the project .env, which is a pain.

## Automated Testing Overview

Existing tests should behave the same

## Release/Deployment Notes

