### PR TITLE
docs: Extend the Drupal installation instructions

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -228,9 +228,11 @@ Read more about customizing the environment and persisting configuration in [Pro
     ddev composer create-project "drupal/recommended-project:^11"
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
-    ddev launch
-    # or automatically log in with
+    # Visit the website by opening its frontpage with a welcome message:
+    ddev launch $(ddev drush uli)
+    # Visit the website by opening its more technical status report page:
     ddev launch $(ddev drush uli admin/reports/status)
+    # (Both commands automatically signs you in to the admin interface.)
     ```
 
     Read more about: [Drupal Core](https://new.drupal.org/about/overview/technical) & [Documentation](https://www.drupal.org/docs)
@@ -257,9 +259,11 @@ Read more about customizing the environment and persisting configuration in [Pro
     ddev composer create-project "drupal/recommended-project:^10"
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
-    ddev launch
-    # or automatically log in with
+    # Visit the website by opening its frontpage with a welcome message:
+    ddev launch $(ddev drush uli)
+    # Visit the website by opening its more technical status report page:
     ddev launch $(ddev drush uli admin/reports/status)
+    # (Both commands automatically signs you in to the admin interface.)
     ```
 
     Read more about: [Drupal Core](https://new.drupal.org/about/overview/technical) & [Documentation](https://www.drupal.org/docs)

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -229,10 +229,8 @@ Read more about customizing the environment and persisting configuration in [Pro
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
     # Visit the website by opening its frontpage with a welcome message:
-    ddev launch $(ddev drush uli)
-    # Visit the website by opening its more technical status report page:
-    ddev launch $(ddev drush uli admin/reports/status)
-    # (Both commands automatically signs you in to the admin interface.)
+    ddev launch $(ddev drush uli "/")
+    # This command automatically signs you in to Drupal's admin interface.
     ```
 
     Read more about: [Drupal Core](https://new.drupal.org/about/overview/technical) & [Documentation](https://www.drupal.org/docs)
@@ -260,10 +258,8 @@ Read more about customizing the environment and persisting configuration in [Pro
     ddev composer require drush/drush
     ddev drush site:install --account-name=admin --account-pass=admin -y
     # Visit the website by opening its frontpage with a welcome message:
-    ddev launch $(ddev drush uli)
-    # Visit the website by opening its more technical status report page:
-    ddev launch $(ddev drush uli admin/reports/status)
-    # (Both commands automatically signs you in to the admin interface.)
+    ddev launch $(ddev drush uli "/")
+    # This command automatically signs you in to Drupal's admin interface.
     ```
 
     Read more about: [Drupal Core](https://new.drupal.org/about/overview/technical) & [Documentation](https://www.drupal.org/docs)

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -221,7 +221,6 @@ Read more about customizing the environment and persisting configuration in [Pro
 === "Drupal 11"
 
     ```bash
-    # Don't open this folder in Finder yet – otherwise the `.DS_Store` file blocks the `composer create-project` script.
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal11 --docroot=web
     ddev start
@@ -250,7 +249,6 @@ Read more about customizing the environment and persisting configuration in [Pro
 === "Drupal 10"
 
     ```bash
-    # Don't open this folder in Finder yet – otherwise the `.DS_Store` file blocks the `composer create-project` script.
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal10 --docroot=web
     ddev start

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -221,6 +221,7 @@ Read more about customizing the environment and persisting configuration in [Pro
 === "Drupal 11"
 
     ```bash
+    # Don't open this folder in Finder yet – otherwise the `.DS_Store` file blocks the `composer create-project` script.
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal11 --docroot=web
     ddev start
@@ -229,7 +230,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     ddev drush site:install --account-name=admin --account-pass=admin -y
     ddev launch
     # or automatically log in with
-    ddev launch $(ddev drush uli)
+    ddev launch $(ddev drush uli admin/reports/status)
     ```
 
     Read more about: [Drupal Core](https://new.drupal.org/about/overview/technical) & [Documentation](https://www.drupal.org/docs)
@@ -249,6 +250,7 @@ Read more about customizing the environment and persisting configuration in [Pro
 === "Drupal 10"
 
     ```bash
+    # Don't open this folder in Finder yet – otherwise the `.DS_Store` file blocks the `composer create-project` script.
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal10 --docroot=web
     ddev start
@@ -257,7 +259,7 @@ Read more about customizing the environment and persisting configuration in [Pro
     ddev drush site:install --account-name=admin --account-pass=admin -y
     ddev launch
     # or automatically log in with
-    ddev launch $(ddev drush uli)
+    ddev launch $(ddev drush uli admin/reports/status)
     ```
 
     Read more about: [Drupal Core](https://new.drupal.org/about/overview/technical) & [Documentation](https://www.drupal.org/docs)


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- [x] 1. macOS' default file manager app _Finder_ automatically creates a hidden `.DS_Store` file when opening an empty directory. The Composer script invoked by the `create-project` command checks whether the directory at the given path is entirely empty and exits with an error message if something is found within. The easiest way to ensure Composer's project creation script can make it through is to NOT visit this folder in Finder after getting manually created in the CLI, only after the script has finished running.<br><br>Some users with less experience/confidence regarding how the macOS file system works might stumble upon this issue and eventually give up the installation process. – Being resolved in MR #7469.
- [ ] 2. The `$ drush uli` command can take an extra argument for a valid URL path existing in Drupal, where the user gets redirected upon successful authentication. With no such argument provided, the default page of the website, the frontpage, is being presented, showing a friendly welcome message useful for newcomer evaluators.<br><br>Suggesting the invocation of a pure `$ ddev launch` command (without piping in the output of `$ drush uli`) is not useful at all, because the user might feel "closed out" themselves from their freshly installed local website instance.


## How This PR Solves The Issue

1. Add a friendly reminder before the first step of the process
2. Delete the (probably) less-useful not-authenticating command
3. Replace it with both auto-authenticating commands with a choice offered

## Manual Testing Instructions

Go through the steps of the installation process.

## Automated Testing Overview

This is documentation update only.

## Release/Deployment Notes

After merging, one day it should appear on https://ddev.readthedocs.io/en/stable/users/quickstart/#drupal