### PR TITLE
test: fix TestNetworkAliases, fixes #7657

### DIFF
--- a/pkg/dockerutil/networks_test.go
+++ b/pkg/dockerutil/networks_test.go
@@ -323,18 +323,16 @@ func TestNetworkAliases(t *testing.T) {
 				}
 				// Test both HTTP and HTTPS URLs
 				urls := map[string]string{
-					"http": tc.httpURL,
+					"http_web":       "http://ddev-" + tc.toApp.Name + "-web",
+					"http_web_alias": tc.httpURL,
 				}
 				if globalconfig.GetCAROOT() != "" {
-					urls["https"] = tc.httpsURL
+					urls["https_web"] = "https://ddev-" + tc.toApp.Name + "-web"
+					urls["https_web_alias"] = tc.httpsURL
 				}
 
 				for protocol, url := range urls {
 					t.Run(tc.name+"_"+protocol, func(t *testing.T) {
-						// Dummy attempt to get webserver "warmed up" before real try.
-						_, _, _ = testcommon.GetLocalHTTPResponse(t, url, 60)
-						_, _ = testcommon.EnsureLocalHTTPContent(t, url, "Hello from "+tc.toApp.Name, 60)
-
 						curlCmd := "curl -sS --fail " + url
 						out, _, err := tc.fromApp.Exec(&ddevapp.ExecOpts{
 							Service: "web",

--- a/pkg/dockerutil/networks_test.go
+++ b/pkg/dockerutil/networks_test.go
@@ -207,7 +207,7 @@ func TestNetworkAliases(t *testing.T) {
 			err = fileutil.CopyFile(filepath.Join(origDir, "testdata", "TestNetworkAliases", "index.php"), filepath.Join(projDir, "index.php"))
 			require.NoError(t, err)
 
-			err = app.Start()
+			err = app.StartAndWait(5)
 			require.NoError(t, err)
 
 			apps = append(apps, app)

--- a/pkg/dockerutil/networks_test.go
+++ b/pkg/dockerutil/networks_test.go
@@ -141,10 +141,6 @@ func TestNetworkAmbiguity(t *testing.T) {
 // where projects can communicate with each other via hostnames without external_links
 // Related test: TestInternalAndExternalAccessToURL
 func TestNetworkAliases(t *testing.T) {
-	if nodeps.IsAppleSilicon() || dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() {
-		t.Skip("Skipping on mac Apple Silicon/Lima/Colima/Rancher to ignore problems with 'connection reset by peer'")
-	}
-
 	origDir, _ := os.Getwd()
 
 	// Create two temporary projects

--- a/pkg/dockerutil/networks_test.go
+++ b/pkg/dockerutil/networks_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/docker/docker/api/types/network"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,14 +34,14 @@ func TestNetworkDuplicates(t *testing.T) {
 
 	t.Cleanup(func() {
 		err := dockerutil.RemoveNetwork(networkName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		nets, err := client.NetworkList(ctx, network.ListOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Ensure the network is not in the list
 		for _, net := range nets {
-			assert.NotEqual(t, networkName, net.Name)
+			require.NotEqual(t, networkName, net.Name)
 		}
 	})
 
@@ -82,16 +81,14 @@ func TestNetworkAmbiguity(t *testing.T) {
 		t.Name() + "-app1": testcommon.CreateTmpDir(t.Name() + "-app1"),
 		t.Name() + "-app2": testcommon.CreateTmpDir(t.Name() + "-app2"),
 	}
-	var err error
 
 	t.Cleanup(func() {
-		err = os.Chdir(origDir)
-		assert.NoError(t, err)
+		_ = os.Chdir(origDir)
 		for projName, projDir := range projects {
 			app, err := ddevapp.GetActiveApp(projName)
-			assert.NoError(t, err)
-			err = app.Stop(true, false)
-			assert.NoError(t, err)
+			if err == nil {
+				_ = app.Stop(true, false)
+			}
 			_ = os.RemoveAll(projDir)
 		}
 	})
@@ -158,16 +155,13 @@ func TestNetworkAliases(t *testing.T) {
 		t.Name() + "-app1": testcommon.CreateTmpDir(t.Name() + "-app1"),
 		t.Name() + "-app2": testcommon.CreateTmpDir(t.Name() + "-app2"),
 	}
-	var err error
 
 	t.Cleanup(func() {
-		err = os.Chdir(origDir)
-		assert.NoError(t, err)
+		_ = os.Chdir(origDir)
 		for projName, projDir := range projects {
 			app, err := ddevapp.GetActiveApp(projName)
 			if err == nil {
-				err = app.Stop(true, false)
-				assert.NoError(t, err)
+				_ = app.Stop(true, false)
 			}
 			_ = os.RemoveAll(projDir)
 		}
@@ -351,10 +345,10 @@ func TestNetworkAliases(t *testing.T) {
 	}
 
 	out, err := exec.RunHostCommand(DdevBin, "list")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Logf("\n=========== output of ddev list ==========\n%s\n============\n", out)
 	out, err = exec.RunHostCommand("docker", "logs", "ddev-router")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Logf("\n=========== output of docker logs ddev-router ==========\n%s\n============\n", out)
 
 	runTime()

--- a/pkg/dockerutil/networks_test.go
+++ b/pkg/dockerutil/networks_test.go
@@ -331,6 +331,10 @@ func TestNetworkAliases(t *testing.T) {
 
 				for protocol, url := range urls {
 					t.Run(tc.name+"_"+protocol, func(t *testing.T) {
+						// Dummy attempt to get webserver "warmed up" before real try.
+						_, _, _ = testcommon.GetLocalHTTPResponse(t, url, 60)
+						_, _ = testcommon.EnsureLocalHTTPContent(t, url, "Hello from "+tc.toApp.Name, 60)
+
 						curlCmd := "curl -sS --fail " + url
 						out, _, err := tc.fromApp.Exec(&ddevapp.ExecOpts{
 							Service: "web",


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #7657

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

- Uses require instead of assert for network tests
- Fixes assign for app1 and app2 - that's why tests failed sometimes
- Runs `TestNetworkAliases` everywhere, I don't think that we can get "connection reset by peer" inside containers.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
