### PR TITLE
feat: display user-defined `ssh-auth-compose.*.yaml` on `ddev start`

### DIFF
--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -159,6 +159,9 @@ Again, these files are mostly regenerated on every `ddev start` so it’s best t
 `.ssh-auth-compose.yaml`
 : The base docker-compose directive used in generating `.ssh-auth-compose-full.yaml`.
 
+`ssh-auth-compose.*.yaml`
+: `docker-compose` files with the name `ssh-auth-compose.*.yaml` can be used to override stanzas in the `.ssh-auth-compose.yaml` file.
+
 `.sshimageBuild`
 : Directory used for storing DDEV’s generated `Dockerfile` used in building the SSH agent image.
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -639,6 +639,14 @@ func (app *DdevApp) CheckCustomConfig() {
 		customConfig = true
 	}
 
+	sshAuthComposeFiles, err := filepath.Glob(filepath.Join(globalconfig.GetGlobalDdevDir(), "ssh-auth-compose.*.yaml"))
+	util.CheckErr(err)
+	if len(sshAuthComposeFiles) > 0 {
+		printableFiles, _ := util.ArrayToReadableOutput(sshAuthComposeFiles)
+		util.Warning("Using custom global ssh-auth-compose configuration (use `docker logs ddev-ssh-agent` for troubleshooting): %v", printableFiles)
+		customConfig = true
+	}
+
 	traefikGlobalConfigPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "traefik")
 	if _, err := os.Stat(traefikGlobalConfigPath); err == nil {
 		traefikGlobalFiles, err := filepath.Glob(filepath.Join(traefikGlobalConfigPath, "static_config.*.yaml"))


### PR DESCRIPTION
## The Issue

- Similar to #7355, we don't show any customizations, and our docs don't mention them.

## How This PR Solves The Issue

- Adds a message about it on `ddev start`.
- Updates the docs.

## Manual Testing Instructions

Review https://ddev--7388.org.readthedocs.build/en/7388/users/usage/architecture/#hidden-global-files

```
$ cat <<'EOF' > ~/.ddev/ssh-auth-compose.test.yaml
services:
  ddev-ssh-agent:
    environment:
      - TEST=foobar
EOF

$ ddev start
...
Using custom global ssh-auth-compose configuration (use `docker logs ddev-ssh-agent` for troubleshooting):
  - /home/stas/.ddev/ssh-auth-compose.test.yaml
...

$ docker exec -it ddev-ssh-agent bash -c 'echo $TEST'
foobar
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
