### PR TITLE
Add MySQL Server ID Override Support

### DIFF
--- a/containers/ddev-dbserver/files/create_base_db.sh
+++ b/containers/ddev-dbserver/files/create_base_db.sh
@@ -26,7 +26,7 @@ mysqld_version=${mysqld_version%.*}
 echo version=$mysqld_version
 # Oracle mysql 5.7+ deprecates mysql_install_db
 if [ "${mysqld_version}" = "5.7" ] || [[  "${mysqld_version%%%.*}" =~ ^8.[04]$ ]]; then
-    mysqld --defaults-file=/var/tmp/my.cnf --initialize-insecure --datadir=${DATADIR:-/var/lib/mysql} --server-id=0
+    mysqld --defaults-file=/var/tmp/my.cnf --initialize-insecure --datadir=${DATADIR:-/var/lib/mysql} --server-id=${MYSQL_SERVER_ID:-0}
 else
     # mysql 5.5 requires running mysql_install_db in /usr/local/mysql
     if command -v mysqld | grep usr.local; then
@@ -35,7 +35,7 @@ else
     mysql_install_db --defaults-file=/var/tmp/my.cnf --force --datadir=${DATADIR:-/var/lib/mysql}
 fi
 echo "Starting mysqld --skip-networking --socket=${MYSQL_UNIX_PORT}"
-mysqld --defaults-file=/var/tmp/my.cnf --user=root --socket=${MYSQL_UNIX_PORT} --innodb_log_file_size=48M --skip-networking --datadir=${DATADIR:-/var/lib/mysql} --server-id=0 --skip-log-bin &
+mysqld --defaults-file=/var/tmp/my.cnf --user=root --socket=${MYSQL_UNIX_PORT} --innodb_log_file_size=48M --skip-networking --datadir=${DATADIR:-/var/lib/mysql} --server-id=${MYSQL_SERVER_ID:-0} --skip-log-bin &
 pid="$!"
 
 # Wait for the server to respond to mysqladmin ping, or fail if it never does,

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -78,7 +78,7 @@ rm -f /tmp/raw_mysql_version.txt
 
 # If we have extra cnf files from user, copy them to where they go.
 if [ -d /mnt/ddev_config/mysql ] && [ "$(echo /mnt/ddev_config/mysql/*.cnf)" != "/mnt/ddev_config/mysql/*.cnf" ] ; then
-  # Ensure re-copying of custom files works on restart. 
+  # Ensure re-copying of custom files works on restart.
   # Has to ignore errors that arise if no custom files have been copied yet.
   chmod -f -R u+w /etc/mysql/conf.d/* || true
   cp /mnt/ddev_config/mysql/*.cnf /etc/mysql/conf.d
@@ -188,4 +188,4 @@ echo
 
 echo "Starting mysqld."
 tail -f /var/log/mysqld.log ${DATADIR:-/var/lib/mysql}/mysqld.err &
-exec mysqld --server-id=0
+exec mysqld --server-id=${MYSQL_SERVER_ID:-0}


### PR DESCRIPTION
# Add MySQL Server ID Override Support

## Summary

This PR adds support for overriding the MySQL `server_id` parameter via the `MYSQL_SERVER_ID` environment variable, enabling MySQL replication setups in ddev.

## Problem

Currently, ddev hardcodes `--server-id=0` in the MySQL startup command, which prevents users from configuring MySQL replication. **Command-line arguments take precedence over configuration files, so it's not possible to override the server ID through custom MySQL `.cnf` files** placed in `.ddev/mysql/`.

According to MySQL documentation: *"If the server ID is set to 0, binary logging takes place, but a source with a server ID of 0 refuses any connections from replicas, and a replica with a server ID of 0 refuses to connect to a source."*

This limitation prevents developers from:
- Testing MySQL replication setups in their local ddev environment
- Using packages that require MySQL replication, such as [laravel-trigger](https://github.com/huangdijia/laravel-trigger) which provides MySQL event subscribers based on MySQL replication
- Developing applications that depend on MySQL binary log events

## Solution

- Replace hardcoded `--server-id=0` with `--server-id=${MYSQL_SERVER_ID:-0}` in both `docker-entrypoint.sh` and `create_base_db.sh`
- Maintains backward compatibility with default value of `0`

## Usage

Users can now set a custom server ID by adding to their `.ddev/config.yaml`:

```yaml
environment:
  - MYSQL_SERVER_ID=1
```

## Use Case Example

This change enables developers to use MySQL replication-dependent packages like [laravel-trigger](https://github.com/huangdijia/laravel-trigger) in their ddev development environment. The laravel-trigger package requires:

```ini
[mysqld]
server-id        = 1
log_bin          = /var/log/mysql/mysql-bin.log
binlog_row_image = full
```

With this PR, developers can now set `MYSQL_SERVER_ID=1` in their ddev configuration and use such packages locally, matching their production MySQL replication setup.
