### PR TITLE
docs: minor update to manual ddev instructions and use apt-get

### DIFF
--- a/docs/content/developers/network-test-environments.md
+++ b/docs/content/developers/network-test-environments.md
@@ -22,7 +22,7 @@ These instructions are for Debian/Ubuntu but can be adapted for container-based 
 1. **Install Squid**
 
     ```bash
-    sudo apt install squid-openssl ssl-cert
+    sudo apt-get install squid-openssl ssl-cert
     ```
 
 2. **Generate a Root CA for Signing**

--- a/docs/content/developers/testing-docs.md
+++ b/docs/content/developers/testing-docs.md
@@ -54,7 +54,7 @@ This will launch a web server on port 8000 and automatically refresh pages as th
 !!!tip "Installing mkdocs locally on Debian/Ubuntu Linux or WSL2 with Ubuntu"
 
     ```bash
-    sudo apt update && sudo apt install python3-full python-is-python3 pipx
+    sudo apt-get update && sudo apt-get install python3-full python-is-python3 pipx
     export PIPX_BIN_DIR=/usr/local/bin
     export PIPX_HOME=/usr/local/pipx
     sudo --preserve-env pipx install mkdocs --pip-args "-r docs/mkdocs-pip-requirements"

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -210,16 +210,16 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
         ```bash
         # WSL2 with Docker CE and specified distro
-        ddev_windows_installer.exe /docker-ce /distro=Ubuntu-24.04 /S
+        ./ddev_windows_amd64_installer.exe /S /docker-ce /distro=DDEV
 
         # WSL2 with Docker Desktop and specified distro
-        ddev_windows_installer.exe /docker-desktop /distro=Ubuntu-22.04 /S
+        ./ddev_windows_amd64_installer.exe /S /docker-desktop /distro=Ubuntu
 
         # Traditional Windows (requires Docker Desktop/Rancher Desktop)
-        ddev_windows_installer.exe /traditional /S
+        ./ddev_windows_installer.exe /S /traditional
 
         # Get help with all options
-        ddev_windows_installer.exe /help
+        ./ddev_windows_amd64_installer.exe /help
         ```
 
         The `/S` flag makes the installation completely silent. Use `/distro=<name>` to specify your WSL2 distribution name (required for WSL2 options).

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -229,18 +229,17 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     If you prefer to install DDEV manually on WSL2, it's not hard. These techniques can be used to install on a non-Ubuntu distro, and can be adapted for Yum-based or ArchLinux-based distros as well:
 
     1. In PowerShell, run `mkcert.exe -install` and follow the prompt to install the Certificate Authority.
-    2. In an administrative PowerShell, run `$env:CAROOT="$(mkcert -CAROOT)"; setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }`. This will set WSL2 to use the Certificate Authority installed on the Windows side. In some cases it takes a reboot to work correctly.
-    3. In administrative PowerShell, run `wsl --install <distro> --name DDEV`, for example `wsl --install Debian --name DDEV`. This will install the WSL2 distro for you. (The name "DDEV" is just a suggestion; you can use any name you like.)
-    4. **Docker CE:** Follow the instructions in the [Linux install section here](docker-installation.md#linux) to install Docker CE and DDEV. In addition, `sudo apt-get install -y ddev-wsl2`.
-    5. **Docker Desktop for Windows (if used):**
-        * Install Docker Desktop for Windows and configure the WSL2-based engine (not legacy Hyper-V) when installing. Download the installer from [docker.com](https://www.docker.com/products/docker-desktop/). Start Docker Desktop. It may prompt you to log out and log in again, or reboot.
+    2. In PowerShell, run `$env:CAROOT="$(mkcert -CAROOT)"; setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }`. This will set WSL2 to use the Certificate Authority installed on the Windows side, so your Windows-side browser can trust it.
+    3. In PowerShell, run `wsl --install <distro-type> --name DDEV`, for example `wsl --install Debian --name DDEV`. This will install the WSL2 distro for you. (The name "DDEV" is just a suggestion; you can use any name you like.)
+    4. **Docker CE:** Follow the instructions in the [Linux install section here](docker-installation.md#linux) to install Docker CE and DDEV. In addition, `sudo apt-get install -y docker-ce ddev ddev-wsl2` (or the equivalent `dnf` or other package manager commands).
+    5. **Docker Desktop for Windows (if used, this is not preferred):**
+        * Download and install the installer from [docker.com](https://www.docker.com/products/docker-desktop/). Choose the WSL2-based configuration. Start Docker Desktop. It may prompt you to log out and log in again, or reboot.
         * Go to Docker Desktop’s *Settings* → *Resources* → *WSL integration* → *enable integration for your distro*. Now `docker` commands will be available from within your WSL2 distro.
-    6. In WSL2, `sudo apt update && sudo apt install -y ddev-wsl2` to add the WSL2 helper package.
-    7. Double-check your distro: `echo $CAROOT` should show something like `/mnt/c/Users/<you>/AppData/Local/mkcert`
-    8. Check that Docker is working inside Ubuntu (or your distro) by running `docker ps` in the distro.
-    9. Open the WSL2 terminal, for example `Debian` from the Windows start menu.
-    10. Follow the [Linux install instructions](#linux) to install DDEV. You can use the `install_ddev_wsl2_docker_inside.sh` script, which is available in the [DDEV GitHub repository](
-    11. In WSL2, run `mkcert -install`.
+    6. Double-check your distro: `echo $CAROOT` should show something like `/mnt/c/Users/<you>/AppData/Local/mkcert`
+    7. Check that Docker is working inside Ubuntu (or your distro) by running `docker ps` in the distro.
+    8. Open the WSL2 terminal, for example `Debian` from the Windows start menu.
+    9. In WSL2, run `mkcert -install`.
+    10. Note that the older manual [PowerShell script](https://github.com/ddev/ddev/blob/main/scripts/install_ddev_wsl2_docker_inside.ps1) may be instructional if you're setting up a non-Ubuntu distro. It has been replaced by the Windows installer, but could be adapted for other distros.
 
     For unusual browsers and situations that don't automatically support the `mkcert` certificate authority, [configure your browser](configuring-browsers.md).
 


### PR DESCRIPTION
## The Issue

Minor docs fails in the manual installation section of DDEV Windows Installation

Thanks to @stasadev for carefully reading all this and catching the problems.

Rendered: https://ddev--7465.org.readthedocs.build/en/7465/users/install/ddev-installation/#ddev-installation-windows
