### PR TITLE
test: ngrok broke their installation moving to bookworm, fix it

### DIFF
--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -17,7 +17,7 @@ sudo apt-get install -y -qq build-essential expect libnss3-tools libcurl4-gnutls
 
 curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc \
   | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null \
-  && echo "deb https://ngrok-agent.s3.amazonaws.com buster main" \
+  && echo "deb https://ngrok-agent.s3.amazonaws.com bookworm main" \
   | sudo tee /etc/apt/sources.list.d/ngrok.list \
   && sudo apt-get update -qq >/dev/null \
   && sudo apt-get install -y -qq ngrok

--- a/docs/content/developers/scripts/wsl2-test-runner-setup.sh
+++ b/docs/content/developers/scripts/wsl2-test-runner-setup.sh
@@ -40,7 +40,7 @@ sudo snap install --classic go
 # ngrok
 curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc \
   | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null \
-  && echo "deb https://ngrok-agent.s3.amazonaws.com buster main" \
+  && echo "deb https://ngrok-agent.s3.amazonaws.com bookworm main" \
   | sudo tee /etc/apt/sources.list.d/ngrok.list \
   && sudo apt-get update >/dev/null \
   && sudo apt-get install -y ngrok >/dev/null


### PR DESCRIPTION

## The Issue

ngrok seems to have changed their Debian/Ubuntu support without a good path forward; deleted their existing package.

## How This PR Solves The Issue

They "moved" to "bookworm support"

Use "bookworm" instead of "buster" in the ngrok installation.

