### PR TITLE
test(buildkite): Minor fixup for buildkite timeout

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -189,7 +189,7 @@ fi
 # Run any testbot maintenance that may need to be done
 echo "--- running testbot_maintenance.sh"
 
-${TIMEOUT} 60s bash "$(dirname "$0")/testbot_maintenance.sh"
+${TIMEOUT} 120s bash "$(dirname "$0")/testbot_maintenance.sh"
 
 # Our testbot should be sane, run the testbot checker to make sure.
 echo "--- running sanetestbot.sh"

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -27,7 +27,7 @@ darwin)
     brew pin buildkite-agent
     brew upgrade
     brew uninstall -f mysql-client || true
-    for item in curl ddev/ddev/ddev golang golangci-lint gtimeout libpq mkcert mkdocs mysql-client@8.0; do
+    for item in coreutils curl ddev/ddev/ddev golang golangci-lint libpq mkcert mkdocs mysql-client@8.0; do
         brew install $item || true
     done
     brew link --force libpq


### PR DESCRIPTION

## The Issue

* I noticed that testbot_maintenance.sh was taking more than a minute on some neglected macos amd64 machines (mostly because it had failed to do the cleanup previously
* We were trying to `brew install gtimeout` but that's not valid. gtimeout comes with the coreutils package

## How This PR Solves The Issue

Increase timeout, install coreutils

If test runs things should be fine. It's minor. 