### PR TITLE
build: Use new cooldown to slow dependabot updates [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+    # Don't respond to updates right away
+    cooldown:
+      - default-days: 30


### PR DESCRIPTION

## The Issue

New Dependabot "cooldown" feature.

* https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/
* https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

Slow down dependabot so we don't see too many updates we don't care about.

