### PR TITLE
test: remove `TestCmdAddon` leftovers in `~/.ddev`

### DIFF
--- a/cmd/ddev/cmd/addon_test.go
+++ b/cmd/ddev/cmd/addon_test.go
@@ -38,6 +38,8 @@ func TestCmdAddon(t *testing.T) {
 		err = os.Chdir(origDir)
 		assert.NoError(err)
 		_ = os.RemoveAll(filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/web/global-touched"))
+		_ = os.RemoveAll(filepath.Join(globalconfig.GetGlobalDdevDir(), "file-with-no-ddev-generated.txt"))
+		_ = os.RemoveAll(filepath.Join(globalconfig.GetGlobalDdevDir(), "globalextras"))
 	})
 
 	// Make sure 'ddev add-on list' works first


### PR DESCRIPTION
## The Issue

I noticed some files in my `~/.ddev` from 2023. Turns out I ran `TestCmdAddon` back then, and it left some leftovers.

## How This PR Solves The Issue

Removes them.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
