### PR TITLE
build: update debian-archive-keyring for archived debian repos, fixes #7320

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -23,13 +23,16 @@ SHELL ["/bin/bash", "-c"]
 
 # Fix APT for Debian Stretch (EOL; upstream mirrors disabled)
 # Based on: https://serverfault.com/a/1131653
-RUN if grep "Debian GNU/Linux 9" /etc/issue >/dev/null; then \
-    rm -f /etc/apt/sources.list.d/mysql.list && \
-    echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" >/etc/apt/sources.list && \
-    echo "deb http://archive.debian.org/debian-security/ stretch/updates main contrib non-free" >>/etc/apt/sources.list && \
-    apt-get -qq update -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true -o APT::Get::AllowUnauthenticated=true && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests -o APT::Get::AllowUnauthenticated=true debian-archive-keyring; \
+RUN <<EOF
+    set -eu -o pipefail
+    if grep "Debian GNU/Linux 9" /etc/issue >/dev/null; then
+        rm -f /etc/apt/sources.list.d/mysql.list
+        echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" >/etc/apt/sources.list
+        echo "deb http://archive.debian.org/debian-security/ stretch/updates main contrib non-free" >>/etc/apt/sources.list
+        apt-get -qq update -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true -o APT::Get::AllowUnauthenticated=true
+        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests -o APT::Get::AllowUnauthenticated=true debian-archive-keyring
     fi
+EOF
 
 # MariaDB 11.x moved MySQL symlinks into separate packages
 RUN set -x; if ( command -v mariadbd && ! command -v mysqld ); then \

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -21,14 +21,15 @@ ARG MYSQL_ROOT_PASSWORD=root
 
 SHELL ["/bin/bash", "-c"]
 
-# Debian Stretch archives have been turned off
-RUN if grep "Debian GNU/Linux 9" /etc/issue >/dev/null ; then \
-    echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" >/etc/apt/sources.list; \
+# Fix APT for Debian Stretch (EOL; upstream mirrors disabled)
+# Based on: https://serverfault.com/a/1131653
+RUN if grep "Debian GNU/Linux 9" /etc/issue >/dev/null; then \
+    rm -f /etc/apt/sources.list.d/mysql.list && \
+    echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" >/etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security/ stretch/updates main contrib non-free" >>/etc/apt/sources.list && \
+    apt-get -qq update -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true -o APT::Get::AllowUnauthenticated=true && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests -o APT::Get::AllowUnauthenticated=true debian-archive-keyring; \
     fi
-# Remove obsolete MySQL 5.5/5.6 Jessie and before keys so they don't make expiration key test stumble
-RUN for item in "75DD C3C4 A499 F1A1 8CB5  F3C8 CBF8 D6FD 518E 17E1" "126C 0D24 BD8A 2942 CC7D  F8AC 7638 D044 2B90 D010" "D211 6914 1CEC D440 F2EB  8DDA 9D6D 8F6B C857 C906" "A1BD 8E9D 78F7 FE5C 3E65  D8AF 8B48 AD62 4692 5553" "ED6D 6527 1AAC F0FF 15D1  2303 6FB2 A1C2 65FF B764"; do \
-    apt-key remove "${item}" || true; \
-  done;
 
 # MariaDB 11.x moved MySQL symlinks into separate packages
 RUN set -x; if ( command -v mariadbd && ! command -v mysqld ); then \

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1177,24 +1177,21 @@ stopasgroup=true
 		return "", err
 	}
 
-	// Add .pgpass to homedir on PostgreSQL
+	// Include PostgreSQL support for EOL Debian releases
+	// debian-security updates added for "stretch" only because this archive is not available for "buster" yet
+	// Based on: https://serverfault.com/a/1131653
+	// And add .pgpass to homedir on PostgreSQL
 	extraDBContent := ""
 	if app.Database.Type == nodeps.Postgres {
-		// PostgreSQL 9/10/11 upstream images are stretch-based, out of support from Debian.
-		// PostgreSQL 9/10 are out of support by PostgreSQL and no new images being pushed, see
-		// https://github.com/docker-library/postgres/issues/1012
-		// However, they do have a postgres:11-bullseye, but we won't start using it yet
-		// because of awkward changes to $DBIMAGE. PostgreSQL 11 will be EOL Nov 2023
-		if nodeps.ArrayContainsString([]string{nodeps.Postgres9, nodeps.Postgres10, nodeps.Postgres11}, app.Database.Version) {
-			extraDBContent = extraDBContent + fmt.Sprintf(`
-RUN rm -f /etc/apt/sources.list.d/pgdg.list
-RUN echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list
-RUN timeout %s apt-get update || true
-RUN apt-get -y install apt-transport-https
-RUN printf "deb http://apt-archive.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-`, app.GetMinimalContainerTimeout())
-		}
 		extraDBContent = extraDBContent + fmt.Sprintf(`
+RUN set -e; source /etc/os-release; if [ "${VERSION_CODENAME:-}" = "stretch" ] || [ "${VERSION_CODENAME:-}" = "buster" ]; then \
+	rm -f /etc/apt/sources.list.d/pgdg.list; \
+    echo "deb http://archive.debian.org/debian/ ${VERSION_CODENAME} main contrib non-free" >/etc/apt/sources.list; \
+	[ "${VERSION_CODENAME}" = "stretch" ] && echo "deb http://archive.debian.org/debian-security/ ${VERSION_CODENAME}/updates main contrib non-free" >>/etc/apt/sources.list; \
+    (timeout %s apt-get -qq update -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true -o APT::Get::AllowUnauthenticated=true || true); \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests -o APT::Get::AllowUnauthenticated=true debian-archive-keyring apt-transport-https ca-certificates; \
+	echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg-archive main" >/etc/apt/sources.list.d/pgdg.list; \
+    fi
 ENV PATH=$PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 ADD postgres_healthcheck.sh /
 RUN chmod ugo+rx /postgres_healthcheck.sh
@@ -1202,7 +1199,7 @@ RUN mkdir -p /etc/postgresql/conf.d && chmod 777 /etc/postgresql/conf.d
 RUN echo "*:*:db:db:db" > ~postgres/.pgpass && chown postgres:postgres ~postgres/.pgpass && chmod 600 ~postgres/.pgpass && chmod 777 /var/tmp && ln -sf /mnt/ddev_config/postgres/postgresql.conf /etc/postgresql && echo "restore_command = 'true'" >> /var/lib/postgresql/recovery.conf
 RUN printf "# TYPE DATABASE USER CIDR-ADDRESS  METHOD \nhost  all  all 0.0.0.0/0 md5\nlocal all all trust\nhost    replication    db             0.0.0.0/0  trust\nhost replication all 0.0.0.0/0 trust\nlocal replication all trust\nlocal replication all peer\n" >/etc/postgresql/pg_hba.conf
 RUN (timeout %s apt-get update || true) && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests bzip2 less procps pv vim
-`, app.GetMinimalContainerTimeout())
+`, app.GetMinimalContainerTimeout(), app.GetMinimalContainerTimeout())
 	}
 
 	err = WriteBuildDockerfile(app, app.GetConfigPath(".dbimageBuild/Dockerfile"), app.GetConfigPath("db-build"), app.DBImageExtraPackages, "", extraDBContent)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1186,10 +1186,10 @@ stopasgroup=true
 		extraDBContent = extraDBContent + fmt.Sprintf(`
 ENV PATH=$PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 ADD postgres_healthcheck.sh /
+
 RUN <<EOF
 set -eu -o pipefail
-source /etc/os-release
-
+source /etc/os-release || true
 if [ "${VERSION_CODENAME:-}" = "stretch" ] || [ "${VERSION_CODENAME:-}" = "buster" ]; then
     rm -f /etc/apt/sources.list.d/pgdg.list
     echo "deb http://archive.debian.org/debian/ ${VERSION_CODENAME} main contrib non-free" >/etc/apt/sources.list
@@ -1202,7 +1202,10 @@ if [ "${VERSION_CODENAME:-}" = "stretch" ] || [ "${VERSION_CODENAME:-}" = "buste
         debian-archive-keyring apt-transport-https ca-certificates
     echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg-archive main" >/etc/apt/sources.list.d/pgdg.list
 fi
+EOF
 
+RUN <<EOF
+set -eu -o pipefail
 chmod ugo+rx /postgres_healthcheck.sh
 mkdir -p /etc/postgresql/conf.d
 chmod 777 /etc/postgresql/conf.d

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "v1.24.6" // Note that this can be overridden by make
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.24.6"
+var BaseDBTag = "20250521_stasadev_archived_debian"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION
## The Issue

- #7320

## How This PR Solves The Issue

- installs or updates `debian-archive-keyring`, which fixes the problem with Debian gpg keys
- no need to remove obsolete MySQL 5.5/5.6 Jessie and before keys, we don't check them with `check_key_expirations.sh`
- unifies PostgreSQL logic; adding new Debian EOL releases to the `if` condition is now simpler
- removes non-working `/etc/apt/sources.list.d/mysql.list` from `mysql:5.6`
- adds debian-security updates repo for stretch
- uses `vim-tiny` instead of `vim` for PostgreSQL `db` image
- replaces `<distro>-pgdg main` with `<distro>-pgdg-archive main` for PostgreSQL
  (pgdg-archive has more packages, see https://apt-archive.postgresql.org/)

## Manual Testing Instructions

Using AMD64 machine, test MySQL 5.5:

See errors here:
```
$ docker run --rm -it --entrypoint=bash ddev/ddev-dbserver-mysql-5.5:v1.24.6 -c "apt-get update"
Ign:1 http://archive.debian.org/debian stretch InRelease
Hit:2 http://repo.percona.com/prel/apt stretch InRelease
Hit:3 http://archive.debian.org/debian stretch Release
Hit:4 http://repo.percona.com/pxb-24/apt stretch InRelease
Err:5 http://archive.debian.org/debian stretch Release.gpg
  The following signatures were invalid: EXPKEYSIG 04EE7237B7D453EC Debian Archive Automatic Signing Key (9/stretch) <ftpmaster@debian.org> EXPKEYSIG EF0F382A1A7B6500 Debian Stable Release Key (9/stretch) <debian-release@lists.debian.org> The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 648ACFD622F3D138 NO_PUBKEY 0E98404D386FA1D9
Reading package lists... Done
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://archive.debian.org/debian stretch Release: The following signatures were invalid: EXPKEYSIG 04EE7237B7D453EC Debian Archive Automatic Signing Key (9/stretch) <ftpmaster@debian.org> EXPKEYSIG EF0F382A1A7B6500 Debian Stable Release Key (9/stretch) <debian-release@lists.debian.org> The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 648ACFD622F3D138 NO_PUBKEY 0E98404D386FA1D9
W: Failed to fetch http://archive.debian.org/debian/dists/stretch/Release.gpg  The following signatures were invalid: EXPKEYSIG 04EE7237B7D453EC Debian Archive Automatic Signing Key (9/stretch) <ftpmaster@debian.org> EXPKEYSIG EF0F382A1A7B6500 Debian Stable Release Key (9/stretch) <debian-release@lists.debian.org> The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 648ACFD622F3D138 NO_PUBKEY 0E98404D386FA1D9
W: Some index files failed to download. They have been ignored, or old ones used instead.
```
No errors:
```
$ docker run --rm -it --entrypoint=bash ddev/ddev-dbserver-mysql-5.5:20250521_stasadev_archived_debian -c "apt-get update"
Ign:1 http://archive.debian.org/debian stretch InRelease
Hit:2 http://repo.percona.com/prel/apt stretch InRelease
Hit:3 http://archive.debian.org/debian-security stretch/updates InRelease
Hit:4 http://repo.percona.com/pxb-24/apt stretch InRelease
Hit:5 http://archive.debian.org/debian stretch Release
Reading package lists... Done
```

Using AMD64 machine, test MySQL 5.6:

```
$ docker run --rm -it --entrypoint=bash ddev/ddev-dbserver-mysql-5.6:v1.24.6 -c "apt-get update"
Ign:1 http://archive.debian.org/debian stretch InRelease
Get:2 http://repo.mysql.com/apt/debian stretch InRelease [21.6 kB]
Hit:3 http://repo.percona.com/prel/apt stretch InRelease                       
Hit:4 http://archive.debian.org/debian stretch Release                   
Hit:5 http://repo.percona.com/pxb-24/apt stretch InRelease               
Ign:2 http://repo.mysql.com/apt/debian stretch InRelease
Fetched 21.6 kB in 1s (21.3 kB/s)
Reading package lists... Done
W: GPG error: http://repo.mysql.com/apt/debian stretch InRelease: The following signatures were invalid: EXPKEYSIG 8C718D3B5072E1F5 MySQL Release Engineering <mysql-build@oss.oracle.com>
W: The repository 'http://repo.mysql.com/apt/debian stretch InRelease' is not signed.
N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```
No errors:
```
$ docker run --rm -it --entrypoint=bash ddev/ddev-dbserver-mysql-5.6:20250521_stasadev_archived_debian -c "apt-get update"
Ign:1 http://archive.debian.org/debian stretch InRelease
Hit:2 http://repo.percona.com/prel/apt stretch InRelease
Hit:3 http://archive.debian.org/debian-security stretch/updates InRelease
Hit:4 http://repo.percona.com/pxb-24/apt stretch InRelease
Hit:5 http://archive.debian.org/debian stretch Release
Reading package lists... Done
```

---

And test different PostgreSQL configs (`ddev start` confirms successful installation):

(PostgreSQL 9,10,11 will work on AMD64 only)

```
# debian stretch
ddev config --database=postgres:9 --dbimage-extra-packages=postgresql-9.6-postgis-2.3,postgresql-9.6-postgis-scripts,postgis
ddev start
ddev delete -Oy
```

```
# debian stretch
ddev config --database=postgres:10 --dbimage-extra-packages=postgresql-10-postgis-2.4,postgresql-10-postgis-2.4-scripts,postgis
ddev start
ddev delete -Oy
```

```
# debian stretch
ddev config --database=postgres:11 --dbimage-extra-packages=postgresql-11-postgis-2.5,postgresql-11-postgis-2.5-scripts,postgis
ddev start
ddev delete -Oy
```

```
# debian bookworm
ddev config --database=postgres:12 --dbimage-extra-packages=postgresql-12-postgis-3,postgresql-12-postgis-3-scripts,postgis
ddev start
ddev delete -Oy
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
