### PR TITLE
fix: Disable corepack on config update for all Drupal versions except 11, fixes #7488

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -427,6 +427,7 @@ func drupalConfigOverrideAction(app *DdevApp) error {
 		app.PHPVersion = nodeps.PHP81
 		drupalVersion = 9
 	case nodeps.AppTypeDrupal10:
+		app.CorepackEnable = false
 		drupalVersion = 10
 	case nodeps.AppTypeDrupal:
 		fallthrough

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -412,6 +412,7 @@ func drupal7ConfigOverrideAction(app *DdevApp) error {
 // drupalConfigOverrideAction selects proper versions for
 func drupalConfigOverrideAction(app *DdevApp) error {
 	var drupalVersion int
+	app.CorepackEnable = false
 	switch app.Type {
 	case nodeps.AppTypeDrupal6:
 		app.PHPVersion = nodeps.PHP56
@@ -427,7 +428,6 @@ func drupalConfigOverrideAction(app *DdevApp) error {
 		app.PHPVersion = nodeps.PHP81
 		drupalVersion = 9
 	case nodeps.AppTypeDrupal10:
-		app.CorepackEnable = false
 		drupalVersion = 10
 	case nodeps.AppTypeDrupal:
 		fallthrough


### PR DESCRIPTION
## The Issue

- #7488

## How This PR Solves The Issue

## Manual Testing Instructions

1. Setup a new project by using `drupal11` as type.
1. Run `ddev yarn --version` and confirm Yarn 4.x.
1. Change type to `drupal10` and run `ddev restart`.
1. Run `ddev yarn --version` and you should see Yarn 1 but you will get 4.x without this change.

## Automated Testing Overview


## Release/Deployment Notes


