### PR TITLE
feat: parallel `docker-compose pull`, improve `ddev debug download-images`, fixes #7163

### DIFF
--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -53,10 +53,17 @@ ddev debug download-images --all
 			if err != nil {
 				util.Failed("Failed to get projects: %v", err)
 			}
-			for _, project := range projects {
-				appImages, err := project.FindAllImages()
+			for _, app := range projects {
+				app.DockerEnv()
+				err = app.WriteDockerComposeYAML()
 				if err != nil {
-					util.Failed("Failed to get app images: %v", err)
+					util.Warning("Failed to run `docker-compose config` for '%s': %v", app.Name, err)
+					continue
+				}
+				appImages, err := app.FindAllImages()
+				if err != nil {
+					util.Warning("Failed to get images for '%s': %v", app.Name, err)
+					continue
 				}
 				for k, v := range appImages {
 					additionalImages[k] = v
@@ -69,11 +76,11 @@ ddev debug download-images --all
 				app.DockerEnv()
 				err = app.WriteDockerComposeYAML()
 				if err != nil {
-					util.Failed("Failed to get compose-config: %v", err)
+					util.Failed("Failed to run `docker-compose config` for '%s': %v", app.Name, err)
 				}
 				appImages, err := app.FindAllImages()
 				if err != nil {
-					util.Failed("Failed to get app images: %v", err)
+					util.Failed("Failed to get images for '%s': %v", app.Name, err)
 				}
 				additionalImages = appImages
 			} else {

--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
@@ -45,7 +43,7 @@ ddev debug download-images --all
 			}
 		}
 
-		additionalImages := map[string]string{}
+		var additionalImages []string
 
 		if downloadAll {
 			util.Success("Downloading images for all projects")
@@ -65,9 +63,7 @@ ddev debug download-images --all
 					util.Warning("Failed to get images for '%s': %v", app.Name, err)
 					continue
 				}
-				for k, v := range appImages {
-					additionalImages[k] = v
-				}
+				additionalImages = append(additionalImages, appImages...)
 			}
 		} else {
 			app, err := ddevapp.GetActiveApp(projectName)
@@ -86,16 +82,16 @@ ddev debug download-images --all
 			} else {
 				util.Success("Downloading basic images")
 
-				additionalImages = map[string]string{
+				additionalImages = []string{
 					// Provide at least the default database image
-					fmt.Sprintf("ddev-dbserver-%s-%s", nodeps.MariaDB, nodeps.MariaDBDefaultVersion): docker.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion),
+					docker.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion),
 				}
 			}
 		}
 
 		err = ddevapp.PullBaseContainerImages(additionalImages, true)
 		if err != nil {
-			util.Failed("Failed to PullBaseContainerImages(): %v", err)
+			util.Failed("Failed to pull DDEV images: %v", err)
 		}
 
 		util.Success("Successfully downloaded DDEV images")

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -508,6 +508,10 @@ Example:
 ```shell
 # Download DDEV’s basic Docker images
 ddev debug download-images
+# Download DDEV’s Docker images for `my-project`
+ddev debug download-images my-project
+# Download DDEV’s Docker images for all projects
+ddev debug download-images --all
 ```
 
 ### `debug fix-commands`

--- a/pkg/dockerutil/composeutils.go
+++ b/pkg/dockerutil/composeutils.go
@@ -2,12 +2,14 @@ package dockerutil
 
 import (
 	"context"
+	"os"
+	"strings"
+
 	composeLoader "github.com/compose-spec/compose-go/v2/loader"
 	composeTypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/mattn/go-isatty"
-	"os"
 )
 
 // CreateComposeProject creates a compose project from a string
@@ -78,15 +80,17 @@ func PullImages(images map[string]string, pullAlways bool) error {
 		util.Debug(`Pulling image for %s ("%s" service)`, image, service)
 	}
 
-	progress := "plain"
 	if !output.JSONOutput && isatty.IsTerminal(os.Stdin.Fd()) {
-		progress = "tty"
+		err = ComposeWithStreams(&ComposeCmdOpts{
+			ComposeYaml: composeYamlPull,
+			Action:      []string{"pull"},
+		}, nil, os.Stdout, os.Stderr)
+	} else {
+		_, _, err = ComposeCmd(&ComposeCmdOpts{
+			ComposeYaml: composeYamlPull,
+			Action:      []string{"pull"},
+		})
 	}
-
-	_, _, err = ComposeCmd(&ComposeCmdOpts{
-		ComposeYaml: composeYamlPull,
-		Action:      []string{"--progress", progress, "pull"},
-	})
 
 	return err
 }

--- a/pkg/dockerutil/composeutils.go
+++ b/pkg/dockerutil/composeutils.go
@@ -97,5 +97,7 @@ func PullImages(images map[string]string, pullAlways bool) error {
 
 // Pull pulls image if it doesn't exist locally
 func Pull(image string) error {
-	return PullImages(map[string]string{"image": image}, false)
+	parts := strings.SplitN(image, "/", 2)
+	service := strings.SplitN(parts[len(parts)-1], ":", 2)[0]
+	return PullImages(map[string]string{service: image}, false)
 }

--- a/pkg/dockerutil/composeutils.go
+++ b/pkg/dockerutil/composeutils.go
@@ -1,0 +1,97 @@
+package dockerutil
+
+import (
+	"context"
+	composeLoader "github.com/compose-spec/compose-go/v2/loader"
+	composeTypes "github.com/compose-spec/compose-go/v2/types"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/mattn/go-isatty"
+	"os"
+)
+
+// CreateComposeProject creates a compose project from a string
+func CreateComposeProject(yamlStr string) (*composeTypes.Project, error) {
+	project, err := composeLoader.LoadWithContext(
+		context.Background(),
+		composeTypes.ConfigDetails{
+			ConfigFiles: []composeTypes.ConfigFile{
+				{Content: []byte(yamlStr)},
+			},
+		},
+		composeLoader.WithProfiles([]string{`*`}),
+	)
+	if err != nil {
+		return project, err
+	}
+	// Initialize Networks, Services, and Volumes to empty maps if nil
+	if project.Networks == nil {
+		project.Networks = composeTypes.Networks{}
+	}
+	if project.Services == nil {
+		project.Services = composeTypes.Services{}
+	}
+	if project.Volumes == nil {
+		project.Volumes = composeTypes.Volumes{}
+	}
+	// Ensure nested fields like Labels, Networks, and Environment are initialized
+	for name, network := range project.Networks {
+		if network.Labels == nil {
+			network.Labels = composeTypes.Labels{}
+		}
+		project.Networks[name] = network
+	}
+	for name, service := range project.Services {
+		if service.Networks == nil {
+			service.Networks = map[string]*composeTypes.ServiceNetworkConfig{}
+		}
+		if service.Environment == nil {
+			service.Environment = composeTypes.MappingWithEquals{}
+		}
+		project.Services[name] = service
+	}
+	return project, nil
+}
+
+// PullImages pulls images in parallel if they don't exist locally
+// If pullAlways is true, it will always pull
+// Otherwise, it will only pull if the image doesn't exist
+func PullImages(images map[string]string, pullAlways bool) error {
+	if len(images) == 0 {
+		return nil
+	}
+
+	composeYamlPull, err := CreateComposeProject("name: compose-yaml-pull")
+	if err != nil {
+		return err
+	}
+
+	for service, image := range images {
+		if !pullAlways {
+			if imageExists, _ := ImageExistsLocally(image); imageExists {
+				continue
+			}
+		}
+		composeYamlPull.Services[service] = composeTypes.ServiceConfig{
+			Image: image,
+		}
+		util.Debug(`Pulling image for %s ("%s" service)`, image, service)
+	}
+
+	progress := "plain"
+	if !output.JSONOutput && isatty.IsTerminal(os.Stdin.Fd()) {
+		progress = "tty"
+	}
+
+	_, _, err = ComposeCmd(&ComposeCmdOpts{
+		ComposeYaml: composeYamlPull,
+		Action:      []string{"--progress", progress, "pull"},
+	})
+
+	return err
+}
+
+// Pull pulls image if it doesn't exist locally
+func Pull(image string) error {
+	return PullImages(map[string]string{"image": image}, false)
+}

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -356,21 +356,30 @@ func TestComposeWithStreams(t *testing.T) {
 
 	// Point stdout to os.Stdout and do simple ps -ef in web container
 	stdout := util.CaptureStdOut()
-	err = dockerutil.ComposeWithStreams(composeFiles, os.Stdin, os.Stdout, os.Stderr, "exec", "-T", "web", "ps", "-ef")
+	err = dockerutil.ComposeWithStreams(&dockerutil.ComposeCmdOpts{
+		ComposeFiles: composeFiles,
+		Action:       []string{"exec", "-T", "web", "ps", "-ef"},
+	}, os.Stdin, os.Stdout, os.Stderr)
 	assert.NoError(err)
 	output := stdout()
 	assert.Contains(output, "supervisord")
 
 	// Reverse stdout and stderr and create an error and normal stdout. We should see only the error captured in stdout
 	stdout = util.CaptureStdOut()
-	err = dockerutil.ComposeWithStreams(composeFiles, os.Stdin, os.Stderr, os.Stdout, "exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2")
+	err = dockerutil.ComposeWithStreams(&dockerutil.ComposeCmdOpts{
+		ComposeFiles: composeFiles,
+		Action:       []string{"exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2"},
+	}, os.Stdin, os.Stderr, os.Stdout)
 	assert.Error(err)
 	output = stdout()
 	assert.Contains(output, "ls: cannot access 'xx': No such file or directory")
 
 	// Flip stdout and stderr and create an error and normal stdout. We should see only the success captured in stdout
 	stdout = util.CaptureStdOut()
-	err = dockerutil.ComposeWithStreams(composeFiles, os.Stdin, os.Stdout, os.Stderr, "exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2")
+	err = dockerutil.ComposeWithStreams(&dockerutil.ComposeCmdOpts{
+		ComposeFiles: composeFiles,
+		Action:       []string{"exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2"},
+	}, os.Stdin, os.Stdout, os.Stderr)
 	assert.Error(err)
 	output = stdout()
 	assert.Contains(output, "/var/run/apache2", output)

--- a/pkg/util/yamltools.go
+++ b/pkg/util/yamltools.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
@@ -77,4 +78,12 @@ func MergeYamlFiles(baseFile string, extraFile ...string) (string, error) {
 	}
 
 	return string(result), nil
+}
+
+// EscapeDollarSign the same thing is done in `docker-compose config`
+// See https://github.com/docker/compose/blob/361c0893a9e16d54f535cdb2e764362363d40702/cmd/compose/config.go#L405-L409
+func EscapeDollarSign(marshal []byte) []byte {
+	dollar := []byte{'$'}
+	escDollar := []byte{'$', '$'}
+	return bytes.ReplaceAll(marshal, dollar, escDollar)
 }


### PR DESCRIPTION
## The Issue

- #7163

## How This PR Solves The Issue

- Removes `docker pull` completely
- Uses `docker-compose pull` everywhere
- Refactors `ddev debug download-images`:
  - Make it always pull, even if the image exists
  - Add optional project arg
  - Add `--all` flag to pull everything for all projects

## Manual Testing Instructions

Speed comparison for pulling basic images (Linux AMD64):

```
ddev delete images --all --yes && docker builder prune -f
start=$(date +%s%N)
ddev debug download-images
echo "Elapsed time: $((($(date +%s%N) - start) / 1000000)) ms"
```

Before (three retries):
```
Elapsed time: 46599 ms
Elapsed time: 47083 ms
Elapsed time: 53672 ms
```

After (three retries):

```
Elapsed time: 25162 ms
Elapsed time: 24964 ms
Elapsed time: 22870 ms
```

---

Check out:

```
ddev debug download-images

cd d11 && ddev debug download-images

cd ~ && ddev debug download-images d11

ddev debug download-images --all
```

![pull](https://github.com/user-attachments/assets/025c2012-35fd-47d0-b8e4-10296a00cb9c)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
