### PR TITLE
chore(mkdocs): disable privacy plugin for local builds, for #6027 [skip ci]

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,7 +69,8 @@ theme:
 # Plugins
 plugins:
 - search
-- privacy
+- privacy:
+    enabled: !ENV [READTHEDOCS, false]
 - redirects:
     redirect_maps:
 - minify:


### PR DESCRIPTION
## The Issue

- #6027

## How This PR Solves The Issue

The `privacy` plugin generates `.cache` directory locally, but:

I don't like it because if it's cached, we can't see if there are any issues with external sources while working locally (and I don't like having one more `.cache` here because if I checkout some old git commit, this directory appears in unstaged files.)

- Used variable: https://docs.readthedocs.com/platform/stable/reference/environment-variables.html#envvar-READTHEDOCS
- Material for MkDocs config https://squidfunk.github.io/mkdocs-material/plugins/privacy/#config.enabled
  > If you want to disable the plugin, e.g., for local builds, you can use an environment variable in mkdocs.yml
- I didn't remove `.cache` from `.gitignore`

## Manual Testing Instructions

Remotely, nothing changes for loaded sources:

<img width="739" height="294" alt="image" src="https://github.com/user-attachments/assets/a92f92e3-9519-48e9-b408-75f6bc6c1dd9" />

---

Run this locally:

```
# in ddev directory
# rm -r .cache

# no `.cache` directory created
make mkdocs

# `.cache` directory created
READTHEDOCS=True make mkdocs
```

---

```
make mkdocs-serve
```

<img width="639" height="299" alt="image" src="https://github.com/user-attachments/assets/9ce87db6-b285-4f37-8c74-80ad90b4e707" />

---

```
READTHEDOCS=True make mkdocs-serve
```

<img width="702" height="297" alt="image" src="https://github.com/user-attachments/assets/3936a872-9f07-4fb8-ab9c-77373dcb030a" />

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
