### PR TITLE
build: use ddev/ddev-utilities instead of busybox, fixes #7499

### DIFF
--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -28,11 +28,11 @@ while ! docker ps >/dev/null 2>&1 ; do
     sleep 60
 done
 
-# Test that docker can allocate 80 and 443, get busybox
-docker pull busybox:stable >/dev/null
+# Test that docker can allocate 80 and 443, get ddev/ddev-utilities
+docker pull ddev/ddev-utilities >/dev/null
 # Try the docker run command twice because of the really annoying mkdir /c: file exists bug
 # Apparently https://github.com/docker/for-win/issues/1560
-(sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:stable ls //tmp/junker99 >/dev/null) || (sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:stable ls //tmp/junker99 >/dev/null ))
+(sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 ddev/ddev-utilities ls //tmp/junker99 >/dev/null) || (sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 ddev/ddev-utilities ls //tmp/junker99 >/dev/null ))
 
 # Check that required commands are available.
 for command in git go make mysql ngrok; do

--- a/.github/workflows/nfstest.sh
+++ b/.github/workflows/nfstest.sh
@@ -21,5 +21,5 @@ fi
 hostDockerInternal=$($(dirname $0)/../../scripts/host-docker-internal.sh)
 
 docker volume create --driver local --opt type=nfs --opt o=addr=${hostDockerInternal},hard,nolock,rw --opt device=:${share} nfstest >/dev/null
-docker run -t --rm -v nfstest:/tmp/nfs busybox:stable ls //tmp/nfs >/dev/null
+docker run -t --rm -v nfstest:/tmp/nfs ddev/ddev-utilities ls //tmp/nfs >/dev/null
 echo "nfsd seems to be set up ok"

--- a/.github/workflows/sanetestbot.sh
+++ b/.github/workflows/sanetestbot.sh
@@ -28,11 +28,11 @@ while ! docker ps >/dev/null 2>&1 ; do
     sleep 60
 done
 
-# Test that docker can allocate 80 and 443, get get busybox
-docker pull busybox:stable >/dev/null
+# Test that docker can allocate 80 and 443, get get ddev/ddev-utilities
+docker pull ddev/ddev-utilities >/dev/null
 # Try the docker run command twice because of the really annoying mkdir /c: file exists bug
 # Apparently https://github.com/docker/for-win/issues/1560
-(sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:stable ls //tmp/junker99 >/dev/null) || (sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 busybox:stable ls //tmp/junker99 >/dev/null ))
+(sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 ddev/ddev-utilities ls //tmp/junker99 >/dev/null) || (sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 ddev/ddev-utilities ls //tmp/junker99 >/dev/null ))
 
 # Check that required commands are available.
 for command in mysql git go make; do

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -171,7 +171,7 @@ if ddev debug dockercheck -h | grep dockercheck >/dev/null; then
   ddev debug dockercheck 2>/dev/null
 fi
 
-printf "\nDocker disk space:\n" && docker run --rm busybox:stable df -h //
+printf "\nDocker disk space:\n" && docker run --rm ddev/ddev-utilities df -h //
 
 header "Existing docker containers"
 docker ps -a

--- a/docs/content/developers/scripts/windows_buildkite_setup.sh
+++ b/docs/content/developers/scripts/windows_buildkite_setup.sh
@@ -34,9 +34,9 @@ nssm.exe stop buildkite-agent || true
 nssm.exe remove buildkite-agent confirm || true
 nssm.exe install buildkite-agent "C:\buildkite-agent\bin\buildkite-agent.exe" "start" || true
 nssm.exe set buildkite-agent AppStdout "C:\buildkite-agent\buildkite-agent.log"
-nssm.exe set buildkite-agent AppStderr "C:\buildkite-agent\buildkite-agent.lwinpty docker run -it -p 80 busybox:stable log"
+nssm.exe set buildkite-agent AppStderr "C:\buildkite-agent\buildkite-agent.lwinpty docker run -it -p 80 ddev/ddev-utilities log"
 nssm.exe start buildkite-agent || true
 nssm.exe status buildkite-agent || true
 
 # Get firewall set up with a single run
-winpty docker run -it --rm -p 80 busybox:stable ls
+winpty docker run -it --rm -p 80 ddev/ddev-utilities ls

--- a/docs/content/developers/scripts/windows_github_agent_setup.sh
+++ b/docs/content/developers/scripts/windows_github_agent_setup.sh
@@ -20,6 +20,6 @@ perl -pi -e 's/autocrlf = true/autocrlf = false\n\teol = lf/' "/c/Program Files/
 # Then wsl --set-default Ubuntu
 
 # Get firewall set up with a single run
-winpty docker run -it --rm -p 80 busybox:stable ls
+winpty docker run -it --rm -p 80 ddev/ddev-utilities ls
 
 bash "/c/Program Files/ddev/windows_ddev_nfs_setup.sh"

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -179,7 +179,7 @@ We can use a single Docker command to make sure Docker is set up to do what we w
 In your *project directory* run the following (using Git Bash if you’re on Windows!):
 
 ```
-docker run --rm -t -p 80:80 -p 443:443 -v "//$PWD:/tmp/projdir" busybox sh -c "echo ---- Project Directory && ls /tmp/projdir"
+docker run --rm -t -p 80:80 -p 443:443 -v "//$PWD:/tmp/projdir" ddev/ddev-utilities sh -c "echo ---- Project Directory && ls /tmp/projdir"
 ```
 
 The result should be a list of the files in your project directory.

--- a/pkg/ddevapp/db.go
+++ b/pkg/ddevapp/db.go
@@ -12,7 +12,7 @@ import (
 // GetExistingDBType returns type/version like mariadb:10.11 or postgres:13 or "" if no existing volume
 // This has to make a Docker container run so is fairly costly.
 func (app *DdevApp) GetExistingDBType() (string, error) {
-	_, out, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "GetExistingDBType-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "( test -f /var/tmp/mysql/db_mariadb_version.txt && cat /var/tmp/mysql/db_mariadb_version.txt ) || ( test -f /var/tmp/postgres/PG_VERSION && cat /var/tmp/postgres/PG_VERSION) || true"}, []string{}, []string{}, []string{app.GetMariaDBVolumeName() + ":/var/tmp/mysql", app.GetPostgresVolumeName() + ":/var/tmp/postgres"}, "", true, false, map[string]string{`com.ddev.site-name`: ""}, nil, nil)
+	_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "GetExistingDBType-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "( test -f /var/tmp/mysql/db_mariadb_version.txt && cat /var/tmp/mysql/db_mariadb_version.txt ) || ( test -f /var/tmp/postgres/PG_VERSION && cat /var/tmp/postgres/PG_VERSION) || true"}, []string{}, []string{}, []string{app.GetMariaDBVolumeName() + ":/var/tmp/mysql", app.GetPostgresVolumeName() + ":/var/tmp/postgres"}, "", true, false, map[string]string{`com.ddev.site-name`: ""}, nil, nil)
 
 	if err != nil {
 		util.Failed("Failed to RunSimpleContainer to inspect database version/type: %v, output=%s", err, out)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1873,11 +1873,11 @@ func (app *DdevApp) PullContainerImages(pullAlways bool) error {
 }
 
 // PullBaseContainerImages pulls only the fundamentally needed images so they can be available early.
-// We always need web image, busybox, and ddev-utilities for housekeeping.
+// We always need web image, and ddev-utilities for housekeeping.
 func PullBaseContainerImages(additionalImages []string, pullAlways bool) error {
 	base := []string{
 		ddevImages.GetWebImage(),
-		versionconstants.BusyboxImage,
+		versionconstants.UtilitiesImage,
 		versionconstants.UtilitiesImage,
 	}
 	if globalconfig.DdevGlobalConfig.XHProfMode == types.XHProfModeXHGui {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1878,7 +1878,6 @@ func PullBaseContainerImages(additionalImages []string, pullAlways bool) error {
 	base := []string{
 		ddevImages.GetWebImage(),
 		versionconstants.UtilitiesImage,
-		versionconstants.UtilitiesImage,
 	}
 	if globalconfig.DdevGlobalConfig.XHProfMode == types.XHProfModeXHGui {
 		base = append(base, ddevImages.GetXhguiImage())

--- a/pkg/ddevapp/poweroff.go
+++ b/pkg/ddevapp/poweroff.go
@@ -14,7 +14,7 @@ func PowerOff() {
 
 	// Remove any custom certs that may have been added
 	// along with all Traefik configuration.
-	_, _, err = dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "poweroff-"+util.RandString(6), []string{"sh", "-c", "rm -rf /mnt/ddev-global-cache/custom_certs/* /mnt/ddev-global-cache/traefik/*"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-global-cache"}, "", true, false, map[string]string{"com.ddev.site-name": ""}, nil, &dockerutil.NoHealthCheck)
+	_, _, err = dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "poweroff-"+util.RandString(6), []string{"sh", "-c", "rm -rf /mnt/ddev-global-cache/custom_certs/* /mnt/ddev-global-cache/traefik/*"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-global-cache"}, "", true, false, map[string]string{"com.ddev.site-name": ""}, nil, &dockerutil.NoHealthCheck)
 	if err != nil {
 		util.Warning("Failed removing custom certs/traefik configuration: %v", err)
 	}

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -215,7 +215,7 @@ func TestContainerWait(t *testing.T) {
 	labels = map[string]string{"test": "quickexit"}
 	// Make sure none already exist
 	_ = dockerutil.RemoveContainersByLabels(labels)
-	c1, _, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, t.Name()+"-quickexit-"+util.RandString(5), []string{"ls"}, nil, nil, nil, "0", false, true, labels, nil, nil)
+	c1, _, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, t.Name()+"-quickexit-"+util.RandString(5), []string{"ls"}, nil, nil, nil, "0", false, true, labels, nil, nil)
 	t.Cleanup(func() {
 		_ = dockerutil.RemoveContainer(c1)
 		assert.NoError(err, "failed to remove container %v (%s)", labels, c1)
@@ -231,7 +231,7 @@ func TestContainerWait(t *testing.T) {
 	// Make sure none already exist
 	_ = dockerutil.RemoveContainersByLabels(labels)
 
-	c2, _, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, t.Name()+"-nohealthcheck-busybox-sleep-60-"+util.RandString(5), []string{"sleep", "60"}, nil, nil, nil, "0", false, true, labels, nil, nil)
+	c2, _, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, t.Name()+"-nohealthcheck-busybox-sleep-60-"+util.RandString(5), []string{"sleep", "60"}, nil, nil, nil, "0", false, true, labels, nil, nil)
 	t.Cleanup(func() {
 		err = dockerutil.RemoveContainer(c2)
 		assert.NoError(err, "failed to remove container (sleep 60) %v (%s)", labels, c2)
@@ -427,7 +427,7 @@ func TestFindContainerByName(t *testing.T) {
 	}
 
 	// Run a container, don't remove it.
-	cID, _, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, containerName, []string{"sleep", "2"}, nil, nil, nil, "25", false, false, nil, nil, nil)
+	cID, _, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, containerName, []string{"sleep", "2"}, nil, nil, nil, "25", false, false, nil, nil, nil)
 	require.NoError(t, err)
 
 	defer func() {
@@ -532,7 +532,7 @@ func TestDockerExec(t *testing.T) {
 	assert := asrt.New(t)
 	ctx, client := dockerutil.GetDockerClient()
 
-	id, _, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"tail", "-f", "/dev/null"}, nil, nil, nil, "0", false, true, nil, nil, nil)
+	id, _, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "", []string{"tail", "-f", "/dev/null"}, nil, nil, nil, "0", false, true, nil, nil, nil)
 	assert.NoError(err)
 
 	t.Cleanup(func() {
@@ -623,7 +623,7 @@ func TestCopyIntoVolume(t *testing.T) {
 
 	// Make sure that the content is the same, and that .test.sh is executable
 	// On Windows the upload can result in losing executable bit
-	_, out, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"sh", "-c", "cd /mnt/" + t.Name() + " && ls -R .test.sh * && ./.test.sh"}, nil, nil, []string{t.Name() + ":/mnt/" + t.Name()}, "25", true, false, nil, nil, nil)
+	_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "", []string{"sh", "-c", "cd /mnt/" + t.Name() + " && ls -R .test.sh * && ./.test.sh"}, nil, nil, []string{t.Name() + ":/mnt/" + t.Name()}, "25", true, false, nil, nil, nil)
 	assert.NoError(err)
 	assert.Equal(`.test.sh
 root.txt
@@ -635,7 +635,7 @@ hi this is a test file
 
 	err = dockerutil.CopyIntoVolume(filepath.Join(pwd, "testdata", t.Name()), t.Name(), "somesubdir", "501", "", true)
 	assert.NoError(err)
-	_, out, err = dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"sh", "-c", "cd /mnt/" + t.Name() + "/somesubdir  && pwd && ls -R"}, nil, nil, []string{t.Name() + ":/mnt/" + t.Name()}, "0", true, false, nil, nil, nil)
+	_, out, err = dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "", []string{"sh", "-c", "cd /mnt/" + t.Name() + "/somesubdir  && pwd && ls -R"}, nil, nil, []string{t.Name() + ":/mnt/" + t.Name()}, "0", true, false, nil, nil, nil)
 	assert.NoError(err)
 	assert.Equal(`/mnt/TestCopyIntoVolume/somesubdir
 .:
@@ -651,7 +651,7 @@ subdir1.txt
 	assert.NoError(err)
 
 	// Make sure that the content is the same, and that .test.sh is executable
-	_, out, err = dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"cat", "/mnt/" + t.Name() + "/root.txt"}, nil, nil, []string{t.Name() + ":/mnt/" + t.Name()}, "25", true, false, nil, nil, nil)
+	_, out, err = dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "", []string{"cat", "/mnt/" + t.Name() + "/root.txt"}, nil, nil, []string{t.Name() + ":/mnt/" + t.Name()}, "25", true, false, nil, nil, nil)
 	assert.NoError(err)
 	assert.Equal("root.txt here\n", out)
 
@@ -659,10 +659,10 @@ subdir1.txt
 	err = dockerutil.CopyIntoVolume(filepath.Join(pwd, "testdata", t.Name()+"2"), t.Name(), "", "0", "", true)
 	require.NoError(t, err)
 
-	_, _, err = dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"ls", "/mnt/" + t.Name() + "/subdir1/subdir1.txt"}, nil, nil, []string{t.Name() + ":/mnt/" + t.Name()}, "25", true, false, nil, nil, nil)
+	_, _, err = dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "", []string{"ls", "/mnt/" + t.Name() + "/subdir1/subdir1.txt"}, nil, nil, []string{t.Name() + ":/mnt/" + t.Name()}, "25", true, false, nil, nil, nil)
 	require.Error(t, err)
 
-	_, _, err = dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"ls", "/mnt/" + t.Name() + "/subdir1/only-the-new-stuff.txt"}, nil, nil, []string{t.Name() + ":/mnt/" + t.Name()}, "25", true, false, nil, nil, nil)
+	_, _, err = dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "", []string{"ls", "/mnt/" + t.Name() + "/subdir1/only-the-new-stuff.txt"}, nil, nil, []string{t.Name() + ":/mnt/" + t.Name()}, "25", true, false, nil, nil, nil)
 	require.NoError(t, err)
 }
 

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -72,7 +72,7 @@ func TestFileHash(t *testing.T) {
 func externalComputeSha1Sum(filePath string) (string, error) {
 	dir := filepath.Dir(filePath)
 	fName := filepath.Base(filePath)
-	_, out, err := dockerutil.RunSimpleContainer(versionconstants.BusyboxImage, "", []string{"sha1sum", path.Join("/mnt/mounteddir", fName)}, nil, nil, []string{dir + ":" + "/mnt/mounteddir"}, "0", true, false, nil, nil, nil)
+	_, out, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "", []string{"sha1sum", path.Join("/mnt/mounteddir", fName)}, nil, nil, []string{dir + ":" + "/mnt/mounteddir"}, "0", true, false, nil, nil, nil)
 
 	if err != nil {
 		return "", err

--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -57,7 +57,7 @@ func TestGetFreePort(t *testing.T) {
 		require.NotContains(t, globalconfig.DdevProjectList["TestGetFreePort"].UsedHostPorts, port)
 
 		// Make sure we can actually use the port.
-		dockerCommand := []string{"run", "--rm", "-p" + dockerIP + ":" + port + ":" + port, versionconstants.BusyboxImage}
+		dockerCommand := []string{"run", "--rm", "-p" + dockerIP + ":" + port + ":" + port, versionconstants.UtilitiesImage}
 		out, err := exec.RunCommand("docker", dockerCommand)
 
 		require.NoError(t, err, "failed to 'docker %v': %v, output='%v'", dockerCommand, err, out)

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -38,7 +38,7 @@ var XhguiImage = "ddev/ddev-xhgui"
 var XhguiTag = "v1.24.7"
 
 // UtilitiesImage is used in bash scripts
-var UtilitiesImage = "ddev/ddev-utilities"
+var UtilitiesImage = "ddev/ddev-utilities:latest"
 
 // BUILDINFO is information with date and context, supplied by make
 var BUILDINFO = "BUILDINFO should have new info"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -31,9 +31,6 @@ var SSHAuthImage = "ddev/ddev-ssh-agent"
 // SSHAuthTag is ssh-agent auth tag
 var SSHAuthTag = "v1.24.7"
 
-// BusyboxImage is used a couple of places for a quick-pull
-var BusyboxImage = "busybox:stable"
-
 // XhguiImage is image for xhgui
 var XhguiImage = "ddev/ddev-xhgui"
 

--- a/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
+++ b/scripts/debian_ubuntu_linux_ddev_nfs_setup.sh
@@ -26,7 +26,7 @@ if [[ $EUID -eq 0 ]]; then
 fi
 
 mkdir -p ~/.ddev
-docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 busybox:stable ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 103)
+docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 ddev/ddev-utilities ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 103)
 
 echo "
 +-------------------------------------------------------------------------+

--- a/scripts/macos_ddev_nfs_setup.sh
+++ b/scripts/macos_ddev_nfs_setup.sh
@@ -19,7 +19,7 @@ if [[ $EUID -eq 0 ]]; then
 fi
 
 mkdir -p ~/.ddev
-docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 busybox:stable ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 103)
+docker run --rm -t -v /$HOME/.ddev:/tmp/junker99 ddev/ddev-utilities ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 103)
 
 echo "
 +-------------------------------------------+

--- a/scripts/windows_ddev_nfs_setup.sh
+++ b/scripts/windows_ddev_nfs_setup.sh
@@ -14,7 +14,7 @@ DDEV_WINDOWS_GID=1000
 nfs_addr=127.0.0.1
 
 mkdir -p ~/.ddev
-docker run --rm -t -v "/$HOME/.ddev:/tmp/junker99" busybox:stable ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 101)
+docker run --rm -t -v "/$HOME/.ddev:/tmp/junker99" ddev/ddev-utilities ls //tmp/junker99 >/dev/null || ( echo "Docker does not seem to be running or functional, please check it for problems" && exit 101)
 
 
 status=uninstalled


### PR DESCRIPTION

## The Issue

- #7499

We already require ddev/ddev-utilities and have it downloaded. Using it will help us to better manage images that we control.

## How This PR Solves The Issue

* Use ddev/ddev-utilities in user-facing activities
* I avoided changes to tests, as they would be intrusive and not useful
* busybox is still used widely in docs and examples, and it's fine there.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
