### PR TITLE
fix: Make sure env-type settings are populated before start, don't override `.ddev/.gitignore` file, for #7236

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -311,7 +311,9 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 
 		// Don't create gitignore if it would be in top-level directory, where
 		// there is almost certainly already a gitignore (like Backdrop)
-		if path.Dir(app.SiteSettingsPath) != app.AppRoot {
+		// Don't override the existing .ddev/.gitignore as well
+		// TODO: we may want to append to .ddev/.gitignore if needed.
+		if path.Dir(app.SiteSettingsPath) != app.AppRoot && path.Dir(app.SiteSettingsPath) != app.GetConfigPath("") && app.SiteDdevSettingsFile != "" {
 			if err = CreateGitIgnore(filepath.Dir(app.SiteSettingsPath), filepath.Base(app.SiteDdevSettingsFile), "drushrc.php"); err != nil {
 				util.Warning("Failed to write .gitignore in %s: %v", filepath.Dir(app.SiteDdevSettingsFile), err)
 			}

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -268,7 +268,7 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 	app.SetApptypeSettingsPaths()
 
 	if app.DisableSettingsManagement && app.Type != nodeps.AppTypePHP && app.Type != nodeps.AppTypeGeneric {
-		util.Warning("Not creating CMS settings files because disable_settings_management=true")
+		util.Warning("Not creating CMS settings files because disable_settings_management=true or project type doesn't require settings")
 		return "", nil
 	}
 

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -309,9 +309,9 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 			util.Warning("Unable to create settings file '%s': %v", app.SiteSettingsPath, err)
 		}
 
-		// Don't create gitignore if it would be in top-level directory, where
+		// Don't create settings-directory .gitignore if it would be in top-level directory, where
 		// there is almost certainly already a gitignore (like Backdrop)
-		// Don't override the existing .ddev/.gitignore as well
+		// Don't accidentally override the existing .ddev/.gitignore as well
 		// TODO: we may want to append to .ddev/.gitignore if needed.
 		if path.Dir(app.SiteSettingsPath) != app.AppRoot && path.Dir(app.SiteSettingsPath) != app.GetConfigPath("") && app.SiteDdevSettingsFile != "" {
 			if err = CreateGitIgnore(filepath.Dir(app.SiteSettingsPath), filepath.Base(app.SiteDdevSettingsFile), "drushrc.php"); err != nil {

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -267,7 +267,7 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 
 	app.SetApptypeSettingsPaths()
 
-	if app.DisableSettingsManagement && app.Type != nodeps.AppTypePHP {
+	if app.DisableSettingsManagement && app.Type != nodeps.AppTypePHP && app.Type != nodeps.AppTypeGeneric {
 		util.Warning("Not creating CMS settings files because disable_settings_management=true")
 		return "", nil
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1769,6 +1769,10 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		return err
 	}
 
+	if _, err = app.CreateSettingsFile(); err != nil {
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
+	}
+
 	err = app.PostStartAction()
 	if err != nil {
 		return err

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1454,6 +1454,10 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	// Fix any obsolete things like old shell commands, etc.
 	app.FixObsolete()
 
+	if _, err = app.CreateSettingsFile(); err != nil {
+		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
+	}
+
 	// WriteConfig .ddev-docker-compose-*.yaml
 	err = app.WriteDockerComposeYAML()
 	if err != nil {
@@ -1763,10 +1767,6 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	err = app.WaitByLabels(waitLabels)
 	if err != nil {
 		return err
-	}
-
-	if _, err = app.CreateSettingsFile(); err != nil {
-		return fmt.Errorf("failed to write settings file %s: %v", app.SiteDdevSettingsFile, err)
 	}
 
 	err = app.PostStartAction()


### PR DESCRIPTION
## The Issue

- #7236
- Discord (breakage of .ddev/.gitignore on craft in v1.24.5): https://discord.com/channels/664580571770388500/1372597483443589264

In https://github.com/ddev/ddev/pull/7236#issuecomment-2876493614 @stasadev pointed out that now that we're using .ddev/.env* for settings (instead of using php application-defined settings load techniques) the settings/env values may be loaded too late (after containers are up) in some situations.

Before #7236 I believe that all explicit use of settings, including project types that used project-level .env (loaded by PHP dotenv for example) were application-loaded, which meant that it didn't matter that we wrote the .env late (post-start). But now with #7236 we're using DDEV's .ddev/.env.* so those only get loaded during `docker-compose up`, and need to be written before `docker-compose up`. 

---

The CraftCMS config overrides `.ddev/.gitignore` completely (which is wrong), and our logic for settings files creates `.gitignore` file in the directory of the settings file. Since CraftCMS uses `.ddev/.env.web`, its parent is `.ddev`, so it used `.ddev/.gitignore`.

## How This PR Solves The Issue

Move the call to app.CreateSettingsFile() in the start sequence to before the `docker-compose up`

Don't override `.ddev/.gitignore` for CraftCMS. 

## Manual Testing Instructions

Mostly automated tests should tell us about this; 

A good check of Craft CMS in light of https://github.com/ddev/ddev/pull/7236#issuecomment-2876493614 is a good idea

## Automated Testing Overview

No changes.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
