### PR TITLE
test: use bats-core/bats-core homebrew tap instead of kaos

### DIFF
--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -27,7 +27,9 @@ echo "capath=/etc/ssl/certs/" >>~/.curlrc
 
 source ~/.bashrc
 
-for item in bats-core ddev/ddev/ddev docker-compose ghr golangci-lint kaos/shell/bats-assert kaos/shell/bats-file; do
+brew tap bats-core/bats-core >/dev/null
+brew tap ddev/ddev >/dev/null
+for item in bats-core ddev docker-compose ghr golangci-lint bats-assert bats-file; do
     brew install $item >/dev/null || brew upgrade $item >/dev/null
 done
 

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 # Requires bats-assert and bats-support
-# brew tap kaos/shell &&
+# brew tap bats-core/bats-core &&
 # brew install bats-core bats-assert bats-support
 setup() {
   load setup.sh

--- a/containers/ddev-webserver/tests/ddev-webserver/project_type.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/project_type.bats
@@ -4,7 +4,7 @@
 # bats tests
 
 # Requires bats-assert and bats-support
-# brew tap kaos/shell &&
+# brew tap bats-core/bats-core &&
 # brew install bats-core bats-assert bats-support jq mkcert yq
 setup() {
   load setup.sh


### PR DESCRIPTION

## The Issue

Use the official bats-core/bats-core brew tap instead of the kaos one.


