### PR TITLE
fix: temporarily allow write to `/etc/mysql/conf.d/*` for `db` container restart, fixes #7457

### DIFF
--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -78,6 +78,9 @@ rm -f /tmp/raw_mysql_version.txt
 
 # If we have extra cnf files from user, copy them to where they go.
 if [ -d /mnt/ddev_config/mysql ] && [ "$(echo /mnt/ddev_config/mysql/*.cnf)" != "/mnt/ddev_config/mysql/*.cnf" ] ; then
+  # Ensure re-copying of custom files works on restart. 
+  # Has to ignore errors that arise if no custom files have been copied yet.
+  chmod -f -R u+w /etc/mysql/conf.d/* || true
   cp /mnt/ddev_config/mysql/*.cnf /etc/mysql/conf.d
   # Ignore errors on files such as .gitmanaged
   chmod -f -R ugo-w /etc/mysql/conf.d/*

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "20250612_stasadev_rebuild_images" // Note that this can be overrid
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20250716_das-peter_fix-extra-db-config-breaks-container-restart"
+var BaseDBTag = "20250716_das-peter_cnf"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "20250612_stasadev_rebuild_images" // Note that this can be overrid
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20250213_rfay_mariadb_11.8"
+var BaseDBTag = "20250716_das-peter_fix-extra-db-config-breaks-container-restart"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #7457

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Makes sure that the custom config files are writeable before attempting to write them on startup.

## Manual Testing Instructions

Before:

```
$ ddev stop
$ touch .ddev/mysql/test.cnf
$ ddev start

$ ddev exec -s db ls -la /etc/mysql/conf.d 
total 12
drwxrwxrwx 1 root root  4096 Jul 17 18:59 .
drwxr-xr-x 1 root root  4096 Jul 16 19:58 ..
-rwxrwxrwx 1 root root     0 Jul 16 19:58 .gitmanaged
-r--r--r-- 1 stas mysql    0 Jul 17 18:59 test.cnf

$ ddev debug rebuild -s db --cache
...
Troubleshoot this with these commands:

  - ddev logs -s db
...
$ ddev logs -s db
+ cp /mnt/ddev_config/mysql/test.cnf /etc/mysql/conf.d
cp: cannot create regular file '/etc/mysql/conf.d/test.cnf': Permission denied
```

After:

```
$ ddev stop
$ touch .ddev/mysql/test.cnf

$ cat <<'EOF' > .ddev/docker-compose.db-entrypoint.yaml
services:
  db:
    entrypoint:
      - sh
      - -c
      - |
        cp /docker-entrypoint.sh ~/docker-entrypoint.sh
        sed -i '81i chmod -f -R u+w /etc/mysql/conf.d/* || true' ~/docker-entrypoint.sh
        exec ~/docker-entrypoint.sh
EOF

$ ddev start

$ ddev exec -s db ls -la /etc/mysql/conf.d
total 12
drwxrwxrwx 1 root root  4096 Jul 17 19:01 .
drwxr-xr-x 1 root root  4096 Jul 16 19:58 ..
-rwxrwxrwx 1 root root     0 Jul 16 19:58 .gitmanaged
-r--r--r-- 1 stas mysql    0 Jul 17 19:01 test.cnf

$ ddev debug rebuild -s db --cache

$ ddev exec -s db ls -la /etc/mysql/conf.d 
total 12
drwxrwxrwx 1 root root  4096 Jul 17 19:01 .
drwxr-xr-x 1 root root  4096 Jul 16 19:58 ..
-rwxrwxrwx 1 root root     0 Jul 16 19:58 .gitmanaged
-r--r--r-- 1 stas mysql    0 Jul 17 19:02 test.cnf
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
