### PR TITLE
feat: add JSON output to `ddev -v`

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -126,6 +126,14 @@ func init() {
 	// This flag represents the output.JSONOutput variable, and parsed very early in pkg/output/output_setup.go
 	RootCmd.PersistentFlags().BoolP("json-output", "j", false, "If true, user-oriented output will be in JSON format.")
 	RootCmd.PersistentFlags().BoolVarP(&ddevapp.SkipHooks, "skip-hooks", "", false, "If true, any hook normally run by the command will be skipped.")
+
+	// Override Cobra version template for JSON output
+	if output.JSONOutput {
+		userOutFunc := util.CaptureUserOut()
+		output.UserOut.WithField("raw", map[string]string{"version": RootCmd.Version}).Printf("%s version %s", RootCmd.DisplayName(), RootCmd.Version)
+		RootCmd.SetVersionTemplate(userOutFunc())
+	}
+
 	// Determine if Docker is running by getting the version.
 	// This helps to prevent a user from seeing the Cobra error: "Error: unknown command "<custom command>" for ddev"
 	_, err := dockerutil.GetDockerVersion()


### PR DESCRIPTION
## The Issue

There is no JSON output:
```
$ ddev -vj
ddev version v1.24.6
```

## How This PR Solves The Issue

Modifies the version template for JSON.

## Manual Testing Instructions

```
$ ddev -vj 
{"level":"info","msg":"ddev version v1.24.6-47-g8113029ac","raw":{"version":"v1.24.6-47-g8113029ac"},"time":"2025-07-07T13:27:20+03:00"}

$ ddev --version -j | jq -r .raw.version
v1.24.6-47-g8113029ac
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
