### PR TITLE
docs: add tip on initial PhpStorm plugin setup

### DIFF
--- a/docs/content/users/install/phpstorm.md
+++ b/docs/content/users/install/phpstorm.md
@@ -10,7 +10,7 @@ Make sure to get at least one project going with `ddev start` before trying to s
 
 Regardless of your setup, make PhpStorm use DDEV’s private `docker-compose` executable.
 
-In PhpStorm, navigate to *Preferences* → *Build, Execution, Deployment* → *Docker* → *Tools*, and set the `docker-compose` executable to the absolute path of DDEV's private `docker-compose` binary, which is `$HOME/.ddev/bin/docker-compose`.
+In PhpStorm, navigate to *Preferences* → *Build, Execution, Deployment* → *Docker*, and set the `docker-compose` executable to the absolute path of DDEV's private `docker-compose` binary, which is `$HOME/.ddev/bin/docker-compose`.
 
 If you’re using WSL2 and running PhpStorm on the Windows side, PhpStorm can’t use `docker-compose` from WSL2, so configure Docker Desktop in *Settings* → *General* to “Use Docker Compose V2” and use a recent version of `docker-compose` either from Docker Desktop or installed another way.
 
@@ -19,6 +19,11 @@ If you’re using WSL2 and running PhpStorm on the Windows side, PhpStorm can’
 It’s easiest to use the DDEV Integration Plugin, which you can install from [its landing page](https://plugins.jetbrains.com/plugin/18813-ddev-integration) or by searching the in-app marketplace (*Preferences* → *Plugins* → *Marketplace*) for “DDEV”. The integration plugin handles nearly everything on this page automatically, and works on all platforms.
 
 Install and enable the plugin, then [set up `phpunit`](#enabling-phpunit) since it doesn’t yet handle that for you.
+
+!!!note "PHP and Node interpreter automatic setup"
+    The plugin automatically adds PHP and Node interpreters to your project.
+
+    If you installed the plugin *after* a project was already open in PhpStorm, you'll need to manually switch to the newly added PHP and Node interpreters in *Preferences*. Alternatively, close your IDE and delete the `.idea` directory in the project root to let the plugin set them up automatically.
 
 ## Manual Setup
 


### PR DESCRIPTION
## The Issue

From Discord https://discord.com/channels/664580571770388500/1376055542048358481/1376055542048358481

I'm trying to test out Junie in PHPStorm, but it's complaining that I don't have a CLI interpreter set. I have the DDEV plugin installed, but it doesn't make a difference.

## How This PR Solves The Issue

I suppose this can happen when installing the DDEV Integration plugin *after* opening the project in PhpStorm.
In this case, the CLI interpreter does not change automatically.
This PR adds a tip about it.

## Manual Testing Instructions

https://ddev--7331.org.readthedocs.build/en/7331/users/install/phpstorm/#ddev-integration-plugin

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
