### PR TITLE
docs(moodle): update moodle quickstart to have composer_root in root, fixes #7692 [skip buildkite]

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -658,10 +658,10 @@ ddev magento setup:upgrade
 
     ```bash
     mkdir my-moodle-site && cd my-moodle-site
-    ddev config --composer-root=public --docroot=public --webserver-type=apache-fpm
+    ddev config --docroot=public --webserver-type=apache-fpm
     ddev start
     ddev composer create-project moodle/moodle
-    ddev exec 'php public/admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
+    ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
     ddev launch /login
     ```
 

--- a/docs/tests/moodle.bats
+++ b/docs/tests/moodle.bats
@@ -15,8 +15,7 @@ teardown() {
   # mkdir ${PROJNAME} && cd ${PROJNAME}
   run mkdir ${PROJNAME} && cd ${PROJNAME}
   assert_success
-  # ddev config --composer-root=public --docroot=public --webserver-type=apache-fpm
-  run ddev config --composer-root=public --docroot=public --webserver-type=apache-fpm
+  run ddev config --docroot=public --webserver-type=apache-fpm
   assert_success
   # ddev start -y
   run ddev start -y
@@ -24,8 +23,7 @@ teardown() {
   # ddev composer create-project moodle/moodle
   run ddev composer create-project moodle/moodle
   assert_success
-  # ddev exec 'php public/admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
-  run ddev exec 'php public/admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
+  run ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
   assert_success
   # ddev launch
   run bash -c "DDEV_DEBUG=true ddev launch /login"


### PR DESCRIPTION

## The Issue

- #7692 

Moodle quickstart just broke; I didn't find the reason. I think they might have shifted underneath us some time ago, but just added validation about using "public" at the end of URL, no longer allowed.

## How This PR Solves The Issue

Don't use `composer_root`

## Manual Testing Instructions

Check out the quickstart.

For extra credit, find the moodle change notice. 

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
