### PR TITLE
refactor: centralize table style configuration

### DIFF
--- a/cmd/ddev/cmd/addon-list.go
+++ b/cmd/ddev/cmd/addon-list.go
@@ -59,14 +59,14 @@ ddev add-on list --installed --project my-project
 	},
 }
 
-// ListInstalledAddons() show the add-ons that have a manifest file
+// ListInstalledAddons show the add-ons that have a manifest file
 func ListInstalledAddons(app *ddevapp.DdevApp) {
 	manifests := ddevapp.GetInstalledAddons(app)
 
 	var out bytes.Buffer
 	t := table.NewWriter()
 	t.SetOutputMirror(&out)
-	styles.SetGlobalTableStyle(t)
+	styles.SetGlobalTableStyle(t, false)
 
 	if !globalconfig.DdevGlobalConfig.SimpleFormatting {
 		t.SetColumnConfigs([]table.ColumnConfig{
@@ -104,7 +104,7 @@ func renderRepositoryList(repos []*github.Repository) string {
 
 	t := table.NewWriter()
 	t.SetOutputMirror(&out)
-	styles.SetGlobalTableStyle(t)
+	styles.SetGlobalTableStyle(t, false)
 	//tWidth, _ := nodeps.GetTerminalWidthHeight()
 	t.SetColumnConfigs([]table.ColumnConfig{
 		{

--- a/cmd/ddev/cmd/aliases.go
+++ b/cmd/ddev/cmd/aliases.go
@@ -21,9 +21,7 @@ var AliasesCmd = &cobra.Command{
 		var out bytes.Buffer
 		t := table.NewWriter()
 		t.SetOutputMirror(&out)
-
-		// Use simple output
-		t.SetStyle(styles.GetTableStyle("default"))
+		styles.SetGlobalTableStyle(t, false)
 
 		// Append table header
 		t.AppendHeader(table.Row{"Command", "Aliases"})

--- a/cmd/ddev/cmd/cmd_version.go
+++ b/cmd/ddev/cmd/cmd_version.go
@@ -38,15 +38,7 @@ var versionCmd = &cobra.Command{
 		var out bytes.Buffer
 		t := table.NewWriter()
 		t.SetOutputMirror(&out)
-
-		// Use simplest possible output
-		s := styles.GetTableStyle("default")
-		s.Options.SeparateRows = false
-		s.Options.SeparateFooter = false
-		s.Options.SeparateColumns = false
-		s.Options.SeparateHeader = false
-		s.Options.DrawBorder = false
-		t.SetStyle(s)
+		styles.SetGlobalTableStyle(t, true)
 
 		t.AppendHeader(table.Row{"Item", "Value"})
 

--- a/cmd/ddev/cmd/debug-message-conditions.go
+++ b/cmd/ddev/cmd/debug-message-conditions.go
@@ -16,7 +16,7 @@ var DebugMessageConditionsCmd = &cobra.Command{
 		conditions := remoteconfig.ListConditions()
 
 		t := table.NewWriter()
-		styles.SetGlobalTableStyle(t)
+		styles.SetGlobalTableStyle(t, false)
 
 		t.AppendHeader(table.Row{"Condition", "Description"})
 

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -67,7 +67,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]interface{}) (strin
 
 	t := table.NewWriter()
 	t.SetOutputMirror(&out)
-	styles.SetGlobalTableStyle(t)
+	styles.SetGlobalTableStyle(t, false)
 	tWidth, _ := nodeps.GetTerminalWidthHeight()
 	urlPortWidth := float64(35)
 	infoWidth := 30

--- a/cmd/ddev/cmd/mutagen-version.go
+++ b/cmd/ddev/cmd/mutagen-version.go
@@ -28,15 +28,7 @@ var MutagenVersionCmd = &cobra.Command{
 		var out bytes.Buffer
 		t := table.NewWriter()
 		t.SetOutputMirror(&out)
-
-		// Use simplest possible output
-		s := styles.GetTableStyle("default")
-		s.Options.SeparateRows = false
-		s.Options.SeparateFooter = false
-		s.Options.SeparateColumns = false
-		s.Options.SeparateHeader = false
-		s.Options.DrawBorder = false
-		t.SetStyle(s)
+		styles.SetGlobalTableStyle(t, true)
 
 		t.AppendHeader(table.Row{"Item", "Value"})
 

--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -69,7 +69,7 @@ func listSnapshots(apps []*ddevapp.DdevApp) {
 	var out bytes.Buffer
 	t := table.NewWriter()
 	t.SetOutputMirror(&out)
-	styles.SetGlobalTableStyle(t)
+	styles.SetGlobalTableStyle(t, false)
 
 	if len(apps) > 1 {
 		columns = append(columns, "Project")

--- a/pkg/config/remoteconfig/messages.go
+++ b/pkg/config/remoteconfig/messages.go
@@ -266,7 +266,7 @@ const (
 )
 
 func applyTableStyle(preset preset, writer table.Writer) {
-	styles.SetGlobalTableStyle(writer)
+	styles.SetGlobalTableStyle(writer, true)
 
 	termWidth, _ := nodeps.GetTerminalWidthHeight()
 	util.Debug("termWidth: %d", termWidth)

--- a/pkg/ddevapp/list.go
+++ b/pkg/ddevapp/list.go
@@ -147,7 +147,7 @@ func CreateAppTable(out *bytes.Buffer, wrapTableText bool) table.Writer {
 			},
 		})
 	}
-	styles.SetGlobalTableStyle(t)
+	styles.SetGlobalTableStyle(t, false)
 	t.SetOutputMirror(out)
 	return t
 }

--- a/pkg/styles/tables.go
+++ b/pkg/styles/tables.go
@@ -10,7 +10,7 @@ var DefaultTableStyle = "StyleLight"
 // For descriptions of the various styles, see
 // https://github.com/jedib0t/go-pretty/blob/main/table/style.go
 
-// Get a style by name, returning the default if not found
+// GetTableStyle Get a style by name, returning the default if not found
 func GetTableStyle(name string) (style table.Style) {
 	if _, ok := globalconfig.StyleMap[name]; ok {
 		style = globalconfig.StyleMap[name]
@@ -19,7 +19,7 @@ func GetTableStyle(name string) (style table.Style) {
 	return globalconfig.StyleMap[DefaultTableStyle]
 }
 
-// SimpleFormattingRequired() returns true if we should not be colorizing/styling text
+// SimpleFormattingRequired returns true if we should not be colorizing/styling text
 func SimpleFormattingRequired() bool {
 	if globalconfig.DdevGlobalConfig.SimpleFormatting {
 		return true
@@ -28,10 +28,10 @@ func SimpleFormattingRequired() bool {
 }
 
 // SetGlobalTableStyle sets the table style to the globally configured style
-func SetGlobalTableStyle(writer table.Writer) {
+func SetGlobalTableStyle(writer table.Writer, useSimpleFormatting bool) {
 	styleName := globalconfig.GetTableStyle()
 	style := GetTableStyle(styleName)
-	if SimpleFormattingRequired() {
+	if useSimpleFormatting || SimpleFormattingRequired() {
 		style = GetTableStyle("default")
 		style.Options.SeparateRows = false
 		style.Options.SeparateFooter = false


### PR DESCRIPTION
## The Issue

We have this code block used in several places:

```go
style = GetTableStyle("default")
style.Options.SeparateRows = false
style.Options.SeparateFooter = false
style.Options.SeparateColumns = false
style.Options.SeparateHeader = false
style.Options.DrawBorder = false
```

But this configuration is already available in `styles.SetGlobalTableStyle()`. We don't need to copy-paste it everywhere.

## How This PR Solves The Issue

Adds `useSimpleFormatting` flag to `styles.SetGlobalTableStyle()`.

## Manual Testing Instructions

Should have the same simple formatting *without* borders:
```
ddev version
ddev mutagen version
```
Should have the same formatting *with* borders:
```
ddev list
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
