### PR TITLE
fix: cache `WarningOnce`, reduce `NewApp` calls, handle `GetDockerClient` errors, for #7472

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -49,7 +49,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 	// Keep a map so we don't add multiple commands with the same name.
 	commandsAdded := map[string]int{}
 
-	activeAppRoot, err := ddevapp.GetActiveAppRoot("")
+	app, err := ddevapp.GetActiveApp("")
 	// If we're not running ddev inside a project directory, we should still add any host commands that can run without one.
 	if err != nil {
 		globalHostCommandPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands", "host")
@@ -64,10 +64,6 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 		return nil
 	}
 
-	app, err := ddevapp.NewApp(activeAppRoot, true)
-	if err != nil {
-		return err
-	}
 	projectCommandPath := app.GetConfigPath("commands")
 	// Make sure our target global command directory is empty
 	globalCommandPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands")

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -49,7 +49,7 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 	// Keep a map so we don't add multiple commands with the same name.
 	commandsAdded := map[string]int{}
 
-	app, err := ddevapp.GetActiveApp("")
+	activeAppRoot, err := ddevapp.GetActiveAppRoot("")
 	// If we're not running ddev inside a project directory, we should still add any host commands that can run without one.
 	if err != nil {
 		globalHostCommandPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands", "host")
@@ -64,6 +64,10 @@ func addCustomCommands(rootCmd *cobra.Command) error {
 		return nil
 	}
 
+	app, err := ddevapp.NewApp(activeAppRoot, true)
+	if err != nil {
+		return err
+	}
 	projectCommandPath := app.GetConfigPath("commands")
 	// Make sure our target global command directory is empty
 	globalCommandPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands")

--- a/cmd/ddev/cmd/debug-dockercheck.go
+++ b/cmd/ddev/cmd/debug-dockercheck.go
@@ -79,11 +79,6 @@ var DebugDockercheckCmd = &cobra.Command{
 		}
 		util.Success("Docker API version: %s", dockerAPIVersion)
 
-		_, client := dockerutil.GetDockerClient()
-		if client == nil {
-			util.Failed("Unable to get Docker client")
-		}
-
 		uid, _, _ := util.GetContainerUIDGid()
 		_, out, err := dockerutil.RunSimpleContainer(docker.GetWebImage(), "dockercheck-runcontainer--"+util.RandString(6), []string{"ls", "/mnt/ddev-global-cache"}, []string{}, []string{}, []string{"ddev-global-cache" + ":/mnt/ddev-global-cache"}, uid, true, false, map[string]string{"com.ddev.site-name": ""}, nil, nil)
 		if err != nil {

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -81,6 +81,9 @@ func init() {
 // If dryRun is true, it only prints images to be deleted without removing them.
 func deleteDdevImages(deleteAll, dryRun bool) error {
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		return dockerutil.GetDockerClientErr()
+	}
 
 	allImages, err := client.ImageList(ctx, dockerImage.ListOptions{
 		All: true,

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -80,9 +80,9 @@ func init() {
 // or com.docker.compose.project starting with "ddev-"
 // If dryRun is true, it only prints images to be deleted without removing them.
 func deleteDdevImages(deleteAll, dryRun bool) error {
-	ctx, client := dockerutil.GetDockerClient()
-	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
-		return cErr
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		return err
 	}
 
 	allImages, err := client.ImageList(ctx, dockerImage.ListOptions{

--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -81,8 +81,8 @@ func init() {
 // If dryRun is true, it only prints images to be deleted without removing them.
 func deleteDdevImages(deleteAll, dryRun bool) error {
 	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		return dockerutil.GetDockerClientErr()
+	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
+		return cErr
 	}
 
 	allImages, err := client.ImageList(ctx, dockerImage.ListOptions{

--- a/cmd/ddev/cmd/networks_test.go
+++ b/cmd/ddev/cmd/networks_test.go
@@ -17,8 +17,8 @@ func TestNetworkDuplicates(t *testing.T) {
 	assert := asrt.New(t)
 
 	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
+		t.Fatalf("Could not get docker client: %v", cErr)
 	}
 
 	// Create two networks with the same name

--- a/cmd/ddev/cmd/networks_test.go
+++ b/cmd/ddev/cmd/networks_test.go
@@ -17,6 +17,9 @@ func TestNetworkDuplicates(t *testing.T) {
 	assert := asrt.New(t)
 
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	}
 
 	// Create two networks with the same name
 	networkName := "ddev-" + t.Name() + "_default"

--- a/cmd/ddev/cmd/networks_test.go
+++ b/cmd/ddev/cmd/networks_test.go
@@ -16,9 +16,9 @@ import (
 func TestNetworkDuplicates(t *testing.T) {
 	assert := asrt.New(t)
 
-	ctx, client := dockerutil.GetDockerClient()
-	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
-		t.Fatalf("Could not get docker client: %v", cErr)
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		t.Fatalf("Could not get docker client: %v", err)
 	}
 
 	// Create two networks with the same name
@@ -45,7 +45,7 @@ func TestNetworkDuplicates(t *testing.T) {
 	}
 
 	// Create the first network
-	_, err := client.NetworkCreate(ctx, networkName, netOptions)
+	_, err = client.NetworkCreate(ctx, networkName, netOptions)
 	assert.NoError(err)
 
 	// Create a second network with the same name

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -83,15 +83,11 @@ func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, s
 func init() {
 	RootCmd.AddCommand(PullCmd)
 
-	activeAppRoot, err := ddevapp.GetActiveAppRoot("")
+	app, err := ddevapp.GetActiveApp("")
 	if err != nil {
 		return
 	}
 
-	app, err := ddevapp.NewApp(activeAppRoot, true)
-	if err != nil {
-		return
-	}
 	pList, err := app.GetValidProviders()
 	if err != nil {
 		return

--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -83,11 +83,12 @@ func appPull(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, s
 func init() {
 	RootCmd.AddCommand(PullCmd)
 
-	app, err := ddevapp.GetActiveApp("")
+	appRoot, err := ddevapp.GetActiveAppRoot("")
 	if err != nil {
 		return
 	}
 
+	app := &ddevapp.DdevApp{AppRoot: appRoot}
 	pList, err := app.GetValidProviders()
 	if err != nil {
 		return

--- a/cmd/ddev/cmd/push.go
+++ b/cmd/ddev/cmd/push.go
@@ -81,11 +81,12 @@ func apppush(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, s
 func init() {
 	RootCmd.AddCommand(PushCmd)
 
-	app, err := ddevapp.GetActiveApp("")
+	appRoot, err := ddevapp.GetActiveAppRoot("")
 	if err != nil {
 		return
 	}
 
+	app := &ddevapp.DdevApp{AppRoot: appRoot}
 	pList, err := app.GetValidProviders()
 	if err != nil {
 		return

--- a/cmd/ddev/cmd/push.go
+++ b/cmd/ddev/cmd/push.go
@@ -81,15 +81,11 @@ func apppush(providerType string, app *ddevapp.DdevApp, skipConfirmation bool, s
 func init() {
 	RootCmd.AddCommand(PushCmd)
 
-	activeAppRoot, err := ddevapp.GetActiveAppRoot("")
+	app, err := ddevapp.GetActiveApp("")
 	if err != nil {
 		return
 	}
 
-	app, err := ddevapp.NewApp(activeAppRoot, true)
-	if err != nil {
-		return
-	}
 	pList, err := app.GetValidProviders()
 	if err != nil {
 		return

--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -69,11 +69,7 @@ Example: "ddev snapshot restore d8git_20180717203845"`,
 }
 
 func init() {
-	activeAppRoot, err := ddevapp.GetActiveAppRoot("")
-	if err != nil {
-		return
-	}
-	app, err := ddevapp.NewApp(activeAppRoot, true)
+	app, err := ddevapp.GetActiveApp("")
 	if err == nil && app != nil && !nodeps.ArrayContainsString(app.OmitContainers, "db") {
 		DdevSnapshotRestoreCommand.Flags().BoolVarP(&snapshotRestoreLatest, "latest", "", false, "use latest snapshot")
 		DdevSnapshotCommand.AddCommand(DdevSnapshotRestoreCommand)

--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -21,6 +21,9 @@ Example: "ddev snapshot restore d8git_20180717203845"`,
 		if err != nil {
 			util.Failed("Failed to find active project: %v", err)
 		}
+		if nodeps.ArrayContainsString(app.OmitContainers, "db") {
+			util.Failed("Snapshots are not available when database container is omitted")
+		}
 		if app.Database.Type == nodeps.Postgres && app.Database.Version == nodeps.Postgres9 {
 			util.Failed("Snapshots are not supported for postgres:9")
 		}
@@ -69,9 +72,6 @@ Example: "ddev snapshot restore d8git_20180717203845"`,
 }
 
 func init() {
-	app, err := ddevapp.GetActiveApp("")
-	if err == nil && app != nil && !nodeps.ArrayContainsString(app.OmitContainers, "db") {
-		DdevSnapshotRestoreCommand.Flags().BoolVarP(&snapshotRestoreLatest, "latest", "", false, "use latest snapshot")
-		DdevSnapshotCommand.AddCommand(DdevSnapshotRestoreCommand)
-	}
+	DdevSnapshotRestoreCommand.Flags().BoolVarP(&snapshotRestoreLatest, "latest", "", false, "use latest snapshot")
+	DdevSnapshotCommand.AddCommand(DdevSnapshotRestoreCommand)
 }

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -64,7 +64,7 @@ func init() {
 
 // NewApp creates a new DdevApp struct with defaults set and overridden by any existing config.yml.
 func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
-	defer util.TimeTrackC(fmt.Sprintf("ddevapp.NewApp(%s, %t)", appRoot, includeOverrides))()
+	defer util.TimeTrackC(fmt.Sprintf("ddevapp.NewApp(%s, includeOverrides=%t)", appRoot, includeOverrides))()
 
 	app := &DdevApp{}
 
@@ -356,6 +356,9 @@ func (app *DdevApp) UpdateGlobalProjectList() error {
 // It does not attempt to set default values; that's NewApp's job.
 // returns the list of config files read
 func (app *DdevApp) ReadConfig(includeOverrides bool) ([]string, error) {
+	if app.ConfigPath == "" {
+		app.ConfigPath = app.GetConfigPath("config.yaml")
+	}
 	// Load base .ddev/config.yaml - original config
 	err := app.LoadConfigYamlFile(app.ConfigPath)
 	if err != nil {

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -168,7 +168,7 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 	// Rendered yaml is not there until after ddev config or ddev start
 	if fileutil.FileExists(app.ConfigPath) && fileutil.FileExists(app.DockerComposeFullRenderedYAMLPath()) {
 		if err := app.ReadDockerComposeYAML(); err != nil {
-			util.WarningOnce("Unable to read '%s' project config at %s: %v", app.Name, app.DockerComposeFullRenderedYAMLPath(), err)
+			util.Verbose("Unable to read '%s' project config at %s: %v", app.Name, app.DockerComposeFullRenderedYAMLPath(), err)
 		}
 	}
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -3,7 +3,6 @@ package ddevapp
 import (
 	"bytes"
 	"fmt"
-	"go.yaml.in/yaml/v3"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -24,6 +23,7 @@ import (
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	copy2 "github.com/otiai10/copy"
+	"go.yaml.in/yaml/v3"
 )
 
 // Regexp pattern to determine if a hostname is valid per RFC 1123.
@@ -64,7 +64,7 @@ func init() {
 
 // NewApp creates a new DdevApp struct with defaults set and overridden by any existing config.yml.
 func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
-	defer util.TimeTrackC(fmt.Sprintf("ddevapp.NewApp(%s)", appRoot))()
+	defer util.TimeTrackC(fmt.Sprintf("ddevapp.NewApp(%s, %t)", appRoot, includeOverrides))()
 
 	app := &DdevApp{}
 
@@ -167,13 +167,8 @@ func NewApp(appRoot string, includeOverrides bool) (*DdevApp, error) {
 
 	// Rendered yaml is not there until after ddev config or ddev start
 	if fileutil.FileExists(app.ConfigPath) && fileutil.FileExists(app.DockerComposeFullRenderedYAMLPath()) {
-		content, err := fileutil.ReadFileIntoString(app.DockerComposeFullRenderedYAMLPath())
-		if err != nil {
-			return app, err
-		}
-		err = app.UpdateComposeYaml(content)
-		if err != nil {
-			return app, err
+		if err := app.ReadDockerComposeYAML(); err != nil {
+			util.WarningOnce("Unable to read '%s' project config at %s: %v", app.Name, app.DockerComposeFullRenderedYAMLPath(), err)
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2322,13 +2322,12 @@ func (app *DdevApp) ExecOnHostOrService(service string, cmd string) error {
 // Logs returns logs for a site's given container.
 // See docker.LogsOptions for more information about valid tailLines values.
 func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tailLines string) error {
-	ctx, client := dockerutil.GetDockerClient()
-	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
-		return cErr
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		return err
 	}
 
 	var container *dockerContainer.Summary
-	var err error
 	// Let people access ddev-router and ddev-ssh-agent logs as well.
 	if service == "ddev-router" || service == "ddev-ssh-agent" {
 		container, err = dockerutil.FindContainerByLabels(map[string]string{
@@ -2375,13 +2374,12 @@ func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tailLines
 // CaptureLogs returns logs for a site's given container.
 // See docker.LogsOptions for more information about valid tailLines values.
 func (app *DdevApp) CaptureLogs(service string, timestamps bool, tailLines string) (string, error) {
-	ctx, client := dockerutil.GetDockerClient()
-	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
-		return "", cErr
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		return "", err
 	}
 
 	var container *dockerContainer.Summary
-	var err error
 	// Let people access ddev-router and ddev-ssh-agent logs as well.
 	if service == "ddev-router" || service == "ddev-ssh-agent" {
 		container, err = dockerutil.FindContainerByLabels(map[string]string{

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2323,8 +2323,8 @@ func (app *DdevApp) ExecOnHostOrService(service string, cmd string) error {
 // See docker.LogsOptions for more information about valid tailLines values.
 func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tailLines string) error {
 	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		return dockerutil.GetDockerClientErr()
+	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
+		return cErr
 	}
 
 	var container *dockerContainer.Summary
@@ -2376,8 +2376,8 @@ func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tailLines
 // See docker.LogsOptions for more information about valid tailLines values.
 func (app *DdevApp) CaptureLogs(service string, timestamps bool, tailLines string) (string, error) {
 	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		return "", dockerutil.GetDockerClientErr()
+	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
+		return "", cErr
 	}
 
 	var container *dockerContainer.Summary

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1009,7 +1009,6 @@ func (app *DdevApp) SiteStatus() (string, string) {
 	for service := range statuses {
 		container, err := app.FindContainerByType(service)
 		if err != nil {
-			util.Error("app.FindContainerByType(%v) failed", service)
 			return "", ""
 		}
 		if container == nil {
@@ -2325,6 +2324,9 @@ func (app *DdevApp) ExecOnHostOrService(service string, cmd string) error {
 // See docker.LogsOptions for more information about valid tailLines values.
 func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tailLines string) error {
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		return dockerutil.GetDockerClientErr()
+	}
 
 	var container *dockerContainer.Summary
 	var err error
@@ -2375,6 +2377,9 @@ func (app *DdevApp) Logs(service string, follow bool, timestamps bool, tailLines
 // See docker.LogsOptions for more information about valid tailLines values.
 func (app *DdevApp) CaptureLogs(service string, timestamps bool, tailLines string) (string, error) {
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		return "", dockerutil.GetDockerClientErr()
+	}
 
 	var container *dockerContainer.Summary
 	var err error

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3076,6 +3076,9 @@ func TestDdevExec(t *testing.T) {
 
 	// Now kill the busybox service and make sure that responses to app.Exec are correct
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	}
 	bbc, err := dockerutil.FindContainerByName(fmt.Sprintf("ddev-%s-%s", app.Name, "busybox"))
 	require.NoError(t, err)
 	require.NotEmpty(t, bbc)
@@ -3277,6 +3280,9 @@ func TestCleanupWithoutCompose(t *testing.T) {
 
 	// Ensure there are no volumes associated with this project
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	}
 	volumes, err := client.VolumeList(ctx, dockerVolume.ListOptions{})
 	assert.NoError(err)
 	for _, volume := range volumes.Volumes {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3076,8 +3076,8 @@ func TestDdevExec(t *testing.T) {
 
 	// Now kill the busybox service and make sure that responses to app.Exec are correct
 	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
+		t.Fatalf("Could not get docker client: %v", cErr)
 	}
 	bbc, err := dockerutil.FindContainerByName(fmt.Sprintf("ddev-%s-%s", app.Name, "busybox"))
 	require.NoError(t, err)
@@ -3280,8 +3280,8 @@ func TestCleanupWithoutCompose(t *testing.T) {
 
 	// Ensure there are no volumes associated with this project
 	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
+		t.Fatalf("Could not get docker client: %v", cErr)
 	}
 	volumes, err := client.VolumeList(ctx, dockerVolume.ListOptions{})
 	assert.NoError(err)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3075,9 +3075,9 @@ func TestDdevExec(t *testing.T) {
 	assert.Contains(stderr, "this: not found")
 
 	// Now kill the busybox service and make sure that responses to app.Exec are correct
-	ctx, client := dockerutil.GetDockerClient()
-	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
-		t.Fatalf("Could not get docker client: %v", cErr)
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		t.Fatalf("Could not get docker client: %v", err)
 	}
 	bbc, err := dockerutil.FindContainerByName(fmt.Sprintf("ddev-%s-%s", app.Name, "busybox"))
 	require.NoError(t, err)
@@ -3279,9 +3279,9 @@ func TestCleanupWithoutCompose(t *testing.T) {
 	}
 
 	// Ensure there are no volumes associated with this project
-	ctx, client := dockerutil.GetDockerClient()
-	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
-		t.Fatalf("Could not get docker client: %v", cErr)
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		t.Fatalf("Could not get docker client: %v", err)
 	}
 	volumes, err := client.VolumeList(ctx, dockerVolume.ListOptions{})
 	assert.NoError(err)

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -701,9 +701,9 @@ func (app *DdevApp) GenerateMutagenYml() error {
 
 // IsMutagenVolumeMounted checks to see if the Mutagen volume is mounted
 func IsMutagenVolumeMounted(app *DdevApp) (bool, error) {
-	ctx, client := dockerutil.GetDockerClient()
-	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
-		return false, cErr
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		return false, err
 	}
 	container, err := dockerutil.FindContainerByName("ddev-" + app.Name + "-web")
 	// If there is no web container found, the volume is not mounted

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -702,8 +702,8 @@ func (app *DdevApp) GenerateMutagenYml() error {
 // IsMutagenVolumeMounted checks to see if the Mutagen volume is mounted
 func IsMutagenVolumeMounted(app *DdevApp) (bool, error) {
 	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		return false, dockerutil.GetDockerClientErr()
+	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
+		return false, cErr
 	}
 	container, err := dockerutil.FindContainerByName("ddev-" + app.Name + "-web")
 	// If there is no web container found, the volume is not mounted

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -702,6 +702,9 @@ func (app *DdevApp) GenerateMutagenYml() error {
 // IsMutagenVolumeMounted checks to see if the Mutagen volume is mounted
 func IsMutagenVolumeMounted(app *DdevApp) (bool, error) {
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		return false, dockerutil.GetDockerClientErr()
+	}
 	container, err := dockerutil.FindContainerByName("ddev-" + app.Name + "-web")
 	// If there is no web container found, the volume is not mounted
 	if err != nil || container == nil {

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -381,7 +381,7 @@ func getConfigBasedRouterPorts() []string {
 	for _, app := range GetActiveProjects() {
 		err := app.ReadDockerComposeYAML()
 		if err != nil {
-			util.WarningOnce("Unable to read '%s' project config at %s: %v", app.Name, app.DockerComposeFullRenderedYAMLPath(), err)
+			util.Verbose("Unable to read '%s' project config at %s: %v", app.Name, app.DockerComposeFullRenderedYAMLPath(), err)
 			continue
 		}
 		if app.ComposeYaml == nil || app.ComposeYaml.Services == nil {

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -381,7 +381,7 @@ func getConfigBasedRouterPorts() []string {
 	for _, app := range GetActiveProjects() {
 		err := app.ReadDockerComposeYAML()
 		if err != nil {
-			util.Warning("Unable to read '%s' project config for determining port mappings: %v", app.Name, err)
+			util.WarningOnce("Unable to read '%s' project config at %s: %v", app.Name, app.DockerComposeFullRenderedYAMLPath(), err)
 			continue
 		}
 		if app.ComposeYaml == nil || app.ComposeYaml.Services == nil {

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -90,8 +90,8 @@ func RenderAppRow(t table.Writer, row map[string]interface{}) {
 // has been deleted.
 func Cleanup(app *DdevApp) error {
 	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		return dockerutil.GetDockerClientErr()
+	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
+		return cErr
 	}
 
 	// Find all containers which match the current site name.

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -228,7 +228,7 @@ func CreateGitIgnore(targetDir string, ignores ...string) error {
 
 		// If we sigFound the file and did not find the signature in .ddev/.gitignore, warn about it.
 		if !sigFound {
-			util.Warning("User-managed %s will not be managed/overwritten by ddev", gitIgnoreFilePath)
+			util.WarningOnce("User-managed %s will not be managed/overwritten by ddev", gitIgnoreFilePath)
 			return nil
 		}
 		// Read the existing content for future comparison.

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -89,9 +89,9 @@ func RenderAppRow(t table.Writer, row map[string]interface{}) {
 // Cleanup will remove DDEV containers and volumes even if docker-compose.yml
 // has been deleted.
 func Cleanup(app *DdevApp) error {
-	ctx, client := dockerutil.GetDockerClient()
-	if cErr := dockerutil.GetDockerClientErr(); cErr != nil {
-		return cErr
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		return err
 	}
 
 	// Find all containers which match the current site name.

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -90,6 +90,9 @@ func RenderAppRow(t table.Writer, row map[string]interface{}) {
 // has been deleted.
 func Cleanup(app *DdevApp) error {
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		return dockerutil.GetDockerClientErr()
+	}
 
 	// Find all containers which match the current site name.
 	labels := map[string]string{

--- a/pkg/dockerutil/dockerutils.go
+++ b/pkg/dockerutil/dockerutils.go
@@ -151,7 +151,7 @@ func RemoveNetworkWithWarningOnError(netName string) {
 	err := RemoveNetwork(netName)
 	// If it's a "no such network" there's no reason to report error
 	if err != nil && !IsErrNotFound(err) {
-		util.Warning("Unable to remove network %s: %v", netName, err)
+		util.WarningOnce("Unable to remove network %s: %v", netName, err)
 	} else if err == nil {
 		output.UserOut.Println("Network", netName, "removed")
 	}
@@ -170,7 +170,7 @@ func RemoveNetworkDuplicates(netName string) {
 				err := client.NetworkRemove(ctx, network.ID)
 				// If it's a "no such network" there's no reason to report error
 				if err != nil && !IsErrNotFound(err) {
-					util.Warning("Unable to remove network %s: %v", netName, err)
+					util.WarningOnce("Unable to remove network %s: %v", netName, err)
 				}
 			} else {
 				networkMatchFound = true

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -132,9 +132,9 @@ func startTestContainer() (string, error) {
 // TestGetContainerHealth tests the function for processing container readiness.
 func TestGetContainerHealth(t *testing.T) {
 	assert := asrt.New(t)
-	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		t.Fatalf("Could not get docker client: %v", err)
 	}
 
 	labels := map[string]string{
@@ -533,9 +533,9 @@ func TestGetBoundHostPorts(t *testing.T) {
 // TestDockerExec() checks docker.Exec()
 func TestDockerExec(t *testing.T) {
 	assert := asrt.New(t)
-	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		t.Fatalf("Could not get docker client: %v", err)
 	}
 
 	id, _, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "", []string{"tail", "-f", "/dev/null"}, nil, nil, nil, "0", false, true, nil, nil, nil)
@@ -573,9 +573,9 @@ func TestCreateVolume(t *testing.T) {
 // TestRemoveVolume makes sure we can remove a volume successfully
 func TestRemoveVolume(t *testing.T) {
 	assert := asrt.New(t)
-	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		t.Fatalf("Could not get docker client: %v", err)
 	}
 
 	testVolume := "junker999"

--- a/pkg/dockerutil/dockerutils_test.go
+++ b/pkg/dockerutil/dockerutils_test.go
@@ -133,6 +133,9 @@ func startTestContainer() (string, error) {
 func TestGetContainerHealth(t *testing.T) {
 	assert := asrt.New(t)
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	}
 
 	labels := map[string]string{
 		"com.ddev.site-name":        testContainerName,
@@ -531,6 +534,9 @@ func TestGetBoundHostPorts(t *testing.T) {
 func TestDockerExec(t *testing.T) {
 	assert := asrt.New(t)
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	}
 
 	id, _, err := dockerutil.RunSimpleContainer(versionconstants.UtilitiesImage, "", []string{"tail", "-f", "/dev/null"}, nil, nil, nil, "0", false, true, nil, nil, nil)
 	assert.NoError(err)
@@ -568,6 +574,9 @@ func TestCreateVolume(t *testing.T) {
 func TestRemoveVolume(t *testing.T) {
 	assert := asrt.New(t)
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		t.Fatalf("Could not get docker client: %v", dockerutil.GetDockerClientErr())
+	}
 
 	testVolume := "junker999"
 	spareVolume := "someVolumeThatCanNeverExit"

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -25,6 +26,43 @@ import (
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
 )
+
+var (
+	outputOnceMutex sync.Mutex
+	outputOnceCache = make(map[string]map[string]bool)
+)
+
+// outputOnce executes a function only once per unique message and function type.
+// It uses a SHA256 hash of the formatted message to detect duplicates.
+func outputOnce(format string, a []interface{}, fn func(string, ...interface{})) {
+	// Format the message first to create the cache key
+	var message string
+	if a != nil {
+		message = fmt.Sprintf(format, a...)
+	} else {
+		message = format
+	}
+
+	// Create hash of the message and function pointer to create unique cache key
+	msgKey := HashSalt(message)
+	fnKey := fmt.Sprintf("%p", fn) // Use function pointer as key
+
+	outputOnceMutex.Lock()
+	defer outputOnceMutex.Unlock()
+
+	// Initialize the function type cache if it doesn't exist
+	if outputOnceCache[fnKey] == nil {
+		outputOnceCache[fnKey] = make(map[string]bool)
+	}
+
+	// Check if we've already executed this message for this function type
+	if outputOnceCache[fnKey][msgKey] {
+		return
+	}
+	// Mark as shown and execute the function
+	outputOnceCache[fnKey][msgKey] = true
+	fn(format, a...)
+}
 
 // Failed will print a red error message and exit with failure.
 func Failed(format string, a ...interface{}) {
@@ -57,6 +95,12 @@ func Warning(format string, a ...interface{}) {
 	} else {
 		output.UserErr.Warn(format)
 	}
+}
+
+// WarningOnce will present the user with warning text only once per message.
+func WarningOnce(format string, a ...interface{}) {
+	defer TimeTrackC("WarningOnce(): " + fmt.Sprintf(format, a...))()
+	outputOnce(format, a, Warning)
 }
 
 // WarningWithColor allows specifying a color for the warning to make it more visible

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -13,7 +13,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"sync"
 	"time"
 	"unicode"
 
@@ -27,10 +26,8 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-var (
-	outputOnceMutex sync.Mutex
-	outputOnceCache = make(map[string]map[string]bool)
-)
+// outputOnceCache is a cache to keep track of messages that have already been shown
+var outputOnceCache = map[string]map[string]bool{}
 
 // outputOnce executes a function only once per unique message and function type.
 // It uses a SHA256 hash of the formatted message to detect duplicates.
@@ -47,12 +44,9 @@ func outputOnce(format string, a []interface{}, fn func(string, ...interface{}))
 	msgKey := HashSalt(message)
 	fnKey := fmt.Sprintf("%p", fn) // Use function pointer as key
 
-	outputOnceMutex.Lock()
-	defer outputOnceMutex.Unlock()
-
 	// Initialize the function type cache if it doesn't exist
 	if outputOnceCache[fnKey] == nil {
-		outputOnceCache[fnKey] = make(map[string]bool)
+		outputOnceCache[fnKey] = map[string]bool{}
 	}
 
 	// Check if we've already executed this message for this function type

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -279,33 +279,33 @@ func compareSlices(a, b []string) bool {
 // TestWarningOnce tests that WarningOnce only shows each unique message once
 func TestWarningOnce(t *testing.T) {
 	assert := asrt.New(t)
-	
+
 	// Capture output to test warning messages (warnings go to UserErr)
 	restoreOutput := util.CaptureUserErr()
-	
+
 	// Test that same message is only shown once
 	util.WarningOnce("test warning message")
 	util.WarningOnce("test warning message")
 	util.WarningOnce("test warning message")
-	
+
 	// Test that different messages are both shown
 	util.WarningOnce("different warning message")
-	
+
 	out := restoreOutput()
-	
+
 	// Should contain each unique message only once
 	assert.Equal(1, strings.Count(out, "test warning message"))
 	assert.Equal(1, strings.Count(out, "different warning message"))
-	
+
 	// Test with format arguments
 	restoreOutput = util.CaptureUserErr()
-	
+
 	util.WarningOnce("warning with %s", "arg1")
 	util.WarningOnce("warning with %s", "arg1")
 	util.WarningOnce("warning with %s", "arg2")
-	
+
 	out = restoreOutput()
-	
+
 	// Should show each formatted message once
 	assert.Equal(1, strings.Count(out, "warning with arg1"))
 	assert.Equal(1, strings.Count(out, "warning with arg2"))

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -276,6 +276,41 @@ func compareSlices(a, b []string) bool {
 	return true
 }
 
+// TestWarningOnce tests that WarningOnce only shows each unique message once
+func TestWarningOnce(t *testing.T) {
+	assert := asrt.New(t)
+	
+	// Capture output to test warning messages (warnings go to UserErr)
+	restoreOutput := util.CaptureUserErr()
+	
+	// Test that same message is only shown once
+	util.WarningOnce("test warning message")
+	util.WarningOnce("test warning message")
+	util.WarningOnce("test warning message")
+	
+	// Test that different messages are both shown
+	util.WarningOnce("different warning message")
+	
+	out := restoreOutput()
+	
+	// Should contain each unique message only once
+	assert.Equal(1, strings.Count(out, "test warning message"))
+	assert.Equal(1, strings.Count(out, "different warning message"))
+	
+	// Test with format arguments
+	restoreOutput = util.CaptureUserErr()
+	
+	util.WarningOnce("warning with %s", "arg1")
+	util.WarningOnce("warning with %s", "arg1")
+	util.WarningOnce("warning with %s", "arg2")
+	
+	out = restoreOutput()
+	
+	// Should show each formatted message once
+	assert.Equal(1, strings.Count(out, "warning with arg1"))
+	assert.Equal(1, strings.Count(out, "warning with arg2"))
+}
+
 // TestSubtractSlices does simple test of SubtractSlices
 func TestSubtractSlices(t *testing.T) {
 	tests := []struct {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -56,6 +56,9 @@ func GetVersionInfo() map[string]string {
 // GetDockerPlatform gets the platform used for Docker engine
 func GetDockerPlatform() (string, error) {
 	ctx, client := dockerutil.GetDockerClient()
+	if dockerutil.GetDockerClientErr() != nil {
+		return "", dockerutil.GetDockerClientErr()
+	}
 
 	info, err := client.Info(ctx)
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -55,9 +55,9 @@ func GetVersionInfo() map[string]string {
 
 // GetDockerPlatform gets the platform used for Docker engine
 func GetDockerPlatform() (string, error) {
-	ctx, client := dockerutil.GetDockerClient()
-	if dockerutil.GetDockerClientErr() != nil {
-		return "", dockerutil.GetDockerClientErr()
+	ctx, client, err := dockerutil.GetDockerClient()
+	if err != nil {
+		return "", err
 	}
 
 	info, err := client.Info(ctx)


### PR DESCRIPTION
## The Issue

- #7472  

While working on #7572, repeated calls to `ddevapp.fixupComposeYaml()` broke the output for `DDEV_DEBUG=true ddev launch`.

## How This PR Solves the Issue

- Adds caching for warnings with the new `util.WarningOnce()` function (other functions can easily use the same approach if needed).  
- Removes `ddevapp.fixupComposeYaml()` from `ddevapp.NewApp()`, it's replaced by `app.ReadDockerComposeYAML()`
- Replaces several `ddevapp.NewApp()` calls with `&ddevapp.DdevApp{}` to simplify the logic.
- Adds error checks for all `dockerutil.GetDockerClient()`:
  For context, why it was done: I switched from `ddevapp.GetActiveApp()` to `ddevapp.GetActiveAppRoot()` + `ddevapp.NewApp()` in #7403. The reason was that `ddevapp.GetActiveApp()` calls `ddevapp.FindContainerByType()`, which could panic if no `DockerClient` was available.

## Manual Testing Instructions

Reduced `ddevapp.NewApp` calls:

before: DDEV HEAD

```
$ DDEV_VERBOSE=true ddev describe | grep 'enter ddevapp.NewApp' | wc -l
6

$ DDEV_VERBOSE=true ddev start | grep 'enter ddevapp.NewApp' | wc -l
11
```

after: this PR

```
$ DDEV_VERBOSE=true ddev describe | grep 'enter ddevapp.NewApp' | wc -l
3

$ DDEV_VERBOSE=true ddev start | grep 'enter ddevapp.NewApp' | wc -l
8
```

---

Break `.ddev/.ddev-docker-compose-full.yaml`:

before: DDEV HEAD (fails because of `compose-spec/compose-go` validation, v1.24.7 is not affected by this)
```
$ echo 'foobar:' >> .ddev/.ddev-docker-compose-full.yaml
$ ddev start
Failed to start project(s): validating :  additional properties 'foobar' not allowed
```

after: this PR (validation error can be viewed with `DDEV_VERBOSE=true ddev start`)
```
$ echo 'foobar:' >> .ddev/.ddev-docker-compose-full.yaml
$ ddev start
Starting d11...
...
```

---

Remove `#ddev-generated` from some DDEV file:

before: DDEV HEAD (three identical "User-managed" warnings)
```
$ echo > .ddev/.gitignore
$ ddev start
Starting d11... 
User-managed /home/stas/code/ddev-quickstarts/d11/.ddev/.gitignore will not be managed/overwritten by ddev 
 Container ddev-ssh-agent  Created 
 Container ddev-ssh-agent  Started 
ssh-agent container is running: If you want to add authentication to the ssh-agent container, run 'ddev auth ssh' to enable your keys. 
User-managed /home/stas/code/ddev-quickstarts/d11/.ddev/.gitignore will not be managed/overwritten by ddev 
Building project images........
Project images built in 6s. 
 Network ddev-d11_default  Created 
 Container ddev-d11-web  Created 
 Container ddev-d11-db  Created 
 Container ddev-d11-web  Started 
 Container ddev-d11-db  Started 
Waiting for containers to become ready: [web db] 
Starting ddev-router if necessary... 
 Container ddev-router  Created 
 Container ddev-router  Started 
User-managed /home/stas/code/ddev-quickstarts/d11/.ddev/.gitignore will not be managed/overwritten by ddev 
Successfully started d11 
Your project can be reached at https://d11.ddev.site
See 'ddev describe' for alternate URLs.
```

after: this PR (only one warning)
```
$ echo > .ddev/.gitignore
$ ddev start
Starting d11...
User-managed /home/stas/code/ddev-quickstarts/d11/.ddev/.gitignore will not be managed/overwritten by ddev
 Container ddev-ssh-agent  Created
 Container ddev-ssh-agent  Started
ssh-agent container is running: If you want to add authentication to the ssh-agent container, run 'ddev auth ssh' to enable your keys.
Building project images....
Project images built in 2s.
 Network ddev-d11_default  Created
 Container ddev-d11-db  Created
 Container ddev-d11-web  Created
 Container ddev-d11-db  Started
 Container ddev-d11-web  Started
Waiting for containers to become ready: [web db]
Starting ddev-router if necessary...
 Container ddev-router  Created
 Container ddev-router  Started
Successfully started d11
Your project can be reached at https://d11.ddev.site
See 'ddev describe' for alternate URLs.
```

---

In theory:

before: DDEV HEAD

There may be a panic if the `DockerClient` (`nil` when `DOCKER_HOST=foobar`) is accessed before `init()` in `root.go`.

after: this PR

No panic because `initErr` is always checked after `dockerutil.GetDockerClient()`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->