### PR TITLE
Add phpmailer_smtp mailpit documentation

### DIFF
--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -93,6 +93,16 @@ For Drupal 9+ `settings.ddev.php` overrides the Symfony Mailer sendmail configur
 
 For Drupal 8/9 `settings.ddev.php` overrides the [Swift Mailer](https://www.drupal.org/project/swiftmailer) transport configuration to use Mailpit.
 
+Alternatively, the [PHPMailer SMTP](https://www.drupal.org/project/phpmailer_smtp) module can be used and configured in the `ddev.settings.php` file as follows:
+
+```
+// // Override drupal/phpmailer_smtp default config to use Mailpit.
+$config['phpmailer_smtp.settings']['smtp_host'] = 'localhost:1025';
+$config['phpmailer_smtp.settings']['smtp_protocol'] = 'standard';
+$config['phpmailer_smtp.settings']['smtp_username'] = '';
+$config['phpmailer_smtp.settings']['smtp_password'] = '';
+```
+
 For Laravel projects, Mailpit will capture Swift messages via SMTP. Update your `.env` to use Mailpit with the following settings:
 
 ```env


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #7337

<!-- Provide a brief description of the issue. -->

This adds the necessary ddev.settings.php changes needed to use PHPMailer SMTP with DDEV to capture emails in Mailpit.

## Manual Testing Instructions

1. Set up a Drupal 9+ site on DDEV with Mailpit
2. Install the PHPMailer SMTP module
3. Configure ddev.settings.php with the configuration provided in this PR
4. Send an email from the site (PHPMailer SMTP provides a test email form)

## Automated Testing Overview

No automated testing is needed for this as it is documentation.

## Release/Deployment Notes

No additional deployment notes. 
