### PR TITLE
feat(provider): add warnings for empty pull/push, fixes #7576

### DIFF
--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -105,7 +105,7 @@ func (app *DdevApp) Pull(provider *Provider, skipDBArg bool, skipFilesArg bool, 
 			if err != nil {
 				return err
 			}
-			output.UserOut.Printf("Importing databases %v\n", fileLocation)
+			output.UserOut.Printf("Importing databases %v", fileLocation)
 			err = provider.importDatabaseBackup(fileLocation, importPath)
 			if err != nil {
 				return err
@@ -244,6 +244,7 @@ func (p *Provider) UploadDB() error {
 	_ = os.Mkdir(p.getDownloadDir(), 0755)
 
 	if p.DBPushCommand.Command == "" {
+		util.Warning("No db_push_command provided, so skipping database push")
 		return nil
 	}
 
@@ -273,6 +274,7 @@ func (p *Provider) UploadFiles() error {
 	_ = os.Mkdir(p.getDownloadDir(), 0755)
 
 	if p.FilesPushCommand.Command == "" {
+		util.Warning("No files_push_command provided, so skipping files push")
 		return nil
 	}
 
@@ -307,6 +309,7 @@ func (p *Provider) doFilesPullCommand() ([]string, error) {
 	_ = os.MkdirAll(destDir, 0755)
 
 	if p.FilesPullCommand.Command == "" {
+		util.Warning("No files_pull_command provided, so skipping files pull")
 		return nil, nil
 	}
 	s := p.FilesPullCommand.Service
@@ -340,6 +343,7 @@ func (p *Provider) getDatabaseBackups() ([]string, error) {
 	}
 
 	if p.DBPullCommand.Command == "" {
+		util.Warning("No db_pull_command provided, so skipping database pull")
 		return nil, nil
 	}
 
@@ -400,6 +404,9 @@ func (p *Provider) importDatabaseBackup(fileLocation []string, importPath []stri
 func (p *Provider) doFilesImport(fileLocation string, importPath string) error {
 	var err error
 	if p.FilesImportCommand.Command == "" {
+		if fileLocation == "" {
+			return nil
+		}
 		err = p.app.ImportFiles("", fileLocation, importPath)
 	} else {
 		s := p.FilesImportCommand.Service


### PR DESCRIPTION
## The Issue

- #7576

DDEV doesn't push or pull anything when no command is provided, but the output still says it was successful, which is unclear.

## How This PR Solves The Issue

Adds warnings to make it clear that nothing was actually done.

## Manual Testing Instructions

Edit `.ddev/providers/pantheon.yaml` by removing every section except `auth_command` and removing `#ddev-generated`.

before:
```
$ ddev push pantheon
You're about to push your local database and files to your upstream production
and replace it with your local project's database and files.
This is normally a very dangerous operation.
Would you like to continue (not recommended)? [y/N] (no): y
Authenticating...
 [notice] Logged in via machine token.
Uploading database...
Database uploaded
Uploading files...
Files uploaded
Push succeeded.
```

after:

```
$ ddev push pantheon
You're about to push your local database and files to your upstream production
and replace it with your local project's database and files.
This is normally a very dangerous operation.
Would you like to continue (not recommended)? [y/N] (no): y
Authenticating...
 [notice] Logged in via machine token.
Uploading database...
No db_push_command provided, so skipping database push
Database uploaded
Uploading files...
No files_push_command provided, so skipping files push
Files uploaded
Push succeeded.
```

---

before:

```
$ ddev pull pantheon
You're about to delete the current database and files and replace with the results of a fresh pull.
Would you like to continue? [Y/n] (yes): y
Authenticating...
 [notice] Logged in via machine token.
Obtaining databases...
Importing databases []

Obtaining files...
Importing files...
Pull failed: lstat : no such file or directory
```

after:

```
$ ddev pull pantheon
You're about to delete the current database and files and replace with the results of a fresh pull.
Would you like to continue? [Y/n] (yes): y
Authenticating...
 [notice] Logged in via machine token.
Obtaining databases...
No db_pull_command provided, so skipping database pull
Importing databases []
Obtaining files...
No files_pull_command provided, so skipping files pull
Importing files...
Pull succeeded.
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
