### PR TITLE
fix(cakephp): do not override APP_DEFAULT_LOCALE

### DIFF
--- a/pkg/ddevapp/cakephp.go
+++ b/pkg/ddevapp/cakephp.go
@@ -59,7 +59,6 @@ func cakephpPostStartAction(app *DdevApp) error {
 		"export APP_NAME":                    app.GetName(),
 		"export DEBUG":                       "true",
 		"export APP_ENCODING":                "UTF-8",
-		"export APP_DEFAULT_LOCALE":          "en_US",
 		"export DATABASE_URL":                dbConnection + "://db:db@db:" + port + "/db" + dbParams,
 		"export EMAIL_TRANSPORT_DEFAULT_URL": "smtp://localhost:1025",
 		"export SECURITY_SALT":               util.HashSalt(app.GetName()),


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://ddev.readthedocs.io/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

Today, I cloned an internal CakePHP4 project.
It appeared to work but some translation strings were not displaying correctly.

DDEV generated a `config/.env` based on `config/.env.example`.
DDEV (correctly) overrode `DATABASE_URL` & `EMAIL_TRANSPORT_DEFAULT_URL` to point to itself.
However, it overrides `APP_DEFAULT_LOCALE` to `en_US` which resulted in CakePHP looking for English translation instead of using the Japanese.

Since DDEV does NOT override `APP_DEFAULT_TIMEZONE`, this feels like unexpected.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

The PR does not explicitly set `APP_DEFAULT_LOCALE`, thus falling back to `config/.env.example` settings.

Tested on CakePHP4 & CakePHP5

## Manual Testing Instructions

1. Check DDEV version

```shell
ddev -v
ddev version v1.24.7
```

1. Create a new CakePHP project following current quickstart guide.

```shell
mkdir my-cakephp-site && cd my-cakephp-site
ddev config --project-type=cakephp --docroot=webroot
ddev start
ddev composer create-project --prefer-dist --no-interaction cakephp/app:~5.0
```

1. Check `config/.env`

```shell
$ cat config/.env | \grep --color=auto APP_DEFAULT
export APP_DEFAULT_LOCALE="en_US"
export APP_DEFAULT_TIMEZONE="UTC"
```

1. Remove `config/.env`

```shell
rm config/.env
```

1. Manually update `config/.env.example` which might normally be configured in a existing project.

```conf
export APP_DEFAULT_LOCALE="ja_JP"
export APP_DEFAULT_TIMEZONE="Asia/Tokyo"
```

1. Restart DDEV to regenerate `config/.env`

```shell
ddev restart
```

1. Check `config/.env` contains expected values set above.

```shell
$ cat config/.env | \grep --color=auto APP_DEFAULT
export APP_DEFAULT_LOCALE="ja_JP"
export APP_DEFAULT_TIMEZONE="Asia/Tokyo"
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

