### PR TITLE
fix(postgres): uninstall postgresql-client with its dependencies, for #7663

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1457,11 +1457,10 @@ set -eu -o pipefail
 EXISTING_PSQL_VERSION=$(psql --version | awk -F '[\. ]*' '{ print $3 }' || true)
 if [ "${EXISTING_PSQL_VERSION}" != "%s" ]; then
   log-stderr.sh apt-get update -o Acquire::Retries=5 -o Dir::Etc::sourcelist="sources.list.d/pgdg.sources" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" || true
-  # TEMP HACK: Remove postgresql-client-18 since it shouldn't have been installed'
-  log-stderr.sh apt-get install -y postgresql-client-%s && apt-get install -y postgresql-client-%s && apt-get remove -y postgresql-client-${EXISTING_PSQL_VERSION} postgresql-client-18  || true
+  log-stderr.sh apt-get install -y postgresql-client-%s && apt-get remove -y --autoremove postgresql-client || true
 fi
 EOF
-`, app.Database.Version, psqlVersion, psqlVersion) + "\n\n"
+`, app.Database.Version, psqlVersion) + "\n\n"
 		}
 	}
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- #7663

The issue with `postgresql-client-18` appeared because we install `postgresql-client` in `ddev-webserver`.

The current `ddev-webserver` has `postgresql-client` and its dependency `postgresql-client-17` installed.

When `postgresql-client-18` was released, it became the new dependency for `postgresql-client`, so removing `postgresql-client-17` automatically installed `postgresql-client-18`.

## How This PR Solves The Issue

Removes `postgresql-client` with its dependencies.

## Manual Testing Instructions

```
ddev delete -Oy
ddev config --database=postgres:15
ddev start
ddev psql --version    # psql (PostgreSQL) 15.14
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
