### PR TITLE
fix: Signature verification issue with Filament Curator, fixes #7248

### DIFF
--- a/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
@@ -78,6 +78,12 @@ server {
         try_files $uri $uri/ /index.php?$args;
     }
 
+    # Fix: Fetching image files from curator fails signature verification
+    #      https://github.com/awcodes/filament-curator/discussions/333
+    location ^~ /curator {
+       try_files $uri $uri/ /index.php?$query_string;
+    }
+
     include /etc/nginx/common.d/*.conf;
     include /mnt/ddev_config/nginx/*.conf;
 }


### PR DESCRIPTION
## The Issue

- #7248

Filament Curator uses /curator/image_path.jpg as a route, but it appends a query string and does processing on the image before serving it, this isn't being passed through correctly hence fails with a signature verification check.

## How This PR Solves The Issue

Copies the same fix for livewire, as it's the same issue with both routes. This is also already documented on their issue tracker
https://github.com/awcodes/filament-curator/discussions/333

## Manual Testing Instructions

1. Clone the repo created for this test here: https://github.com/SOD96/ddev-filament-repo (git@github.com:SOD96/ddev-filament-repo.git)
2. run the following commands inside the directory
3. `ddev start`
4. `ddev composer install`
5. `ddev php artisan key:generate`
6. `ddev npm install`
7. `ddev npm run build`
8. `ddev php artisan migrate:fresh --seed`

This should net you with a laravel project, with filament, with curator. You may need to configure your .env file to have the appropriate connection details to your DB if you have that kind of thing going on, but it worked out the box for me.

The seeder should generate media for you, so you won't even need to login to filament or use curator, we're focusing on Glider.
Now visit https://ddev-filament-repo.ddev.site/

You will see a blank page, perhaps some text, if you check the network log you'll likely see a 404 error stating it could not find the media. This is our bug. If you dive into that request and follow the chain, you'll see it's a 403 due to signature verification.

To fix this, go into .ddev/nginx_full/nginx-site.conf (This is the file we change with our PR, and add the entry we've changed)

EX, This is the end of my file currently:
```
    # Fix: File upload over https fails signature verification
    #      https://github.com/livewire/livewire/discussions/3084
    location ^~ /livewire {
        try_files $uri $uri/ /index.php?$args;
    }

    include /etc/nginx/common.d/*.conf;
    include /mnt/ddev_config/nginx/*.conf;
}
```

I have changed it to be

```
    # Fix: File upload over https fails signature verification
    #      https://github.com/livewire/livewire/discussions/3084
    location ^~ /livewire {
        try_files $uri $uri/ /index.php?$args;
    }

    # Fix: Fetching image files from curator fails signature verification
    #      https://github.com/awcodes/filament-curator/discussions/333
    location ^~ /curator {
       try_files $uri $uri/ /index.php?$query_string;
    }

    include /etc/nginx/common.d/*.conf;
    include /mnt/ddev_config/nginx/*.conf;
}
```

Now, if you remove the autogenerated line and do a 
`ddev restart`, then go to the homepage of the running site, your image will load fine.

![image](https://github.com/user-attachments/assets/23249f96-f3ba-4a1f-b8c0-66dc8fa7e98d)


If I remove the location block I added, you can see the 404 comes straight back

![image](https://github.com/user-attachments/assets/ad9df8dc-4479-4bce-94dc-c2a9949cd127)



## Automated Testing Overview

N/A

## Release/Deployment Notes

N/A
