### PR TITLE
ci: install `ddev` on Windows before test

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -152,8 +152,12 @@ esac
 
 echo "Docker version:"
 docker version
-echo "ddev version"
-ddev version
+if command -v ddev >/dev/null ; then
+  echo "ddev version:"
+  ddev version
+else
+  echo "ddev not installed"
+fi
 echo
 
 export DDEV_NONINTERACTIVE=true

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -34,7 +34,7 @@ darwin)
     brew link mysql-client@8.0
     ;;
 windows)
-    (yes | choco upgrade -y golang nodejs markdownlint-cli mkcert mkdocs postgresql) || true
+    (yes | choco upgrade -y ddev golang nodejs markdownlint-cli mkcert mkdocs postgresql) || true
     ;;
 esac
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

https://buildkite.com/ddev/ddev-windows-mutagen/builds/5351#01982d69-836a-4106-b361-f9fd1bd01e7a
```
ddev version
.buildkite/test.sh: line 156: ddev: command not found
```

It failed because previous build was cancelled https://buildkite.com/ddev/ddev-windows-mutagen/builds/5349#019823b4-82ce-4e4e-a7d7-78389ed7a15e

## How This PR Solves The Issue

Installs `ddev` via choco in `testbot_maintenance.sh`.

## Manual Testing Instructions

I tested it in https://buildkite.com/ddev/ddev-windows-mutagen/builds/5352#01982e5b-b047-4b67-ab35-33d867bf600c

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
