### PR TITLE
test: do tests of windows installer, fixes #7440

### DIFF
--- a/.buildkite/test_installer.cmd
+++ b/.buildkite/test_installer.cmd
@@ -1,0 +1,12 @@
+@echo "Running Windows installer tests..."
+
+TASKKILL /T /F /IM mutagen.exe 2>NUL
+
+make testwininstaller
+
+if %ERRORLEVEL% EQU 0 (
+   @echo Successful installer test
+) else (
+   @echo Installer test failed with error code %errorlevel%
+   exit /b %errorlevel%
+)

--- a/.buildkite/windows-installer-test.yml
+++ b/.buildkite/windows-installer-test.yml
@@ -1,0 +1,21 @@
+# Windows installer test pipeline
+# This runs the testwininstaller target exclusively on Windows agents
+# Uses agent tag 'installer-test=true' for agents that can run installer tests
+# Runs exclusively (not concurrent with regular tests)
+
+steps:
+  - command: ".buildkite/test_installer.cmd"
+    label: "Windows Installer Test"
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/
+    agents:
+      - "os=windows"
+      - "installer-test=true"
+      - "architecture=amd64"
+    env:
+      BUILDKITE_CLEAN_CHECKOUT: true
+      DDEV_TEST_USE_REAL_INSTALLER: true
+    timeout_in_minutes: 35
+    parallelism: 1
+    concurrency: 1
+    concurrency_group: "windows-tests"

--- a/.buildkite/windows-rancher-desktop.yml
+++ b/.buildkite/windows-rancher-desktop.yml
@@ -15,4 +15,6 @@
       DDEV_TEST_USE_NFSMOUNT: false
       DOCKER_TYPE: rancher-desktop
     parallelism: 1
+    concurrency: 1
+    concurrency_group: "windows-tests"
 

--- a/.buildkite/windows10dockerforwindows.yml
+++ b/.buildkite/windows10dockerforwindows.yml
@@ -14,3 +14,5 @@
       DDEV_TEST_USE_NFSMOUNT: false
       DOCKER_TYPE: dockerforwindows
     parallelism: 1
+    concurrency: 1
+    concurrency_group: "windows-tests"


### PR DESCRIPTION

## The Issue

- #7440

We would like to have automated tests of the new DDEV windows installer

## How This PR Solves The Issue

Run basic tests (written in go) of the Windows installer (in silent mode)

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
