### PR TITLE
fix: add mutagen sync flush after XHProf enable to prevent intermittent test failures

### DIFF
--- a/pkg/ddevapp/xhprof_xhgui.go
+++ b/pkg/ddevapp/xhprof_xhgui.go
@@ -36,6 +36,11 @@ func XHGuiSetup(app *DdevApp) error {
 		return err
 	}
 
+	// Sync after enabling xhprof to ensure code files are available
+	if err = app.MutagenSyncFlush(); err != nil {
+		return err
+	}
+
 	if !IsXHGuiContainerRunning(app) {
 		err = app.StartOptionalProfiles([]string{"xhgui"})
 		if err != nil {


### PR DESCRIPTION
## The Issue:

I was annoyed by Intermittent test failures in [`xhgui_test.go:63`](https://github.com/ddev/ddev/blob/main/cmd/ddev/cmd/xhgui_test.go#L63) in (apparently) macOS Mutagen environments. Test failure: https://buildkite.com/ddev/ddev-macos-arm64-mutagen/builds/11225#0198c846-13ca-4ab9-92e2-5f3542025d96

So Claude and I had a discussion about it. 

The test executes `ddev xhgui on` followed immediately by an HTTP request to the primary URL, which fails with 403 errors because project files haven't been synced yet.

## How This PR Solves The Issue:
Added `MutagenSyncFlush()` call after `XHProfEnable(app)` in the `XHGuiSetup` function.

When `ddev xhgui on` runs, it:
1. Enables XHProf (modifies PHP configuration)
2. Now flushes Mutagen sync to ensure all project files are available in container
3. Starts XHGui service

This ensures the docroot contains index files before any HTTP requests are made.

## Manual Testing Instructions:

(I'm not at all sure this failure can be reproduced manually... but if it were, probably Docker Desktop/macOS would be the place)

1. Set up DDEV project with Mutagen performance mode on macOS
2. Run `ddev config global --xhprof-mode=xhgui && ddev start`
3. Run `ddev xhgui on`
4. Immediately hit primary URL - should return 200, not 403
5. Verify XHGui interface is accessible

## Automated Testing Overview:

Existing `TestCmdXHGui` should now pass consistently on Mutagen environments. The fix addresses the race condition without changing test logic.

## Release/Deployment Notes:
Low risk change - only adds sync flush operation that's already safely used elsewhere. No breaking changes. Improves reliability of XHGui functionality in Mutagen environments.

🤖 Generated with [Claude Code](https://claude.ai/code)
