### PR TITLE
feat: replace `docker run` in `ddev auth ssh` with Docker API and accept stdin

### DIFF
--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -227,7 +227,7 @@ func runSSHAuthContainer(uidStr string, mounts []dockerMount.Mount) error {
 	// Container configuration
 	config := &dockerContainer.Config{
 		Image:        docker.GetSSHAuthImage() + "-built",
-		Cmd:          dockerStrslice.StrSlice{"bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && keys=$(grep -l '^-----BEGIN .* PRIVATE KEY-----' * || { echo "No SSH private keys found" >&2; exit 1; }) && for key in $keys; do ssh-add "$key" || exit $?; done`},
+		Cmd:          dockerStrslice.StrSlice{"bash", "-c", `cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && mapfile -t keys < <(grep -l '^-----BEGIN .* PRIVATE KEY-----' *) && ((${#keys[@]})) || { echo "No SSH private keys found" >&2; exit 1; } && for key in "${keys[@]}"; do ssh-add "$key" || exit $?; done`},
 		Entrypoint:   dockerStrslice.StrSlice{},
 		Tty:          term.IsTerminal(int(os.Stdin.Fd())),
 		OpenStdin:    true,

--- a/cmd/ddev/cmd/auth-ssh.go
+++ b/cmd/ddev/cmd/auth-ssh.go
@@ -235,6 +235,7 @@ func runSSHAuthContainer(uidStr string, mounts []dockerMount.Mount) error {
 		AttachStdout: true,
 		AttachStderr: true,
 		User:         uidStr,
+		Labels:       map[string]string{"com.ddev.site-name": ""},
 	}
 
 	// Host configuration with volume mounts

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -566,7 +566,7 @@ func StopMutagenDaemon(mutagenDataDirectory string) {
 	}
 	if fileutil.FileExists(globalconfig.GetMutagenPath()) {
 		env := []string{"MUTAGEN_DATA_DIRECTORY=" + mutagenDataDirectory, "HOME=" + os.Getenv(`HOME`), "PWD=" + os.Getenv(`PWD`)}
-		out, err := exec.RunHostCommandWithEnv(globalconfig.GetMutagenPath(), env, "daemon", "stop")
+		out, err := exec.RunHostCommandWithOptions(globalconfig.GetMutagenPath(), []exec.CmdOption{exec.WithEnv(env)}, "daemon", "stop")
 		if err != nil && !strings.Contains(out, "unable to connect to daemon") {
 			util.Debug("Unable to stop Mutagen daemon: %v; MUTAGEN_DATA_DIRECTORY=%s", err, mutagenDataDirectory)
 		}

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -36,6 +36,7 @@ import (
 	dockerCliCommand "github.com/docker/cli/cli/command"
 	dockerCliFlags "github.com/docker/cli/cli/flags"
 	dockerCliVersion "github.com/docker/cli/cli/version"
+	dockerTypes "github.com/docker/docker/api/types"
 	dockerContainer "github.com/docker/docker/api/types/container"
 	dockerFilters "github.com/docker/docker/api/types/filters"
 	dockerImage "github.com/docker/docker/api/types/image"
@@ -46,6 +47,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
+	"golang.org/x/term"
 )
 
 // NetName provides the default network name for ddev.
@@ -991,7 +993,35 @@ func GetDockerIP() (string, error) {
 // https://pkg.go.dev/github.com/moby/docker-image-spec/specs-go/v1#HealthcheckConfig
 // Returns containerID, output, error
 func RunSimpleContainer(image string, name string, cmd []string, entrypoint []string, env []string, binds []string, uid string, removeContainerAfterRun bool, detach bool, labels map[string]string, portBindings nat.PortMap, healthConfig *dockerContainer.HealthConfig) (containerID string, output string, returnErr error) {
+	config := &dockerContainer.Config{
+		Image:       image,
+		Cmd:         cmd,
+		Env:         env,
+		User:        uid,
+		Labels:      labels,
+		Entrypoint:  entrypoint,
+		Healthcheck: healthConfig,
+	}
+	hostConfig := &dockerContainer.HostConfig{
+		Binds:        binds,
+		PortBindings: portBindings,
+	}
+	return RunSimpleContainerExtended(name, config, hostConfig, removeContainerAfterRun, detach)
+}
+
+// RunSimpleContainerExtended runs a container (non-daemonized) and captures the stdout/stderr.
+// Accepts any config and hostConfig. If stdin is provided, enables interactive mode with stdin forwarding.
+func RunSimpleContainerExtended(name string, config *dockerContainer.Config, hostConfig *dockerContainer.HostConfig, removeContainerAfterRun bool, detach bool) (containerID string, output string, returnErr error) {
 	ctx, client := GetDockerClient()
+
+	image := config.Image
+
+	if image == "" {
+		return "", "", fmt.Errorf("RunSimpleContainerExtended requires config.Image to be set")
+	}
+	if config.Cmd == nil {
+		return "", "", fmt.Errorf("RunSimpleContainerExtended requires config.Cmd to be set")
+	}
 
 	// Ensure image string includes a tag
 	imageChunks := strings.Split(image, ":")
@@ -1017,30 +1047,30 @@ func RunSimpleContainer(image string, name string, cmd []string, entrypoint []st
 		}
 	}
 
-	containerConfig := &dockerContainer.Config{
-		Image:        image,
-		Cmd:          cmd,
-		Env:          env,
-		User:         uid,
-		Labels:       labels,
-		Entrypoint:   entrypoint,
-		AttachStderr: true,
-		AttachStdout: true,
-		Healthcheck:  healthConfig,
+	config.AttachStderr = true
+	config.AttachStdout = true
+
+	if config.AttachStdin {
+		config.AttachStdin = true
+		config.OpenStdin = true
+		config.Tty = term.IsTerminal(int(os.Stdin.Fd()))
 	}
 
-	containerHostConfig := &dockerContainer.HostConfig{
-		Binds:        binds,
-		PortBindings: portBindings,
+	if config.Labels == nil {
+		config.Labels = make(map[string]string)
+	}
+	// Assign a default label so this container can be removed with 'ddev poweroff'
+	if _, exists := config.Labels["com.ddev.site-name"]; !exists {
+		config.Labels["com.ddev.site-name"] = ""
 	}
 
-	if runtime.GOOS == "linux" && !IsDockerDesktop() {
-		containerHostConfig.ExtraHosts = []string{"host.docker.internal:host-gateway"}
+	if runtime.GOOS == "linux" && !IsDockerDesktop() && !slices.Contains(hostConfig.ExtraHosts, "host.docker.internal:host-gateway") {
+		hostConfig.ExtraHosts = append(hostConfig.ExtraHosts, "host.docker.internal:host-gateway")
 	}
 
-	container, err := client.ContainerCreate(ctx, containerConfig, containerHostConfig, nil, nil, name)
+	container, err := client.ContainerCreate(ctx, config, hostConfig, nil, nil, name)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to create/start Docker container %v (%v, %v): %v", name, containerConfig, containerHostConfig, err)
+		return "", "", fmt.Errorf("failed to create/start Docker container %v (%v, %v): %v", name, config, hostConfig, err)
 	}
 
 	if removeContainerAfterRun {
@@ -1053,19 +1083,77 @@ func RunSimpleContainer(image string, name string, cmd []string, entrypoint []st
 		return container.ID, "", fmt.Errorf("failed to StartContainer: %v", err)
 	}
 
+	var hijackedResp *dockerTypes.HijackedResponse
+	var outputDone chan struct{}
+
+	if config.AttachStdin {
+		// Interactive mode with stdin - use attach for real-time I/O
+		attachOptions := dockerContainer.AttachOptions{
+			Stream: true,
+			Stdin:  true,
+			Stdout: true,
+			Stderr: true,
+		}
+
+		resp, err := client.ContainerAttach(ctx, container.ID, attachOptions)
+		if err != nil {
+			return container.ID, "", fmt.Errorf("failed to attach to container: %v", err)
+		}
+		hijackedResp = &resp
+		defer hijackedResp.Close()
+
+		// Initialize synchronization channel for output completion
+		outputDone = make(chan struct{})
+
+		// Forward output from container to stdout
+		go func() {
+			_, _ = io.Copy(os.Stdout, resp.Reader)
+			if outputDone != nil {
+				close(outputDone)
+			}
+		}()
+
+		// Forward input from stdin to container
+		go func() {
+			_, _ = io.Copy(resp.Conn, os.Stdin)
+		}()
+	}
+
 	exitCode := 0
+
 	if !detach {
-		waitChan, errChan := client.ContainerWait(ctx, container.ID, "")
+		waitChan, errChan := client.ContainerWait(ctx, container.ID, dockerContainer.WaitConditionNotRunning)
 		select {
 		case status := <-waitChan:
 			exitCode = int(status.StatusCode)
 		case err := <-errChan:
 			return container.ID, "", fmt.Errorf("failed to ContainerWait: %v", err)
 		}
+
+		// For interactive containers, wait for I/O forwarding to complete
+		if config.AttachStdin {
+			// Close hijacked connection to signal EOF to goroutines
+			hijackedResp.Close()
+
+			// Wait for output forwarding to complete (input may still be running)
+			if outputDone != nil {
+				<-outputDone
+			}
+		}
 	}
 
-	// Get logs so we can report them if exitCode failed
-	var stdout bytes.Buffer
+	var exitErr error
+
+	if exitCode != 0 {
+		exitErr = fmt.Errorf("container run failed with exit code %d", exitCode)
+	}
+
+	// Don't capture logs if we're attaching stdin, as it will block stdout
+	if config.AttachStdin {
+		return container.ID, "", exitErr
+	}
+
+	// Get logs so we can report them
 	options := dockerContainer.LogsOptions{ShowStdout: true, ShowStderr: true}
 	rc, err := client.ContainerLogs(ctx, container.ID, options)
 	if err != nil {
@@ -1073,17 +1161,13 @@ func RunSimpleContainer(image string, name string, cmd []string, entrypoint []st
 	}
 	defer rc.Close()
 
+	var stdout bytes.Buffer
 	_, err = stdcopy.StdCopy(&stdout, &stdout, rc)
 	if err != nil {
-		util.Warning("failed to copy container logs: %v", err)
+		return container.ID, "", fmt.Errorf("failed to copy container logs: %v", err)
 	}
 
-	// This is the exitCode from the cli.ContainerWait()
-	if exitCode != 0 {
-		return container.ID, stdout.String(), fmt.Errorf("container run failed with exit code %d", exitCode)
-	}
-
-	return container.ID, stdout.String(), nil
+	return container.ID, stdout.String(), exitErr
 }
 
 // RemoveContainer stops and removes a container

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -1015,12 +1015,8 @@ func RunSimpleContainerExtended(name string, config *dockerContainer.Config, hos
 	ctx, client := GetDockerClient()
 
 	image := config.Image
-
 	if image == "" {
 		return "", "", fmt.Errorf("RunSimpleContainerExtended requires config.Image to be set")
-	}
-	if config.Cmd == nil {
-		return "", "", fmt.Errorf("RunSimpleContainerExtended requires config.Cmd to be set")
 	}
 
 	// Ensure image string includes a tag

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -1,0 +1,106 @@
+package exec_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunHostCommandWithOptions(t *testing.T) {
+	bashPath := util.FindBashPath()
+
+	// Test basic command execution without options
+	t.Run("no options", func(t *testing.T) {
+		output, err := exec.RunHostCommandWithOptions(bashPath, []exec.CmdOption{}, "-c", "echo hello")
+		require.NoError(t, err)
+		assert.Equal(t, "hello", strings.TrimSpace(output))
+	})
+
+	// Test WithStdin option
+	t.Run("with stdin", func(t *testing.T) {
+		stdin := strings.NewReader("test input")
+
+		output, err := exec.RunHostCommandWithOptions(bashPath, []exec.CmdOption{
+			exec.WithStdin(stdin),
+		}, "-c", "cat")
+		require.NoError(t, err)
+		assert.Equal(t, "test input", strings.TrimSpace(output))
+	})
+
+	// Test WithEnv option
+	t.Run("with env", func(t *testing.T) {
+		output, err := exec.RunHostCommandWithOptions(bashPath, []exec.CmdOption{
+			exec.WithEnv([]string{"TEST_VAR=test_value"}),
+		}, "-c", "echo $TEST_VAR")
+		require.NoError(t, err)
+		assert.Equal(t, "test_value", strings.TrimSpace(output))
+	})
+
+	// Test multiple options combined
+	t.Run("with stdin and env", func(t *testing.T) {
+		stdin := strings.NewReader("hello world")
+		output, err := exec.RunHostCommandWithOptions(bashPath, []exec.CmdOption{
+			exec.WithStdin(stdin),
+			exec.WithEnv(append(os.Environ(), "TEST_PREFIX=prefix:")),
+		}, "-c", "echo $TEST_PREFIX$(cat)")
+		require.NoError(t, err)
+		assert.Equal(t, "prefix:hello world", strings.TrimSpace(output))
+	})
+
+	// Test empty options slice
+	t.Run("empty options", func(t *testing.T) {
+		output, err := exec.RunHostCommandWithOptions(bashPath, []exec.CmdOption{}, "-c", "echo test")
+		require.NoError(t, err)
+		assert.Equal(t, "test", strings.TrimSpace(output))
+	})
+
+	// Test nil options slice
+	t.Run("nil options", func(t *testing.T) {
+		output, err := exec.RunHostCommandWithOptions(bashPath, nil, "-c", "echo test")
+		require.NoError(t, err)
+		assert.Equal(t, "test", strings.TrimSpace(output))
+	})
+
+	// Test command with error
+	t.Run("command error", func(t *testing.T) {
+		_, err := exec.RunHostCommandWithOptions("nonexistent-ddev-command", []exec.CmdOption{})
+		require.Error(t, err, "expected error for nonexistent-ddev-command")
+	})
+
+	// Test WithEnv with multiple environment variables
+	t.Run("with multiple env vars", func(t *testing.T) {
+		output, err := exec.RunHostCommandWithOptions(bashPath, []exec.CmdOption{
+			exec.WithEnv([]string{"VAR1=hello", "VAR2=world"}),
+		}, "-c", "echo $VAR1-$VAR2")
+		require.NoError(t, err)
+		assert.Equal(t, "hello-world", strings.TrimSpace(output))
+	})
+
+	// Test WithEnv overriding system environment
+	t.Run("with env override", func(t *testing.T) {
+		// Set a system env var
+		t.Setenv("TEST_OVERRIDE", "system_value")
+
+		output, err := exec.RunHostCommandWithOptions(bashPath, []exec.CmdOption{
+			exec.WithEnv([]string{"TEST_OVERRIDE=custom_value"}),
+		}, "-c", "echo $TEST_OVERRIDE")
+		require.NoError(t, err)
+		assert.Equal(t, "custom_value", strings.TrimSpace(output))
+	})
+
+	// Test WithStdin with empty reader
+	t.Run("with empty stdin", func(t *testing.T) {
+		stdin := strings.NewReader("")
+
+		output, err := exec.RunHostCommandWithOptions(bashPath, []exec.CmdOption{
+			exec.WithStdin(stdin),
+		}, "-c", "cat")
+		require.NoError(t, err)
+		assert.Equal(t, "", output)
+	})
+}


### PR DESCRIPTION
## The Issue

- #6720

I couldn't reopen the closed PR, so this is a new attempt.

## How This PR Solves The Issue

Replace the `docker run` approach with direct Docker client API calls for better control over container I/O and error handling. This enables proper support for both interactive terminal usage and piped input scenarios.

Key improvements:
- Use Docker client API instead of `docker run` for container management
- Add proper terminal raw mode handling to hide passphrase input
- Preserve `ssh-add` error codes and provide more detailed error messages
- Remove `xargs` because it doesn't work with stdin
- Add non-interactive stdin (I didn't add this feature to the docs, because I don't think we should encourage people to use it.)

## Manual Testing Instructions

Prepare keys:

- `key 0` has "key 0" passphrase
- `key_1` has "key_1" passphrase
- `key_2` has no passphrase
- `key_3` has "key_3" passphrase

```
mkdir ~/test && cd ~/test
ssh-keygen -t rsa -b 4096 -C "key_0@example.com" -f "key 0" -N "key 0"
ssh-keygen -t rsa -b 4096 -C "key_1@example.com" -f "key_1" -N "key_1"
ssh-keygen -t rsa -b 4096 -C "key_2@example.com" -f "key_2" -N ""
ssh-keygen -t rsa -b 4096 -C "key_3@example.com" -f "key_3" -N "key_3"
```

- With v1.24.7:

	Press `<Enter>`,  `<Enter>`,  `<Enter>` (it fails, but it should fail early after the first key):
	```
	$ ddev auth ssh -d ~/test
	Enter passphrase for key 0: 
	Enter passphrase for key_1: 
	Identity added: key_2 (key_2@example.com)
	Enter passphrase for key_3: 
	Docker command 'docker run -it --rm --volumes-from=ddev-ssh-agent --user=1000 --entrypoint= "--mount=type=bind,src=/home/stas/test/key 0,dst=/tmp/sshtmp/key 0" --mount=type=bind,src=/home/stas/test/key_1,dst=/tmp/sshtmp/key_1 --mount=type=bind,src=/home/stas/test/key_2,dst=/tmp/sshtmp/key_2 --mount=type=bind,src=/home/stas/test/key_3,dst=/tmp/sshtmp/key_3 ddev/ddev-ssh-agent:v1.24.7-built bash -c "cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && grep -l '^-----BEGIN .* PRIVATE KEY-----' * | xargs -d '\n' ssh-add"' failed: exit status 123
	```
	
	Write `key 0`, `<Enter>`, write `key_1`, `<Enter>`, write `key_3`, `<Enter>`, works as expected:
	```
	$ ddev auth ssh -d ~/test
	Enter passphrase for key 0: 
	Identity added: key 0 (key_0@example.com)
	Enter passphrase for key_1: 
	Identity added: key_1 (key_1@example.com)
	Identity added: key_2 (key_2@example.com)
	Enter passphrase for key_3: 
	Identity added: key_3 (key_3@example.com)
	```
	
	Stdin doesn't work:
	```
	$ printf "key 0\nkey_1\nkey_3\n" | ddev auth ssh -d ~/test
	the input device is not a TTY
	Docker command 'docker run -it --rm --volumes-from=ddev-ssh-agent --user=1000 --entrypoint= "--mount=type=bind,src=/home/stas/test/key 0,dst=/tmp/sshtmp/key 0" --mount=type=bind,src=/home/stas/test/key_1,dst=/tmp/sshtmp/key_1 --mount=type=bind,src=/home/stas/test/key_2,dst=/tmp/sshtmp/key_2 --mount=type=bind,src=/home/stas/test/key_3,dst=/tmp/sshtmp/key_3 ddev/ddev-ssh-agent:v1.24.7-built bash -c "cp -r /tmp/sshtmp ~/.ssh && chmod -R go-rwx ~/.ssh && cd ~/.ssh && grep -l '^-----BEGIN .* PRIVATE KEY-----' * | xargs -d '\n' ssh-add"' failed: exit status 1
	```

- With this PR:

	Press `<Enter>`, fails immediately as expected:
	```
	$ ddev auth ssh -d ~/test
	Enter passphrase for key 0: 
	Failed to execute command `ddev auth ssh`: exit status 1
	```
	
	Write `key 0`, `<Enter>`, write `key_1`, `<Enter>`, write `key_3`, `<Enter>`, works as expected:
	```
	$ ddev auth ssh -d ~/test
	Enter passphrase for key 0: 
	Identity added: key 0 (key_0@example.com)
	Enter passphrase for key_1: 
	Identity added: key_1 (key_1@example.com)
	Identity added: key_2 (key_2@example.com)
	Enter passphrase for key_3: 
	Identity added: key_3 (key_3@example.com
	```
	
	Stdin works as expected:
	```
	$ printf "key 0\nkey_1\nkey_3\n" | ddev auth ssh -d ~/test
	Enter passphrase for key 0: *Identity added: key 0 (key_0@example.com)
	Enter passphrase for key_1: *Identity added: key_1 (key_1@example.com)
	*Identity added: key_2 (key_2@example.com)
	Enter passphrase for key_3: *Identity added: key_3 (key_3@example.com)
	```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
