### PR TITLE
feat: add TYPO3 create-sitepackage global command

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -192,7 +192,7 @@ func TestCustomCommands(t *testing.T) {
 		assert.NoError(err, "Failed to run ddev %s --version", c)
 	}
 	// The various CMS commands should not be available here
-	for _, c := range []string{"artisan", "art", "cake", "drush", "magento", "typo3", "wp"} {
+	for _, c := range []string{"artisan", "art", "cake", "create-sitepackage", "drush", "magento", "typo3", "wp"} {
 		_, err = exec.RunHostCommand(DdevBin, c, "-h")
 		assert.Error(err, "found command %s when it should not have been there (no error) app.Type=%s", c, app.Type)
 	}
@@ -204,7 +204,7 @@ func TestCustomCommands(t *testing.T) {
 	_, _ = exec.RunHostCommand(DdevBin, "debug", "fix-commands")
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
-	for _, c := range []string{"typo3"} {
+	for _, c := range []string{"create-sitepackage", "typo3"} {
 		_, err = exec.RunHostCommand(DdevBin, "help", c)
 		assert.NoError(err)
 	}

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/create-sitepackage
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/create-sitepackage
@@ -38,9 +38,6 @@ curl -X 'POST' \
   -H 'Content-Type: application/json' \
   -d @"/tmp/data.json" --output /tmp/my_site_package.zip
 
-composer require my-vendor/my-site-package:@dev
-
-rm -rf packages/my_site_package/*
-rm -rf packages/my_site_package/.*
 unzip /tmp/my_site_package.zip -d "packages/my_site_package/"
+composer require my-vendor/my-site-package:@dev
 rm -f /tmp/my_site_package.zip /tmp/data.json

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/create-sitepackage
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/create-sitepackage
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+
+## Description: Create a default TYPO3 composer-style sitepackage
+## Usage: create-sitepackage
+## Example: "ddev create-sitepackage"
+## ProjectTypes: typo3
+## ExecRaw: true
+## MutagenSync: true
+set -eu -o pipefail
+
+cd ${DDEV_COMPOSER_ROOT:-/var/www/html}
+curl -X 'POST' \
+  'https://get.typo3.org/api/v1/sitepackage/' \
+  -s \
+  --fail \
+  -H 'accept: application/zip' \
+  -H 'Content-Type: application/json' \
+  -d @"./data.json" --output /tmp/my_site_package.zip
+
+rm -rf packages/my_site_package/*
+rm -rf packages/my_site_package/.*
+unzip /tmp/my_site_package.zip -d "packages/my_site_package/"
+rm /tmp/my_site_package.zip

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/create-sitepackage
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/create-sitepackage
@@ -10,16 +10,37 @@
 ## MutagenSync: true
 set -eu -o pipefail
 
+
 cd ${DDEV_COMPOSER_ROOT:-/var/www/html}
+
+# Create the required data.json
+cat << 'EOF' > /tmp/data.json
+{
+  "base_package": "site_package_tutorial",
+  "typo3_version": 13.4,
+  "title": "My Site Package",
+  "description": "Site package to follow the tutorial. ",
+  "repository_url": "https://github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-SitePackage",
+  "author": {
+    "name": "J. Doe",
+    "email": "j.doe@example.org",
+    "company": "My Vendor",
+    "homepage": "https://docs.typo3.org/permalink/t3sitepackage:start"
+  }
+}
+EOF
+
 curl -X 'POST' \
   'https://get.typo3.org/api/v1/sitepackage/' \
   -s \
   --fail \
   -H 'accept: application/zip' \
   -H 'Content-Type: application/json' \
-  -d @"./data.json" --output /tmp/my_site_package.zip
+  -d @"/tmp/data.json" --output /tmp/my_site_package.zip
+
+composer require my-vendor/my-site-package:@dev
 
 rm -rf packages/my_site_package/*
 rm -rf packages/my_site_package/.*
 unzip /tmp/my_site_package.zip -d "packages/my_site_package/"
-rm /tmp/my_site_package.zip
+rm -f /tmp/my_site_package.zip /tmp/data.json

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/create-sitepackage
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/create-sitepackage
@@ -2,7 +2,7 @@
 
 #ddev-generated
 
-## Description: Create a default TYPO3 composer-style sitepackage
+## Description: Create a simple default TYPO3 composer-style sitepackage
 ## Usage: create-sitepackage
 ## Example: "ddev create-sitepackage"
 ## ProjectTypes: typo3


### PR DESCRIPTION

## The Issue

TYPO3's complexity of creating a default site package; we'd like to have a simple way for n00bs to get started with a sitepackage, which is fundamentally required to do anything.

## How This PR Solves The Issue

Try to provide a TYPO3-only global web command that creates a site package (theme)

This is taken as suggested by @linawolf from the files in https://github.com/TYPO3-Documentation/site-introduction/tree/main/Build/DownloadSitePackage

## Manual Testing Instructions

`ddev create-sitepackage` in a TYPO3 v13 composer-build

It should create the site package and composer-install it.

## Automated Testing Overview

- [x] If this is successful, it needs a test or at least a mention in a test.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
