### PR TITLE
build: update brew instructions for old formula, fixes #7297

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -208,8 +208,8 @@ brews:
           ERROR: your homebrew tap is the ancient #{tap.full_name},
           but that repository has moved.
           Please run:
+            rm -rf "$(brew --repo #{tap.full_name})"
             brew uninstall -f ddev
-            brew untap #{tap.full_name}
             brew install ddev/ddev/ddev
         EOS
       end
@@ -265,8 +265,8 @@ brews:
           ERROR: your homebrew tap is the ancient #{tap.full_name},
           but that repository has moved.
           Please run:
+            rm -rf "$(brew --repo #{tap.full_name})"
             brew uninstall -f ddev
-            brew untap #{tap.full_name}
             brew install ddev/ddev-edge/ddev
         EOS
       end

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -260,7 +260,7 @@ brews:
     # fail fast if tapped under the old drud or rfay names
     def initialize(*args, **kwargs)
       super(*args, **kwargs)
-      if ["drud/homebrew-ddev", "drud/homebrew-ddev-edge",  "ddev-test/homebrew-ddev-edge", "rfay/homebrew-ddev-edge"].include?(tap&.full_name)
+      if ["drud/homebrew-ddev", "drud/homebrew-ddev-edge", "ddev-test/homebrew-ddev-edge", "rfay/homebrew-ddev-edge"].include?(tap&.full_name)
         odie <<~EOS
           ERROR: your homebrew tap is the ancient #{tap.full_name},
           but that repository has moved.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -203,7 +203,7 @@ brews:
     # fail fast if tapped under the old drud or rfay names
     def initialize(*args, **kwargs)
       super(*args, **kwargs)
-      if ["drud/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap.full_name)
+      if ["drud/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap&.full_name)
         odie <<~EOS
           ERROR: your homebrew tap is the ancient #{tap.full_name},
           but that repository has moved.
@@ -260,14 +260,14 @@ brews:
     # fail fast if tapped under the old drud or rfay names
     def initialize(*args, **kwargs)
       super(*args, **kwargs)
-      if ["drud/homebrew-ddev", "drud/homebrew-ddev-edge",  "ddev-test/homebrew-ddev-edge", "rfay/homebrew-ddev-edge"].include?(tap.full_name)
+      if ["drud/homebrew-ddev", "drud/homebrew-ddev-edge",  "ddev-test/homebrew-ddev-edge", "rfay/homebrew-ddev-edge"].include?(tap&.full_name)
         odie <<~EOS
           ERROR: your homebrew tap is the ancient #{tap.full_name},
           but that repository has moved.
           Please run:
             rm -rf "$(brew --repo #{tap.full_name})"
             brew uninstall -f ddev
-            brew install ddev/ddev-edge/ddev
+            brew install ddev/ddev-edge/ddev-edge
         EOS
       end
     end

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -266,7 +266,7 @@ brews:
           but that repository has moved.
           Please run:
             rm -rf "$(brew --repo #{tap.full_name})"
-            brew uninstall -f ddev
+            brew uninstall -f ddev ddev-edge
             brew install ddev/ddev-edge/ddev-edge
         EOS
       end


### PR DESCRIPTION
## The Issue

- #7297

See:
- https://github.com/ddev/homebrew-ddev/pull/51
- https://github.com/ddev/homebrew-ddev-edge/pull/4

## How This PR Solves The Issue

`initialize` doesn't seem to know about `uninstall`. And moving the check to `install` didn't help.

We can remove the formula repo before removing the `ddev` binary.

## Manual Testing Instructions

```
brew install drud/ddev/ddev
cd "$(brew --repo drud/homebrew-ddev)"
git reset --hard HEAD~1
brew install drud/ddev/ddev
cd ~
brew update
brew uninstall -f ddev
# old error here (see the updated instructions below in ddev-test example)

rm -rf "$(brew --repo drud/homebrew-ddev)"
brew uninstall -f ddev
brew install ddev/ddev/ddev
```

Testing the instructions update in `ddev-test`:

```
brew install ddev-test/ddev-edge/ddev
cd "$(brew --repo ddev-test/homebrew-ddev-edge)"

# install old version version without the check for old formula
brew install ddev-test/ddev-edge/ddev
git checkout c1d0f9b725a50ddd58043ca3b7d4f01d9b61aecf
$ ddev -v
ddev version v1.23.31

cd ~
brew update

$ brew uninstall -f ddev
Error: ERROR: your homebrew tap is the ancient ddev-test/homebrew-ddev-edge,
but that repository has moved.
Please run:
  rm -rf "$(brew --repo ddev-test/homebrew-ddev-edge)"
  brew uninstall -f ddev
  brew install ddev/ddev-edge/ddev

rm -rf "$(brew --repo ddev-test/homebrew-ddev-edge)"
brew uninstall -f ddev
# should succeed
```


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
