### PR TITLE
feat: restart only specified service in `ddev debug rebuild`

### DIFF
--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -112,7 +112,7 @@ var AuthSSHCommand = &cobra.Command{
 			if strings.Contains(err.Error(), "bind source path does not exist") {
 				helpMessage = "\n\nThe specified SSH private key path is not shared with your Docker provider."
 			}
-			util.Failed("Docker command 'docker %v' failed: %v %v", echoDockerCmd(dockerCmd), err, helpMessage)
+			util.Failed("Docker command 'docker %v' failed: %v %v", prettyCmd(dockerCmd), err, helpMessage)
 		}
 	},
 }
@@ -197,16 +197,6 @@ func getCertificateForPrivateKey(path string, name string) (string, string) {
 	certPath = util.WindowsPathToCygwinPath(certPath)
 	certName := name + "-cert.pub"
 	return certPath, certName
-}
-
-// echoDockerCmd formats the Docker command to be more readable.
-func echoDockerCmd(dockerCmd []string) string {
-	for i, arg := range dockerCmd {
-		if strings.Contains(arg, " ") {
-			dockerCmd[i] = `"` + arg + `"`
-		}
-	}
-	return strings.Join(dockerCmd, " ")
 }
 
 func init() {

--- a/cmd/ddev/cmd/debug-rebuild.go
+++ b/cmd/ddev/cmd/debug-rebuild.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	exec2 "github.com/ddev/ddev/pkg/exec"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"strings"
 	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	exec2 "github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
@@ -22,15 +22,14 @@ var (
 var DebugRebuildCmd = &cobra.Command{
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 1),
 	Use:               "rebuild",
-	Short:             "Rebuilds Docker cache for project with verbose output",
+	Short:             "Rebuilds the project's Docker cache with verbose output and restarts the project or the specified service.",
 	Aliases:           []string{"refresh"},
 	Run: func(cmd *cobra.Command, args []string) {
-		projectName := ""
-
 		if len(args) > 1 {
 			util.Failed("This command only takes one optional argument: project name")
 		}
 
+		projectName := ""
 		if len(args) == 1 {
 			projectName = args[0]
 		}
@@ -43,6 +42,7 @@ var DebugRebuildCmd = &cobra.Command{
 		if err != nil {
 			util.Failed("could not download docker-compose: %v", err)
 		}
+
 		composeBinaryPath, err := globalconfig.GetDockerComposePath()
 		if err != nil {
 			util.Failed("could not GetDockerComposePath(): %v", err)
@@ -54,11 +54,11 @@ var DebugRebuildCmd = &cobra.Command{
 		}
 
 		app.DockerEnv()
+
 		if err = app.WriteDockerComposeYAML(); err != nil {
 			util.Failed("Failed to get compose-config: %v", err)
 		}
 
-		output.UserOut.Printf("Rebuilding project images...")
 		buildDurationStart := util.ElapsedDuration(time.Now())
 		composeRenderedPath := app.DockerComposeFullRenderedYAMLPath()
 		withoutCache := !cmd.Flags().Changed("cache")
@@ -66,32 +66,75 @@ var DebugRebuildCmd = &cobra.Command{
 		buildArgs := []string{"-f", composeRenderedPath, "--progress", "plain", "build"}
 
 		if !buildAll {
-			buildArgs = append(buildArgs, cmd.Flag("service").Value.String())
+			buildArgs = append(buildArgs, service)
 		}
 
 		if withoutCache {
 			buildArgs = append(buildArgs, "--no-cache")
+			output.UserOut.Printf("Rebuilding project images without Docker cache...")
+		} else {
+			output.UserOut.Printf("Rebuilding project images using Docker cache...")
 		}
 
-		util.Success("Rebuilding project %s with `%s %v`", app.Name, composeBinaryPath, strings.Join(buildArgs, " "))
-
+		output.UserOut.Printf("Executing `%s %v`", composeBinaryPath, prettyCmd(buildArgs))
 		err = exec2.RunInteractiveCommand(composeBinaryPath, buildArgs)
 		if err != nil {
-			util.Failed("Failed to execute `%s %v`: %v", composeBinaryPath, strings.Join(buildArgs, " "), err)
+			util.Failed("Failed to execute `%s %v`: %v", composeBinaryPath, prettyCmd(buildArgs), err)
 		}
-		buildDuration := util.FormatDuration(buildDurationStart())
-		util.Success("Rebuilt Docker cache for project %s in %s", app.Name, buildDuration)
 
-		err = app.Restart()
-		if err != nil {
-			util.Failed("Failed to restart project: %v", err)
+		buildDuration := util.FormatDuration(buildDurationStart())
+		if buildAll {
+			util.Success("Rebuilt %s cache in %s", app.Name, buildDuration)
+		} else {
+			util.Success("Rebuilt %s service cache for %s in %s", service, app.Name, buildDuration)
+		}
+
+		// Restart the entire project only when changing "web",
+		// since app.Start() includes a lot of extra logic
+		// and just restarting the web service isn't enough here
+		if buildAll || service == "web" {
+			err = app.Restart()
+			if err != nil {
+				util.Failed("Failed to restart project: %v", err)
+			}
+			util.Success("Restarted %s", app.GetName())
+			return
+		}
+
+		labels := map[string]string{
+			"com.ddev.site-name":         app.GetName(),
+			"com.docker.compose.oneoff":  "False",
+			"com.docker.compose.service": service,
+		}
+
+		// Restart the specified service using docker-compose, if it is running
+		if container, err := dockerutil.FindContainerByLabels(labels); err == nil && container != nil {
+			restartArgs := []string{"-f", composeRenderedPath, "--progress", "plain", "restart", service}
+			output.UserOut.Printf("Executing `%s %v`", composeBinaryPath, prettyCmd(restartArgs))
+			err = exec2.RunInteractiveCommand(composeBinaryPath, restartArgs)
+			if err != nil {
+				util.Failed("Failed to execute `%s %v`: %v", composeBinaryPath, prettyCmd(restartArgs), err)
+			}
+			output.UserOut.Printf("Waiting %ds for project container [%v] to become ready...", app.GetMaxContainerWaitTime(), service)
+			err = app.WaitByLabels(labels)
+			if err != nil {
+				util.Failed("Failed to wait for project container [%v] to become ready: %v", service, err)
+			}
+			if !ddevapp.IsRouterDisabled(app) {
+				util.Debug("Starting %s if necessary...", nodeps.RouterContainer)
+				err = ddevapp.StartDdevRouter()
+				if err != nil {
+					util.Failed("Failed to start %s: %v", nodeps.RouterContainer, err)
+				}
+			}
+			util.Success("Restarted %s service for %s", service, app.GetName())
 		}
 	},
 }
 
 func init() {
 	DebugCmd.AddCommand(DebugRebuildCmd)
-	DebugRebuildCmd.Flags().BoolVarP(&buildAll, "all", "a", false, "Rebuild all services")
+	DebugRebuildCmd.Flags().BoolVarP(&buildAll, "all", "a", false, "Rebuild all services and restart the project")
 	DebugRebuildCmd.Flags().Bool("cache", false, "Keep Docker cache")
-	DebugRebuildCmd.Flags().StringVarP(&service, "service", "s", "web", "Rebuild specified service")
+	DebugRebuildCmd.Flags().StringVarP(&service, "service", "s", "web", "Rebuild the specified service and restart it")
 }

--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -145,3 +145,13 @@ func GetUnknownFlags(cmd *cobra.Command) (map[string]string, error) {
 	}
 	return unknownFlags, nil
 }
+
+// prettyCmd formats the Docker command to be more readable.
+func prettyCmd(cmd []string) string {
+	for i, arg := range cmd {
+		if strings.Contains(arg, " ") {
+			cmd[i] = `"` + arg + `"`
+		}
+	}
+	return strings.Join(cmd, " ")
+}

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -583,13 +583,13 @@ ddev debug nfsmount
 
 *Alias: `debug refresh`.*
 
-Rebuilds the project’s Docker cache with verbose output.
+Rebuilds the project’s Docker cache with verbose output and restarts the project or the specified service.
 
 Flags:
 
-* `--all`, `-a`: Rebuild all services.
+* `--all`, `-a`: Rebuild all services and restart the project.
 * `--cache`: Keep Docker cache.
-* `--service`, `-s`: Rebuild specified service. (default `web`)
+* `--service`, `-s`: Rebuild the specified service and restart it. (default `web`)
 
 Example:
 


### PR DESCRIPTION
## The Issue

From StackOverflow https://stackoverflow.com/questions/79522674/how-to-restart-a-single-ddev-service-docker-container-without-restarting-the-f/79523060?noredirect=1#comment140420056_79523060

## How This PR Solves The Issue

Improves `ddev debug rebuild`, so it doesn't restart the entire project when it's not needed.

## Manual Testing Instructions

```
# get additional containers
ddev add-on get ddev/ddev-opensearch
ddev add-on get ddev/ddev-phpmyadmin
ddev restart

# break them
ddev exec -s opensearch kill 1
ddev exec -s phpmyadmin kill 1
ddev describe

# rebuild and restart opensearch using cache
ddev debug rebuild -s opensearch --cache
ddev describe

# rebuild and restart phpmyadmin without cache
ddev debug rebuild -s phpmyadmin
ddev describe
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
