### PR TITLE
fix: allow status code 429 for linkspector

### DIFF
--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -64,13 +64,13 @@ jobs:
       - name: Run textlint
         uses: tsuyoshicho/action-textlint@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
           textlint_flags: "{README.md,version-history.md,docs/**}"
       - name: Run linkspector to check external links
         uses: umbrelladocs/action-linkspector@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
           fail_on_error: true
           # Check links only in the added lines for PRs, but check everything otherwise

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -31,5 +31,7 @@ aliveStatusCodes:
   - 200
   - 206
   - 301
-
+  # TODO: GitHub changed its limits, now we get 429, remove this workaround when it is resolved
+  # See https://github.com/UmbrellaDocs/action-linkspector/issues/43
+  - 429
 #modifiedFilesOnly: true


### PR DESCRIPTION
## The Issue

We get 429 from GitHub links for linkspector https://github.com/ddev/ddev/actions/runs/14861937842/attempts/2

It seems that GitHub changed some limits.

- https://github.com/UmbrellaDocs/action-linkspector/issues/43

## How This PR Solves The Issue

I noticed that we use `GITHUB_TOKEN` for actions (this is not the env itself, it's name for custom action variable) instead of `github_token` (IDE highlighted it for me)

Adds an exception for 429 status.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
