### PR TITLE
fix: treat argument as literal in `ddevcd` despite leading dash

### DIFF
--- a/cmd/ddev/cmd/debug-cd.go
+++ b/cmd/ddev/cmd/debug-cd.go
@@ -55,7 +55,7 @@ var DebugCdCmd = &cobra.Command{
 			if len(args) != 0 {
 				util.Failed("The provided flag does not take any arguments")
 			}
-			projects, _ := cmd.ValidArgsFunction(cmd, args, "")
+			projects, _ := cmd.ValidArgsFunction(cmd, nil, "")
 			output.UserOut.Println(strings.Join(projects, "\n"))
 			return
 		}
@@ -68,7 +68,8 @@ var DebugCdCmd = &cobra.Command{
 			ddevapp.RunValidateConfig = false
 			app, err := ddevapp.GetActiveApp(projectName)
 			if err != nil {
-				util.Failed("Failed to find path for project: %v", err)
+				projects, _ := cmd.ValidArgsFunction(cmd, nil, "")
+				util.Failed("Usage: 'ddevcd project-name' where project name matches one of: %s", strings.Join(projects, ", "))
 			}
 			ddevapp.RunValidateConfig = originalRunValidateConfig
 			output.UserOut.Println(app.AppRoot)

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.fish
@@ -8,7 +8,7 @@
 # "ddevcd project-name" to cd into the project directory.
 
 function ddevcd
-  cd (DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd "$argv[1]" --get-approot)
+  cd (DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd --get-approot -- "$argv[1]")
 end
 
 function __ddevcd_autocomplete

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.sh
@@ -6,7 +6,7 @@
 # "ddevcd project-name" to cd into the project directory.
 
 ddevcd() {
-  cd "$(DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd "$1" --get-approot)"
+  cd "$(DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd --get-approot -- "$1")"
 }
 
 _ddevcd_autocomplete() {

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.zsh
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/shells/ddev.zsh
@@ -6,7 +6,7 @@
 # "ddevcd project-name" to cd into the project directory.
 
 ddevcd() {
-  cd "$(DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd "$1" --get-approot)"
+  cd "$(DDEV_VERBOSE=false DDEV_DEBUG=false ddev debug cd --get-approot -- "$1")"
 }
 
 _ddevcd_autocomplete() {


### PR DESCRIPTION
## The Issue

@rfay noticed this:

```
$ ddevcd -h
ddevcd:cd:1: no such file or directory: To enable the 'ddevcd' function, source the ddev.sh script from your rc-script.\n\nFor bash:\n\nprintf '\n[ -f "/home/stas/.ddev/commands/host/shells/ddev.sh" ] && source "/home/stas/.ddev/commands/host/shells/ddev.sh"\n' >> ~/.bashrc\n\nFor zsh:\n\nprintf '\n[ -f "/home/stas/.ddev/commands/host/shells/ddev.zsh" ] && source "/home/stas/.ddev/commands/host/shells/ddev.zsh"\n' >> ~/.zshrc\n\nFor fish:\n\nprintf '\n[ -f "/home/stas/.ddev/commands/host/shells/ddev.fish" ] && source "/home/stas/.ddev/commands/host/shells/ddev.fish"\n' >> ~/.config/fish/config.fish\n\nRestart your shell, and use 'ddevcd project-name'.\n\nUsage:\n  ddev debug cd [flags]\n\nExamples:\n  ddev debug cd\n  ddevcd project-name\n\n\nFlags:\n  -h, --help   help for cd\n\nGlobal Flags:\n  -j, --json-output   If true, user-oriented output will be in JSON format.\n      --skip-hooks    If true, any hook normally run by the command will be skipped.
```

## How This PR Solves The Issue

- Treats everything passed to the `ddevcd` function as literal.
- Improves error message

## Manual Testing Instructions

```
$ ddevcd -h
Usage: 'ddevcd project-name' where project name matches one of: d10, d11, laravel-test
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
