### PR TITLE
fix(traefik): improve router port discovery and optimize YAML writes, fixes ddev/ddev-mongo#24

### DIFF
--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -71,6 +71,11 @@ func TestMain(m *testing.M) {
 
 	if os.Getenv("DDEV_BINARY_FULLPATH") != "" {
 		DdevBin = os.Getenv("DDEV_BINARY_FULLPATH")
+	} else {
+		binPath, err := osexec.LookPath(DdevBin)
+		if err == nil {
+			DdevBin = binPath
+		}
 	}
 	output.UserOut.Println("Running DDEV with ddev=", DdevBin)
 

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -74,6 +74,10 @@ func TestCmdStart(t *testing.T) {
 func TestCmdStartOptionalProfiles(t *testing.T) {
 	testcommon.ClearDockerEnv()
 
+	// When DDEV_GOROUTINES is set as it is in CI, its output is added to the
+	// json in our curl tests below.
+	t.Setenv("DDEV_GOROUTINES", "")
+
 	site := TestSites[0]
 	origDir, _ := os.Getwd()
 	err := os.Chdir(TestSites[0].Dir)

--- a/cmd/ddev/cmd/testdata/TestCmdStartOptionalProfiles/docker-compose.busybox.yaml
+++ b/cmd/ddev/cmd/testdata/TestCmdStartOptionalProfiles/docker-compose.busybox.yaml
@@ -8,6 +8,12 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
+    # ports from optional profiles should be exposed for Traefik
+    # and used as entryPoints, if it doesn't work, router fails
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=18125:80
+      - HTTPS_EXPOSE=18126:80
   busybox2:
     image: busybox:stable
     command: tail -f /dev/null

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -404,7 +404,7 @@ func getConfigBasedRouterPorts() []string {
 				}
 			}
 
-			routerPorts = processExposePorts(exposePorts, routerPorts)
+			routerPorts = ProcessExposePorts(exposePorts, routerPorts)
 		}
 	}
 
@@ -439,17 +439,17 @@ func getContainerBasedRouterPorts() []string {
 				exposePorts = append(exposePorts, ports...)
 			}
 
-			routerPorts = processExposePorts(exposePorts, routerPorts)
+			routerPorts = ProcessExposePorts(exposePorts, routerPorts)
 		}
 	}
 
 	return routerPorts
 }
 
-// processExposePorts processes HTTP_EXPOSE and HTTPS_EXPOSE port strings and returns
+// ProcessExposePorts processes HTTP_EXPOSE and HTTPS_EXPOSE port strings and returns
 // a list of external ports that need to be bound by the router.
 // It handles port pair formats like "8080:80" or "8080" and validates the format.
-func processExposePorts(exposePorts []string, routerPorts []string) []string {
+func ProcessExposePorts(exposePorts []string, routerPorts []string) []string {
 	for _, exposePortPair := range exposePorts {
 		// Ports defined as hostPort:containerPort allow for router to configure upstreams
 		// for containerPort, with server listening on hostPort.

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -278,6 +278,98 @@ func TestUseEphemeralPort(t *testing.T) {
 	}
 }
 
+// TestProcessExposePorts tests the ProcessExposePorts function for various input scenarios
+func TestProcessExposePorts(t *testing.T) {
+	type testCase struct {
+		name          string
+		exposePorts   []string
+		initialPorts  []string
+		expectedPorts []string
+	}
+
+	tests := []testCase{
+		{
+			name:          "Empty expose ports",
+			exposePorts:   []string{},
+			initialPorts:  []string{},
+			expectedPorts: []string{},
+		},
+		{
+			name:          "Single port format",
+			exposePorts:   []string{"8080"},
+			initialPorts:  []string{},
+			expectedPorts: []string{"8080"},
+		},
+		{
+			name:          "Port pair format",
+			exposePorts:   []string{"8080:80"},
+			initialPorts:  []string{},
+			expectedPorts: []string{"8080"},
+		},
+		{
+			name:          "Multiple ports",
+			exposePorts:   []string{"8080", "9090:90", "3000"},
+			initialPorts:  []string{},
+			expectedPorts: []string{"8080", "9090", "3000"},
+		},
+		{
+			name:          "Duplicate ports are not added",
+			exposePorts:   []string{"8080", "8080:80"},
+			initialPorts:  []string{},
+			expectedPorts: []string{"8080"},
+		},
+		{
+			name:          "Existing ports are preserved",
+			exposePorts:   []string{"9090"},
+			initialPorts:  []string{"8080"},
+			expectedPorts: []string{"8080", "9090"},
+		},
+		{
+			name:          "Port already exists in initial list",
+			exposePorts:   []string{"8080"},
+			initialPorts:  []string{"8080", "9090"},
+			expectedPorts: []string{"8080", "9090"},
+		},
+		{
+			name:          "Invalid port format is ignored",
+			exposePorts:   []string{"invalid", "8080", "abc:def"},
+			initialPorts:  []string{},
+			expectedPorts: []string{"8080"},
+		},
+		{
+			name:          "Port with letters is ignored",
+			exposePorts:   []string{"80a0", "8080"},
+			initialPorts:  []string{},
+			expectedPorts: []string{"8080"},
+		},
+		{
+			name:          "Port pair with invalid numbers is ignored",
+			exposePorts:   []string{"80a0:80", "8080:8b0", "9090:90"},
+			initialPorts:  []string{},
+			expectedPorts: []string{"9090"},
+		},
+		{
+			name:          "Empty strings are ignored",
+			exposePorts:   []string{"", "8080", ""},
+			initialPorts:  []string{},
+			expectedPorts: []string{"8080"},
+		},
+		{
+			name:          "Complex scenario with mixed formats",
+			exposePorts:   []string{"8080", "9090:90", "invalid", "3000:3000", "8080:80"},
+			initialPorts:  []string{"7070", "8080"},
+			expectedPorts: []string{"7070", "8080", "9090", "3000"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ddevapp.ProcessExposePorts(tc.exposePorts, tc.initialPorts)
+			require.Equal(t, tc.expectedPorts, result)
+		})
+	}
+}
+
 // TestAssignRouterPortsToGenericWebserverPorts ensures that RouterHTTPPort and RouterHTTPSPort
 // are assigned correctly based on WebExtraExposedPorts for Generic webservers.
 func TestAssignRouterPortsToGenericWebserverPorts(t *testing.T) {

--- a/pkg/fileutil/embed.go
+++ b/pkg/fileutil/embed.go
@@ -1,6 +1,7 @@
 package fileutil
 
 import (
+	"bytes"
 	"embed"
 	"os"
 	"path"
@@ -42,8 +43,10 @@ func CopyEmbedAssets(fsys embed.FS, sourceDir string, targetDir string, excluded
 				}
 				if sigFound {
 					// If the file already exists and has the same content, don't overwrite it.
-					if existingContent, err := os.ReadFile(localPath); err == nil && string(existingContent) == string(content) {
-						continue
+					if existingContent, err := os.ReadFile(localPath); err == nil {
+						if bytes.Equal(content, existingContent) {
+							continue
+						}
 					}
 					// If the file already exists and is excluded, don't overwrite it.
 					if excludedFiles != nil && slices.Contains(excludedFiles, localPath) {


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev-mongo/issues/24

Router doesn't become healthy because of missing Traefik entrypoints for optional services.

## How This PR Solves The Issue

- Adds host port detection for Traefik entrypoint by reading `.ddev/.ddev-docker-compose-full.yaml`
- Removes hardcoded XHGui ports, they are now read from YAML.
- Optimizes file writes for `.ddev/.ddev-docker-compose-base.yaml` and `.ddev/.ddev-docker-compose-full.yaml` if the content is not changed.

## Manual Testing Instructions

Start a project with optional profiles:

```
ddev add-on get ddev/ddev-mongo
ddev start
```

Check `~/.ddev/traefik/.static_config.yaml`:

```yaml
entryPoints:
    http-80:
        address: :80
    http-443:
        address: :443
    http-8025:
        address: :8025
    http-8026:
        address: :8026
    http-8142:                 <= comes from xhgui
        address: :8142
    http-8143::                <= comes from xhgui
        address: :8143
    http-9091:                 <= comes from mongo-express
        address: :9091
    http-9092:                 <= comes from mongo-express
        address: :9092
    traefik:
        address: :10999
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
