### PR TITLE
fix: correct warning output formatting (Drupal) and don't try to do exec when not running

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -560,17 +560,14 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 			util.Warning("Unable to set permissions: %v", err)
 		}
 	}
+	// Don't run app.Exec() without a running container.
+	status, _ := app.SiteStatus()
 	// It is possible that a Drupal install has been done, setting sites/default and sites/default/settings.php
 	// to read-only, which breaks mutagen's access to them so mutagen then
 	// can't sync. See https://github.com/ddev/ddev/issues/6491
 	// So we chmod +w the two files that a Drupal install may set read-only
 	// *inside* the container, allowing mutagen access to it again
-	if app.IsMutagenEnabled() {
-		// Don't run app.Exec() without a running container.
-		status, _ := app.SiteStatus()
-		if status != SiteRunning {
-			return nil
-		}
+	if app.IsMutagenEnabled() && status == SiteRunning {
 		settingsFiles := []string{
 			path.Join(app.GetAbsDocroot(true), `sites/default`),
 			path.Join(app.GetAbsDocroot(true), `sites/default/settings.php`),

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -572,11 +572,12 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 			path.Join(app.GetAbsDocroot(true), `sites/default`),
 			path.Join(app.GetAbsDocroot(true), `sites/default/settings.php`),
 		}
-		stdout, _, err := app.Exec(&ExecOpts{
+		stdout, stderr, err := app.Exec(&ExecOpts{
 			Cmd: fmt.Sprintf(`chmod u+w %s 2>&1`, strings.Join(settingsFiles, " ")),
 		})
 		if err != nil {
-			util.Warning("Unable to set permissions inside container on settings files:\n%s", stdout)
+			util.Warning("Unable to set permissions inside container on settings files; err='%v', stdout='%s', stderr='%s'", err, stdout, stderr)
+
 		}
 	}
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -574,7 +574,7 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 			Cmd: fmt.Sprintf(`chmod -f u+w %s`, strings.Join(settingsFiles, " ")),
 		})
 		if err != nil {
-			util.Warning("Unable to set permissions inside container on settings files: '%s'", stderr)
+			util.Warning("Unable to set permissions inside container on settings files: err=%v, stderr=%s", err, stderr)
 		}
 	}
 

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -566,6 +566,11 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 	// So we chmod +w the two files that a Drupal install may set read-only
 	// *inside* the container, allowing mutagen access to it again
 	if app.IsMutagenEnabled() {
+		// Don't run app.Exec() without a running container.
+		status, _ := app.SiteStatus()
+		if status != SiteRunning {
+			return nil
+		}
 		settingsFiles := []string{
 			path.Join(app.GetAbsDocroot(true), `sites/default`),
 			path.Join(app.GetAbsDocroot(true), `sites/default/settings.php`),

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -570,11 +570,11 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 			path.Join(app.GetAbsDocroot(true), `sites/default`),
 			path.Join(app.GetAbsDocroot(true), `sites/default/settings.php`),
 		}
-		_, stderr, err := app.Exec(&ExecOpts{
-			Cmd: fmt.Sprintf(`chmod -f u+w %s`, strings.Join(settingsFiles, " ")),
+		stdout, _, err := app.Exec(&ExecOpts{
+			Cmd: fmt.Sprintf(`chmod u+w %s 2>&1`, strings.Join(settingsFiles, " ")),
 		})
 		if err != nil {
-			util.Warning("Unable to set permissions inside container on settings files: err=%v, stderr=%s", err, stderr)
+			util.Warning("Unable to set permissions inside container on settings files:\n%s", stdout)
 		}
 	}
 


### PR DESCRIPTION
## The Issue

From Drupal Slack https://drupal.slack.com/archives/C5TQRQZRR/p1746102793754109

When I did `ddev config` it said: `Unable to set permissions inside container on settings files: ''` <- empty string in the quotes

## How This PR Solves The Issue

- Adds `stderr` redirect to `stdout`.
- Removes `-f` silent flag.
- Doesn't run `app.Exec()` without a running container.

## Manual Testing Instructions

Now it outputs this (I reproduced it using a dummy go command):
```
Unable to set permissions inside container on settings files:
chmod: cannot access '/var/www/html/web/sites/default': No such file or directory
chmod: cannot access '/var/www/html/web/sites/default/settings.php': No such file or directory
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
