### PR TITLE
build: apply more staticcheck rules from golangci-lint, fixes #7155

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,30 +16,18 @@ linters:
     - ineffassign
     - revive
     - staticcheck
-    # TODO: enable these checks
-    #- whitespace
+    - whitespace
+    # Enable these when working on test refactoring
     #- testifylint
     #- usetesting
   settings:
     staticcheck:
       checks:
         - all
-        # TODO: enable these disabled checks
         - -QF1001 # Apply De Morgan's law
-        - -QF1002 # Convert untagged switch to tagged switch
         - -QF1003 # Convert if/else-if chain to tagged switch
-        - -QF1004 # Use strings.ReplaceAll instead of strings.Replace with n == -1
-        - -QF1008 # Omit embedded fields from selector expression
-        - -S1002 # Omit comparison with boolean constant
         - -S1008 # Simplify returning boolean expression
-        - -S1009 # Omit redundant nil check on slices, maps, and channels
         - -S1023 # Omit redundant control flow
-        - -S1025 # Don’t use fmt.Sprintf("%s", x) unnecessarily
-        - -S1038 # Unnecessarily complex way of printing formatted string
-        - -S1039 # Unnecessary use of fmt.Sprint
-        - -ST1003 # Poorly chosen identifier
-        - -ST1005 # Incorrectly formatted error string
-        - -ST1017 # Don’t use Yoda conditions
   exclusions:
     presets:
       - comments

--- a/cmd/ddev/cmd/addon-list.go
+++ b/cmd/ddev/cmd/addon-list.go
@@ -61,7 +61,6 @@ ddev add-on list --installed --project my-project
 
 // ListInstalledAddons() show the add-ons that have a manifest file
 func ListInstalledAddons(app *ddevapp.DdevApp) {
-
 	manifests := ddevapp.GetInstalledAddons(app)
 
 	var out bytes.Buffer

--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -81,5 +81,4 @@ func TestCmdAuthSSH(t *testing.T) {
 	})
 	assert.NoError(err)
 	assert.Contains(out, "/root")
-
 }

--- a/cmd/ddev/cmd/auth.go
+++ b/cmd/ddev/cmd/auth.go
@@ -29,5 +29,4 @@ func init() {
 			output.UserOut.Print("`ddev auth pantheon` is no longer needed, see docs")
 		},
 	})
-
 }

--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -48,7 +48,7 @@ func handleGlobalConfig(cmd *cobra.Command, _ []string) {
 		dirty = true
 	}
 	if cmd.Flag("omit-containers").Changed {
-		omitContainers = strings.Replace(omitContainers, " ", "", -1)
+		omitContainers = strings.ReplaceAll(omitContainers, " ", "")
 		if omitContainers == "" || omitContainers == `""` || omitContainers == `''` {
 			globalconfig.DdevGlobalConfig.OmitContainersGlobal = []string{}
 		} else {
@@ -276,7 +276,7 @@ func handleGlobalConfig(cmd *cobra.Command, _ []string) {
 		//name := typeOfVal.Field(i).Name
 		fieldValue := v.Field(i).Interface()
 		if tag != "build info" && tag != "web_environment" && tag != "project_info" && tag != "remote_config" && tag != "messages" && tag != "router" {
-			tagWithDashes := strings.Replace(tag, "_", "-", -1)
+			tagWithDashes := strings.ReplaceAll(tag, "_", "-")
 			valMap[tagWithDashes] = fmt.Sprintf("%v", fieldValue)
 			keys = append(keys, tagWithDashes)
 		}

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -758,7 +758,7 @@ func processFlag(cmd *cobra.Command, flagName string, currentValue []string) []s
 	arg := cmd.Flag(flagName).Value.String()
 
 	// Remove all spaces from the flag value.
-	arg = strings.Replace(arg, " ", "", -1)
+	arg = strings.ReplaceAll(arg, " ", "")
 
 	// If the flag value is an empty string, return an empty slice.
 	if arg == "" || arg == `""` || arg == `''` {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -451,7 +451,6 @@ func TestConfigCreateDocroot(t *testing.T) {
 			require.DirExists(t, filepath.Join(tmpDir, tc.expected))
 		})
 	}
-
 }
 
 // TestConfigInvalidProjectname tests to make sure that invalid projectnames
@@ -504,7 +503,6 @@ func TestConfigInvalidProjectname(t *testing.T) {
 		assert.NotContains(out, "You may now run 'ddev start'")
 		_ = os.Remove(filepath.Join(tmpdir, ".ddev", "config.yaml"))
 	}
-
 }
 
 // TestCmdConfigHasAllowedLocation tests to ensure that 'ddev config'
@@ -747,7 +745,6 @@ func checkValues(t *testing.T, name string, expectation ddevapp.DdevApp, app *dd
 	reflectedApp := reflect.ValueOf(*app)
 
 	for _, member := range []string{"Type", "PHPVersion", "Docroot", "CorepackEnable", "Database"} {
-
 		fieldExpectation := reflectedExpectation.FieldByName(member)
 		if fieldExpectation.IsValid() {
 			fieldValueExpectation := fieldExpectation.Interface()

--- a/cmd/ddev/cmd/debug-match-constraint_test.go
+++ b/cmd/ddev/cmd/debug-match-constraint_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/stretchr/testify/require"
@@ -26,7 +25,7 @@ func TestDebugMatchConstraintCmd(t *testing.T) {
 	require.NoError(t, err, "Match constraint should not have errored for %s, out='%s'", constraint, out)
 
 	if !regexp.MustCompile(`^v[0-9]+\.`).MatchString(versionconstants.DdevVersion) {
-		t.Skip(fmt.Sprintf("Skipping check for semver because DDEV version doesn't start with any valid version tag, it's '%v'", versionconstants.DdevVersion))
+		t.Skipf("Skipping check for semver because DDEV version doesn't start with any valid version tag, it's '%v'", versionconstants.DdevVersion)
 	}
 
 	constraint = ">= 1.0"

--- a/cmd/ddev/cmd/debug-rebuild_test.go
+++ b/cmd/ddev/cmd/debug-rebuild_test.go
@@ -62,7 +62,7 @@ RUN shuf -i 0-99999 -n1 > /random-db.txt
 	})
 	require.NoError(t, err)
 
-	origRandomDb, _, err := app.Exec(&ddevapp.ExecOpts{
+	origRandomDB, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd:     "cat /random-db.txt",
 		Service: "db",
 	})
@@ -77,12 +77,12 @@ RUN shuf -i 0-99999 -n1 > /random-db.txt
 	require.NoError(t, err)
 	assert.Equal(origRandomWeb, newRandomWeb)
 
-	newRandomDb, _, err := app.Exec(&ddevapp.ExecOpts{
+	newRandomDB, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd:     "cat /random-db.txt",
 		Service: "db",
 	})
 	require.NoError(t, err)
-	assert.Equal(origRandomDb, newRandomDb)
+	assert.Equal(origRandomDB, newRandomDB)
 
 	// Now run ddev debug rebuild to blow away the Docker cache
 	_, err = exec.RunHostCommand(DdevBin, "debug", "rebuild")
@@ -98,12 +98,12 @@ RUN shuf -i 0-99999 -n1 > /random-db.txt
 	assert.NotEqual(origRandomWeb, freshRandomWeb)
 
 	// And it should remain the same for db
-	freshRandomDb, _, err := app.Exec(&ddevapp.ExecOpts{
+	freshRandomDB, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd:     "cat /random-db.txt",
 		Service: "db",
 	})
 	require.NoError(t, err)
-	assert.Equal(origRandomDb, freshRandomDb)
+	assert.Equal(origRandomDB, freshRandomDB)
 
 	// Now run ddev debug rebuild to blow away the Docker cache for db
 	_, err = exec.RunHostCommand(DdevBin, "debug", "rebuild", "--service", "db")
@@ -121,12 +121,12 @@ RUN shuf -i 0-99999 -n1 > /random-db.txt
 	// And we should see a new value for db
 	err = app.Restart()
 	require.NoError(t, err)
-	freshRandomDbNew, _, err := app.Exec(&ddevapp.ExecOpts{
+	freshRandomDBNew, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd:     "cat /random-db.txt",
 		Service: "db",
 	})
 	require.NoError(t, err)
-	assert.NotEqual(freshRandomDb, freshRandomDbNew)
+	assert.NotEqual(freshRandomDB, freshRandomDBNew)
 
 	// Repeat the same with all services, but use cache
 	_, err = exec.RunHostCommand(DdevBin, "debug", "rebuild", "--all", "--cache")
@@ -144,10 +144,10 @@ RUN shuf -i 0-99999 -n1 > /random-db.txt
 	// And it should remain the same for db
 	err = app.Restart()
 	require.NoError(t, err)
-	cachedRandomDb, _, err := app.Exec(&ddevapp.ExecOpts{
+	cachedRandomDB, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd:     "cat /random-db.txt",
 		Service: "db",
 	})
 	require.NoError(t, err)
-	assert.Equal(cachedRandomDb, freshRandomDbNew)
+	assert.Equal(cachedRandomDB, freshRandomDBNew)
 }

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -71,13 +71,11 @@ func deleteDdevImages(deleteAll bool) error {
 		// be done to improve finding database images.
 		for _, image := range images {
 			for _, tag := range image.RepoTags {
-
 				if strings.HasPrefix(tag, "drud/ddev-") || strings.HasPrefix(tag, "ddev/ddev-") {
 					if err := dockerutil.RemoveImage(tag); err != nil {
 						return err
 					}
 				}
-
 			}
 		}
 		return nil
@@ -86,10 +84,10 @@ func deleteDdevImages(deleteAll bool) error {
 	// Sort so that images that have -built on the end
 	// come up before their parent images that don't
 	sort.Slice(images, func(i, j int) bool {
-		if images[i].RepoTags == nil || len(images[i].RepoTags) == 0 {
+		if len(images[i].RepoTags) == 0 {
 			return false
 		}
-		if images[j].RepoTags == nil || len(images[j].RepoTags) == 0 {
+		if len(images[j].RepoTags) == 0 {
 			return false
 		}
 		return images[i].RepoTags[0] > images[j].RepoTags[0]

--- a/cmd/ddev/cmd/describe_test.go
+++ b/cmd/ddev/cmd/describe_test.go
@@ -49,7 +49,6 @@ func TestDescribeBadArgs(t *testing.T) {
 	out, err = exec.RunCommand(DdevBin, args)
 	assert.Error(err)
 	assert.Contains(string(out), "Too many arguments provided")
-
 }
 
 // TestCmdDescribe tests that the describe command works properly when using the binary.

--- a/cmd/ddev/cmd/flags_test.go
+++ b/cmd/ddev/cmd/flags_test.go
@@ -105,7 +105,6 @@ func getCommand() cobra.Command {
 			UnknownFlags: true,
 		},
 	}
-
 }
 
 // TestUnitCmdFlagsAssignToCommand checks AssignToCommand works correctly and

--- a/cmd/ddev/cmd/hostname.go
+++ b/cmd/ddev/cmd/hostname.go
@@ -92,7 +92,6 @@ func removeInactiveHostnames() {
 			util.Warning("Unable to remove hosts entries for project '%s': %v", app.Name, err)
 		}
 	}
-	return
 }
 
 func init() {

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -85,7 +85,6 @@ func TestCmdList(t *testing.T) {
 			}
 		}
 		assert.True(found, "Failed to find project %s in ddev list -j", v.Name)
-
 	}
 
 	// Now filter the list by the type of the first running test app

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -34,18 +34,17 @@ ddev pull platform --environment=PLATFORM_ENVIRONMENT=main,PLATFORMSH_CLI_TOKEN=
 }
 
 // appPull() does the work of pull
-func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, skipImportArg bool, skipDbArg bool, skipFilesArg bool, env string) {
-
+func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, skipImportArg bool, skipDBArg bool, skipFilesArg bool, env string) {
 	// If we're not performing the import step, we won't be deleting the existing db or files.
 	if !skipConfirmation && !skipImportArg && os.Getenv("DDEV_NONINTERACTIVE") == "" {
 		// Only warn the user about relevant risks.
 		var message string
-		if skipDbArg && skipFilesArg {
+		if skipDBArg && skipFilesArg {
 			util.Warning("Both database and files import steps skipped.")
 			return
-		} else if !skipDbArg && skipFilesArg {
+		} else if !skipDBArg && skipFilesArg {
 			message = "database"
-		} else if !skipFilesArg && skipDbArg {
+		} else if !skipFilesArg && skipDBArg {
 			message = "files"
 		} else {
 			message = "database and files"
@@ -74,7 +73,7 @@ func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, s
 		}
 	}
 
-	if err := app.Pull(provider, skipDbArg, skipFilesArg, skipImportArg); err != nil {
+	if err := app.Pull(provider, skipDBArg, skipFilesArg, skipImportArg); err != nil {
 		util.Failed("Pull failed: %v", err)
 	}
 

--- a/cmd/ddev/cmd/push.go
+++ b/cmd/ddev/cmd/push.go
@@ -32,18 +32,17 @@ ddev push platform --environment=PLATFORM_ENVIRONMENT=main,PLATFORMSH_CLI_TOKEN=
 }
 
 // apppush() does the work of push
-func apppush(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, skipImportArg bool, skipDbArg bool, skipFilesArg bool, env string) {
-
+func apppush(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, skipImportArg bool, skipDBArg bool, skipFilesArg bool, env string) {
 	// If we're not performing the import step, we won't be deleting the existing db or files.
 	if !skipConfirmation && !skipImportArg && os.Getenv("DDEV_NONINTERACTIVE") == "" {
 		// Only warn the user about relevant risks.
 		var message string
-		if skipDbArg && skipFilesArg {
+		if skipDBArg && skipFilesArg {
 			util.Warning("Both database and files import steps skipped.")
 			return
-		} else if !skipDbArg && skipFilesArg {
+		} else if !skipDBArg && skipFilesArg {
 			message = "database"
-		} else if !skipFilesArg && skipDbArg {
+		} else if !skipFilesArg && skipDBArg {
 			message = "files"
 		} else {
 			message = "database and files"
@@ -72,7 +71,7 @@ func apppush(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, s
 		}
 	}
 
-	if err := app.Push(provider, skipDbArg, skipFilesArg); err != nil {
+	if err := app.Push(provider, skipDBArg, skipFilesArg); err != nil {
 		util.Failed("push failed: %v", err)
 	}
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -123,7 +123,6 @@ func Execute() {
 }
 
 func init() {
-
 	RootCmd.PersistentFlags().BoolVarP(&output.JSONOutput, "json-output", "j", false, "If true, user-oriented output will be in JSON format.")
 	RootCmd.PersistentFlags().BoolVarP(&ddevapp.SkipHooks, "skip-hooks", "", false, "If true, any hook normally run by the command will be skipped.")
 
@@ -158,7 +157,7 @@ func init() {
 // from the last saved version. If it is, prompt to request anon DDEV usage stats
 // and update the info.
 func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
-	if !output.JSONOutput && semver.Compare(versionconstants.DdevVersion, globalconfig.DdevGlobalConfig.LastStartedVersion) > 0 && globalconfig.DdevGlobalConfig.InstrumentationOptIn == false && !globalconfig.DdevNoInstrumentation && !skipConfirmation {
+	if !output.JSONOutput && semver.Compare(versionconstants.DdevVersion, globalconfig.DdevGlobalConfig.LastStartedVersion) > 0 && !globalconfig.DdevGlobalConfig.InstrumentationOptIn && !globalconfig.DdevNoInstrumentation && !skipConfirmation {
 		allowStats := util.Confirm("It looks like you have a new DDEV release.\nMay we send anonymous DDEV usage statistics and errors?\nTo know what we will see please take a look at\nhttps://ddev.readthedocs.io/en/stable/users/usage/diagnostics/#opt-in-usage-information\nPermission to beam up?")
 		if allowStats {
 			globalconfig.DdevGlobalConfig.InstrumentationOptIn = true
@@ -166,7 +165,6 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 	}
 
 	if globalconfig.DdevGlobalConfig.LastStartedVersion != versionconstants.DdevVersion && !skipConfirmation {
-
 		// If they have a new version (but not first-timer) then prompt to poweroff
 		if globalconfig.DdevGlobalConfig.LastStartedVersion != "v0.0" {
 			output.UserOut.Print("You seem to have a new DDEV version.")

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -134,7 +134,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(testRun)
-
 }
 
 func TestGetActiveAppRoot(t *testing.T) {

--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -116,7 +116,6 @@ func listSnapshots(apps []*ddevapp.DdevApp) {
 }
 
 func createAppSnapshot(app *ddevapp.DdevApp) {
-
 	// If the database is omitted, do not snapshot
 	omittedContainers := app.GetOmittedContainers()
 	if nodeps.ArrayContainsString(omittedContainers, "db") {

--- a/cmd/ddev/main.go
+++ b/cmd/ddev/main.go
@@ -25,5 +25,4 @@ func main() {
 	}
 
 	cmd.Execute()
-
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -275,7 +275,6 @@ func Untar(source string, dest string, extractionDir string) error {
 			if err != nil {
 				return fmt.Errorf("failed to chmod %v file %v, err: %v", fs.FileMode(file.Mode), fullPath, err)
 			}
-
 		}
 	}
 
@@ -444,9 +443,9 @@ func Tar(src string, tarballFilePath string, exclusion string) error {
 		}
 
 		// update the name to correctly reflect the desired destination when untarring
-		header.Name = strings.TrimPrefix(strings.Replace(file, src, "", -1), string(filepath.Separator))
+		header.Name = strings.TrimPrefix(strings.ReplaceAll(file, src, ""), string(filepath.Separator))
 		if runtime.GOOS == "windows" {
-			header.Name = strings.Replace(header.Name, `\`, `/`, -1)
+			header.Name = strings.ReplaceAll(header.Name, `\`, `/`)
 		}
 
 		// write the header

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -15,7 +15,6 @@ import (
 
 // TestUnarchive tests unzip/tar/tar.gz/tgz functionality, including the starting extraction-skip directory
 func TestUnarchive(t *testing.T) {
-
 	// testUnarchiveDir is the directory we may want to use to start extracting.
 	testUnarchiveDir := "dir2/"
 

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -153,7 +153,7 @@ func ProcessAddonAction(action string, dict map[string]interface{}, bashPath str
 			if desc != "" {
 				util.Warning("%c %s", '\U0001F44E', desc)
 			}
-			err = fmt.Errorf("Unable to run action %v: %v, output=%s", action, err, out)
+			err = fmt.Errorf("unable to run action %v: %v, output=%s", action, err, out)
 		}
 	} else {
 		if desc != "" {
@@ -208,7 +208,6 @@ func ListAvailableAddons(officialOnly bool) ([]*github.Repository, error) {
 	opts := &github.SearchOptions{Sort: "updated", Order: "desc", ListOptions: github.ListOptions{PerPage: 200}}
 	var allRepos []*github.Repository
 	for {
-
 		repos, resp, err := client.Search.Repositories(context.Background(), q, opts)
 		if err != nil {
 			msg := fmt.Sprintf("Unable to get list of available services: %v", err)
@@ -223,14 +222,14 @@ func ListAvailableAddons(officialOnly bool) ([]*github.Repository, error) {
 		}
 
 		// Set the next page number for the next request
-		opts.ListOptions.Page = resp.NextPage
+		opts.Page = resp.NextPage
 	}
 	out := ""
 	for _, r := range allRepos {
 		out = out + fmt.Sprintf("%s: %s\n", r.GetFullName(), r.GetDescription())
 	}
 	if len(allRepos) == 0 {
-		return nil, fmt.Errorf("No add-ons found")
+		return nil, fmt.Errorf("no add-ons found")
 	}
 	return allRepos, nil
 }
@@ -240,7 +239,7 @@ func ListAvailableAddons(officialOnly bool) ([]*github.Repository, error) {
 // the final par of the repository name like ddev-redis
 func RemoveAddon(app *DdevApp, addonName string, dict map[string]interface{}, bash string, verbose bool, skipRemovalActions bool) error {
 	if addonName == "" {
-		return fmt.Errorf("No add-on name specified for removal")
+		return fmt.Errorf("no add-on name specified for removal")
 	}
 
 	manifests, err := GatherAllManifests(app)
@@ -298,7 +297,7 @@ func RemoveAddon(app *DdevApp, addonName string, dict map[string]interface{}, ba
 
 	err = os.RemoveAll(app.GetConfigPath(filepath.Join(AddonMetadataDir, manifestData.Name)))
 	if err != nil {
-		return fmt.Errorf("Error removing addon metadata directory %s: %v", manifestData.Name, err)
+		return fmt.Errorf("error removing addon metadata directory %s: %v", manifestData.Name, err)
 	}
 	util.Success("Removed add-on %s", addonName)
 	return nil
@@ -331,7 +330,7 @@ func GatherAllManifests(app *DdevApp) (map[string]AddonManifest, error) {
 		var manifestData = &AddonManifest{}
 		err = yaml.Unmarshal([]byte(manifestString), manifestData)
 		if err != nil {
-			return nil, fmt.Errorf("Error unmarshalling manifest data: %v", err)
+			return nil, fmt.Errorf("error unmarshalling manifest data: %v", err)
 		}
 		allManifests[manifestData.Name] = *manifestData
 		allManifests[manifestData.Repository] = *manifestData

--- a/pkg/ddevapp/amplitude_project.go
+++ b/pkg/ddevapp/amplitude_project.go
@@ -92,7 +92,6 @@ func (app *DdevApp) TrackProject() {
 func webExtraExposedPortsNames(app *DdevApp) []string {
 	var exposedPortsNames []string
 	for _, exposedPortDetail := range app.WebExtraExposedPorts {
-
 		exposedPortsNames = append(exposedPortsNames, exposedPortDetail.Name)
 	}
 	return exposedPortsNames
@@ -102,7 +101,6 @@ func webExtraExposedPortsNames(app *DdevApp) []string {
 func webExtraDaemonsNames(app *DdevApp) []string {
 	var extraDaemonNames []string
 	for _, daemon := range app.WebExtraDaemons {
-
 		extraDaemonNames = append(extraDaemonNames, daemon.Name)
 	}
 	return extraDaemonNames

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -424,7 +424,6 @@ func (app *DdevApp) DetectAppType() string {
 // PostImportDBAction calls each apptype's detector until it finds a match,
 // or returns 'php' as a last resort.
 func (app *DdevApp) PostImportDBAction() error {
-
 	if appFuncs, ok := appTypeMatrix[app.Type]; ok && appFuncs.postImportDBAction != nil {
 		return appFuncs.postImportDBAction(app)
 	}

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -165,5 +165,4 @@ func TestConfigOverrideActionOnExistingConfig(t *testing.T) {
 		// We can override existing config.
 		assert.EqualValues(expectedPHPVersion, app.PHPVersion, "expected PHP version %s but got %s for apptype=%s", expectedPHPVersion, app.PHPVersion, appType)
 	}
-
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -191,7 +191,6 @@ func (app *DdevApp) GetConfigPath(filename string) string {
 
 // WriteConfig writes the app configuration into the .ddev folder.
 func (app *DdevApp) WriteConfig() error {
-
 	// Work against a copy of the DdevApp, since we don't want to actually change it.
 	appcopy := *app
 
@@ -321,7 +320,6 @@ func (app *DdevApp) UpdateGlobalProjectList() error {
 // It does not attempt to set default values; that's NewApp's job.
 // returns the list of config files read
 func (app *DdevApp) ReadConfig(includeOverrides bool) ([]string, error) {
-
 	// Load base .ddev/config.yaml - original config
 	err := app.LoadConfigYamlFile(app.ConfigPath)
 	if err != nil {
@@ -389,7 +387,6 @@ func (app *DdevApp) WarnIfConfigReplace() {
 
 // PromptForConfig goes through a set of prompts to receive user input and generate an Config struct.
 func (app *DdevApp) PromptForConfig() error {
-
 	app.WarnIfConfigReplace()
 
 	for {
@@ -590,7 +587,6 @@ func (app *DdevApp) GetHostname() string {
 
 // GetHostnames returns a slice of all the configured hostnames.
 func (app *DdevApp) GetHostnames() []string {
-
 	// Use a map to make sure that we have unique hostnames
 	// The value is useless, so use the int 1 for assignment.
 	nameListMap := make(map[string]int)
@@ -623,7 +619,6 @@ func (app *DdevApp) GetHostnames() []string {
 
 // CheckCustomConfig warns the user if any custom configuration files are in use.
 func (app *DdevApp) CheckCustomConfig() {
-
 	// Get the path to .ddev for the current app.
 	ddevDir := filepath.Dir(app.ConfigPath)
 
@@ -762,7 +757,6 @@ func (app *DdevApp) CheckCustomConfig() {
 	if customConfig {
 		util.Warning("Custom configuration is updated on restart.\nIf you don't see your custom configuration taking effect, run 'ddev restart'.")
 	}
-
 }
 
 // CheckDeprecations warns the user if anything in use is deprecated.
@@ -1247,7 +1241,6 @@ RUN (timeout %s apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-ge
 // docker-compose 'build'
 // It may include the contents of .ddev/<container>-build
 func WriteBuildDockerfile(app *DdevApp, fullpath string, userDockerfilePath string, extraPackages []string, composerVersion string, extraContent string) error {
-
 	// Start with user-built dockerfile if there is one.
 	err := os.MkdirAll(filepath.Dir(fullpath), 0755)
 	if err != nil {
@@ -1354,7 +1347,6 @@ RUN (timeout %s apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-ge
 
 	// webimage only things
 	if strings.Contains(fullpath, "webimageBuild") {
-
 		// For webimage, update to latest Composer.
 		// Version to run composer self-update to the version
 		var composerSelfUpdateArg string
@@ -1409,7 +1401,6 @@ if [ "${EXISTING_PSQL_VERSION}" != "%s" ]; then \
   apt-get remove -y postgresql-client-${EXISTING_PSQL_VERSION}" || true; \
 fi`, app.Database.Version, app.GetStartScriptTimeout(), psqlVersion) + "\n\n"
 		}
-
 	}
 
 	// If there are user dockerfiles, appends their contents
@@ -1459,11 +1450,11 @@ fi`, app.Database.Version, app.GetStartScriptTimeout(), psqlVersion) + "\n\n"
 	// This may cause problems with previously set permissions when installing/upgrading packages.
 	// Place this at the very end of the Dockerfile.
 	if strings.Contains(fullpath, "webimageBuild") {
-		contents = contents + fmt.Sprintf(`
+		contents = contents + `
 ### DDEV-injected folders permission fix
 RUN chmod 777 /run/php /var/log
 RUN mkdir -p /tmp/xhprof && chmod -R ugo+w /etc/php /var/lib/php /tmp/xhprof
-`)
+`
 	}
 
 	return WriteImageDockerfile(fullpath, []byte(contents))
@@ -1610,7 +1601,6 @@ func DiscoverDefaultDocroot(app *DdevApp) string {
 
 // Determine the document root.
 func (app *DdevApp) docrootPrompt() error {
-
 	// Determine the document root.
 	output.UserOut.Printf("\nThe docroot is the directory from which your site is served.\nThis is a relative path from your project root at %s\n", app.AppRoot)
 	output.UserOut.Printf("Leave docroot empty (hit <RETURN>) to use the location shown in parentheses.\nOr specify a custom path if your index.php is in a different directory.\nOr use '.' (a dot) to explicitly set it to the project root.\n")
@@ -1678,7 +1668,6 @@ func PrepDdevDirectory(app *DdevApp) error {
 	var err error
 	dir := app.GetConfigPath("")
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-
 		log.WithFields(log.Fields{
 			"directory": dir,
 		}).Debug("Config Directory does not exist, attempting to create.")
@@ -1767,9 +1756,7 @@ func validateHookYAML(source []byte) error {
 			if !match {
 				return fmt.Errorf("invalid task '%s' defined for hook %s in config.yaml", foundTask, foundHook)
 			}
-
 		}
-
 	}
 
 	return nil

--- a/pkg/ddevapp/config_merge_test.go
+++ b/pkg/ddevapp/config_merge_test.go
@@ -84,7 +84,6 @@ func TestConfigMergeEnvItems(t *testing.T) {
 	for _, v := range []string{`LARRY=lz`, `MOE=mz`, `CURLEY=c`, `SHEMP=s`} {
 		assert.Contains(withOverridesApp.WebEnvironment, v, "the app without overrides should have had %v but it didn't, webEnvironment=%v", v, noOverridesApp.WebEnvironment)
 	}
-
 }
 
 // TestConfigHooksMerge makes sure that hooks get merged with additional config.*.yaml
@@ -126,7 +125,6 @@ func TestConfigHooksMerge(t *testing.T) {
 			if taskDesc == desc {
 				found = true
 			}
-
 		}
 		return found
 	}
@@ -155,12 +153,10 @@ func TestConfigHooksMerge(t *testing.T) {
 	assertTask(true, "post-start", "exec-host", "simple host command")
 	assertTask(true, "post-start", "exec", "simple web command")
 	assertTask(true, "post-import-db", "exec", "drush uli")
-
 }
 
 // SetupTestTempDir creates the test directory and related objects.
 func SetupTestTempDir(t *testing.T, subDir string) *ddevapp.DdevApp {
-
 	projDir, err := filepath.Abs(testcommon.CreateTmpDir(t.Name()))
 	require.NoError(t, err)
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -354,7 +354,6 @@ func TestConfigCommandProjectNormalization(t *testing.T) {
 
 	for _, tc := range testMatrix {
 		t.Run(tc.name, func(t *testing.T) {
-
 			baseTestDir := t.TempDir()
 			testDir := filepath.Join(baseTestDir, tc.name)
 			err := os.Mkdir(testDir, 0755)
@@ -892,7 +891,6 @@ func TestConfigOverrideDetection(t *testing.T) {
 		require.Contains(t, stdout, "mutagen.yml")
 	}
 	require.Contains(t, stdout, "Custom configuration is updated")
-
 }
 
 // TestPHPOverrides tests to make sure that PHP overrides work in all webservers.
@@ -957,7 +955,6 @@ func TestPHPOverrides(t *testing.T) {
 	err = app.MutagenSyncFlush()
 	require.NoError(t, err, "failed to flush Mutagen sync")
 	_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL()+"/phpinfo.php", `max_input_time</td><td class="v">999`, 60)
-
 }
 
 // TestPHPConfig checks some key PHP configuration items

--- a/pkg/ddevapp/container_test.go
+++ b/pkg/ddevapp/container_test.go
@@ -41,7 +41,6 @@ func TestUserProvisioningInContainer(t *testing.T) {
 	uid, gid, username := util.GetContainerUIDGid()
 
 	for _, service := range []string{"web", "db"} {
-
 		out, _, err := app.Exec(&ddevapp.ExecOpts{
 			Service: service,
 			Cmd:     "id -un",
@@ -63,5 +62,4 @@ func TestUserProvisioningInContainer(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(gid, strings.Trim(out, "\r\n"))
 	}
-
 }

--- a/pkg/ddevapp/db.go
+++ b/pkg/ddevapp/db.go
@@ -33,7 +33,6 @@ func (app *DdevApp) GetExistingDBType() (string, error) {
 // 2. It has N+.N, meaning it's a pre-v1.19 MariaDB or MySQL version
 // 3. It has N+, meaning it's PostgreSQL
 func dbTypeVersionFromString(in string) string {
-
 	idType := ""
 
 	postgresStyle := regexp.MustCompile(`^[0-9]+$`)

--- a/pkg/ddevapp/db_test.go
+++ b/pkg/ddevapp/db_test.go
@@ -44,5 +44,4 @@ func TestDBTypeVersionFromString(t *testing.T) {
 	for input, expectation := range expectations {
 		assert.Equal(expectation, dbTypeVersionFromString(input))
 	}
-
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -209,7 +209,6 @@ func (app *DdevApp) FindContainerByType(containerType string) (*dockerContainer.
 // Describe returns a map which provides detailed information on services associated with the running site.
 // if short==true, then only the basic information is returned.
 func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
-
 	app.DockerEnv()
 	err := app.ProcessHooks("pre-describe")
 	if err != nil {
@@ -291,7 +290,6 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 		} else {
 			appDesc["xhgui_status"] = "disabled"
 		}
-
 	}
 
 	routerStatus, logOutput := GetRouterStatus()
@@ -389,7 +387,7 @@ func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
 
 			if virtualHost, ok := envMap["VIRTUAL_HOST"]; ok {
 				vhostVal := virtualHost
-				vhostValStr := fmt.Sprintf("%s", vhostVal)
+				vhostValStr := fmt.Sprintf("%v", vhostVal)
 				vhostsList := strings.Split(vhostValStr, ",")
 
 				// There might be more than one VIRTUAL_HOST value, but this only handles the first listed,
@@ -630,7 +628,6 @@ func (app *DdevApp) TargetPortFromExposeVariable(exposeEnvVar string, targetPort
 // 3. The project router_https_port
 // 4. The global router_https_port
 func (app *DdevApp) GetPrimaryRouterHTTPSPort() string {
-
 	proposedPrimaryRouterHTTPSPort := "443"
 	if globalconfig.DdevGlobalConfig.RouterHTTPSPort != "" {
 		proposedPrimaryRouterHTTPSPort = globalconfig.DdevGlobalConfig.RouterHTTPSPort
@@ -651,7 +648,6 @@ func (app *DdevApp) GetPrimaryRouterHTTPSPort() string {
 // If HTTP_EXPOSE has a mapping to port 8025 in the container, use that
 // If not, use the global or project MailpitHTTPPort
 func (app *DdevApp) GetMailpitHTTPPort() string {
-
 	if httpExpose := app.GetWebEnvVar("HTTP_EXPOSE"); httpExpose != "" {
 		httpPort := app.TargetPortFromExposeVariable(httpExpose, "8025")
 		if httpPort != "" {
@@ -673,7 +669,6 @@ func (app *DdevApp) GetMailpitHTTPPort() string {
 // If HTTPS_EXPOSE has a mapping to port 8025 in the container, use that
 // If not, use the global or project MailpitHTTPSPort
 func (app *DdevApp) GetMailpitHTTPSPort() string {
-
 	if httpsExpose := app.GetWebEnvVar("HTTPS_EXPOSE"); httpsExpose != "" {
 		httpsPort := app.TargetPortFromExposeVariable(httpsExpose, "8025")
 		if httpsPort != "" {
@@ -994,7 +989,7 @@ func (app *DdevApp) SiteStatus() (string, string) {
 
 	_, err := CheckForConf(app.GetAppRoot())
 	if err != nil {
-		return SiteConfigMissing, fmt.Sprintf("%s", SiteConfigMissing)
+		return SiteConfigMissing, SiteConfigMissing
 	}
 
 	statuses := map[string]string{"web": ""}
@@ -2430,7 +2425,6 @@ func (app *DdevApp) CaptureLogs(service string, timestamps bool, tailLines strin
 
 // DockerEnv sets environment variables for a docker-compose run.
 func (app *DdevApp) DockerEnv() {
-
 	uidStr, gidStr, _ := util.GetContainerUIDGid()
 
 	// Warn about running as root if we're not on Windows.
@@ -2505,7 +2499,6 @@ func (app *DdevApp) DockerEnv() {
 		hostHTTPSPortStr = strconv.Itoa(hostHTTPSPort)
 	} else {
 		hostHTTPSPortStr = app.HostHTTPSPort
-
 	}
 
 	// DDEV_DATABASE_FAMILY can be use for connection URLs
@@ -2826,7 +2819,6 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 
 // getBackupCommand returns the command to dump the entire db system for the various databases
 func getBackupCommand(app *DdevApp, targetFile string) string {
-
 	c := fmt.Sprintf(`mariabackup --backup --stream=mbstream --user=root --password=root --socket=/var/tmp/mysql.sock  2>/tmp/snapshot_%s.log | gzip > "%s"`, path.Base(targetFile), targetFile)
 
 	oldMariaVersions := []string{"5.5", "10.0"}
@@ -3328,7 +3320,6 @@ func restoreApp(app *DdevApp, siteName string) error {
 
 // GetProvider returns a pointer to the provider instance interface.
 func (app *DdevApp) GetProvider(providerName string) (*Provider, error) {
-
 	var p Provider
 	var err error
 
@@ -3403,7 +3394,7 @@ func (app *DdevApp) GetPostgresVolumeName() string {
 
 // GetComposeProjectName returns the name of the docker-compose project
 func (app *DdevApp) GetComposeProjectName() string {
-	return strings.ToLower("ddev-" + strings.Replace(app.Name, `.`, "", -1))
+	return strings.ToLower("ddev-" + strings.ReplaceAll(app.Name, `.`, ""))
 }
 
 // GetDefaultNetworkName returns the default project network name

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -865,7 +865,6 @@ func TestDdevStartUnmanagedSettings(t *testing.T) {
 	// Now with DisableSettingsManagement=false, start should have created both
 	assert.FileExists(app.SiteSettingsPath)
 	assert.FileExists(app.SiteDdevSettingsFile)
-
 }
 
 // TestDdevNoProjectMount tests running without the app file mount.
@@ -1164,7 +1163,6 @@ func TestDdevMysqlWorks(t *testing.T) {
 	assert.NoError(err)
 
 	runTime()
-
 }
 
 // TestStartWithoutDdev makes sure we don't have a regression where lack of .ddev
@@ -1287,7 +1285,6 @@ func TestDdevImportDB(t *testing.T) {
 			err = dockerutil.RemoveVolume(app.Name + "-" + dbType)
 			require.NoError(t, err)
 		}
-
 	})
 
 	c := make(map[string]string)
@@ -1488,7 +1485,7 @@ func TestDdevImportDB(t *testing.T) {
 	path := filepath.Join(origDir, "testdata", t.Name(), "mariadb", file)
 	err = app.ImportDB(path, "", false, false, "db")
 	assert.NoError(err, "Failed to app.ImportDB path: %s err: %v", path, err)
-	checkImportDbImports(t, app)
+	checkImportDBImports(t, app)
 
 	// Now test the same when importing from stdin, same file
 	_, _, err = app.Exec(&ddevapp.ExecOpts{Service: "db", Cmd: "mysql -N -e 'DROP TABLE wp_posts;'"})
@@ -1504,7 +1501,7 @@ func TestDdevImportDB(t *testing.T) {
 	err = app.ImportDB("", "", false, false, "db")
 	assert.NoError(err, "Failed to app.ImportDB path: %s err: %v", path, err)
 	os.Stdin = oldStdin
-	checkImportDbImports(t, app)
+	checkImportDBImports(t, app)
 
 	// Verify that the count of tables is exactly what it should be, that nothing was lost in the
 	// import due to embedded DDL statements.
@@ -1547,10 +1544,9 @@ func TestDdevImportDB(t *testing.T) {
 		err = app.ImportDB(cachedArchive, "data.sql", false, false, "db")
 		assert.NoError(err, "Failed to find data.sql at root of tarball %s", cachedArchive)
 	}
-
 }
 
-func checkImportDbImports(t *testing.T, app *ddevapp.DdevApp) {
+func checkImportDBImports(t *testing.T, app *ddevapp.DdevApp) {
 	assert := asrt.New(t)
 
 	// There should be exactly the one wp_posts table for this file
@@ -2198,7 +2194,6 @@ func TestWebserverPostgresDBClient(t *testing.T) {
 			// Output might be "pg_restore (PostgreSQL) 16.3 (Debian 16.3-1.pgdg120+1)"
 			// Or for postgres 9: "pg_dump (PostgreSQL) 9.6.24"
 			require.True(t, strings.HasPrefix(parts[2], expectedClientVersion), "string=%s dbType=%s dbVersion=%s; should have dbVersion as prefix", stdout, dbType, dbVersion)
-
 		}
 
 		importPath := filepath.Join(origDir, "testdata", t.Name(), dbType, "users.sql")
@@ -2752,7 +2747,6 @@ func TestDdevUploadDirNoPackage(t *testing.T) {
 		runTime()
 		switchDir()
 	}
-
 }
 
 // TestDdevImportFilesCustomUploadDir ensures that files are imported to a custom upload directory when requested
@@ -2892,7 +2886,6 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 // Requires a project where the docroot is in a subdirectory, as Drupal's 'web' directory.
 // It checks the DDEV_FILES_DIRS and DDEV_FILES_DIR environment variables
 func TestUploadDirs(t *testing.T) {
-
 	testDir := testcommon.CreateTmpDir(t.Name())
 
 	origDir, _ := os.Getwd()
@@ -2925,14 +2918,14 @@ func TestUploadDirs(t *testing.T) {
 
 	out, _, err := app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     fmt.Sprintf("echo ${DDEV_FILES_DIRS}"),
+		Cmd:     "echo ${DDEV_FILES_DIRS}",
 	})
 	require.NoError(t, err)
 	envDirs := strings.Split(out, ",")
 
 	out, _, err = app.Exec(&ddevapp.ExecOpts{
 		Service: "web",
-		Cmd:     fmt.Sprintf("echo ${DDEV_FILES_DIR}"),
+		Cmd:     "echo ${DDEV_FILES_DIR}",
 	})
 	require.NoError(t, err)
 	firstDir := strings.Trim(out, " \n\t")
@@ -3282,7 +3275,6 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	for _, volume := range volumes.Volumes {
 		assert.False(volume.Labels["com.docker.compose.project"] == "ddev"+strings.ToLower(app.GetName()))
 	}
-
 }
 
 // TestGetAppsEmpty ensures that GetActiveProjects returns an empty list when no applications are running.
@@ -3606,7 +3598,6 @@ func TestMultipleComposeFiles(t *testing.T) {
 		} else {
 			t.Errorf("failed to parse web services: %v", services)
 		}
-
 	} else {
 		t.Error("Unable to access ComposeYaml[services]")
 	}
@@ -3966,7 +3957,6 @@ func TestPHPWebserverType(t *testing.T) {
 
 		assert.NoError(err)
 		for _, app.WebserverType = range []string{nodeps.WebserverApacheFPM, nodeps.WebserverNginxFPM} {
-
 			err = app.WriteConfig()
 			assert.NoError(err)
 
@@ -4723,7 +4713,6 @@ func TestEnvironmentVariables(t *testing.T) {
 		lines := strings.Split(envVal, "\n")
 		assert.Equal(v, lines[0], "expected envvar $%s to equal '%s', but it was '%s'", k, v, envVal)
 	}
-
 }
 
 // TestEnvFile tests checks behavior of .ddev/.env files

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -117,7 +117,6 @@ func manageDrupalSettingsFile(app *DdevApp, drupalConfig *DrupalSettings) error 
 
 // writeDrupalSettingsPHP creates the project's settings.php if it doesn't exist
 func writeDrupalSettingsPHP(app *DdevApp) error {
-
 	var appType string
 	if app.Type == nodeps.AppTypeBackdrop {
 		appType = app.Type
@@ -577,7 +576,6 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 		})
 		if err != nil {
 			util.Warning("Unable to set permissions inside container on settings files; err='%v', stdout='%s', stderr='%s'", err, stdout, stderr)
-
 		}
 	}
 

--- a/pkg/ddevapp/envfile_test.go
+++ b/pkg/ddevapp/envfile_test.go
@@ -73,6 +73,5 @@ func TestWriteProjectEnvFile(t *testing.T) {
 				assert.Equal(l, newLines[i], "comment '%s' in original .env expected in revised .env but doesn't match (envfile=%s)", l, envFileName)
 			}
 		}
-
 	}
 }

--- a/pkg/ddevapp/hostname_mgt.go
+++ b/pkg/ddevapp/hostname_mgt.go
@@ -88,7 +88,6 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 	}
 
 	for _, name := range app.GetHostnames() {
-
 		// If we're able to resolve the hostname via DNS or otherwise we
 		// don't have to worry about this. This will allow resolution
 		// of <whatever>.ddev.site for example

--- a/pkg/ddevapp/laravel.go
+++ b/pkg/ddevapp/laravel.go
@@ -46,8 +46,8 @@ func laravelPostStartAction(app *DdevApp) error {
 	port := "3306"
 	dbConnection := "mariadb"
 	if app.Database.Type == nodeps.MariaDB {
-		hasMariaDbDriver, _ := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, "config/database.php"), "mariadb")
-		if !hasMariaDbDriver {
+		hasMariaDBDriver, _ := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, "config/database.php"), "mariadb")
+		if !hasMariaDBDriver {
 			// Older versions of Laravel (before 11) use "mysql" driver for MariaDB
 			// This change is required to prevent this error on "php artisan migrate":
 			// InvalidArgumentException Database connection [mariadb] not configured

--- a/pkg/ddevapp/list.go
+++ b/pkg/ddevapp/list.go
@@ -123,7 +123,6 @@ func CreateAppTable(out *bytes.Buffer, wrapTableText bool) table.Writer {
 	t.SortBy([]table.SortBy{{Name: "Name"}})
 
 	if !globalconfig.DdevGlobalConfig.SimpleFormatting {
-
 		t.SetColumnConfigs([]table.ColumnConfig{
 			{
 				Name: "Name",

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -32,7 +32,6 @@ func isMagento2App(app *DdevApp) bool {
 
 // createMagentoSettingsFile manages creation and modification of local.xml.
 func createMagentoSettingsFile(app *DdevApp) (string, error) {
-
 	if fileutil.FileExists(app.SiteSettingsPath) {
 		// Check if the file is managed by ddev.
 		signatureFound, err := fileutil.FgrepStringInFile(app.SiteSettingsPath, nodeps.DdevFileSignature)
@@ -123,7 +122,6 @@ func getMagento2UploadDirs(_ *DdevApp) []string {
 
 // createMagento2SettingsFile manages creation and modification of app/etc/env.php.
 func createMagento2SettingsFile(app *DdevApp) (string, error) {
-
 	if fileutil.FileExists(app.SiteSettingsPath) {
 		// Check if the file is managed by ddev.
 		signatureFound, err := fileutil.FgrepStringInFile(app.SiteSettingsPath, nodeps.DdevFileSignature)

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -361,7 +361,7 @@ func (app *DdevApp) MutagenStatus() (status string, shortResult string, mapResul
 		return fmt.Sprintf("nosession for MUTAGEN_DATA_DIRECTORY=%s; failed to unmarshal Mutagen sync list results '%v'", globalconfig.GetMutagenDataDirectory(), fullJSONResult), fullJSONResult, nil, err
 	}
 
-	if paused, ok := session["paused"].(bool); ok && paused == true {
+	if paused, ok := session["paused"].(bool); ok && paused {
 		return "paused", "paused", session, nil
 	}
 	var ok bool
@@ -534,14 +534,14 @@ func DownloadMutagen() error {
 	// Discussion in https://github.com/mutagen-io/mutagen/issues/290#issuecomment-906612749
 	err := fileutil.RemoveFilesMatchingGlob(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen*"))
 	if err != nil {
-		return fmt.Errorf("Unable to remove mutagen files: %v", err)
+		return fmt.Errorf("unable to remove mutagen files: %v", err)
 	}
 
 	err = os.MkdirAll(globalMutagenDir, 0777)
 	if err != nil {
 		return errors.Errorf("Unable to create directory %s: %v", globalMutagenDir, err)
 	}
-	err = util.DownloadFile(destFile, mutagenURL, "true" != os.Getenv("DDEV_NONINTERACTIVE"), shasumFileURL)
+	err = util.DownloadFile(destFile, mutagenURL, os.Getenv("DDEV_NONINTERACTIVE") != "true", shasumFileURL)
 	if err != nil {
 		_ = fileutil.RemoveFilesMatchingGlob(filepath.Join(globalconfig.GetDDEVBinDir(), "mutagen*"))
 		_ = os.Remove(destFile)
@@ -801,7 +801,7 @@ func CheckMutagenVolumeSyncCompatibility(app *DdevApp) (ok bool, volumeExists bo
 func GetMutagenSyncLabel(app *DdevApp) (string, error) {
 	status, _, mapResult, err := app.MutagenStatus()
 	if status == "not enabled" {
-		return "", fmt.Errorf("Mutagen sync session for app '%s' does not exist or is not enabled; status=%v; err=%v", app.Name, status, err)
+		return "", fmt.Errorf("a Mutagen sync session for app '%s' does not exist or is not enabled; status=%v; err=%v", app.Name, status, err)
 	}
 	if strings.HasPrefix(status, "nosession") || err != nil {
 		return "", fmt.Errorf("no session %s found: %v", MutagenSyncName(app.Name), status)

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -185,7 +185,6 @@ func TestMutagenSimple(t *testing.T) {
 		_, err := exec.RunHostCommand("pkill", "-HUP", "mutagen")
 		assert.Error(err)
 	}
-
 }
 
 // TestMutagenConfigChange tests Mutagen new session creation on mutagen.yml change

--- a/pkg/ddevapp/network_test.go
+++ b/pkg/ddevapp/network_test.go
@@ -80,5 +80,4 @@ func TestNetworkAmbiguity(t *testing.T) {
 			assert.Len(ips, expectation)
 		}
 	}
-
 }

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -96,7 +96,6 @@ func TestNodeJSVersions(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(out, "v8.17")
-
 }
 
 // TestCorepackEnable tests behavior of corepack_enable

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -61,7 +61,7 @@ func (p *Provider) Init(pType string, app *DdevApp) error {
 }
 
 // Pull performs an import of db and files
-func (app *DdevApp) Pull(provider *Provider, skipDbArg bool, skipFilesArg bool, skipImportArg bool) error {
+func (app *DdevApp) Pull(provider *Provider, skipDBArg bool, skipFilesArg bool, skipImportArg bool) error {
 	var err error
 	err = app.ProcessHooks("pre-pull")
 	if err != nil {
@@ -85,7 +85,7 @@ func (app *DdevApp) Pull(provider *Provider, skipDbArg bool, skipFilesArg bool, 
 		}
 	}
 
-	if skipDbArg {
+	if skipDBArg {
 		output.UserOut.Println("Skipping database pull.")
 	} else {
 		output.UserOut.Println("Obtaining databases...")
@@ -132,7 +132,7 @@ func (app *DdevApp) Pull(provider *Provider, skipDbArg bool, skipFilesArg bool, 
 		} else {
 			output.UserOut.Println("Importing files...")
 			f := ""
-			if files != nil && len(files) > 0 {
+			if len(files) > 0 {
 				f = files[0]
 			}
 			err = provider.doFilesImport(f, "")
@@ -150,7 +150,7 @@ func (app *DdevApp) Pull(provider *Provider, skipDbArg bool, skipFilesArg bool, 
 }
 
 // Push pushes db and files up to upstream hosting provider
-func (app *DdevApp) Push(provider *Provider, skipDbArg bool, skipFilesArg bool) error {
+func (app *DdevApp) Push(provider *Provider, skipDBArg bool, skipFilesArg bool) error {
 	var err error
 	err = app.ProcessHooks("pre-push")
 	if err != nil {
@@ -174,7 +174,7 @@ func (app *DdevApp) Push(provider *Provider, skipDbArg bool, skipFilesArg bool) 
 		}
 	}
 
-	if skipDbArg {
+	if skipDBArg {
 		output.UserOut.Println("Skipping database push.")
 	} else {
 		output.UserOut.Println("Uploading database...")
@@ -440,7 +440,7 @@ func (p *Provider) injectedEnvironment() string {
 	if len(p.EnvironmentVariables) > 0 {
 		s = "export"
 		for k, v := range p.EnvironmentVariables {
-			v = strings.Replace(v, " ", `\ `, -1)
+			v = strings.ReplaceAll(v, " ", `\ `)
 			s = s + fmt.Sprintf(" %s=%s ", k, v)
 		}
 	}

--- a/pkg/ddevapp/providerLocalfile_test.go
+++ b/pkg/ddevapp/providerLocalfile_test.go
@@ -62,9 +62,9 @@ func TestLocalfilePull(t *testing.T) {
 	// Build our localfile.yaml from the example file
 	s, err := os.ReadFile(app.GetConfigPath("providers/localfile.yaml.example"))
 	require.NoError(t, err)
-	x := strings.Replace(string(s), "~/Dropbox", path.Join(util.WindowsPathToCygwinPath(origDir), "testdata", t.Name()), -1)
+	x := strings.ReplaceAll(string(s), "~/Dropbox", path.Join(util.WindowsPathToCygwinPath(origDir), "testdata", t.Name()))
 	appRoot := util.WindowsPathToCygwinPath(app.AppRoot)
-	x = strings.Replace(x, "/full/path/to/project/root", appRoot, -1)
+	x = strings.ReplaceAll(x, "/full/path/to/project/root", appRoot)
 	err = os.WriteFile(app.GetConfigPath("providers/localfile.yaml"), []byte(x), 0666)
 	assert.NoError(err)
 	err = app.WriteConfig()

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -276,7 +276,6 @@ func TestUseEphemeralPort(t *testing.T) {
 			require.Contains(t, app.GetHTTPSURL(), app.GetHostname())
 		}
 	}
-
 }
 
 // TestAssignRouterPortsToGenericWebserverPorts ensures that RouterHTTPPort and RouterHTTPSPort

--- a/pkg/ddevapp/silverstripe.go
+++ b/pkg/ddevapp/silverstripe.go
@@ -23,7 +23,7 @@ func silverstripePostStartAction(app *DdevApp) error {
 	envFilePath := filepath.Join(app.AppRoot, app.ComposerRoot, ".env")
 	_, envText, err := ReadProjectEnvFile(envFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("Unable to read .env file: %v", err)
+		return fmt.Errorf("unable to read .env file: %v", err)
 	}
 	if os.IsNotExist(err) {
 		err = fileutil.CopyFile(filepath.Join(app.AppRoot, app.ComposerRoot, ".env.example"), envFilePath)

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -94,7 +94,6 @@ func RemoveSSHAgentContainer() error {
 
 // CreateSSHAuthComposeFile creates the docker-compose file for the ddev-ssh-agent
 func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
-
 	var doc bytes.Buffer
 	f, ferr := os.Create(SSHAuthComposeYAMLPath())
 	if ferr != nil {
@@ -202,5 +201,4 @@ func GetSSHAuthStatus() string {
 	}
 	health, _ := dockerutil.GetContainerHealth(container)
 	return health
-
 }

--- a/pkg/ddevapp/start_test.go
+++ b/pkg/ddevapp/start_test.go
@@ -12,7 +12,6 @@ import (
 
 // TestDdevApp_StartOptionalProfiles makes sure that we can start an optional service appropriately
 func TestDdevApp_StartOptionalProfiles(t *testing.T) {
-
 	origDir, _ := os.Getwd()
 	site := TestSites[0]
 

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -196,7 +196,6 @@ func (app *DdevApp) CreateUploadDirsIfNecessary() {
 // - slice of string (possibly empty)
 // - boolean false
 func (app *DdevApp) validateUploadDirs() error {
-
 	// Check that upload dirs aren't outside the project root.
 	for _, uploadDir := range app.UploadDirs {
 		if !strings.HasPrefix(app.calculateHostUploadDirFullPath(uploadDir), app.AppRoot) {

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -64,7 +64,7 @@ func RenderHomeRootedDir(path string) string {
 	userDir, err := os.UserHomeDir()
 	util.CheckErr(err)
 	result := strings.Replace(path, userDir, "~", 1)
-	result = strings.Replace(result, "\\", "/", -1)
+	result = strings.ReplaceAll(result, "\\", "/")
 	return result
 }
 
@@ -93,7 +93,6 @@ func RenderAppRow(t table.Writer, row map[string]interface{}) {
 	t.AppendRow(table.Row{
 		row["name"], status, row["shortroot"], urls, row["type"],
 	})
-
 }
 
 // Cleanup will remove DDEV containers and volumes even if docker-compose.yml
@@ -325,8 +324,8 @@ func GetErrLogsFromApp(app *DdevApp, errorReceived error) (string, string, error
 		return "no error detected", "", nil
 	}
 	errString := errorReceived.Error()
-	errString = strings.Replace(errString, "Received unexpected error:", "", -1)
-	errString = strings.Replace(errString, "\n", "", -1)
+	errString = strings.ReplaceAll(errString, "Received unexpected error:", "")
+	errString = strings.ReplaceAll(errString, "\n", "")
 	errString = strings.Trim(errString, " \t\n\r")
 	if strings.Contains(errString, "container failed") || strings.Contains(errString, "container did not become ready") || strings.Contains(errString, "failed to become ready") {
 		splitError := strings.Split(errString, " ")

--- a/pkg/ddevapp/wordpress.go
+++ b/pkg/ddevapp/wordpress.go
@@ -37,8 +37,8 @@ type WordpressConfig struct {
 	SiteSettings     string
 	SiteSettingsDdev string
 	AbsPath          string
-	DbCharset        string
-	DbCollate        string
+	DBCharset        string
+	DBCollate        string
 }
 
 // NewWordpressConfig produces a WordpressConfig object with defaults.
@@ -64,8 +64,8 @@ func NewWordpressConfig(app *DdevApp, absPath string) *WordpressConfig {
 		SiteSettings:     "wp-config.php",
 		SiteSettingsDdev: "wp-config-ddev.php",
 		AbsPath:          absPath,
-		DbCharset:        "utf8",
-		DbCollate:        "",
+		DBCharset:        "utf8",
+		DBCollate:        "",
 	}
 }
 

--- a/pkg/ddevapp/wordpress/wp-config.php
+++ b/pkg/ddevapp/wordpress/wp-config.php
@@ -8,10 +8,10 @@
  */
 
 /** Database charset to use in creating database tables. */
-define( 'DB_CHARSET', '{{ $config.DbCharset }}' );
+define( 'DB_CHARSET', '{{ $config.DBCharset }}' );
 
 /** The database collate type. Don't change this if in doubt. */
-define( 'DB_COLLATE', '{{ $config.DbCollate }}' );
+define( 'DB_COLLATE', '{{ $config.DBCollate }}' );
 
 /** Authentication Unique Keys and Salts. */
 define( 'AUTH_KEY', '{{ $config.AuthKey }}' );

--- a/pkg/ddevapp/xhprof_xhgui.go
+++ b/pkg/ddevapp/xhprof_xhgui.go
@@ -143,7 +143,6 @@ func (app *DdevApp) GetXHProfMode() types.XHProfMode {
 // If HTTP_EXPOSE has a mapping to port 8143 in the container, use that
 // If not, use the global or project XHGuiHTTPPort
 func (app *DdevApp) GetXHGuiHTTPPort() string {
-
 	if httpExpose := app.GetXHGuiEnvVar("HTTP_EXPOSE"); httpExpose != "" {
 		httpPort := app.TargetPortFromExposeVariable(httpExpose, nodeps.DdevDefaultXHGuiHTTPPort)
 		if httpPort != "" {
@@ -165,7 +164,6 @@ func (app *DdevApp) GetXHGuiHTTPPort() string {
 // If HTTPS_EXPOSE has a mapping to port 8142 in the container, use that
 // If not, use the global or project XHGuiHTTPSPort
 func (app *DdevApp) GetXHGuiHTTPSPort() string {
-
 	if httpsExpose := app.GetXHGuiEnvVar("HTTPS_EXPOSE"); httpsExpose != "" {
 		httpsPort := app.TargetPortFromExposeVariable(httpsExpose, nodeps.DdevDefaultXHGuiHTTPSPort)
 		if httpsPort != "" {

--- a/pkg/dockerutil/docker_compose_version_test.go
+++ b/pkg/dockerutil/docker_compose_version_test.go
@@ -63,5 +63,4 @@ func TestDockerComposeDownload(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(globalconfig.GetRequiredDockerComposeVersion(), activeVersion)
 	}
-
 }

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -180,7 +180,6 @@ func TestGetContainerHealth(t *testing.T) {
 	status, log = dockerutil.GetContainerHealth(container)
 	assert.Equal("unhealthy", status, "container should be unhealthy; log=%v", log)
 	assert.NoError(err)
-
 }
 
 // TestContainerWait tests the error cases for the container check wait loop.
@@ -224,7 +223,6 @@ func TestContainerWait(t *testing.T) {
 	t.Cleanup(func() {
 		_ = dockerutil.RemoveContainer(c1)
 		assert.NoError(err, "failed to remove container %v (%s)", labels, c1)
-
 	})
 	require.NoError(t, err)
 	_, err = dockerutil.ContainerWait(5, labels)
@@ -546,7 +544,6 @@ func TestDockerExec(t *testing.T) {
 	_, stderr, err := dockerutil.Exec(id, "ls /nothingthere", "")
 	assert.Error(err)
 	assert.Contains(stderr, "No such file or directory")
-
 }
 
 // TestCreateVolume does a trivial test of creating a trivial Docker volume.
@@ -604,7 +601,6 @@ func TestRemoveVolume(t *testing.T) {
 	_ = dockerutil.RemoveVolume(spareVolume)
 	err = dockerutil.RemoveVolume(spareVolume)
 	assert.NoError(err)
-
 }
 
 // TestCopyIntoVolume makes sure CopyToVolume copies a local directory into a volume

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -19,7 +19,6 @@ import (
 
 // TestFileHash is a unit test for FileHash()
 func TestFileHash(t *testing.T) {
-
 	testCases := []struct {
 		content       string
 		optionalExtra string

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -99,7 +99,6 @@ func CopyDir(src string, dst string) error {
 	}
 
 	for _, de := range dirEntrySlice {
-
 		srcPath := filepath.Join(src, de.Name())
 		dstPath := filepath.Join(dst, de.Name())
 
@@ -246,7 +245,7 @@ func ReplaceStringInFile(searchString string, replaceString string, origPath str
 		return err
 	}
 
-	output := bytes.Replace(input, []byte(searchString), []byte(replaceString), -1)
+	output := bytes.ReplaceAll(input, []byte(searchString), []byte(replaceString))
 
 	// nolint: revive
 	if err = os.WriteFile(destPath, output, 0666); err != nil {
@@ -385,7 +384,6 @@ func ReplaceSimulatedLinks(path string) {
 		replacedLinks = append(replacedLinks, l.LinkLocation)
 	}
 	util.Success("Replaced these simulated symlinks with real symlinks: %v", replacedLinks)
-	return
 }
 
 // RemoveContents removes contents of passed directory
@@ -433,7 +431,6 @@ func RemoveFilesMatchingGlob(pattern string) error {
 
 // TemplateStringToFile takes a template string, runs templ.Execute on it, and writes it out to file
 func TemplateStringToFile(content string, vars map[string]interface{}, targetFilePath string) error {
-
 	templ := template.New("templateStringToFile:" + targetFilePath)
 	templ, err := templ.Parse(content)
 	if err != nil {

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -62,7 +62,6 @@ func TestCopyDir(t *testing.T) {
 	assert.NoError(err)
 	err = os.RemoveAll(targetDir)
 	assert.NoError(err)
-
 }
 
 // TestCopyFile tests copying a file.
@@ -212,7 +211,6 @@ func TestReplaceSimulatedXsymSymlinks(t *testing.T) {
 			_ = targetFile
 		}
 	}
-
 }
 
 // TestIsSameFile tests the IsSameFile utility function.

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -83,7 +83,6 @@ type GlobalConfig struct {
 
 // New returns a default GlobalConfig
 func New() GlobalConfig {
-
 	cfg := GlobalConfig{
 		RequiredDockerComposeVersion: versionconstants.RequiredDockerComposeVersionDefault,
 		InternetDetectionTimeout:     nodeps.InternetDetectionTimeoutDefault,
@@ -505,7 +504,7 @@ func ReadProjectList() error {
 		}
 		if os.IsNotExist(err) {
 			// If someone upgrades from an earlier version, the global config may hold the project list.
-			if DdevGlobalConfig.ProjectList != nil && len(DdevGlobalConfig.ProjectList) > 0 {
+			if len(DdevGlobalConfig.ProjectList) > 0 {
 				DdevProjectList = DdevGlobalConfig.ProjectList
 				err := WriteProjectList(DdevProjectList)
 				if err != nil {
@@ -717,7 +716,6 @@ func GetFreePort(localIPAddr string) (string, error) {
 		return port, nil
 	}
 	return "-1", fmt.Errorf("getFreePort() failed to find a free port")
-
 }
 
 // ReservePorts adds the ProjectInfo if necessary and assigns the reserved ports
@@ -861,7 +859,7 @@ func IsInternetActive() bool {
 	// Internet is active (active == true) if both err and ctx.Err() were nil
 	active := err == nil && ctx.Err() == nil
 	if DdevDebug {
-		if active == false {
+		if !active {
 			output.UserErr.Println("Internet connection not detected, DNS may not work, see https://ddev.readthedocs.io/en/stable/users/usage/offline/ for info.")
 		}
 		output.UserErr.Debugf("IsInternetActive(): err=%v ctx.Err()=%v addrs=%v IsInternetactive==%v, testURL=%v internet_detection_timeout_ms=%dms\n", err, ctx.Err(), addrs, active, testURL, DdevGlobalConfig.InternetDetectionTimeout)

--- a/pkg/globalconfig/xhprof_mode.go
+++ b/pkg/globalconfig/xhprof_mode.go
@@ -7,8 +7,8 @@ import (
 // GetXHProfMode returns the xhprof mode config respecting
 // defaults.
 func (c *GlobalConfig) GetXHProfMode() types.XHProfMode {
-	switch {
-	case c.XHProfMode == types.XHProfModeEmpty:
+	switch c.XHProfMode {
+	case types.XHProfModeEmpty:
 		return types.FlagXHProfModeDefault
 	default:
 		return c.XHProfMode

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -17,7 +17,6 @@ import (
 
 // IsPortActive checks to see if the given port on Docker IP is answering.
 func IsPortActive(port string) bool {
-
 	dialTimeout := 0 * time.Millisecond
 	if nodeps.IsWSL2() {
 		dialTimeout = 200 * time.Millisecond

--- a/pkg/output/text_formatter.go
+++ b/pkg/output/text_formatter.go
@@ -20,13 +20,12 @@ import (
 
 const defaultTimestampFormat = time.RFC3339
 
-// nolint: deadcode
 const (
 	nocolor = 0
 	red     = 31
-	green   = 32 // nolint: varcheck
+	green   = 32
 	yellow  = 33
-	blue    = 36 // nolint: varcheck
+	blue    = 36
 	gray    = 37
 )
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -247,7 +247,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 	originalGlobalConfig := globalconfig.DdevGlobalConfig
 	// Stop the Mutagen daemon running in the ~/.ddev
 	ddevapp.StopMutagenDaemon("")
-	t.Log(fmt.Sprintf("stopped mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
+	t.Logf("stopped mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory())
 	// Set $XDG_CONFIG_HOME for tests
 	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
 	// Make sure that the global config directory is set to $XDG_CONFIG_HOME/ddev
@@ -274,7 +274,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 	// Start mutagen daemon if it's enabled
 	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 		ddevapp.StartMutagenDaemon()
-		t.Log(fmt.Sprintf("started mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY='%s'", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
+		t.Logf("started mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY='%s'", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory())
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
 		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), globalconfig.GetMutagenDataDirectory())
 	}
@@ -286,7 +286,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 	// Stop the Mutagen daemon running in the $XDG_CONFIG_HOME/ddev
 	ddevapp.StopMutagenDaemon("")
-	t.Log(fmt.Sprintf("stopped mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
+	t.Logf("stopped mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory())
 	// After the $XDG_CONFIG_HOME directory is removed,
 	// globalconfig.GetGlobalDdevDir() should point to ~/.ddev
 	t.Setenv("XDG_CONFIG_HOME", "")
@@ -304,7 +304,7 @@ func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 	// Start mutagen daemon if it's enabled
 	if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
 		ddevapp.StartMutagenDaemon()
-		t.Log(fmt.Sprintf("started mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory()))
+		t.Logf("started mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory())
 		// Make sure that $MUTAGEN_DATA_DIRECTORY is set to the correct directory
 		require.Equal(t, os.Getenv("MUTAGEN_DATA_DIRECTORY"), globalconfig.GetMutagenDataDirectory())
 	}

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -183,7 +183,6 @@ func TestGetLocalHTTPResponse(t *testing.T) {
 			_, _ = EnsureLocalHTTPContent(t, safeURL, site.Safe200URIWithExpectation.Expect)
 		}
 	}
-
 }
 
 // TestGetCachedArchive tests download and extraction of archives for test sites

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -176,7 +176,6 @@ func NewHTTPOptions(URL string) *HTTPOptions {
 
 // EnsureHTTPStatus will verify a URL responds with a given response code within the Timeout period (in seconds)
 func EnsureHTTPStatus(o *HTTPOptions) error {
-
 	client := &http.Client{
 		Timeout: o.Timeout * time.Second,
 	}
@@ -216,7 +215,6 @@ func EnsureHTTPStatus(o *HTTPOptions) error {
 			"expected": o.ExpectedStatus,
 			"got":      resp.StatusCode,
 		}).Infof("HTTP Status could not be matched, expected %d, received %d", o.ExpectedStatus, resp.StatusCode)
-
 	}
 	return fmt.Errorf("failed to match status code: %d: %v", o.ExpectedStatus, err)
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -127,7 +127,6 @@ var letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 // SetLetterBytes exists solely so that tests can override the default characters used by
 // RandString. It should probably be avoided for 'normal' operations.
 // this is actually used in utils_test.go (test only) so we set nolint on it.
-// nolint: deadcode
 func SetLetterBytes(lb string) {
 	letterBytes = lb
 }
@@ -142,7 +141,7 @@ func RandString(n int) string {
 }
 
 // HashSalt returns a hash of the projectName to be used as a salt.
-// This is appropriate onlly for development work, but means
+// This is appropriate only for development work, but means
 // that the HashSalt will be predictable for users on a team
 func HashSalt(projectName string) string {
 	hash := sha256.Sum256([]byte(projectName))

--- a/pkg/util/yaml_test.go
+++ b/pkg/util/yaml_test.go
@@ -48,7 +48,6 @@ func TestYamlFileToMap(t *testing.T) {
 	slashloc, ok := locations["/"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal("web", slashloc["root"])
-
 }
 
 func TestYamlToDict(t *testing.T) {


### PR DESCRIPTION
## The Issue

- #7155

## How This PR Solves The Issue

Most of the fixes have been automated with:

```
golangci-lint run --fix
```

I didn't apply all `staticcheck` rules because some aren't simple or make the code less readable than before, and I don't know Go well enough to judge if they're good.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
