### PR TITLE
feat: add `ddev npx` command

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -505,6 +505,7 @@ func TestNpmNpxYarnCommands(t *testing.T) {
 		out, err = exec.RunHostCommand(DdevBin, "yarn", "install")
 		assert.NoError(err)
 		assert.Contains(out, "success Saved lockfile")
+	
 		err = os.RemoveAll(packageJSONFile)
 		assert.NoError(err)
 		err = os.RemoveAll(filepath.Join(workDir, "package-lock.json"))

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -499,7 +499,7 @@ func TestNpmNpxYarnCommands(t *testing.T) {
 		out, err := exec.RunHostCommand(DdevBin, "npm", "install", "--no-audit")
 		assert.NoError(err)
 		assert.Contains(out, "up to date in", "d='%s', npm install has wrong output; output='%s'", d, out)
-		out, err := exec.RunHostCommand(DdevBin, "npx", "-c", "'echo hello'")
+		out, err := exec.RunHostCommand(DdevBin, "npx", "-c", "echo hello")
 		assert.NoError(err)
 		assert.Contains(out, "hello", "d='%s', npx -c 'echo hello' has wrong output; output='%s'", d, out)
 		out, err = exec.RunHostCommand(DdevBin, "yarn", "install")

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -499,7 +499,7 @@ func TestNpmNpxYarnCommands(t *testing.T) {
 		out, err := exec.RunHostCommand(DdevBin, "npm", "install", "--no-audit")
 		assert.NoError(err)
 		assert.Contains(out, "up to date in", "d='%s', npm install has wrong output; output='%s'", d, out)
-		out, err := exec.RunHostCommand(DdevBin, "npx", "-c", "echo hello")
+		out, err = exec.RunHostCommand(DdevBin, "npx", "-c", "echo hello")
 		assert.NoError(err)
 		assert.Contains(out, "hello", "d='%s', npx -c 'echo hello' has wrong output; output='%s'", d, out)
 		out, err = exec.RunHostCommand(DdevBin, "yarn", "install")

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -505,7 +505,7 @@ func TestNpmNpxYarnCommands(t *testing.T) {
 		out, err = exec.RunHostCommand(DdevBin, "yarn", "install")
 		assert.NoError(err)
 		assert.Contains(out, "success Saved lockfile")
-	
+
 		err = os.RemoveAll(packageJSONFile)
 		assert.NoError(err)
 		err = os.RemoveAll(filepath.Join(workDir, "package-lock.json"))

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -444,9 +444,9 @@ func TestPsqlCommand(t *testing.T) {
 	assert.Contains(out, `db        | db    | UTF8`)
 }
 
-// TestNpmYarnCommands tests that the `ddev npm` and yarn commands behaves and install run in
-// expected relative directory.
-func TestNpmYarnCommands(t *testing.T) {
+// TestNpmNpxYarnCommands tests that the `ddev npm`, npx, and yarn commands behaves and install
+// run in expected relative directory.
+func TestNpmNpxYarnCommands(t *testing.T) {
 	assert := asrt.New(t)
 
 	origDir, _ := os.Getwd()
@@ -499,10 +499,12 @@ func TestNpmYarnCommands(t *testing.T) {
 		out, err := exec.RunHostCommand(DdevBin, "npm", "install", "--no-audit")
 		assert.NoError(err)
 		assert.Contains(out, "up to date in", "d='%s', npm install has wrong output; output='%s'", d, out)
+		out, err := exec.RunHostCommand(DdevBin, "npx", "-c", "'echo hello'")
+		assert.NoError(err)
+		assert.Contains(out, "hello", "d='%s', npx -c 'echo hello' has wrong output; output='%s'", d, out)
 		out, err = exec.RunHostCommand(DdevBin, "yarn", "install")
 		assert.NoError(err)
 		assert.Contains(out, "success Saved lockfile")
-
 		err = os.RemoveAll(packageJSONFile)
 		assert.NoError(err)
 		err = os.RemoveAll(filepath.Join(workDir, "package-lock.json"))

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -16,26 +16,33 @@ Type `ddev` or `ddev -h` in a terminal window to see the available DDEV [command
 
 ## Lots of Other Commands
 
-* [`ddev mysql`](../usage/commands.md#mysql) gives direct access to the MySQL client and `ddev psql` to the PostgreSQL `psql` client.
-* `ddev sequelace`, [`ddev tableplus`](../usage/commands.md#tableplus), and `ddev querious` (macOS only, if the app is installed) give access to the Sequel Ace, TablePlus or Querious database browser GUIs.
-* `ddev heidisql` (Windows/WSL2 only, if installed) gives access to the HeidiSQL database browser GUI.
+* [`ddev mysql`](../usage/commands.md#mysql) gives direct access to the MySQL client and [`ddev psql`](../usage/commands.md#psql) to the PostgreSQL `psql` client.
+* [`ddev sequelace`](../usage/commands.md#sequelace), [`ddev tableplus`](../usage/commands.md#tableplus), and [`ddev querious`](../usage/commands.md#querious) (macOS only, if the app is installed) give access to the Sequel Ace, TablePlus or Querious database browser GUIs.
+* [`ddev dbeaver`](../usage/commands.md#dbeaver) (if installed) gives access to the DBeaver database browser GUI.
+* [`ddev heidisql`](../usage/commands.md#heidisql) (Windows/WSL2/Linux, if installed) gives access to the HeidiSQL database browser GUI.
 * [`ddev import-db`](../usage/commands.md#import-db) and [`ddev export-db`](../usage/commands.md#export-db) import or export SQL or compressed SQL files.
 * [`ddev composer`](../usage/commands.md#composer) runs Composer inside the container. For example, `ddev composer install` will do a full composer install for you without even needing Composer on your computer. See [developer tools](developer-tools.md#ddev-and-composer).
 * [`ddev snapshot`](../usage/commands.md#snapshot) makes a very fast snapshot of your database that can be easily and quickly restored with [`ddev snapshot restore`](../usage/commands.md#snapshot-restore).
 * [`ddev share`](../usage/commands.md#share) requires ngrok and at least a free account on [ngrok.com](https://ngrok.com) so you can let someone in the next office or on the other side of the planet see your project and what you’re working on. `ddev share -h` gives more info about how to set up ngrok.
 * [`ddev xdebug`](../usage/commands.md#xdebug) enables Xdebug, `ddev xdebug off` disables it, and `ddev xdebug status` shows status. You can toggle Xdebug on and off easily using `ddev xdebug toggle`.
 * [`ddev xhprof`](../usage/commands.md#xhprof) enables xhprof, `ddev xhprof off` disables it, and `ddev xhprof status` shows status.
-* `ddev drush` (Drupal and Backdrop only) gives direct access to the `drush` CLI.
-* `ddev artisan` (Laravel only) gives direct access to the Laravel `artisan` CLI.
-* `ddev magento` (Magento2 only) gives access to the `magento` CLI.
-* `ddev console` (Symfony only) gives access to the `symfony console` CLI.
+* [`ddev xhgui`](../usage/commands.md#xhgui) enables XHGui, `ddev xhgui off` disables it, and `ddev xhgui status` shows status.
+* [`ddev drush`](../usage/commands.md#drush) (Drupal and Backdrop only) gives direct access to the `drush` CLI.
+* [`ddev artisan`](../usage/commands.md#artisan) (Laravel only) gives direct access to the Laravel `artisan` CLI.
+* [`ddev magento`](../usage/commands.md#magento) (Magento2 only) gives access to the `magento` CLI.
+* [`ddev console`](../usage/commands.md#console) (Symfony only) gives access to the `symfony console` CLI.
 * [`ddev craft`](../usage/commands.md#craft) (Craft CMS only) gives access to the `craft` CLI.
-* [`ddev yarn`](../usage/commands.md#yarn) and [`ddev npm`](../usage/commands.md#npm) give direct access to the `yarn` and `npm` CLIs.
-* `ddev cake` (CakePHP only) gives direct access to the CakePHP `cake` CLI.
+* [`ddev npm`](../usage/commands.md#npm) gives direct access to the `npm` CLI.
+* [`ddev npx`](../usage/commands.md#npx) gives direct access to the `npx` CLI.
+* [`ddev yarn`](../usage/commands.md#yarn) gives direct access to the `yarn` CLI.
+* [`ddev cake`](../usage/commands.md#cake) (CakePHP only) gives direct access to the `cake` CLI.
+* [`ddev sake`](../usage/commands.md#sake) (Silverstripe CMS only) gives direct access to the `sake` CLI.
+* [`ddev typo3`](../usage/commands.md#typo3) (TYPO3 only) gives direct access to the `typo3` CLI.
+* [`ddev wp`](../usage/commands.md#wp) (WordPress only) gives direct access to the `wp` CLI.
 
-## Node.js, npm, nvm, and Yarn
+## Node.js Tools
 
-`node`, `nodejs`, `npm`, `nvm` and `yarn` are preinstalled in the web container. You can configure the default value of the installed Node.js version with the [`nodejs_version`](../configuration/config.md#nodejs_version) option in `.ddev/config.yaml` or with `ddev config --nodejs_version`. You can also override that with any value using the built-in `nvm` in the web container or with [`ddev nvm`](../usage/commands.md#nvm), for example `ddev nvm install 6`. There is also a [`ddev yarn`](../usage/commands.md#yarn) command. (Note that since `nodejs_version` configuration can now specify any `node` version, including patch versions, it's preferred to using the less robust `ddev nvm` way of specifying the `node` version.)
+`node`, `nodejs`, `npm`, `npx`, `nvm` and `yarn` are preinstalled in the web container. You can configure the default value of the installed Node.js version with the [`nodejs_version`](../configuration/config.md#nodejs_version) option in `.ddev/config.yaml` or with `ddev config --nodejs-version`. You can also override that with any value using the built-in `nvm` in the web container or with [`ddev nvm`](../usage/commands.md#nvm), for example `ddev nvm install 6`. There is also a [`ddev yarn`](../usage/commands.md#yarn) command. (Note that since `nodejs_version` configuration can now specify any `node` version, including patch versions, it's preferred to using the less robust `ddev nvm` way of specifying the `node` version.)
 
 ## More Bundled Tools
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1257,7 +1257,7 @@ echo 'SHOW TABLES;' | ddev mysql
 
 ## `npm`
 
-Run [`npm`](https://docs.npmjs.com/cli/v9/commands/npm) inside the web container (global shell web container command).
+Run [`npm`](https://docs.npmjs.com/cli/commands/npm) inside the web container (global shell web container command).
 
 Example:
 
@@ -1267,6 +1267,20 @@ ddev npm install
 
 # Update JavaScript packages using `npm`
 ddev npm update
+```
+
+## `npx`
+
+Run [`npx`](https://docs.npmjs.com/cli/commands/npx) inside the web container (global shell web container command).
+
+Example:
+
+```shell
+# Initialize Biome in the project
+ddev npx @biomejs/biome init
+
+# Create a new Next.js app
+ddev npx create-next-app@latest
 ```
 
 ## `nvm`

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/npx
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/npx
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#ddev-generated
+## Description: Run npx inside the web container
+## Usage: npx [pkg] [args]
+## Example: "ddev npx @biomejs/biome init"
+## ExecRaw: true
+## HostWorkingDir: true
+## MutagenSync: true
+
+npx "$@"


### PR DESCRIPTION
## The Issue

* `npx` is not an existing ddev command.
* `npx` is an alias of `npm exec --` that comes with the npm package, so no new code is needed.
* `npx` is used to run JS code without installing it, which is often for setup, init, demos, config, and other one time executions.

## How This PR Solves The Issue

This allows users to `ddev npx` in the same way they can do `ddev npm` without having to do `ddev exec npx`.

## Manual Testing Instructions

1. `ddev config`
2. `ddev start`
3. `ddev npx -c 'echo hello'` will say hello. Or any npx command like `ddev npx @biomejs/biome init` which will setup biomejs config in your project.

## Automated Testing Overview

* The change is minor in the way that this is an alias of another command, npm, that already has  a test, so if the npm test passes this should as well. 
* There is also the consideration of how to make it not be flaky since it largely involves external network resources.

Because of those points, I decided to just check the simple local command execution part of npx via the `-c` flag. The test does a simple `echo hello` and checks if hello is returned. In combination with the above npm test, I think that should be sufficient without adding any network request to the system.

## Release/Deployment Notes

Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? 

Nope
