### PR TITLE
feat: add `NO_COLOR` variable support, fixes #7058

### DIFF
--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -308,7 +308,7 @@ func init() {
 	configGlobalCommand.Flags().Bool("use-letsencrypt", false, "Enables experimental Let's Encrypt integration, 'ddev config global --use-letsencrypt' or 'ddev config global --use-letsencrypt=false'")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("use-letsencrypt", configCompletionFunc([]string{"true", "false"}))
 	configGlobalCommand.Flags().String("letsencrypt-email", "", "Email associated with Let's Encrypt, 'ddev config global --letsencrypt-email=me@example.com'")
-	configGlobalCommand.Flags().Bool("simple-formatting", false, "If true, use simple formatting and no color for tables")
+	configGlobalCommand.Flags().Bool("simple-formatting", false, "If true, use simple formatting for tables and implicitly set 'NO_COLOR=true'")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("simple-formatting", configCompletionFunc([]string{"true", "false"}))
 	configGlobalCommand.Flags().Bool("use-hardened-images", false, "If true, use more secure 'hardened' images for an actual internet deployment")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("use-hardened-images", configCompletionFunc([]string{"true", "false"}))

--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -308,7 +308,7 @@ func init() {
 	configGlobalCommand.Flags().Bool("use-letsencrypt", false, "Enables experimental Let's Encrypt integration, 'ddev config global --use-letsencrypt' or 'ddev config global --use-letsencrypt=false'")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("use-letsencrypt", configCompletionFunc([]string{"true", "false"}))
 	configGlobalCommand.Flags().String("letsencrypt-email", "", "Email associated with Let's Encrypt, 'ddev config global --letsencrypt-email=me@example.com'")
-	configGlobalCommand.Flags().Bool("simple-formatting", false, "If true, use simple formatting for tables and implicitly set 'NO_COLOR=true'")
+	configGlobalCommand.Flags().Bool("simple-formatting", false, "If true, use simple formatting for tables and implicitly set 'NO_COLOR=1'")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("simple-formatting", configCompletionFunc([]string{"true", "false"}))
 	configGlobalCommand.Flags().Bool("use-hardened-images", false, "If true, use more secure 'hardened' images for an actual internet deployment")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("use-hardened-images", configCompletionFunc([]string{"true", "false"}))

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -527,7 +527,7 @@ See the [Troubleshooting](../usage/troubleshooting.md#web-server-ports-already-o
 
 ## `simple_formatting`
 
-Whether to disable most [`ddev list`](../usage/commands.md#list) and [`ddev describe`](../usage/commands.md#describe) table formatting and implicitly set `NO_COLOR=true`.
+Whether to disable most [`ddev list`](../usage/commands.md#list) and [`ddev describe`](../usage/commands.md#describe) table formatting and implicitly set `NO_COLOR=1`.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -527,7 +527,7 @@ See the [Troubleshooting](../usage/troubleshooting.md#web-server-ports-already-o
 
 ## `simple_formatting`
 
-Whether to disable most [`ddev list`](../usage/commands.md#list) and [`ddev describe`](../usage/commands.md#describe) table formatting.
+Whether to disable most [`ddev list`](../usage/commands.md#list) and [`ddev describe`](../usage/commands.md#describe) table formatting and implicitly set `NO_COLOR=true`.
 
 | Type | Default | Usage
 | -- | -- | --

--- a/docs/content/users/extend/in-container-configuration.md
+++ b/docs/content/users/extend/in-container-configuration.md
@@ -31,6 +31,16 @@ Usage examples:
     alias ll="ls -lhA"
     ```
 
+## Using `NO_COLOR` Inside Containers
+
+To set the `NO_COLOR` variable in all containers across all projects, define the `NO_COLOR` environment variable in your shell configuration file (e.g., `~/.bashrc` or `~/.zshrc`), outside of DDEV, for example:
+
+```bash
+export NO_COLOR=true
+```
+
+`NO_COLOR=true` can also be implicitly set using [`simple_formatting`](../configuration/config.md#simple_formatting) option.
+
 ## Using `PAGER` Inside Containers
 
 To set the `PAGER` variable in the `web` and `db` containers across all projects, define the `DDEV_PAGER` environment variable in your shell configuration file (e.g., `~/.bashrc` or `~/.zshrc`), outside of DDEV, for example:

--- a/docs/content/users/extend/in-container-configuration.md
+++ b/docs/content/users/extend/in-container-configuration.md
@@ -36,10 +36,10 @@ Usage examples:
 To set the `NO_COLOR` variable in all containers across all projects, define the `NO_COLOR` environment variable in your shell configuration file (e.g., `~/.bashrc` or `~/.zshrc`), outside of DDEV, for example:
 
 ```bash
-export NO_COLOR=true
+export NO_COLOR=1
 ```
 
-`NO_COLOR=true` can also be implicitly set using [`simple_formatting`](../configuration/config.md#simple_formatting) option.
+`NO_COLOR=1` can also be implicitly set using [`simple_formatting`](../configuration/config.md#simple_formatting) option.
 
 ## Using `PAGER` Inside Containers
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -387,7 +387,7 @@ ddev config global --omit-containers=ddev-ssh-agent
 * `--router-bind-all-interfaces`: Bind host router ports on all interfaces, not only on the localhost network interface.
 * `--router-http-port`: The default router HTTP port for all projects, can be overridden by project configuration (see [default](../configuration/config.md#router_http_port)).
 * `--router-https-port`: The default router HTTPS port for all projects, can be overridden by project configuration (see [default](../configuration/config.md#router_https_port)).
-* `--simple-formatting`: If `true`, use simple formatting and no color for tables.
+* `--simple-formatting`: If `true`, use simple formatting for tables and implicitly set `NO_COLOR=true`.
 * `--table-style`: Table style for `ddev list` and `ddev describe`, possible values are `default`, `bold`, `bright` (see [default](../configuration/config.md#table_style)).
 * `--traefik-monitor-port`: Can be used to change the Traefik monitor port in case of port conflicts, for example `ddev config global --traefik-monitor-port=11999` (see [default](../configuration/config.md#traefik_monitor_port)).
 * `--use-hardened-images`: If `true`, use more secure 'hardened' images for an actual internet deployment.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -387,7 +387,7 @@ ddev config global --omit-containers=ddev-ssh-agent
 * `--router-bind-all-interfaces`: Bind host router ports on all interfaces, not only on the localhost network interface.
 * `--router-http-port`: The default router HTTP port for all projects, can be overridden by project configuration (see [default](../configuration/config.md#router_http_port)).
 * `--router-https-port`: The default router HTTPS port for all projects, can be overridden by project configuration (see [default](../configuration/config.md#router_https_port)).
-* `--simple-formatting`: If `true`, use simple formatting for tables and implicitly set `NO_COLOR=true`.
+* `--simple-formatting`: If `true`, use simple formatting for tables and implicitly set `NO_COLOR=1`.
 * `--table-style`: Table style for `ddev list` and `ddev describe`, possible values are `default`, `bold`, `bright` (see [default](../configuration/config.md#table_style)).
 * `--traefik-monitor-port`: Can be used to change the Traefik monitor port in case of port conflicts, for example `ddev config global --traefik-monitor-port=11999` (see [default](../configuration/config.md#traefik_monitor_port)).
 * `--use-hardened-images`: If `true`, use more secure 'hardened' images for an actual internet deployment.

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"go.yaml.in/yaml/v3"
 	//compose_cli "github.com/compose-spec/compose-go/cli"
@@ -183,6 +184,18 @@ func fixupComposeYaml(yamlStr string, app *DdevApp) (map[string]interface{}, err
 				}
 			}
 		}
+		// Pass NO_COLOR to containers
+		if !output.ColorsEnabled() {
+			if serviceMap["environment"] == nil {
+				serviceMap["environment"] = map[string]interface{}{}
+			}
+			if environmentMap, ok := serviceMap["environment"].(map[string]interface{}); ok {
+				if _, exists := environmentMap["NO_COLOR"]; !exists {
+					environmentMap["NO_COLOR"] = os.Getenv("NO_COLOR")
+				}
+			}
+		}
+
 		// Assign the host_ip for each port if it's not already set.
 		// This is needed for custom-defined user ports. For example:
 		// ports:

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -100,7 +100,7 @@ func New() GlobalConfig {
 	return cfg
 }
 
-// Make sure the global configuration has been initialized
+// EnsureGlobalConfig Make sure the global configuration has been initialized
 func EnsureGlobalConfig() {
 	DdevGlobalConfig = New()
 	DdevProjectList = make(map[string]*ProjectInfo)
@@ -111,6 +111,11 @@ func EnsureGlobalConfig() {
 	err = ReadProjectList()
 	if err != nil {
 		output.UserErr.Fatalf("unable to read global projects list: %v", err)
+	}
+	// Using simple formatting means we don't use colors
+	if DdevGlobalConfig.SimpleFormatting {
+		_ = os.Setenv("NO_COLOR", "1")
+		output.DdevOutputFormatter.DisableColors = !output.ColorsEnabled()
 	}
 }
 

--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -44,7 +44,7 @@ var (
 	}()
 	// DdevOutputFormatter is the specialized formatter for UserOut
 	DdevOutputFormatter = &TextFormatter{
-		// TODO: add DisableColors handler in a different PR
+		DisableColors:    !ColorsEnabled(),
 		DisableTimestamp: true,
 	}
 	// DdevOutputJSONFormatter is the specialized JSON formatter for UserOut
@@ -103,4 +103,10 @@ func ParseBoolFlag(long string, short string) bool {
 		}
 	}
 	return false
+}
+
+// ColorsEnabled returns true if colored output is enabled
+// Implementation from https://no-color.org/
+func ColorsEnabled() bool {
+	return os.Getenv("NO_COLOR") == "" || os.Getenv("NO_COLOR") == "0"
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -312,13 +312,9 @@ func IsBeforeCutoffTime(cutoff string) bool {
 	return false
 }
 
-func DisableColors() {
-	text.DisableColors()
-}
-
 // ColorizeText colorizes text unless SimpleFormatting is turned on
 func ColorizeText(s string, c string) (out string) {
-	if globalconfig.DdevGlobalConfig.SimpleFormatting || output.JSONOutput {
+	if !output.ColorsEnabled() || output.JSONOutput {
 		text.DisableColors()
 	}
 	switch c {


### PR DESCRIPTION
## The Issue

- #7058

See https://no-color.org/

## How This PR Solves The Issue

- Passes `NO_COLOR` from the host to containers.
- Sets `NO_COLOR=1` when `ddev config global --simple-formatting`

## Manual Testing Instructions

Search for `NO_COLOR` in the docs https://ddev--7419.org.readthedocs.build/en/7419/

Should be no colored output here:
```
NO_COLOR=1 ddev start
ddev composer -V
```

Should be no colored output here:
```
ddev config global --simple-formatting
ddev start
ddev composer -V
```

`NO_COLOR` should be set inside the containers:
```
$ ddev exec printenv NO_COLOR
1
$ ddev exec -s db printenv NO_COLOR
1
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

Create a PR here about `NO_COLOR` support in DDEV after v1.24.7 release:

- https://github.com/jcs/no_color