### PR TITLE
build: bump images to v1.24.6 for release, fixes #7310

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -2,7 +2,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:v1.24.5 AS ddev-webserver-base
+FROM ddev/ddev-php-base:v1.24.6 AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,25 +11,25 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.24.5" // Note that this can be overridden by make
+var WebTag = "v1.24.6" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.24.5"
+var BaseDBTag = "v1.24.6"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"
 
 // TraefikRouterTag is traefik router tag
-var TraefikRouterTag = "v1.24.5"
+var TraefikRouterTag = "v1.24.6"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.24.5"
+var SSHAuthTag = "v1.24.6"
 
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"
@@ -38,7 +38,7 @@ var BusyboxImage = "busybox:stable"
 var XhguiImage = "ddev/ddev-xhgui"
 
 // XhguiTag is xhgui tag
-var XhguiTag = "v1.24.5"
+var XhguiTag = "v1.24.6"
 
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities"


### PR DESCRIPTION
## The Issue

- #7310

## How This PR Solves The Issue

Using:

- https://github.com/docker/buildx/issues/1744#issuecomment-1896645786

I pushed the existing v1.24.5 images as v1.24.6:

```
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.0:v1.24.6 ddev/ddev-dbserver-mariadb-10.0:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.1:v1.24.6 ddev/ddev-dbserver-mariadb-10.1:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.2:v1.24.6 ddev/ddev-dbserver-mariadb-10.2:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.3:v1.24.6 ddev/ddev-dbserver-mariadb-10.3:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.4:v1.24.6 ddev/ddev-dbserver-mariadb-10.4:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.5:v1.24.6 ddev/ddev-dbserver-mariadb-10.5:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.6:v1.24.6 ddev/ddev-dbserver-mariadb-10.6:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.7:v1.24.6 ddev/ddev-dbserver-mariadb-10.7:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.8:v1.24.6 ddev/ddev-dbserver-mariadb-10.8:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-10.11:v1.24.6 ddev/ddev-dbserver-mariadb-10.11:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-11.4:v1.24.6 ddev/ddev-dbserver-mariadb-11.4:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mariadb-5.5:v1.24.6 ddev/ddev-dbserver-mariadb-5.5:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mysql-5.5:v1.24.6 ddev/ddev-dbserver-mysql-5.5:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mysql-5.6:v1.24.6 ddev/ddev-dbserver-mysql-5.6:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mysql-5.7:v1.24.6 ddev/ddev-dbserver-mysql-5.7:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mysql-8.0:v1.24.6 ddev/ddev-dbserver-mysql-8.0:v1.24.5
docker buildx imagetools create -t ddev/ddev-dbserver-mysql-8.4:v1.24.6 ddev/ddev-dbserver-mysql-8.4:v1.24.5
docker buildx imagetools create -t ddev/ddev-php-base:v1.24.6 ddev/ddev-php-base:v1.24.5
docker buildx imagetools create -t ddev/ddev-php-prod:v1.24.6 ddev/ddev-php-prod:v1.24.5
docker buildx imagetools create -t ddev/ddev-ssh-agent:v1.24.6 ddev/ddev-ssh-agent:v1.24.5
docker buildx imagetools create -t ddev/ddev-traefik-router:v1.24.6 ddev/ddev-traefik-router:v1.24.5
docker buildx imagetools create -t ddev/ddev-webserver-prod:v1.24.6 ddev/ddev-webserver-prod:v1.24.5
docker buildx imagetools create -t ddev/ddev-webserver:v1.24.6 ddev/ddev-webserver:v1.24.5
docker buildx imagetools create -t ddev/ddev-xhgui:v1.24.6 ddev/ddev-xhgui:v1.24.5
```

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
