### PR TITLE
feat: update Pantheon provider to use environment variables, fixes #4760

### DIFF
--- a/docs/content/users/providers/pantheon.md
+++ b/docs/content/users/providers/pantheon.md
@@ -40,8 +40,20 @@ If you have DDEV installed, and have an active Pantheon account with an active s
 
 7. If using Drupal 8+, verify that Drush is installed in your project with `ddev composer require drush/drush`. If using Drupal 6 or 7, Drush 8 is already provided in the web container’s `/usr/local/bin/drush`, so you can skip this step.
 
-8. In your **project’s** `.ddev/providers` directory, copy `pantheon.yaml.example` to `pantheon.yaml` (*This refers to your project `.ddev` folder and not the global `.ddev` folder*).  Edit the `project` environment variable under `environment_variables`. It will be in the format `<projectname>.<environment>`, for example `yourprojectname.dev` or (in cases of ambiguity) `<project_uuid>.<environment>`, for example `009a2cda-2c22-4eee-8f9d-96f017321555.dev`.
+8. In your **project's** `.ddev/providers` directory, copy `pantheon.yaml` to your providers directory (*This refers to your project `.ddev` folder and not the global `.ddev` folder*). Add `PANTHEON_SITE` and `PANTHEON_ENVIRONMENT` variables to your project `.ddev/config.yaml`:
 
+    ```yaml
+    web_environment:
+        - PANTHEON_SITE=yourprojectname
+        - PANTHEON_ENVIRONMENT=dev
+    ```
+
+    You can also do this with `ddev config --web-environment-add="PANTHEON_SITE=yourprojectname,PANTHEON_ENVIRONMENT=dev"`.
+
+    You can usually use the site name, but in some environments you may need the site ID, which is the long third component of your site dashboard URL. So if the site dashboard is at `https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/`, the site ID is `009a2cda-2c22-4eee-8f9d-96f017321555`.
+
+    Instead of setting the environment variables in configuration files, you can use
+    `ddev pull pantheon --environment=PANTHEON_SITE=yourprojectname,PANTHEON_ENVIRONMENT=dev` for example.
 9. If using Colima, may need to set an explicit nameserver in `~/.colima/default/colima.yaml` like `1.1.1.1`. If this configuration is changed, may also need to restart Colima.
 
 10. Run [`ddev restart`](../usage/commands.md#restart).

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
@@ -75,7 +75,7 @@ db_pull_command:
     pushd /var/www/html/.ddev/.downloads >/dev/null
     terminus backup:get ${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT} --element=db --to=db.sql.gz
 
-files_import_command:
+files_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
@@ -1,5 +1,5 @@
 #ddev-generated
-# Example Pantheon.io provider configuration.
+# Pantheon.io provider configuration.
 # This example is Drupal/drush oriented,
 # but can be adapted for other CMSs supported by Pantheon
 
@@ -7,7 +7,7 @@
 #
 # 1. Get your Pantheon.io machine token:
 #    a. Login to your Pantheon Dashboard, and [Generate a Machine Token](https://pantheon.io/docs/machine-tokens/) for ddev to use.
-#    b. Add the API token to the `web_environment` section in your global ddev configuration at ~/.ddev/global_config.yaml
+#    b. Add the API token to the `web_environment` section in your global ddev configuration at ~/.ddev/global_config.yaml:
 #    ```yaml
 #    web_environment:
 #        - TERMINUS_MACHINE_TOKEN=abcdeyourtoken
@@ -21,11 +21,22 @@
 #        - TERMINUS_MACHINE_TOKEN=abcdeyourtoken
 #    ```
 #
-# 2. Choose a Pantheon site and environment you want to use with ddev. You can usually use the site name, but in some environments you may need the site uuid, which is the long 3rd component of your site dashboard URL. So if the site dashboard is at <https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/>, the site ID is 009a2cda-2c22-4eee-8f9d-96f017321555.
+# 2. Add PANTHEON_SITE and PANTHEON_ENVIRONMENT variables to your project `.ddev/config.yaml`:
+#    ```yaml
+#    web_environment:
+#        - PANTHEON_SITE=yourproject
+#        - PANTHEON_ENVIRONMENT=dev
+#    ```
+#    You can also do this with `ddev config --web-environment-add="PANTHEON_SITE=yourproject,PANTHEON_ENVIRONMENT=dev"`.
+#
+#    You can usually use the site name, but in some environments you may need the site uuid, 
+#    which is the long 3rd component of your site dashboard URL. So if the site dashboard is at 
+#    <https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/>, 
+#    the site ID is 009a2cda-2c22-4eee-8f9d-96f017321555.
 #
 # 3. On the pantheon dashboard, make sure that at least one backup has been created. (When you need to refresh what you pull, do a new backup.)
 #
-# 4. For `ddev push pantheon` sure your public ssh key is configured in Pantheon (Account->SSH Keys)
+# 4. For `ddev push pantheon` make sure your public ssh key is configured in Pantheon (Account->SSH Keys)
 #
 # 5. Check out project codebase from Pantheon. Enable the "Git Connection Mode" and use `git clone` to check out the code locally.
 #
@@ -33,61 +44,60 @@
 #
 # 7. Verify that drush is installed in your project, `ddev composer require drush/drush`
 #
-# 8. In your project's .ddev/providers directory, copy pantheon.yaml.example to pantheon.yaml and edit the "project" under `environment_variables` (change it from `yourproject.dev`). If you want to use a different environment than "dev", change `dev` to the name of the environment.
+# 8. `ddev restart`
 #
-# 9. If using Colima, may need to set an explicit nameserver in `~/.colima/default/colima.yaml` like `1.1.1.1`. If this configuration is changed, may also need to restart Colima.
+# 9. Run `ddev pull pantheon`. The ddev environment will download the Pantheon database and files using terminus and will import the database and files into the ddev environment. You should now be able to access the project locally.
 #
-# 10. `ddev restart`
+# 10. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 #
-# 11. Run `ddev pull pantheon`. The ddev environment will download the Pantheon database and files using terminus and will import the database and files into the ddev environment. You should now be able to access the project locally.
-#
-# 12. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
-#
+
+# Instead of setting the environment variables in configuration files, you can use
+# `ddev pull pantheon --environment=PANTHEON_SITE=yourproject,PANTHEON_ENVIRONMENT=dev` for example
 
 # Debugging: Use `ddev exec terminus auth:whoami` to see what terminus knows about
 # `ddev exec terminus site:list` will show available sites
-
-environment_variables:
-  project: yourproject.dev
 
 auth_command:
   command: |
     set -eu -o pipefail
     if ! command -v drush >/dev/null ; then echo "Please make sure your project contains drush, ddev composer require drush/drush" && exit 1; fi
     if [ -z "${TERMINUS_MACHINE_TOKEN:-}" ]; then echo "Please make sure you have set TERMINUS_MACHINE_TOKEN in ~/.ddev/global_config.yaml" && exit 1; fi
+    if [ -z "${PANTHEON_SITE:-}" ]; then echo "Please make sure you have set PANTHEON_SITE via config.yaml or with '--environment=PANTHEON_SITE=xxx'" && exit 1; fi
+    if [ -z "${PANTHEON_ENVIRONMENT:-}" ]; then echo "Please make sure you have set PANTHEON_ENVIRONMENT via config.yaml or with '--environment=PANTHEON_ENVIRONMENT=xxx'" && exit 1; fi
     terminus auth:login --machine-token="${TERMINUS_MACHINE_TOKEN}" || ( echo "terminus auth login failed, check your TERMINUS_MACHINE_TOKEN" && exit 1 )
     terminus aliases 2>/dev/null
 
 db_pull_command:
   command: |
-    set -x   # You can enable bash debugging output by uncommenting
+    # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
+    echo "Using PANTHEON_SITE=${PANTHEON_SITE} PANTHEON_ENVIRONMENT=${PANTHEON_ENVIRONMENT}"
     pushd /var/www/html/.ddev/.downloads >/dev/null
-    terminus backup:get ${project} --element=db --to=db.sql.gz
+    terminus backup:get ${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT} --element=db --to=db.sql.gz
 
-files_pull_command:
+files_import_command:
   command: |
-    set -x   # You can enable bash debugging output by uncommenting
+    # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     pushd /var/www/html/.ddev/.downloads >/dev/null;
-    terminus backup:get ${project} --element=files --to=files.tgz
+    terminus backup:get ${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT} --element=files --to=files.tgz
     mkdir -p files && tar --strip-components=1 -C files -zxf files.tgz
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 db_push_command:
   command: |
-    set -x   # You can enable bash debugging output by uncommenting
+    # set -x   # You can enable bash debugging output by uncommenting
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     set -eu -o pipefail
     pushd /var/www/html/.ddev/.downloads >/dev/null;
-    terminus remote:drush ${project} -- sql-drop -y
-    gzip -dc db.sql.gz | terminus remote:drush ${project} -- sql-cli
+    terminus remote:drush ${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT} -- sql-drop -y
+    gzip -dc db.sql.gz | terminus remote:drush ${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT} -- sql-cli
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
 files_push_command:
   command: |
-    set -x   # You can enable bash debugging output by uncommenting
+    # set -x   # You can enable bash debugging output by uncommenting
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     set -eu -o pipefail
     ls ${DDEV_FILES_DIR} >/dev/null # This just refreshes stale NFS if possible
-    drush rsync -y @self:%files @${project}:%files
+    drush rsync -y @self:%files @${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT}:%files

--- a/pkg/ddevapp/providerPantheon_test.go
+++ b/pkg/ddevapp/providerPantheon_test.go
@@ -87,12 +87,11 @@ func TestPantheonPull(t *testing.T) {
 	err = ddevapp.PopulateExamplesCommandsHomeadditions(app.Name)
 	require.NoError(t, err)
 
-	// Build our pantheon.yaml from the example file
-	s, err := os.ReadFile(app.GetConfigPath("providers/pantheon.yaml.example"))
-	require.NoError(t, err)
-	x := strings.Replace(string(s), "project:", fmt.Sprintf("project: %s\n#project:", pantheonPullTestSite), 1)
-	err = os.WriteFile(app.GetConfigPath("providers/pantheon.yaml"), []byte(x), 0666)
-	assert.NoError(err)
+	// Add PANTHEON_SITE and PANTHEON_ENVIRONMENT to the app config
+	parts := strings.Split(pantheonPullTestSite, ".")
+	site, env := parts[0], parts[1]
+	app.WebEnvironment = append(app.WebEnvironment, fmt.Sprintf("PANTHEON_SITE=%s", site))
+	app.WebEnvironment = append(app.WebEnvironment, fmt.Sprintf("PANTHEON_ENVIRONMENT=%s", env))
 	err = app.WriteConfig()
 	require.NoError(t, err)
 
@@ -195,12 +194,11 @@ func TestPantheonPush(t *testing.T) {
 	err = os.WriteFile(filepath.Join(app.AppRoot, app.Docroot, "sites/default/files", fName), fContent, 0644)
 	require.NoError(t, err)
 
-	// Build our pantheon.yaml from the example file
-	s, err := os.ReadFile(app.GetConfigPath("providers/pantheon.yaml.example"))
-	require.NoError(t, err)
-	x := strings.Replace(string(s), "project:", fmt.Sprintf("project: %s\n#project:", pantheonPushTestSite), 1)
-	err = os.WriteFile(app.GetConfigPath("providers/pantheon.yaml"), []byte(x), 0666)
-	assert.NoError(err)
+	// Add PANTHEON_SITE and PANTHEON_ENVIRONMENT to the app config
+	parts := strings.Split(pantheonPushTestSite, ".")
+	site, env := parts[0], parts[1]
+	app.WebEnvironment = append(app.WebEnvironment, fmt.Sprintf("PANTHEON_SITE=%s", site))
+	app.WebEnvironment = append(app.WebEnvironment, fmt.Sprintf("PANTHEON_ENVIRONMENT=%s", env))
 	err = app.WriteConfig()
 	require.NoError(t, err)
 


### PR DESCRIPTION
## The Issue

- #4760

The Pantheon provider integration required users to manually edit provider configuration files, which was inconvenient and inconsistent with other modernized providers like Acquia, Lagoon, Platform.sh, and Upsun that use environment variables.

## How This PR Solves The Issue

This PR modernizes the Pantheon provider to use environment variables instead of requiring file editing:

- **Provider Configuration**: Renamed `pantheon.yaml.example` to `pantheon.yaml` and removed hardcoded `environment_variables: project: yourproject.dev` section
- **Environment Variable Validation**: Added validation in `auth_command` for required `PANTHEON_SITE` and `PANTHEON_ENVIRONMENT` variables
- **Command Updates**: Updated all command references from `${project}` to `${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT}`
- **Test Updates**: Modified `TestPantheonPull` and `TestPantheonPush` to use environment variable approach instead of file editing
- **Documentation**: Updated step 8 in `docs/content/users/providers/pantheon.md` with new configuration method

**Configuration Method Change:**

*Before (required editing provider file):*
```yaml
environment_variables:
  project: yourproject.dev
```

*After (set in project config):*
```yaml
web_environment:
    - PANTHEON_SITE=yourproject
    - PANTHEON_ENVIRONMENT=dev
```

## Manual Testing Instructions

1. Build ddev: `make`
2. Set up test project with Pantheon credentials in global config:
   ```bash
   ddev config global --web-environment-add="TERMINUS_MACHINE_TOKEN=your_token"
   ```
3. Create project with Pantheon environment variables:
   ```yaml
   web_environment:
       - PANTHEON_SITE=your_site
       - PANTHEON_ENVIRONMENT=dev
   ```
4. Test pull: `ddev pull pantheon` - should download database and files
5. Test push: `ddev push pantheon` - should upload database and files (ensure SSH key configured)

## Automated Testing Overview

- **TestPantheonPull**: Updated to use environment variable configuration, passes
- **TestPantheonPush**: Updated to use environment variable configuration, passes
- **Static Analysis**: All code quality checks pass (`make staticrequired`)
- **Manual Testing**: Both pull and push operations verified working with real Pantheon site

Tests now configure environment variables programmatically instead of editing provider files, making them more reliable and consistent with other provider tests.

## Release/Deployment Notes

This is a breaking change for users currently using the Pantheon provider:

- Users will need to migrate from editing `pantheon.yaml.example` to setting environment variables in their project configuration
- The provider file is now named `pantheon.yaml` (not `.example`) and should not be edited
- Documentation has been updated to guide users through the new configuration method
- Existing installations will need to update their configuration when upgrading

🤖 Generated with [Claude Code](https://claude.ai/code)