### PR TITLE
fix(hack-postgres): hack postgres client since postgresql-client:18 is misbehaving, for #7661

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1457,10 +1457,11 @@ set -eu -o pipefail
 EXISTING_PSQL_VERSION=$(psql --version | awk -F '[\. ]*' '{ print $3 }' || true)
 if [ "${EXISTING_PSQL_VERSION}" != "%s" ]; then
   log-stderr.sh apt-get update -o Acquire::Retries=5 -o Dir::Etc::sourcelist="sources.list.d/pgdg.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
-  log-stderr.sh apt-get install -y postgresql-client-%s && apt-get remove -y postgresql-client-${EXISTING_PSQL_VERSION} || true
+  # TEMP HACK: Remove postgresql-client-18 since it shouldn't have been installed'
+  log-stderr.sh apt-get install -y postgresql-client-%s && apt-get install -y postgresql-client-%s && apt-get remove -y postgresql-client-${EXISTING_PSQL_VERSION} postgresql-client-18  || true
 fi
 EOF
-`, app.Database.Version, psqlVersion) + "\n\n"
+`, app.Database.Version, psqlVersion, psqlVersion) + "\n\n"
 		}
 	}
 


### PR DESCRIPTION

## The Issue

- #7661

With the arrival of postgres 18, postgresql-client always installs 18 apparently

## How This PR Solves The Issue

Temp hack, to be reverted:
Uninstall postgresql-client:18 after the required client is installed

## Manual Testing Instructions

```
ddev config --database=postgres:15
ddev delete -Oy
ddev start -y
ddev exec psql --version # should get 15
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
