### PR TITLE
fix: WSL2 install script should wait longer for DDEV Windows installer to complete [skip ci]

### DIFF
--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -95,7 +95,7 @@ Start-Process $DdevInstallerPath -ArgumentList "/S", -Wait
 $env:PATH += ";C:\Program Files\DDEV"
 
 $mkcertPath = "C:\Program Files\DDEV\mkcert.exe"
-$maxWait = 10
+$maxWait = 60
 $waited = 0
 while (-not (Test-Path $mkcertPath) -and $waited -lt $maxWait) {
     Start-Sleep -Seconds 1

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -96,6 +96,7 @@ $env:PATH += ";C:\Program Files\DDEV"
 
 $mkcertPath = "C:\Program Files\DDEV\mkcert.exe"
 $maxWait = 60
+Write-Host "Waiting up to $maxWait seconds for $mkcertPath binary..."
 $waited = 0
 while (-not (Test-Path $mkcertPath) -and $waited -lt $maxWait) {
     Start-Sleep -Seconds 1

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -92,7 +92,7 @@ Write-Host "DDEV installation complete."
 
 $mkcertPath = "C:\Program Files\DDEV\mkcert.exe"
 $maxWait = 60
-Write-Host "Waiting $maxWait seconds for $mkcertPath binary..."
+Write-Host "Waiting up to $maxWait seconds for $mkcertPath binary..."
 $waited = 0
 while (-not (Test-Path $mkcertPath) -and $waited -lt $maxWait) {
     Start-Sleep -Seconds 1

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -91,7 +91,7 @@ $env:PATH += ";C:\Program Files\DDEV"
 Write-Host "DDEV installation complete."
 
 $mkcertPath = "C:\Program Files\DDEV\mkcert.exe"
-$maxWait = 10
+$maxWait = 60
 $waited = 0
 while (-not (Test-Path $mkcertPath) -and $waited -lt $maxWait) {
     Start-Sleep -Seconds 1

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -92,6 +92,7 @@ Write-Host "DDEV installation complete."
 
 $mkcertPath = "C:\Program Files\DDEV\mkcert.exe"
 $maxWait = 60
+Write-Host "Waiting $maxWait seconds for $mkcertPath binary..."
 $waited = 0
 while (-not (Test-Path $mkcertPath) -and $waited -lt $maxWait) {
     Start-Sleep -Seconds 1


### PR DESCRIPTION

## The Issue

Discord: https://discord.com/channels/664580571770388500/1367962405237166233

Using the new (without chocolatey) script for WSL2 install, the PS script calls the Windows installer, and then waited only 10s for the completion.

## How This PR Solves The Issue

Apparently the NSIS installer hands off installation of files to a child process and can run to completion before the child process is done. In this situation the reporter said it was an older computer. There are ways to wait for the child process, but it seems simpler just to increase the wait time, so we increase it from 10s to 60s here.

## Manual Testing Instructions

If we could reproduce on older computer it would be great.

