### PR TITLE
fix: make TYPO3 nginx config work with TYPO3 v12, fixes #7299, for #7230

### DIFF
--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -106,46 +106,6 @@ teardown() {
   assert_success
 }
 
-# bats test_tags=typo3-setup,t3v12
-@test "TYPO3 v12 'ddev typo3 setup' composer test with $(ddev --version)" {
-  PROJNAME=my-typo3-site
-  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
-  assert_success
-
-  run ddev config --project-type=typo3 --docroot=public --php-version=8.3
-  assert_success
-
-  run ddev start -y >/dev/null
-  assert_success
-
-  run ddev composer create-project "typo3/cms-base-distribution:^12" >/dev/null
-  assert_success
-
-  run ddev exec touch public/FIRST_INSTALL
-  assert_success
-
-  run ddev typo3 setup \
-    --admin-user-password="Demo123*" \
-    --driver=mysqli \
-    --create-site=https://${PROJNAME}.ddev.site \
-    --server-type=other \
-    --dbname=db \
-    --username=db \
-    --password=db \
-    --port=3306 \
-    --host=db \
-    --admin-username=admin \
-    --admin-email=admin@example.com \
-    --project-name="demo TYPO3 site" \
-    --force
-  assert_success
-
-  run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/ \| grep "Welcome to a default website made with"
-  assert_success
-  run bats_pipe curl s-sfL https://${PROJNAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
-  assert_success
-}
-
 # bats test_tags=typo3-setup,t3v13
 @test "TYPO3 v13 'ddev typo3 setup' composer test with $(ddev --version)" {
   PROJNAME=my-typo3-site
@@ -158,7 +118,7 @@ teardown() {
   run ddev start -y >/dev/null
   assert_success
 
-  run ddev composer create-project "typo3/cms-base-distribution:^13" >/dev/null
+  run ddev composer create-project typo3/cms-base-distribution >/dev/null
   assert_success
 
   run ddev exec touch public/FIRST_INSTALL

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -106,6 +106,46 @@ teardown() {
   assert_success
 }
 
+# bats test_tags=typo3-setup,t3v12
+@test "TYPO3 v12 'ddev typo3 setup' composer test with $(ddev --version)" {
+  PROJNAME=my-typo3-site
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
+  assert_success
+
+  run ddev config --project-type=typo3 --docroot=public --php-version=8.3
+  assert_success
+
+  run ddev start -y >/dev/null
+  assert_success
+
+  run ddev composer create-project "typo3/cms-base-distribution:^12" >/dev/null
+  assert_success
+
+  run ddev exec touch public/FIRST_INSTALL
+  assert_success
+
+  run ddev typo3 setup \
+    --admin-user-password="Demo123*" \
+    --driver=mysqli \
+    --create-site=https://${PROJNAME}.ddev.site \
+    --server-type=other \
+    --dbname=db \
+    --username=db \
+    --password=db \
+    --port=3306 \
+    --host=db \
+    --admin-username=admin \
+    --admin-email=admin@example.com \
+    --project-name="demo TYPO3 site" \
+    --force
+  assert_success
+
+  run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/ \| grep "Welcome to a default website made with"
+  assert_success
+  run bats_pipe curl s-sfL https://${PROJNAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
+  assert_success
+}
+
 # bats test_tags=typo3-setup,t3v13
 @test "TYPO3 v13 'ddev typo3 setup' composer test with $(ddev --version)" {
   PROJNAME=my-typo3-site
@@ -118,7 +158,7 @@ teardown() {
   run ddev start -y >/dev/null
   assert_success
 
-  run ddev composer create-project typo3/cms-base-distribution >/dev/null
+  run ddev composer create-project "typo3/cms-base-distribution:^13" >/dev/null
   assert_success
 
   run ddev exec touch public/FIRST_INSTALL

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -12,6 +12,13 @@ map $http_accept $webp_suffix {
     "~*webp"  ".webp";
 }
 
+# /index.php is used for TYPO3 v14+
+# /typo3/index.php is used for TYPO3 pre-v14
+map $typo3_index_exists $typo3_index {
+    default   "/index.php";
+    1         "/typo3/index.php";
+}
+
 server {
     listen 80 default_server;
     listen 443 ssl default_server;
@@ -63,14 +70,15 @@ server {
         rewrite ^ /typo3/;
     }
 
+    # check if /typo3/index.php exists
+    set $typo3_index_exists 0;
+    if (-f $document_root/typo3/index.php) {
+        set $typo3_index_exists 1;
+    }
+
     location /typo3/ {
         absolute_redirect off;
-        # TYPO3 pre-v14 rewrite
-        if (-f $document_root/typo3/index.php) {
-            rewrite ^/typo3(/.*)?$ /typo3/index.php$is_args$args last;
-        }
-        # TYPO3 v14 rewrite
-        rewrite ^/typo3(/.*)?$ /index.php$is_args$args last;
+        try_files $uri $typo3_index$is_args$args;
     }
 
     # pass the PHP scripts to FastCGI server listening on socket

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -12,12 +12,6 @@ map $http_accept $webp_suffix {
     "~*webp"  ".webp";
 }
 
-# Try both pre-v14 in /typo3 and also v14+ location (/index.php)
-map $document_root/typo3/index.php $typo3_fallback_target {
-    default /typo3/index.php;
-    "~*" /index.php;
-}
-
 server {
     listen 80 default_server;
     listen 443 ssl default_server;
@@ -71,7 +65,12 @@ server {
 
     location /typo3/ {
         absolute_redirect off;
-        try_files $uri $typo3_fallback_target$is_args$args;
+        # TYPO3 pre-v14 rewrite
+        if (-f $document_root/typo3/index.php) {
+            rewrite ^/typo3(/.*)?$ /typo3/index.php$is_args$args last;
+        }
+        # TYPO3 v14 rewrite
+        rewrite ^/typo3(/.*)?$ /index.php$is_args$args last;
     }
 
     # pass the PHP scripts to FastCGI server listening on socket


### PR DESCRIPTION
## The Issue

- #7299

Culprit:

- #7230

## How This PR Solves The Issue

Uses a different nginx technique. Spent long hours with ChatGPT.

## Manual Testing Instructions

Try TYPO3 quickstart for v11, v12, v13, v14 (full install with login)

https://ddev.readthedocs.io/en/stable/users/quickstart/#typo3

v14:
```
git clone git@github.com:TYPO3/TYPO3.CMS.BaseDistribution.git my-typo3-site14
cd my-typo3-site14
ddev config --project-type=typo3 --docroot=public --php-version=8.3
ddev composer install
ddev config --auto # create TYPO3 settings after TYPO3 classes are installed in vendor
ddev exec touch public/FIRST_INSTALL
ddev launch /typo3/install.php
```

v13:
```
PROJECT_NAME=my-typo3-site13
mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
ddev config --project-type=typo3 --docroot=public --php-version=8.3
ddev start
ddev composer create-project "typo3/cms-base-distribution:^13"
ddev exec touch public/FIRST_INSTALL
ddev launch /typo3/install.php
```

v12:
```
PROJECT_NAME=my-typo3-site12
mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
ddev config --project-type=typo3 --docroot=public --php-version=8.3
ddev start
ddev composer create-project "typo3/cms-base-distribution:^12"
ddev exec touch public/FIRST_INSTALL
ddev launch /typo3/install.php
```

v11:
```
PROJECT_NAME=my-typo3-site11
mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
ddev config --project-type=typo3 --docroot=public --php-version=8.1
ddev start
ddev composer create-project "typo3/cms-base-distribution:^11"
ddev exec touch public/FIRST_INSTALL
ddev launch /typo3/install.php
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
