### PR TITLE
fix: don't show timeout suggestion for ddev-router and ddev-ssh-agent on `ddev start`

### DIFF
--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -282,7 +282,7 @@ func getSuggestedCommandForContainerLog(container *container.Summary, timeout in
 	suggestedCommands = append(suggestedCommands, fmt.Sprintf("docker logs %s", name), fmt.Sprintf("docker inspect --format \"{{ json .State.Health }}\" %s | docker run -i --rm ddev/ddev-utilities jq -r", name))
 	troubleshootingCommand, _ := util.ArrayToReadableOutput(suggestedCommands)
 	suggestedCommand := "\nTroubleshoot this with these commands:\n" + troubleshootingCommand
-	if timeout > 0 {
+	if timeout > 0 && service != "ddev-router" && service != "ddev-ssh-agent" {
 		timeoutNote := "\nIf your internet connection is slow, consider increasing the timeout by running this:\n"
 		timeoutCommand, _ := util.ArrayToReadableOutput([]string{fmt.Sprintf("ddev config --default-container-timeout=%d && ddev restart", timeout*2)})
 		suggestedCommand = suggestedCommand + timeoutNote + timeoutCommand


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/issues/7526#issuecomment-3300554741

The error suggests to run `ddev config --default-container-timeout=120 && ddev restart` which makes no sense for router errors, because `default-container-timeout` have no effect on that.

## How This PR Solves The Issue

Excludes ddev-router and ddev-ssh-agent from timeout suggestion.

## Manual Testing Instructions

```
$ cat << 'EOF' > .ddev/traefik/config/test.yaml
http:
  routers:
    test:
      entrypoints:
        - http-12345
EOF

$ ddev poweroff && ddev start
```

Before:

```
Failed to start d11: ddev-router failed to become ready; log=, err=health check timed out after 1m0s: labels map[com.docker.compose.oneoff:False com.docker.compose.service:ddev-router] timed out without becoming healthy, status=, detail= ddev-router:starting

Troubleshoot this with these commands:

  - docker logs ddev-router
  - docker inspect --format "{{ json .State.Health }}" ddev-router | docker run -i --rm ddev/ddev-utilities jq -r

If your internet connection is slow, consider increasing the timeout by running this:

  - ddev config --default-container-timeout=120 && ddev restart
```

After:

```
Failed to start d11: ddev-router failed to become ready; log=, err=health check timed out after 1m0s: labels map[com.docker.compose.oneoff:False com.docker.compose.service:ddev-router] timed out without becoming healthy, status=, detail= ddev-router:starting

Troubleshoot this with these commands:

  - docker logs ddev-router
  - docker inspect --format "{{ json .State.Health }}" ddev-router | docker run -i --rm ddev/ddev-utilities jq -r
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
