### PR TITLE
build(direnv): Make direnv .envrc idempotent so it doesn't do all that work all the time

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -79,3 +79,100 @@ fi
 BIN_DIR="$PWD/.gotmp/bin/$(go env GOHOSTOS)_$(go env GOHOSTARCH)"
 # Prepend to PATH
 export PATH="$BIN_DIR:$PATH"
+
+#!/usr/bin/env bash
+
+# Fast, idempotent direnv bootstrap for docs tooling
+# - Creates a local Python venv and Node env once, then reuses them
+# - Skips work if tools are already present
+# - Avoids slow npm/pip noise and update checks
+
+set -euo pipefail
+
+# Steps to set up:
+# 1. Install direnv: https://direnv.net/docs/installation.html
+# 2. Hook direnv into your shell: https://direnv.net/docs/hook.html
+# 3. (Optional) Whitelist this file in ~/.config/direnv/direnv.toml to avoid prompts
+#    [global]
+#    hide_env_diff = true
+#    [whitelist]
+#    exact = ["~/workspace/ddev/.envrc"]
+# 4. After setting this up, when you `cd` into this directory, all required tools
+#    will automatically be installed in `.gotmp/env` and sourced.
+# 5. To update tools, run `make clean`, then `cd` out of and back into this directory.
+
+PYTHON_ENV=.gotmp/env/python
+NODE_ENV=.gotmp/env/node
+
+# Quieter + faster package managers
+export PIP_DISABLE_PIP_VERSION_CHECK=1
+export PIP_ROOT_USER_ACTION=ignore
+export npm_config_update_notifier=false
+export npm_config_fund=false
+export NPM_CONFIG_PREFIX="${NODE_ENV}"
+
+mkdir -p .gotmp/env .gotmp/bin
+
+# Basic pre-reqs
+if ! command -v python >/dev/null 2>&1 && ! command -v python3 >/dev/null 2>&1; then
+  echo "Python is not available." >&2
+  exit 1
+fi
+if ! command -v go >/dev/null 2>&1; then
+  echo "Go is not available." >&2
+  exit 1
+fi
+
+# --- Python venv ---
+if [[ ! -f "${PYTHON_ENV}/bin/activate" ]]; then
+  echo "Initializing python venv..."
+  (command -v python >/dev/null 2>&1 && python -m venv "${PYTHON_ENV}") \
+    || python3 -m venv "${PYTHON_ENV}"
+fi
+# shellcheck disable=SC1090
+source "${PYTHON_ENV}/bin/activate"
+
+# Ensure nodeenv is available inside the venv (only install if missing)
+if ! command -v nodeenv >/dev/null 2>&1; then
+  python -m pip install -q nodeenv
+fi
+
+# --- Node env (managed by nodeenv) ---
+# If node binary is missing (or env is corrupt), recreate it once
+if [[ ! -x "${NODE_ENV}/bin/node" ]]; then
+  echo "Creating nodeenv (LTS)..."
+  rm -rf "${NODE_ENV}"
+  nodeenv --node=lts --prebuilt "${NODE_ENV}"
+fi
+# Activate by PATH only (faster than sourcing an activate script)
+export PATH="${NODE_ENV}/bin:${PATH}"
+
+# --- Python tooling ---
+if [[ ! -x "${PYTHON_ENV}/bin/mkdocs" ]]; then
+  echo "Installing mkdocs..."
+  python -m pip install -q -r docs/mkdocs-pip-requirements
+fi
+
+# --- Node CLI tooling (install once if missing) ---
+if [[ ! -x "${NODE_ENV}/bin/markdownlint" ]]; then
+  echo "Installing markdownlint..."
+  npm install -g --silent markdownlint-cli
+fi
+
+if [[ ! -x "${NODE_ENV}/bin/linkspector" ]]; then
+  echo "Installing linkspector..."
+  npm install -g --silent @umbrelladocs/linkspector
+fi
+
+if [[ ! -x "${NODE_ENV}/bin/textlint" ]]; then
+  echo "Installing textlint..."
+  npm install -g --silent textlint \
+    textlint-filter-rule-comments \
+    textlint-rule-no-todo \
+    textlint-rule-stop-words \
+    textlint-rule-terminology
+fi
+
+# Prepend ddev build bin to PATH
+BIN_DIR="$PWD/.gotmp/bin/$(go env GOHOSTOS)_$(go env GOHOSTARCH)"
+export PATH="$BIN_DIR:$PATH"

--- a/.envrc
+++ b/.envrc
@@ -1,110 +1,14 @@
 #!/usr/bin/env bash
-
-# This file is used by `direnv` to install all Python and Node dependencies
-# specified in the Makefile into the virtual env located in the `.gotmp/env` directory.
-
-# Steps to set up:
-# 1. Install direnv: https://direnv.net/docs/installation.html
-# 2. Hook direnv into your shell: https://direnv.net/docs/hook.html
-# 3. Create the global config: https://github.com/direnv/direnv/blob/master/man/direnv.toml.1.md
-#    where `~/workspace/ddev/.envrc` is the path to this file.
-#    (Alternatively, `.envrc` file can be loaded with `direnv allow .`)
-#    $ cat ~/.config/direnv/direnv.toml
-#    [global]
-#    hide_env_diff = true
-#    [whitelist]
-#    exact = ["~/workspace/ddev/.envrc"]
-# 4. After setting this up, when you `cd` into this directory, all required tools
-#    will automatically be installed in `.gotmp/env` and sourced.
-# 5. To update tools, run `make clean`, then `cd` out of and back into this directory.
-
-PYTHON_ENV=.gotmp/env/python
-NODE_ENV=.gotmp/env/node
-
-if ! command -v python >/dev/null 2>&1 && ! command -v python3 >/dev/null 2>&1; then
-    echo "Python is not available."
-    exit 1
-fi
-
-if ! command -v go >/dev/null 2>&1; then
-    echo "Go is not available."
-    exit 1
-fi
-
-if [[ ! -f "${PYTHON_ENV}/bin/activate" ]]; then
-    echo "Initializing python venv..."
-    python -m venv "${PYTHON_ENV}" || python3 -m venv "${PYTHON_ENV}"
-fi
-
-source "${PYTHON_ENV}/bin/activate"
-
-if [[ ! -f "${NODE_ENV}/bin/activate" ]]; then
-    echo "Initializing python nodeenv..."
-    pip install nodeenv
-    nodeenv --node=lts --prebuilt "${NODE_ENV}"
-fi
-
-source "${NODE_ENV}/bin/activate"
-
-if [[ ! -f "${PYTHON_ENV}/bin/mkdocs" ]]; then
-    echo "Installing mkdocs..."
-    pip install -r docs/mkdocs-pip-requirements
-fi
-
-# if [[ ! -f "${PYTHON_ENV}/bin/pyspelling" ]]; then
-#     echo "Installing pyspelling..."
-#     pip install pyspelling pymdown-extensions
-# fi
-
-if [[ ! -f "${NODE_ENV}/bin/markdownlint" ]]; then
-    echo "Installing markdownlint..."
-    npm install -g markdownlint-cli
-fi
-
-if [[ ! -f "${NODE_ENV}/bin/linkspector" ]]; then
-    echo "Installing linkspector..."
-    npm install -g @umbrelladocs/linkspector
-fi
-
-if [[ ! -f "${NODE_ENV}/bin/textlint" ]]; then
-    echo "Installing textlint..."
-    npm install -g textlint \
-        textlint-filter-rule-comments \
-        textlint-rule-no-todo \
-        textlint-rule-stop-words \
-        textlint-rule-terminology
-fi
-
-# prepend ddev build to PATH when entering a directory
-BIN_DIR="$PWD/.gotmp/bin/$(go env GOHOSTOS)_$(go env GOHOSTARCH)"
-# Prepend to PATH
-export PATH="$BIN_DIR:$PATH"
-
-#!/usr/bin/env bash
-
-# Fast, idempotent direnv bootstrap for docs tooling
-# - Creates a local Python venv and Node env once, then reuses them
-# - Skips work if tools are already present
-# - Avoids slow npm/pip noise and update checks
+# Direnv bootstrap for docs + dev tooling
+# 1) Install direnv and hook into your shell. 2) (Optional) whitelist this file in ~/.config/direnv/direnv.toml
+# When you cd into this dir, a local Python venv and Node env (via nodeenv) are ensured in .gotmp/env, and CLI tools added to PATH.
 
 set -euo pipefail
 
-# Steps to set up:
-# 1. Install direnv: https://direnv.net/docs/installation.html
-# 2. Hook direnv into your shell: https://direnv.net/docs/hook.html
-# 3. (Optional) Whitelist this file in ~/.config/direnv/direnv.toml to avoid prompts
-#    [global]
-#    hide_env_diff = true
-#    [whitelist]
-#    exact = ["~/workspace/ddev/.envrc"]
-# 4. After setting this up, when you `cd` into this directory, all required tools
-#    will automatically be installed in `.gotmp/env` and sourced.
-# 5. To update tools, run `make clean`, then `cd` out of and back into this directory.
+PYTHON_ENV=".gotmp/env/python"
+NODE_ENV=".gotmp/env/node"
 
-PYTHON_ENV=.gotmp/env/python
-NODE_ENV=.gotmp/env/node
-
-# Quieter + faster package managers
+# Quieter/faster package managers
 export PIP_DISABLE_PIP_VERSION_CHECK=1
 export PIP_ROOT_USER_ACTION=ignore
 export npm_config_update_notifier=false
@@ -113,21 +17,18 @@ export NPM_CONFIG_PREFIX="${NODE_ENV}"
 
 mkdir -p .gotmp/env .gotmp/bin
 
-# Basic pre-reqs
+# Pre-reqs
 if ! command -v python >/dev/null 2>&1 && ! command -v python3 >/dev/null 2>&1; then
-  echo "Python is not available." >&2
-  exit 1
+  echo "Python is not available." >&2; exit 1
 fi
 if ! command -v go >/dev/null 2>&1; then
-  echo "Go is not available." >&2
-  exit 1
+  echo "Go is not available." >&2; exit 1
 fi
 
 # --- Python venv ---
 if [[ ! -f "${PYTHON_ENV}/bin/activate" ]]; then
   echo "Initializing python venv..."
-  (command -v python >/dev/null 2>&1 && python -m venv "${PYTHON_ENV}") \
-    || python3 -m venv "${PYTHON_ENV}"
+  (command -v python >/dev/null 2>&1 && python -m venv "${PYTHON_ENV}") || python3 -m venv "${PYTHON_ENV}"
 fi
 # shellcheck disable=SC1090
 source "${PYTHON_ENV}/bin/activate"

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -96,6 +96,23 @@ After you’re done testing, you can delete your downloaded executable, restart 
 rm ~/bin/ddev
 ```
 
+## Helpers for `mkdocs`, `linkspector`, `markdownlint`
+
+When testing the documentation for various problems, tools like `mkdocs` and `markdownlint` are required, and these may be installed differently on different systems. (This helps with `make staticrequired`, `make mkdocs-serve`, `make markdownlint`.)
+
+DDEV provides a project-level `.envrc` which with `direnv` can install these for the project.
+
+1. Install `direnv` with `brew install direnv` or `sudo apt-get update && sudo apt-get install -y direnv` or whatever technique is appropriate for your system.
+2. Hook `direnv` into your shell, see [docs](https://direnv.net/docs/hook.html).
+3. Create global configuration for `direnv` in `~/.config/direnv/direnv.toml` allowing it to be loaded without the `direnv allow` command, see  [docs](https://github.com/direnv/direnv/blob/master/man/direnv.toml.1.md), adjusting for your project path:
+
+```
+[global]
+strict_env = true
+[whitelist]
+exact = ["~/workspace/ddev/.envrc"]
+```
+
 ## Making Changes to DDEV Images
 
 If you need to make a change to one of the DDEV images, it will need to be built with a specific tag that’s updated in `pkg/versionconstants/versionconstants.go`.

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -96,23 +96,6 @@ After you’re done testing, you can delete your downloaded executable, restart 
 rm ~/bin/ddev
 ```
 
-## Helpers for `mkdocs`, `linkspector`, `markdownlint`
-
-When testing the documentation for various problems, tools like `mkdocs` and `markdownlint` are required, and these may be installed differently on different systems. (This helps with `make staticrequired`, `make mkdocs-serve`, `make markdownlint`.)
-
-DDEV provides a project-level `.envrc` which with `direnv` can install these for the project.
-
-1. Install `direnv` with `brew install direnv` or `sudo apt-get update && sudo apt-get install -y direnv` or whatever technique is appropriate for your system.
-2. Hook `direnv` into your shell, see [docs](https://direnv.net/docs/hook.html).
-3. Create global configuration for `direnv` in `~/.config/direnv/direnv.toml` allowing it to be loaded without the `direnv allow` command, see  [docs](https://github.com/direnv/direnv/blob/master/man/direnv.toml.1.md), adjusting for your project path:
-
-```
-[global]
-strict_env = true
-[whitelist]
-exact = ["~/workspace/ddev/.envrc"]
-```
-
 ## Making Changes to DDEV Images
 
 If you need to make a change to one of the DDEV images, it will need to be built with a specific tag that’s updated in `pkg/versionconstants/versionconstants.go`.

--- a/docs/content/developers/testing-docs.md
+++ b/docs/content/developers/testing-docs.md
@@ -34,6 +34,23 @@ Now that you’ve got a local copy, you can make your changes.
 | MkDocs configuration | `./mkdocs.yml`                                                          |
 | Front end            | `./docs/content/assets/extra.css` <br> `./docs/content/assets/extra.js` |
 
+## Helpers for `mkdocs`, `linkspector`, `markdownlint`
+
+The docs below give helpful instructions about installing `mkdocs` and `markdownlint`, but these can be done using `direnv` as well.
+
+DDEV provides a project-level `.envrc` which with `direnv` can install these for the project.
+
+1. Install `direnv` with `brew install direnv` or `sudo apt-get update && sudo apt-get install -y direnv` or whatever technique is appropriate for your system.
+2. Hook `direnv` into your shell, see [docs](https://direnv.net/docs/hook.html).
+3. Create global configuration for `direnv` in `~/.config/direnv/direnv.toml` allowing it to be loaded without the `direnv allow` command, see  [docs](https://github.com/direnv/direnv/blob/master/man/direnv.toml.1.md), adjusting for your project path:
+
+```
+[global]
+strict_env = true
+[whitelist]
+exact = ["~/workspace/ddev/.envrc"]
+```
+
 ## Preview Changes
 
 Preview your changes locally by running `make mkdocs-serve`.
@@ -41,7 +58,7 @@ Preview your changes locally by running `make mkdocs-serve`.
 This will launch a web server on port 8000 and automatically refresh pages as they’re edited.
 
 !!!tip "Installing mkdocs locally on macOS"
-    On macOS with recent versions of Homebrew use this technique to install mkdocs:
+    On macOS with recent versions of Homebrew use this technique (or `direnv` above) to install `mkdocs`:
 
     ```bash
     brew install pipx
@@ -52,6 +69,7 @@ This will launch a web server on port 8000 and automatically refresh pages as th
     ```
 
 !!!tip "Installing mkdocs locally on Debian/Ubuntu Linux or WSL2 with Ubuntu"
+    On Debian/Ubuntu Linux or WSL2 with Ubuntu, use this technique (or `direnv` above) to install `mkdocs`:
 
     ```bash
     sudo apt-get update && sudo apt-get install python3-full python-is-python3 pipx
@@ -65,7 +83,7 @@ This will launch a web server on port 8000 and automatically refresh pages as th
 Run `make markdownlint` before you publish changes to quickly check your files for errors or inconsistencies.
 
 !!!warning "`markdownlint-cli` required!"
-    The `make markdownlint` command requires you to have `markdownlint-cli` installed, which you can do by executing `npm install -g markdownlint-cli`
+    The `make markdownlint` command requires you to have `markdownlint-cli` installed, which you can do by executing `npm install -g markdownlint-cli` or by using the `direnv` method above.
 
 ## Check for Spelling Errors
 


### PR DESCRIPTION
## The Issue

Every time I switch into a ddev directory (a lot) I get several seconds of useless work being done:

```
direnv: loading ~/workspace/ddev/.envrc
Initializing python nodeenv...
Requirement already satisfied: nodeenv in ./.gotmp/env/python/lib/python3.13/site-packages (1.9.1)

[notice] A new release of pip is available: 25.1.1 -> 25.2
[notice] To update, run: pip install --upgrade pip
 * Environment already exists: .gotmp/env/node
./.envrc:47: .gotmp/env/node/bin/activate: No such file or directory
Installing markdownlint...

changed 104 packages in 2s

54 packages are looking for funding
  run `npm fund` for details
Installing linkspector...
⠼direnv: ([/opt/homebrew/bin/direnv export bash]) is taking a while to execute. Use CTRL-C to give up.

changed 231 packages in 5s

93 packages are looking for funding
  run `npm fund` for details
Installing textlint...

changed 298 packages in 6s

92 packages are looking for funding
  run `npm fund` for details
direnv: export +VIRTUAL_ENV +VIRTUAL_ENV_PROMPT ~PATH
```

## How This PR Solves The Issue

Make it check to see if things are already properly installed and not do them in that case. 

## Manual Testing Instructions

Rendered at https://ddev--7520.org.readthedocs.build/en/7520/developers/building-contributing/#helpers-for-mkdocs-linkspector-markdownlint

Use it in .envrc
- [ ] cd into ddev dir see easy fast response
- [ ] rm -r .gotmp/env
- [ ] Switch out
- [ ] Switch back in, see installs happen
- [ ] Switch out
- [ ] Switch back in, see fast result

## Questions

Why are we even installing these things in the project instead of an external directory like ~/.cache? It's conceivably possible that some dependency of mkdocs could change, but it doesn't seem like it ever happens. I think that's the key question. And in that case... does it need to be done in .envrc at all?


## Comments

Assisted by ChatGPT