### PR TITLE
feat: add artisan `a` alias

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -191,7 +191,7 @@ func TestCustomCommands(t *testing.T) {
 		assert.NoError(err, "Failed to run ddev %s --version", c)
 	}
 	// The various CMS commands should not be available here
-	for _, c := range []string{"artisan", "art", "cake", "drush", "magento", "typo3", "wp"} {
+	for _, c := range []string{"artisan", "art", "a", "cake", "drush", "magento", "typo3", "wp"} {
 		_, err = exec.RunHostCommand(DdevBin, c, "-h")
 		assert.Error(err, "found command %s when it should not have been there (no error) app.Type=%s", c, app.Type)
 	}
@@ -228,7 +228,7 @@ func TestCustomCommands(t *testing.T) {
 	_, _ = exec.RunHostCommand(DdevBin)
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
-	for _, c := range []string{"artisan", "art", "pint"} {
+	for _, c := range []string{"artisan", "art", "a", "pint"} {
 		_, err = exec.RunHostCommand(DdevBin, "help", c)
 		assert.NoError(err)
 	}

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -169,7 +169,7 @@ ddev aliases
 
 ## `artisan`
 
-*Alias: `art`.*
+*Aliases: `art`, `a`.*
 
 Run the `artisan` command; available only in projects of type `laravel`, and only available if `artisan` is in the project root.
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/artisan
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/artisan
@@ -4,7 +4,7 @@
 ## Description: Run artisan CLI inside the web container
 ## Usage: artisan [flags] [args]
 ## Example: "ddev artisan list" or "ddev artisan cache:clear"
-## Aliases: art
+## Aliases: art,a
 ## ProjectTypes: laravel
 ## ExecRaw: true
 ## MutagenSync: true


### PR DESCRIPTION
## The Issue

This PR adds a new alias `a` for the `artisan` command. Previously, only `artisan` and `art` were available. This speeds up the work of Laravel developers who frequently call artisan commands.

## How This PR Solves The Issue

- Added support for the alias `a` for `ddev artisan` in the configuration.
- Updated autotests to check the availability of the new alias.
- Made changes to the documentation (`commands.md`) to reflect the new alias.

## Manual Testing Instructions

Create a new Laravel project in DDEV or use an existing one and execute commands via a new alias

```sh
ddev config --project-type=laravel
ddev start

ddev a list
```