### PR TITLE
fix: make `ddev composer create-project` work with stdin

### DIFF
--- a/cmd/ddev/cmd/composer-create-project.go
+++ b/cmd/ddev/cmd/composer-create-project.go
@@ -547,6 +547,10 @@ func wrapTTYCommandWithStdin(data []byte, cmd []string) []string {
 		_, _ = stdinWriter.Write(data)
 	}()
 	os.Stdin = stdinReader
+	// 'script' forces execution in a pseudo-terminal (PTY)
+	// '-q' suppresses script's start and end messages (quiet mode)
+	// '-c' specifies the command to run in the PTY
+	// '/dev/null' discards the session log
 	return []string{"script", "-q", "-c", strings.Join(cmd, " "), "/dev/null"}
 }
 

--- a/cmd/ddev/cmd/composer-create-project.go
+++ b/cmd/ddev/cmd/composer-create-project.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -38,6 +39,8 @@ ddev composer create-project --prefer-dist --no-interaction --no-dev psr/log .
 `,
 	ValidArgsFunction: getComposerCompletionFunc(true),
 	Run: func(cmd *cobra.Command, args []string) {
+		inputData := readPipedInput()
+
 		app, err := ddevapp.GetActiveApp("")
 		if err != nil {
 			util.Failed(err.Error())
@@ -186,16 +189,21 @@ ddev composer create-project --prefer-dist --no-interaction --no-dev psr/log .
 			}
 
 			composerCmd = append(composerCmd, validRunScriptArgs...)
+			composerCmd = wrapTTYCommandWithStdin(inputData, composerCmd)
 
 			output.UserOut.Printf("Executing Composer command: %v\n", composerCmd)
 
-			stdout, stderr, _ = app.Exec(&ddevapp.ExecOpts{
+			stdout, stderr, err = app.Exec(&ddevapp.ExecOpts{
 				Service: "web",
 				Dir:     getComposerRootInContainer(app),
 				RawCmd:  composerCmd,
 				Tty:     isatty.IsTerminal(os.Stdin.Fd()),
 				Env:     []string{"XDEBUG_MODE=off"},
 			})
+
+			if err != nil {
+				util.Failed("Failed to run post-root-package-install: %v\nstderr=%v", err, stderr)
+			}
 
 			if len(stdout) > 0 {
 				output.UserOut.Println(stdout)
@@ -227,6 +235,7 @@ ddev composer create-project --prefer-dist --no-interaction --no-dev psr/log .
 				}
 			}
 
+			composerCmd = wrapTTYCommandWithStdin(inputData, composerCmd)
 			// Run install command.
 			output.UserOut.Printf("Executing Composer command: %v\n", composerCmd)
 
@@ -282,16 +291,21 @@ ddev composer create-project --prefer-dist --no-interaction --no-dev psr/log .
 			}
 
 			composerCmd = append(composerCmd, validRunScriptArgs...)
+			composerCmd = wrapTTYCommandWithStdin(inputData, composerCmd)
 
 			output.UserOut.Printf("Executing Composer command: %v\n", composerCmd)
 
-			stdout, stderr, _ = app.Exec(&ddevapp.ExecOpts{
+			stdout, stderr, err = app.Exec(&ddevapp.ExecOpts{
 				Service: "web",
 				Dir:     getComposerRootInContainer(app),
 				RawCmd:  composerCmd,
 				Tty:     isatty.IsTerminal(os.Stdin.Fd()),
 				Env:     []string{"XDEBUG_MODE=off"},
 			})
+
+			if err != nil {
+				util.Failed("Failed to run post-create-project-cmd: %v\nstderr=%v", err, stderr)
+			}
 
 			if len(stdout) > 0 {
 				output.UserOut.Println(stdout)
@@ -500,6 +514,40 @@ func prepareAppForComposer(app *ddevapp.DdevApp) {
 	if err := app.PostStartAction(); err != nil {
 		util.Warning("Could not run PostStartAction: %v", err)
 	}
+}
+
+// readPipedInput reads from os.Stdin if it's not a terminal.
+// Returns nil if stdin is a terminal or unreadable.
+// Required because os.Stdin is consumed by the first app.Exec() call
+// and not forwarded to subsequent executions.
+func readPipedInput() []byte {
+	if isatty.IsTerminal(os.Stdin.Fd()) {
+		return nil
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+// wrapTTYCommandWithStdin wraps the given command in `script` to simulate a TTY,
+// allowing interactive prompts to work with piped stdin (e.g., inside containers).
+// If stdin is already a terminal or input is empty, returns the original command.
+func wrapTTYCommandWithStdin(data []byte, cmd []string) []string {
+	if isatty.IsTerminal(os.Stdin.Fd()) || len(data) == 0 {
+		return cmd
+	}
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		return cmd
+	}
+	go func() {
+		defer stdinWriter.Close()
+		_, _ = stdinWriter.Write(data)
+	}()
+	os.Stdin = stdinReader
+	return []string{"script", "-q", "-c", strings.Join(cmd, " "), "/dev/null"}
 }
 
 // ComposerCreateCmd does the same thing as "ddev composer create-project".

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -14,17 +14,28 @@ teardown() {
 @test "Shopware Composer based quickstart with $(ddev --version)" {
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
+
   run ddev config --project-type=shopware6 --docroot=public
   assert_success
+
   run ddev start -y
   assert_success
+
+  # Do you want to include Docker configuration from recipes?
+  # [x] No permanently, never ask again for this project
   run bats_pipe echo x \| ddev composer create-project shopware/production
   assert_success
+  assert_output --partial "Do you want to include Docker configuration from recipes?"
+  assert_file_not_exist compose.yaml
+  assert_file_not_exist compose.override.yaml
+
   run ddev exec console system:install --basic-setup
   assert_success
-  run bash -c "DDEV_DEBUG=true ddev launch /admin"
+
+  DDEV_DEBUG=true run ddev launch /admin
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site/admin"
   assert_success
+
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site/admin
   assert_success


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/7323#pullrequestreview-2861494051

stdin doesn't seem to work properly with `ddev composer create-project`.

I.e. `echo x | ddev composer create-project shopware/production` doesn't pass `x`, Composer thinks there is no TTY, and doesn't ask any question.

And there is no error on failed `composer run-script`.

We want to have better test coverage by using stdin in our quickstart tests.

## How This PR Solves The Issue

I investaged the problem and found out that:
1. `os.Stdin` is empty after it's passed to the first `app.Exec()` call, nothing there afterwards.
2. Composer doesn't recognize TTY at all when using pipes.

So I used `os.Pipe` to pass `os.Stdin` for each `app.Exec()` call and wrapped Composer commands in preudo-TTY with `script`:
- `composer run-script post-root-package-install` can have interaction
- `composer install` can have interaction in `post-install-cmd` (can be tested with https://ddev.readthedocs.io/en/stable/users/quickstart/#cakephp without `--no-interaction` flag)
- `composer run-script post-create-project-cmd` can have interaction

> [!NOTE]  
> Stdin is passed to each of the commands above. The *entire* input is forwarded, so if multiple steps include interactive questions, it may not behave as expected: there's no way to tell which input was consumed and which wasn't.
>
> Example: `composer run-script post-root-package-install` asks "What is your first name?" and `composer run-script post-create-project-cmd` asks "What is your last name?", If you run `printf "Stas\nZhuk\n" | ddev composer creat-project ...`, then `"Stas\nZhuk\n"` is passed to both scripts, which means `Stas` will be consumed in both cases.
>
> Considering that usually you only need to pass `Y`/`yes` to agree to something, or that most interaction happens only in `composer run-script post-create-project-cmd`, I think it an acceptable compromise, especially since it didn't work at all before.

And I added an error check for `composer run-script`.

## Manual Testing Instructions

Craft CMS quickstart using pipe should work now:

```
ddev config --project-type=craftcms --docroot=web
printf "admin\nadmin@example.com\nnewpassword\nnewpassword\ntestsite\n\n\n" | ddev composer create-project craftcms/craft
ddev launch # login with `admin@example.com` and `newpassword`
```

In addition, check Shopware quickstart https://ddev.readthedocs.io/en/stable/users/quickstart/#shopware with:
```
echo x | ddev composer create-project shopware/production
```
And Cake PHP quickstart https://ddev.readthedocs.io/en/stable/users/quickstart/#cakephp with:
```
echo n | ddev composer create-project --prefer-dist cakephp/app:~5.0
```

## Automated Testing Overview

Updates Shopware quickstart test by adding a real check to confirm the selected option was executed correctly.
This test fails in v1.24.6, but not in this PR.

## Release/Deployment Notes

It doesn't touch the existing interactive `ddev composer create-project` logic, so I consider this PR safe to pull.