### PR TITLE
test: use `main` for  setup-homebrew action instead of `master`

### DIFF
--- a/.github/workflows/colima-tests.yml
+++ b/.github/workflows/colima-tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - run: echo "/usr/local/opt/mysql-client/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Setup tmate session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Install Docker and deps
         run: ./.github/workflows/linux-setup.sh

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -46,7 +46,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Install build tools
         run: ./.github/workflows/linux-build-setup.sh

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Install Docker and deps (Linux)
         run: ./.github/workflows/linux-setup.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Remove unnecessary items on disk
         run: |


### PR DESCRIPTION
Homebrew recently updated the default branch from `master` to `main` for homebrew/actions repo, so this PR updates the default branch refs in here.