### PR TITLE
build(aur): add docker-buildx dependency

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -445,6 +445,7 @@ aurs:
   git_url: '{{ .Env.AUR_STABLE_GIT_URL }}'
   depends:
   - docker
+  - docker-buildx
   - mkcert
   optdepends:
   - 'bash-completion: subcommand completion support'
@@ -486,6 +487,7 @@ aurs:
   git_url: '{{ .Env.AUR_EDGE_GIT_URL }}'
   depends:
   - docker
+  - docker-buildx
   - mkcert
   optdepends:
   - 'bash-completion: subcommand completion support'


### PR DESCRIPTION
## The Issue

- #7545

DDEV [v1.24.8](https://github.com/ddev/ddev/releases/tag/v1.24.8) uses `docker-compose` v2.39.3, which requires `docker-buildx` https://archlinux.org/packages/extra/x86_64/docker-buildx/

(`docker-compose` [v2.37.0](https://github.com/docker/compose/releases/tag/v2.37.0) switched to Bake builder by default.)

## How This PR Solves The Issue

Adds missing AUR dependency.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
