### PR TITLE
fix(ddev-php-base): Remove php8.4-obsolete config, fixes #7616

### DIFF
--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.4/apache2/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.4/apache2/php.ini
@@ -140,7 +140,6 @@ session.gc_maxlifetime = 1440
 session.referer_check =
 session.cache_limiter = nocache
 session.cache_expire = 180
-session.use_trans_sid = 0
 session.hash_function = 0
 session.hash_bits_per_character = 5
 url_rewriter.tags = "a=href,area=href,frame=src,input=src,form=fakeentry"

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.4/cli/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.4/cli/php.ini
@@ -139,16 +139,6 @@
 ;   Development Value: 1000
 ;   Production Value: 1000
 
-; session.sid_bits_per_character
-;   Default Value: 4
-;   Development Value: 5
-;   Production Value: 5
-
-; session.sid_length
-;   Default Value: 32
-;   Development Value: 26
-;   Production Value: 26
-
 ; short_open_tag
 ;   Default Value: On
 ;   Development Value: Off
@@ -1490,43 +1480,6 @@ session.cache_limiter = nocache
 ; Document expires after n minutes.
 ; https://php.net/session.cache-expire
 session.cache_expire = 180
-
-; trans sid support is disabled by default.
-; Use of trans sid may risk your users' security.
-; Use this option with caution.
-; - User may send URL contains active session ID
-;   to other person via. email/irc/etc.
-; - URL that contains active session ID may be stored
-;   in publicly accessible computer.
-; - User may access your site with the same session ID
-;   always using URL stored in browser's history or bookmarks.
-; https://php.net/session.use-trans-sid
-session.use_trans_sid = 0
-
-; The URL rewriter will look for URLs in a defined set of HTML tags.
-; <form> is special; if you include them here, the rewriter will
-; add a hidden <input> field with the info which is otherwise appended
-; to URLs. <form> tag's action attribute URL will not be modified
-; unless it is specified.
-; Note that all valid entries require a "=", even if no value follows.
-; Default Value: "a=href,area=href,frame=src,form="
-; Development Value: "a=href,area=href,frame=src,form="
-; Production Value: "a=href,area=href,frame=src,form="
-; https://php.net/url-rewriter.tags
-session.trans_sid_tags = "a=href,area=href,frame=src,form="
-
-; URL rewriter does not rewrite absolute URLs by default.
-; To enable rewrites for absolute paths, target hosts must be specified
-; at RUNTIME. i.e. use ini_set()
-; <form> tags is special. PHP will check action attribute's URL regardless
-; of session.trans_sid_tags setting.
-; If no host is defined, HTTP_HOST will be used for allowed host.
-; Example value: php.net,www.php.net,wiki.php.net
-; Use "," for multiple hosts. No spaces are allowed.
-; Default Value: ""
-; Development Value: ""
-; Production Value: ""
-;session.trans_sid_hosts=""
 
 ; Enable upload progress tracking in $_SESSION
 ; Default Value: On

--- a/containers/ddev-php-base/ddev-php-files/etc/php/8.4/fpm/php.ini
+++ b/containers/ddev-php-base/ddev-php-files/etc/php/8.4/fpm/php.ini
@@ -139,16 +139,6 @@
 ;   Development Value: 1000
 ;   Production Value: 1000
 
-; session.sid_bits_per_character
-;   Default Value: 4
-;   Development Value: 5
-;   Production Value: 5
-
-; session.sid_length
-;   Default Value: 32
-;   Development Value: 26
-;   Production Value: 26
-
 ; short_open_tag
 ;   Default Value: On
 ;   Development Value: Off
@@ -253,7 +243,6 @@ output_buffering = 4096
 ; URL rewriter function rewrites URL on the fly by using
 ; output buffer. You can set target tags by this configuration.
 ; "form" tag is special tag. It will add hidden input tag to pass values.
-; Refer to session.trans_sid_tags for usage.
 ; Default Value: "form="
 ; Development Value: "form="
 ; Production Value: "form="
@@ -261,7 +250,6 @@ output_buffering = 4096
 
 ; URL rewriter will not rewrite absolute URL nor form by default. To enable
 ; absolute URL rewrite, allowed hosts must be defined at RUNTIME.
-; Refer to session.trans_sid_hosts for more details.
 ; Default Value: ""
 ; Development Value: ""
 ; Production Value: ""
@@ -1490,64 +1478,6 @@ session.cache_limiter = nocache
 ; Document expires after n minutes.
 ; https://php.net/session.cache-expire
 session.cache_expire = 180
-
-; trans sid support is disabled by default.
-; Use of trans sid may risk your users' security.
-; Use this option with caution.
-; - User may send URL contains active session ID
-;   to other person via. email/irc/etc.
-; - URL that contains active session ID may be stored
-;   in publicly accessible computer.
-; - User may access your site with the same session ID
-;   always using URL stored in browser's history or bookmarks.
-; https://php.net/session.use-trans-sid
-session.use_trans_sid = 0
-
-; Set session ID character length. This value could be between 22 to 256.
-; Shorter length than default is supported only for compatibility reason.
-; Users should use 32 or more chars.
-; https://php.net/session.sid-length
-; Default Value: 32
-; Development Value: 26
-; Production Value: 26
-session.sid_length = 26
-
-; The URL rewriter will look for URLs in a defined set of HTML tags.
-; <form> is special; if you include them here, the rewriter will
-; add a hidden <input> field with the info which is otherwise appended
-; to URLs. <form> tag's action attribute URL will not be modified
-; unless it is specified.
-; Note that all valid entries require a "=", even if no value follows.
-; Default Value: "a=href,area=href,frame=src,form="
-; Development Value: "a=href,area=href,frame=src,form="
-; Production Value: "a=href,area=href,frame=src,form="
-; https://php.net/url-rewriter.tags
-session.trans_sid_tags = "a=href,area=href,frame=src,form="
-
-; URL rewriter does not rewrite absolute URLs by default.
-; To enable rewrites for absolute paths, target hosts must be specified
-; at RUNTIME. i.e. use ini_set()
-; <form> tags is special. PHP will check action attribute's URL regardless
-; of session.trans_sid_tags setting.
-; If no host is defined, HTTP_HOST will be used for allowed host.
-; Example value: php.net,www.php.net,wiki.php.net
-; Use "," for multiple hosts. No spaces are allowed.
-; Default Value: ""
-; Development Value: ""
-; Production Value: ""
-;session.trans_sid_hosts=""
-
-; Define how many bits are stored in each character when converting
-; the binary hash data to something readable.
-; Possible values:
-;   4  (4 bits: 0-9, a-f)
-;   5  (5 bits: 0-9, a-v)
-;   6  (6 bits: 0-9, a-z, A-Z, "-", ",")
-; Default Value: 4
-; Development Value: 5
-; Production Value: 5
-; https://php.net/session.hash-bits-per-character
-session.sid_bits_per_character = 5
 
 ; Enable upload progress tracking in $_SESSION
 ; Default Value: On

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -2,7 +2,7 @@
 ### Build ddev-php-base from ddev-webserver-base
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
-FROM ddev/ddev-php-base:20250820_rfay_debug_test AS ddev-webserver-base
+FROM ddev/ddev-php-base:20250912_rfay_php84_settings AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20250820_rfay_debug_test" // Note that this can be overridden by make
+var WebTag = "20250912_rfay_php84_settings" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION

## The Issue

- #7616 

A few "sid" related configurations were deprecated in php8.4 and we don't seem to have caught this last year when updating config for php8.4 and they slipped in as copy from php8.3.

## How This PR Solves The Issue

Remove the relevant `sid` configurations

The behavior is all the same, we just won't see the warnings.

## Manual Testing Instructions

See #7616 

## Automated Testing Overview

I don't think we need to change anything

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
