### PR TITLE
refactor: improve `ddev add-on get` output, add warning exit code annotation

### DIFF
--- a/cmd/ddev/cmd/addon-get_test.go
+++ b/cmd/ddev/cmd/addon-get_test.go
@@ -116,6 +116,7 @@ func TestCmdAddonActionsOutput(t *testing.T) {
 	assert.FileExists(app.GetConfigPath("test_cmd_addon_actions_output.txt"))
 
 	// The fourth action should also be success with output
+	// This action also has an invalid #ddev-warning-exit-code, so it should have been ignored.
 	text3Part1 := regexp.QuoteMeta(util.ColorizeText(fmt.Sprintf("%c Action 4 that errs if .ddev/test_cmd_addon_actions_output_error.txt is present", '\U0001F44D'), "green"))
 	text3Part2 := regexp.QuoteMeta(util.ColorizeText("test_cmd_addon_actions_output_error.txt not found!\n", "yellow"))
 	text3Regex := regexp.MustCompile(fmt.Sprintf(`%s\n%s`, text3Part1, text3Part2))
@@ -166,6 +167,7 @@ func TestCmdAddonActionsOutput(t *testing.T) {
 	require.Error(t, err, "out=%s", out)
 
 	// The fourth action should have erred with output.
+	// This action also has an invalid #ddev-warning-exit-code, so it should have been ignored.
 	text9Part1 := regexp.QuoteMeta(util.ColorizeText(fmt.Sprintf("%c Action 4 that errs if .ddev/test_cmd_addon_actions_output_error.txt is present", '\U0001F44E'), "yellow"))
 	text9Part2 := regexp.QuoteMeta(util.ColorizeText("test_cmd_addon_actions_output_error.txt found!\n", "yellow"))
 	text9Regex := regexp.MustCompile(fmt.Sprintf(`%s\n%s`, text9Part1, text9Part2))

--- a/cmd/ddev/cmd/testdata/TestCmdAddonActionsOutput/recipe/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdAddonActionsOutput/recipe/install.yaml
@@ -13,8 +13,9 @@ post_install_actions:
     echo "test_cmd_addon_actions_output.txt created"
   # Action #4
   - |
-    #ddev-description:Action 4 that errs if .ddev/test_cmd_addon_actions_output_error.txt is present
+    #ddev-description:Action 4 that errs if .ddev/test_cmd_addon_actions_output_error.txt is present    
     #ddev-warning-exit-code:1,2
+    # ddev-warning-exit-code is invalid on purpose, it should be ignored.
     if [ -f "test_cmd_addon_actions_output_error.txt" ]; then
       echo "test_cmd_addon_actions_output_error.txt found!"
       exit 1

--- a/cmd/ddev/cmd/testdata/TestCmdAddonActionsOutput/recipe/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdAddonActionsOutput/recipe/install.yaml
@@ -14,6 +14,7 @@ post_install_actions:
   # Action #4
   - |
     #ddev-description:Action 4 that errs if .ddev/test_cmd_addon_actions_output_error.txt is present
+    #ddev-warning-exit-code:1,2
     if [ -f "test_cmd_addon_actions_output_error.txt" ]; then
       echo "test_cmd_addon_actions_output_error.txt found!"
       exit 1

--- a/cmd/ddev/cmd/testdata/TestCmdAddonActionsOutput/recipe/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdAddonActionsOutput/recipe/install.yaml
@@ -13,7 +13,7 @@ post_install_actions:
     echo "test_cmd_addon_actions_output.txt created"
   # Action #4
   - |
-    #ddev-description:Action 4 that errs if .ddev/test_cmd_addon_actions_output_error.txt is present    
+    #ddev-description:Action 4 that errs if .ddev/test_cmd_addon_actions_output_error.txt is present
     #ddev-warning-exit-code:1,2
     # ddev-warning-exit-code is invalid on purpose, it should be ignored.
     if [ -f "test_cmd_addon_actions_output_error.txt" ]; then

--- a/cmd/ddev/cmd/testdata/TestCmdAddonActionsOutput/recipe/install.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdAddonActionsOutput/recipe/install.yaml
@@ -1,0 +1,50 @@
+name: sample_actions
+
+post_install_actions:
+  # Action #1
+  - touch test_cmd_addon_actions_no_output.txt
+  # Action #2
+  - |
+    echo "action 2 with output and no #ddev-description"
+  # Action #3
+  - |
+    #ddev-description:Action 3 with #ddev-description and output
+    touch test_cmd_addon_actions_output.txt
+    echo "test_cmd_addon_actions_output.txt created"
+  # Action #4
+  - |
+    #ddev-description:Action 4 that errs if .ddev/test_cmd_addon_actions_output_error.txt is present
+    if [ -f "test_cmd_addon_actions_output_error.txt" ]; then
+      echo "test_cmd_addon_actions_output_error.txt found!"
+      exit 1
+    fi
+    echo "test_cmd_addon_actions_output_error.txt not found!"
+  # Action #5
+  - |
+    #ddev-warning-exit-code:126
+    touch test_cmd_addon_actions_no_output_warning.txt
+    exit 126
+  # Action #6
+  - |
+    #ddev-warning-exit-code:127
+    echo "action 6 with output, #ddev-warning-exit-code and no #ddev-description"
+    exit 127
+  # Action #7
+  - |
+    #ddev-description:Action 7 with #ddev-description and no output
+    touch test_cmd_addon_actions_description.txt
+  # Action #8
+  - |
+    #ddev-description:Action 8 with #ddev-warning-exit-code and #ddev-description and no output
+    #ddev-warning-exit-code:127
+    exit 127
+  # Action #9
+  - |
+    #ddev-description:Action 9 with #ddev-warning-exit-code and #ddev-description and some output
+    #ddev-warning-exit-code:127
+    echo "This is a warning!!!"
+    exit 127
+    echo "This line that comes after an exit should never be output"
+  # Action #10
+  - |
+    #ddev-description:Action 10 is our final action doing nothing

--- a/docs/content/users/extend/additional-services.md
+++ b/docs/content/users/extend/additional-services.md
@@ -87,6 +87,7 @@ The `install.yaml` is a simple YAML file with a few main sections:
 In any stanza of `pre_install_actions` and `post_install_actions` you can:
 
 * Use `#ddev-description:<some description of what stanza is doing>` to instruct DDEV to output a description of the action it's taking.
+* Use `#ddev-warning-exit-code:<an integer between 1-255>` to instruct DDEV to consider a certain exit code of the stanza as a warning, not an error, continuing with other actions as normal.
 
 You can see a simple `install.yaml` in [`ddev-addon-template`’s `install.yaml`](https://github.com/ddev/ddev-addon-template/blob/main/install.yaml).
 

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -140,7 +140,7 @@ func ProcessAddonAction(action string, dict map[string]interface{}, bashPath str
 			// Get the exit code
 			exitCode := exitErr.ExitCode()
 			if exitCode == 63 {
-				util.Warning("%c %s", '\U000026A1', desc)
+				util.Warning("%s %s", "\U000026A0\U0000FE0F", desc)
 				err = nil
 			} else {
 				util.Warning("%c %s", '\U0001F44E', desc)

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -134,7 +134,6 @@ func ProcessAddonAction(action string, dict map[string]interface{}, bashPath str
 		action = "set -x; " + action
 	}
 	out, err := exec.RunHostCommand(bashPath, "-c", action)
-
 	if err != nil {
 		warningCode := GetAddonDdevWarningExitCode(action)
 		if warningCode > 0 {
@@ -148,7 +147,6 @@ func ProcessAddonAction(action string, dict map[string]interface{}, bashPath str
 				}
 			}
 		}
-
 		if err != nil {
 			util.Warning("%c %s", '\U0001F44E', desc)
 			err = fmt.Errorf("Unable to run action %v: %v, output=%s", action, err, out)

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -142,17 +142,23 @@ func ProcessAddonAction(action string, dict map[string]interface{}, bashPath str
 				// Get the exit code
 				exitCode := exitErr.ExitCode()
 				if exitCode == warningCode {
-					util.Warning("%s %s", "\U000026A0\U0000FE0F", desc)
+					if desc != "" {
+						util.Warning("%s %s", "\U000026A0\U0000FE0F", desc)
+					}
 					err = nil
 				}
 			}
 		}
 		if err != nil {
-			util.Warning("%c %s", '\U0001F44E', desc)
+			if desc != "" {
+				util.Warning("%c %s", '\U0001F44E', desc)
+			}
 			err = fmt.Errorf("Unable to run action %v: %v, output=%s", action, err, out)
 		}
 	} else {
-		util.Success("%c %s", '\U0001F44D', desc)
+		if desc != "" {
+			util.Success("%c %s", '\U0001F44D', desc)
+		}
 	}
 	if len(out) > 0 {
 		util.Warning(out)


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

This is just an idea on improving slightly the `ddev add-on get` output.

I was working on hanoii/ddev-pimp-my-shell and wanted to support installing it in both pre-1.24.5 and later so that I can keep for a while maintaining the two approaches (single stage/multi-stage).

I noticed something that was bothering me before as well, it is unrelated to the above, but it was what triggered it.

First, when an action outputs something, it stays above the description:

<img width="1204" alt="Screenshot 2025-05-05 at 11 48 02" src="https://github.com/user-attachments/assets/dbd74c2e-5d79-4a63-8109-d1e076b819f3" />

which is confusing, I rather have it below.

Also, I would have loved to have something other than 👍🏻  and 👎🏻  to make it visually clear that is neither success, nor error (call it a warning).

So I come up with this PR which translates to this:

<img width="700" alt="Screenshot 2025-05-06 at 08 50 08" src="https://github.com/user-attachments/assets/73c13514-3a27-4be6-ba92-29186df64c2d" />

It doesn't report as error either.

It relies on a a new annotation like `#ddev-description`: `#ddev-warning-exit-code:`

i.e.

```yaml
post_install_actions:
  - |
    #ddev-description:Checking DDEV version
    #ddev-warning-exit-code: 64
    if ! ${DDEV_EXECUTABLE} debug match-constraint ">= 1.24.5" 2>/dev/null ; then
      echo "This add-on works best with DDEV v1.24.5+ or higher, please upgrade." && exit 64
    fi
```

# Manual test:

```bash
mkdir -p /tmp/ddev-add-on
wget https://raw.githubusercontent.com/hanoii/ddev/refs/heads/improve-add-on-action-output/cmd/ddev/cmd/testdata/TestCmdAddonActionsOutput/recipe/install.yaml -O /tmp/ddev-add-on/install.yaml

# success

mkdir -p /tmp/ddev-test-project1
cd /tmp/ddev-test-project1
ddev config --project-type=php
ddev add-on get /tmp/ddev-add-on

# with error

mkdir -p /tmp/ddev-test-project2
cd /tmp/ddev-test-project2
ddev config --project-type=php
touch .ddev/test_cmd_addon_actions_output_error.txt
ddev add-on get /tmp/ddev-add-on
```