### PR TITLE
fix: make xdebug work with WSL2 mirrored mode, fixes #7272

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -62,6 +62,13 @@ header "installed DDEV add-ons"
 
 ddev add-on list --installed
 
+header "WSL2 information"
+
+if command -v wslinfo >/dev/null ; then
+  echo "WSL version=$(wsl.exe --version | tr -d '\0')";
+  echo "WSL2 networking mode=$(wslinfo --networking-mode)"
+fi
+
 header "mutagen situation"
 
 echo "looking for #ddev-generated in mutagen.yml in project ${PWD}"

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -36,16 +36,19 @@ These environments can be extended, version controlled, and shared, so you can t
 
     * RAM: 8GB
     * Storage: 256GB
-    * [Docker Desktop](https://www.docker.com/products/docker-desktop/) on the Windows side or [Docker CE](https://docs.docker.com/engine/install/ubuntu/) inside WSL2
+    * [Docker CE](https://docs.docker.com/engine/install/ubuntu/) inside WSL2 or [Docker Desktop](https://www.docker.com/products/docker-desktop/) on the Windows side.
     * Ubuntu or an Ubuntu-derived distro is recommended, though others may work fine
 
     **Next steps:**
 
     *You’ll need a Docker provider on your system before you can install DDEV.*
     
-    1. Install Docker with [recommended settings](users/install/docker-installation.md#windows).
-    2. Install [DDEV for Windows](users/install/ddev-installation.md#windows).
-    3. Launch your [first project](users/project.md) and start developing. 🚀
+    1. Install [DDEV for Windows](users/install/ddev-installation.md#windows).
+    2. Launch your [first project](users/project.md) and start developing. 🚀
+
+    **WSL2 in Mirrored Mode**
+
+    If you're using Windows WSL2 with the "Mirrored" Networking Mode, set the experimental `hostAddressLoopback=true` feature.
 
 === "Traditional Windows"
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -259,7 +259,10 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     7. For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 
-    Now you can use the "Ubuntu" terminal app or Windows Terminal to access your Ubuntu distro, which has DDEV and Docker Desktop integrated with it.
+    Now you can use the "Ubuntu" terminal app or Windows Terminal to access your Ubuntu distro.
+
+    !!!note "WSL2 with Networking Mode set to 'Mirrored'"
+        If you're using the ['Mirrored' networking mode](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking) with WSL2, you need to also set the experimental `hostAddressLoopback=true` in your `~/.wslconfig` file.
 
     ### WSL2/Docker Desktop Manual Installation
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1032,10 +1032,9 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		XhguiImage:              docker.GetXhguiImage(),
 		XHProfMode:              app.GetXHProfMode(),
 
-		// Use the extra_hosts technique for Linux and WSL2 in networkingMode=mirrored, but not for Colima
-		// (we don't support Colima on Linux, but here's code anyway)
-		// If WSL2 in default networkingMode=nat we have to figure out other things, see GetHostDockerInternalIP()
-		UseHostDockerInternalExtraHosts: ((runtime.GOOS == "linux" || nodeps.IsWSL2MirroredMode()) && !dockerutil.IsColima()) || (nodeps.IsWSL2() && globalconfig.DdevGlobalConfig.XdebugIDELocation == globalconfig.XdebugIDELocationWSL2),
+		// Only use the extra_hosts technique for Linux and only if not WSL2 and not Colima
+		// If WSL2 we have to figure out other things, see GetHostDockerInternalIP()
+		UseHostDockerInternalExtraHosts: (runtime.GOOS == "linux" && !nodeps.IsWSL2() && !dockerutil.IsColima()) || (nodeps.IsWSL2() && globalconfig.DdevGlobalConfig.XdebugIDELocation == globalconfig.XdebugIDELocationWSL2),
 		BitnamiVolumeDir:                "",
 		UseHardenedImages:               globalconfig.DdevGlobalConfig.UseHardenedImages,
 	}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1032,9 +1032,10 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		XhguiImage:              docker.GetXhguiImage(),
 		XHProfMode:              app.GetXHProfMode(),
 
-		// Only use the extra_hosts technique for Linux and only if not WSL2 and not Colima
-		// If WSL2 we have to figure out other things, see GetHostDockerInternalIP()
-		UseHostDockerInternalExtraHosts: (runtime.GOOS == "linux" && !nodeps.IsWSL2() && !dockerutil.IsColima()) || (nodeps.IsWSL2() && globalconfig.DdevGlobalConfig.XdebugIDELocation == globalconfig.XdebugIDELocationWSL2),
+		// Use the extra_hosts technique for Linux and WSL2 in networkingMode=mirrored, but not for Colima
+		// (we don't support Colima on Linux, but here's code anyway)
+		// If WSL2 in default networkingMode=nat we have to figure out other things, see GetHostDockerInternalIP()
+		UseHostDockerInternalExtraHosts: ((runtime.GOOS == "linux" || nodeps.IsWSL2MirroredMode()) && !dockerutil.IsColima()) || (nodeps.IsWSL2() && globalconfig.DdevGlobalConfig.XdebugIDELocation == globalconfig.XdebugIDELocationWSL2),
 		BitnamiVolumeDir:                "",
 		UseHardenedImages:               globalconfig.DdevGlobalConfig.UseHardenedImages,
 	}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1293,19 +1293,21 @@ func GetHostDockerInternalIP() (string, error) {
 		util.Debug("host.docker.internal='%s' because globalconfig.DdevGlobalConfig.XdebugIDELocation=%s", hostDockerInternal, globalconfig.XdebugIDELocationWSL2)
 		break
 
-	case nodeps.IsWSL2() && !IsDockerDesktop():
+	case nodeps.IsWSL2() && !nodeps.IsWSL2MirroredMode() && !IsDockerDesktop():
 		// Microsoft instructions for finding Windows IP address at
 		// https://learn.microsoft.com/en-us/windows/wsl/networking#accessing-windows-networking-apps-from-linux-host-ip
 		// If IDE is on Windows, we have to parse /etc/resolv.conf
 		hostDockerInternal = wsl2GetWindowsHostIP()
 		util.Debug("host.docker.internal='%s' because IsWSL2 and !IsDockerDesktop; received from ip -4 route show default", hostDockerInternal)
+		break
 
 	// Docker on Linux doesn't define host.docker.internal
-	// so we need to go get the bridge IP address
+	// so we need to go get the bridge IP address.
+	// This is also done the same for WSL2 in networkingMode=mirrored
 	// Docker Desktop) defines host.docker.internal itself.
 	case runtime.GOOS == "linux":
 		// In Docker 20.10+, host.docker.internal is already taken care of by extra_hosts in docker-compose
-		util.Debug("host.docker.internal='%s' runtime.GOOS==linux and docker 20.10+", hostDockerInternal)
+		util.Debug("host.docker.internal='%s' runtime.GOOS==linux (or WSL2 mirrored mode) and docker 20.10+", hostDockerInternal)
 		break
 
 	default:

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1301,10 +1301,15 @@ func GetHostDockerInternalIP() (string, error) {
 		util.Debug("host.docker.internal='%s' because IsWSL2 and !IsDockerDesktop; received from ip -4 route show default", hostDockerInternal)
 		break
 
+	case nodeps.IsWSL2MirroredMode() && !IsDockerDesktop():
+		if ip, err := getWindowsReachableIP(); err == nil && ip != "" {
+			hostDockerInternal = ip
+			util.Debug("host.docker.internal='%s' because IsWSL2MirroredMode and !IsDockerDesktop; received from getWindowsReachableIP()", hostDockerInternal)
+		}
+		break
+
 	// Docker on Linux doesn't define host.docker.internal
 	// so we need to go get the bridge IP address.
-	// This is also done the same for WSL2 in networkingMode=mirrored
-	// Docker Desktop) defines host.docker.internal itself.
 	case runtime.GOOS == "linux":
 		// In Docker 20.10+, host.docker.internal is already taken care of by extra_hosts in docker-compose
 		util.Debug("host.docker.internal='%s' runtime.GOOS==linux (or WSL2 mirrored mode) and docker 20.10+", hostDockerInternal)
@@ -1318,7 +1323,27 @@ func GetHostDockerInternalIP() (string, error) {
 	return hostDockerInternal, nil
 }
 
-// GetNFSServerAddr gets the addrss that can be used for the NFS server.
+// getWindowsReachableIP() uses PowerShell to find a windows-side IP
+// address that can be accessed from inside a container.
+// This is needed for networkMode=mirrored in WSL2.
+func getWindowsReachableIP() (string, error) {
+	cmd := exec.Command("powershell.exe", "-Command", `
+Get-NetIPAddress -AddressFamily IPv4 |
+  Where-Object {
+    $_.IPAddress -notlike "169.254*" -and
+    $_.IPAddress -ne "127.0.0.1"
+  } |
+  Sort-Object InterfaceMetric |
+  Select-Object -First 1 -ExpandProperty IPAddress
+`)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("powershell failed: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// GetNFSServerAddr gets the address that can be used for the NFS server.
 // It's almost the same as GetDockerHostInternalIP() but we have
 // to get the actual addr in the case of Linux; still, Linux rarely
 // is used with NFS. Returns "host.docker.internal" by default (not empty)


### PR DESCRIPTION
## The Issue

- #7272

WSL2 Mirrored Mode is yet another kink in the already complex WSL2 landscape. Containers can only connect to Windows-side IP addresses, not to, for example. `docker0` in WSL2.

## How This PR Solves The Issue

* Derive a candidate Windows-side IP address to connect to and provide it as host.docker.internal
* Update `ddev debug test` to give this kind of information.
* See https://github.com/ddev/ddev/issues/7272#issuecomment-2862942816

## TODO

- [ ] I pretty much hate the (ChatGPT-assisted) PowerShell snippet being used to determine the appropriate IP address. Oh would I like something better. There might be a way to run a proxy in the WSL2 distro... or ???
- [x] Add docs for WSL2 configuration (~/.wslconfig, including `hostAddressLoopback=true`
- [x] It's conceivable that now that we have a way of detecting mirrored mode we could improve the timeout handling in https://github.com/ddev/ddev/blob/82c1988f0a11bb5d9474439c486f454b15b1334b/pkg/netutil/netutil.go#L41-L51

## Manual Testing Instructions

- [ ] This was tested with WSL pre-release 2.5.7.0. It probably works with current stable 2.4.x
- [ ] Use Xdebug with WSL2 in mirrored mode against an IDE on Windows. You must also have the experimental `hostAddressLoopback=true`. (This may require a WIndows reboot to be successful.) Example ~/.wslconfig (on Windows side):
```
[wsl2]
networkingMode=mirrored

[experimental]
hostAddressLoopback=true
```
- [ ] Verify that we can use Xdebug in WSL2 in mirrored mode with an IDE running in WSL2

## Automated Testing Overview

* No changed tests at this point, and we'll be forced to run a mirrored mode WSL2 test runner at some point.

This passes manual run of TestDdevXdebugEnabled and TestCmdXdebug on WSL2 as configured above

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
