### PR TITLE
build: bump images to v1.24.7 for release, docker-compose v2.38.2 (`COMPOSE_BAKE=false`), fixes #7383

### DIFF
--- a/containers/ddev-dbserver/README.md
+++ b/containers/ddev-dbserver/README.md
@@ -8,9 +8,9 @@ This container image is part of DDEV, and not typically used stand-alone.
 
 ### Features
 
-* MariaDB 5.5 though current stable
-* MySQL 5.5 through current stable
-* Backup facilities like xtrabackup and mariabackup.
+* MariaDB 5.5 through current LTS
+* MySQL 5.5 through current LTS
+* Backup facilities like `xtrabackup` and `mariadb-backup` (previously called `mariabackup`).
 
 ## Instructions
 

--- a/containers/ddev-php-base/README.md
+++ b/containers/ddev-php-base/README.md
@@ -8,7 +8,7 @@ This container image is part of DDEV, and not typically used stand-alone.
 
 ### Features
 
-* php-fpm and all dependencies for all supported, non-EOL PHP versions.
+* php-fpm and all dependencies for many PHP versions from 5.6 and up (non-EOL versions are bundled by default).
 
 ## Instructions
 

--- a/containers/ddev-php-base/README.md
+++ b/containers/ddev-php-base/README.md
@@ -8,7 +8,7 @@ This container image is part of DDEV, and not typically used stand-alone.
 
 ### Features
 
-* php-fpm and all dependencies for many versions of PHP from PHP 5.6 up.
+* php-fpm and all dependencies for all supported, non-EOL PHP versions.
 
 ## Instructions
 
@@ -23,7 +23,7 @@ See [DDEV docs](https://ddev.readthedocs.io/en/stable/developers/release-managem
 To run the container by itself:
 
 ```bash
-docker run -it --rm ddev/php-base:<tag> bash
+docker run -it --rm ddev/ddev-php-base:<tag> bash
 ```
 
 ## Source:

--- a/containers/ddev-ssh-agent/README.md
+++ b/containers/ddev-ssh-agent/README.md
@@ -1,9 +1,10 @@
 # ddev-ssh-agent Docker Image
 
-originally forked from <https://github.com/nardeas/docker-ssh-agent>
+Originally forked from <https://github.com/nardeas/docker-ssh-agent>
 at `fb6822d0003d1c0a795e183f5d257c2540fa74a4`.
 
 ## Overview
+
 Docker container image for DDEV's ddev-ssh-agent container.
 
 This container image is part of DDEV, and not typically used stand-alone.
@@ -20,21 +21,25 @@ Use [DDEV](https://ddev.readthedocs.io)
 
 See [DDEV docs](https://ddev.readthedocs.io/en/stable/developers/release-management/#pushing-docker-images-with-the-github-actions-workflow)
 
-
 ## Source:
+
 [ddev-ssh-agent](https://github.com/ddev/ddev/tree/main/containers/ddev-ssh-agent)
 
 ## Maintained by:
+
 The [DDEV Docker Maintainers](https://github.com/ddev)
 
 ## Where to get help:
+
 * [DDEV Community Discord](https://ddev.com/s/discord)
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
 
 ## Where to file issues:
+
 https://github.com/ddev/ddev/issues
 
 ## Documentation:
+
 * https://ddev.readthedocs.io/en/stable/users/support/
 * https://ddev.com/
 

--- a/containers/ddev-traefik-router/README.md
+++ b/containers/ddev-traefik-router/README.md
@@ -23,6 +23,7 @@ Use [DDEV](https://ddev.readthedocs.io)
 See [DDEV docs](https://ddev.readthedocs.io/en/stable/developers/release-management/#pushing-docker-images-with-the-github-actions-workflow)
 
 ### Running
+
 To run the container by itself:
 
 ```bash
@@ -64,4 +65,3 @@ View [license information](https://github.com/ddev/ddev/blob/main/LICENSE) for t
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 
 As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.
-

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -2,7 +2,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20250612_stasadev_rebuild_images AS ddev-webserver-base
+FROM ddev/ddev-php-base:v1.24.7 AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/containers/ddev-webserver/README.md
+++ b/containers/ddev-webserver/README.md
@@ -10,7 +10,7 @@ This container image is part of DDEV, and is not typically used stand-alone.
 
 * Nginx
 * Apache
-* All supported, non-EOL PHP versions
+* Many PHP versions (non-EOL versions are bundled by default)
 * [Composer](https://getcomposer.org/) (from the production container)
 * [Drush](http://www.drush.org) (from the production container)
 * [PHIVE](https://phar.io/) (from the production container)

--- a/containers/ddev-webserver/README.md
+++ b/containers/ddev-webserver/README.md
@@ -1,6 +1,7 @@
 # ddev-webserver Docker image
 
 ## Overview
+
 DDEV's ddev-webserver image.
 
 This container image is part of DDEV, and is not typically used stand-alone.
@@ -9,7 +10,7 @@ This container image is part of DDEV, and is not typically used stand-alone.
 
 * Nginx
 * Apache
-* Many PHP versions
+* All supported, non-EOL PHP versions
 * [Composer](https://getcomposer.org/) (from the production container)
 * [Drush](http://www.drush.org) (from the production container)
 * [PHIVE](https://phar.io/) (from the production container)
@@ -18,7 +19,6 @@ This container image is part of DDEV, and is not typically used stand-alone.
 * [mailpit](https://github.com/axllent/mailpit)
 * npm
 * yarn
-
 
 ## Instructions
 
@@ -29,6 +29,7 @@ Use [DDEV](https://ddev.readthedocs.io)
 See [DDEV docs](https://ddev.readthedocs.io/en/stable/developers/release-management/#pushing-docker-images-with-the-github-actions-workflow)
 
 ### Running
+
 To run the container by itself:
 
 ```bash
@@ -36,20 +37,24 @@ docker run -it --rm ddev/ddev-webserver:<tag> bash
 ```
 
 ## Source:
+
 [ddev-webserver](https://github.com/ddev/ddev/tree/main/containers/ddev-webserver)
 
-
 ## Maintained by:
+
 The [DDEV Maintainers](https://github.com/ddev)
 
 ## Where to get help:
+
 * [DDEV Community Discord](https://ddev.com/s/discord)
 * [Stack Overflow](https://stackoverflow.com/questions/tagged/ddev)
 
 ## Where to file issues:
+
 https://github.com/ddev/ddev/issues
 
 ## Documentation:
+
 * https://ddev.readthedocs.io/
 * https://ddev.com/
 

--- a/containers/test-ssh-server/README.md
+++ b/containers/test-ssh-server/README.md
@@ -17,6 +17,7 @@ Use [DDEV](https://ddev.readthedocs.io)
 See [DDEV docs](https://ddev.readthedocs.io/en/stable/developers/release-management/#pushing-docker-images-with-the-github-actions-workflow)
 
 ### Running
+
 To run the container by itself:
 
 ```bash

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2571,6 +2571,17 @@ func (app *DdevApp) DockerEnv() {
 		"IS_GITPOD":                     strconv.FormatBool(nodeps.IsGitpod()),
 		"IS_CODESPACES":                 strconv.FormatBool(nodeps.IsCodespaces()),
 		"IS_WSL2":                       isWSL2,
+		// TODO: Disable bake builder (default since compose v2.37.0) to restore image label
+		// com.docker.compose.project used by `ddev delete` to detect DDEV-created images
+		// See: https://github.com/docker/compose/releases/tag/v2.37.0
+		//
+		// Label can be added via build.labels:
+		// services:
+		//  web:
+		//    build:
+		//      labels:
+		//        com.docker.compose.project: "project-name"
+		"COMPOSE_BAKE": "false",
 	}
 
 	// Set the DDEV_DB_CONTAINER_COMMAND command to empty to prevent docker-compose from complaining normally.

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,25 +11,25 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250612_stasadev_rebuild_images" // Note that this can be overridden by make
+var WebTag = "v1.24.7" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20250716_das-peter_cnf"
+var BaseDBTag = "v1.24.7"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"
 
 // TraefikRouterTag is traefik router tag
-var TraefikRouterTag = "20250612_stasadev_rebuild_images"
+var TraefikRouterTag = "v1.24.7"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.24.6"
+var SSHAuthTag = "v1.24.7"
 
 // BusyboxImage is used a couple of places for a quick-pull
 var BusyboxImage = "busybox:stable"
@@ -38,7 +38,7 @@ var BusyboxImage = "busybox:stable"
 var XhguiImage = "ddev/ddev-xhgui"
 
 // XhguiTag is xhgui tag
-var XhguiTag = "v1.24.6"
+var XhguiTag = "v1.24.7"
 
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities"
@@ -51,4 +51,4 @@ var MutagenVersion = ""
 
 const RequiredMutagenVersion = "0.18.1"
 
-const RequiredDockerComposeVersionDefault = "v2.36.1"
+const RequiredDockerComposeVersionDefault = "v2.38.2"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #7383

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

- Bumps Docker images to v1.24.7
- Updates some Docker Hub README.md
- Bumps `docker-compose` to v2.38.2 (and sets `COMPOSE_BAKE=false` to restore the old behavior we rely on)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
