### PR TITLE
build: Move ddev-webserver base image to debian trixie

### DIFF
--- a/cmd/ddev/cmd/addon_test.go
+++ b/cmd/ddev/cmd/addon_test.go
@@ -20,6 +20,11 @@ func TestCmdAddon(t *testing.T) {
 	if os.Getenv("DDEV_RUN_GET_TESTS") != "true" {
 		t.Skip("Skipping because DDEV_RUN_GET_TESTS is not set")
 	}
+	// EXPERIMENTAL: Skip memcached-related tests if running on Debian Trixie
+	// where memcached packages are missing from Sury repository
+	if os.Getenv("SKIP_MEMCACHED_TESTS") == "true" {
+		t.Skip("Skipping memcached add-on tests (SKIP_MEMCACHED_TESTS=true)")
+	}
 	assert := asrt.New(t)
 
 	origDir, _ := os.Getwd()
@@ -90,6 +95,11 @@ func TestCmdAddon(t *testing.T) {
 func TestCmdAddonInstalled(t *testing.T) {
 	if os.Getenv("DDEV_RUN_GET_TESTS") != "true" {
 		t.Skip("Skipping because DDEV_RUN_GET_TESTS is not set")
+	}
+	// EXPERIMENTAL: Skip memcached-related tests if running on Debian Trixie
+	// where memcached packages are missing from Sury repository
+	if os.Getenv("SKIP_MEMCACHED_TESTS") == "true" {
+		t.Skip("Skipping memcached add-on tests (SKIP_MEMCACHED_TESTS=true)")
 	}
 	origDdevDebug := os.Getenv("DDEV_DEBUG")
 	_ = os.Unsetenv("DDEV_DEBUG")

--- a/cmd/ddev/cmd/service_test.go
+++ b/cmd/ddev/cmd/service_test.go
@@ -13,6 +13,11 @@ import (
 
 // TestCmdService tests ddev service enable/disable .
 func TestCmdService(t *testing.T) {
+	// EXPERIMENTAL: Skip memcached-related tests if running on Debian Trixie
+	// where memcached packages are missing from Sury repository
+	if os.Getenv("SKIP_MEMCACHED_TESTS") == "true" {
+		t.Skip("Skipping memcached service tests (SKIP_MEMCACHED_TESTS=true)")
+	}
 	assert := asrt.New(t)
 
 	origDir, _ := os.Getwd()

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -33,10 +33,11 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
 RUN url="https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETPLATFORM#linux/}"; wget ${url} -q -O /usr/bin/yq && chmod +x /usr/bin/yq
 ADD generic-files /
 
-RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
-    | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
-RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
-http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
+# TODO: Do we need nginx.org packages, or are Trixie (or deb.sury.org) good enough?
+#RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
+#    | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+#RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+#http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
 
 # This curl -I is debugging for intermittent failures on https://github.com/oerdnj/deb.sury.org/issues/2046
 RUN curl -s -I https://packages.sury.org/php/

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -33,12 +33,6 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
 RUN url="https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETPLATFORM#linux/}"; wget ${url} -q -O /usr/bin/yq && chmod +x /usr/bin/yq
 ADD generic-files /
 
-# TODO: Do we need nginx.org packages, or are Trixie (or deb.sury.org) good enough?
-#RUN curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
-#    | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
-#RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
-#http://nginx.org/packages/debian `lsb_release -cs` nginx" > /etc/apt/sources.list.d/nginx.list
-
 # This curl -I is debugging for intermittent failures on https://github.com/oerdnj/deb.sury.org/issues/2046
 RUN curl -s -I https://packages.sury.org/php/
 

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -1,6 +1,6 @@
 ### ---------------------------------base-----------------------------------------
 ### Build the base Debian image that will be used in every other image
-FROM debian:bookworm-slim AS base
+FROM debian:trixie-slim AS base
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]

--- a/containers/ddev-php-base/generic-files/etc/php-packages.yaml
+++ b/containers/ddev-php-base/generic-files/etc/php-packages.yaml
@@ -1,43 +1,52 @@
+# EXPERIMENTAL: Temporarily remove packages missing from Debian Trixie in Sury repository
+# Based on testing results from test_web_packages.sh on 2025-07-28
+# Missing packages: 
+#   - memcached (php5.6 arm64, php7.0-8.4 all archs)
+#   - redis (php7.0-7.3 all archs) 
+#   - apcu-bc (php5.6-8.3 all archs)
+#   - json (php8.0+ all archs) - NOTE: JSON is built into PHP 8.0+ core, so this is expected
+# Issue: https://github.com/oerdnj/deb.sury.org/issues/TBD
+
 php56:
   amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xml", "xhprof", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php70:
-  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php71:
-  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mcrypt", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php72:
-  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common" , "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php73:
-  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php74:
-  amd64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "apcu-bc", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "json", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php80:
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php81:
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php82:
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php83:
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
 
 php84:
-  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
-  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "memcached", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  amd64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]
+  arm64: ["apcu", "bcmath", "bz2", "cli", "common", "curl", "fpm", "gd", "imagick", "intl", "ldap", "mbstring", "mysql", "opcache", "pgsql", "readline", "redis", "soap", "sqlite3", "uploadprogress", "xdebug", "xhprof", "xml", "xmlrpc", "zip"]

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -31,17 +31,8 @@ RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | b
 # Install mariadb_repo_setup to get mariadb-client from them directly
 RUN curl -LsSf https://r.mariadb.com/downloads/mariadb_repo_setup -o /usr/local/bin/mariadb_repo_setup && chmod +x /usr/local/bin/mariadb_repo_setup
 # Search for CHANGE_MARIADB_CLIENT to update related code.
-# Workaround for Debian Trixie (13) not being supported yet - modify debian_version and os-release
-RUN cp /etc/os-release /etc/os-release.backup && \
-    cp /etc/debian_version /etc/debian_version.backup && \
-    sed -i 's/VERSION_ID="13"/VERSION_ID="12"/' /etc/os-release && \
-    sed -i 's/VERSION="13 (trixie)"/VERSION="12 (bookworm)"/' /etc/os-release && \
-    sed -i 's/VERSION_CODENAME=trixie/VERSION_CODENAME=bookworm/' /etc/os-release && \
-    sed -i 's/DEBIAN_VERSION_FULL=13.0/DEBIAN_VERSION_FULL=12.0/' /etc/os-release && \
-    echo "12.0" > /etc/debian_version && \
-    mariadb_repo_setup --mariadb-server-version="mariadb-10.11" --skip-maxscale --skip-tools && \
-    mv /etc/os-release.backup /etc/os-release && \
-    mv /etc/debian_version.backup /etc/debian_version
+# Workaround for Debian Trixie (13) not being supported yet - use bookworm compatibility
+RUN mariadb_repo_setup --mariadb-server-version="mariadb-10.11" --skip-maxscale --skip-tools --os-type=debian --os-version=bookworm
 
 # Set up Postgresql apt repository
 RUN install -d /usr/share/postgresql-common/pgdg && curl -s -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -93,13 +93,6 @@ RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then cd /tmp && curl -L -s 
 RUN set -x && cd /tmp && for item in *.deb; do dpkg-deb -x ${item} extracted; done
 RUN mkdir -p /usr/local/mariadb-old/bin && cp -ap /tmp/extracted/usr/bin/{mariadb,mariadb-dump,mysql,mysqldump} /usr/local/mariadb-old/bin
 
-### Drupal 11+ requires a minimum sqlite3 version (3.45 currently)
-### TODO: When we have this from upstream Debian 13 Trixie, we must remove this stanza
-ARG SQLITE_VERSION="3.45.1"
-RUN mkdir -p /usr/local/sqlite3-drupal11 && cd /usr/local/sqlite3-drupal11 && \
-    wget https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/sqlite3_${SQLITE_VERSION}-1_${TARGETARCH}.deb && \
-    wget https://snapshot.debian.org/archive/debian/20240203T152533Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${TARGETARCH}.deb
-
 ### -------------------------END ddev-webserver-base------------------------------
 
 ### -------------------------ddev-webserver-dev-base------------------------------

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -113,8 +113,10 @@ SHELL ["/bin/bash", "-eu", "-o", "pipefail", "-c"]
 ENV CAROOT=/mnt/ddev-global-cache/mkcert
 ENV PHP_DEFAULT_VERSION="8.3"
 
+# Workaround for Blackfire SHA1 GPG signature issue on Debian Trixie
+# Skip signature verification for Blackfire repository due to SHA1 deprecation
 RUN curl -s --fail https://packages.blackfire.io/gpg.key > /usr/share/keyrings/blackfire-archive-keyring.asc
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/blackfire-archive-keyring.asc] http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
+RUN echo "deb [arch=$(dpkg --print-architecture) trusted=yes] http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
 RUN apt-get -qq update
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests -y \
@@ -248,8 +250,10 @@ ENV PHP_DEFAULT_VERSION="8.3"
 ARG TARGETPLATFORM
 ARG TARGETARCH
 
+# Workaround for Blackfire SHA1 GPG signature issue on Debian Trixie
+# Skip signature verification for Blackfire repository due to SHA1 deprecation
 RUN curl -s --fail https://packages.blackfire.io/gpg.key > /usr/share/keyrings/blackfire-archive-keyring.asc
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/blackfire-archive-keyring.asc] http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
+RUN echo "deb [arch=$(dpkg --print-architecture) trusted=yes] http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
 RUN apt-get -qq update
 
 # Blackfire outputs errors about not having systemd, but they do no harm to our usage

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -2,7 +2,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:v1.24.7 AS ddev-webserver-base
+FROM ddev/ddev-php-base:20250728_rfay_debian_trixie AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -57,7 +57,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y -o Dpkg::Options::="--
     less \
     libcap2-bin \
     libldap-common \
-    libmagickcore-6.q16-6-extra \
+    libmagickcore-7.q16-10-extra \
     locales \
     mariadb-client \
     openssh-client \

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -31,7 +31,17 @@ RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | b
 # Install mariadb_repo_setup to get mariadb-client from them directly
 RUN curl -LsSf https://r.mariadb.com/downloads/mariadb_repo_setup -o /usr/local/bin/mariadb_repo_setup && chmod +x /usr/local/bin/mariadb_repo_setup
 # Search for CHANGE_MARIADB_CLIENT to update related code.
-RUN mariadb_repo_setup --mariadb-server-version="mariadb-10.11" --skip-maxscale --skip-tools
+# Workaround for Debian Trixie (13) not being supported yet - modify debian_version and os-release
+RUN cp /etc/os-release /etc/os-release.backup && \
+    cp /etc/debian_version /etc/debian_version.backup && \
+    sed -i 's/VERSION_ID="13"/VERSION_ID="12"/' /etc/os-release && \
+    sed -i 's/VERSION="13 (trixie)"/VERSION="12 (bookworm)"/' /etc/os-release && \
+    sed -i 's/VERSION_CODENAME=trixie/VERSION_CODENAME=bookworm/' /etc/os-release && \
+    sed -i 's/DEBIAN_VERSION_FULL=13.0/DEBIAN_VERSION_FULL=12.0/' /etc/os-release && \
+    echo "12.0" > /etc/debian_version && \
+    mariadb_repo_setup --mariadb-server-version="mariadb-10.11" --skip-maxscale --skip-tools && \
+    mv /etc/os-release.backup /etc/os-release && \
+    mv /etc/debian_version.backup /etc/debian_version
 
 # Set up Postgresql apt repository
 RUN install -d /usr/share/postgresql-common/pgdg && curl -s -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
@@ -15,7 +15,7 @@ MARIADB_VERSION=${DDEV_DATABASE#*:}
 
 # Configure the correct repository for mariadb
 set -x
-log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --os-type=debian --os-version=bookworm || exit $?
+log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --os-type=debian --os-version=bookworm --skip-key-import || exit $?
 rm -f /etc/apt/sources.list.d/mariadb.list.old_*
 # --skip-key-import flag doesn't download the existing key again and omits "apt-get update",
 # so we can run "apt-get update" manually only for mariadb and debian repos to make it faster

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-client-install.sh
@@ -15,7 +15,7 @@ MARIADB_VERSION=${DDEV_DATABASE#*:}
 
 # Configure the correct repository for mariadb
 set -x
-log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --skip-key-import || exit $?
+log-stderr.sh --timeout "${START_SCRIPT_TIMEOUT:-30}" mariadb_repo_setup --mariadb-server-version="mariadb-${MARIADB_VERSION}" --skip-maxscale --skip-tools --os-type=debian --os-version=bookworm || exit $?
 rm -f /etc/apt/sources.list.d/mariadb.list.old_*
 # --skip-key-import flag doesn't download the existing key again and omits "apt-get update",
 # so we can run "apt-get update" manually only for mariadb and debian repos to make it faster

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -74,12 +74,35 @@
 @test "verify key php extensions are loaded on PHP${PHP_VERSION}" {
   if [ "${WEBSERVER_TYPE}" = "apache-fpm" ]; then skip "Skipping on apache-fpm because we don't have to do this twice"; fi
 
-  extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
+  # EXPERIMENTAL: Conditional extension list based on Debian Trixie Sury repository availability
+  # Base extensions that should always be available
+  extensions="apcu bcmath bz2 curl gd imagick intl ldap mbstring mysqli pgsql readline soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
+  
+  # Conditionally add extensions based on PHP version and known Sury repository issues
   case ${PHP_VERSION} in
-  8.[1234])
-    extensions="apcu bcmath bz2 curl gd imagick intl json ldap mbstring memcached mysqli pgsql readline redis soap sqlite3 uploadprogress xhprof xml xmlrpc zip"
+  5.6)
+    # php5.6: memcached missing on arm64, redis available, json available
+    extensions="$extensions redis json"
+    if [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "arm64" ]; then
+      extensions="$extensions memcached"
+    fi
     ;;
-
+  7.0|7.1|7.2|7.3)
+    # php7.0-7.3: both memcached and redis missing in Debian Trixie Sury repo, json available
+    extensions="$extensions json"
+    ;;
+  7.4)
+    # php7.4: memcached missing, redis available, json available  
+    extensions="$extensions redis json"
+    ;;
+  8.0|8.1|8.2|8.3|8.4)
+    # php8.0+: memcached missing, redis available, json built into PHP core (not separate extension)
+    extensions="$extensions redis"
+    ;;
+  *)
+    # Default fallback for future PHP versions
+    extensions="$extensions redis"
+    ;;
   esac
 
   run docker exec -t $CONTAINER_NAME enable_xdebug

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1121,12 +1121,6 @@ ENV N_INSTALL_VERSION="%s"
 	if app.CorepackEnable {
 		extraWebContent = extraWebContent + "\nRUN corepack enable"
 	}
-	// TODO: When we have this from upstream Debian 13 Trixie, we must remove this condition
-	if app.Type == nodeps.AppTypeDrupal11 {
-		extraWebContent = extraWebContent + `
-### DDEV-injected SQLite 3.45.1 is required for Drupal 11 tests, change the project type if you don't need this
-RUN apt-get install -y /usr/local/sqlite3-drupal11/*.deb`
-	}
 	// Add supervisord config for WebExtraDaemons
 	var supervisorGroup []string
 	for _, appStart := range app.WebExtraDaemons {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1127,7 +1127,7 @@ func TestExtraPackages(t *testing.T) {
 	require.NoError(t, err)
 
 	addedDBPackage := "sudo"
-	addedWebPackage := "dnsutils"
+	addedWebPackage := "bind9-dnsutils"
 
 	// Test db container to make sure no sudo in there at beginning
 	_, _, err = app.Exec(&ddevapp.ExecOpts{

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -996,7 +996,7 @@ func TestPHPConfig(t *testing.T) {
 
 	for _, v := range phpKeys {
 		app.PHPVersion = v
-		app.WebImageExtraPackages = []string{"php" + app.PHPVersion + "-redis"}
+		app.WebImageExtraPackages = []string{"php" + app.PHPVersion + "-solr"}
 		err = app.Restart()
 		require.NoError(t, err)
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2374,17 +2374,6 @@ func TestDdevFullSiteSetup(t *testing.T) {
 			assert.Contains(err.Error(), "upload_dirs is not set", app.Type)
 		}
 
-		// TODO: When we have this from upstream Debian 13 Trixie, we must remove this condition
-		// Special installed sqlite3 test for drupal11.
-		if app.Type == nodeps.AppTypeDrupal11 {
-			stdout, stderr, err := app.Exec(&ddevapp.ExecOpts{
-				Cmd: "sqlite3 --version | awk '{print $1}'",
-			})
-			require.NoError(t, err, "sqlite3 --version failed, output=%v, stderr=%v", stdout, stderr)
-			stdout = strings.Trim(stdout, "\r\n")
-			require.Equal(t, "3.45.1", stdout)
-		}
-
 		// We don't want all the projects running at once.
 		err = app.Stop(true, false)
 		assert.NoError(err)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.24.7" // Note that this can be overridden by make
+var WebTag = "20250728_rfay_debian_trixie" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- #7108

In DDEV v1.25.0 we expect to migrate the base image for ddev-webserver to debian trixie v13.

I know this is jumping the gun. I was inspired by #7484 from @GuySartorelli but they reported later it wasn't a fix. I did it anyway. There were a few workarounds required to get the various components going.

## TODO

- [ ] Convince blackfire to go to a newer key type (or maybe they have and we're using an old recipe (revert workaround ) I requested this change in [their discord](https://discord.com/channels/1121795479785721957/1399735861465186354/1399735861465186354)
- [ ] Get mariadb to support Debian Trixie with their client installer package (revert workaround https://github.com/ddev/ddev/commit/d25f4c014f30422f3ef230e58d08bc8566ec4af7 ) https://jira.mariadb.org/browse/MDEV-37241
- [ ] Get full support for needed PHP extensions from deb.sury.org and (revert workaround https://github.com/ddev/ddev/commit/35ecc77b4c99a3f07d382f5e9c3c1011273a8ba9 ) - see https://github.com/oerdnj/deb.sury.org/issues/2330
- [ ] Re-enable memcached/redis tests after deb.sury.org updated, revert https://github.com/ddev/ddev/commit/35ecc77b4c99a3f07d382f5e9c3c1011273a8ba9
- [ ] The base install of mariadb-client is explicitly using debian 12 and probably needs to be updated, https://github.com/ddev/ddev/blob/87d4aa526fc22cfb161d840b8201b42ebc458ce7/containers/ddev-webserver/Dockerfile#L101-L102

## How This PR Solves The Issue

* Use Trixie as base
* Remove terrible sqlite 3.45.1 hacks for Drupal 11
* Experimental: Use Debian trixie nginx packages instead of nginx.org
* Upgrade libmagiccore

## Manual Testing Instructions

Try it out

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
