### PR TITLE
docs(provider): soften language about use of provider push

### DIFF
--- a/cmd/ddev/cmd/push.go
+++ b/cmd/ddev/cmd/push.go
@@ -17,7 +17,8 @@ var PushCmd = &cobra.Command{
 	Short: "push files and database using a configured provider plugin.",
 	Long: `push files and database using a configured provider plugin.
 	Running push will connect to the configured provider and export and upload the
-	database and/or files. It is not recommended for most workflows since it is extremely dangerous to your production hosting.`,
+	database and/or files. It is very useful for pushing to non-production
+	environments, but should rarely be used to push to production.`,
 	Example: `ddev push pantheon
 ddev push platform
 ddev push pantheon -y

--- a/docs/content/users/providers/index.md
+++ b/docs/content/users/providers/index.md
@@ -10,7 +10,7 @@ In addition, each project includes [example recipes](https://github.com/ddev/dde
 
 DDEV provides the `pull` command with whatever recipes you have configured. For example, `ddev pull platform` is available by default, and `ddev pull pantheon` is available if you have created `.ddev/providers/pantheon.yaml`.
 
-DDEV also provides the `push` command to push database and files to upstream. This is very dangerous to your upstream site and should only be used when appropriate. We don’t even recommended implementing the push stanzas in your YAML file, but it’s there if it suits your workflow.
+DDEV also provides the `push` command to push database and files to upstream. This is very useful for pushing to non-production environments, but could be very dangerous to your upstream production environment and should only be used when appropriate. If you find the `push` section dangerous, you can disable it by removing it from your provider YAML file.
 
 Each provider recipe is a YAML file that can have whatever name you want. The examples are mostly named after the hosting providers, but they could be named `upstream.yaml` or `live.yaml`, so you could `ddev pull upstream` or `ddev pull live`. If you wanted different upstream environments to pull from, you could name one “prod” and one “dev” and `ddev pull prod` and `ddev pull dev`.
 

--- a/pkg/ddevapp/dotddev_assets/providers/README.txt
+++ b/pkg/ddevapp/dotddev_assets/providers/README.txt
@@ -15,7 +15,7 @@ In addition, each project includes example recipes https://github.com/ddev/ddev/
 
 DDEV provides the `pull` command with whatever recipes you have configured. For example, `ddev pull platform` is available by default, and `ddev pull pantheon` is available if you have created `.ddev/providers/pantheon.yaml`.
 
-DDEV also provides the `push` command to push database and files to upstream. This is very dangerous to your upstream site and should only be used when appropriate. We don’t even recommended implementing the push stanzas in your YAML file, but it’s there if it suits your workflow.
+DDEV also provides the `push` command to push database and files to upstream. This is very useful for non-production environments, but could be quite dangerous to your upstream production site and should only be used when appropriate. If you consider it to be dangerous, you can remove the `push` section of the provider YAML file.
 
 Each provider recipe is a YAML file that can have whatever name you want. The examples are mostly named after the hosting providers, but they could be named `upstream.yaml` or `live.yaml`, so you could `ddev pull upstream` or `ddev pull live`. If you wanted different upstream environments to pull from, you could name one “prod” and one “dev” and `ddev pull prod` and `ddev pull dev`.
 

--- a/pkg/ddevapp/dotddev_assets/providers/acquia.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/acquia.yaml
@@ -67,7 +67,9 @@ files_import_command:
     set -eu -o pipefail
     acli -n pull:files ${ACQUIA_ENVIRONMENT_ID} default
 
-# push is a dangerous command. If not absolutely needed it's better to delete these lines.
+# push is very useful for non-production environments, but can be
+# very dangerous to production environments. If it is dangerous to your
+# workflow you can remove the lines below and remove the `#ddev-generated` in this file
 db_push_command:
   command: |
     set -eu -o pipefail

--- a/pkg/ddevapp/dotddev_assets/providers/lagoon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/lagoon.yaml
@@ -39,7 +39,9 @@ files_import_command:
     set -eu -o pipefail
     lagoon-sync sync files -p ${LAGOON_PROJECT} -e ${LAGOON_ENVIRONMENT} --no-interaction 
 
-# push is a dangerous command. If not absolutely needed it's better to delete these lines.
+# push is very useful for non-production environments, but can be
+# very dangerous to production environments. If it is dangerous to your
+# workflow you can remove the lines below and remove the `#ddev-generated` in this file
 db_push_command:
   command: |
     set -eu -o pipefail
@@ -47,7 +49,9 @@ db_push_command:
     export MARIADB_HOST=db MARIADB_USERNAME=db MARIADB_PASSWORD=db MARIADB_DATABASE=db
     lagoon-sync sync mariadb -p ${LAGOON_PROJECT} -t ${LAGOON_ENVIRONMENT} -e local --no-interaction 
 
-# push is a dangerous command. If not absolutely needed it's better to delete these lines.
+# push is very useful for non-production environments, but can be
+# very dangerous to production environments. If it is dangerous to your
+# workflow you can remove the lines below and remove the `#ddev-generated` in this file
 files_push_command:
   command: |
     set -eu -o pipefail

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
@@ -85,7 +85,9 @@ files_pull_command:
     terminus backup:get ${PANTHEON_SITE}.${PANTHEON_ENVIRONMENT} --element=files --to=files.tgz
     mkdir -p files && tar --strip-components=1 -C files -zxf files.tgz
 
-# push is a dangerous command. If not absolutely needed it's better to delete these lines.
+# push is very useful for non-production environments, but can be
+# very dangerous to production environments. If it is dangerous to your
+# workflow you can remove the lines below and remove the `#ddev-generated` in this file
 db_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
@@ -101,9 +103,9 @@ db_push_command:
     gzip -dc db.sql.gz | eval "$MYSQL_CMD"
     echo "Database push complete"
 
-# push is a dangerous command. If not absolutely needed it's better to delete these lines.
-# terminus rsync plugin for CMS agnostic file push
-# this will push the files directory to Pantheon
+# push is very useful for non-production environments, but can be
+# very dangerous to production environments. If it is dangerous to your
+# workflow you can remove the lines below and remove the `#ddev-generated` in this file
 files_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -94,7 +94,9 @@ files_import_command:
     platform mount:download --all --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" ${PLATFORM_APP:+"--app=${PLATFORM_APP}"} --target=/var/www/html
 
 
-# push is a dangerous command. If not absolutely needed it's better to delete these lines.
+# push is very useful for non-production environments, but can be
+# very dangerous to production environments. If it is dangerous to your
+# workflow you can remove the lines below and remove the `#ddev-generated` in this file
 db_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
@@ -106,7 +108,9 @@ db_push_command:
     fi
     gzip -dc db.sql.gz | platform db:sql --project="${PLATFORM_PROJECT}" ${rel:-} --environment="${PLATFORM_ENVIRONMENT}" ${PLATFORM_APP:+"--app=${PLATFORM_APP}"}
 
-# push is a dangerous command. If not absolutely needed it's better to delete these lines.
+# push is very useful for non-production environments, but can be
+# very dangerous to production environments. If it is dangerous to your
+# workflow you can remove the lines below and remove the `#ddev-generated` in this file
 # TODO: This is a naive, Drupal-centric push, which needs adjustment for the mount to be pushed.
 files_push_command:
   command: |

--- a/pkg/ddevapp/dotddev_assets/providers/rsync.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/rsync.yaml.example
@@ -44,7 +44,7 @@ files_pull_command:
     tar -xzf files.tar.gz -C files/
   service: web
 
-# Pushing a database or files to upstream can be dangerous and not recommended.
+# Pushing a database or files to a production environment can be dangerous and not recommended.
 # This example is not very dangerous because it's not actually deploying the
 # files. But if the db were deployed on production it would overwrite
 # the current db or files there.

--- a/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
@@ -94,7 +94,9 @@ files_import_command:
     upsun mount:download --all --yes --quiet --project="${PLATFORM_PROJECT}" --environment="${PLATFORM_ENVIRONMENT}" ${PLATFORM_APP:+"--app=${PLATFORM_APP}"} --target=/var/www/html
 
 
-# push is a dangerous command. If not absolutely needed it's better to delete these lines.
+# push is very useful for non-production environments, but can be
+# very dangerous to production environments. If it is dangerous to your
+# workflow you can remove the lines below and remove the `#ddev-generated` in this file
 db_push_command:
   command: |
     # set -x   # You can enable bash debugging output by uncommenting
@@ -108,7 +110,9 @@ db_push_command:
     fi
     gzip -dc db.sql.gz | upsun db:sql --project="${PLATFORM_PROJECT}" ${rel:-} --environment="${PLATFORM_ENVIRONMENT}" ${PLATFORM_APP:+"--app=${PLATFORM_APP}"}
 
-# push is a dangerous command. If not absolutely needed it's better to delete these lines.
+# push is very useful for non-production environments, but can be
+# very dangerous to production environments. If it is dangerous to your
+# workflow you can remove the lines below and remove the `#ddev-generated` in this file
 # TODO: This is a naive, Drupal-centric push, which needs adjustment for the mount to be pushed.
 files_push_command:
   command: |


### PR DESCRIPTION

## The Issue

As I've been working with providers recently (upsun, pantheon, platform) I've found `ddev push` to be very useful to non-production environments. It's a great way to push a db/files for testing.

The same caveats remain for pushing to production environments.

## How This PR Solves The Issue

Soften the language about how to use `ddev push`

