### PR TITLE
docs: fiddle with sponsorship title [skip ci]

### DIFF
--- a/pkg/config/remoteconfig/messages.go
+++ b/pkg/config/remoteconfig/messages.go
@@ -300,7 +300,7 @@ func (c *remoteConfig) ShowSponsorshipAppreciation() {
 
 	t := table.NewWriter()
 	applyTableStyle(sponsorship, t)
-	title := "❤️  DDEV Sponsorship Status"
+	title := "❤️ DDEV Sponsorship Status"
 	t.AppendHeader(table.Row{title})
 	t.AppendRow(table.Row{message})
 


### PR DESCRIPTION

## The Issue

I didn't like the 1-space difference between the two lines of the sponsorship update.

<img width="1420" height="105" alt="image" src="https://github.com/user-attachments/assets/9a5a8553-c8bd-4fbc-b74e-4130620c2f7a" />

## How This PR Solves The Issue

Remove a space.

This could have been done by changing the source data for the second line, but we might as well do this now.

There are probably other ways we could improve this, probably the two hearts aren't necessary. But we can change the bulk of that without changing DDEV.

