### PR TITLE
fix: show errors for custom commands when flags are parsed, fixes #7409

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -367,6 +367,9 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 					originalHelpFunc(command, strings)
 				})
 			}
+		} else {
+			// Disallow unknown flags to avoid silently ignoring errors
+			commandToAdd.FParseErrWhitelist.UnknownFlags = false
 		}
 
 		// Mark custom command


### PR DESCRIPTION
## The Issue

- #7409

Create a `.ddev/commands/host/test-example` or `.ddev/commands/web/test-example` (the important part is `## Flags: []`):

```bash
#!/usr/bin/env bash

## Usage: test-example <input>
## Flags: []
## CanRunGlobally: true

echo $1
```

And run it:

```
ddev test-example '- h'
```

## How This PR Solves The Issue

Shows hidden error.

This PR doesn't really fix the described behavior in the issue, but it's not a DDEV problem.

## Manual Testing Instructions

Before (shows help only, which is confusing):

```bash
$ ddev test-example '- h'
test-example (shell host container command)

Usage:
  ddev test-example <input> [flags]
...
```

After (shows hidden error and help):

```bash
$ ddev test-example '- h'
Error: unknown shorthand flag: ' ' in - h
Usage:
  ddev test-example <input> [flags]
...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
