### PR TITLE
fix: Improve devcontainer.json to use current Ubuntu and docker, fixes #7287 [skip ci]

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,8 @@
           "ppa": "false"
         },
         "ghcr.io/devcontainers/features/docker-in-docker:2": {
-          "version": "latest"
+          "version": "latest",
+          "enableNonRootDocker": true
         },
         "ghcr.io/devcontainers/features/go:1": {
           "version": "latest"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,12 +8,29 @@
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
 			"packages": "autojump,curl,wget,xdg-utils"
 		},
-		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
-		// "ghcr.io/edouard-lopez/devcontainer-features/bats:0": {}
+        "ghcr.io/devcontainers/features/common-utils:2": {
+          "username": "codespace",
+          "userUid": "1000",
+          "userGid": "1000"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+          "version": "latest",
+          "ppa": "false"
+        },
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+          "version": "latest"
+        },
+        "ghcr.io/devcontainers/features/go:1": {
+          "version": "latest"
+        },
+        "ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
+        "ghcr.io/edouard-lopez/devcontainer-features/bats:0": {}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
+    "remoteUser": "codespace",
+    "containerUser": "codespace",
 
 	"postCreateCommand": "./.devcontainer/setup_test_project.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,11 @@
 		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
 		"ghcr.io/edouard-lopez/devcontainer-features/bats:0": {}
 	},
+	"postStartCommand": [
+		// change socket group so vscode (in docker group) can talk without sudo
+		"sudo chgrp docker /var/run/docker.sock",
+		"sudo chmod 660   /var/run/docker.sock"
+	],
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
 	],
@@ -32,7 +37,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "./.devcontainer/setup_test_project.sh",
+	"postCreateCommand": "./.devcontainer/setup_test_project.sh"
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 			"packages": "autojump,curl,wget,xdg-utils"
 		},
 		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
-		"ghcr.io/edouard-lopez/devcontainer-features/bats:0": {}
+		// "ghcr.io/edouard-lopez/devcontainer-features/bats:0": {}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,11 +17,7 @@
 		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
 		"ghcr.io/edouard-lopez/devcontainer-features/bats:0": {}
 	},
-	"postStartCommand": [
-		// change socket group so vscode (in docker group) can talk without sudo
-		"sudo chgrp docker /var/run/docker.sock",
-		"sudo chmod 660   /var/run/docker.sock"
-	],
+	"postStartCommand": "sudo chgrp docker /var/run/docker.sock",
 	"mounts": [
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
 	],
@@ -32,12 +28,14 @@
 	"runArgs": [
 		"--privileged"
 	],
+	"updateContentCommand": "sudo chgrp docker /var/run/docker.sock",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "./.devcontainer/setup_test_project.sh"
+	
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,12 +2,14 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "Go",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "."
+	},
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"version": "latest",
-			"addNonRootUserToDockerGroup": true
+			"enableNonRootDocker": true
 		},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
 			"packages": "autojump,curl,wget,xdg-utils"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,9 +9,6 @@
 			"packages": "autojump,curl,wget,xdg-utils"
 		},
         "ghcr.io/devcontainers/features/common-utils:2": {
-          "username": "codespace",
-          "userUid": "1000",
-          "userGid": "1000"
         },
         "ghcr.io/devcontainers/features/git:1": {
           "version": "latest",
@@ -29,8 +26,8 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-    "remoteUser": "codespace",
-    "containerUser": "codespace",
+//    "remoteUser": "codespace",
+//    "containerUser": "codespace",
 
 	"postCreateCommand": "./.devcontainer/setup_test_project.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,8 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
-	"name": "Go",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"context": "."
-	},
+	"name": "DDEV PR Tester",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"version": "latest",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,27 +3,39 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-    "image": "mcr.microsoft.com/devcontainers/universal:2",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
 	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"version": "latest",
+			"addNonRootUserToDockerGroup": true
+		},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
 			"packages": "autojump,curl,wget,xdg-utils"
+		},
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "1.24"
 		},
 		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
 		"ghcr.io/edouard-lopez/devcontainer-features/bats:0": {}
 	},
-
+	"mounts": [
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+	],
+	"hostRequirements": {
+		"cpus": 2,
+		"memory": "4gb"
+	},
+	"runArgs": [
+		"--privileged"
+	],
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "./.devcontainer/setup_test_project.sh",
-
 	// Configure tool-specific properties.
 	// "customizations": {},
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,8 +21,8 @@
         "ghcr.io/devcontainers/features/go:1": {
           "version": "latest"
         },
-        "ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
-        "ghcr.io/edouard-lopez/devcontainer-features/bats:0": {}
+        "ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {}
+//        "ghcr.io/edouard-lopez/devcontainer-features/bats:0": {}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
 			"packages": "autojump,curl,wget,xdg-utils"
 		},
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.24"
+			"version": "1.24",
+			"installTools": false
 		},
 		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
 		"ghcr.io/edouard-lopez/devcontainer-features/bats:0": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,44 +1,19 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
-	"name": "DDEV PR Tester",
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+	"name": "DDEV Devcontainer",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "ddev/ddev-devcontainer:20250513_rfay_devcontainer_codespaces",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {
-			"version": "latest",
-			"enableNonRootDocker": true
-		},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
 			"packages": "autojump,curl,wget,xdg-utils"
-		},
-		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.24",
-			"installTools": false
 		},
 		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
 		"ghcr.io/edouard-lopez/devcontainer-features/bats:0": {}
 	},
-	"postStartCommand": "sudo chgrp docker /var/run/docker.sock",
-	"mounts": [
-		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
-	],
-	"hostRequirements": {
-		"cpus": 2,
-		"memory": "4gb"
-	},
-	"runArgs": [
-		"--privileged"
-	],
-	"updateContentCommand": "sudo chgrp docker /var/run/docker.sock",
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-	// Use 'postCreateCommand' to run commands after the container is created.
+
 	"postCreateCommand": "./.devcontainer/setup_test_project.sh"
-	
-	// Configure tool-specific properties.
-	// "customizations": {},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,8 +26,8 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-//    "remoteUser": "codespace",
-//    "containerUser": "codespace",
+    "remoteUser": "devcontainer",
+    "containerUser": "devcontainer",
 
 	"postCreateCommand": "./.devcontainer/setup_test_project.sh"
 }

--- a/.devcontainer/setup_test_project.sh
+++ b/.devcontainer/setup_test_project.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 echo "You don't need to wait for the test project to be set up."
 set -x
 make
-sudo ln -sf ${PWD}/.gotmp/bin/linux_amd64/ddev /usr/local/bin/ddev
+sudo ln -sf "${PWD}/.gotmp/bin/linux_$(dpkg --print-architecture)/ddev" /usr/local/bin/ddev
 ddev debug download-images
 ddev delete -Oy tmp >/dev/null || true
 ddev --version

--- a/.devcontainer/setup_test_project.sh
+++ b/.devcontainer/setup_test_project.sh
@@ -11,7 +11,7 @@ ddev delete -Oy tmp >/dev/null || true
 ddev --version
 
 export DDEV_NONINTERACTIVE=true
-DDEV_REPO=${DDEV_REPO:-https://github.com/ddev/d10simple}
+DDEV_REPO=${DDEV_REPO:-https://github.com/ddev/d11simple}
 DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
 git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
 reponame=${DDEV_REPO##*/}

--- a/.devcontainer/setup_test_project.sh
+++ b/.devcontainer/setup_test_project.sh
@@ -2,6 +2,8 @@
 
 set -eu -o pipefail
 
+git config --global --add safe.directory '*'
+
 echo "You don't need to wait for the test project to be set up."
 set -x
 make

--- a/.devcontainer/setup_test_project.sh
+++ b/.devcontainer/setup_test_project.sh
@@ -2,7 +2,9 @@
 
 set -eu -o pipefail
 
+# These things should probably be done earlier in startup, not in this script
 git config --global --add safe.directory '*'
+echo '[ -f /usr/share/autojump/autojump.sh ] && . /usr/share/autojump/autojump.sh ]' >> ~/.bash_profile
 
 echo "You don't need to wait for the test project to be set up."
 set -x

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,9 +7,14 @@
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceRoot}/cmd/ddev",
-            "cwd": "${workspaceRoot}/../d10simple",
-            "env": {"DDEV_DEBUG": "true"},
-            "args": ["start", "-y"],
+            "cwd": "${workspaceRoot}/../d11simple",
+            "env": {
+                "DDEV_DEBUG": "true"
+            },
+            "args": [
+                "start",
+                "-y"
+            ],
             "showLog": true
         },
         {
@@ -18,20 +23,28 @@
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceRoot}/cmd/ddev",
-            "cwd": "${workspaceRoot}/../d10simple",
-            "env": {"DDEV_DEBUG": "true"},
-            "args": ["snapshot"],
+            "cwd": "${workspaceRoot}/../d11simple",
+            "env": {
+                "DDEV_DEBUG": "true"
+            },
+            "args": [
+                "snapshot"
+            ],
             "showLog": true
         },
-
         {
             "name": "debug ddev describe",
             "type": "go",
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceRoot}/cmd/ddev",
-            "env": {"DDEV_DEBUG": "true"},
-            "args": ["describe"],
+            "env": {
+                "DDEV_DEBUG": "true"
+            },
+            "args": [
+                "describe"
+            ],
+            "cwd": "${workspaceRoot}/../d11simple",
             "showLog": true
         },
         {
@@ -40,9 +53,13 @@
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceRoot}/cmd/ddev",
-            "cwd": "${workspaceRoot}/../d9",
-            "env": {"DDEV_DEBUG": "true"},
-            "args": ["list"],
+            "cwd": "${workspaceRoot}/../d11simple",
+            "env": {
+                "DDEV_DEBUG": "true"
+            },
+            "args": [
+                "list"
+            ],
             "showLog": true
         },
         {
@@ -52,8 +69,13 @@
             "mode": "debug",
             "program": "${workspaceRoot}/cmd/ddev",
             "cwd": "${workspaceRoot}",
-            "env": {"DDEV_DEBUG": "true"},
-            "args": ["clean", "-a"],
+            "env": {
+                "DDEV_DEBUG": "true"
+            },
+            "args": [
+                "clean",
+                "-a"
+            ],
             "showLog": true
         },
         {
@@ -63,8 +85,15 @@
             "mode": "debug",
             "program": "${workspaceRoot}/cmd/ddev",
             "cwd": "${workspaceRoot}",
-            "env": {"DDEV_DEBUG": "true"},
-            "args": ["delete", "images", "-y", "-a"],
+            "env": {
+                "DDEV_DEBUG": "true"
+            },
+            "args": [
+                "delete",
+                "images",
+                "-y",
+                "-a"
+            ],
             "showLog": true
         },
         {
@@ -75,7 +104,9 @@
             "port": 2345,
             "host": "127.0.0.1",
             "program": "${workspaceRoot}/pkg/plugins/platform",
-            "env": {"DDEV_DEBUG": "true"},
+            "env": {
+                "DDEV_DEBUG": "true"
+            },
             "args": [],
             "showLog": true
         },

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -139,7 +139,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 				}
 
 			// Gitpod, web container only, using port proxied by Gitpod
-			case (nodeps.IsGitpod() || nodeps.IsCodespaces()) && k == "web":
+			case (nodeps.IsGitpod() || nodeps.IsCodespaces() || nodeps.IsRemoteContainers()) && k == "web":
 				urlPortParts = append(urlPortParts, app.GetPrimaryURL())
 
 			// Router disabled, but not because of Gitpod, use direct http url

--- a/containers/ddev-devcontainer/.gitignore
+++ b/containers/ddev-devcontainer/.gitignore
@@ -1,0 +1,5 @@
+# Temporary build-tools artifacts to be ignored
+/VERSION.txt
+# These are not artifacts that should be ignored
+!files/usr/bin/
+!files/usr/local/bin/

--- a/containers/ddev-devcontainer/Dockerfile
+++ b/containers/ddev-devcontainer/Dockerfile
@@ -1,0 +1,106 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
+
+# Adapted from MS Universal Devcontainer: https://github.com/devcontainers/images/blob/main/src/universal/.devcontainer/Dockerfile
+# Original Copyright:
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM ubuntu:24.04 AS ddev-devcontainer
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    # Restore man command
+    && yes | unminimize 2>&1
+
+ENV LANG="C.UTF-8"
+
+# Install basic build tools
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        make \
+        unzip \
+        # The tools in this package are used when installing packages for Python
+        build-essential \
+        swig3.0 \
+        # Required for Microsoft SQL Server
+        unixodbc-dev \
+        # Required for PostgreSQL
+        libpq-dev \
+        # Required for mysqlclient
+        default-libmysqlclient-dev \
+        # Required for ts
+        moreutils \
+        rsync \
+        zip \
+        libgdiplus \
+        jq \
+        # By default pip is not available in the buildpacks image
+        #python-pip3-whl \
+        python3-pip \
+        #.NET Core related pre-requisites
+        libc6 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libncurses6 \
+        liblttng-ust1 \
+        libssl-dev \
+        libstdc++6 \
+        zlib1g \
+        libuuid1 \
+        libunwind8 \
+        sqlite3 \
+        libsqlite3-dev \
+        software-properties-common \
+        tk-dev \
+        uuid-dev \
+        curl \
+        gettext \
+        inotify-tools \
+    && rm -rf /var/lib/apt/lists/* \
+    # This is the folder containing 'links' to benv and build script generator
+    && apt-get update \
+    && apt-get upgrade -y \
+    && add-apt-repository universe \
+    && rm -rf /var/lib/apt/lists/*
+
+# Verify expected build and debug tools are present
+RUN apt-get update \
+    && apt-get -y install build-essential cmake cppcheck valgrind clang lldb llvm gdb python3-dev \
+    # Install tools and shells not in common script
+    && apt-get install -yq vim vim-doc xtail software-properties-common libsecret-1-dev \
+    # Install additional tools (useful for 'puppeteer' project)
+    && apt-get install -y --no-install-recommends libnss3 libnspr4 libatk-bridge2.0-0 libatk1.0-0 libx11-6 libpangocairo-1.0-0 \
+                                                  libx11-xcb1 libcups2 libxcomposite1 libxdamage1 libxfixes3 libpango-1.0-0 libgbm1 libgtk-3-0 \
+    # Clean up
+    && apt-get autoremove -y && apt-get clean -y \
+    # Move first run notice to right spot
+    && mkdir -p "/usr/local/etc/vscode-dev-containers/"
+
+# Default to bash shell (other shells available at /usr/bin/fish and /usr/bin/zsh)
+ENV SHELL=/bin/bash \
+    DOCKER_BUILDKIT=1
+
+# Install and setup fish
+RUN apt-get install -yq fish \
+    && FISH_PROMPT="function fish_prompt\n    set_color green\n    echo -n (whoami)\n    set_color normal\n    echo -n \":\"\n    set_color blue\n    echo -n (pwd)\n    set_color normal\n    echo -n \"> \"\nend\n" \
+    && printf "$FISH_PROMPT" >> /etc/fish/functions/fish_prompt.fish \
+    && printf "if type code-insiders > /dev/null 2>&1; and not type code > /dev/null 2>&1\n  alias code=code-insiders\nend" >> /etc/fish/conf.d/code_alias.fish
+
+# Remove scripts now that we're done with them
+RUN apt-get clean -y && rm -rf /tmp/scripts
+
+# Mount for docker-in-docker
+VOLUME [ "/var/lib/docker" ]
+
+CMD [ "sleep", "infinity" ]
+
+# [Optional] Install debugger for development of Codespaces - Not in resulting image by default
+ARG DeveloperBuild
+RUN if [ -z $DeveloperBuild ]; then \
+        echo "not including debugger" ; \
+    else \
+        curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg ; \
+    fi

--- a/containers/ddev-devcontainer/Makefile
+++ b/containers/ddev-devcontainer/Makefile
@@ -1,0 +1,15 @@
+
+VERSION := $(shell git describe --tags --always --dirty)
+
+DEFAULT_IMAGES = ddev-devcontainer
+
+# Tests always run against amd64 (build host). Once tests have passed, a multi-arch build
+# will be generated and pushed (the amd64 build will be cached automatically to prevent it from building twice).
+BUILD_ARCHS=linux/amd64,linux/arm64
+
+include ../containers_shared.mk
+
+DOCKER_REPO ?= $(DOCKER_ORG)/ddev-devcontainer
+
+test: container
+	test/test.sh $(DOCKER_REPO):$(VERSION)

--- a/containers/ddev-devcontainer/README.md
+++ b/containers/ddev-devcontainer/README.md
@@ -1,0 +1,49 @@
+# ddev-devcontainer Docker Image
+
+## Overview
+
+Docker container image devcontainers on GitHub Codespaces or VS Code.
+
+### Features
+
+Adaptation of Microsoft's Universal Devcontainer (but multi-image).
+
+## Instructions
+
+Use [DDEV](https://ddev.readthedocs.io)
+
+### Building and pushing to Docker Hub
+
+See [DDEV docs](https://ddev.readthedocs.io/en/stable/developers/release-management/#pushing-docker-images-with-the-github-actions-workflow)
+
+
+## Source:
+[ddev-ssh-agent](https://github.com/ddev/ddev/tree/main/containers/ddev-ssh-agent)
+
+## Maintained by:
+The [DDEV Docker Maintainers](https://github.com/ddev)
+
+## Where to get help:
+* [DDEV Community Discord](https://ddev.com/s/discord)
+* [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
+
+## Where to file issues:
+https://github.com/ddev/ddev/issues
+
+## Documentation:
+* https://ddev.readthedocs.io/en/stable/users/support/
+* https://ddev.com/
+
+## What is DDEV?
+
+[DDEV](https://github.com/ddev/ddev) is an open source tool for launching local web development environments in minutes. It supports PHP and Node.js.
+
+These environments can be extended, version controlled, and shared, so you can take advantage of a Docker workflow without Docker experience or bespoke configuration. Projects can be changed, powered down, or removed as easily as they’re started.
+
+## License
+
+View [license information](https://github.com/ddev/ddev/blob/main/LICENSE) for the software contained in this image.
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.

--- a/containers/ddev-devcontainer/test/functions.sh
+++ b/containers/ddev-devcontainer/test/functions.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+function basic_setup {
+    export CONTAINER_NAME="testserver"
+    export HOSTPORT=31000
+    export MYTMPDIR="${HOME}/tmp/testserver-sh_${RANDOM}_$$"
+    export outdir="${HOME}/tmp/ddev-devcontainer-test/output_${RANDOM}_$$"
+    export VOLUME="ddev-devcontainer-test-${RANDOM}_$$"
+
+    export MOUNTUID=33
+    export MOUNTGID=33
+
+    docker rm -f ${CONTAINER_NAME} 2>/dev/null || true
+
+    # Initialize the volume with the correct ownership
+    docker run --rm -v "${VOLUME}:/var/lib/mysql:nocopy" busybox:stable chown -R ${MOUNTUID}:${MOUNTGID} /var/lib/mysql
+}
+
+function teardown {
+  docker rm -f ${CONTAINER_NAME}
+  docker volume rm $VOLUME || true
+}
+
+# Wait for container to be ready.
+function containercheck {
+  for i in {15..0}; do
+    # fail if we can't find the container
+    if ! docker inspect ${CONTAINER_NAME} >/dev/null; then
+      break
+    fi
+
+    status="$(docker inspect ${CONTAINER_NAME} | jq -r '.[0].State.Status')"
+    if [ "${status}" != "running" ]; then
+      break
+    fi
+    health="$(docker inspect --format '{{json .State.Health }}' ${CONTAINER_NAME} | jq -r .Status)"
+    case ${health} in
+    healthy)
+      return 0
+      ;;
+    *)
+      sleep 1
+      ;;
+    esac
+  done
+  echo "# --- ddev-devcontainer FAIL -----"
+  return 1
+}

--- a/containers/ddev-devcontainer/test/image_general.bats
+++ b/containers/ddev-devcontainer/test/image_general.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+# Run these tests from the repo root directory
+
+load functions.sh
+
+function setup {
+  basic_setup
+
+  echo "# Starting ${IMAGE}" >&3
+  docker run --rm -u "$MOUNTUID:$MOUNTGID" --name=$CONTAINER_NAME -d ${IMAGE}
+  containercheck
+}
+
+@test "verify apt keys are not expiring within ${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90} days" {
+  if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
+    skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"
+  fi
+  docker cp ${TEST_SCRIPT_DIR}/check_key_expirations.sh ${CONTAINER_NAME}:/tmp
+  docker exec -u root -e "DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION=$DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION" ${CONTAINER_NAME} /tmp/check_key_expirations.sh >&3
+
+}

--- a/containers/ddev-devcontainer/test/test.sh
+++ b/containers/ddev-devcontainer/test/test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Find the directory of this script
+export DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+export TEST_SCRIPT_DIR=${DIR}/../../testscripts
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [ $# != 1 ]; then
+  echo "Usage: $0 <imagespec>"
+  exit 1
+fi
+export IMAGE=$1
+
+export CURRENT_ARCH=$(../get_arch.sh)
+
+# /usr/local/bin is added for git-bash, where it may not be in the $PATH.
+export PATH="/usr/local/bin:$PATH"
+bats --show-output-of-passing-tests test || (echo "bats tests failed for IMAGE=${IMAGE}" && exit 2)
+printf "Test successful for IMAGE=${IMAGE}\n\n"

--- a/containers/ddev-ssh-agent/test/functions.sh
+++ b/containers/ddev-ssh-agent/test/functions.sh
@@ -4,8 +4,8 @@ function basic_setup {
     export CONTAINER_NAME="testserver"
     export HOSTPORT=31000
     export MYTMPDIR="${HOME}/tmp/testserver-sh_${RANDOM}_$$"
-    export outdir="${HOME}/tmp/mariadb_testserver/output_${RANDOM}_$$"
-    export VOLUME="dbserver_test-${RANDOM}_$$"
+    export outdir="${HOME}/tmp/sshagent-test/output_${RANDOM}_$$"
+    export VOLUME="sshagent-test-${RANDOM}_$$"
 
     export MOUNTUID=33
     export MOUNTGID=33
@@ -43,6 +43,6 @@ function containercheck {
       ;;
     esac
   done
-  echo "# --- ddev-dbserver FAIL -----"
+  echo "# --- ddev-ssh-agent FAIL -----"
   return 1
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -97,9 +97,9 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	// Provide a default app name based on directory name
 	app.Name = NormalizeProjectName(filepath.Base(app.AppRoot))
 
-	// Gather containers to omit, adding ddev-router for gitpod/codespaces
+	// Gather containers to omit, adding ddev-router for gitpod/codespaces/devcontainers
 	app.OmitContainersGlobal = globalconfig.DdevGlobalConfig.OmitContainersGlobal
-	if nodeps.IsGitpod() || nodeps.IsCodespaces() {
+	if nodeps.IsGitpod() || nodeps.IsCodespaces() || nodeps.IsRemoteContainers() {
 		app.OmitContainersGlobal = append(app.OmitContainersGlobal, "ddev-router")
 	}
 
@@ -910,6 +910,7 @@ type composeYAMLVars struct {
 	GitDirMount                     bool
 	IsGitpod                        bool
 	IsCodespaces                    bool
+	IsRemoteContainers              bool
 	DefaultContainerTimeout         string
 	StartScriptTimeout              string
 	UseHostDockerInternalExtraHosts bool
@@ -1017,6 +1018,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		GitDirMount:        false,
 		IsGitpod:           nodeps.IsGitpod(),
 		IsCodespaces:       nodeps.IsCodespaces(),
+		IsRemoteContainers: nodeps.IsRemoteContainers(),
 		// Default max time we wait for containers to be healthy
 		DefaultContainerTimeout: app.DefaultContainerTimeout,
 		StartScriptTimeout:      app.GetStartScriptTimeout(),

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -3102,6 +3102,11 @@ func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs
 			httpsURLs = append(httpsURLs, netutil.NormalizeURL(url))
 		}
 	}
+	// TODO: There should be a way to make remote container trust the HTTPS port.
+	if nodeps.IsRemoteContainers() {
+		url := app.GetWebContainerDirectHTTPURL()
+		httpURLs = append(httpURLs, url)
+	}
 
 	// Get configured URLs
 	for _, name := range app.GetHostnames() {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -3102,11 +3102,6 @@ func (app *DdevApp) GetAllURLs() (httpURLs []string, httpsURLs []string, allURLs
 			httpsURLs = append(httpsURLs, netutil.NormalizeURL(url))
 		}
 	}
-	// TODO: There should be a way to make remote container trust the HTTPS port.
-	if nodeps.IsRemoteContainers() {
-		url := app.GetWebContainerDirectHTTPURL()
-		httpURLs = append(httpURLs, url)
-	}
 
 	// Get configured URLs
 	for _, name := range app.GetHostnames() {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2442,7 +2442,7 @@ func (app *DdevApp) DockerEnv() {
 			app.HostWebserverPort = "80"
 		}
 	}
-	if nodeps.IsGitpod() || nodeps.IsCodespaces() {
+	if nodeps.IsGitpod() || nodeps.IsCodespaces() || nodeps.IsRemoteContainers() {
 		if app.HostWebserverPort == "" {
 			app.HostWebserverPort = "8080"
 		}
@@ -2570,6 +2570,7 @@ func (app *DdevApp) DockerEnv() {
 		"IS_DDEV_PROJECT":               "true",
 		"IS_GITPOD":                     strconv.FormatBool(nodeps.IsGitpod()),
 		"IS_CODESPACES":                 strconv.FormatBool(nodeps.IsCodespaces()),
+		"IS_REMOTE_CONTAINERS":          strconv.FormatBool(nodeps.IsRemoteContainers()),
 		"IS_WSL2":                       isWSL2,
 		// TODO: Disable bake builder (default since compose v2.37.0) to restore image label
 		// com.docker.compose.project used by `ddev delete` to detect DDEV-created images

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -54,7 +54,7 @@ func FullRenderedRouterComposeYAMLPath() string {
 
 // IsRouterDisabled returns true if the router is disabled
 func IsRouterDisabled(app *DdevApp) bool {
-	if nodeps.IsGitpod() || nodeps.IsCodespaces() {
+	if nodeps.IsGitpod() || nodeps.IsCodespaces() || nodeps.IsRemoteContainers() {
 		return true
 	}
 	return nodeps.ArrayContainsString(app.GetOmittedContainers(), globalconfig.DdevRouterContainer)

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -543,7 +543,7 @@ func (app *DdevApp) HasCustomCert() bool {
 func (app *DdevApp) CanUseHTTPOnly() bool {
 	switch {
 	// Gitpod and Codespaces have their own router with TLS termination
-	case nodeps.IsGitpod() || nodeps.IsCodespaces() || nodeps.IsRemoteContainers():
+	case nodeps.IsGitpod() || nodeps.IsCodespaces():
 		return false
 	// If we have no router, then no https otherwise
 	case IsRouterDisabled(app):

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -543,7 +543,7 @@ func (app *DdevApp) HasCustomCert() bool {
 func (app *DdevApp) CanUseHTTPOnly() bool {
 	switch {
 	// Gitpod and Codespaces have their own router with TLS termination
-	case nodeps.IsGitpod() || nodeps.IsCodespaces():
+	case nodeps.IsGitpod() || nodeps.IsCodespaces() || nodeps.IsRemoteContainers():
 		return false
 	// If we have no router, then no https otherwise
 	case IsRouterDisabled(app):

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1266,6 +1266,9 @@ func GetHostDockerInternalIP() (string, error) {
 	case nodeps.IsCodespaces():
 		util.Debug("host.docker.internal='%s' because on Codespaces", hostDockerInternal)
 		break
+	case nodeps.IsRemoteContainers():
+		util.Debug("host.docker.internal='%s' because on Remote Containers", hostDockerInternal)
+		break
 
 	case nodeps.IsWSL2() && IsDockerDesktop():
 		// If IDE is on Windows, return; we don't have to do anything.
@@ -1344,7 +1347,7 @@ func GetNFSServerAddr() (string, error) {
 	// However, NFS will never be used on Gitpod.
 	case nodeps.IsGitpod():
 		break
-	case nodeps.IsCodespaces():
+	case nodeps.IsCodespaces() || nodeps.IsRemoteContainers():
 		break
 
 	case nodeps.IsWSL2() && IsDockerDesktop():

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -10,7 +10,7 @@ const (
 	DDEVEnvironmentWindows          = "windows"
 	DDEVEnvironmentLinux            = "linux"
 	DDEVEnvironmentWSL2             = "wsl2"
-	DDEVEnvironmentWSL2Mirrored = "wsl2-mirrored"
+	DDEVEnvironmentWSL2Mirrored     = "wsl2-mirrored"
 	DDEVEnvironmentGitpod           = "gitpod"
 	DDEVEnvironmentCodespaces       = "codespaces"
 	DDEVEnvironmentRemoteContainers = "remotecontainers"

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -6,13 +6,14 @@ import (
 )
 
 const (
-	DDEVEnvironmentDarwin       = "darwin"
-	DDEVEnvironmentWindows      = "windows"
-	DDEVEnvironmentLinux        = "linux"
-	DDEVEnvironmentWSL2         = "wsl2"
+	DDEVEnvironmentDarwin           = "darwin"
+	DDEVEnvironmentWindows          = "windows"
+	DDEVEnvironmentLinux            = "linux"
+	DDEVEnvironmentWSL2             = "wsl2"
 	DDEVEnvironmentWSL2Mirrored = "wsl2-mirrored"
-	DDEVEnvironmentGitpod       = "gitpod"
-	DDEVEnvironmentCodespaces   = "codespaces"
+	DDEVEnvironmentGitpod           = "gitpod"
+	DDEVEnvironmentCodespaces       = "codespaces"
+	DDEVEnvironmentRemoteContainers = "remotecontainers"
 )
 
 // GetDDEVEnvironment returns the type of environment DDEV is being used in
@@ -21,6 +22,8 @@ func GetDDEVEnvironment() string {
 	switch {
 	case nodeps.IsCodespaces():
 		e = DDEVEnvironmentCodespaces
+	case nodeps.IsRemoteContainers():
+		e = DDEVEnvironmentRemoteContainers
 	case nodeps.IsGitpod():
 		e = DDEVEnvironmentGitpod
 	case nodeps.IsWSL2MirroredMode():

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -87,6 +87,14 @@ func IsCodespaces() bool {
 	return runtime.GOOS == "linux" && os.Getenv("CODESPACES") == "true"
 }
 
+// IsRemoteContainers returns true if running in devcontainers (except on Codespaces)
+func IsRemoteContainers() bool {
+	if os.Getenv("DDEV_PRETEND_REMOTE_CONTAINERS") == "true" {
+		return true
+	}
+	return runtime.GOOS == "linux" && os.Getenv("REMOTE_CONTAINERS") == "true"
+}
+
 // GetWSLDistro returns the WSL2 distro name if on Linux
 func GetWSLDistro() string {
 	wslDistro := ""


### PR DESCRIPTION
## The Issue

- #7287 

devcontainer.json has an ancient Ubuntu version (20.04)

## How This PR Solves The Issue

Upgrade. Use 24.04

## TODO

- [ ] The golang feature is huge and takes a lot of time to install. We don't need all of that.
- [ ] (Probably separate PR) Update [ddev install docs](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/#github-codespaces) and the related devcontainer package
- [ ] Automatically push the new ddev-devcontainer image on build with correct tag (and configure tag)

## Manual Testing Instructions

Try out this PR using the Codespaces link: https://github.com/codespaces/new?ref=20250513_rfay_devcontainer_codespaces&repo=80927419

## Automated Testing Overview

We don't know how to test these things yet but maybe we'll learn

## Release/Deployment Notes

There are a number of other things wrong with codespaces still:
- [x] No port is mapped, so the d10simple we create isn't useful until manually mapped
- [x] d10simple is out of date. And why not d11? And why Drupal specifically?

However, this may be a first step toward and architecture-independent devcontainer that will work on arm64 mac (unrelated to Codespaces, but related to 
* https://github.com/ddev/ddev/issues/6891