### PR TITLE
feat: add DDEV_ env vars to commands

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -460,6 +460,8 @@ func makeHostCmd(app *ddevapp.DdevApp, fullPath, name string, mutagenSync bool) 
 			_ = os.Setenv("DDEV_PROJECT_STATUS", "")
 		}
 
+		os.Setenv("DDEV_COMMAND", name)
+
 		osArgs := []string{}
 		if len(os.Args) > 2 {
 			osArgs = os.Args[2:]
@@ -519,6 +521,7 @@ func makeContainerCmd(app *ddevapp.DdevApp, fullPath, name, service string, exec
 			Dir:       app.GetWorkingDir(s, ""),
 			Tty:       isatty.IsTerminal(os.Stdin.Fd()),
 			NoCapture: true,
+			Env:       []string{"DDEV_COMMAND=" + name},
 		}
 		if relative {
 			opts.Dir = path.Join(opts.Dir, app.GetRelativeWorkingDirectory())

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2177,6 +2177,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		}
 	}
 
+	baseComposeExecCmd = append(baseComposeExecCmd, "-e", "DDEV_EXEC=true")
 	baseComposeExecCmd = append(baseComposeExecCmd, opts.Service)
 
 	// Cases to handle


### PR DESCRIPTION
I normally work inside the shell in the web container, but a lot of what I ship within the projects I work with other team members run them from the host. I have previously relied on other techniques to "detect" wether a particular script was run from the shell inside the container or from the host, but I figured having a way to detect that univocally coming from ddev might be a good addition.

The PR is simple and looks safe.

Wanted to get your opinion on this.

To test you can run:

- `ddev exec set | grep -i DDEV_EXEC`
- (create a custom host and web command with just `set`)  and run `ddev custom-web-command | | grep -iE "DDEV_COMMAND|DDEV_EXEC"`