### PR TITLE
chore(deps): bump docker-compose to v2.39.2, remove `COMPOSE_BAKE=false`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/amplitude/analytics-go v1.2.0
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/cheggaaa/pb v1.0.29
-	github.com/compose-spec/compose-go/v2 v2.7.1
+	github.com/compose-spec/compose-go/v2 v2.8.1
 	github.com/containerd/errdefs v1.0.0
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/docker/cli v28.3.3+incompatible
@@ -31,7 +31,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/ulikunitz/xz v0.5.12
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1
-	go.yaml.in/yaml/v3 v3.0.3
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/mod v0.24.0
 	golang.org/x/oauth2 v0.28.0
 	golang.org/x/sys v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
-github.com/compose-spec/compose-go/v2 v2.7.1 h1:EUIbuaD0R/J1KA+FbJMNbcS9+jt/CVudbp5iHqUllSs=
-github.com/compose-spec/compose-go/v2 v2.7.1/go.mod h1:TmjkIB9W73fwVxkYY+u2uhMbMUakjiif79DlYgXsyvU=
+github.com/compose-spec/compose-go/v2 v2.8.1 h1:27O4dzyhiS/UEUKp1zHOHCBWD1WbxGsYGMNNaSejTk4=
+github.com/compose-spec/compose-go/v2 v2.8.1/go.mod h1:veko/VB7URrg/tKz3vmIAQDaz+CGiXH8vZsW79NmAww=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -351,8 +351,8 @@ go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.yaml.in/yaml/v3 v3.0.3 h1:bXOww4E/J3f66rav3pX3m8w6jDE4knZjGOw8b5Y6iNE=
-go.yaml.in/yaml/v3 v3.0.3/go.mod h1:tBHosrYAkRZjRAOREWbDnBXUf08JOwYq++0QNwQiWzI=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2566,17 +2566,6 @@ func (app *DdevApp) DockerEnv() {
 		"IS_GITPOD":                     strconv.FormatBool(nodeps.IsGitpod()),
 		"IS_CODESPACES":                 strconv.FormatBool(nodeps.IsCodespaces()),
 		"IS_WSL2":                       isWSL2,
-		// TODO: Disable bake builder (default since compose v2.37.0) to restore image label
-		// com.docker.compose.project used by `ddev delete` to detect DDEV-created images
-		// See: https://github.com/docker/compose/releases/tag/v2.37.0
-		//
-		// Label can be added via build.labels:
-		// services:
-		//  web:
-		//    build:
-		//      labels:
-		//        com.docker.compose.project: "project-name"
-		"COMPOSE_BAKE": "false",
 	}
 
 	// Set the DDEV_DB_CONTAINER_COMMAND command to empty to prevent docker-compose from complaining normally.

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -52,4 +52,4 @@ const RequiredMutagenVersion = "0.18.1"
 // RequiredDockerComposeVersionDefault defines the required version of docker-compose
 // Keep this in sync with github.com/compose-spec/compose-go/v2 in go.mod,
 // matching the version used in https://github.com/docker/compose/blob/main/go.mod for the same tag
-const RequiredDockerComposeVersionDefault = "v2.38.2"
+const RequiredDockerComposeVersionDefault = "v2.39.2"

--- a/vendor/github.com/compose-spec/compose-go/v2/dotenv/env.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/dotenv/env.go
@@ -56,7 +56,7 @@ func GetEnvFromFile(currentEnv map[string]string, filenames []string) (map[strin
 			return envMap, err
 		}
 
-		env, err := ParseWithLookup(bytes.NewReader(b), func(k string) (string, bool) {
+		err = parseWithLookup(bytes.NewReader(b), envMap, func(k string) (string, bool) {
 			v, ok := currentEnv[k]
 			if ok {
 				return v, true
@@ -66,9 +66,6 @@ func GetEnvFromFile(currentEnv map[string]string, filenames []string) (map[strin
 		})
 		if err != nil {
 			return envMap, fmt.Errorf("failed to read %s: %w", dotEnvFile, err)
-		}
-		for k, v := range env {
-			envMap[k] = v
 		}
 	}
 

--- a/vendor/github.com/compose-spec/compose-go/v2/loader/loader.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/loader/loader.go
@@ -43,7 +43,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/validation"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Options supported by Load
@@ -320,17 +320,17 @@ func LoadConfigFiles(ctx context.Context, configFiles []string, workingDir strin
 
 // LoadWithContext reads a ConfigDetails and returns a fully loaded configuration as a compose-go Project
 func LoadWithContext(ctx context.Context, configDetails types.ConfigDetails, options ...func(*Options)) (*types.Project, error) {
-	opts := toOptions(&configDetails, options)
+	opts := ToOptions(&configDetails, options)
 	dict, err := loadModelWithContext(ctx, &configDetails, opts)
 	if err != nil {
 		return nil, err
 	}
-	return modelToProject(dict, opts, configDetails)
+	return ModelToProject(dict, opts, configDetails)
 }
 
 // LoadModelWithContext reads a ConfigDetails and returns a fully loaded configuration as a yaml dictionary
 func LoadModelWithContext(ctx context.Context, configDetails types.ConfigDetails, options ...func(*Options)) (map[string]any, error) {
-	opts := toOptions(&configDetails, options)
+	opts := ToOptions(&configDetails, options)
 	return loadModelWithContext(ctx, &configDetails, opts)
 }
 
@@ -348,7 +348,7 @@ func loadModelWithContext(ctx context.Context, configDetails *types.ConfigDetail
 	return load(ctx, *configDetails, opts, nil)
 }
 
-func toOptions(configDetails *types.ConfigDetails, options []func(*Options)) *Options {
+func ToOptions(configDetails *types.ConfigDetails, options []func(*Options)) *Options {
 	opts := &Options{
 		Interpolate: &interp.Options{
 			Substitute:      template.Substitute,
@@ -557,8 +557,8 @@ func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options,
 	return dict, nil
 }
 
-// modelToProject binds a canonical yaml dict into compose-go structs
-func modelToProject(dict map[string]interface{}, opts *Options, configDetails types.ConfigDetails) (*types.Project, error) {
+// ModelToProject binds a canonical yaml dict into compose-go structs
+func ModelToProject(dict map[string]interface{}, opts *Options, configDetails types.ConfigDetails) (*types.Project, error) {
 	project := &types.Project{
 		Name:        opts.projectName,
 		WorkingDir:  configDetails.WorkingDir,

--- a/vendor/github.com/compose-spec/compose-go/v2/loader/reset.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/loader/reset.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/tree"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type ResetProcessor struct {

--- a/vendor/github.com/compose-spec/compose-go/v2/loader/validate.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/loader/validate.go
@@ -117,6 +117,12 @@ func checkConsistency(project *types.Project) error { //nolint:gocyclo
 			}
 		}
 
+		for model := range s.Models {
+			if _, ok := project.Models[model]; !ok {
+				return fmt.Errorf("service %q refers to undefined model %s: %w", s.Name, model, errdefs.ErrInvalid)
+			}
+		}
+
 		for _, secret := range s.Secrets {
 			if _, ok := project.Secrets[secret.Source]; !ok {
 				return fmt.Errorf("service %q refers to undefined secret %s: %w", s.Name, secret.Source, errdefs.ErrInvalid)

--- a/vendor/github.com/compose-spec/compose-go/v2/schema/compose-spec.json
+++ b/vendor/github.com/compose-spec/compose-go/v2/schema/compose-spec.json
@@ -123,6 +123,8 @@
                 "no_cache": {"type": ["boolean", "string"], "description": "Do not use cache when building the image."},
                 "additional_contexts": {"$ref": "#/definitions/list_or_dict", "description": "Additional build contexts to use, specified as a map of name to context path or URL."},
                 "network": {"type": "string", "description": "Network mode to use for the build. Options include 'default', 'none', 'host', or a network name."},
+                "provenance": {"type": ["string","boolean"], "description": "Add a provenance attestation"},
+                "sbom": {"type": ["string","boolean"], "description": "Add a SBOM attestation"},
                 "pull": {"type": ["boolean", "string"], "description": "Always attempt to pull a newer version of the image."},
                 "target": {"type": "string", "description": "Build stage to target in a multi-stage Dockerfile."},
                 "shm_size": {"type": ["integer", "string"], "description": "Size of /dev/shm for the build container. A string value can use suffix like '2g' for 2 gigabytes."},
@@ -206,7 +208,8 @@
         },
         "container_name": {
           "type": "string",
-          "description": "Specify a custom container name, rather than a generated default name."
+          "description": "Specify a custom container name, rather than a generated default name.",
+          "pattern": "[a-zA-Z0-9][a-zA-Z0-9_.-]+"
         },
         "cpu_count": {
           "oneOf": [

--- a/vendor/github.com/compose-spec/compose-go/v2/template/variables.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/template/variables.go
@@ -57,10 +57,9 @@ func recurseExtract(value interface{}, pattern *regexp.Regexp) map[string]Variab
 
 	case []interface{}:
 		for _, elem := range value {
-			if values, is := extractVariable(elem, pattern); is {
-				for _, v := range values {
-					m[v.Name] = v
-				}
+			submap := recurseExtract(elem, pattern)
+			for key, value := range submap {
+				m[key] = value
 			}
 		}
 	}

--- a/vendor/github.com/compose-spec/compose-go/v2/transform/canonical.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/transform/canonical.go
@@ -17,16 +17,21 @@
 package transform
 
 import (
+	"fmt"
+
 	"github.com/compose-spec/compose-go/v2/tree"
 )
 
-type transformFunc func(data any, p tree.Path, ignoreParseError bool) (any, error)
+// Func is a function that can transform data at a specific path
+type Func func(data any, p tree.Path, ignoreParseError bool) (any, error)
 
-var transformers = map[tree.Path]transformFunc{}
+var transformers = map[tree.Path]Func{}
 
 func init() {
 	transformers["services.*"] = transformService
 	transformers["services.*.build.secrets.*"] = transformFileMount
+	transformers["services.*.build.provenance"] = transformStringOrX
+	transformers["services.*.build.sbom"] = transformStringOrX
 	transformers["services.*.build.additional_contexts"] = transformKeyValue
 	transformers["services.*.depends_on"] = transformDependsOn
 	transformers["services.*.env_file"] = transformEnvFile
@@ -120,4 +125,13 @@ func transformMapping(v map[string]any, p tree.Path, ignoreParseError bool) (map
 		v[k] = t
 	}
 	return v, nil
+}
+
+func transformStringOrX(data any, _ tree.Path, _ bool) (any, error) {
+	switch v := data.(type) {
+	case string:
+		return v, nil
+	default:
+		return fmt.Sprint(v), nil
+	}
 }

--- a/vendor/github.com/compose-spec/compose-go/v2/transform/defaults.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/transform/defaults.go
@@ -20,14 +20,20 @@ import (
 	"github.com/compose-spec/compose-go/v2/tree"
 )
 
-var defaultValues = map[tree.Path]transformFunc{}
+// DefaultValues contains the default value transformers for compose fields
+var DefaultValues = map[tree.Path]Func{}
 
 func init() {
-	defaultValues["services.*.build"] = defaultBuildContext
-	defaultValues["services.*.secrets.*"] = defaultSecretMount
-	defaultValues["services.*.ports.*"] = portDefaults
-	defaultValues["services.*.deploy.resources.reservations.devices.*"] = deviceRequestDefaults
-	defaultValues["services.*.gpus.*"] = deviceRequestDefaults
+	DefaultValues["services.*.build"] = defaultBuildContext
+	DefaultValues["services.*.secrets.*"] = defaultSecretMount
+	DefaultValues["services.*.ports.*"] = portDefaults
+	DefaultValues["services.*.deploy.resources.reservations.devices.*"] = deviceRequestDefaults
+	DefaultValues["services.*.gpus.*"] = deviceRequestDefaults
+}
+
+// RegisterDefaultValue registers a custom transformer for the given path pattern
+func RegisterDefaultValue(path string, transformer Func) {
+	DefaultValues[tree.Path(path)] = transformer
 }
 
 // SetDefaultValues transforms a compose model to set default values to missing attributes
@@ -40,7 +46,7 @@ func SetDefaultValues(yaml map[string]any) (map[string]any, error) {
 }
 
 func setDefaults(data any, p tree.Path) (any, error) {
-	for pattern, transformer := range defaultValues {
+	for pattern, transformer := range DefaultValues {
 		if p.Matches(pattern) {
 			t, err := transformer(data, p, false)
 			if err != nil {

--- a/vendor/github.com/compose-spec/compose-go/v2/types/command.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/types/command.go
@@ -34,7 +34,7 @@ import "github.com/mattn/go-shellwords"
 // preserved so that it can override any base value (e.g. container entrypoint).
 //
 // The different semantics between YAML and JSON are due to limitations with
-// JSON marshaling + `omitempty` in the Go stdlib, while gopkg.in/yaml.v3 gives
+// JSON marshaling + `omitempty` in the Go stdlib, while go.yaml.in/yaml/v3 gives
 // us more flexibility via the yaml.IsZeroer interface.
 //
 // In the future, it might make sense to make fields of this type be
@@ -58,7 +58,7 @@ func (s ShellCommand) IsZero() bool {
 // accurately if the `omitempty` struct tag is omitted/forgotten.
 //
 // A similar MarshalJSON() implementation is not needed because the Go stdlib
-// already serializes nil slices to `null`, whereas gopkg.in/yaml.v3 by default
+// already serializes nil slices to `null`, whereas go.yaml.in/yaml/v3 by default
 // serializes nil slices to `[]`.
 func (s ShellCommand) MarshalYAML() (interface{}, error) {
 	if s == nil {

--- a/vendor/github.com/compose-spec/compose-go/v2/types/derived.gen.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/types/derived.gen.go
@@ -875,6 +875,8 @@ func deriveDeepCopy_6(dst, src *BuildConfig) {
 	} else {
 		dst.Args = nil
 	}
+	dst.Provenance = src.Provenance
+	dst.SBOM = src.SBOM
 	if src.SSH == nil {
 		dst.SSH = nil
 	} else {

--- a/vendor/github.com/compose-spec/compose-go/v2/types/mapping.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/types/mapping.go
@@ -95,7 +95,7 @@ func (m *MappingWithEquals) DecodeMapstructure(value interface{}) error {
 		mapping := make(MappingWithEquals, len(v))
 		for _, s := range v {
 			k, e, ok := strings.Cut(fmt.Sprint(s), "=")
-			if unicode.IsSpace(rune(k[len(k)-1])) {
+			if k != "" && unicode.IsSpace(rune(k[len(k)-1])) {
 				return fmt.Errorf("environment variable %s is declared with a trailing space", k)
 			}
 			if !ok {

--- a/vendor/github.com/compose-spec/compose-go/v2/types/project.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/types/project.go
@@ -32,8 +32,8 @@ import (
 	"github.com/compose-spec/compose-go/v2/utils"
 	"github.com/distribution/reference"
 	godigest "github.com/opencontainers/go-digest"
+	"go.yaml.in/yaml/v3"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/yaml.v3"
 )
 
 // Project is the result of loading a set of compose files
@@ -118,6 +118,16 @@ func (p *Project) ConfigNames() []string {
 	return names
 }
 
+// ModelNames return names for all models in this Compose config
+func (p *Project) ModelNames() []string {
+	var names []string
+	for k := range p.Models {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
 func (p *Project) ServicesWithBuild() []string {
 	servicesBuild := p.Services.Filter(func(s ServiceConfig) bool {
 		return s.Build != nil && s.Build.Context != ""
@@ -137,6 +147,11 @@ func (p *Project) ServicesWithDependsOn() []string {
 		return len(s.DependsOn) > 0
 	})
 	return slices.Collect(maps.Keys(servicesDependsOn))
+}
+
+func (p *Project) ServicesWithModels() []string {
+	servicesModels := p.Services.Filter(func(s ServiceConfig) bool { return len(s.Models) > 0 })
+	return slices.Collect(maps.Keys(servicesModels))
 }
 
 func (p *Project) ServicesWithCapabilities() ([]string, []string, []string) {

--- a/vendor/github.com/compose-spec/compose-go/v2/types/types.go
+++ b/vendor/github.com/compose-spec/compose-go/v2/types/types.go
@@ -309,6 +309,8 @@ type BuildConfig struct {
 	DockerfileInline   string                    `yaml:"dockerfile_inline,omitempty" json:"dockerfile_inline,omitempty"`
 	Entitlements       []string                  `yaml:"entitlements,omitempty" json:"entitlements,omitempty"`
 	Args               MappingWithEquals         `yaml:"args,omitempty" json:"args,omitempty"`
+	Provenance         string                    `yaml:"provenance,omitempty" json:"provenance,omitempty"`
+	SBOM               string                    `yaml:"sbom,omitempty" json:"sbom,omitempty"`
 	SSH                SSHConfig                 `yaml:"ssh,omitempty" json:"ssh,omitempty"`
 	Labels             Labels                    `yaml:"labels,omitempty" json:"labels,omitempty"`
 	CacheFrom          StringList                `yaml:"cache_from,omitempty" json:"cache_from,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -47,7 +47,7 @@ github.com/cheggaaa/pb
 # github.com/chzyer/readline v1.5.1
 ## explicit; go 1.15
 github.com/chzyer/readline
-# github.com/compose-spec/compose-go/v2 v2.7.1
+# github.com/compose-spec/compose-go/v2 v2.8.1
 ## explicit; go 1.23
 github.com/compose-spec/compose-go/v2/consts
 github.com/compose-spec/compose-go/v2/dotenv
@@ -408,8 +408,8 @@ go.opentelemetry.io/proto/otlp/common/v1
 go.opentelemetry.io/proto/otlp/metrics/v1
 go.opentelemetry.io/proto/otlp/resource/v1
 go.opentelemetry.io/proto/otlp/trace/v1
-# go.yaml.in/yaml/v3 v3.0.3
-## explicit; go 1.22
+# go.yaml.in/yaml/v3 v3.0.4
+## explicit; go 1.16
 go.yaml.in/yaml/v3
 # golang.org/x/crypto v0.36.0
 ## explicit; go 1.23.0


### PR DESCRIPTION
## The Issue

There is a new warning in `docker-compose` v2.39.0+:

- https://github.com/docker/compose/pull/13065

```
$ ddev start
Starting l12...
Building project images....time="2025-08-21T10:43:30+03:00" level=warning msg="COMPOSE_BAKE=false is deprecated, support for internal compose builder will be removed in next release"
...
```

I added `COMPOSE_BAKE=false` for `docker-compose` v2.38.2 in:

- #7456

## How This PR Solves The Issue

- bumps `docker-compose` to v2.39.2
- bumps `github.com/compose-spec/compose-go/v2` to v2.8.1 (the same library version as used in `docker-compose` v2.39.2)
- removes `COMPOSE_BAKE=false`
	There is no need to manually add the `com.docker.compose.project` label to the built images, as it's already fixed in:
	- https://github.com/docker/compose/pull/13049

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
