### PR TITLE
fix: add BASE_IMAGE arg before everything else, for #7071

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -197,7 +197,7 @@ The following environment variables are available for the web Dockerfile to use 
 * `$TARGETOS`: The build target operating system (always `linux`)
 * `$TARGETPLATFORM`: `linux/amd64` or `linux/arm64` depending on the machine it's been executed on
 
-!!! warning "Only `$BASE_IMAGE` is automatically available in `prepend.Dockerfile*` variants"
+!!!warning "Only `$BASE_IMAGE` is automatically available in `prepend.Dockerfile*` variants"
     If you need to use any of the other variables you will need to manually add them to your `prepend.Dockerfile*` files using [ARG](https://docs.docker.com/reference/dockerfile/#arg) instructions.
 
 For example, a Dockerfile might want to build an extension for the configured PHP version like this using `$DDEV_PHP_VERSION` to specify the proper version:

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -157,7 +157,7 @@ An example [Multi-stage](https://docs.docker.com/build/building/multi-stage/) we
 # If we want to use any of the build time environment variables injected by ddev
 # on the prepend.Dockerfile* variants we need to manually declare them to make
 # them available using the ARG instruction.
-# Only $BASE_IMAGE is already added as it must be global be used on FROM 
+# Only $BASE_IMAGE is already added as it must be global to be used on FROM 
 # statements. 
 FROM $BASE_IMAGE AS build-stage-go
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -161,6 +161,8 @@ An example [Multi-stage](https://docs.docker.com/build/building/multi-stage/) we
 # statements. 
 FROM $BASE_IMAGE AS build-stage-go
 
+# While we are not using $uid and $gid in the code below, this serves as an example
+# of how any of the other DDEV's build variables must be defined. 
 ARG uid
 ARG gid
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -157,7 +157,8 @@ An example [Multi-stage](https://docs.docker.com/build/building/multi-stage/) we
 # If we want to use any of the build time environment variables injected by ddev
 # on the prepend.Dockerfile* variants we need to manually declare them to make
 # them available using the ARG instruction.
-ARG BASE_IMAGE="scratch"
+# Only $BASE_IMAGE is already added as it must be global be used on FROM 
+# statements. 
 FROM $BASE_IMAGE AS build-stage-go
 
 ARG uid
@@ -185,7 +186,7 @@ COPY --from=build-stage-go /usr/local/go /usr/local
 
 The following environment variables are available for the web Dockerfile to use at build time:
 
-* `$BASE_IMAGE`: the base image, like `ddev/ddev-webserver:v1.24.0`
+* `$BASE_IMAGE`: the base image, like `ddev/ddev-webserver:v1.24.0` ([global scope](https://docs.docker.com/build/building/variables/#scoping))
 * `$username`: the username inferred from your host-side username
 * `$uid`: the user ID inferred from your host-side user ID
 * `$gid`: the group ID inferred from your host-side group ID
@@ -194,8 +195,8 @@ The following environment variables are available for the web Dockerfile to use 
 * `$TARGETOS`: The build target operating system (always `linux`)
 * `$TARGETPLATFORM`: `linux/amd64` or `linux/arm64` depending on the machine it's been executed on
 
-!!!warning "These variables won't be automatically available on `prepend.Dockerfile*` variants"
-    If you need to use any of these variables you will need to manually add them to your `prepend.Dockerfile*` files using [ARG](https://docs.docker.com/reference/dockerfile/#arg) instructions.
+!!! warning "Only `$BASE_IMAGE` is automatically available in `prepend.Dockerfile*` variants"
+    If you need to use any of the other variables you will need to manually add them to your `prepend.Dockerfile*` files using [ARG](https://docs.docker.com/reference/dockerfile/#arg) instructions.
 
 For example, a Dockerfile might want to build an extension for the configured PHP version like this using `$DDEV_PHP_VERSION` to specify the proper version:
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1257,6 +1257,7 @@ func WriteBuildDockerfile(app *DdevApp, fullpath string, userDockerfilePath stri
 	// Normal starting content is the arg and base image
 	contents := `
 #ddev-generated - Do not modify this file; your modifications will be overwritten.
+ARG BASE_IMAGE="scratch"
 `
 	// If there are user prepend.Dockerfile* files, insert their contents
 	if userDockerfilePath != "" {
@@ -1281,7 +1282,6 @@ func WriteBuildDockerfile(app *DdevApp, fullpath string, userDockerfilePath stri
 
 	contents = contents + `
 ### DDEV-injected base Dockerfile contents
-ARG BASE_IMAGE="scratch"
 FROM $BASE_IMAGE
 SHELL ["/bin/bash", "-c"]
 `

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1258,8 +1258,6 @@ func WriteBuildDockerfile(app *DdevApp, fullpath string, userDockerfilePath stri
 	contents := `
 #ddev-generated - Do not modify this file; your modifications will be overwritten.
 ARG BASE_IMAGE="scratch"
-# Do not redefined DDEV_RESERVED_BASE_IMAGE in any of your custom Dockerfile variants.
-ARG DDEV_RESERVED_BASE_IMAGE=$BASE_IMAGE
 `
 	// If there are user prepend.Dockerfile* files, insert their contents
 	if userDockerfilePath != "" {
@@ -1284,7 +1282,7 @@ ARG DDEV_RESERVED_BASE_IMAGE=$BASE_IMAGE
 
 	contents = contents + `
 ### DDEV-injected base Dockerfile contents
-FROM $DDEV_RESERVED_BASE_IMAGE
+FROM $BASE_IMAGE
 SHELL ["/bin/bash", "-c"]
 `
 	// bitnami/mysql inappropriately sets ENV HOME=/, see https://github.com/bitnami/containers/issues/75578

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1258,6 +1258,8 @@ func WriteBuildDockerfile(app *DdevApp, fullpath string, userDockerfilePath stri
 	contents := `
 #ddev-generated - Do not modify this file; your modifications will be overwritten.
 ARG BASE_IMAGE="scratch"
+# Do not redefined DDEV_RESERVED_BASE_IMAGE in any of your custom Dockerfile variants.
+ARG DDEV_RESERVED_BASE_IMAGE=$BASE_IMAGE
 `
 	// If there are user prepend.Dockerfile* files, insert their contents
 	if userDockerfilePath != "" {
@@ -1282,7 +1284,7 @@ ARG BASE_IMAGE="scratch"
 
 	contents = contents + `
 ### DDEV-injected base Dockerfile contents
-FROM $BASE_IMAGE
+FROM $DDEV_RESERVED_BASE_IMAGE
 SHELL ["/bin/bash", "-c"]
 `
 	// bitnami/mysql inappropriately sets ENV HOME=/, see https://github.com/bitnami/containers/issues/75578

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1352,11 +1352,10 @@ RUN rm /var/tmp/`+"added-by-"+item+"-test4.txt"))
 
 		// Testing prepend.Dockerfile* with a simple multi-stage build
 		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/prepend.Dockerfile"), []byte(`
-ARG BASE_IMAGE="scratch"
-FROM $BASE_IMAGE AS stage
+FROM busybox AS stage
 `+
-			`RUN touch /var/tmp/`+"added-by-"+item+"-stage.txt"+`
-			 RUN touch /var/tmp/`+"added-by-"+item+"-stage-other.txt"))
+			`RUN touch /tmp/`+"added-by-busybox-"+item+"-stage.txt"+`
+			 RUN touch /tmp/`+"added-by-busybox-"+item+"-stage-other.txt"))
 		assert.NoError(err)
 		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/prepend.Dockerfile.test5"), []byte(`
 ARG BASE_IMAGE="scratch"
@@ -1366,7 +1365,7 @@ FROM $BASE_IMAGE AS test5
 		assert.NoError(err)
 
 		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test5"), []byte(`
-COPY --from=stage /var/tmp/`+"added-by-"+item+"-stage.txt /var/tmp/"+"added-by-"+item+"-stage.txt"+`
+COPY --from=stage /tmp/`+"added-by-busybox-"+item+"-stage.txt /var/tmp/"+"added-by-busybox-"+item+"-stage.txt"+`
 COPY --from=test5 /var/tmp/`+"added-by-"+item+"-test5.txt /var/tmp/"+"added-by-"+item+"-test5.txt"))
 		assert.NoError(err)
 	}
@@ -1457,7 +1456,7 @@ RUN mkdir -p "/var/tmp/my-arch-info-is-${TARGETOS}-${TARGETARCH}-${TARGETPLATFOR
 		assert.NoFileExists(app.GetConfigPath("." + item + "imageBuild/Dockerfile.test5"))
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: item,
-			Cmd:     "ls /var/tmp/added-by-" + item + "-stage.txt >/dev/null",
+			Cmd:     "ls /var/tmp/added-by-busybox-" + item + "-stage.txt >/dev/null",
 		})
 		assert.NoError(err)
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
@@ -1469,7 +1468,7 @@ RUN mkdir -p "/var/tmp/my-arch-info-is-${TARGETOS}-${TARGETARCH}-${TARGETPLATFOR
 		// but not copied on the final image
 		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: item,
-			Cmd:     "ls /var/tmp/added-by-" + item + "-stage-other.txt 2>/dev/null",
+			Cmd:     "ls /tmp/added-by-busybox-" + item + "-stage-other.txt 2>/dev/null",
 		})
 		assert.Error(err)
 	}


### PR DESCRIPTION
## The Issue

- Follow up to #7071 

I started playing with this with HEAD and found an issue which took me a bit to figure out. All of my examples and even tests that worked before was because `ARG BASE_IMAGE="scratch"` was added on the prepend file but I just didn't as I was using a smaller base image for a build stage and the Dockerfile build failed because of https://docs.docker.com/reference/dockerfile/#understand-how-arg-and-from-interact.

That particular ARG has to be before that first FROM so it can be used in any FROM afterwards. While we can be documented and leave prepend as plain as possible, I think this might confuse those that are trying to use this feature (if any). I figured that as BASE_IMAGE is a very important ARG to have defined, so I think it's best this is added before everything else (including prepend.Dockerfile variants). 

How to reproduce this with the current HEAD:

- Add a simple `prepend.Dockerfile` with:

```Dockerfile
FROM busybox AS test1
RUN echo "aa"
```

- `ddev start` will fail with an error of $BASE_IMAGE not being present.