### PR TITLE
test: re-enable no-bind-mounts test since it's used some places [skip buildkite]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,8 +53,8 @@ jobs:
             webserver: "nginx-fpm"
           - name: "mutagen"
             mutagen: true
-#          - name: "no-bind-mounts"
-#            no-bind-mounts: "true"
+          - name: "no-bind-mounts"
+            no-bind-mounts: "true"
           - name: "pull-push-test-platforms"
             pull-push-test-platforms: true
           - name: "race-detection"


### PR DESCRIPTION
## The Issue

- #7587

This massive and important refactor is about to go in, and could affect no-bind-mounts, which is rarely used, but is required for remote docker.

## How This PR Solves The Issue

* Start testing no-bind-mounts at least for a while

## Considerations

I'd be happier if we had a remote docker test matrix, since we support this in docs, but only rarely test manually.