### PR TITLE
fix: Add path to docroot in wp parameters when not set, fixes #7241

### DIFF
--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -150,7 +150,7 @@ See also [TYPO3 Documentation](https://docs.typo3.org/m/typo3/reference-coreapi/
 
 !!!note "DDEV v1.24.5+ automatically adds `--path=$DDEV_DOCROOT` to the `ddev wp` command if needed."
 
-If you use something other than the root directory (`''`) for your docroot, [`ddev wp`](../usage/commands.md#wp) will not work properly. To fix this, create a `wp-cli.yml` file in the root directory that contains `path: <docroot/path>`.
+If you use something other than the root directory (`''`) for your docroot, [`ddev wp`](../usage/commands.md#wp) will not work properly. To fix this, create a `wp-cli.yml` file in the project root directory that contains `path: <docroot/path>`.
 
 For example, if your docroot is `public`, your `wp-cli.yml` file should contain:
 

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -148,7 +148,9 @@ See also [TYPO3 Documentation](https://docs.typo3.org/m/typo3/reference-coreapi/
 
 #### WP-CLI and changing the docroot in config.yaml
 
-If you use something other than the root directory (`''`) for your docroot, wp-cli will not work properly. To fix this, create a `wp-cli.yml` file in the root directory that contains `path: <docroot/path>`.
+!!!note "DDEV v1.24.5+ automatically adds `--path=$DDEV_DOCROOT` to the `ddev wp` command if needed."
+
+If you use something other than the root directory (`''`) for your docroot, [`ddev wp`](../usage/commands.md#wp) will not work properly. To fix this, create a `wp-cli.yml` file in the root directory that contains `path: <docroot/path>`.
 
 For example, if your docroot is `public`, your `wp-cli.yml` file should contain:
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1587,6 +1587,8 @@ ddev version
 
 Run the [WP-CLI `wp` command](https://wp-cli.org/); available only in projects of type `wordpress`.
 
+!!!note "DDEV v1.24.5+ automatically adds `--path=$DDEV_DOCROOT` to the `ddev wp` command if needed."
+
 ```shell
 # Install WordPress site using `wp core install`
 ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_email=admin@example.com --prompt=admin_password

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1587,13 +1587,13 @@ ddev version
 
 Run the [WP-CLI `wp` command](https://wp-cli.org/); available only in projects of type `wordpress`.
 
-!!!note "DDEV v1.24.5+ automatically adds `--path=$DDEV_DOCROOT` to the `ddev wp` command if needed."
-
 ```shell
 # Install WordPress site using `wp core install`
 ddev wp core install --url='$DDEV_PRIMARY_URL' --title='New-WordPress' --admin_user=admin --admin_email=admin@example.com --prompt=admin_password
-
 ```
+
+!!!tip
+    See [WordPress Specifics](./cms-settings.md#wordpress-specifics) for more information.
 
 ## `xdebug`
 

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -43,6 +43,38 @@ teardown() {
   assert_output --partial "HTTP/2 302"
 }
 
+@test "WordPress wp-cli based quickstart (different docroot) with $(ddev --version)" {
+  # mkdir my-wp-site && cd my-wp-site
+  run mkdir my-wp-site && cd my-wp-site
+  assert_success
+  # ddev config --project-type=wordpress --docroot=web/wp
+  run ddev config --project-type=wordpress --docroot=web/wp
+  assert_success
+  # ddev start -y
+  run ddev start -y
+  assert_success
+  # ddev wp core download
+  run ddev wp core download
+  assert_success
+  # ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  assert_success
+  # ddev launch
+  run bash -c "DDEV_DEBUG=true ddev launch"
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "link: <https://my-wp-site.ddev.site/wp-json/>; rel=\"https://api.w.org/\""
+  assert_output --partial "HTTP/2 200"
+  # validate running project
+  run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
+  assert_success
+  assert_output --partial "location: https://my-wp-site.ddev.site/wp-login.php"
+  assert_output --partial "HTTP/2 302"
+}
+
 @test "WordPress Bedrock based quickstart with $(ddev --version)" {
   # mkdir my-wp-site && cd my-wp-site
   run mkdir my-wp-site && cd my-wp-site

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/wp
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/wp
@@ -10,4 +10,12 @@
 # Ignore anything we find in the mounted global commands
 PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
 
+# Add --path if not already set
+if [[ ! " $* " =~ (--path(=|\s)) ]]; then
+  # Build the path value based on DDEV_COMPOSER_ROOT and DDEV_DOCROOT
+  path_value="${DDEV_COMPOSER_ROOT%/}"
+  [[ -n "$DDEV_DOCROOT" ]] && path_value+="/${DDEV_DOCROOT#/}"
+  set -- "$@" --path="$path_value"
+fi
+
 wp "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/wp
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/wp
@@ -13,7 +13,7 @@ PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
 # Add --path if not already set and $DDEV_DOCROOT is defined
 if [[ ! " $* " =~ (--path(=|\s)) ]] && [[ -n "$DDEV_DOCROOT" ]]; then
   # Get the configured path from wp-cli.yml or other config file
-  existing_wp_path=$(yq -r '.path // ""' "$(wp cli info --format=json 2>/dev/null | jq -r '.project_config_path // empty' 2>/dev/null)" 2>/dev/null)
+  existing_wp_path="$(yq -r '.path // ""' "$(wp cli info --format=json 2>/dev/null | jq -r '.project_config_path // empty' 2>/dev/null)" 2>/dev/null)"
   # If there is no path, set it to DDEV_DOCROOT
   [[ -z "$existing_wp_path" ]] && set -- "$@" --path="$DDEV_DOCROOT"
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/wp
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/wp
@@ -14,7 +14,7 @@ PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
 if [[ ! " $* " =~ (--path(=|\s)) ]] && [[ -n "$DDEV_DOCROOT" ]]; then
   # Get the configured path from wp-cli.yml or other config file
   existing_wp_path="$(yq -r '.path // ""' "$(wp cli info --format=json 2>/dev/null | jq -r '.project_config_path // empty' 2>/dev/null)" 2>/dev/null)"
-  # If there is no path, set it to DDEV_DOCROOT
+  # If there is no path, set it to $DDEV_DOCROOT
   [[ -z "$existing_wp_path" ]] && set -- "$@" --path="$DDEV_DOCROOT"
 fi
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/wp
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/wp
@@ -10,12 +10,12 @@
 # Ignore anything we find in the mounted global commands
 PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
 
-# Add --path if not already set
-if [[ ! " $* " =~ (--path(=|\s)) ]]; then
-  # Build the path value based on DDEV_COMPOSER_ROOT and DDEV_DOCROOT
-  path_value="${DDEV_COMPOSER_ROOT%/}"
-  [[ -n "$DDEV_DOCROOT" ]] && path_value+="/${DDEV_DOCROOT#/}"
-  set -- "$@" --path="$path_value"
+# Add --path if not already set and $DDEV_DOCROOT is defined
+if [[ ! " $* " =~ (--path(=|\s)) ]] && [[ -n "$DDEV_DOCROOT" ]]; then
+  # Get the configured path from wp-cli.yml or other config file
+  existing_wp_path=$(yq -r '.path // ""' "$(wp cli info --format=json 2>/dev/null | jq -r '.project_config_path // empty' 2>/dev/null)" 2>/dev/null)
+  # If there is no path, set it to DDEV_DOCROOT
+  [[ -z "$existing_wp_path" ]] && set -- "$@" --path="$DDEV_DOCROOT"
 fi
 
 wp "$@"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #7241

This was done using my working time, please, consider giving credit to www.nazaries.com 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue
Adds `--path` to `$DDEV_DOCROOT` when `--path` is not present, `$DDEV_DOCROOT` is set, and there is no `path` in `wp-cli.yml` (or other config file), so it´s always executed in the right path.

## Manual Testing Instructions
1. `mkdir my-wp-site && cd my-wp-site`
2. `ddev config --project-type=wordpress --docroot=web`
3. Everything will be installed in `web`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
Added a wordpress bats tests, which is a copy of a regular one with `--docroot`.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
Make sure `wp` script is updated
