### PR TITLE
feat: add shell completion for --service (-s) flag

### DIFF
--- a/cmd/ddev/cmd/autocompletion_test.go
+++ b/cmd/ddev/cmd/autocompletion_test.go
@@ -289,6 +289,65 @@ func TestAutocompletionForCustomCmds(t *testing.T) {
 	}
 }
 
+// TestAutocompleteServiceForServiceFlag checks service autocompletion for service flag
+func TestAutocompleteServiceForServiceFlag(t *testing.T) {
+	assert := asrt.New(t)
+
+	origDir, _ := os.Getwd()
+
+	site := TestSites[0]
+	err := os.Chdir(site.Dir)
+	require.NoError(t, err)
+
+	app, err := ddevapp.NewApp("", false)
+	assert.NoError(err)
+
+	t.Cleanup(func() {
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		_ = os.Chdir(origDir)
+	})
+	err = app.Start()
+	require.NoError(t, err)
+
+	// Check completion results are as expected for each command
+	for _, cmd := range []string{"exec", "logs", "ssh"} {
+		out, err := exec.RunHostCommand(DdevBin, "__complete", cmd, "-s", "")
+		assert.NoError(err)
+		assert.Contains(out, "web")
+		assert.Contains(out, "db")
+		// xhgui is not running, so it should not be in the output
+		assert.NotContains(out, "xhgui")
+	}
+
+	// ddev debug rebuild should contain all services, no matter if they are running or not
+	out, err := exec.RunHostCommand(DdevBin, "__complete", "debug", "rebuild", "-s", "")
+	assert.NoError(err)
+	assert.Contains(out, "web")
+	assert.Contains(out, "db")
+	assert.Contains(out, "xhgui")
+
+	err = app.Stop(true, false)
+	require.NoError(t, err)
+
+	// Check completion results are as expected for each command
+	for _, cmd := range []string{"exec", "logs", "ssh"} {
+		out, err := exec.RunHostCommand(DdevBin, "__complete", cmd, "-s", "")
+		assert.NoError(err)
+		// not running services should not be here
+		assert.NotContains(out, "web")
+		assert.NotContains(out, "db")
+		assert.NotContains(out, "xhgui")
+	}
+
+	// ddev debug rebuild should contain all services, no matter if they are running or not
+	out, err = exec.RunHostCommand(DdevBin, "__complete", "debug", "rebuild", "-s", "")
+	assert.NoError(err)
+	assert.Contains(out, "web")
+	assert.Contains(out, "db")
+	assert.Contains(out, "xhgui")
+}
+
 // TestAutocompleteTermsForCustomCmds tests the AutocompleteTerms annotation for custom host and container commands
 func TestAutocompleteTermsForCustomCmds(t *testing.T) {
 	if dockerutil.IsColima() || dockerutil.IsLima() {

--- a/cmd/ddev/cmd/autocompletion_test.go
+++ b/cmd/ddev/cmd/autocompletion_test.go
@@ -318,6 +318,16 @@ func TestAutocompleteServiceForServiceFlag(t *testing.T) {
 		assert.Contains(out, "db")
 		// xhgui is not running, so it should not be in the output
 		assert.NotContains(out, "xhgui")
+
+		// check with project argument
+		if cmd != "exec" {
+			out, err := exec.RunHostCommand(DdevBin, "__complete", cmd, site.Name, "-s", "")
+			assert.NoError(err)
+			assert.Contains(out, "web")
+			assert.Contains(out, "db")
+			// xhgui is not running, so it should not be in the output
+			assert.NotContains(out, "xhgui")
+		}
 	}
 
 	// ddev debug rebuild should contain all services, no matter if they are running or not
@@ -327,7 +337,7 @@ func TestAutocompleteServiceForServiceFlag(t *testing.T) {
 	assert.Contains(out, "db")
 	assert.Contains(out, "xhgui")
 
-	err = app.Stop(true, false)
+	err = app.Stop(false, false)
 	require.NoError(t, err)
 
 	// Check completion results are as expected for each command
@@ -338,10 +348,20 @@ func TestAutocompleteServiceForServiceFlag(t *testing.T) {
 		assert.NotContains(out, "web")
 		assert.NotContains(out, "db")
 		assert.NotContains(out, "xhgui")
+
+		// check with project argument
+		if cmd != "exec" {
+			out, err := exec.RunHostCommand(DdevBin, "__complete", cmd, site.Name, "-s", "")
+			assert.NoError(err)
+			// not running services should not be here
+			assert.NotContains(out, "web")
+			assert.NotContains(out, "db")
+			assert.NotContains(out, "xhgui")
+		}
 	}
 
-	// ddev debug rebuild should contain all services, no matter if they are running or not
-	out, err = exec.RunHostCommand(DdevBin, "__complete", "debug", "rebuild", "-s", "")
+	// ddev debug rebuild should contain all services, no matter if they are running or not (with project argument)
+	out, err = exec.RunHostCommand(DdevBin, "__complete", "debug", "rebuild", site.Name, "-s", "")
 	assert.NoError(err)
 	assert.Contains(out, "web")
 	assert.Contains(out, "db")

--- a/cmd/ddev/cmd/debug-rebuild.go
+++ b/cmd/ddev/cmd/debug-rebuild.go
@@ -137,4 +137,5 @@ func init() {
 	DebugRebuildCmd.Flags().BoolVarP(&buildAll, "all", "a", false, "Rebuild all services and restart the project")
 	DebugRebuildCmd.Flags().Bool("cache", false, "Keep Docker cache")
 	DebugRebuildCmd.Flags().StringVarP(&service, "service", "s", "web", "Rebuild the specified service and restart it")
+	_ = DebugRebuildCmd.RegisterFlagCompletionFunc("service", ddevapp.GetServiceNamesFunc(false))
 }

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -99,6 +99,7 @@ func quoteArgs(args []string) string {
 
 func init() {
 	DdevExecCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Defines the service to connect to. [e.g. web, db]")
+	_ = DdevExecCmd.RegisterFlagCompletionFunc("service", ddevapp.GetServiceNamesFunc(true))
 	DdevExecCmd.Flags().StringVarP(&execDirArg, "dir", "d", "", "Defines the execution directory within the container")
 	DdevExecCmd.Flags().Bool("raw", true, "Use raw exec (do not interpret with Bash inside container)")
 	// This requires flags for exec to be specified prior to any arguments, allowing for

--- a/cmd/ddev/cmd/logs.go
+++ b/cmd/ddev/cmd/logs.go
@@ -44,6 +44,7 @@ func init() {
 	DdevLogsCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow the logs in real time.")
 	DdevLogsCmd.Flags().BoolVarP(&timestamp, "time", "t", false, "Add timestamps to logs")
 	DdevLogsCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Defines the service to retrieve logs from. [e.g. web, db]")
+	_ = DdevLogsCmd.RegisterFlagCompletionFunc("service", ddevapp.GetServiceNamesFunc(true))
 	DdevLogsCmd.Flags().StringVarP(&tail, "tail", "", "", "How many lines to show")
 
 	// JSON formatted output isn't supported, so we should hide the global --json-output flag

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -56,6 +56,7 @@ ddev ssh -d /var/www/html`,
 
 func init() {
 	DdevSSHCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Defines the service to connect to. [e.g. web, db]")
+	_ = DdevSSHCmd.RegisterFlagCompletionFunc("service", ddevapp.GetServiceNamesFunc(true))
 	DdevSSHCmd.Flags().StringVarP(&sshDirArg, "dir", "d", "", "Defines the destination directory within the container")
 	RootCmd.AddCommand(DdevSSHCmd)
 }

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -493,8 +493,13 @@ func GetProjectNamesFunc(status string, numArgs int) func(*cobra.Command, []stri
 // GetServiceNamesFunc returns a function for autocompleting service names for service flag.
 // If existingOnly is true, only names of existing services will be returned.
 func GetServiceNamesFunc(existingOnly bool) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		app, err := GetActiveApp("")
+	return func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		// the project name can be passed as an argument
+		projectName := ""
+		if len(args) > 0 {
+			projectName = args[0]
+		}
+		app, err := GetActiveApp(projectName)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}


### PR DESCRIPTION
## The Issue

We don't have autocompletion for services.

## How This PR Solves The Issue

Adds it.

## Manual Testing Instructions

```
ddev start
ddev exec -s <TAB><TAB>
ddev logs -s <TAB><TAB>
ddev ssh -s <TAB><TAB>
ddev debug rebuild -s <TAB><TAB> # should contain all services

ddev logs d11 -s <TAB><TAB>
ddev ssh d11 -s <TAB><TAB>
ddev debug rebuild d11 -s <TAB><TAB> # should contain all services
```

```
ddev add-on get ddev/ddev-redis
ddev restart
ddev exec -s <TAB><TAB> # see redis
```

```
ddev stop
ddev exec -s <TAB><TAB> # should be empty
ddev logs -s <TAB><TAB> # should be empty
ddev ssh -s <TAB><TAB> # should be empty
ddev debug rebuild -s <TAB><TAB> # should contain all services

ddev logs d11 -s <TAB><TAB> # should be empty
ddev ssh d11 -s <TAB><TAB> # should be empty
ddev debug rebuild d11 -s <TAB><TAB> # should contain all services
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
