### PR TITLE
test(buildkite): buildkite can take a few minutes to pull new images [skip ci]

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -189,7 +189,7 @@ fi
 # Run any testbot maintenance that may need to be done
 echo "--- running testbot_maintenance.sh"
 
-${TIMEOUT} 120s bash "$(dirname "$0")/testbot_maintenance.sh"
+${TIMEOUT} 10m bash "$(dirname "$0")/testbot_maintenance.sh"
 
 # Our testbot should be sane, run the testbot checker to make sure.
 echo "--- running sanetestbot.sh"


### PR DESCRIPTION

## The Issue

When we pulled the updated docker singleton PR yesterday, several runners timed out because there were updated Postgres images.

## How This PR Solves The Issue

Give testbot_maintenance.sh some more time to run. Some manual image deletion might be in order as well.

