### PR TITLE
fix: change download timeout to 5 minutes instead of 20s, fixes #7298

### DIFF
--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -21,7 +21,7 @@ var DebugDownloadImagesCmd = &cobra.Command{
 		}
 		_, err := dockerutil.DownloadDockerComposeIfNeeded()
 		if err != nil {
-			util.Warning("Unable to download docker-compose: %v", err)
+			util.Failed("Unable to download docker-compose: %v", err)
 		}
 		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 			err = ddevapp.DownloadMutagenIfNeeded()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1255,9 +1255,16 @@ func (app *DdevApp) Start() error {
 	dockerutil.RemoveNetworkDuplicates(ctx, client, app.GetDefaultNetworkName())
 
 	if err = dockerutil.CheckDockerCompose(); err != nil {
-		util.Failed(`Your docker-compose version does not exist or is set to an invalid version.
-Please use the built-in docker-compose.
+		if os.IsTimeout(err) || strings.Contains(err.Error(), "timeout") {
+			util.Failed(`Failed to download updated docker-compose binary.
+This might be due to network issues or a slow response.
+Please ensure your network is stable and try again:
+%v`, err)
+		} else {
+			util.Failed(`DDEV's private docker-compose binary does not exist or is set to an invalid version.
+Please use DDEV's' built-in docker-compose.
 Fix with 'ddev config global --required-docker-compose-version="" --use-docker-compose-from-path=false': %v`, err)
+		}
 	}
 
 	if runtime.GOOS == "darwin" {

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -43,7 +43,7 @@ func DownloadFile(destPath string, fileURL string, progressBar bool, shaSumURL s
 	}
 	client.Backoff = retryablehttp.DefaultBackoff
 	client.Logger = nil
-	client.HTTPClient.Timeout = 20 * time.Second
+	client.HTTPClient.Timeout = 5 * time.Minute
 	client.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, attempt int) {
 		if attempt > 0 {
 			// attempt==1 is the first retry, 2 the second, etc


### PR DESCRIPTION

## The Issue

- #7298 

On slower networks, the download of docker-compose times out in just 20s and gives an odd message

## How This PR Solves The Issue

- [x] Increase the timeout
- [x] Improve the message given on failure

## Manual Testing Instructions

I used network conditioning in Parallels to slow the download speed to 20Mbps to reproduce this.

Running TestDockerComposeDownload with the network slowed down shows the failure at 20s, but it succeed with this fix.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
