### PR TITLE
test(xhgui): add more retries for GetLocalHTTPResponse, for #7543

### DIFF
--- a/cmd/ddev/cmd/xhgui_test.go
+++ b/cmd/ddev/cmd/xhgui_test.go
@@ -37,7 +37,7 @@ func TestCmdXHGui(t *testing.T) {
 
 	_, err = exec.RunHostCommand(DdevBin, "config", "global", "--xhprof-mode=xhgui")
 	require.NoError(t, err)
-	_, err = exec.RunHostCommand(DdevBin, "start")
+	_, err = exec.RunHostCommand(DdevBin, "restart")
 	require.NoError(t, err)
 
 	out, err := exec.RunHostCommand(DdevBin, "xhgui", "status")

--- a/cmd/ddev/cmd/xhgui_test.go
+++ b/cmd/ddev/cmd/xhgui_test.go
@@ -57,9 +57,15 @@ func TestCmdXHGui(t *testing.T) {
 	require.Contains(t, out, "XHProf is enabled and capturing")
 	require.Contains(t, out, fmt.Sprintf("XHGui service is running and you can access it at %s", app.GetXHGuiURL()))
 
+	// Use more retries as it may fail on macOS at first
+	opts := testcommon.HTTPRequestOpts{
+		TimeoutSeconds: 2,
+		MaxRetries:     5,
+	}
+
 	// Test to see if xhgui UI is working
 	// Hit the site
-	_, _, err = testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL(), 2)
+	_, _, err = testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL(), opts)
 	require.NoError(t, err, "failed to get http response from %s", app.GetPrimaryURL())
 	// Give xhprof a moment to write the results; it may be asynchronous sometimes
 	time.Sleep(2 * time.Second)
@@ -71,7 +77,7 @@ func TestCmdXHGui(t *testing.T) {
 	require.NotNil(t, desc["xhgui_https_url"])
 	xhguiURL := desc["xhgui_https_url"].(string)
 
-	out, _, err = testcommon.GetLocalHTTPResponse(t, xhguiURL, 2)
+	out, _, err = testcommon.GetLocalHTTPResponse(t, xhguiURL, opts)
 	require.NoError(t, err)
 	// Output should contain at least one run
 	require.Contains(t, out, strings.ToLower(app.GetHostname()))

--- a/pkg/ddevapp/mailpit_test.go
+++ b/pkg/ddevapp/mailpit_test.go
@@ -2,6 +2,10 @@ package ddevapp_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -10,10 +14,6 @@ import (
 	"github.com/ddev/ddev/pkg/testcommon"
 	assert2 "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
 )
 
 // TestMailpit does a basic test of mailpit.
@@ -109,17 +109,11 @@ func TestMailpit(t *testing.T) {
 	require.NotNil(t, desc["mailpit_https_url"])
 
 	// The API may not be ready the first time we hit it, especially on Rancher Desktop
-	// So try a few times
-	for i := 0; i < 5; i++ {
-		_, _, err = testcommon.GetLocalHTTPResponse(t, desc["mailpit_url"].(string)+"/api/v1/messages")
-		if err != nil {
-			t.Logf("Error hitting mailpit_url (try %d): %v resp=%v", i, err, resp)
-			time.Sleep(1 * time.Second)
-		} else {
-			break
-		}
+	opts := testcommon.HTTPRequestOpts{
+		MaxRetries: 5,
 	}
-	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
+
+	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation, opts)
 	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
 	// Colima tests on GitHub don't respect https
 	if !dockerutil.IsColima() && !dockerutil.IsLima() {
@@ -146,18 +140,7 @@ func TestMailpit(t *testing.T) {
 	require.NotNil(t, desc["mailpit_url"])
 	require.NotNil(t, desc["mailpit_https_url"])
 
-	// The API may not be ready the first time we hit it, especially on Rancher Desktop
-	// So try a few times
-	for i := 0; i < 5; i++ {
-		_, _, err = testcommon.GetLocalHTTPResponse(t, desc["mailpit_url"].(string)+"/api/v1/messages")
-		if err != nil {
-			t.Logf("Error hitting mailpit_url (try %d): %v resp=%v", i, err, resp)
-			time.Sleep(1 * time.Second)
-		} else {
-			break
-		}
-	}
-	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
+	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation, opts)
 	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
 	// Colima tests on github don't respect https
 	if !dockerutil.IsColima() && !dockerutil.IsLima() {

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -269,10 +269,10 @@ func TestUseEphemeralPort(t *testing.T) {
 		}, "HTTPS port must be between %d and %d, got %d", expectedEphemeralHTTPSPort, expectedEphemeralHTTPSPort+2, actualHTTPSPort)
 
 		// Make sure that both http and https URLs have proper content
-		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), testString, 0)
+		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), testString, -1)
 		require.Contains(t, app.GetHTTPURL(), app.GetHostname())
 		if globalconfig.GetCAROOT() != "" {
-			_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPSURL(), testString, 0)
+			_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPSURL(), testString, -1)
 			require.Contains(t, app.GetHTTPSURL(), app.GetHostname())
 		}
 	}

--- a/pkg/ddevapp/xhprof_xhgui_test.go
+++ b/pkg/ddevapp/xhprof_xhgui_test.go
@@ -22,11 +22,6 @@ import (
 
 // TestDdevXhprofPrependEnabled tests running with xhprof_enabled = true and xhprof_mode=prepend
 func TestDdevXhprofPrependEnabled(t *testing.T) {
-	if nodeps.IsMacOS() && os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" {
-		// TODO: Return to this when working on xhprof xhgui etc.
-		t.Skip("Skipping on darwin to ignore problems with 'connection reset by peer'")
-	}
-
 	origDir, _ := os.Getwd()
 
 	testcommon.ClearDockerEnv()
@@ -84,6 +79,12 @@ func TestDdevXhprofPrependEnabled(t *testing.T) {
 		webserverKeys = []string{nodeps.WebserverDefault}
 	}
 
+	// Use more retries as it may fail on macOS at first
+	opts := testcommon.HTTPRequestOpts{
+		TimeoutSeconds: 2,
+		MaxRetries:     5,
+	}
+
 	for _, webserverKey := range webserverKeys {
 		app.WebserverType = webserverKey
 
@@ -115,11 +116,11 @@ func TestDdevXhprofPrependEnabled(t *testing.T) {
 			require.NoError(t, err)
 			require.Contains(t, stdout, "xhprof.output_dir", "xhprof should be enabled but is not enabled for %s", v)
 
-			out, _, err := testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL(), 2)
+			out, _, err := testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL(), opts)
 			require.NoError(t, err, "Failed to get base URL webserver_type=%s, php_version=%s", webserverKey, v)
 			require.Contains(t, out, "module_xhprof")
 
-			out, _, err = testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL()+"/xhprof/", 2)
+			out, _, err = testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL()+"/xhprof/", opts)
 			require.NoError(t, err)
 			// Output should contain at least one run
 			require.Contains(t, out, ".ddev.xhprof</a><small>")
@@ -136,11 +137,6 @@ func TestDdevXhprofPrependEnabled(t *testing.T) {
 
 // TestDdevXhprofXhguiEnabled tests running with xhprof_enabled = true and xhprof_mode=xhgui
 func TestDdevXhprofXhguiEnabled(t *testing.T) {
-	if nodeps.IsMacOS() && os.Getenv("DDEV_RUN_TEST_ANYWAY") != "true" {
-		// TODO: Return to this when working on xhprof xhgui etc.
-		t.Skip("Skipping on darwin to ignore problems with 'connection reset by peer'")
-	}
-
 	assert := assert2.New(t)
 	origDir, _ := os.Getwd()
 
@@ -196,6 +192,12 @@ func TestDdevXhprofXhguiEnabled(t *testing.T) {
 		webserverKeys = []string{nodeps.WebserverDefault}
 	}
 
+	// Use more retries as it may fail on macOS at first
+	opts := testcommon.HTTPRequestOpts{
+		TimeoutSeconds: 2,
+		MaxRetries:     5,
+	}
+
 	for _, webserverKey := range webserverKeys {
 		app.WebserverType = webserverKey
 
@@ -233,14 +235,14 @@ func TestDdevXhprofXhguiEnabled(t *testing.T) {
 			require.NoError(t, err)
 			assert.Contains(stdout, "xhprof.output_dir", "xhprof should be enabled but is not enabled for %s", v)
 
-			out, _, err := testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL(), 2)
+			out, _, err := testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL(), opts)
 			require.NoError(t, err, "Failed to get base URL webserver_type=%s, php_version=%s", webserverKey, v)
 			require.Contains(t, out, "module_xhprof")
 
 			// NOW try using xhgui
 
 			xhguiURL := app.GetXHGuiURL()
-			out, _, err = testcommon.GetLocalHTTPResponse(t, xhguiURL, 2)
+			out, _, err = testcommon.GetLocalHTTPResponse(t, xhguiURL, opts)
 			require.NoError(t, err)
 			// Output should contain at least one run
 			require.Contains(t, out, strings.ToLower(t.Name()+"."+nodeps.DdevDefaultTLD))


### PR DESCRIPTION
## The Issue

- #7543

`TestCmdXHGui` started failing too often:

```
    xhgui_test.go:63:
        	Error Trace:	/Users/testbot/tmp/buildkite-agent/builds/macstadium-m1-1-local-1/ddev/ddev-macos-arm64-mutagen/cmd/ddev/cmd/xhgui_test.go:63
        	Error:      	Received unexpected error:
        	            	http status code for 'https://127.0.0.1' was 403, not 200
        	Test:       	TestCmdXHGui
        	Messages:   	failed to get http response from https://testcmdwordpress.ddev.site
```

- https://buildkite.com/ddev/ddev-macos-arm64-mutagen/builds/11333
- https://buildkite.com/ddev/ddev-macos-arm64-mutagen/builds/11393

## How This PR Solves The Issue

- Uses `ddev restart` instead of `ddev start` in `xhgui_test.go`
- Adds `testcommon.HTTPRequestOpts`, function signature is backward compatible.
- Adds more retries, just like it is done in `mailpit_test.go`.
- Enables `TestDdevXhprofPrependEnabled` and `TestDdevXhprofXhguiEnabled` on macOS to see if retries can help here as well.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
