### PR TITLE
docs: Remove --no-interaction from Pimcore, disable test, fixes #7243

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -817,7 +817,13 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
 
     ddev start
     ddev composer create-project pimcore/skeleton
-    ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin --no-interaction
+    ddev exec pimcore-install \
+        --mysql-username=db \
+        --mysql-password=db \
+        --mysql-host-socket=db \
+        --mysql-database=db \
+        --admin-password=admin \
+        --admin-username=admin
     echo "web_extra_daemons:
       - name: consumer
         command: 'while true; do /var/www/html/bin/console messenger:consume pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update --memory-limit=250M --time-limit=3600; done'

--- a/docs/tests/pimcore.bats
+++ b/docs/tests/pimcore.bats
@@ -12,6 +12,8 @@ teardown() {
 }
 
 @test "Pimcore Composer quickstart with $(ddev --version)" {
+  skip "Pimcore requires a license key"
+
   # mkdir -p ${PROJNAME} && cd ${PROJNAME}
   run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
@@ -24,8 +26,7 @@ teardown() {
   # ddev composer create-project pimcore/skeleton
   run ddev composer create-project pimcore/skeleton
   assert_success
-  # ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin --no-interaction
-  run ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin --no-interaction
+  run ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin
   assert_success
   # echo "web_extra_daemons:
   #   - name: consumer


### PR DESCRIPTION
## The Issue

- #7243 

Pimcore 12.0.0 came out today, and now you can't install without getting a product key.

## How This PR Solves The Issue

- [x] Remove `--no-interaction` from the quickstart. It gives an odd error about a secret. (With it removed it prompts properly for the key)
- [x] Skip the pimcore quickstart test. I'm sure we could get a secret for it, but it seems like too much work for right now.

## Manual Testing Instructions

Rendered quickstart at https://ddev--7245.org.readthedocs.build/en/7245/users/quickstart/#pimcore

- [x] Test the updated quickstart manually

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
