### PR TITLE
refactor: Update Pantheon database pull to get fresh DB and file push to be CMS-agnostic

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
@@ -67,13 +67,16 @@ auth_command:
     terminus auth:login --machine-token="${TERMINUS_MACHINE_TOKEN}" || ( echo "terminus auth login failed, check your TERMINUS_MACHINE_TOKEN" && exit 1 )
     terminus aliases 2>/dev/null
 
+#make sure env is awake, and grab a fresh DB export
 db_pull_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     set -eu -o pipefail
     echo "Using PANTHEON_SITE=${PANTHEON_SITE} PANTHEON_ENVIRONMENT=${PANTHEON_ENVIRONMENT}"
     pushd /var/www/html/.ddev/.downloads >/dev/null
-    terminus backup:get ${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT} --element=db --to=db.sql.gz
+    terminus env:wake -- ${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT}
+    FRESH_DB_DUMP_STRING=$(terminus connection:info "$project" --field=mysql_command | sed 's,^mysql,mysqldump --no-autocommit --single-transaction --opt -Q,')
+    eval "$FRESH_DB_DUMP_STRING | gzip > db.sql.gz" > /dev/null 2>&1
 
 files_pull_command:
   command: |
@@ -94,10 +97,13 @@ db_push_command:
     gzip -dc db.sql.gz | terminus remote:drush ${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT} -- sql-cli
 
 # push is a dangerous command. If not absolutely needed it's better to delete these lines.
+# terminus rsync plugin for CMS agnostic file push
+# this will push the files directory to Pantheon
 files_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
     ssh-add -l >/dev/null || ( echo "Please 'ddev auth ssh' before running this command." && exit 1 )
     set -eu -o pipefail
     ls ${DDEV_FILES_DIR} >/dev/null # This just refreshes stale NFS if possible
-    drush rsync -y @self:%files @${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT}:%files
+    terminus self:plugin:install terminus-rsync-plugin
+    terminus rsync -y ${DDEV_FILES_DIR}/ ${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT}:files


### PR DESCRIPTION
## The Issue

1. When executing `ddev pull pantheon`, ddev pulls a backup from Pantheon.  If this is a new site or if no backups exist for the environment, this will fail.  If there are no new backups, this may restore a very old snapshot. 
2. When executing `ddev push pantheon`, ddev uses drush rsync which is Drupal specific and will fail for WordPress sites.

## How This PR Solves The Issue

1. Taking a page out of [Lando's book](https://github.com/lando/pantheon/blob/58cf95d9849e5b7aae01e5830edbaeadc2d19c0a/scripts/pull.sh#L129), we can grab a fresh mysqldump to ensure `ddev pull pantheon` gets us a current DB, whether or not there are backups.  This could also be remedied by firing off a `terminus backup:create`, but this would add significant time to the overall db pull operation.  A possible improvement here would be to allow a flag to specify whether the pull should get a realtime dump or an existing backup.
2. Instead of drush rsync, install the [terminus rsync plugin](https://github.com/pantheon-systems/terminus-rsync-plugin) and leverage terminus rsync for CMS-agnostic file push.  Since this function is not commonly used, I am OK with installing the plugin at time of execution but it may be desirable to install the terminus rsync plugin globally for Pantheon use, I don't feel strongly either way.

## Manual Testing Instructions

1. Fire up your ddev instance for a Pantheon Drupal or WordPress site
2. Using this updated yaml, execute `ddev pull pantheon --skip-files` to test the DB pull
3. To test the rsync, add some new files to your site's files directory (sites/default/files or wp-content/uploads), and execute `ddev push pantheon --skip-db`

## Release/Deployment Notes

Should have no functional impacts to existing instances, though db_pull may take longer now due to fresh mysqldump vs using existing archive