### PR TITLE
build: bump ddev-webserver and ddev-traefik-router, for #7282

### DIFF
--- a/containers/ddev-traefik-router/Dockerfile
+++ b/containers/ddev-traefik-router/Dockerfile
@@ -1,7 +1,7 @@
 FROM traefik:3 AS ddev-traefik-router
 
 ENV TRAEFIK_MONITOR_PORT=10999
-RUN apk add bash curl htop vim
+RUN apk add --no-cache bash curl htop vim
 WORKDIR /mnt/ddev-global-cache/traefik
 # Make Traefik commands work without --configFile by using default location
 # https://doc.traefik.io/traefik/getting-started/configuration-overview/#configuration-file

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -2,7 +2,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:v1.24.6 AS ddev-webserver-base
+FROM ddev/ddev-php-base:20250612_stasadev_rebuild_images AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250213_rfay_mariadb_11.8" // Note that this can be overridden by make
+var WebTag = "20250612_stasadev_rebuild_images" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
@@ -23,7 +23,7 @@ var BaseDBTag = "20250213_rfay_mariadb_11.8"
 var TraefikRouterImage = "ddev/ddev-traefik-router"
 
 // TraefikRouterTag is traefik router tag
-var TraefikRouterTag = "v1.24.6"
+var TraefikRouterTag = "20250612_stasadev_rebuild_images"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"


### PR DESCRIPTION
## The Issue

- #7282

Xdebug 3.4.4 is available in `deb.sury.org` https://salsa.debian.org/php-team/pecl/xdebug

~~But it has some regressions:~~

~~- https://github.com/oerdnj/deb.sury.org/issues/2316~~

## How This PR Solves The Issue

- Pushes `ddev-php-base` with `ddev-webserver`
- Adds `--no-cache` to `ddev-traefik-router` to make it 2.5 MB smaller.

## Manual Testing Instructions

```
$ ddev config --php-version=8.4 && ddev restart && ddev xdebug on && ddev php -v
PHP 8.4.8 (cli) (built: Jun  9 2025 13:42:27) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.4.8, Copyright (c) Zend Technologies
    with Zend OPcache v8.4.8, Copyright (c), by Zend Technologies
    with Xdebug v3.4.4, Copyright (c) 2002-2025, by Derick Rethans

$ ddev config --php-version=8.3 && ddev restart && ddev xdebug on && ddev php -v
PHP 8.3.22 (cli) (built: Jun  9 2025 13:58:34) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.3.22, Copyright (c) Zend Technologies
    with Zend OPcache v8.3.22, Copyright (c), by Zend Technologies
    with Xdebug v3.4.4, Copyright (c) 2002-2025, by Derick Rethans

$ ddev config --php-version=8.2 && ddev restart && ddev xdebug on && ddev php -v
PHP 8.2.28 (cli) (built: Mar 13 2025 18:10:30) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.28, Copyright (c) Zend Technologies
    with Zend OPcache v8.2.28, Copyright (c), by Zend Technologies
    with Xdebug v3.4.4, Copyright (c) 2002-2025, by Derick Rethans

$ ddev config --php-version=8.1 && ddev restart && ddev xdebug on && ddev php -v
PHP 8.1.32 (cli) (built: Mar 13 2025 18:12:19) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.32, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.32, Copyright (c), by Zend Technologies
    with Xdebug v3.4.4, Copyright (c) 2002-2025, by Derick Rethans
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
