### PR TITLE
fix: disable `.env` parsing for `docker-compose pull`, fixes #7671

### DIFF
--- a/cmd/ddev/cmd/addon-get.go
+++ b/cmd/ddev/cmd/addon-get.go
@@ -310,31 +310,6 @@ func createManifestFile(app *ddevapp.DdevApp, addonName string, repository strin
 	return manifest, nil
 }
 
-// getInjectedEnv returns bash export string for env variables
-// that will be used in PreInstallActions and PostInstallActions
-func getInjectedEnv(envFile string, verbose bool) string {
-	injectedEnv := "true"
-	envMap, _, err := ddevapp.ReadProjectEnvFile(envFile)
-	if err != nil && !os.IsNotExist(err) {
-		util.Failed("Unable to read %s file: %v", envFile, err)
-	}
-	if len(envMap) > 0 {
-		if verbose {
-			util.Warning("Using env file %s", envFile)
-		}
-		injectedEnv = "export"
-		for k, v := range envMap {
-			// Escape all spaces and dollar signs
-			v = strings.ReplaceAll(strings.ReplaceAll(v, `$`, `\$`), ` `, `\ `)
-			injectedEnv = injectedEnv + fmt.Sprintf(" %s=%s ", k, v)
-			if verbose {
-				util.Warning(`%s=%s`, k, v)
-			}
-		}
-	}
-	return injectedEnv
-}
-
 func init() {
 	AddonGetCmd.Flags().String("version", "", `Specify a particular version of add-on to install`)
 	AddonGetCmd.Flags().BoolP("verbose", "v", false, "Extended/verbose output")

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -66,7 +66,7 @@ ddev exec --raw -- ls -lR`,
 			}
 			// opts.RawCmd is used instead of opts.Cmd
 			opts.RawCmd = args
-			opts.Env = env
+			opts.Env = append(os.Environ(), env...)
 		}
 
 		_, _, err = app.Exec(opts)

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -66,7 +66,7 @@ ddev exec --raw -- ls -lR`,
 			}
 			// opts.RawCmd is used instead of opts.Cmd
 			opts.RawCmd = args
-			opts.Env = append(os.Environ(), env...)
+			opts.Env = env
 		}
 
 		_, _, err = app.Exec(opts)

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -18,7 +18,7 @@ import (
 // CmdOption is a function type for configuring exec.Cmd
 type CmdOption func(*exec.Cmd)
 
-// WithStdin sets the stdin for the command
+// WithStdin sets the stdin for the host command
 func WithStdin(stdin io.Reader) CmdOption {
 	return func(cmd *exec.Cmd) {
 		if globalconfig.DdevVerbose {
@@ -28,13 +28,16 @@ func WithStdin(stdin io.Reader) CmdOption {
 	}
 }
 
-// WithEnv sets the environment variables for the command
+// WithEnv sets the environment variables for the host command
 func WithEnv(env []string) CmdOption {
 	return func(cmd *exec.Cmd) {
 		if globalconfig.DdevVerbose {
 			output.UserOut.Printf("WithEnv: setting env vars %v", env)
 		}
-		cmd.Env = append(os.Environ(), env...)
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
+		cmd.Env = append(cmd.Env, env...)
 	}
 }
 

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -34,7 +34,7 @@ func WithEnv(env []string) CmdOption {
 		if globalconfig.DdevVerbose {
 			output.UserOut.Printf("WithEnv: setting env vars %v", env)
 		}
-		cmd.Env = env
+		cmd.Env = append(os.Environ(), env...)
 	}
 }
 


### PR DESCRIPTION
## The Issue

- #7671

## How This PR Solves The Issue

- Adds `Env` to `dockerutils.ComposeCmdOpts`
- Adds `COMPOSE_DISABLE_ENV_FILE=1` for `docker-compose pull`, see https://github.com/compose-spec/compose-go/pull/510
- Skips `docker-compose pull` when there is nothing to pull (previously it ran every time)
- Removes unused `getInjectedEnv`
- Appends to `Env` instead of full overriding in different places.

## Manual Testing Instructions

```
echo "FOO=\$BAR" > .env
docker rmi ddev/ddev-utilities
ddev start
```

v1.24.8:
```
$ ddev start
Starting project... 
WARN[0000] The "BAR" variable is not set. Defaulting to a blank string. 
WARN[0000] The "BAR" variable is not set. Defaulting to a blank string. 
WARN[0000] The "BAR" variable is not set. Defaulting to a blank string. 
WARN[0000] The "BAR" variable is not set. Defaulting to a blank string. 
[+] Pulling 3/3
 ✔ ddev-ddev-utilities-latest Pulled                                       4.1s 
   ✔ 43c4264eed91 Pull complete                                            1.5s 
   ✔ 134d3819e0e6 Pull complete                                            2.4s 
WARN[0000] The "BAR" variable is not set. Defaulting to a blank string. 
WARN[0000] The "BAR" variable is not set. Defaulting to a blank string. 
WARN[0000] The "BAR" variable is not set. Defaulting to a blank string. 
WARN[0000] The "BAR" variable is not set. Defaulting to a blank string. 
Building project images....
Project images built in 2s.
...
```

This PR:

```
$ ddev start
Starting project... 
[+] Pulling 3/3
 ✔ ddev-ddev-utilities-latest Pulled                                       3.8s 
   ✔ 43c4264eed91 Pull complete                                            1.0s 
   ✔ 134d3819e0e6 Pull complete                                            2.1s 
Building project images....
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
