### PR TITLE
fix(magerun): use stable branch for autocompletion

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -74,9 +74,9 @@ RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/apache2
 
 # magerun and magerun2 for magento
 RUN curl --fail -sSL https://files.magerun.net/n98-magerun-latest.phar -o /usr/local/bin/magerun && chmod 777 /usr/local/bin/magerun
-RUN curl --fail -sSL https://raw.githubusercontent.com/netz98/n98-magerun/develop/res/autocompletion/bash/n98-magerun.phar.bash -o /etc/bash_completion.d/n98-magerun.phar
+RUN curl --fail -sSL https://raw.githubusercontent.com/netz98/n98-magerun/master/res/autocompletion/bash/n98-magerun.phar.bash -o /etc/bash_completion.d/n98-magerun.phar
 RUN curl --fail -sSL https://files.magerun.net/n98-magerun2-latest.phar -o /usr/local/bin/magerun2 && chmod 777 /usr/local/bin/magerun2
-RUN curl --fail -sSL https://raw.githubusercontent.com/netz98/n98-magerun2/develop/res/autocompletion/bash/n98-magerun2.phar.bash -o /etc/bash_completion.d/n98-magerun2.phar && chmod +x /usr/local/bin/magerun
+RUN curl --fail -sSL https://raw.githubusercontent.com/netz98/n98-magerun2/master/res/autocompletion/bash/n98-magerun2.phar.bash -o /etc/bash_completion.d/n98-magerun2.phar
 
 RUN apt-get -qq autoremove && apt-get -qq clean -y && rm -rf /var/lib/apt/lists/* /tmp/*
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -11,7 +11,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250806_rfay_php_addon" // Note that this can be overridden by make
+var WebTag = "20250826_stasadev_magerun" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- https://github.com/netz98/n98-magerun2/issues/1773

> The Debian bash autocomplete `n98-magerun2.phar` uses `local` where it can't be used, so everybody doing a `ddev ssh` in DDEV gets this since latest release:
> 
> ```
> rfay@ubuntu-len:~/workspace/d11$ ddev ssh
> bash: local: can only be used in a function
> bash: local: can only be used in a function
> ```

## How This PR Solves The Issue

Uses the stable `master` branch as recommended in https://github.com/netz98/n98-magerun2/issues/1773#issuecomment-3224697637:

> > Is that what you'd recommend? It's been a lot of years. Is that still the recommended install technique?
> 
> The phar file is from stable release. The completion script is from unstable release. It whould be better to load the completion from stable "master" branch to have the completion compatible.

## Manual Testing Instructions

```
ddev ssh
```

Shouldn't have this output `bash: local: can only be used in a function`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
