### PR TITLE
refactor: improve message about missing docroot on `ddev start`

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1813,7 +1813,7 @@ func warnMissingDocroot(app *DdevApp) {
 		return
 	}
 	if len(matches) == 0 {
-		util.WarningWithColor("magenta", "The index.php or index.html does not yet exist in\n%s\nso you may get 403 errors 'permission denied' from the browser until it does.\nDon't worry about this if a later action \n(like `ddev composer install`) will create the file.\n", pattern)
+		util.WarningWithColor("magenta", "The index.php or index.html does not yet exist in this path:\n%s\nYou may get 403 errors 'permission denied' from the browser until it does.\nIgnore if a later action will create it (like `ddev composer create-project`).\n", pattern)
 	}
 }
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1802,7 +1802,7 @@ func warnMissingDocroot(app *DdevApp) {
 	}
 	docroot := app.GetAbsDocroot(false)
 	if !fileutil.FileExists(docroot) {
-		util.WarningWithColor("magenta", "The project docroot '%s' does not yet exist\n(or `docroot` is misconfigured),\nuntil it exists, you may get a 403 'permission denied' visiting the project in a web browser.\n", docroot)
+		util.WarningWithColor("magenta", "The project docroot does not yet exist or is misconfigured at this path:\n%s\nYou may get 403 errors 'permission denied' from the browser until it does.\n", docroot)
 		return
 	}
 
@@ -1813,7 +1813,7 @@ func warnMissingDocroot(app *DdevApp) {
 		return
 	}
 	if len(matches) == 0 {
-		util.WarningWithColor("magenta", "The index.php or index.html does not yet exist in this path:\n%s\nYou may get 403 errors 'permission denied' from the browser until it does.\nIgnore if a later action will create it (like `ddev composer create-project`).\n", pattern)
+		util.WarningWithColor("magenta", "The index.php or index.html does not yet exist at this path:\n%s\nYou may get 403 errors 'permission denied' from the browser until it does.\nIgnore if a later action (like `ddev composer create-project`) will create it.\n", pattern)
 	}
 }
 


### PR DESCRIPTION
## The Issue

- #7330

```
$ ddev start
Starting missing-docroot-test...
The index.php or index.html does not yet exist in
/home/stas/code/ddev/missing-docroot-test/index.*
so you may get 403 errors 'permission denied' from the browser until it does.
Don't worry about this if a later action 
(like `ddev composer install`) will create the file.
...
```

## How This PR Solves The Issue

- Adds a change suggested by @GuySartorelli
- Replaces `ddev composer install` with `ddev composer create-project` (this is the command that downloads all files)

## Manual Testing Instructions

```
mkdir missing-docroot-test && cd missing-docroot-test
ddev config --auto
ddev start
```
See:
```
$ ddev start
Starting missing-docroot-test...
The index.php or index.html does not yet exist at this path:
/home/stas/code/ddev/missing-docroot-test/index.*
You may get 403 errors 'permission denied' from the browser until it does.
Ignore if a later action (like `ddev composer create-project`) will create it.
...
```

---

```
mkdir missing-docroot-test2 && cd missing-docroot-test2
ddev config --docroot=docroot-test
rmdir docroot-test
ddev start
```

See:
```
$ ddev start
Starting missing-docroot-test2...
The project docroot does not yet exist or is misconfigured at this path:
/home/stas/code/pet/missing-docroot-test2/docroot-test
You may get 403 errors 'permission denied' from the browser until it does.
...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
