### PR TITLE
fix: Update obsolete WSL2 install scripts to reflect new ddev-wsl2 and not needing ddev.exe, fixes #7464 [skip ci]

### DIFF
--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -1,6 +1,8 @@
 # This PowerShell script tries to do almost all the things required to set up
 # an Ubuntu WSL2 instance for use with DDEV and Docker Desktop.
-# It requires that an Ubuntu wsl2 distro be installed already, preferably with `wsl --install`, but it can also be
+# These days it's very unusual to do this because DDEV v1.24.7+ ships with a GUI installer for Windows/WSL2
+# So use that instead.
+# This requires that an Ubuntu wsl2 distro be installed already, preferably with `wsl --install`, but it can also be
 # done manually.
 # It requires that Docker Desktop is installed and running, and that it has integration enabled with the Ubuntu
 # distro, which is the default behavior.
@@ -32,97 +34,23 @@ if (-not(wsl -e docker ps) ) {
 }
 $ErrorActionPreference = "Stop"
 
-# Determine the architecture we're running on to fetch the correct installer.
-$realArchitecture = $env:PROCESSOR_ARCHITEW6432
-if (-not $realArchitecture) {
-    $realArchitecture = $env:PROCESSOR_ARCHITECTURE
-}
-switch ($realArchitecture) {
-    "AMD64" {
-        $architectureForInstaller = "amd64"
-    }
-    "ARM64" {
-        $architectureForInstaller = "arm64"
-    }
-    "x86" {
-        Write-Error "Error: x86 Windows detected, which is not supported."
-        exit 1
-    }
-    Default {
-        $architectureForInstaller = "amd64"
-    }
-}
-Write-Host "Detected OS architecture: $realArchitecture; using DDEV installer: $architectureForInstaller"
-
-# Install DDEV on Windows to manipulate the host OS's hosts file.
-$GitHubOwner = "ddev"
-$RepoName    = "ddev"
-# Get the latest release JSON from the GitHub API endpoint.
-
-# Delete existing old installers
-Get-ChildItem -Path $env:TEMP -Filter "ddev_windows_*_installer.*.exe" -ErrorAction SilentlyContinue | ForEach-Object {
-    try {
-        Remove-Item $_.FullName -Force -ErrorAction Stop
-    } catch {
-        Write-Warning "Could not delete old installer file $($_.FullName): $_"
-    }
-}
-
-$apiUrl = "https://api.github.com/repos/$GitHubOwner/$RepoName/releases/latest"
-try {
-    $response = Invoke-WebRequest -Headers @{ Accept = 'application/json' } -Uri $apiUrl
-} catch {
-    Write-Error "Could not fetch latest release info from $apiUrl. Details: $_"
-    exit 1
-}
-$json = $response.Content | ConvertFrom-Json
-$tagName = $json.tag_name
-Write-Host "The latest $GitHubOwner/$RepoName version is $tagName."
-# Because the published artifact includes the version in its name, we have to insert $tagName into the filename.
-$installerFilename = "ddev_windows_${architectureForInstaller}_installer.${tagName}.exe"
-$downloadUrl = "https://github.com/$GitHubOwner/$RepoName/releases/download/$tagName/$installerFilename"
-$TempDir = $env:TEMP
-$DdevInstallerPath = Join-Path $TempDir ([guid]::NewGuid().ToString() + "_" + $installerFilename)
-
-Write-Host "Downloading from $downloadUrl..."
-try {
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $DdevInstallerPath
-} catch {
-    Write-Error "Could not download the installer from $downloadUrl. Details: $_"
-    exit 1
-}
-Start-Process $DdevInstallerPath -ArgumentList "/S", -Wait
-$env:PATH += ";C:\Program Files\DDEV"
-
-$mkcertPath = "C:\Program Files\DDEV\mkcert.exe"
-$maxWait = 60
-Write-Host "Waiting up to $maxWait seconds for $mkcertPath binary..."
-$waited = 0
-while (-not (Test-Path $mkcertPath) -and $waited -lt $maxWait) {
-    Start-Sleep -Seconds 1
-    $waited++
-}
-if (-not (Test-Path $mkcertPath)) {
-    Write-Error "mkcert.exe did not appear at $mkcertPath after waiting $maxWait seconds"
-    exit 1
-}
-
-& $mkcertPath -install
-$env:CAROOT = & $mkcertPath -CAROOT
-
 wsl -u root -e bash -c "apt-get update && apt-get install -y curl"
 wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/ddev.gpg > /dev/null"
 wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
 wsl -u root -e bash -c "apt-get update && apt-get install -y wslu"
-wsl -u root -e bash -c "apt-get install -y --no-install-recommends ddev"
-wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
+wsl -u root -e bash -c "apt-get install -y --no-install-recommends ddev ddev-wsl2"
 
+& wsl mkcert.exe -install
+$env:CAROOT = & wsl mkcert.exe -CAROOT
+setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
+# TODO: We may need restart of distro here to pick up CAROOT
 wsl bash -c 'echo $CAROOT'
 wsl -u root mkcert -install
 if (-not(wsl -e docker ps)) {
     throw "docker does not seem to be working inside the WSL2 distro yet. Check Resources->WSL Integration in Docker Desktop"
 }
-wsl -u root -e bash -c "touch /etc/wsl.conf && if ! fgrep '[boot]' /etc/wsl.conf >/dev/null; then printf '\n[boot]\nsystemd=true\n' >>/etc/wsl.conf; fi"
 
 wsl ddev version
+
+# TODO: restart may be required to pick up CAROOT in distro

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -34,6 +34,12 @@ if (-not(wsl -e docker ps) ) {
 }
 $ErrorActionPreference = "Stop"
 
+# Remove old Windows ddev.exe if it exists using uninstaller
+if (Test-Path "$env:PROGRAMFILES\DDEV\ddev_uninstall.exe") {
+    Write-Host "Removing old Windows ddev.exe installation"
+    Start-Process "$env:PROGRAMFILES\DDEV\ddev_uninstall.exe" -ArgumentList "/SILENT" -Wait
+}
+
 wsl -u root -e bash -c "apt-get update && apt-get install -y curl"
 wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/ddev.gpg > /dev/null"
 wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -49,7 +49,7 @@ Write-Host "Terminating default WSL2 distro: $defaultDistro"
 wsl --terminate $defaultDistro
 
 wsl bash -c 'echo CAROOT=$CAROOT'
-wsl -u root mkcert -install
+wsl mkcert -install
 if (-not(wsl -e docker ps)) {
     throw "docker does not seem to be working inside the WSL2 distro yet. Check Resources->WSL Integration in Docker Desktop"
 }

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -30,6 +30,12 @@ if (wsl bash -c "test -d /mnt/wsl/docker-desktop >/dev/null 2>&1" ) {
 }
 $ErrorActionPreference = "Stop"
 
+# Remove old Windows ddev.exe if it exists using uninstaller
+if (Test-Path "$env:PROGRAMFILES\DDEV\ddev_uninstall.exe") {
+    Write-Host "Removing old Windows ddev.exe installation"
+    Start-Process "$env:PROGRAMFILES\DDEV\ddev_uninstall.exe" -ArgumentList "/SILENT" -Wait
+}
+
 wsl -u root bash -c "apt-get remove -y -qq docker docker-engine docker.io containerd runc >/dev/null 2>&1"
 wsl -u root apt-get update
 wsl -u root apt-get install -y ca-certificates curl gnupg lsb-release

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -51,7 +51,7 @@ wsl bash -c 'sudo usermod -aG docker $USER'
 
 wsl mkcert.exe -install
 $env:CAROOT = & wsl mkcert.exe -CAROOT
-setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV
+setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 $defaultDistro = (wsl --list --quiet | Select-Object -First 1) -replace '[\r\n\x00-\x1F\x7F-\x9F]', '' -replace '^\s+|\s+$', ''
 Write-Host "Terminating default WSL2 distro: $defaultDistro"
 wsl --terminate $defaultDistro

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -1,5 +1,7 @@
 # This PowerShell script tries to do almost all the things required to set up
 # an Ubuntu WSL2 instance for use with DDEV and docker-ce installed inside WSL2.
+# These days it's very unusual to do this because DDEV v1.24.7+ ships with a GUI installer for Windows/WSL2
+# So use that instead.
 # It requires that an Ubuntu wsl2 distro be installed already, preferably with `wsl --install`, but it can also be
 # done manually.
 # You can download, inspect, and run this, or run it directly with
@@ -27,86 +29,6 @@ if (wsl bash -c "test -d /mnt/wsl/docker-desktop >/dev/null 2>&1" ) {
 }
 $ErrorActionPreference = "Stop"
 
-# Determine the architecture we're running on to fetch the correct installer.
-$realArchitecture = $env:PROCESSOR_ARCHITEW6432
-if (-not $realArchitecture) {
-    $realArchitecture = $env:PROCESSOR_ARCHITECTURE
-}
-switch ($realArchitecture) {
-    "AMD64" {
-        $architectureForInstaller = "amd64"
-    }
-    "ARM64" {
-        $architectureForInstaller = "arm64"
-    }
-    "x86" {
-        Write-Error "Error: x86 Windows detected, which is not supported."
-        exit 1
-    }
-    Default {
-        $architectureForInstaller = "amd64"
-    }
-}
-Write-Host "Detected OS architecture: $realArchitecture; using DDEV installer: $architectureForInstaller"
-
-# Cleanup old installers
-Get-ChildItem -Path $env:TEMP -Filter "ddev_windows_*_installer.*.exe" -ErrorAction SilentlyContinue | ForEach-Object {
-    try {
-        Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
-    } catch {
-        # Intentionally silent
-    }
-}
-
-# Install DDEV on Windows to manipulate the host OS's hosts file.
-$GitHubOwner = "ddev"
-$RepoName    = "ddev"
-# Get the latest release JSON from the GitHub API endpoint.
-$apiUrl = "https://api.github.com/repos/$GitHubOwner/$RepoName/releases/latest"
-try {
-    $response = Invoke-WebRequest -Headers @{ Accept = 'application/json' } -Uri $apiUrl
-} catch {
-    Write-Error "Could not fetch latest release info from $apiUrl. Details: $_"
-    exit 1
-}
-$json = $response.Content | ConvertFrom-Json
-$tagName = $json.tag_name
-Write-Host "The latest $GitHubOwner/$RepoName version is $tagName."
-# Because the published artifact includes the version in its name, we have to insert $tagName into the filename.
-$installerFilename = "ddev_windows_${architectureForInstaller}_installer.${tagName}.exe"
-$downloadUrl = "https://github.com/$GitHubOwner/$RepoName/releases/download/$tagName/$installerFilename"
-$TempDir = $env:TEMP
-$DdevInstallerPath = Join-Path $TempDir ([guid]::NewGuid().ToString() + "_" + $installerFilename)
-
-Write-Host "Downloading from $downloadUrl..."
-try {
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $DdevInstallerPath
-} catch {
-    Write-Error "Could not download the installer from $downloadUrl. Details: $_"
-    exit 1
-}
-Start-Process $DdevInstallerPath -ArgumentList "/S", -Wait
-$env:PATH += ";C:\Program Files\DDEV"
-
-Write-Host "DDEV installation complete."
-
-$mkcertPath = "C:\Program Files\DDEV\mkcert.exe"
-$maxWait = 60
-Write-Host "Waiting up to $maxWait seconds for $mkcertPath binary..."
-$waited = 0
-while (-not (Test-Path $mkcertPath) -and $waited -lt $maxWait) {
-    Start-Sleep -Seconds 1
-    $waited++
-}
-if (-not (Test-Path $mkcertPath)) {
-    Write-Error "mkcert.exe did not appear at $mkcertPath after waiting $maxWait seconds"
-    exit 1
-}
-
-& $mkcertPath -install
-$env:CAROOT = & $mkcertPath -CAROOT
-setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
-
 wsl -u root bash -c "apt-get remove -y -qq docker docker-engine docker.io containerd runc >/dev/null 2>&1"
 wsl -u root apt-get update
 wsl -u root apt-get install -y ca-certificates curl gnupg lsb-release
@@ -117,18 +39,20 @@ wsl -u root -e bash -c 'echo deb [arch=$(dpkg --print-architecture) signed-by=/e
 wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg && curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/ddev.gpg > /dev/null"
 wsl -u root -e bash -c 'echo deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ \* \* > /etc/apt/sources.list.d/ddev.list'
 wsl -u root -e bash -c "apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io wslu"
-wsl -u root -e bash -c "apt-get install -y --no-install-recommends ddev"
-wsl -u root -e bash -c "apt-get upgrade -y >/dev/null"
+wsl -u root -e bash -c "apt-get install -y --no-install-recommends ddev ddev-wsl2"
 wsl bash -c 'sudo usermod -aG docker $USER'
 
+& wsl mkcert.exe -install
+$env:CAROOT = & wsl mkcert.exe -CAROOT
+setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
+
+# TODO: We may need restart of distro here to pick up CAROOT
 wsl bash -c 'echo CAROOT=$CAROOT'
-wsl -u root mkcert -install
+wsl mkcert -install
 if (-not(wsl -e docker ps)) {
     throw "docker does not seem to be working inside the WSL2 distro yet. "
 }
 # If docker desktop was previously set up, the .docker can break normal use of docker client.
 wsl rm -rf ~/.docker
-
-wsl -u root -e bash -c "touch /etc/wsl.conf && if ! fgrep '[boot]' /etc/wsl.conf >/dev/null; then printf '\n[boot]\nsystemd=true\n' >>/etc/wsl.conf; fi"
 
 wsl ddev version

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -26,7 +26,7 @@ if (-not(Compare-Object "root" (wsl -e whoami)) ) {
 }
 
 if (wsl bash -c "test -d /mnt/wsl/docker-desktop >/dev/null 2>&1" ) {
-    throw "Docker Desktop integration is enabled with the default distro and it must but turned off."
+    throw "Docker Desktop integration is enabled with the default distro and it must be turned off."
 }
 $ErrorActionPreference = "Stop"
 
@@ -45,8 +45,7 @@ wsl bash -c 'sudo usermod -aG docker $USER'
 
 wsl mkcert.exe -install
 $env:CAROOT = & wsl mkcert.exe -CAROOT
-setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
-
+setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV
 $defaultDistro = (wsl --list --quiet | Select-Object -First 1) -replace '[\r\n\x00-\x1F\x7F-\x9F]', '' -replace '^\s+|\s+$', ''
 Write-Host "Terminating default WSL2 distro: $defaultDistro"
 wsl --terminate $defaultDistro


### PR DESCRIPTION
## The Issue

- #7464

The Windows installer in v1.24.7+ obsoletes the installer scripts, but they remain simple examples to follow for manual installation of DDEV.

## How This PR Solves The Issue

* Add warning at top (use installer)
* Remove installation of windows-side ddev
* Rework mkcert install to use wsl2-side mkcert.exe

## Manual Testing Instructions

Try running using the instructions at the top (instructions have been removed from docs)

## Automated Testing Overview

No testing

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
