### PR TITLE
fix: avoid mutating input slice in `cmd.prettyCmd()`

### DIFF
--- a/cmd/ddev/cmd/utils.go
+++ b/cmd/ddev/cmd/utils.go
@@ -148,10 +148,13 @@ func GetUnknownFlags(cmd *cobra.Command) (map[string]string, error) {
 
 // prettyCmd formats the Docker command to be more readable.
 func prettyCmd(cmd []string) string {
+	out := make([]string, len(cmd))
 	for i, arg := range cmd {
 		if strings.Contains(arg, " ") {
-			cmd[i] = `"` + arg + `"`
+			out[i] = `"` + strings.ReplaceAll(arg, `"`, `\"`) + `"`
+		} else {
+			out[i] = arg
 		}
 	}
-	return strings.Join(cmd, " ")
+	return strings.Join(out, " ")
 }


### PR DESCRIPTION
## The Issue

I noticed a flaw in `cmd.prettyCmd()`:

https://go.dev/play/p/EVaaARj1uYn

```
cmd := []string{"bash", "-c", `echo "test"`}
fmt.Printf("original cmd: %v\n", cmd)            # original cmd: [bash -c echo "test"]
fmt.Printf("  pretty cmd: %v\n", prettyCmd(cmd)) #   pretty cmd: bash -c "echo "test""
fmt.Printf("original cmd: %v\n", cmd)            # original cmd: [bash -c "echo "test""] - bad
```

## How This PR Solves The Issue

Makes a copy, escapes double quotes.

## Manual Testing Instructions

https://go.dev/play/p/ZDcMH1TgqE1

```
cmd := []string{"bash", "-c", `echo "test"`}
fmt.Printf("original cmd: %v\n", cmd)            # original cmd: [bash -c echo "test"]
fmt.Printf("  pretty cmd: %v\n", prettyCmd(cmd)) #   pretty cmd: bash -c "echo \"test\""
fmt.Printf("original cmd: %v\n", cmd)            # original cmd: [bash -c echo "test"] - good
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
