### PR TITLE
fix: make DdevProjectConfig include overrides, fixes #7154

### DIFF
--- a/cmd/ddev/cmd/addon-get.go
+++ b/cmd/ddev/cmd/addon-get.go
@@ -169,11 +169,20 @@ ddev add-on get /path/to/tarball.tar.gz
 				util.Warning("Unable to import yaml file %s: %v", fullpath, err)
 			}
 		}
-		for k, v := range map[string]string{"DdevGlobalConfig": globalconfig.GetGlobalConfigPath(), "DdevProjectConfig": app.GetConfigPath("config.yaml")} {
-			yamlMap[k], err = util.YamlFileToMap(v)
-			if err != nil {
-				util.Warning("Unable to read file %s", v)
-			}
+
+		yamlMap["DdevGlobalConfig"], err = util.YamlFileToMap(globalconfig.GetGlobalConfigPath())
+		if err != nil {
+			util.Warning("Unable to read file %s: %v", globalconfig.GetGlobalConfigPath(), err)
+		}
+
+		// Get project config with overrides
+		var projectConfigMap map[string]interface{}
+		if b, err := yaml.Marshal(app); err != nil {
+			util.Warning("Unable to marshal app: %v", err)
+		} else if err = yaml.Unmarshal(b, &projectConfigMap); err != nil {
+			util.Warning("Unable to unmarshal app: %v", err)
+		} else {
+			yamlMap["DdevProjectConfig"] = projectConfigMap
 		}
 
 		dict, err := util.YamlToDict(yamlMap)


### PR DESCRIPTION
## The Issue

- #7154

This bug may not be important, if we change the add-on logic (see #7316), but the fix is quick and shouldn't affect anything.

## How This PR Solves The Issue

Marshals and unmarshals the app to get a complete configuration.

## Manual Testing Instructions

```
$ ddev config --web-environment="TEST=foo"

$ cat <<'EOF' > .ddev/config.db-php.yaml
php_version: "8.4"
database:
    type: mysql
    version: "8.0"
EOF

$ cat <<'EOF' > .ddev/config.override.yaml
override_config: true
web_environment:
    - TEST=bar
EOF

$ cat <<'EOF' > install.yaml
name: test
pre_install_actions:
  - |
    echo "{{ range $k, $v := .DdevProjectConfig }}{{ $k }}: {{ $v }}
    {{ end }}"
EOF

$ ddev add-on get .
```

Compare the output for `ddev add-on get .` to see the difference in `DdevProjectConfig`:

DDEV HEAD:

```yaml
additional_fqdns: []
additional_hostnames: []
composer_version: 2
corepack_enable: false
database: map[type:mariadb version:10.11]
docroot: 
name: test
php_version: 8.3
type: php
use_dns_when_possible: true
web_environment: [TEST=foo]
webserver_type: nginx-fpm
xdebug_enabled: false
```

This PR:

```yaml
additional_fqdns: []
additional_hostnames: []
composer_version: 2
corepack_enable: false
database: map[type:mysql version:8.0]
default_container_timeout: 120
docroot: 
name: test
nodejs_version: 22
php_version: 8.4
project_tld: ddev.site
type: php
use_dns_when_possible: true
web_environment: [TEST=bar]
webimage: ddev/ddev-webserver:20250612_stasadev_rebuild_images
webserver_type: nginx-fpm
xdebug_enabled: false
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
