### PR TITLE
fix: add missing ephemeral port handling to xhgui service, fixes #7557

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1247,10 +1247,12 @@ func (app *DdevApp) Start() error {
 	app.RouterHTTPSPort = app.GetPrimaryRouterHTTPSPort()
 	app.MailpitHTTPPort = app.GetMailpitHTTPPort()
 	app.MailpitHTTPSPort = app.GetMailpitHTTPSPort()
+	app.XHGuiHTTPPort = app.GetXHGuiHTTPPort()
+	app.XHGuiHTTPSPort = app.GetXHGuiHTTPSPort()
 
 	AssignRouterPortsToGenericWebserverPorts(app)
 
-	portsToCheck := []*string{&app.RouterHTTPPort, &app.RouterHTTPSPort, &app.MailpitHTTPPort, &app.MailpitHTTPSPort}
+	portsToCheck := []*string{&app.RouterHTTPPort, &app.RouterHTTPSPort, &app.MailpitHTTPPort, &app.MailpitHTTPSPort, &app.XHGuiHTTPPort, &app.XHGuiHTTPSPort}
 	GetEphemeralPortsIfNeeded(portsToCheck, true)
 
 	SyncGenericWebserverPortsWithRouterPorts(app)

--- a/pkg/ddevapp/xhprof_xhgui.go
+++ b/pkg/ddevapp/xhprof_xhgui.go
@@ -2,11 +2,12 @@ package ddevapp
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
-	"strings"
 )
 
 // XHGuiSetup does prerequisite work to make XHGui work
@@ -149,7 +150,7 @@ func (app *DdevApp) GetXHProfMode() types.XHProfMode {
 // If not, use the global or project XHGuiHTTPPort
 func (app *DdevApp) GetXHGuiHTTPPort() string {
 	if httpExpose := app.GetXHGuiEnvVar("HTTP_EXPOSE"); httpExpose != "" {
-		httpPort := app.TargetPortFromExposeVariable(httpExpose, nodeps.DdevDefaultXHGuiHTTPPort)
+		httpPort := app.TargetPortFromExposeVariable(httpExpose, "80")
 		if httpPort != "" {
 			return httpPort
 		}
@@ -170,7 +171,7 @@ func (app *DdevApp) GetXHGuiHTTPPort() string {
 // If not, use the global or project XHGuiHTTPSPort
 func (app *DdevApp) GetXHGuiHTTPSPort() string {
 	if httpsExpose := app.GetXHGuiEnvVar("HTTPS_EXPOSE"); httpsExpose != "" {
-		httpsPort := app.TargetPortFromExposeVariable(httpsExpose, nodeps.DdevDefaultXHGuiHTTPSPort)
+		httpsPort := app.TargetPortFromExposeVariable(httpsExpose, "80")
 		if httpsPort != "" {
 			return httpsPort
 		}


### PR DESCRIPTION
## The Issue

- #7557

## How This PR Solves The Issue

Add XHGui ports to the ephemeral port resolution, and fix the incorrect TargetPortFromExposeVariable calls

## Manual Testing Instructions

Start other service on the default XHGui port 8142, e.g. via `nc -kl 8142`
ddev start
ddev xhgui

This will open up the browser showing xhgui using a port in the ephemeral range (33000-35000).

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
