### PR TITLE
fix: improve MOTD and sponsorship message controls, fixes #7468, fixes #7676, fixes #6918

### DIFF
--- a/pkg/config/remoteconfig/messages.go
+++ b/pkg/config/remoteconfig/messages.go
@@ -2,6 +2,7 @@ package remoteconfig
 
 import (
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -220,6 +221,7 @@ func (c *remoteConfig) getTickerInterval() time.Duration {
 // interval has been elapsed.
 func (c *remoteConfig) showTickerMessage() bool {
 	return !output.JSONOutput &&
+		os.Getenv("CI") != "true" &&
 		!c.isTickerDisabled() &&
 		c.state.LastTickerAt.Add(c.getTickerInterval()).Before(time.Now())
 }
@@ -230,6 +232,8 @@ func (c *remoteConfig) showSponsorshipMessage() bool {
 	// Use the same interval as ticker for consistency (once per day)
 	sponsorshipInterval := c.getTickerInterval()
 	return !output.JSONOutput &&
+		os.Getenv("CI") != "true" &&
+		!c.isTickerDisabled() &&
 		c.state.LastSponsorshipAt.Add(sponsorshipInterval).Before(time.Now())
 }
 
@@ -362,8 +366,8 @@ func applyTableStyle(preset preset, writer table.Writer) {
 		}
 	case ticker:
 		style.Color = table.ColorOptions{
-			Header: text.Colors{text.BgHiWhite, text.FgBlack},
-			Row:    text.Colors{text.BgHiWhite, text.FgBlack},
+			Header: text.Colors{text.BgHiCyan, text.FgBlack},
+			Row:    text.Colors{text.BgHiCyan, text.FgBlack},
 		}
 	case sponsorship:
 		style.Color = table.ColorOptions{

--- a/pkg/globalconfig/values.go
+++ b/pkg/globalconfig/values.go
@@ -23,7 +23,7 @@ var ValidOmitContainers = map[string]bool{
 }
 
 // DdevNoInstrumentation is set to true if the env var is set
-var DdevNoInstrumentation = os.Getenv("DDEV_NO_INSTRUMENTATION") == "true"
+var DdevNoInstrumentation = os.Getenv("DDEV_NO_INSTRUMENTATION") == "true" || os.Getenv("CI") == "true"
 
 // DdevDebug is set to true if the env var is set
 // If DdevVerbose is true, DdevDebug is true


### PR DESCRIPTION
## The Issue

- #7468 - Need ability to disable sponsorship and MOTD messages
- #7676 - MOTD should have coloring to stand out better
- #6918

Currently the sponsorship message doesn't respect the ticker disabled setting, both messages show in CI environments where they clutter logs, and the MOTD lacks visual distinction compared to the colorful sponsorship message.

## How This PR Solves The Issue

1. Makes sponsorship message respect ticker disabled setting by checking `isTickerDisabled()` in `showSponsorshipMessage()`
2. Disables both MOTD and sponsorship when `CI=true` environment variable is set, which covers most automated test environments
3. Changes MOTD color from white (`BgHiWhite`) to cyan (`BgHiCyan`) to provide visual distinction from the green sponsorship message
4. Stops reporting instrumentation events/telemetry when CI=true

## Manual Testing Instructions

1. Delete `~/.ddev/.remote-config`, `~/.ddev/.state.yaml`, and `~/.ddev/.sponsorship-data` to reset state
2. Run `ddev start` - you should see both MOTD (cyan) and sponsorship (green) messages with different colors
3. Set ticker interval to -1 to disable: `ddev config global --ticker-interval=-1`
5. Run `ddev start` - neither MOTD nor sponsorship should appear
6. Reset ticker: `ddev config global --ticker-interval=1`
7. Set `CI=true` and run `ddev start` - neither message should appear
8. Unset `CI` and run `ddev start` - messages should appear again

## Automated Testing Overview

No new tests needed - existing tests cover the remote config messaging system.

## Release/Deployment Notes

The CI environment variable check is a standard convention (used by GitHub Actions, GitLab CI, etc.) and will automatically suppress these messages in most CI environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

