### PR TITLE
fix: add checks for "generic" webserver without 80/443 ports, for #6935, fixes #7313

### DIFF
--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -219,9 +219,11 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 
 			// All URLs stanza
 			_, _, urls := app.GetAllURLs()
-			s := strings.Join(urls, ", ")
-			urlString := text.WrapSoft(s, int(urlPortWidth))
-			t.AppendRow(table.Row{"Project URLs", "", urlString})
+			if len(urls) > 0 {
+				s := strings.Join(urls, ", ")
+				urlString := text.WrapSoft(s, int(urlPortWidth))
+				t.AppendRow(table.Row{"Project URLs", "", urlString})
+			}
 		}
 		bindInfo := []string{}
 		if app.BindAllInterfaces {

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -153,7 +153,9 @@ ddev start --all`,
 }
 
 func emitReachProjectMessage(project *ddevapp.DdevApp) {
-	util.Success("Your project can be reached at %s\nSee 'ddev describe' for alternate URLs.", project.GetPrimaryURL())
+	if project.GetPrimaryURL() != "" {
+		util.Success("Your project can be reached at %s\nSee 'ddev describe' for alternate URLs.", project.GetPrimaryURL())
+	}
 }
 
 func init() {

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -474,6 +474,10 @@ func AllocateAvailablePortForRouter(start, upTo int) (int, bool) {
 // and a bool which is true if the proposedPort has been
 // replaced with an ephemeralPort
 func GetAvailableRouterPort(proposedPort string, minPort, maxPort int) (string, string, bool) {
+	// If the proposedPort is empty, we don't need to do anything
+	if proposedPort == "" {
+		return proposedPort, "", false
+	}
 	// If the router is alive and well, we can see if it's already handling the proposedPort
 	status, _ := GetRouterStatus()
 	if status == "healthy" {


### PR DESCRIPTION
## The Issue

We have `generic` webserver added in:

- #6935

But if we don't use `web_extra_exposed_ports`:

- #7313
- https://github.com/ddev/ddev/pull/7171#issuecomment-2794803633
- https://github.com/ddev/ddev/pull/7171#issuecomment-2797299320

```
$ mkdir generic-no-ports && cd generic-no-ports
$ ddev config --webserver-type=generic --omit-containers=db
$ ddev start
...
Unable to properly check port status for 127.0.0.1:: err=dial tcp 127.0.0.1:0: connect: can't assign requested address
Unable to properly check port status for 127.0.0.1:: err=dial tcp 127.0.0.1:0: connect: can't assign requested address

^ warnings on macOS
...
Successfully started generic-no-ports 
Your project can be reached at             <= this is wrong
See 'ddev describe' for alternate URLs.
...

$ ddev describe
...
├──────────────┼──────┼──────────────────────────────────────────────────┼─────────────────┤
│ Project URLs │      │                                                  │                 │
└──────────────┴──────┴──────────────────────────────────────────────────┴─────────────────┘
```

## How This PR Solves The Issue

Adds checks for empty, so we don't show unnecessary information on `ddev start` and `ddev describe`.

## Manual Testing Instructions

```
mkdir generic-no-ports && cd generic-no-ports
ddev config --webserver-type=generic --omit-containers=db
ddev start # "Your project can be reached at" should not be here, and no warnings for empty ports on macOS.
ddev describe # "Project URLs" should not be here
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
