### PR TITLE
fix: change download timeout to 30 minutes instead of 5 minutes, fixes #7298

### DIFF
--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"golang.org/x/term"
 	"io"
 	"net/http"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"github.com/cheggaaa/pb"
 	"github.com/ddev/ddev/pkg/output"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
+	"golang.org/x/term"
 )
 
 // DownloadFile retrieves a file with retry logic, optional progress bar, and SHA256 verification.
@@ -27,8 +27,8 @@ func DownloadFile(destPath string, fileURL string, progressBar bool, shaSumURL s
 	// Configure retryablehttp client with backoff, retry policy, and global timeout.
 	client := retryablehttp.NewClient()
 	client.RetryMax = 4
-	client.RetryWaitMin = 500 * time.Millisecond
-	client.RetryWaitMax = 5 * time.Second
+	client.RetryWaitMin = 1 * time.Second
+	client.RetryWaitMax = 15 * time.Second
 	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 		// Default retry policy only retries on
 		// - connection reset
@@ -42,7 +42,7 @@ func DownloadFile(destPath string, fileURL string, progressBar bool, shaSumURL s
 	}
 	client.Backoff = retryablehttp.DefaultBackoff
 	client.Logger = nil
-	client.HTTPClient.Timeout = 5 * time.Minute
+	client.HTTPClient.Timeout = 30 * time.Minute
 	client.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, attempt int) {
 		if attempt > 0 {
 			// attempt==1 is the first retry, 2 the second, etc


### PR DESCRIPTION
## The Issue

- #7298

## How This PR Solves The Issue

We already increased the timeout in:

- #7300

But it still doesn't seem enough. 30 minutes should be sufficient for everyone.

The reason for having a timeout is to prevent our tests from stalling for hours if something goes wrong.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
