### PR TITLE
feat: enhance PHP addon environment with DockerEnv() integration

### DIFF
--- a/cmd/ddev/cmd/addon-get.go
+++ b/cmd/ddev/cmd/addon-get.go
@@ -61,7 +61,7 @@ ddev add-on get /path/to/tarball.tar.gz
 		if err != nil {
 			util.Failed("Unable to change directory to project root %s: %v", app.AppRoot, err)
 		}
-		app.DockerEnv()
+		_ = app.DockerEnv()
 
 		sourceRepoArg := args[0]
 		extractedDir := ""

--- a/cmd/ddev/cmd/addon-remove.go
+++ b/cmd/ddev/cmd/addon-remove.go
@@ -38,7 +38,7 @@ ddev add-on remove ddev-someaddonname --project my-project
 			util.Failed("Unable to chdir to %v: %v", app.GetConfigPath(""), err)
 		}
 
-		app.DockerEnv()
+		_ = app.DockerEnv()
 
 		err = ddevapp.RemoveAddon(app, args[0], cmd.Flags().Changed("verbose"), false)
 		if err != nil {

--- a/cmd/ddev/cmd/auth-ssh_test.go
+++ b/cmd/ddev/cmd/auth-ssh_test.go
@@ -54,7 +54,7 @@ func TestCmdAuthSSH(t *testing.T) {
 	internalIPAddr = strings.Trim(internalIPAddr, "\r\n\"'")
 	assert.NoError(err)
 
-	app.DockerEnv()
+	_ = app.DockerEnv()
 
 	// Before we add the password with ddev auth ssh, we should not be able to access the SSH server
 	// Turn off StrictHostChecking because the server can have been run more than once with different

--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -454,7 +454,7 @@ func makeHostCmd(app *ddevapp.DdevApp, fullPath, name string, mutagenSync bool) 
 	return func(_ *cobra.Command, _ []string) {
 		if app != nil {
 			status, _ := app.SiteStatus()
-			app.DockerEnv()
+			_ = app.DockerEnv()
 			_ = os.Setenv("DDEV_PROJECT_STATUS", status)
 		} else {
 			_ = os.Setenv("DDEV_PROJECT_STATUS", "")
@@ -467,7 +467,7 @@ func makeHostCmd(app *ddevapp.DdevApp, fullPath, name string, mutagenSync bool) 
 		var err error
 		// Load environment variables that may be useful for script.
 		if app != nil {
-			app.DockerEnv()
+			_ = app.DockerEnv()
 		}
 
 		runMutagenSync(app, mutagenSync)
@@ -502,7 +502,7 @@ func makeContainerCmd(app *ddevapp.DdevApp, fullPath, name, service string, exec
 				util.Failed("Failed to start project for custom command: %v", err)
 			}
 		}
-		app.DockerEnv()
+		_ = app.DockerEnv()
 
 		if service == "web" {
 			runMutagenSync(app, mutagenSync)

--- a/cmd/ddev/cmd/debug-compose-config.go
+++ b/cmd/ddev/cmd/debug-compose-config.go
@@ -32,7 +32,7 @@ var DebugComposeConfigCmd = &cobra.Command{
 			util.Failed("Failed to get compose-config: %v", err)
 		}
 
-		app.DockerEnv()
+		_ = app.DockerEnv()
 		if err = app.WriteDockerComposeYAML(); err != nil {
 			util.Failed("Failed to get compose-config: %v", err)
 		}

--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -58,7 +58,7 @@ ddev debug download-images --all
 			var projectNames []string
 			for _, app := range projects {
 				projectNames = append(projectNames, app.Name)
-				app.DockerEnv()
+				_ = app.DockerEnv()
 				err = app.WriteDockerComposeYAML()
 				if err != nil {
 					util.Failed("Failed to run `docker-compose config` for '%s': %v", app.Name, err)

--- a/cmd/ddev/cmd/debug-rebuild.go
+++ b/cmd/ddev/cmd/debug-rebuild.go
@@ -53,7 +53,7 @@ var DebugRebuildCmd = &cobra.Command{
 			util.Failed("Failed to get project: %v", err)
 		}
 
-		app.DockerEnv()
+		_ = app.DockerEnv()
 
 		if err = app.WriteDockerComposeYAML(); err != nil {
 			util.Failed("Failed to get compose-config: %v", err)

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -43,7 +43,7 @@ ddev exec --raw -- ls -lR`,
 			util.Failed("Project is not currently running. Try 'ddev start'.")
 		}
 
-		app.DockerEnv()
+		_ = app.DockerEnv()
 
 		opts := &ddevapp.ExecOpts{
 			Service: serviceType,

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -32,7 +32,7 @@ ddev ssh -d /var/www/html`,
 		app := projects[0]
 		instrumentationApp = app
 
-		app.DockerEnv()
+		_ = app.DockerEnv()
 
 		// Use Bash for our containers, sh for 3rd-party containers
 		// that may not have Bash.

--- a/cmd/ddev/cmd/xhgui.go
+++ b/cmd/ddev/cmd/xhgui.go
@@ -36,7 +36,7 @@ var DdevXHGuiCmd = &cobra.Command{
 			return fmt.Errorf("unable to get project: %v", err)
 		}
 
-		app.DockerEnv()
+		_ = app.DockerEnv()
 
 		if globalconfig.DdevGlobalConfig.UseHardenedImages {
 			util.Failed("XHGui is not available with use-hardened-images.")

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -439,6 +439,8 @@ func buildPHPActionEnvironment(app *DdevApp, installDesc InstallDesc, verbose bo
 			return nil, fmt.Errorf("unable to merge addon environment variables: %v", err)
 		}
 	}
+	// Use the in-container version of approot
+	envMap["DDEV_APPROOT"] = "/var/www/html"
 
 	// Convert map to slice
 	var env []string

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 	"time"
 
+	"dario.cat/mergo"
 	"github.com/ddev/ddev/pkg/archive"
 	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
@@ -22,7 +23,6 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	dockerContainer "github.com/docker/docker/api/types/container"
 	dockerMount "github.com/docker/docker/api/types/mount"
 	dockerStrslice "github.com/docker/docker/api/types/strslice"
@@ -419,39 +419,29 @@ func (app *DdevApp) CleanupConfigurationFiles() error {
 
 // buildPHPActionEnvironment creates the environment variables for PHP actions
 func buildPHPActionEnvironment(app *DdevApp, installDesc InstallDesc, verbose bool) ([]string, error) {
-	// Database family for connection URLs
-	dbFamily := "mysql"
-	if app.Database.Type == "postgres" {
-		dbFamily = "postgres"
-	}
-
-	env := []string{
-		"DDEV_APPROOT=/var/www/html",
-		"DDEV_DOCROOT=" + app.GetDocroot(),
-		"DDEV_PROJECT_TYPE=" + app.Type,
-		"DDEV_SITENAME=" + app.Name,
-		"DDEV_PROJECT=" + app.Name,
-		"DDEV_PHP_VERSION=" + app.PHPVersion,
-		"DDEV_WEBSERVER_TYPE=" + app.WebserverType,
-		"DDEV_DATABASE=" + app.Database.Type + ":" + app.Database.Version,
-		"DDEV_DATABASE_FAMILY=" + dbFamily,
-		"DDEV_FILES_DIRS=" + strings.Join(app.GetUploadDirs(), ","),
-		"DDEV_MUTAGEN_ENABLED=" + strconv.FormatBool(app.IsMutagenEnabled()),
-		"DDEV_VERSION=" + versionconstants.DdevVersion,
-		"DDEV_TLD=" + app.ProjectTLD,
-		"IS_DDEV_PROJECT=true",
-	}
-
+	// Start with Docker environment variables
+	envMap := app.DockerEnv()
 	if verbose {
-		env = append(env, "DDEV_VERBOSE=true")
+		envMap["DDEV_VERBOSE"] = "true"
 	}
 
 	// Add all environment variables from the .ddev/.env.<addon-name>
 	envFile := app.GetConfigPath(".env." + installDesc.Name)
-	envMap, _, err := ReadProjectEnvFile(envFile)
+	addonEnvMap, _, err := ReadProjectEnvFile(envFile)
 	if err != nil && !os.IsNotExist(err) {
-		return env, fmt.Errorf("unable to read %s file: %v", envFile, err)
+		return nil, fmt.Errorf("unable to read %s file: %v", envFile, err)
 	}
+
+	// Merge addon-specific environment variables using mergo
+	if len(addonEnvMap) > 0 {
+		err = mergo.Merge(&envMap, addonEnvMap, mergo.WithOverride)
+		if err != nil {
+			return nil, fmt.Errorf("unable to merge addon environment variables: %v", err)
+		}
+	}
+
+	// Convert map to slice
+	var env []string
 	for k, v := range envMap {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -241,7 +241,7 @@ func TestWriteDockerComposeYaml(t *testing.T) {
 	assert.NoError(err)
 
 	// After the config has been written and directories exist, the write should work.
-	app.DockerEnv()
+	_ = app.DockerEnv()
 	err = app.WriteDockerComposeYAML()
 	assert.NoError(err)
 
@@ -1770,7 +1770,7 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 	for _, tc := range simpleWaitTimeMatrix {
 		t.Run(tc.description, func(t *testing.T) {
 			app.DefaultContainerTimeout = strconv.Itoa(tc.maxWaitTime)
-			app.DockerEnv()
+			_ = app.DockerEnv()
 			dockerComposeSource := filepath.Join(origDir, "testdata", tName, fmt.Sprintf("docker-compose.%s.yaml", tc.description))
 			dockerComposeTarget := app.GetConfigPath("docker-compose." + tName + ".yaml")
 			err = copy2.Copy(dockerComposeSource, dockerComposeTarget, copy2.Options{})
@@ -1788,7 +1788,7 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 	_ = os.RemoveAll(app.GetConfigPath("docker-compose." + tName + ".yaml"))
 	for _, maxWaitTime := range []string{nodeps.DefaultDefaultContainerTimeout, "850"} {
 		app.DefaultContainerTimeout = maxWaitTime
-		app.DockerEnv()
+		_ = app.DockerEnv()
 		err = app.WriteConfig()
 		require.NoError(t, err)
 		err = app.Restart()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -209,7 +209,7 @@ func (app *DdevApp) FindContainerByType(containerType string) (*dockerContainer.
 // Describe returns a map which provides detailed information on services associated with the running site.
 // if short==true, then only the basic information is returned.
 func (app *DdevApp) Describe(short bool) (map[string]interface{}, error) {
-	app.DockerEnv()
+	_ = app.DockerEnv()
 	err := app.ProcessHooks("pre-describe")
 	if err != nil {
 		return nil, fmt.Errorf("failed to process pre-describe hooks: %v", err)
@@ -697,7 +697,7 @@ func (app *DdevApp) GetMailpitHTTPSPort() string {
 
 // ImportDB takes a source sql dump and imports it to an active site's database container.
 func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool, noDrop bool, targetDB string) error {
-	app.DockerEnv()
+	_ = app.DockerEnv()
 	dockerutil.CheckAvailableSpace()
 
 	if targetDB == "" {
@@ -922,7 +922,7 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 // ExportDB exports the db, with optional output to a file, default gzip
 // targetDB is the db name if not default "db"
 func (app *DdevApp) ExportDB(dumpFile string, compressionType string, targetDB string) error {
-	app.DockerEnv()
+	_ = app.DockerEnv()
 	if targetDB == "" {
 		targetDB = "db"
 	}
@@ -1078,7 +1078,7 @@ func (app *DdevApp) getCommonStatus(statuses map[string]string) (bool, string) {
 
 // ImportFiles takes a source directory or archive and copies to the uploaded files directory of a given app.
 func (app *DdevApp) ImportFiles(uploadDir, importPath, extractPath string) error {
-	app.DockerEnv()
+	_ = app.DockerEnv()
 
 	if err := app.ProcessHooks("pre-import-files"); err != nil {
 		return err
@@ -1256,7 +1256,7 @@ func (app *DdevApp) Start() error {
 
 	SyncGenericWebserverPortsWithRouterPorts(app)
 
-	app.DockerEnv()
+	_ = app.DockerEnv()
 	dockerutil.EnsureDdevNetwork()
 	// The project network may have duplicates, we can remove them here.
 	// See https://github.com/ddev/ddev/pull/5508
@@ -2164,7 +2164,7 @@ type ExecOpts struct {
 // Returns ComposeCmd results of stdout, stderr, err
 // If Nocapture arg is true, stdout/stderr will be empty and output directly to stdout/stderr
 func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
-	app.DockerEnv()
+	_ = app.DockerEnv()
 
 	defer util.TimeTrackC(fmt.Sprintf("app.Exec %v", opts))()
 
@@ -2268,7 +2268,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 // ExecWithTty executes a given command in the container of given type.
 // It allocates a pty for interactive work.
 func (app *DdevApp) ExecWithTty(opts *ExecOpts) error {
-	app.DockerEnv()
+	_ = app.DockerEnv()
 
 	if opts.Service == "" {
 		opts.Service = "web"
@@ -2339,7 +2339,7 @@ func (app *DdevApp) ExecOnHostOrService(service string, cmd string) error {
 			cmd,
 		}
 
-		app.DockerEnv()
+		_ = app.DockerEnv()
 		err = exec.RunInteractiveCommand(bashPath, args)
 		_ = os.Chdir(cwd)
 	} else { // handle case in container
@@ -2458,7 +2458,7 @@ func (app *DdevApp) CaptureLogs(service string, timestamps bool, tailLines strin
 }
 
 // DockerEnv sets environment variables for a docker-compose run.
-func (app *DdevApp) DockerEnv() {
+func (app *DdevApp) DockerEnv() map[string]string {
 	uidStr, gidStr, username := util.GetContainerUIDGid()
 
 	// Warn about running as root if we're not on Windows.
@@ -2633,11 +2633,12 @@ func (app *DdevApp) DockerEnv() {
 			util.Error("Failed to set the environment variable %s=%s: %v", k, v, err)
 		}
 	}
+	return envVars
 }
 
 // Pause initiates docker-compose stop
 func (app *DdevApp) Pause() error {
-	app.DockerEnv()
+	_ = app.DockerEnv()
 
 	status, _ := app.SiteStatus()
 	if status == SiteStopped {
@@ -2891,7 +2892,7 @@ func fullDBFromVersion(v string) string {
 
 // Stop stops and Removes the Docker containers for the project in current directory.
 func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
-	app.DockerEnv()
+	_ = app.DockerEnv()
 	var err error
 
 	clear(EphemeralRouterPortsAssigned)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3526,7 +3526,7 @@ func TestMultipleComposeFiles(t *testing.T) {
 	// Make sure that valid yaml files get properly loaded in the proper order
 	app, err := ddevapp.NewApp(testDir, true)
 	assert.NoError(err)
-	app.DockerEnv()
+	_ = app.DockerEnv()
 
 	//nolint: errcheck
 	defer app.Stop(true, false)
@@ -3597,7 +3597,7 @@ func TestFixupComposeYaml(t *testing.T) {
 
 	app, err := ddevapp.NewApp(testDir, true)
 	require.NoError(t, err)
-	app.DockerEnv()
+	_ = app.DockerEnv()
 
 	t.Cleanup(func() {
 		err := app.Stop(true, false)
@@ -4709,7 +4709,7 @@ func TestEnvironmentVariables(t *testing.T) {
 		"IS_DDEV_PROJECT":               "true",
 	}
 
-	app.DockerEnv()
+	_ = app.DockerEnv()
 	for k, v := range webContainerExpectations {
 		envVal, _, err := app.Exec(&ddevapp.ExecOpts{
 			Cmd: fmt.Sprintf("echo ${%s}", k),

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -51,7 +51,7 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 		return err
 	}
 
-	app.DockerEnv()
+	_ = app.DockerEnv()
 
 	// run docker-compose up -d
 	// This will force-recreate, discarding existing auth if there is a stopped container.
@@ -109,7 +109,7 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 
 	uid, gid, username := util.GetContainerUIDGid()
 
-	app.DockerEnv()
+	_ = app.DockerEnv()
 
 	templateVars := map[string]interface{}{
 		"ssh_auth_image": versionconstants.SSHAuthImage,


### PR DESCRIPTION
## The Issue

Working on ddev-upsun, I discovered that PHP addons were using a limited set of hardcoded environment variables instead of the complete environment provided by DockerEnv(). This resulted in:
- Empty port values instead of actual configured ports
- Missing environment variables available to other DDEV components
- Hardcoded DDEV_APPROOT instead of configurable app root

Most of all I needed DDEV_PRIMARY_URL

## How This PR Solves The Issue

- Replace manual environment variable creation with app.DockerEnv()
- Use mergo library for proper map merging of addon-specific environment variables
- Maintain backward compatibility for .ddev/.env.<addon-name> files
- Preserve DDEV_VERBOSE functionality for verbose mode

This does change the signature of DockerEnv() but shouldn't do any damage that way.

## Manual Testing Instructions

1. Install a PHP addon that uses environment variables
2. Verify addon has access to proper port numbers and URLs
3. Test with custom .ddev/.env.<addon-name> files to ensure merging works
4. Confirm verbose mode still adds DDEV_VERBOSE=true

## Automated Testing Overview

No changes

## Release/Deployment Notes

- [ ] On release, ddev-upsun can have all these environment variable workarounds removed.

🤖 Generated with [Claude Code](https://claude.ai/code)

