### PR TITLE
docs: trailing whitespace on template

### DIFF
--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -48,7 +48,7 @@ const ConfigInstructions = `
 
 # host_xhgui_port: 8142
 # Can be used to change the host binding port of the xhgui
-# application. Rarely used; only when port conflict and 
+# application. Rarely used; only when port conflict and
 # bind_all_ports is used (normally with router disabled)
 
 # xhprof_enabled: false  # Set to true to enable Xhprof and "ddev start" or "ddev restart"


### PR DESCRIPTION
I noticed this trailing space on a project.