### PR TITLE
fix: ddev debug test shouldn't leave dead ddev-utilities containers [skip ci]

### DIFF
--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -58,7 +58,7 @@ get_default_shell() {
 }
 
 get_global_ddev_dir() {
-  ddev version -j | docker run -i ddev/ddev-utilities jq -r '.raw["global-ddev-dir"]'
+  ddev version -j | docker run --rm -i ddev/ddev-utilities jq -r '.raw["global-ddev-dir"]'
 }
 
 function cleanup {


### PR DESCRIPTION

## The Issue

I noticed a bunch of dead ddev-utilities containers on my machine.

```
rfay@rfay-mba-m4:~/workspace/ddev$ docker ps -a | grep jq
caf74504871d   ddev/ddev-utilities                                             "jq -r .raw[\"global-…"   5 days ago       Exited (0) 5 days ago               infallible_elbakyan
61c9ed48786d   ddev/ddev-utilities                                             "jq -r .raw[\"global-…"   5 days ago       Exited (0) 5 days ago               reverent_hamilton
0c3809960c75   ddev/ddev-utilities                                             "jq -r .raw[\"global-…"   5 days ago       Exited (0) 5 days ago               stoic_blackburn
6059e07e313d   ddev/ddev-utilities                                             "jq -r .raw[\"global-…"   5 days ago       Exited (3) 5 days ago               stupefied_grothendieck
383aa9b21945   ddev/ddev-utilities                                             "jq -r .raw[\"global-…"   5 days ago       Exited (0) 5 days ago               gracious_wu
e5041e8c2ffb   ddev/ddev-utilities                                             "jq -r .raw[\"global-…"   5 days ago       Exited (0) 5 days ago               elated_nash
9bb1991fd254   ddev/ddev-utilities                                             "jq -r .raw[\"global-…"   5 days ago       Exited (137) 2 days ago             confident_montalcini
50b311bec8ec   ddev/ddev-utilities                                             "-t jq -r .raw[\"glob…"   5 days ago       Created                             frosty_bell
8e7569cf9811   ddev/ddev-utilities                                             "jq -r .raw[\"global-…"   5 days ago       Exited (0) 5 days ago               blissful_euler
b9568a57648a   ddev/ddev-utilities                                             "jq -r .raw[\"global-…"   5 weeks ago      Exited (0) 5 weeks ago              naughty_dewdney

```

## How This PR Solves The Issue

`ddev debug test` should use `docker run --rm` to run ddev-utilities

## Manual Testing Instructions

`ddev debug test` and look for dead containers with `docker ps -aq`

I put this as `[skip ci]` so manual testing only

