### PR TITLE
test: add a no-interaction flag to the install command in ibexa bats file

### DIFF
--- a/docs/tests/ibexa.bats
+++ b/docs/tests/ibexa.bats
@@ -24,8 +24,8 @@ teardown() {
   # ddev composer create-project ibexa/oss-skeleton
   run ddev composer create-project ibexa/oss-skeleton
   assert_success
-  # ddev exec console ibexa:install
-  run ddev exec console ibexa:install
+  # ddev exec console ibexa:install --no-interaction
+  run ddev exec console ibexa:install --no-interaction
   assert_success
   # ddev exec console ibexa:graphql:generate-schema
   run ddev exec console ibexa:graphql:generate-schema

--- a/docs/tests/ibexa.bats
+++ b/docs/tests/ibexa.bats
@@ -37,6 +37,6 @@ teardown() {
   # validate running project
   run curl -sfI https://${PROJNAME}.ddev.site
   assert_success
-  assert_output --partial "x-powered-by: Ibexa Open Source v4"
+  assert_output --partial "x-powered-by: Ibexa Open Source v5"
   assert_output --partial "HTTP/2 200"
 }

--- a/docs/tests/ibexa.bats
+++ b/docs/tests/ibexa.bats
@@ -39,4 +39,14 @@ teardown() {
   assert_success
   assert_output --partial "x-powered-by: Ibexa Open Source v5"
   assert_output --partial "HTTP/2 200"
+
+  run curl -sf https://${PROJNAME}.ddev.site
+  assert_success
+  assert_output --partial "Open-source solution for building custom, scalable websites."
+  assert_output --partial "Powered by Ibexa DXP"
+
+  run curl -sf https://${PROJNAME}.ddev.site/admin/login
+  assert_success
+  assert_output --partial "Welcome to<br/> Ibexa DXP"
+  assert_output --partial "<h3 class=\"ibexa-login__support-headline\">Get to know Ibexa DXP</h3>"
 }


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

the ibexa tests were failing according to @rfay . turned out that the `ddev exec console ibexa:install` now requires the manual entry of an admin password. it was probably added recently but according to https://doc.ibexa.co/en/latest/getting_started/install_ibexa_dxp/#create-a-database it is possible to override that with a no-interaction flag in the context of for example CI process like in this case. 


- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
