### PR TITLE
refactor: Add svg to rewrite rule for TYPO3

### DIFF
--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -186,7 +186,7 @@ server {
     }
 
     if (!-e $request_filename) {
-        rewrite ^/(.+)\.(\d+)\.(php|js|css|png|jpg|gif|gzip)$ /$1.$3 last;
+        rewrite ^/(.+)\.(\d+)\.(php|js|css|png|jpg|gif|svg|gzip)$ /$1.$3 last;
     }
     include /etc/nginx/common.d/*.conf;
     include /mnt/ddev_config/nginx/*.conf;


### PR DESCRIPTION
SVG are not rewriten, if the TYPO3 option BE versionNumberInFilename is activated.

Example in the backend:
/_assets/6104b7f46d656dcf567ead154886bf37/Icons/modules/install-update.1753364958.svg