### PR TITLE
fix(ddev-hostname): sudo can't find ddev-hostname in linuxbrew, fixes #7510

### DIFF
--- a/cmd/ddev-hostname/elevate.go
+++ b/cmd/ddev-hostname/elevate.go
@@ -15,7 +15,7 @@ func elevateIfNeeded() {
 		return
 	}
 	// Prepend our own path to the args
-	args := append([]string{os.Args[0]}, os.Args[1:]...)
+	args := append([]string{"--preserve-env=PATH"}, os.Args[0:]...)
 	cmd := exec.Command("sudo", args...)
 	// Pass through the terminal’s stdin/stdout/stderr
 	cmd.Stdin = os.Stdin

--- a/cmd/ddev-hostname/elevate.go
+++ b/cmd/ddev-hostname/elevate.go
@@ -15,7 +15,7 @@ func elevateIfNeeded() {
 		return
 	}
 	// Prepend our own path to the args
-	args := append([]string{"--preserve-env=PATH"}, os.Args[0:]...)
+	args := append([]string{os.Args[0]}, os.Args[1:]...)
 	cmd := exec.Command("sudo", args...)
 	// Pass through the terminal’s stdin/stdout/stderr
 	cmd.Stdin = os.Stdin

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -37,7 +37,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 23. In “Advanced Windows Update Settings” enable “Receive updates for other Microsoft products” to make sure you get WSL2 kernel upgrades. Make sure to run Windows Update to get the latest kernel.
 24. Turn off the settings that cause the "windows experience" prompts after new upgrades:
 ![disable_windows_experience](../images/disable_windows_experience.png)
-25. In PowerShell: `wsl.exe --update`. Watch for the escalation to complete, it may require escalation.
+25. In PowerShell: `wsl.exe --update`. Watch for the elevation to complete, it may require elevation.
 
 ## Both Docker Desktop/WSL2 and Docker-ce/WSL2
 

--- a/pkg/ddevapp/hostname_mgt.go
+++ b/pkg/ddevapp/hostname_mgt.go
@@ -15,7 +15,7 @@ import (
 )
 
 // AddHostsEntriesIfNeeded will run sudo ddev hostname to the site URL to the host's /etc/hosts.
-// This should be run without admin privs; the DDEV hostname command will handle escalation.
+// This should be run without admin privs; the DDEV hostname command will handle elevation.
 func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 	var err error
 	dockerIP, err := dockerutil.GetDockerIP()
@@ -72,7 +72,7 @@ func (app *DdevApp) AddHostsEntriesIfNeeded() error {
 }
 
 // RemoveHostsEntriesIfNeeded will remove the site URL from the host's /etc/hosts.
-// This should be run without administrative privileges and will escalate
+// This should be run without administrative privileges and will elevate
 // where needed.
 func (app *DdevApp) RemoveHostsEntriesIfNeeded() error {
 	if os.Getenv("DDEV_NONINTERACTIVE") == "true" {

--- a/pkg/hostname/hostname.go
+++ b/pkg/hostname/hostname.go
@@ -3,6 +3,7 @@ package hostname
 import (
 	"fmt"
 	"os"
+	exec2 "os/exec"
 	"runtime"
 	"strings"
 
@@ -39,8 +40,13 @@ func GetDdevHostnameBinary() string {
 	if runtime.GOOS == "windows" || (nodeps.IsWSL2() && !globalconfig.DdevGlobalConfig.WSL2NoWindowsHostsMgt) {
 		binary = ddevHostnameWindowsBinary
 	}
-	util.Debug("ddevHostnameBinary=%s", binary)
-	return binary
+	path, err := exec2.LookPath(binary)
+	if err != nil {
+		util.Debug("ddevHostnameBinary not found in PATH: %v", err)
+		return binary
+	}
+	util.Debug("ddevHostnameBinary=%s", path)
+	return path
 }
 
 // elevateHostsManipulation uses elevation (sudo or runas) to manipulate the hosts file.

--- a/pkg/hostname/hostname.go
+++ b/pkg/hostname/hostname.go
@@ -43,9 +43,9 @@ func GetDdevHostnameBinary() string {
 	return binary
 }
 
-// elevateHostsManipulation uses escalation (sudo or runas) to manipulate the hosts file.
+// elevateHostsManipulation uses elevation (sudo or runas) to manipulate the hosts file.
 func elevateHostsManipulation(args []string) (out string, err error) {
-	// We can't escalate in tests, and they know how to deal with it.
+	// We can't elevate in tests, and they know how to deal with it.
 	if os.Getenv("DDEV_NONINTERACTIVE") != "" {
 		util.Warning("DDEV_NONINTERACTIVE is set. You must manually run '%s'", strings.Join(args, " "))
 		return "", nil
@@ -56,7 +56,7 @@ func elevateHostsManipulation(args []string) (out string, err error) {
 	}
 
 	c := args
-	output.UserOut.Printf("%s needs to run with administrative privileges.\nThis is required to add unresolvable hostnames to the hosts file.\nYou may need to enter your password for sudo or allow escalation.", GetDdevHostnameBinary())
+	output.UserOut.Printf("%s needs to run with administrative privileges.\nThis is required to add unresolvable hostnames to the hosts file.\nYou may need to enter your password for sudo or allow elevation.", GetDdevHostnameBinary())
 	output.UserOut.Printf("DDEV will issue the command:\n  %s\n", strings.Join(c, ` `))
 
 	out, err = exec.RunHostCommand(c[0], c[1:]...)


### PR DESCRIPTION
## The Issue

- #7510

With a Linux homebrew installation, `ddev-hostname` elevation does not succeed

## How This PR Solves The Issue

* Run `sudo /absolute/path/to/ddev-hostname` to make sure sudo doesn't stumble finding the target
* Minor docs changes to use "elevate" or "elevation" instead of "escalation", which is usually about security problems.

## Manual Testing Instructions

On linux AND macOS, with homebrew-installed ddev (but overwritten with the ddev from this PR)
```
ddev config --additional-fqdns=2.example.com
ddev start
```

- [x] Linuxbrew
- [x] macOS/homebrew
- [x] Linux apt
- [x] WSL2

## Automated Testing Overview

We don't have a strategy for testing things that use sudo; we used to allow passwordless sudo on the buildkite machines, but that hid other problems. Maybe there's a way to solve this with a temporary overwrite of the /etc/sudoers.d/something

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
