### PR TITLE
build: Reject the use of `drud/ddev/ddev` homebrew recipe

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -196,8 +196,8 @@ brews:
       depends_on "make" => :build
     end
     # fail fast if tapped under the old drud or rfay names
-    def initialize(...)
-      super
+    def initialize(*args, **kwargs)
+      super(*args, **kwargs)
       if ["drud/homebrew-ddev", "ddev-test/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap.full_name)
         odie <<~EOS
           ERROR: your homebrew tap is the ancient #{tap.full_name},
@@ -252,9 +252,9 @@ brews:
       depends_on "make" => :build
     end
     # fail fast if tapped under the old drud or rfay names
-    def initialize(...)
-      super
-      if ["drud/homebrew-ddev", "ddev-test/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap.full_name)
+    def initialize(*args, **kwargs)
+      super(*args, **kwargs)
+      if ["drud/homebrew-ddev", "drud/homebrew-ddev-edge", "ddev-test/homebrew-ddev", "ddev-test/homebrew-ddev-edge", "rfay/homebrew-ddev"].include?(tap.full_name)
         odie <<~EOS
           ERROR: your homebrew tap is the ancient #{tap.full_name},
           but that repository has moved.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -203,7 +203,7 @@ brews:
     # fail fast if tapped under the old drud or rfay names
     def initialize(*args, **kwargs)
       super(*args, **kwargs)
-      if ["drud/homebrew-ddev", "ddev-test/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap.full_name)
+      if ["drud/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap.full_name)
         odie <<~EOS
           ERROR: your homebrew tap is the ancient #{tap.full_name},
           but that repository has moved.
@@ -260,7 +260,7 @@ brews:
     # fail fast if tapped under the old drud or rfay names
     def initialize(*args, **kwargs)
       super(*args, **kwargs)
-      if ["drud/homebrew-ddev", "drud/homebrew-ddev-edge", "ddev-test/homebrew-ddev", "ddev-test/homebrew-ddev-edge", "rfay/homebrew-ddev"].include?(tap.full_name)
+      if ["drud/homebrew-ddev", "drud/homebrew-ddev-edge",  "ddev-test/homebrew-ddev-edge", "rfay/homebrew-ddev-edge"].include?(tap.full_name)
         odie <<~EOS
           ERROR: your homebrew tap is the ancient #{tap.full_name},
           but that repository has moved.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -193,7 +193,7 @@ brews:
     # fail fast if tapped under the old drud or rfay names
     def initialize(...)
       super
-      if ["drud/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap.full_name)
+      if ["drud/homebrew-ddev", "ddev-test/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap.full_name)
         odie <<~EOS
           ERROR: your homebrew tap is the ancient #{tap.full_name},
           but that repository has moved.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -125,19 +125,20 @@ builds:
 
 ###### Archives ######
 archives:
-- id: ddev
-  builds:
-  - ddev
-  - mkcert
-  - ddev_bash_completion.sh
-  - ddev_zsh_completion.sh
-  - ddev_fish_completion.sh
-  format: tar.gz
+  ids:
+    - ddev
+    - mkcert
+    - ddev_bash_completion.sh
+    - ddev_zsh_completion.sh
+    - ddev_fish_completion.sh
+  formats:
+  - tar.gz
   name_template: >-
     {{ .ProjectName }}_{{- if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{- .Arch }}.v{{- .Version }}
   format_overrides:
   - goos: windows
-    format: zip
+    formats:
+    - zip
   wrap_in_directory: false
   files:
   - LICENSE
@@ -295,7 +296,7 @@ nfpms:
   homepage: https://github.com/ddev/ddev
   description: |
     Open-source local web development tool
-  builds:
+  ids:
   - ddev
   - mkcert
   formats:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -148,19 +148,22 @@ archives:
 - id: completions-tarball
   ids:
   - completions-tarball
-  format: binary
+  formats:
+  - binary
   name_template: ddev_shell_completion_scripts.v{{.Version}}.tar.gz
 
 - id: ddev-windows-amd64-installer
   ids:
   - ddev-windows-amd64-installer
-  format: binary
+  formats:
+  - binary
   name_template: "ddev_windows_amd64_installer.v{{.Version}}"
 
 - id: ddev-windows-arm64-installer
   ids:
   - ddev-windows-arm64-installer
-  format: binary
+  formats:
+  - binary
   name_template: "ddev_windows_arm64_installer.v{{.Version}}"
 
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -208,6 +208,7 @@ brews:
             brew install ddev/ddev/ddev
         EOS
       end
+    end
 
   install: |
     if build.head?
@@ -261,9 +262,10 @@ brews:
           Please run:
             brew uninstall -f ddev
             brew untap #{tap.full_name}
-            brew install ddev/ddev/ddev
+            brew install ddev/ddev/ddev-edge
         EOS
       end
+    end
   install: |
     if build.head?
         system "sh", "-c", "git fetch --unshallow >/dev/null 2>&1" if File.exist?("#{HOMEBREW_REPOSITORY}/.git/shallow")

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -190,6 +190,11 @@ brews:
     - name: mkcert
 
   custom_block: |
+    head do
+      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "main"
+      depends_on "go" => :build
+      depends_on "make" => :build
+    end
     # fail fast if tapped under the old drud or rfay names
     def initialize(...)
       super
@@ -204,11 +209,6 @@ brews:
         EOS
       end
 
-    head do
-      url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "main"
-      depends_on "go" => :build
-      depends_on "make" => :build
-    end
   install: |
     if build.head?
         system "sh", "-c", "git fetch --unshallow >/dev/null 2>&1" if File.exist?("#{HOMEBREW_REPOSITORY}/.git/shallow")
@@ -251,6 +251,19 @@ brews:
       depends_on "go" => :build
       depends_on "make" => :build
     end
+    # fail fast if tapped under the old drud or rfay names
+    def initialize(...)
+      super
+      if ["drud/homebrew-ddev", "ddev-test/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap.full_name)
+        odie <<~EOS
+          ERROR: your homebrew tap is the ancient #{tap.full_name},
+          but that repository has moved.
+          Please run:
+            brew uninstall -f ddev
+            brew untap #{tap.full_name}
+            brew install ddev/ddev/ddev
+        EOS
+      end
   install: |
     if build.head?
         system "sh", "-c", "git fetch --unshallow >/dev/null 2>&1" if File.exist?("#{HOMEBREW_REPOSITORY}/.git/shallow")

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -431,6 +431,7 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's ddev-dbserver image
+    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-dbserver/README.md
@@ -441,6 +442,7 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: Gitpod integration for DDEV
+    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-gitpod-base/README.md
@@ -452,6 +454,7 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's ddev-php-base image, base image for ddev-webserver
+    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-php-base/README.md
@@ -462,6 +465,7 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's ddev-ssh-agent image
+    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-ssh-agent/README.md
@@ -472,6 +476,7 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's ddev-traefik-router, a wrapper on traefik
+    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-traefik-router/README.md
@@ -482,6 +487,7 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: Utility provider for jq, base64, etc
+    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_url:
         url: https://github.com/ddev/ddev-utilities/raw/main/README.md
@@ -493,6 +499,7 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's ddev-webserver image
+    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-webserver/README.md
@@ -503,6 +510,7 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: xhgui facility for DDEV integration
+    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-xhgui/README.md
@@ -513,6 +521,7 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: ARM64 base images for ddev-dbserver-mysql-8.0 and 5.7
+    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_url:
         url: https://github.com/ddev/mysql-arm64-images/raw/main/README.md
@@ -523,6 +532,7 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: Utility builder for mysql client binaries
+    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_url:
         url: https://github.com/ddev/mysql-client-build/raw/main/README.md
@@ -533,6 +543,7 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's test-ssh-server image, used only for automated tests
+    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/test-ssh-server/README.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -267,7 +267,7 @@ brews:
           Please run:
             brew uninstall -f ddev
             brew untap #{tap.full_name}
-            brew install ddev/ddev/ddev-edge
+            brew install ddev/ddev-edge/ddev
         EOS
       end
     end

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -125,6 +125,7 @@ builds:
 
 ###### Archives ######
 archives:
+- id: ddev
   ids:
     - ddev
     - mkcert
@@ -145,19 +146,19 @@ archives:
   allow_different_binary_count: true
 
 - id: completions-tarball
-  builds:
+  ids:
   - completions-tarball
   format: binary
   name_template: ddev_shell_completion_scripts.v{{.Version}}.tar.gz
 
 - id: ddev-windows-amd64-installer
-  builds:
+  ids:
   - ddev-windows-amd64-installer
   format: binary
   name_template: "ddev_windows_amd64_installer.v{{.Version}}"
 
 - id: ddev-windows-arm64-installer
-  builds:
+  ids:
   - ddev-windows-arm64-installer
   format: binary
   name_template: "ddev_windows_arm64_installer.v{{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -232,7 +232,7 @@ brews:
   test: |
     system "#{bin}/ddev --version"
 
-- name: ddev
+- name: ddev-edge
   ids:
   - ddev
   repository:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -428,10 +428,11 @@ dockerhub:
       - '{{ .Env.DOCKER_ORG }}/ddev-dbserver-mysql-5.6'
       - '{{ .Env.DOCKER_ORG }}/ddev-dbserver-mysql-5.7'
       - '{{ .Env.DOCKER_ORG }}/ddev-dbserver-mysql-8.0'
+      - '{{ .Env.DOCKER_ORG }}/ddev-dbserver-mysql-8.4'
+
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's ddev-dbserver image
-    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-dbserver/README.md
@@ -442,7 +443,6 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: Gitpod integration for DDEV
-    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-gitpod-base/README.md
@@ -454,7 +454,6 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's ddev-php-base image, base image for ddev-webserver
-    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-php-base/README.md
@@ -465,7 +464,6 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's ddev-ssh-agent image
-    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-ssh-agent/README.md
@@ -476,7 +474,6 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's ddev-traefik-router, a wrapper on traefik
-    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-traefik-router/README.md
@@ -487,7 +484,6 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: Utility provider for jq, base64, etc
-    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_url:
         url: https://github.com/ddev/ddev-utilities/raw/main/README.md
@@ -499,7 +495,6 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's ddev-webserver image
-    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-webserver/README.md
@@ -510,7 +505,6 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: xhgui facility for DDEV integration
-    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/ddev-xhgui/README.md
@@ -521,7 +515,6 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: ARM64 base images for ddev-dbserver-mysql-8.0 and 5.7
-    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_url:
         url: https://github.com/ddev/mysql-arm64-images/raw/main/README.md
@@ -532,7 +525,6 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: Utility builder for mysql client binaries
-    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_url:
         url: https://github.com/ddev/mysql-client-build/raw/main/README.md
@@ -543,7 +535,6 @@ dockerhub:
     username: '{{ .Env.DOCKERHUB_USERNAME }}'
     secret_name: "DOCKERHUB_TOKEN"
     description: DDEV's test-ssh-server image, used only for automated tests
-    disable: "{{ eq .Env.DOCKERHUB_TOKEN \"\" }}"
     full_description:
       from_file:
         path: ./containers/test-ssh-server/README.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -179,6 +179,7 @@ brews:
   repository:
     owner: "{{ .Env.REPOSITORY_OWNER }}"
     name: homebrew-ddev
+
   description: DDEV
   directory: Formula
   homepage: https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev
@@ -189,6 +190,20 @@ brews:
     - name: mkcert
 
   custom_block: |
+    # fail fast if tapped under the old drud or rfay names
+    def initialize(...)
+      super
+      if ["drud/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap.full_name)
+        odie <<~EOS
+          ERROR: your homebrew tap is the ancient #{tap.full_name},
+          but that repository has moved.
+          Please run:
+            brew uninstall -f ddev
+            brew untap #{tap.full_name}
+            brew install ddev/ddev/ddev
+        EOS
+      end
+
     head do
       url "https://github.com/{{ .Env.REPOSITORY_OWNER }}/ddev.git", branch: "main"
       depends_on "go" => :build


### PR DESCRIPTION
## The Issue

We've had a few reports of people using the old `drud/ddev` homebrew tap and not getting updated. It's been well over a year since that was valid, but we still get the reports.

Drupal slack: https://drupal.slack.com/archives/C5TQRQZRR/p1746000327117559

## How This PR Solves The Issue

- [x] Reject drud/ddev/ddev and give instructions
- [x] Update deprecations in the homebrew recipe
- [x] Add dockerhub repositories in ddevhq recipe that needed to be there for the ddev-test install to succeed
- [x] Add mysql-8.4 docker image to the list of dockerhubs so it gets its readme updated

## Manual Testing Instructions

- [ ] `brew install ddev-test/ddev/ddev` should work
- [ ] `brew install ddev-test/ddev-edge/ddev` should fail in the same way drud/ddev/ddev should fail

## Release considerations

- [ ] At release time, we need to test the drud/ddev and ddev/ddev taps to make sure they work as predicted.

## Output

```
rfay@ubuntu-len:~/workspace/ddev$ brew install ddev-test/ddev/ddev
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Tapping ddev-test/ddev
Cloning into '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/ddev-test/homebrew-ddev'...
remote: Enumerating objects: 573, done.
remote: Counting objects: 100% (98/98), done.
remote: Compressing objects: 100% (62/62), done.
remote: Total 573 (delta 46), reused 30 (delta 30), pack-reused 475 (from 2)
Receiving objects: 100% (573/573), 103.24 KiB | 1.72 MiB/s, done.
Resolving deltas: 100% (146/146), done.
Tapped 1 formula (15 files, 205.8KB).
==> Fetching dependencies for ddev-test/ddev/ddev: mkcert
==> Fetching mkcert
==> Downloading https://ghcr.io/v2/homebrew/core/mkcert/manifests/1.4.4
Already downloaded: /home/rfay/.cache/Homebrew/downloads/24c4f71feda55fe7cb884c5a67848b5d9c92403505271cefe146644bc4d096d6--mkcert-1.4.4.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/mkcert/blobs/sha256:f674faa8be61e225ae604b2ffe215927f6ecbc992aac75e7691
Already downloaded: /home/rfay/.cache/Homebrew/downloads/a03ea5222867f6a6c655938f2b27097ae59d0d12fbffab402447b3cedc7c8007--mkcert--1.4.4.x86_64_linux.bottle.tar.gz
==> Fetching ddev-test/ddev/ddev
==> Downloading https://github.com/ddev-test/ddev/releases/download/v1.23.41/ddev_linux-amd64.v1.23.41.tar.gz
Already downloaded: /home/rfay/.cache/Homebrew/downloads/85dfcf466402079fd74d4ddad414f835ca81e9285aabf787b8aaae9782d9c6f3--ddev_linux-amd64.v1.23.41.tar.gz
==> Installing ddev from ddev-test/ddev
==> Installing dependencies for ddev-test/ddev/ddev: mkcert
==> Installing ddev-test/ddev/ddev dependency: mkcert
==> Downloading https://ghcr.io/v2/homebrew/core/mkcert/manifests/1.4.4
Already downloaded: /home/rfay/.cache/Homebrew/downloads/24c4f71feda55fe7cb884c5a67848b5d9c92403505271cefe146644bc4d096d6--mkcert-1.4.4.bottle_manifest.json
==> Pouring mkcert--1.4.4.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/mkcert/1.4.4: 7 files, 3.2MB
==> Installing ddev-test/ddev/ddev
==> Caveats
Bash completion has been installed to:
  /home/linuxbrew/.linuxbrew/etc/bash_completion.d
==> Summary
🍺  /home/linuxbrew/.linuxbrew/Cellar/ddev/1.23.41: 8 files, 22.4MB, built in 1 second
==> Running `brew cleanup ddev`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Caveats
==> ddev
Bash completion has been installed to:
  /home/linuxbrew/.linuxbrew/etc/bash_completion.d
rfay@ubuntu-len:~/workspace/ddev$
rfay@ubuntu-len:~/workspace/ddev$ brew install ddev-test/ddev-edge/ddev
==> Tapping ddev-test/ddev-edge
Cloning into '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/ddev-test/homebrew-ddev-edge'...
remote: Enumerating objects: 1123, done.
remote: Counting objects: 100% (293/293), done.
remote: Compressing objects: 100% (148/148), done.
remote: Total 1123 (delta 164), reused 141 (delta 141), pack-reused 830 (from 3)
Receiving objects: 100% (1123/1123), 180.50 KiB | 1.53 MiB/s, done.
Resolving deltas: 100% (283/283), done.
Tapped 2 formulae (16 files, 305.7KB).
Error: ERROR: your homebrew tap is the ancient ddev-test/homebrew-ddev-edge,
but that repository has moved.
Please run:
  brew uninstall -f ddev
  brew untap ddev-test/homebrew-ddev-edge
  brew install ddev/ddev/ddev-edge
```