### PR TITLE
refractor: updated mkcert and certutil installation

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -65,6 +65,10 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     sudo sh -c 'echo ""'
     sudo apt-get update && sudo apt-get install -y ddev
 
+    # Install mkcert and the certutil
+    sudo apt-get install libnss3-tools
+    sudo apt-get install mkcert
+
     # One-time initialization of mkcert
     mkcert -install
     ```


### PR DESCRIPTION
## The Issue

mkcert and certutil needs to be installed before using mkcert in debain and ubuntu linux

## How This PR Solves The Issue
This adds installation instructions for how to install mkcert and its dependancies.  This makes it so that the requirments of mkcert are there before the next init step.

## Manual Testing Instructions

## Automated Testing Overview

This is only adding an installation step. No tests should be required for this.

## Release/Deployment Notes

No