### PR TITLE
ci: use `skip-package-name-checks`, pin `golangci-lint` to v2.2.1, remove `only-new-issues`, for #7415

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -50,9 +50,7 @@ jobs:
       - name: Lint Go Files
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
-          # Check code only for the changed lines for PRs
-          only-new-issues: ${{ github.event_name == 'pull_request' && true || false }}
+          version: v2.2.1
           args: --config=.golangci.yml
 
   check_modules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,13 @@ linters:
         - -QF1003 # Convert if/else-if chain to tagged switch
         - -S1008 # Simplify returning boolean expression
         - -S1023 # Omit redundant control flow
+    revive:
+      rules:
+        - name: var-naming
+          arguments:
+            - []
+            - []
+            - - skip-package-name-checks: true
   exclusions:
     presets:
       - comments

--- a/pkg/config/remoteconfig/state.go
+++ b/pkg/config/remoteconfig/state.go
@@ -1,4 +1,4 @@
-package remoteconfig //nolint:revive
+package remoteconfig
 
 import (
 	"time"

--- a/pkg/config/remoteconfig/types/remote_config_storage.go
+++ b/pkg/config/remoteconfig/types/remote_config_storage.go
@@ -1,4 +1,4 @@
-package types //nolint:revive
+package types
 
 import (
 	"github.com/ddev/ddev/pkg/config/remoteconfig/internal"

--- a/pkg/config/state/types/state.go
+++ b/pkg/config/state/types/state.go
@@ -1,4 +1,4 @@
-package types //nolint:revive
+package types
 
 type StateEntry = interface{}
 type StateEntryKey = string

--- a/pkg/config/state/types/state_storage.go
+++ b/pkg/config/state/types/state_storage.go
@@ -1,4 +1,4 @@
-package types //nolint:revive
+package types
 
 // RawState is used to hold a weak type in-memory representation of the state.
 type RawState = map[string]any

--- a/pkg/config/types/xhprof_mode.go
+++ b/pkg/config/types/xhprof_mode.go
@@ -1,4 +1,4 @@
-package types //nolint:revive
+package types
 
 import (
 	"fmt"

--- a/pkg/globalconfig/types/types.go
+++ b/pkg/globalconfig/types/types.go
@@ -1,4 +1,4 @@
-package types //nolint:revive
+package types
 
 import "github.com/ddev/ddev/pkg/nodeps"
 

--- a/pkg/globalconfig/xhprof_mode.go
+++ b/pkg/globalconfig/xhprof_mode.go
@@ -1,4 +1,4 @@
-package globalconfig //nolint:revive
+package globalconfig
 
 import (
 	"github.com/ddev/ddev/pkg/config/types"

--- a/pkg/util/errcheck.go
+++ b/pkg/util/errcheck.go
@@ -1,4 +1,4 @@
-package util //nolint:revive
+package util
 
 import (
 	"io"


### PR DESCRIPTION
## The Issue

There are some more warnings related to:

- #7415

And @rfay pointed out that behavior added in the PR below is confusing:

- #6954

## How This PR Solves The Issue

- Uses `skip-package-name-checks` to disable this check. It often reports inconsistent results, likely due to caching issues (`golangci-lint cache clean && make golangci-lint`)
- Reverts changes made in #7415 as not needed.
- Removes `only-new-issues`, so full lint checks run on PRs.
- Pins for `golangci-lint` to v2.2.1, which avoids future breakage from upstream changes. This adds some maintenance since we need to bump it manually, but it prevents unexpected linter failures.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
