### PR TITLE
build: add `make go-mod-update` 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,19 @@ golangci-lint:
 		echo "Skipping golangci-lint as not installed"; \
 	fi
 
+# golang doesn't always clean indirect dependencies in go.mod
+# we can remove all '// indirect' lines, and they will be re-added
+bump:
+	@echo "bump dependencies: "
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		sed -i '' '/\/\/ indirect$$/d' go.mod; \
+	else \
+		sed -i '/\/\/ indirect$$/d' go.mod; \
+	fi
+	go get -u ./...
+	go mod tidy
+	go mod vendor
+
 quickstart-test: build
 	@echo "quickstart-test:"
 	@echo DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH)

--- a/Makefile
+++ b/Makefile
@@ -289,9 +289,9 @@ golangci-lint:
 
 # golang doesn't always clean indirect dependencies in go.mod
 # we can remove all '// indirect' lines, and they will be re-added
-bump:
-	@echo "bump dependencies: "
-	awk '!/\/\/ indirect$$/' go.mod > go.mod.tmp && mv go.mod.tmp go.mod
+go-mod-update:
+	@echo "bump golang dependencies: "
+	@awk '!/\/\/ indirect$$/' go.mod > go.mod.tmp && mv go.mod.tmp go.mod
 	go get -u ./...
 	go mod tidy
 	go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -287,11 +287,8 @@ golangci-lint:
 		echo "Skipping golangci-lint as not installed"; \
 	fi
 
-# golang doesn't always clean indirect dependencies in go.mod
-# we can remove all '// indirect' lines, and they will be re-added
 go-mod-update:
 	@echo "bump golang dependencies: "
-	@awk '!/\/\/ indirect$$/' go.mod > go.mod.tmp && mv go.mod.tmp go.mod
 	go get -u ./...
 	go mod tidy
 	go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -291,11 +291,7 @@ golangci-lint:
 # we can remove all '// indirect' lines, and they will be re-added
 bump:
 	@echo "bump dependencies: "
-	@if [ "$$(uname)" = "Darwin" ]; then \
-		sed -i '' '/\/\/ indirect$$/d' go.mod; \
-	else \
-		sed -i '/\/\/ indirect$$/d' go.mod; \
-	fi
+	awk '!/\/\/ indirect$$/' go.mod > go.mod.tmp && mv go.mod.tmp go.mod
 	go get -u ./...
 	go mod tidy
 	go mod vendor


### PR DESCRIPTION
## The Issue

I don't want to remember how to bump dependencies in `go.mod`.

## How This PR Solves The Issue

Adds `make go-mod-update`.

## Manual Testing Instructions

```
make go-mod-update
make
```

I don't bump the dependencies here because I don't want to overload this PR with changed lines.

And I probably won't bump it for v1.24.5, I don't see any reason for that.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
