### PR TITLE
test: adding quickstarts for typo3 v13 and v12 plus bats tests

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1088,16 +1088,56 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 
 ## TYPO3
 
-=== "Composer"
+=== "TYPO3 v13"
 
     ```bash
     PROJECT_NAME=my-typo3-site
     mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
-    ddev config --project-type=typo3 --docroot=public --php-version=8.3
+    ddev config --project-type=typo3 --docroot=public --php-version 8.3
     ddev start
-    ddev composer create-project "typo3/cms-base-distribution"
-    ddev exec touch public/FIRST_INSTALL
-    ddev launch /typo3/install.php
+    ddev composer create-project "typo3/cms-base-distribution:^13"
+    ddev typo3 setup \
+        --admin-user-password="Demo123*" \
+        --driver=mysqli \
+        --create-site=https://${PROJECT_NAME}.ddev.site \
+        --server-type=other \
+        --dbname=db \
+        --username=db \
+        --password=db \
+        --port=3306 \
+        --host=db \
+        --admin-username=admin \
+        --admin-email=admin@example.com \
+        --project-name="My TYPO3 site" \
+        --force
+
+    ddev launch /typo3/
+    ```
+
+=== "TYPO3 v12"
+
+    ```bash
+    PROJECT_NAME=my-typo3-site
+    mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
+    ddev config --project-type=typo3 --docroot=public --php-version 8.1
+    ddev start
+    ddev composer create-project "typo3/cms-base-distribution:^12"
+    ddev typo3 setup \
+        --admin-user-password="Demo123*" \
+        --driver=mysqli \
+        --create-site=https://${PROJECT_NAME}.ddev.site \
+        --server-type=other \
+        --dbname=db \
+        --username=db \
+        --password=db \
+        --port=3306 \
+        --host=db \
+        --admin-username=admin \
+        --admin-email=admin@example.com \
+        --project-name="My TYPO3 site" \
+        --force
+
+    ddev launch /typo3/
     ```
 
 === "Git Clone"
@@ -1124,9 +1164,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
     ddev config --project-type=typo3 --docroot=public --php-version=8.3
     ddev start
-    ddev composer create-project typo3/cms-base-distribution 
-    ddev exec touch public/FIRST_INSTALL
-    
+    ddev composer create-project typo3/cms-base-distribution
     ddev typo3 setup \
         --admin-user-password="Demo123*" \
         --driver=mysqli \

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1088,40 +1088,14 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 
 ## TYPO3
 
-=== "TYPO3 v13"
+=== "Composer"
 
     ```bash
     PROJECT_NAME=my-typo3-site
     mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
     ddev config --project-type=typo3 --docroot=public --php-version 8.3
     ddev start
-    ddev composer create-project "typo3/cms-base-distribution:^13"
-    ddev typo3 setup \
-        --admin-user-password="Demo123*" \
-        --driver=mysqli \
-        --create-site=https://${PROJECT_NAME}.ddev.site \
-        --server-type=other \
-        --dbname=db \
-        --username=db \
-        --password=db \
-        --port=3306 \
-        --host=db \
-        --admin-username=admin \
-        --admin-email=admin@example.com \
-        --project-name="My TYPO3 site" \
-        --force
-
-    ddev launch /typo3/
-    ```
-
-=== "TYPO3 v12"
-
-    ```bash
-    PROJECT_NAME=my-typo3-site
-    mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
-    ddev config --project-type=typo3 --docroot=public --php-version 8.1
-    ddev start
-    ddev composer create-project "typo3/cms-base-distribution:^12"
+    ddev composer create-project "typo3/cms-base-distribution"
     ddev typo3 setup \
         --admin-user-password="Demo123*" \
         --driver=mysqli \

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1093,7 +1093,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ```bash
     PROJECT_NAME=my-typo3-site
     mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
-    ddev config --project-type=typo3 --docroot=public --php-version 8.3
+    ddev config --project-type=typo3 --docroot=public --php-version=8.3
     ddev start
     ddev composer create-project "typo3/cms-base-distribution"
     ddev typo3 setup \

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -89,6 +89,30 @@ teardown() {
   assert_success
 }
 
+@test "TYPO3 v11 'web installer' composer test with $(ddev --version)" {
+  PROJNAME=my-typo3-site
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
+  assert_success
+  run ddev config --project-type=typo3 --docroot=public --php-version=8.1
+  assert_success
+  run ddev start -y >/dev/null
+  assert_success
+  run ddev composer create-project "typo3/cms-base-distribution:^11" >/dev/null
+  assert_success
+  run ddev exec touch public/FIRST_INSTALL
+  assert_success
+
+  run bash -c "DDEV_DEBUG=true ddev launch /typo3/install.php"
+  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site/typo3/install.php"
+  assert_success
+
+  run bats_pipe curl -sfI https://${PROJNAME}.ddev.site/typo3/install.php \| grep "HTTP/2 200"
+  assert_success
+  run bats_pipe curl -sfL https://${PROJNAME}.ddev.site/typo3/install.php \| grep "data-init=\"TYPO3/CMS/Install/Installer\""
+  assert_success
+}
+
+
 @test "TYPO3 git based quickstart with $(ddev --version)" {
   PROJECT_GIT_URL=https://github.com/ddev/test-typo3.git
   PROJNAME=my-typo3-site


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue
the test for v12 will fail in current HEAD, it requires https://github.com/ddev/ddev/pull/7301

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
