### PR TITLE
docs: wrap quotes around commands that use the caret symbol

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -235,7 +235,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal11 --docroot=web
     ddev start
-    ddev composer create-project drupal/recommended-project:^11
+    ddev composer create-project "drupal/recommended-project:^11"
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
     ddev launch
@@ -263,7 +263,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal10 --docroot=web
     ddev start
-    ddev composer create-project drupal/recommended-project:^10
+    ddev composer create-project "drupal/recommended-project:^10"
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
     ddev launch
@@ -897,7 +897,7 @@ If you have any questions there is lots of help in the [DDEV thread in the Proce
     mkdir my-shopware-site && cd my-shopware-site
     ddev config --project-type=shopware6 --docroot=public
     ddev start
-    ddev composer create-project shopware/production:^v6.5
+    ddev composer create-project "shopware/production:^v6.5"
     # If it asks `Do you want to include Docker configuration from recipes?`
     # answer `x`, as we're using DDEV for this rather than its recipes.
     ddev exec console system:install --basic-setup

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -21,8 +21,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create-project drupal/recommended-project:^11
-  run ddev composer create-project drupal/recommended-project:^11
+  # ddev composer create-project "drupal/recommended-project:^11"
+  run ddev composer create-project "drupal/recommended-project:^11"
   assert_success
   # ddev composer require drush/drush
   run ddev composer require drush/drush
@@ -51,8 +51,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev composer create-project drupal/recommended-project:^10
-  run ddev composer create-project drupal/recommended-project:^10
+  # ddev composer create-project "drupal/recommended-project:^10"
+  run ddev composer create-project "drupal/recommended-project:^10"
   assert_success
   # ddev composer require drush/drush
   run ddev composer require drush/drush

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -21,8 +21,8 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
-  # ddev . echo x | ddev composer create-project shopware/production:^v6.5
-  run ddev . echo x | ddev composer create-project shopware/production:^v6.5
+  # ddev . echo x | ddev composer create-project "shopware/production:^v6.5"
+  run ddev . echo x | ddev composer create-project "shopware/production:^v6.5"
   # ddev exec console system:install --basic-setup
   run ddev exec console system:install --basic-setup
   assert_success


### PR DESCRIPTION
## The Issue

When using Zsh, the `composer create ...` command will fail if using a caret symbol to specify the project version.

Drupal Slack conversation: https://drupal.slack.com/archives/C5TQRQZRR/p1745774586216839

Zsh issue:

- https://github.com/ohmyzsh/ohmyzsh/pull/3919

## How This PR Solves The Issue

Wrapping the project and version number in quotes will prevent Zsh from globbing, and allow the command to execute as expected.

## Manual Testing Instructions

Review https://ddev--7237.org.readthedocs.build/en/7237/users/quickstart/