### PR TITLE
docs: explain how to make `build` stage in `docker-compose.*.yaml` work offline

### DIFF
--- a/docs/content/users/extend/custom-compose-files.md
+++ b/docs/content/users/extend/custom-compose-files.md
@@ -22,7 +22,7 @@ To add custom configuration or additional services to your project, create `dock
 
 ```yaml
 services:
-  someservice:
+  dummy-service:
     ports:
     - "9999:9999"
 ```
@@ -31,8 +31,8 @@ That approach usually isn’t sustainable because two projects might want to use
 
 ```yaml
 services:
-  someservice:
-    container_name: "ddev-${DDEV_SITENAME}-someservice"
+  dummy-service:
+    container_name: "ddev-${DDEV_SITENAME}-dummy-service"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
@@ -57,7 +57,7 @@ When defining additional services for your project, we recommend following these
 
     ```yaml
     services:
-      someservice:
+      dummy-service:
         labels:
           com.ddev.site-name: ${DDEV_SITENAME}
           com.ddev.approot: ${DDEV_APPROOT}
@@ -67,15 +67,15 @@ When defining additional services for your project, we recommend following these
 
     ```yaml
     services:
-      someservice:
-        image: ${CUSTOM_DOCKER_IMAGE:-busybox:latest}-${DDEV_SITENAME}-built
+      dummy-service:
+        image: ${YOUR_DOCKER_IMAGE:-example/example:latest}-${DDEV_SITENAME}-built
         build:
           dockerfile_inline: |
-            ARG CUSTOM_DOCKER_IMAGE="scratch"
-            FROM $${CUSTOM_DOCKER_IMAGE}
+            ARG YOUR_DOCKER_IMAGE="scratch"
+            FROM $${YOUR_DOCKER_IMAGE}
             # ...
           args:
-            CUSTOM_DOCKER_IMAGE: ${CUSTOM_DOCKER_IMAGE:-busybox:latest}
+            YOUR_DOCKER_IMAGE: ${YOUR_DOCKER_IMAGE:-example/example:latest}
     ```
 
     This enables DDEV to operate in [offline mode](../usage/offline.md) once the base image has been pulled.
@@ -115,11 +115,11 @@ services:
     command: "bash -c 'mkcert -install && original-start-command-from-image'"
     # Add an image and a build stage so we can add `mkcert`, etc.
     # The Dockerfile for the build stage goes in the `.ddev/example directory` here
-    image: ${EXAMPLE_DOCKER_IMAGE:-example/example:latest}-${DDEV_SITENAME}-built
+    image: ${YOUR_DOCKER_IMAGE:-example/example:latest}-${DDEV_SITENAME}-built
     build:
       context: example
       args:
-        EXAMPLE_DOCKER_IMAGE: ${EXAMPLE_DOCKER_IMAGE:-example/example:latest}
+        YOUR_DOCKER_IMAGE: ${YOUR_DOCKER_IMAGE:-example/example:latest}
     environment:
       - HTTP_EXPOSE=3001:3000
       - HTTPS_EXPOSE=3000:3000
@@ -129,7 +129,7 @@ services:
     external_links:
       - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
     labels:
-      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.approot: ${DDEV_APPROOT}
       com.ddev.site-name: ${DDEV_SITENAME}
     restart: 'no'
     volumes:
@@ -141,8 +141,8 @@ services:
 ```
 
 ```Dockerfile
-ARG EXAMPLE_DOCKER_IMAGE="scratch"
-FROM $EXAMPLE_DOCKER_IMAGE
+ARG YOUR_DOCKER_IMAGE="scratch"
+FROM $YOUR_DOCKER_IMAGE
 
 # CAROOT for `mkcert` to use, has the CA config
 ENV CAROOT=/mnt/ddev-global-cache/mkcert

--- a/docs/content/users/extend/custom-compose-files.md
+++ b/docs/content/users/extend/custom-compose-files.md
@@ -73,6 +73,7 @@ When defining additional services for your project, we recommend following these
           dockerfile_inline: |
             ARG CUSTOM_DOCKER_IMAGE="scratch"
             FROM $${CUSTOM_DOCKER_IMAGE}
+            # ...
           args:
             CUSTOM_DOCKER_IMAGE: ${CUSTOM_DOCKER_IMAGE:-busybox:latest}
     ```
@@ -114,11 +115,11 @@ services:
     command: "bash -c 'mkcert -install && original-start-command-from-image'"
     # Add an image and a build stage so we can add `mkcert`, etc.
     # The Dockerfile for the build stage goes in the `.ddev/example directory` here
-    image: ${EXAMPLE_DOCKER_IMAGE:-example/example}-${DDEV_SITENAME}-built
+    image: ${EXAMPLE_DOCKER_IMAGE:-example/example:latest}-${DDEV_SITENAME}-built
     build:
       context: example
       args:
-        EXAMPLE_DOCKER_IMAGE: ${EXAMPLE_DOCKER_IMAGE:-example/example}
+        EXAMPLE_DOCKER_IMAGE: ${EXAMPLE_DOCKER_IMAGE:-example/example:latest}
     environment:
       - HTTP_EXPOSE=3001:3000
       - HTTPS_EXPOSE=3000:3000

--- a/docs/content/users/extend/custom-compose-files.md
+++ b/docs/content/users/extend/custom-compose-files.md
@@ -58,6 +58,7 @@ When defining additional services for your project, we recommend following these
     ```yaml
     services:
       dummy-service:
+        image: ${YOUR_DOCKER_IMAGE:-example/example:latest}
         labels:
           com.ddev.site-name: ${DDEV_SITENAME}
           com.ddev.approot: ${DDEV_APPROOT}


### PR DESCRIPTION
## The Issue

When you don't have an `image` with `build` stage, your DDEV can't work offline:

- https://github.com/ddev/ddev-addon-template/pull/81

## How This PR Solves The Issue

Explains it.

## Manual Testing Instructions

https://ddev--7480.org.readthedocs.build/en/7480/users/extend/custom-compose-files/#conventions-for-defining-additional-services

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
