### PR TITLE
fix: make xdg-utils optional, use explorer.exe on WSL2 [skip buildkite]

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -344,10 +344,11 @@ nfpms:
     dst:  /usr/share/zsh/vendor-completions/_ddev
     file_info:
       mode: 0644
+  recommends:
+    - xdg-utils
   suggests:
     - bash-completion
     - zsh-completions
-    - xdg-utils
   overrides:
     deb:
       dependencies:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -347,17 +347,16 @@ nfpms:
   suggests:
     - bash-completion
     - zsh-completions
+    - xdg-utils
   overrides:
     deb:
       dependencies:
       - libnss3-tools
-      - xdg-utils
       replaces:
       - mkcert
     rpm:
       dependencies:
       - nss-tools
-      - xdg-utils
 
 snapshot:
   version_template: '{{ .Version }}-{{.ShortCommit}}'

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -63,7 +63,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     # Update package information and install DDEV
     sudo sh -c 'echo ""'
-    sudo apt-get update && sudo apt-get install -y ddev
+    sudo apt-get update && sudo apt-get install --install-suggests -y ddev
 
     # One-time initialization of mkcert
     mkcert -install
@@ -96,7 +96,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     # Install DDEV
     sudo sh -c 'echo ""'
-    sudo dnf install --refresh ddev
+    sudo dnf install --refresh ddev xdg-utils
 
     # One-time initialization of mkcert
     mkcert -install

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -63,7 +63,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     # Update package information and install DDEV
     sudo sh -c 'echo ""'
-    sudo apt-get update && sudo apt-get install --install-suggests -y ddev
+    sudo apt-get update && sudo apt-get install -y ddev
 
     # One-time initialization of mkcert
     mkcert -install
@@ -284,7 +284,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         sudo install -m 0755 -d /etc/apt/keyrings
         curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/ddev.gpg > /dev/null
         echo "deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
-        sudo apt-get update && sudo apt-get install -y ddev
+        sudo apt-get update && sudo apt-get install --no-install-recommends -y ddev
         ```
 
     12. In WSL2, run `mkcert -install`.

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -96,7 +96,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     # Install DDEV
     sudo sh -c 'echo ""'
-    sudo dnf install --refresh ddev xdg-utils
+    sudo dnf install --refresh ddev
 
     # One-time initialization of mkcert
     mkcert -install

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -112,8 +112,11 @@ case $OSTYPE in
   linux-gnu)
     if [[ ! -z "${GITPOD_INSTANCE_ID}" ]]; then
         gp preview ${FULLURL}
+    elif command -v explorer.exe; then explorer.exe ${FULLURL};
+    elif command -v xdg-open; then xdg-open ${FULLURL};
     else
-        xdg-open ${FULLURL}
+        echo "No technique found to open URL: ${FULLURL}; please install xdg-utils."
+        exit 1
     fi
     ;;
   "darwin"*)

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -112,8 +112,8 @@ case $OSTYPE in
   linux-gnu)
     if [[ ! -z "${GITPOD_INSTANCE_ID}" ]]; then
         gp preview ${FULLURL}
-    elif command -v explorer.exe; then explorer.exe ${FULLURL};
-    elif command -v xdg-open; then xdg-open ${FULLURL};
+    elif command -v explorer.exe >/dev/null; then explorer.exe ${FULLURL} || true;
+    elif command -v xdg-open >/dev/null; then xdg-open ${FULLURL};
     else
         echo "No technique found to open URL: ${FULLURL}; please install xdg-utils."
         exit 1

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -113,7 +113,8 @@ $env:CAROOT = & $mkcertPath -CAROOT
 wsl -u root -e bash -c "apt-get update && apt-get install -y curl"
 wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/ddev.gpg > /dev/null"
 wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
-wsl -u root -e bash -c "apt-get update && apt-get install -y ddev wslu"
+wsl -u root -e bash -c "apt-get update && apt-get install -y wslu"
+wsl -u root -e bash -c "apt-get install -y --no-install-recommends ddev"
 wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
 
 

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -116,7 +116,8 @@ wsl -u root -e bash -c 'echo deb [arch=$(dpkg --print-architecture) signed-by=/e
 
 wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/ddev.gpg > /dev/null"
 wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
-wsl -u root -e bash -c "apt-get update && apt-get install -y ddev docker-ce docker-ce-cli containerd.io wslu"
+wsl -u root -e bash -c "apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io wslu"
+wsl -u root -e bash -c "apt-get install -y --no-install-recommends ddev"
 wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
 wsl bash -c 'sudo usermod -aG docker $USER'
 


### PR DESCRIPTION
## The Issue

Our use of xdg-open works fine in Debian/Ubuntu/Fedora, but on WSL2 it adds a huge dependency chain with all of Linux's gui features. It's also sometimes not reliable on WSL2 (can't find default browser, etc)

## How This PR Solves The Issue

* Make xdg-utils a suggested dependency (and don't add it in WSL2)
* Add `--install-suggests` in docs for regular Linux install (or equivalent dnf for Fedora/etc) (but not on WSL2)
* In `ddev launch` prefer explorer.exe for launching instead of xdg-open

## Manual Testing Instructions

- [ ] Test using (current PR apt install); /etc/apt/sources.list.d/ddev.list can have this
```
deb [trusted=yes] https://apt.fury.io/rfay/ * *
```
- [ ] Verify smaller number of packages installed
- [ ] Install fresh WSL2 using that, use `ddev launch`
- [ ] Install fresh non-WSL2 Debian/Ubuntu, use `ddev launch`, verify it works

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

- [ ] Update "Get Started" on ddev.com after this goes in and a new release is made.

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
