### PR TITLE
feat: return real exit code from `ddev exec` and add quiet flag to it, fixes #3518

### DIFF
--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -80,7 +79,7 @@ ddev exec --raw -- ls -lR`,
 				exitCode = exiterr.ExitCode()
 			}
 			if !quiet {
-				output.UserErr.Errorf(util.ColorizeText(fmt.Sprintf("Failed to execute command `%s`: %v", opts.Cmd, err), "red"))
+				util.Error("Failed to execute command `%s`: %v", opts.Cmd, err)
 			}
 			output.UserErr.Exit(exitCode)
 		}

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -67,9 +67,9 @@ ddev exec --raw -- ls -lR`,
 		}
 
 		_, _, err = app.Exec(opts)
-		verbose, _ := cmd.Flags().GetBool("verbose")
+		quiet, _ := cmd.Flags().GetBool("quiet")
 
-		if err != nil && verbose {
+		if err != nil && !quiet {
 			util.Failed("Failed to execute command `%s`: %v", opts.Cmd, err)
 		}
 	},
@@ -103,7 +103,7 @@ func init() {
 	_ = DdevExecCmd.RegisterFlagCompletionFunc("service", ddevapp.GetServiceNamesFunc(true))
 	DdevExecCmd.Flags().StringVarP(&execDirArg, "dir", "d", "", "Defines the execution directory within the container")
 	DdevExecCmd.Flags().Bool("raw", true, "Use raw exec (do not interpret with Bash inside container)")
-	DdevExecCmd.Flags().BoolP("verbose", "v", false, "Add DDEV default error output")
+	DdevExecCmd.Flags().BoolP("quiet", "q", false, "Disables DDEV default error output")
 	// This requires flags for exec to be specified prior to any arguments, allowing for
 	// flags to be ignored by cobra for commands that are to be executed in a container.
 	DdevExecCmd.Flags().SetInterspersed(false)

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -67,8 +67,9 @@ ddev exec --raw -- ls -lR`,
 		}
 
 		_, _, err = app.Exec(opts)
+		verbose, _ := cmd.Flags().GetBool("verbose")
 
-		if err != nil {
+		if err != nil && verbose {
 			util.Failed("Failed to execute command `%s`: %v", opts.Cmd, err)
 		}
 	},
@@ -102,6 +103,7 @@ func init() {
 	_ = DdevExecCmd.RegisterFlagCompletionFunc("service", ddevapp.GetServiceNamesFunc(true))
 	DdevExecCmd.Flags().StringVarP(&execDirArg, "dir", "d", "", "Defines the execution directory within the container")
 	DdevExecCmd.Flags().Bool("raw", true, "Use raw exec (do not interpret with Bash inside container)")
+	DdevExecCmd.Flags().BoolP("verbose", "v", false, "Add DDEV default error output")
 	// This requires flags for exec to be specified prior to any arguments, allowing for
 	// flags to be ignored by cobra for commands that are to be executed in a container.
 	DdevExecCmd.Flags().SetInterspersed(false)

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -69,8 +69,12 @@ ddev exec --raw -- ls -lR`,
 		_, _, err = app.Exec(opts)
 		quiet, _ := cmd.Flags().GetBool("quiet")
 
-		if err != nil && !quiet {
-			util.Failed("Failed to execute command `%s`: %v", opts.Cmd, err)
+		if err != nil {
+			if !quiet {
+				util.Failed("Failed to execute command `%s`: %v", opts.Cmd, err)
+			} else {
+				os.Exit(1)
+			}
 		}
 	},
 }
@@ -99,11 +103,11 @@ func quoteArgs(args []string) string {
 }
 
 func init() {
-	DdevExecCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Defines the service to connect to. [e.g. web, db]")
+	DdevExecCmd.Flags().StringVarP(&serviceType, "service", "s", "web", "Define the service to connect to. [e.g. web, db]")
 	_ = DdevExecCmd.RegisterFlagCompletionFunc("service", ddevapp.GetServiceNamesFunc(true))
-	DdevExecCmd.Flags().StringVarP(&execDirArg, "dir", "d", "", "Defines the execution directory within the container")
+	DdevExecCmd.Flags().StringVarP(&execDirArg, "dir", "d", "", "Define the execution directory within the container")
 	DdevExecCmd.Flags().Bool("raw", true, "Use raw exec (do not interpret with Bash inside container)")
-	DdevExecCmd.Flags().BoolP("quiet", "q", false, "Disables DDEV default error output")
+	DdevExecCmd.Flags().BoolP("quiet", "q", false, "Suppress detailed error output")
 	// This requires flags for exec to be specified prior to any arguments, allowing for
 	// flags to be ignored by cobra for commands that are to be executed in a container.
 	DdevExecCmd.Flags().SetInterspersed(false)

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -756,9 +756,10 @@ To run your command in a different service container, run `ddev exec --service <
 
 Flags:
 
-* `--dir`, `-d`: Defines the execution directory within the container.
+* `--dir`, `-d`: Define the execution directory within the container.
 * `--raw`: Use raw exec (do not interpret with Bash inside container). (default `true`)
-* `--service`, `-s`: Defines the service to connect to. (e.g. `web`, `db`) (default `"web"`)
+* `--service`, `-s`: Define the service to connect to. (e.g. `web`, `db`) (default `"web"`)
+* `--quiet`, `-q`: Suppress detailed error message.
 
 Example:
 
@@ -771,6 +772,10 @@ ddev exec --dir /var/www/html/vendor ls
 
 # Output a long, recursive list of the files in the web container
 ddev exec --raw -- ls -lR
+
+# Suppress detailed error message: 
+# "Failed to execute command `exit 1`: exit status 1"
+ddev exec -q "exit 1"
 ```
 
 ## `export-db`


### PR DESCRIPTION
## Issue

- #3518

DDEV adds by default an command line text `Failed to execute command  ...` to stderr.

## How This PR Solves The Issue

- Returns the exit code from the subcommand in `ddev exec`
- Adds a flag to suppress  `Failed to execute command  ...` with a command line flag for command `ddev exec`.

## Manual Testing Instructions

Usual output:
```
$ ddev exec "echo stdout; echo >&2 stderr; exit 42"
stdout
stderr

Failed to execute command `echo stdout; echo >&2 stderr; exit 42`: exit status 42

$ echo $?
42
```

Using quiet:

```
$ ddev exec -q "echo stdout; echo >&2 stderr; exit 42"
stdout
stderr

$ echo $?
42
```

---

Previously, this logic could be used to suppress the error message:

```
$ ddev exec "echo stdout; echo >&2 stderr; exit 42" 2>/dev/null
stdout
stderr
```

## Automated Testing Overview

## Release/Deployment Notes

