### PR TITLE
fix: Include ddev-hostname in main build zipballs, fixes #7420

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -296,27 +296,27 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ddev-macos-amd64
-          path: .gotmp/bin/darwin_amd64/ddev
+          path: .gotmp/bin/darwin_amd64/ddev*
       - name: Upload macos-arm64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-macos-arm64
-          path: .gotmp/bin/darwin_arm64/ddev
+          path: .gotmp/bin/darwin_arm64/ddev*
       - name: Upload linux-arm64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-linux-arm64
-          path: .gotmp/bin/linux_arm64/ddev
+          path: .gotmp/bin/linux_arm64/ddev*
       - name: Upload linux-amd64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-linux-amd64
-          path: .gotmp/bin/linux_amd64/ddev
+          path: .gotmp/bin/linux_amd64/ddev*
       - name: Upload windows-amd64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-amd64
-          path: .gotmp/bin/windows_amd64/ddev.exe
+          path: .gotmp/bin/windows_amd64/ddev*.exe
 
       - name: Upload windows_amd64 installer
         uses: actions/upload-artifact@v4
@@ -327,7 +327,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-arm64
-          path: .gotmp/bin/windows_arm64/ddev.exe
+          path: .gotmp/bin/windows_arm64/ddev*.exe
       - name: Upload windows_arm64 installer
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -296,43 +296,55 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ddev-macos-amd64
-          path: .gotmp/bin/darwin_amd64/ddev*
+          path: |
+            .gotmp/bin/darwin_amd64/ddev
+            .gotmp/bin/darwin_amd64/ddev-hostname
       - name: Upload macos-arm64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-macos-arm64
-          path: .gotmp/bin/darwin_arm64/ddev*
+          path: |
+            .gotmp/bin/darwin_arm64/ddev
+            .gotmp/bin/darwin_arm64/ddev-hostname
       - name: Upload linux-arm64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-linux-arm64
-          path: .gotmp/bin/linux_arm64/ddev*
+          path: |
+            .gotmp/bin/linux_arm64/ddev
+            .gotmp/bin/linux_arm64/ddev-hostname
       - name: Upload linux-amd64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-linux-amd64
-          path: .gotmp/bin/linux_amd64/ddev*
+          path: |
+            .gotmp/bin/linux_amd64/ddev
+            .gotmp/bin/linux_amd64/ddev-hostname
       - name: Upload windows-amd64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-amd64
-          path: .gotmp/bin/windows_amd64/ddev*.exe
+          path: |
+            .gotmp/bin/windows_amd64/ddev.exe
+            .gotmp/bin/windows_amd64/ddev-hostname.exe
 
       - name: Upload windows_amd64 installer
         uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-amd64-installer
-          path: .gotmp/bin/windows_amd64/ddev_windows_amd64_installer*.exe
+          path: .gotmp/bin/windows_amd64/ddev_windows_amd64_installer.exe
       - name: Upload windows-arm64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-arm64
-          path: .gotmp/bin/windows_arm64/ddev*.exe
+          path: |
+            .gotmp/bin/windows_arm64/ddev.exe
+            .gotmp/bin/windows_arm64/ddev-hostname.exe
       - name: Upload windows_arm64 installer
         uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-arm64-installer
-          path: .gotmp/bin/windows_arm64/ddev_windows_arm64_installer*.exe
+          path: .gotmp/bin/windows_arm64/ddev_windows_arm64_installer.exe
 
       - name: Show github.ref
         run: echo ${{ github.ref }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -75,39 +75,51 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ddev-macos-amd64
-          path: .gotmp/bin/darwin_amd64/ddev*
+          path: |
+            .gotmp/bin/darwin_amd64/ddev
+            .gotmp/bin/darwin_amd64/ddev-hostname
       - name: Upload macos-arm64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-macos-arm64
-          path: .gotmp/bin/darwin_arm64/ddev*
+          path: |
+            .gotmp/bin/darwin_arm64/ddev
+            .gotmp/bin/darwin_arm64/ddev-hostname
       - name: Upload linux-arm64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-linux-arm64
-          path: .gotmp/bin/linux_arm64/ddev*
+          path: |
+            .gotmp/bin/linux_arm64/ddev
+            .gotmp/bin/linux_arm64/ddev-hostname
       - name: Upload linux-amd64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-linux-amd64
-          path: .gotmp/bin/linux_amd64/ddev*
+          path: |
+            .gotmp/bin/linux_amd64/ddev
+            .gotmp/bin/linux_amd64/ddev-hostname
       - name: Upload windows-amd64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-amd64
-          path: .gotmp/bin/windows_amd64/ddev*
+          path: |
+            .gotmp/bin/windows_amd64/ddev.exe
+            .gotmp/bin/windows_amd64/ddev-hostname.exe
       - name: Upload windows_amd64 installer
         uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-amd64-installer
-          path: .gotmp/bin/windows_amd64/ddev_windows_amd64_installer*.exe
+          path: .gotmp/bin/windows_amd64/ddev_windows_amd64_installer.exe
       - name: Upload windows-arm64 binary
         uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-arm64
-          path: .gotmp/bin/windows_arm64/ddev*
+          path: |
+            .gotmp/bin/windows_arm64/ddev.exe
+            .gotmp/bin/windows_arm64/ddev-hostname.exe
       - name: Upload windows_arm64 installer
         uses: actions/upload-artifact@v4
         with:
           name: ddev-windows-arm64-installer
-          path: .gotmp/bin/windows_arm64/ddev_windows_arm64_installer*.exe
+          path: .gotmp/bin/windows_arm64/ddev_windows_arm64_installer.exe


### PR DESCRIPTION

## The Issue

- #7420 

The upstream/main tarballs (done on every commit to main) didn't have ddev-hostname in them.

## How This PR Solves The Issue

Add it, same as in PR build.

## Manual Testing Instructions

I'll pull this into main on ddev-test and we can see what happens.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
