### PR TITLE
build(mariadb): turn off innodb_use_native_aio for mariadb:10.6

### DIFF
--- a/containers/ddev-dbserver/files/etc/mysql/version-conf.d/mariadb_10.6.cnf.txt
+++ b/containers/ddev-dbserver/files/etc/mysql/version-conf.d/mariadb_10.6.cnf.txt
@@ -1,0 +1,22 @@
+[mysqld]
+
+skip-host-cache
+symbolic-links=0
+query-cache-type               = 0
+query-cache-size               = 0
+
+# mariadb 10.6 and 10.8 and higher don't seem to be able to work with innodb_use_native_aio
+# without a privileged container, which seems like too much risk
+innodb-use-native-aio=0
+
+# Message on start is like this:
+#  [Warning] mysqld: io_uring_queue_init() failed with errno 1
+#  [Warning] InnoDB: liburing disabled: falling back to innodb_use_native_aio=OFF
+# These docker-compose overrides were able to make innodb-use-native-aio work
+# For innodb_use_native_aio=ON mariadb versions need this, see
+# https://github.com/MariaDB/mariadb-docker/issues/454#issuecomment-1212040735
+#privileged: true
+#ulimits:
+#  memlock:
+#    soft: "-1"
+#    hard: "-1"

--- a/containers/ddev-dbserver/test/testdata/database_config/mariadb_10.6.ini
+++ b/containers/ddev-dbserver/test/testdata/database_config/mariadb_10.6.ini
@@ -2,7 +2,7 @@ socket=/var/tmp/mysql.sock
 skip_name_resolve=ON
 datadir=/var/lib/mysql/
 secure_file_priv=""
-innodb_use_native_aio=ON
+innodb_use_native_aio=OFF
 # expire_logs_days is not used because skip-log-bin
 # expire_logs_days=1.000000
 character_set_server=utf8mb4

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,7 +17,7 @@ var WebTag = "v1.24.7" // Note that this can be overridden by make
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.24.7"
+var BaseDBTag = "2050813_rfay_mariadb_fail"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION

## The Issue

Our nightly container build/test [started failing last night](https://github.com/ddev/ddev/actions/runs/16924325047). Only the mariadb:10.6 test was failing, and it was failing because we expected to see 

On server startup `docker logs` you could see:

```
2025-08-13 21:04:08 0 [Warning] mysqld: io_uring_queue_init() failed with EPERM: sysctl kernel.io_uring_disabled has the value 2, or 1 and the user of the process is not a member of sysctl kernel.io_uring_group. (see man 2 io_uring_setup).
2025-08-13 21:04:08 0 [Warning] InnoDB: liburing disabled: falling back to innodb_use_native_aio=OFF
```

## How This PR Solves The Issue

It turns out we had seen this before, and it was noted in more than one of our configs for mariadb, for example, [mariadb:10.11](https://github.com/ddev/ddev/blob/main/containers/ddev-dbserver/files/etc/mysql/version-conf.d/mariadb_10.11.cnf.txt#L8-L16) and also 10.8.

So apparently they have the same restriction with 10.6 now. 

This isn't very important I don't think, and so I just changed the configuration to innodb_use_native_aio=OFF and changed the test expectation to find it OFF.. 

## Manual Testing Instructions

I think if it passes the tests it's ok.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
