### PR TITLE
feat: provide `host.docker.internal` for all services, fixes #7537

### DIFF
--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -67,7 +67,6 @@ services:
       - DDEV_USER
       - DDEV_VERSION
       - DOCKER_IP={{ .DockerIP }}
-      - HOST_DOCKER_INTERNAL_IP={{ .HostDockerInternalIP }}
       - IS_DDEV_PROJECT=true
       - LINES
       - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-db/mysql_history
@@ -224,7 +223,6 @@ services:
     - DRUSH_OPTIONS_URI=$DDEV_PRIMARY_URL
     {{ end }}
     - DOCKER_IP={{ .DockerIP }}
-    - HOST_DOCKER_INTERNAL_IP={{ .HostDockerInternalIP }}
     # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
     # To expose a container port to a different host port, define the port as hostPort:containerPort
     # You can optionally expose an HTTPS port option for any ports defined in HTTP_EXPOSE.
@@ -266,13 +264,6 @@ services:
       com.ddev.platform: {{ .Plugin }}
       com.ddev.app-type: {{ .AppType }}
       com.ddev.approot: $DDEV_APPROOT
-
-      {{ if .HostDockerInternalIP }}
-    extra_hosts: [ "host.docker.internal:{{ .HostDockerInternalIP }}" ]
-      {{ else if .UseHostDockerInternalExtraHosts }}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-      {{ end }}
 
       {{ if not .OmitRouter }}
     external_links:

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -896,74 +896,72 @@ func (app *DdevApp) FixObsolete() {
 }
 
 type composeYAMLVars struct {
-	Name                            string
-	Plugin                          string
-	AppType                         string
-	WebserverType                   string
-	MailpitPort                     string
-	HostMailpitPort                 string
-	DBType                          string
-	DBVersion                       string
-	DBMountDir                      string
-	DBAPort                         string
-	DBPort                          string
-	DdevGenerated                   string
-	HostDockerInternalIP            string
-	NFSServerAddr                   string
-	DisableSettingsManagement       bool
-	MountType                       string
-	WebMount                        string
-	WebBuildContext                 string
-	DBBuildContext                  string
-	WebBuildDockerfile              string
-	DBBuildDockerfile               string
-	SSHAgentBuildContext            string
-	OmitDB                          bool
-	OmitDBA                         bool
-	OmitRouter                      bool
-	OmitSSHAgent                    bool
-	BindAllInterfaces               bool
-	MariaDBVolumeName               string
-	PostgresVolumeName              string
-	MutagenEnabled                  bool
-	MutagenVolumeName               string
-	NFSMountEnabled                 bool
-	NFSSource                       string
-	NFSMountVolumeName              string
-	DockerIP                        string
-	IsWindowsFS                     bool
-	NoProjectMount                  bool
-	Hostnames                       []string
-	Timezone                        string
-	ComposerVersion                 string
-	Username                        string
-	UID                             string
-	GID                             string
-	FailOnHookFail                  bool
-	WebWorkingDir                   string
-	DBWorkingDir                    string
-	DBAWorkingDir                   string
-	WebEnvironment                  []string
-	NoBindMounts                    bool
-	Docroot                         string
-	UploadDirsMap                   []string
-	GitDirMount                     bool
-	IsGitpod                        bool
-	IsCodespaces                    bool
-	DefaultContainerTimeout         string
-	UseHostDockerInternalExtraHosts bool
-	WebExtraContainerPorts          []int
-	WebExtraHTTPPorts               string
-	WebExtraHTTPSPorts              string
-	WebExtraExposedPorts            string
-	BitnamiVolumeDir                string
-	UseHardenedImages               bool
-	XHGuiHTTPPort                   string
-	XHGuiHTTPSPort                  string
-	XHGuiPort                       string
-	HostXHGuiPort                   string
-	XhguiImage                      string
-	XHProfMode                      types.XHProfMode
+	Name                      string
+	Plugin                    string
+	AppType                   string
+	WebserverType             string
+	MailpitPort               string
+	HostMailpitPort           string
+	DBType                    string
+	DBVersion                 string
+	DBMountDir                string
+	DBAPort                   string
+	DBPort                    string
+	DdevGenerated             string
+	NFSServerAddr             string
+	DisableSettingsManagement bool
+	MountType                 string
+	WebMount                  string
+	WebBuildContext           string
+	DBBuildContext            string
+	WebBuildDockerfile        string
+	DBBuildDockerfile         string
+	SSHAgentBuildContext      string
+	OmitDB                    bool
+	OmitDBA                   bool
+	OmitRouter                bool
+	OmitSSHAgent              bool
+	BindAllInterfaces         bool
+	MariaDBVolumeName         string
+	PostgresVolumeName        string
+	MutagenEnabled            bool
+	MutagenVolumeName         string
+	NFSMountEnabled           bool
+	NFSSource                 string
+	NFSMountVolumeName        string
+	DockerIP                  string
+	IsWindowsFS               bool
+	NoProjectMount            bool
+	Hostnames                 []string
+	Timezone                  string
+	ComposerVersion           string
+	Username                  string
+	UID                       string
+	GID                       string
+	FailOnHookFail            bool
+	WebWorkingDir             string
+	DBWorkingDir              string
+	DBAWorkingDir             string
+	WebEnvironment            []string
+	NoBindMounts              bool
+	Docroot                   string
+	UploadDirsMap             []string
+	GitDirMount               bool
+	IsGitpod                  bool
+	IsCodespaces              bool
+	DefaultContainerTimeout   string
+	WebExtraContainerPorts    []int
+	WebExtraHTTPPorts         string
+	WebExtraHTTPSPorts        string
+	WebExtraExposedPorts      string
+	BitnamiVolumeDir          string
+	UseHardenedImages         bool
+	XHGuiHTTPPort             string
+	XHGuiHTTPSPort            string
+	XHGuiPort                 string
+	HostXHGuiPort             string
+	XhguiImage                string
+	XHProfMode                types.XHProfMode
 }
 
 // RenderComposeYAML renders the contents of .ddev/.ddev-docker-compose*.
@@ -1019,7 +1017,6 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		DBMountDir:                "/var/lib/mysql",
 		DBPort:                    GetInternalPort(app, "db"),
 		DdevGenerated:             nodeps.DdevFileSignature,
-		HostDockerInternalIP:      hostDockerInternal.IPAddress,
 		NFSServerAddr:             nfsServerAddr,
 		DisableSettingsManagement: app.DisableSettingsManagement,
 		OmitDB:                    nodeps.ArrayContainsString(app.GetOmittedContainers(), nodeps.DBContainer),
@@ -1063,12 +1060,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		HostXHGuiPort:           app.HostXHGuiPort,
 		XhguiImage:              docker.GetXhguiImage(),
 		XHProfMode:              app.GetXHProfMode(),
-
-		// Only use the extra_hosts technique for Linux and only if not WSL2 and not Colima
-		// If WSL2 we have to figure out other things, see GetHostDockerInternal()
-		UseHostDockerInternalExtraHosts: hostDockerInternal.ExtraHost == "host-gateway",
-		BitnamiVolumeDir:                "",
-		UseHardenedImages:               globalconfig.DdevGlobalConfig.UseHardenedImages,
+		BitnamiVolumeDir:        "",
+		UseHardenedImages:       globalconfig.DdevGlobalConfig.UseHardenedImages,
 	}
 	// We don't want to bind-mount Git directory if it doesn't exist
 	if fileutil.IsDirectory(filepath.Join(app.AppRoot, ".git")) {


### PR DESCRIPTION
## The Issue

- Fixes #7537

## How This PR Solves The Issue

Consolidates `host.docker.internal` configuration by moving it from template-time to compose post-processing.

- Remove `.HostDockerInternalIP` and `.UseHostDockerInternalExtraHosts` from the template 
- Add `host.docker.internal` handling in `fixupComposeYaml()` for all services
- Add `HOST_DOCKER_INTERNAL_IP` env variable for all services

## Manual Testing Instructions

```
ddev config --webserver-type=generic
ddev add-on get stasadev/ddev-frankenphp
ddev restart

for s in $(ddev describe -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.services | keys[]'); do
  echo "Service: $s"
  ddev exec -s "$s" getent hosts host.docker.internal
  ddev exec -s "$s" 'echo HOST_DOCKER_INTERNAL_IP=$HOST_DOCKER_INTERNAL_IP'
  echo
done
```

Testing on Linux:

v1.24.7:
```
Service: db
Failed to execute command `getent hosts host.docker.internal`: exit status 2
HOST_DOCKER_INTERNAL_IP=

Service: frankenphp
Failed to execute command `getent hosts host.docker.internal`: exit status 2
sh: 1: HOST_DOCKER_INTERNAL_IP: parameter not set
Failed to execute command `echo HOST_DOCKER_INTERNAL_IP=$HOST_DOCKER_INTERNAL_IP`: exit status 2

Service: web
172.17.0.1      host.docker.internal
HOST_DOCKER_INTERNAL_IP=
```

This PR:
```
Service: db
172.17.0.1      host.docker.internal
HOST_DOCKER_INTERNAL_IP=172.17.0.1

Service: frankenphp
172.17.0.1      host.docker.internal
HOST_DOCKER_INTERNAL_IP=172.17.0.1

Service: web
172.17.0.1      host.docker.internal
HOST_DOCKER_INTERNAL_IP=172.17.0.1
```

---

```
ddev config global --xdebug-ide-location=192.168.1.1

ddev config --webserver-type=generic
ddev add-on get stasadev/ddev-frankenphp
ddev restart

for s in $(ddev describe -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.services | keys[]'); do
  echo "Service: $s"
  ddev exec -s "$s" getent hosts host.docker.internal
  ddev exec -s "$s" 'echo HOST_DOCKER_INTERNAL_IP=$HOST_DOCKER_INTERNAL_IP'
  echo
done

ddev config global --xdebug-ide-location=
```

v1.24.7:
```
Service: db
Failed to execute command `getent hosts host.docker.internal`: exit status 2
HOST_DOCKER_INTERNAL_IP=192.168.1.1

Service: frankenphp
Failed to execute command `getent hosts host.docker.internal`: exit status 2
sh: 1: HOST_DOCKER_INTERNAL_IP: parameter not set
Failed to execute command `echo HOST_DOCKER_INTERNAL_IP=$HOST_DOCKER_INTERNAL_IP`: exit status 2

Service: web
192.168.1.1      host.docker.internal
HOST_DOCKER_INTERNAL_IP=192.168.1.1
```

This PR:
```
Service: db
192.168.1.1     host.docker.internal
HOST_DOCKER_INTERNAL_IP=192.168.1.1

Service: frankenphp
192.168.1.1     host.docker.internal
HOST_DOCKER_INTERNAL_IP=192.168.1.1

Service: web
192.168.1.1     host.docker.internal
HOST_DOCKER_INTERNAL_IP=192.168.1.1
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
