### PR TITLE
docs: add blog and add-on registry to navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,7 +150,7 @@ markdown_extensions:
 - smarty
 
 nav:
-  - "Start!":
+  - 'Start!':
     - index.md
     - 'Installing':
       - users/install/index.md
@@ -217,17 +217,19 @@ nav:
       - 'Platform.sh': users/providers/platform.md
       - 'Upsun': users/providers/upsun.md
   - 'Development':
-      - developers/index.md
-      - developers/building-contributing.md
-      - developers/buildkite-testmachine-setup.md
-      - developers/github-selfhosted-setup.md
-      - developers/project-types.md
-      - developers/quickstart-maintenance.md
-      - developers/release-management.md
-      - developers/brand-guide.md
-      - developers/testing-docs.md
-      - developers/writing-style-guide.md
-      - developers/remote-config.md
-      - developers/maintainers.md
-      - developers/network-test-environments.md
-      - developers/secret-management.md
+    - developers/index.md
+    - developers/building-contributing.md
+    - developers/buildkite-testmachine-setup.md
+    - developers/github-selfhosted-setup.md
+    - developers/project-types.md
+    - developers/quickstart-maintenance.md
+    - developers/release-management.md
+    - developers/brand-guide.md
+    - developers/testing-docs.md
+    - developers/writing-style-guide.md
+    - developers/remote-config.md
+    - developers/maintainers.md
+    - developers/network-test-environments.md
+    - developers/secret-management.md
+  - 'Blog': https://ddev.com
+  - 'Add-on Registry': https://addons.ddev.com


### PR DESCRIPTION
## The Issue

From Discord https://discord.com/channels/664580571770388500/1361580318665998426

> There should be an easy and conspicuous way to access https://ddev.com/ from https://ddev.readthedocs.io/

## How This PR Solves The Issue

Adds links for blog and add-on registry to navigation.

## Manual Testing Instructions

https://ddev--7427.org.readthedocs.build/en/7427/

![image](https://github.com/user-attachments/assets/328287e5-aff5-4817-a193-67f4c118b8ad)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
