### PR TITLE
docs: add `.wslconfig` example for mirrored networking mode in WSL2

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -48,10 +48,16 @@ These environments can be extended, version controlled, and shared, so you can t
 
     **WSL2 in Mirrored Mode**
 
-    If you're using Windows WSL2 with "Mirrored" Networking Mode, enable the experimental `hostAddressLoopback=true` setting:
+    If you're using Windows WSL2 with ["mirrored" networking mode](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking), enable the experimental `hostAddressLoopback=true` setting.
+
+    You can do this using the "WSL Settings" app:
+
+    - Networking > Networking mode: set to *Mirrored*
+    - Networking > Host Address Loopback: turn *On*.
+
+    Or by creating/editing the file at `C:\Users\<you>\.wslconfig`:
 
     ```ini
-    # Contents of C:\Users\<you>\.wslconfig
     [wsl2]
     networkingMode=mirrored
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -48,7 +48,16 @@ These environments can be extended, version controlled, and shared, so you can t
 
     **WSL2 in Mirrored Mode**
 
-    If you're using Windows WSL2 with the "Mirrored" Networking Mode, set the experimental `hostAddressLoopback=true` feature.
+    If you're using Windows WSL2 with "Mirrored" Networking Mode, enable the experimental `hostAddressLoopback=true` setting:
+
+    ```ini
+    # Contents of C:\Users\<you>\.wslconfig
+    [wsl2]
+    networkingMode=mirrored
+
+    [experimental]
+    hostAddressLoopback=true
+    ```
 
 === "Traditional Windows"
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -48,7 +48,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
     **WSL2 in Mirrored Mode**
 
-    If you're using Windows WSL2 with ["mirrored" networking mode](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking), enable the experimental `hostAddressLoopback=true` setting.
+    If you're using Windows WSL2 with ["Mirrored" networking mode](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking), enable the experimental `hostAddressLoopback=true` setting.
 
     You can do this using the "WSL Settings" app:
 
@@ -59,7 +59,7 @@ These environments can be extended, version controlled, and shared, so you can t
 
     ```ini
     [wsl2]
-    networkingMode=mirrored
+    networkingMode=Mirrored
 
     [experimental]
     hostAddressLoopback=true


### PR DESCRIPTION
## The Issue

It may be unclear what needs to be done for mirrored networking mode in WSL2.

## How This PR Solves The Issue

Adds an example.

## Manual Testing Instructions

https://ddev--7463.org.readthedocs.build/en/7463/#system-requirements-windows-wsl2

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
