### PR TITLE
feat: Update AGENTS.md to reference organization-wide patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,8 @@
 # AGENTS.md
 
-This file provides guidance to AI agents when working with code in this repository.
+This file provides guidance to AI agents when working with the DDEV core codebase.
 
-## Communication Style
-
-- Use direct, concise language without unnecessary adjectives or adverbs
-- Avoid flowery or marketing-style language ("tremendous", "dramatically", "revolutionary", "working perfectly", etc.)
-- Don't include flattery or excessive praise ("excellent!", "perfect!", "great job!")
-- State facts and findings directly without embellishment
-- Skip introductory phrases like "I'm excited to", "I'd be happy to", "Let me dive into"
-- Avoid concluding with summary statements unless specifically requested
-- When presenting options or analysis, lead with the core information, not commentary about it
-
-### AI Language Guidelines
-
-- Avoid words that reveal AI writing: "Comprehensive", "works perfectly", "You're absolutely right"
-- Don't say "perfect" in response to actions
-- Don't claim results are "ready for production use" without verification
-
-## Project Overview
+## DDEV Core Project Overview
 
 DDEV is an open-source tool for running local web development environments for PHP and Node.js. It uses Docker containers to provide consistent, isolated development environments with minimal configuration.
 
@@ -374,6 +358,10 @@ For optimal performance with DDEV development, consider these configuration patt
   }
 }
 ```
+
+## General DDEV Development Patterns
+
+For standard DDEV organization patterns including communication style, branch naming, PR creation, and common development practices, see the [organization-wide AGENTS.md](https://github.com/ddev/.github/blob/main/AGENTS.md).
 
 ## Task Master AI Instructions
 


### PR DESCRIPTION

## The Issue

- https://github.com/ddev/.github/pull/1

Global source for general AGENTS.md information.

This should go in after that one.

## How This PR Solves The Issue

- Add reference to ddev/.github/AGENTS.md for shared development patterns
- Focus project-specific content on core DDEV development
- Remove duplication of general DDEV organization practices
- Implement manual import pattern for AI agent instructions
- Maintain project-specific Go development, architecture, and testing guidance

🤖 Generated with [Claude Code](https://claude.ai/code)


