### PR TITLE
build: bump docker-compose to v2.36.1

### DIFF
--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -51,4 +51,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.18.1"
 
-const RequiredDockerComposeVersionDefault = "v2.36.0"
+const RequiredDockerComposeVersionDefault = "v2.36.1"


### PR DESCRIPTION
## The Issue

`docker-compose` [v2.36.1](https://github.com/docker/compose/releases/tag/v2.36.1) is out.

## How This PR Solves The Issue

Bumps it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
