### PR TITLE
fix: use `output.UserOut` for JSON output, retry on invalid input in interactive `ddev config`, for #7403

### DIFF
--- a/cmd/ddev/cmd/aliases.go
+++ b/cmd/ddev/cmd/aliases.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/styles"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -40,15 +40,15 @@ var AliasesCmd = &cobra.Command{
 		sort.Strings(sortedCommands)
 
 		// Append rows to the table in sorted order
+		rawOutput := make(map[string][]string, len(sortedCommands))
 		for _, cmdPath := range sortedCommands {
-			t.AppendRows([]table.Row{
-				{cmdPath, strings.Join(commandAliases[cmdPath], ", ")},
-			})
+			t.AppendRow(table.Row{cmdPath, strings.Join(commandAliases[cmdPath], ", ")})
+			rawOutput[cmdPath] = commandAliases[cmdPath]
 		}
 
 		// Render the table
 		t.Render()
-		fmt.Println(out.String())
+		output.UserOut.WithField("raw", rawOutput).Println(out.String())
 	},
 }
 

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -41,7 +41,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 	if runtime.GOOS == "windows" {
 		windowsBashPath := util.FindBashPath()
 		if windowsBashPath == "" {
-			fmt.Println("Unable to find bash.exe in PATH, not loading custom commands")
+			util.Warning("Unable to find bash.exe in PATH, not loading custom commands")
 			return nil
 		}
 	}

--- a/cmd/ddev/cmd/dotenv-get.go
+++ b/cmd/ddev/cmd/dotenv-get.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -80,7 +81,7 @@ ddev dotenv get .ddev/.env.redis --redis-tag`,
 		if val, exists := envMap[envName]; exists {
 			// Show a raw, unescaped value without double quotes.
 			// See https://stackoverflow.com/questions/50054666/golang-not-escape-a-string-variable
-			fmt.Println(strings.Trim(fmt.Sprintf("%#v", val), `"`))
+			output.UserOut.Printf(strings.Trim(fmt.Sprintf("%#v", val), `"`))
 		} else {
 			util.Failed("The environment variable '%s' not found in %s", envName, envFile)
 		}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -387,36 +387,22 @@ func (app *DdevApp) WarnIfConfigReplace() {
 // PromptForConfig goes through a set of prompts to receive user input and generate an Config struct.
 func (app *DdevApp) PromptForConfig() error {
 	app.WarnIfConfigReplace()
-
-	for {
-		err := app.promptForName()
-
-		if err == nil {
-			break
-		}
-
-		output.UserOut.Printf("%v", err)
-	}
-
-	if err := app.docrootPrompt(); err != nil {
+	var err error
+	if err = app.projectNamePrompt(); err != nil {
 		return err
 	}
-
-	err := app.AppTypePrompt()
-	if err != nil {
+	if err = app.docrootPrompt(); err != nil {
 		return err
 	}
-
-	err = app.ConfigFileOverrideAction(false)
-	if err != nil {
+	if err = app.AppTypePrompt(); err != nil {
 		return err
 	}
-
-	err = app.ValidateConfig()
-	if err != nil {
+	if err = app.ConfigFileOverrideAction(false); err != nil {
 		return err
 	}
-
+	if err = app.ValidateConfig(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1568,8 +1554,8 @@ func HasAllowedLocation(app *DdevApp) error {
 	return nil
 }
 
-// Prompt for a project name.
-func (app *DdevApp) promptForName() error {
+// projectNamePrompt Prompt for a project name.
+func (app *DdevApp) projectNamePrompt() error {
 	if app.Name == "" {
 		dir, err := os.Getwd()
 		if err == nil && hostRegex.MatchString(NormalizeProjectName(filepath.Base(dir))) {
@@ -1577,15 +1563,19 @@ func (app *DdevApp) promptForName() error {
 		}
 	}
 
-	name := util.Prompt("Project name", app.Name)
-	if err := ValidateProjectName(name); err != nil {
-		return err
+	for {
+		name := util.Prompt("Project name", app.Name)
+		if err := ValidateProjectName(name); err != nil {
+			output.UserOut.Printf(util.ColorizeText(err.Error(), "yellow"))
+		} else {
+			app.Name = name
+			break
+		}
 	}
-	app.Name = name
 
 	err := app.CheckExistingAppInApproot()
 	if err != nil {
-		util.Failed(err.Error())
+		return err
 	}
 
 	return nil
@@ -1643,7 +1633,7 @@ func DiscoverDefaultDocroot(app *DdevApp) string {
 	return defaultDocroot
 }
 
-// Determine the document root.
+// docrootPrompt Determine the document root.
 func (app *DdevApp) docrootPrompt() error {
 	// Determine the document root.
 	output.UserOut.Printf("\nThe docroot is the directory from which your site is served.\nThis is a relative path from your project root at %s\n", app.AppRoot)
@@ -1657,12 +1647,17 @@ func (app *DdevApp) docrootPrompt() error {
 		docrootPrompt = fmt.Sprintf("%s (project root)", docrootPrompt)
 	}
 
-	fmt.Print(docrootPrompt + ": ")
-	app.Docroot = util.GetQuotedInput(defaultDocroot)
+	for {
+		fmt.Print(docrootPrompt + ": ")
+		app.Docroot = util.GetQuotedInput(defaultDocroot)
 
-	// Ensure that the docroot exists
-	if err := app.CreateDocroot(); err != nil {
-		return fmt.Errorf("unable to create docroot at '%s': %v", app.GetAbsDocroot(false), err)
+		// Ensure that the docroot exists
+		if err := app.CreateDocroot(); err != nil {
+			output.UserOut.Printf(util.ColorizeText(err.Error(), "yellow"))
+		} else {
+			output.UserOut.Println()
+			break
+		}
 	}
 
 	return nil
@@ -1700,7 +1695,7 @@ func (app *DdevApp) AppTypePrompt() error {
 		if IsValidAppType(appType) {
 			break
 		}
-		util.Warning("'%s' is not a valid project type.\n", appType)
+		output.UserOut.Printf(util.ColorizeText(fmt.Sprintf("'%s' is not a valid project type", appType), "yellow"))
 	}
 
 	app.Type = appType

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1692,14 +1692,15 @@ func (app *DdevApp) AppTypePrompt() error {
 		defaultAppType = detectedAppType
 	}
 
-	fmt.Printf(typePrompt, validAppTypes, defaultAppType)
-	appType := strings.ToLower(util.GetInput(defaultAppType))
+	appType := ""
 
-	for !IsValidAppType(appType) {
-		output.UserOut.Errorf("'%s' is not a valid project type. Allowed project types are: %s\n", appType, validAppTypes)
-
-		fmt.Printf(typePrompt, validAppTypes, appType)
-		return fmt.Errorf("invalid project type")
+	for {
+		fmt.Printf(typePrompt, validAppTypes, defaultAppType)
+		appType = strings.ToLower(util.GetInput(defaultAppType))
+		if IsValidAppType(appType) {
+			break
+		}
+		util.Warning("'%s' is not a valid project type.\n", appType)
 	}
 
 	app.Type = appType

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -304,7 +304,7 @@ func TestConfigCommand(t *testing.T) {
 
 		restoreOutput := util.CaptureUserOut()
 		err = app.PromptForConfig()
-		require.Error(t, err, "invalid project type error should have been caught")
+		require.NoError(t, err)
 		out := restoreOutput()
 
 		// Ensure we have expected vales in output.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -733,7 +733,7 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 		if err != nil {
 			if isArchive && extPathPrompt {
 				output.UserOut.Println("You provided an archive. Do you want to extract from a specific path in your archive? You may leave this blank if you wish to use the full archive contents")
-				fmt.Print("Archive extraction path:")
+				fmt.Print("Archive extraction path: ")
 
 				extractPath = util.GetQuotedInput("")
 			} else {

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -281,7 +281,9 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 				break
 			}
 			time.Sleep(1 * time.Second)
-			fmt.Print(".")
+			if !output.JSONOutput {
+				fmt.Print(".")
+			}
 		}
 	}
 	app.DefaultContainerTimeout = origTimeout

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -263,7 +263,7 @@ func FindBashPath() string {
 		// This one could come back with the WSL Bash, in which case we may have some trouble.
 		windowsBashPath, err = osexec.LookPath("bash.exe")
 		if err != nil {
-			fmt.Println("Not loading custom commands; Bash is not in PATH")
+			Warning("Not loading custom commands; Bash is not in PATH")
 			return ""
 		}
 	}


### PR DESCRIPTION
## The Issue

- #7403

## How This PR Solves The Issue

I noticed more places without correct JSON output.

In addition, interactive `ddev config` didn't ask for `docroot` and `type` again, it failed immediately:

This should be a warning, not an error, DDEV should ask for docroot again, like it's done for project name:

```
echo "test_test\n\n/test" | ddev config
```

![before-1](https://github.com/user-attachments/assets/9d59135b-bc1f-4973-9189-e4b6513633ee)

This should be a warning, not an error, DDEV should ask for app type again, like it's done for project name:

```
echo "\ntest\nfoo\n" | ddev config
```

![before-2](https://github.com/user-attachments/assets/de3b6d03-e199-45d5-a228-9ef2ffad02c1)

## Manual Testing Instructions

```bash
# should have JSON output
ddev aliases -j | jq .raw

# type wrong project type, and it should ask for it again
ddev config

ddev dotenv set .ddev/.env.tmp --test=123
# should have JSON output
ddev dotenv get .ddev/.env.tmp --test -j
```

Colored warnings as expected:

```
echo "test_test\n\n/test\ntest\nfoo\nphp\n" | ddev config
```

![after](https://github.com/user-attachments/assets/9c0d4391-a8e2-491f-8d5e-b603107bb27e)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
