### PR TITLE
test: update check for starter page in Silverstripe CMS

### DIFF
--- a/docs/tests/silverstripe.bats
+++ b/docs/tests/silverstripe.bats
@@ -12,28 +12,22 @@ teardown() {
 }
 
 @test "Silverstripe CMS Composer quickstart with $(ddev --version)" {
-  # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
-  # ddev config --project-type=silverstripe --docroot=public
   run ddev config --project-type=silverstripe --docroot=public
   assert_success
 
-  # ddev config --project-type=silverstripe --docroot=public
   run ddev start -y
   assert_success
 
-  # ddev sake dev/build flush=all
   run ddev composer create-project --prefer-dist silverstripe/installer
   assert_success
 
-  # ddev sake dev/build flush=all
   run ddev sake dev/build flush=all
   assert_success
 
-  # validate ddev launch
-  run bash -c "DDEV_DEBUG=true ddev launch /admin"
+  DDEV_DEBUG=true run ddev launch /admin
   assert_output "FULLURL https://${PROJNAME}.ddev.site/admin"
   assert_success
 
@@ -44,7 +38,7 @@ teardown() {
   assert_output --partial "HTTP/2 200"
   run curl -sf https://${PROJNAME}.ddev.site
   assert_success
-  assert_output --partial "Powered by <a href=\"http://silverstripe.org\">SilverStripe</a>"
+  assert_output --partial "Welcome to Silverstripe"
   run curl -sf https://${PROJNAME}.ddev.site/Security/login
   assert_success
   assert_output --partial "<title>Your Site Name: Log in</title>"


### PR DESCRIPTION
## The Issue

The quickstart test for Silverstripe CMS is failing because of the new template in today's 6.0.0 release.
https://www.silverstripe.org/blog/silverstripe-cms-6-0/

## How This PR Solves The Issue

Fixes it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
