### PR TITLE
docs: Fix blog link in main nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -235,5 +235,5 @@ nav:
     - developers/network-test-environments.md
     - developers/http-proxy-test-environments.md
     - developers/secret-management.md
-  - 'Blog': https://ddev.com
+  - 'Blog': https://ddev.com/blog
   - 'Add-on Registry': https://addons.ddev.com


### PR DESCRIPTION
The Blog link is currently redirect users to the front page instead of the blog section directly.

Rendered: https://ddev--7566.org.readthedocs.build/en/7566/

