### PR TITLE
docs(quickstart): Improve quickstarts to resolve problems with copy/paste

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -22,7 +22,7 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Download Backdrop core and create admin user:
@@ -86,7 +86,7 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Import database and files backups:
@@ -142,7 +142,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install CakePHP via Composer:
@@ -187,7 +187,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install dependencies and launch:
@@ -372,7 +372,7 @@ Further information on the DDEV procedure can also be found in the [Contao docum
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Download the Contao Manager:
@@ -431,7 +431,7 @@ DDEV injects a number of special environment variables into the container (via `
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Scaffold a new project with Composer:
@@ -480,7 +480,7 @@ DDEV injects a number of special environment variables into the container (via `
     Start DDEV and install Composer packages:
 
     ```bash
-    ddev start -y
+    ddev start
     ddev composer install
     ```
 
@@ -533,7 +533,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install Drupal via Composer:
@@ -585,7 +585,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install Drupal CMS via Composer:
@@ -631,7 +631,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install Drupal via Composer:
@@ -689,7 +689,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     Start DDEV and launch:
 
     ```bash
-    ddev start -y
+    ddev start
     ddev launch /install.php
     ```
 
@@ -728,7 +728,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
     ```bash
     ddev config --project-type=drupal11 --docroot=web
-    ddev start -y
+    ddev start
     ```
 
     Install dependencies and set up Drupal:
@@ -787,7 +787,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
     ```bash
     ddev config --database=mysql:8.0
-    ddev start -y
+    ddev start
     ```
 
     Launch the installation wizard:
@@ -833,7 +833,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
     ```bash
     ddev config --database=mysql:8.0
-    ddev start -y
+    ddev start
     ```
 
     Install Composer dependencies and prepare installation:
@@ -993,7 +993,7 @@ ddev launch $(ddev drush uli)
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install Grav via Composer:
@@ -1045,7 +1045,7 @@ ddev launch $(ddev drush uli)
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install dependencies and initialize Grav:
@@ -1224,7 +1224,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install the Kirby Starterkit:
@@ -1275,7 +1275,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Launch the site:
@@ -1323,7 +1323,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install Laravel via Composer:
@@ -1369,7 +1369,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install Laravel via Composer:
@@ -1466,7 +1466,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Run Laravel installer (follow prompts and select starter kit):
@@ -1540,7 +1540,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
     ```bash
     ddev config --project-type=laravel --docroot=public
-    ddev start -y
+    ddev start
     ```
 
     Install dependencies and run post-install scripts:
@@ -1709,7 +1709,7 @@ ddev magento setup:upgrade
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install Moodle via Composer:
@@ -1767,7 +1767,7 @@ ddev magento setup:upgrade
     export SVELTEKIT_SITENAME=my-sveltekit-site
     mkdir ${SVELTEKIT_SITENAME} && cd ${SVELTEKIT_SITENAME}
     ddev config --project-type=generic --webserver-type=generic
-    ddev start -y
+    ddev start
 
     cat <<EOF > .ddev/config.sveltekit.yaml
     web_extra_exposed_ports:
@@ -1806,7 +1806,7 @@ ddev magento setup:upgrade
     export NODEJS_SITENAME=my-nodejs-site
     mkdir ${NODEJS_SITENAME} && cd ${NODEJS_SITENAME}
     ddev config --project-type=generic --webserver-type=generic
-    ddev start -y
+    ddev start
     ddev npm install express
 
     cat <<EOF > .ddev/config.nodejs.yaml
@@ -1845,7 +1845,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Initialize and configure Composer:
@@ -1925,7 +1925,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
 
     ```bash
     ddev config --project-type=magento --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
-    ddev start -y
+    ddev start
     ```
 
     Install Composer dependencies:
@@ -1983,7 +1983,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install Pimcore via Composer:
@@ -2072,7 +2072,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
 
     ```bash
     ddev config --project-type=php --webserver-type=apache-fpm
-    ddev start -y
+    ddev start
     ```
 
     Launch ProcessWire:
@@ -2111,7 +2111,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install ProcessWire via Composer:
@@ -2163,7 +2163,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
 
     ```bash
     ddev config --webserver-type=apache-fpm
-    ddev start -y
+    ddev start
     ```
 
     Launch ProcessWire:
@@ -2224,7 +2224,7 @@ If you have any questions there is lots of help in the [DDEV thread in the Proce
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install Shopware via Composer:
@@ -2281,7 +2281,7 @@ Use a new or existing Composer project, or clone a Git repository.
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install Silverstripe via Composer:
@@ -2321,7 +2321,7 @@ Use a new or existing Composer project, or clone a Git repository.
     git clone <my-silverstripe-repo> my-silverstripe-site
     cd my-silverstripe-site
     ddev config --project-type=silverstripe --docroot=public
-    ddev start -y
+    ddev start
     ddev composer install
     ddev sake dev/build flush=all
     ```
@@ -2386,7 +2386,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
     git clone <my-statamic-repo> my-statamic-site
     cd my-statamic-site
     ddev config --project-type=laravel --docroot=public
-    ddev start -y
+    ddev start
     ddev composer install
     ddev exec "php artisan key:generate"
     ddev launch /cp
@@ -2503,7 +2503,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install Symfony via Composer:
@@ -2543,7 +2543,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ```bash
     mkdir my-symfony-site && cd my-symfony-site
     ddev config --project-type=symfony --docroot=public
-    ddev start -y
+    ddev start
     ddev exec symfony check:requirements
     ddev exec symfony new temp --version="7.1.*" --webapp
     # 'symfony new' can't install in the current directory right away,
@@ -2558,7 +2558,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     git clone <my-symfony-repo> my-symfony-site
     cd my-symfony-site
     ddev config --project-type=symfony --docroot=public
-    ddev start -y
+    ddev start
     ddev composer install
     ddev launch
     ```
@@ -2592,7 +2592,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Install TYPO3 via Composer:
@@ -2669,7 +2669,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
     git clone ${PROJECT_GIT_REPOSITORY} .
     ddev config --project-type=typo3 --docroot=public --php-version=8.3
-    ddev start -y
+    ddev start
     ddev composer install
     ddev exec touch public/FIRST_INSTALL
     ddev launch /typo3/install.php
@@ -2695,7 +2695,7 @@ There are several easy ways to use DDEV with WordPress:
     Start DDEV (this may take a minute):
 
     ```bash
-    ddev start -y
+    ddev start
     ```
 
     Download WordPress:
@@ -2745,7 +2745,7 @@ There are several easy ways to use DDEV with WordPress:
     ```bash
     mkdir my-wp-site && cd my-wp-site
     ddev config --project-type=wordpress --docroot=web
-    ddev start -y
+    ddev start
     ddev composer create-project roots/bedrock
     ```
 
@@ -2779,7 +2779,7 @@ There are several easy ways to use DDEV with WordPress:
     git clone ${PROJECT_GIT_URL} my-wp-site
     cd my-wp-site
     ddev config --project-type=wordpress
-    ddev start -y
+    ddev start
     ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
     ddev launch wp-admin/
     ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -10,19 +10,55 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
 
 === "New projects"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-backdrop-site && cd my-backdrop-site
     ddev config --project-type=backdrop
     # Add the official Bee CLI add-on
     ddev add-on get backdrop-ops/ddev-backdrop-bee
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Download Backdrop core and create admin user:
+
+    ```bash
     # Download Backdrop core
     ddev bee download-core
     # Create admin user
     ddev bee si --username=admin --password=Password123 --db-name=db --db-user=db --db-pass=db --db-host=db --auto
+    ```
+
+    Launch the site:
+
+    ```bash
     # Login using `admin` user and `Password123` password
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-backdrop.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-backdrop-site && cd my-backdrop-site
+        ddev config --project-type=backdrop
+        ddev add-on get backdrop-ops/ddev-backdrop-bee
+        ddev start -y
+        ddev bee download-core
+        ddev bee si --username=admin --password=Password123 --db-name=db --db-user=db --db-pass=db --db-host=db --auto
+        ddev launch
+        EOF
+        chmod +x setup-backdrop.sh
+        ./setup-backdrop.sh
+        ```
 
 === "Existing projects"
 
@@ -42,7 +78,7 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
     ddev add-on get backdrop-ops/ddev-backdrop-bee
 
     # Start the project
-    ddev start
+    ddev start -y
 
     # Import a database backup:
     ddev import-db --file=/path/to/db.sql.gz
@@ -64,21 +100,67 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
 === "Composer"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-cakephp-site && cd my-cakephp-site
     ddev config --project-type=cakephp --docroot=webroot
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Install CakePHP via Composer:
+
+    ```bash
     ddev composer create-project --prefer-dist --no-interaction cakephp/app:~5.0
+    ```
+
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
 
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-cakephp.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-cakephp-site && cd my-cakephp-site
+        ddev config --project-type=cakephp --docroot=webroot
+        ddev start -y
+        ddev composer create-project --prefer-dist --no-interaction cakephp/app:~5.0
+        ddev launch
+        EOF
+        chmod +x setup-cakephp.sh
+        ./setup-cakephp.sh
+        ```
+
 === "Git Clone"
+
+    Clone the repository and configure DDEV:
 
     ```bash
     git clone <my-cakephp-repo> my-cakephp-site
     cd my-cakephp-site
     ddev config --project-type=cakephp --docroot=webroot
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Install dependencies and launch:
+
+    ```bash
     ddev composer install
     ddev cake
     ddev launch
@@ -88,14 +170,31 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
 [CiviCRM Standalone](https://civicrm.org/blog/ufundo/next-steps-civicrm-standalone) allows running [CiviCRM](https://civicrm.org/) without a CMS. Visit [Install CiviCRM (Standalone)](https://docs.civicrm.org/installation/en/latest/standalone) for more installation details.
 
+Create the project directory and configure DDEV:
+
 ```bash
 mkdir my-civicrm-site && cd my-civicrm-site
 ddev config --project-type=php --composer-root=core --upload-dirs=public/media
-ddev start
+```
+
+Start DDEV (this may take a minute):
+
+```bash
+ddev start -y
+```
+
+Download and extract CiviCRM:
+
+```bash
 ddev exec "curl -LsS https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz -o /tmp/civicrm-standalone.tar.gz"
 ddev exec "tar --strip-components=1 -xzf /tmp/civicrm-standalone.tar.gz"
 ddev composer require civicrm/cli-tools --no-scripts
-# You can now install CiviCRM manually in your browser using `ddev launch`
+```
+
+Install CiviCRM (or use `ddev launch` to install manually):
+
+```bash
+# You can install CiviCRM manually in your browser using `ddev launch`
 # and selecting `db` for the server and `db` for database/username/password
 # or do the same automatically using the command below:
 # The parameter `-m loadGenerated=1` includes sample data
@@ -106,8 +205,39 @@ ddev exec cv core:install \
     -m extras.adminUser=admin \
     -m extras.adminPass=admin \
     -m extras.adminEmail=admin@example.com
+```
+
+Launch the site:
+
+```bash
 ddev launch
 ```
+
+??? tip "Prefer to run as a script?"
+    To run the whole setup as a script, examine and run this script:
+
+    ```bash
+    cat > setup-civicrm.sh << 'EOF'
+    #!/bin/bash
+    set -euo pipefail
+    mkdir my-civicrm-site && cd my-civicrm-site
+    ddev config --project-type=php --composer-root=core --upload-dirs=public/media
+    ddev start -y
+    ddev exec "curl -LsS https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz -o /tmp/civicrm-standalone.tar.gz"
+    ddev exec "tar --strip-components=1 -xzf /tmp/civicrm-standalone.tar.gz"
+    ddev composer require civicrm/cli-tools --no-scripts
+    ddev exec cv core:install \
+        --cms-base-url='$DDEV_PRIMARY_URL' \
+        --db=mysql://db:db@db/db \
+        -m loadGenerated=1 \
+        -m extras.adminUser=admin \
+        -m extras.adminPass=admin \
+        -m extras.adminEmail=admin@example.com
+    ddev launch
+    EOF
+    chmod +x setup-civicrm.sh
+    ./setup-civicrm.sh
+    ```
 
 ## Contao
 
@@ -115,42 +245,114 @@ Further information on the DDEV procedure can also be found in the [Contao docum
 
 === "Composer"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-contao-site && cd my-contao-site
     ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+    ```
+
+    Install Contao via Composer (this may take a minute):
+
+    ```bash
     ddev composer create-project contao/managed-edition:5.3
+    ```
 
-    # Set DATABASE_URL and MAILER_DSN in .env.local
+    Configure database and mailer settings:
+
+    ```bash
     ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
+    ```
 
-    # Create the database
+    Create the database:
+
+    ```bash
     ddev exec contao-console contao:migrate --no-interaction
+    ```
 
-    # Create backend user
+    Create backend user:
+
+    ```bash
     ddev exec contao-console contao:user:create --username=admin --name=Administrator --email=admin@example.com --language=en --password=Password123 --admin
+    ```
 
-    # Access the administration area
+    Launch the administration area:
+
+    ```bash
     ddev launch contao
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-contao.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-contao-site && cd my-contao-site
+        ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+        ddev composer create-project contao/managed-edition:5.3
+        ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
+        ddev exec contao-console contao:migrate --no-interaction
+        ddev exec contao-console contao:user:create --username=admin --name=Administrator --email=admin@example.com --language=en --password=Password123 --admin
+        ddev launch contao
+        EOF
+        chmod +x setup-contao.sh
+        ./setup-contao.sh
+        ```
 
 === "Contao Manager"
 
     Like most PHP projects, Contao could be installed and updated with Composer. The [Contao Manager](https://docs.contao.org/manual/en/installation/contao-manager/) is a tool that provides a graphical user interface to manage a Contao installation.
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-contao-site && cd my-contao-site
     ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+    ```
 
-    # set DATABASE_URL and MAILER_DSN in .env.local
+    Configure database and mailer settings:
+
+    ```bash
     ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
+    ```
 
-    # Download the Contao Manager
-    ddev start
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Download the Contao Manager:
+
+    ```bash
     ddev exec "wget -O public/contao-manager.phar.php https://download.contao.org/contao-manager/stable/contao-manager.phar"
+    ```
 
-    # Follow the further steps within the Contao Manager
+    Launch the Contao Manager and follow the setup wizard:
+
+    ```bash
     ddev launch contao-manager.phar.php
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-contao-manager.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-contao-site && cd my-contao-site
+        ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+        ddev dotenv set .env.local --database-url=mysql://db:db@db:3306/db --mailer-dsn=smtp://localhost:1025
+        ddev start -y
+        ddev exec "wget -O public/contao-manager.phar.php https://download.contao.org/contao-manager/stable/contao-manager.phar"
+        ddev launch contao-manager.phar.php
+        EOF
+        chmod +x setup-contao-manager.sh
+        ./setup-contao-manager.sh
+        ```
 
 === "Demo Website"
 
@@ -168,21 +370,44 @@ DDEV injects a number of special environment variables into the container (via `
 
 === "New projects"
 
+    Create the project directory and configure DDEV:
+
     ```bash
-    # Create a project directory and move into it:
     mkdir my-craft-site && cd my-craft-site
-
-    # Set up the DDEV environment and boot the project:
     ddev config --project-type=craftcms --docroot=web
-    ddev start
+    ```
 
-    # Scaffold a new project with Composer:
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Scaffold a new project with Composer:
+
+    ```bash
     ddev composer create-project craftcms/craft
     ```
 
-    Craft’s setup wizard will start automatically!
+    Craft's setup wizard will start automatically!
 
     [Third-party starter projects](https://craftcms.com/knowledge-base/using-the-starter-project#community-starter-projects) can be substituted for `craftcms/craft` when running `ddev composer create-project`.
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-craft.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-craft-site && cd my-craft-site
+        ddev config --project-type=craftcms --docroot=web
+        ddev start -y
+        ddev composer create-project craftcms/craft
+        EOF
+        chmod +x setup-craft.sh
+        ./setup-craft.sh
+        ```
 
 === "Existing projects"
 
@@ -197,7 +422,7 @@ DDEV injects a number of special environment variables into the container (via `
     ddev config --project-type=craftcms --docroot=web
 
     # Boot the project and install Composer packages:
-    ddev start
+    ddev start -y
     ddev composer install
 
     # Import a database backup and open the site in your browser:
@@ -218,12 +443,29 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
 === "Drupal 11"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal11 --docroot=web
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Install Drupal via Composer:
+
+    ```bash
     ddev composer create-project "drupal/recommended-project:^11"
     ddev composer require drush/drush
+    ```
+
+    Run Drupal installation and launch:
+
+    ```bash
     ddev drush site:install --account-name=admin --account-pass=admin -y
     ddev launch
     # or automatically log in with:
@@ -232,26 +474,96 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
     Read more about: [Drupal Core](https://new.drupal.org/about/overview/technical) & [Documentation](https://www.drupal.org/docs)
 
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-drupal11.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-drupal-site && cd my-drupal-site
+        ddev config --project-type=drupal11 --docroot=web
+        ddev start -y
+        ddev composer create-project "drupal/recommended-project:^11"
+        ddev composer require drush/drush
+        ddev drush site:install --account-name=admin --account-pass=admin -y
+        ddev launch
+        EOF
+        chmod +x setup-drupal11.sh
+        ./setup-drupal11.sh
+        ```
+
 === "Drupal CMS"
+
+    Create the project directory and configure DDEV:
 
     ```bash
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal11 --docroot=web
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Install Drupal CMS via Composer:
+
+    ```bash
     ddev composer create-project drupal/cms
+    ```
+
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
 
     Read more about: [Drupal CMS](https://new.drupal.org/drupal-cms) & [Documentation](https://new.drupal.org/docs/drupal-cms)
 
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-drupal-cms.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-drupal-site && cd my-drupal-site
+        ddev config --project-type=drupal11 --docroot=web
+        ddev start -y
+        ddev composer create-project drupal/cms
+        ddev launch
+        EOF
+        chmod +x setup-drupal-cms.sh
+        ./setup-drupal-cms.sh
+        ```
+
 === "Drupal 10"
+
+    Create the project directory and configure DDEV:
 
     ```bash
     mkdir my-drupal-site && cd my-drupal-site
     ddev config --project-type=drupal10 --docroot=web
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Install Drupal via Composer:
+
+    ```bash
     ddev composer create-project "drupal/recommended-project:^10"
     ddev composer require drush/drush
+    ```
+
+    Run Drupal installation and launch:
+
+    ```bash
     ddev drush site:install --account-name=admin --account-pass=admin -y
     ddev launch
     # or automatically log in with:
@@ -259,6 +571,25 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     ```
 
     Read more about: [Drupal Core](https://new.drupal.org/about/overview/technical) & [Documentation](https://www.drupal.org/docs)
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-drupal10.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-drupal-site && cd my-drupal-site
+        ddev config --project-type=drupal10 --docroot=web
+        ddev start -y
+        ddev composer create-project "drupal/recommended-project:^10"
+        ddev composer require drush/drush
+        ddev drush site:install --account-name=admin --account-pass=admin -y
+        ddev launch
+        EOF
+        chmod +x setup-drupal10.sh
+        ./setup-drupal10.sh
+        ```
 
 === "Drupal 6/7"
 
@@ -266,7 +597,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     git clone https://github.com/example/my-drupal-site
     cd my-drupal-site
     ddev config # Follow the prompts to select type and docroot
-    ddev start
+    ddev start -y
     ddev launch /install.php
     ```
 
@@ -281,7 +612,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
     git clone ${PROJECT_GIT_URL} my-drupal-site
     cd my-drupal-site
     ddev config --project-type=drupal11 --docroot=web
-    ddev start
+    ddev start -y
     ddev composer install # If a composer build
     ddev drush site:install --account-name=admin --account-pass=admin -y
     ddev launch
@@ -293,35 +624,107 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
 === "ExpressionEngine ZIP File Download"
 
+    Create the project directory:
+
     ```bash
     mkdir my-ee-site && cd my-ee-site
+    ```
+
+    Download and extract the latest ExpressionEngine release:
+
+    ```bash
     curl -o ee.zip -L $(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
     unzip ee.zip && rm -f ee.zip
+    ```
+
+    Configure and start DDEV:
+
+    ```bash
     ddev config --database=mysql:8.0
-    ddev start
-    ddev launch /admin.php # Open installation wizard in browser
+    ddev start -y
+    ```
+
+    Launch the installation wizard:
+
+    ```bash
+    ddev launch /admin.php
     ```
 
     When the installation wizard prompts for database settings, enter `db` for the _DB Server Address_, _DB Name_, _DB Username_, and _DB Password_.
 
     Visit your site.
 
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-ee.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-ee-site && cd my-ee-site
+        curl -o ee.zip -L $(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
+        unzip ee.zip && rm -f ee.zip
+        ddev config --database=mysql:8.0
+        ddev start -y
+        ddev launch /admin.php
+        EOF
+        chmod +x setup-ee.sh
+        ./setup-ee.sh
+        ```
+
 === "ExpressionEngine Git Checkout"
 
     Follow these steps based on the [ExpressionEngine Git Repository README.md](https://github.com/ExpressionEngine/ExpressionEngine#how-to-install):
 
+    Create the project directory and clone the repository:
+
     ```bash
     mkdir my-ee-site && cd my-ee-site
     git clone https://github.com/ExpressionEngine/ExpressionEngine .
+    ```
+
+    Configure and start DDEV:
+
+    ```bash
     ddev config --database=mysql:8.0
-    ddev start
+    ddev start -y
+    ```
+
+    Install Composer dependencies and prepare installation:
+
+    ```bash
     ddev composer install
     touch system/user/config/config.php
     echo "EE_INSTALL_MODE=TRUE" >.env.php
-    ddev launch /admin.php  # Open installation wizard in browser
+    ```
+
+    Launch the installation wizard:
+
+    ```bash
+    ddev launch /admin.php
     ```
 
     When the installation wizard prompts for database settings, enter `db` for the _DB Server Address_, _DB Name_, _DB Username_, and _DB Password_.
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-ee-git.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-ee-site && cd my-ee-site
+        git clone https://github.com/ExpressionEngine/ExpressionEngine .
+        ddev config --database=mysql:8.0
+        ddev start -y
+        ddev composer install
+        touch system/user/config/config.php
+        echo "EE_INSTALL_MODE=TRUE" >.env.php
+        ddev launch /admin.php
+        EOF
+        chmod +x setup-ee-git.sh
+        ./setup-ee-git.sh
+        ```
 
 ## Generic (FrankenPHP)
 
@@ -337,7 +740,7 @@ The `generic` `webserver_type` is used here, so the `ddev-webserver` does not st
 export FRANKENPHP_SITENAME=my-frankenphp-site
 mkdir ${FRANKENPHP_SITENAME} && cd ${FRANKENPHP_SITENAME}
 ddev config --project-type=drupal11 --webserver-type=generic --docroot=web --php-version=8.4
-ddev start
+ddev start -y
 
 cat <<'EOF' > .ddev/config.frankenphp.yaml
 web_extra_daemons:
@@ -373,7 +776,7 @@ ddev launch $(ddev drush uli)
     ```bash
     mkdir my-grav-site && cd my-grav-site
     ddev config --omit-containers=db
-    ddev start
+    ddev start -y
     ddev composer create-project getgrav/grav
     ddev exec gpm install admin -y
     ddev launch
@@ -385,7 +788,7 @@ ddev launch $(ddev drush uli)
     mkdir my-grav-site && cd my-grav-site
     git clone -b master https://github.com/getgrav/grav.git .
     ddev config --omit-containers=db
-    ddev start
+    ddev start -y
     ddev composer install
     ddev exec grav install
     ddev exec gpm install admin -y
@@ -414,7 +817,7 @@ Install [Ibexa DXP](https://www.ibexa.co) OSS Edition.
 ```bash
 mkdir my-ibexa-site && cd my-ibexa-site
 ddev config --project-type=php --docroot=public --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
-ddev start
+ddev start -y
 ddev composer create-project ibexa/oss-skeleton
 ddev exec console ibexa:install
 ddev exec console ibexa:graphql:generate-schema
@@ -427,17 +830,53 @@ Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/insta
 
 ## Joomla
 
+Create the project directory and download Joomla:
+
 ```bash
 mkdir my-joomla-site && cd my-joomla-site
 # Download the latest version of Joomla! and unzip it.
 # This can be manually downloaded from https://downloads.joomla.org/ or done using curl as here.
 curl -o joomla.zip -L $(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^Joomla.*Stable-Full_Package\\.zip$")))[0].browser_download_url')
 unzip joomla.zip && rm -f joomla.zip
+```
+
+Configure DDEV:
+
+```bash
 ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
-ddev start
+```
+
+Start DDEV (this may take a minute):
+
+```bash
+ddev start -y
+```
+
+Install Joomla and launch:
+
+```bash
 ddev php installation/joomla.php install --site-name="My Joomla Site" --admin-user="Administrator" --admin-username=admin --admin-password=AdminAdmin1! --admin-email=admin@example.com --db-type=mysql --db-encryption=0 --db-host=db --db-user=db --db-pass="db" --db-name=db --db-prefix=ddev_ --public-folder=""
 ddev launch /administrator
 ```
+
+??? tip "Prefer to run as a script?"
+    To run the whole setup as a script, examine and run this script:
+
+    ```bash
+    cat > setup-joomla.sh << 'EOF'
+    #!/bin/bash
+    set -euo pipefail
+    mkdir my-joomla-site && cd my-joomla-site
+    curl -o joomla.zip -L $(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^Joomla.*Stable-Full_Package\\.zip$")))[0].browser_download_url')
+    unzip joomla.zip && rm -f joomla.zip
+    ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
+    ddev start -y
+    ddev php installation/joomla.php install --site-name="My Joomla Site" --admin-user="Administrator" --admin-username=admin --admin-password=AdminAdmin1! --admin-email=admin@example.com --db-type=mysql --db-encryption=0 --db-host=db --db-user=db --db-pass="db" --db-name=db --db-prefix=ddev_ --public-folder=""
+    ddev launch /administrator
+    EOF
+    chmod +x setup-joomla.sh
+    ./setup-joomla.sh
+    ```
 
 ## Kirby CMS
 
@@ -455,7 +894,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     ddev config --omit-containers=db --webserver-type=apache-fpm
 
     # Spin up the project and install the Kirby Starterkit
-    ddev start
+    ddev start -y
     ddev composer create-project getkirby/starterkit
 
     # Open the site in your browser
@@ -474,7 +913,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
     ddev config --omit-containers=db --webserver-type=apache-fpm
 
     # Spin up the project
-    ddev start
+    ddev start -y
 
     # Open the site in your browser
     ddev launch
@@ -493,13 +932,47 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
     Laravel defaults to SQLite, but we use MariaDB to better mimic a production environment:
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-laravel-site && cd my-laravel-site
     ddev config --project-type=laravel --docroot=public
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Install Laravel via Composer:
+
+    ```bash
     ddev composer create-project "laravel/laravel:^12"
+    ```
+
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-laravel.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-laravel-site && cd my-laravel-site
+        ddev config --project-type=laravel --docroot=public
+        ddev start -y
+        ddev composer create-project "laravel/laravel:^12"
+        ddev launch
+        EOF
+        chmod +x setup-laravel.sh
+        ./setup-laravel.sh
+        ```
 
 === "Composer (SQLite)"
 
@@ -508,7 +981,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     ```bash
     mkdir my-laravel-site && cd my-laravel-site
     ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
-    ddev start
+    ddev start -y
     ddev composer create-project "laravel/laravel:^12"
     ddev launch
     ```
@@ -544,7 +1017,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     DOCKERFILEEND
 
     # Start the project
-    ddev start
+    ddev start -y
 
     # Follow the prompts, select a starter kit of your choice (or none),
     # and agree to run npm commands
@@ -574,7 +1047,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
     git clone <my-laravel-repo> my-laravel-site
     cd my-laravel-site
     ddev config --project-type=laravel --docroot=public
-    ddev start
+    ddev start -y
     ddev composer install
     ddev composer run-script post-root-package-install
     ddev composer run-script post-create-project-cmd
@@ -615,21 +1088,41 @@ Normal details of a Composer build for Magento 2 are on the [Magento 2 site](htt
         "${docker_command[@]}"
         ```
 
+Create the project directory and configure DDEV:
+
 ```bash
 export MAGENTO_HOSTNAME=my-magento2-site
 mkdir ${MAGENTO_HOSTNAME} && cd ${MAGENTO_HOSTNAME}
 ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
 ddev add-on get ddev/ddev-opensearch
-ddev start
+```
+
+Start DDEV (this may take a minute):
+
+```bash
+ddev start -y
+```
+
+Install Magento via Composer:
+
+```bash
 ddev composer create-project --repository https://repo.magento.com/ magento/project-community-edition
 rm -f app/etc/env.php
+```
 
+Run Magento setup:
+
+```bash
 ddev magento setup:install --base-url="https://${MAGENTO_HOSTNAME}.ddev.site/" \
     --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db \
     --opensearch-host=opensearch --search-engine=opensearch --opensearch-port=9200 \
     --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
     --admin-user=admin --admin-password=Password123 --language=en_US
+```
 
+Configure Magento and launch:
+
+```bash
 ddev magento deploy:mode:set developer
 ddev magento module:disable Magento_TwoFactorAuth Magento_AdminAdobeImsTwoFactorAuth
 ddev config --disable-settings-management=false
@@ -640,6 +1133,35 @@ ddev launch /admin_ddev
 ```
 
 Change the admin name and related information as needed.
+
+??? tip "Prefer to run as a script?"
+    To run the whole setup as a script, examine and run this script:
+
+    ```bash
+    cat > setup-magento.sh << 'EOF'
+    #!/bin/bash
+    set -euo pipefail
+    export MAGENTO_HOSTNAME=my-magento2-site
+    mkdir ${MAGENTO_HOSTNAME} && cd ${MAGENTO_HOSTNAME}
+    ddev config --project-type=magento2 --docroot=pub --upload-dirs=media --disable-settings-management
+    ddev add-on get ddev/ddev-opensearch
+    ddev start -y
+    ddev composer create-project --repository https://repo.magento.com/ magento/project-community-edition
+    rm -f app/etc/env.php
+    ddev magento setup:install --base-url="https://${MAGENTO_HOSTNAME}.ddev.site/" \
+        --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db \
+        --opensearch-host=opensearch --search-engine=opensearch --opensearch-port=9200 \
+        --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
+        --admin-user=admin --admin-password=Password123 --language=en_US
+    ddev magento deploy:mode:set developer
+    ddev magento module:disable Magento_TwoFactorAuth Magento_AdminAdobeImsTwoFactorAuth
+    ddev config --disable-settings-management=false
+    ddev magento setup:config:set --backend-frontname="admin_ddev" --no-interaction
+    ddev launch /admin_ddev
+    EOF
+    chmod +x setup-magento.sh
+    ./setup-magento.sh
+    ```
 
 The admin login URL is specified by `frontName` in `app/etc/env.php`.
 
@@ -654,12 +1176,34 @@ ddev magento setup:upgrade
 
 === "Composer"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-moodle-site && cd my-moodle-site
     ddev config --docroot=public --webserver-type=apache-fpm
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Install Moodle via Composer:
+
+    ```bash
     ddev composer create-project moodle/moodle
+    ```
+
+    Run Moodle installation:
+
+    ```bash
     ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
+    ```
+
+    Launch Moodle:
+
+    ```bash
     ddev launch /login
     ```
 
@@ -668,7 +1212,25 @@ ddev magento setup:upgrade
     Visit the [Moodle Admin Quick Guide](https://docs.moodle.org/400/en/Admin_quick_guide) for more information.
 
     !!!tip
-        Moodle relies on a periodic cron job—don’t forget to set that up! See [ddev/ddev-cron](https://github.com/ddev/ddev-cron).
+        Moodle relies on a periodic cron job—don't forget to set that up! See [ddev/ddev-cron](https://github.com/ddev/ddev-cron).
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-moodle.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-moodle-site && cd my-moodle-site
+        ddev config --docroot=public --webserver-type=apache-fpm
+        ddev start -y
+        ddev composer create-project moodle/moodle
+        ddev exec 'php admin/cli/install.php --non-interactive --agree-license --wwwroot=$DDEV_PRIMARY_URL --dbtype=mariadb --dbhost=db --dbname=db --dbuser=db --dbpass=db --fullname="DDEV Moodle Demo" --shortname=Demo --adminpass=password'
+        ddev launch /login
+        EOF
+        chmod +x setup-moodle.sh
+        ./setup-moodle.sh
+        ```
 
 ## Node.js
 
@@ -682,7 +1244,7 @@ ddev magento setup:upgrade
     export SVELTEKIT_SITENAME=my-sveltekit-site
     mkdir ${SVELTEKIT_SITENAME} && cd ${SVELTEKIT_SITENAME}
     ddev config --project-type=generic --webserver-type=generic
-    ddev start
+    ddev start -y
 
     cat <<EOF > .ddev/config.sveltekit.yaml
     web_extra_exposed_ports:
@@ -721,7 +1283,7 @@ ddev magento setup:upgrade
     export NODEJS_SITENAME=my-nodejs-site
     mkdir ${NODEJS_SITENAME} && cd ${NODEJS_SITENAME}
     ddev config --project-type=generic --webserver-type=generic
-    ddev start
+    ddev start -y
     ddev npm install express
 
     cat <<EOF > .ddev/config.nodejs.yaml
@@ -753,7 +1315,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
     ```bash
     mkdir my-openmage-site && cd my-openmage-site
     ddev config --project-type=magento --docroot=public_test --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
-    ddev start
+    ddev start -y
     ddev composer init --name "openmage/composer-test" --description "OpenMage starter project" --type "project" -l "OSL-3.0" -s "dev" -q
     ddev composer config extra.magento-root-dir "public_test"
     ddev composer config extra.enable-patching true
@@ -781,7 +1343,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
     mkdir my-openmage-site && cd my-openmage-site
     git clone https://github.com/OpenMage/magento-lts .
     ddev config --project-type=magento --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
-    ddev start
+    ddev start -y
     ddev composer install
     # Silent OpenMage install with sample data
     # See `ddev openmage-install -h` for more options
@@ -802,7 +1364,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
     mkdir my-pimcore-site && cd my-pimcore-site
     ddev config --project-type=php --docroot=public --webimage-extra-packages='php${DDEV_PHP_VERSION}-amqp'
 
-    ddev start
+    ddev start -y
     ddev composer create-project pimcore/skeleton
     ddev exec pimcore-install \
         --mysql-username=db \
@@ -831,7 +1393,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     curl -LJOf https://github.com/processwire/processwire/archive/master.zip
     unzip processwire-master.zip && rm -f processwire-master.zip && mv processwire-master/* . && mv processwire-master/.* . 2>/dev/null && rm -rf processwire-master
     ddev config --project-type=php --webserver-type=apache-fpm
-    ddev start
+    ddev start -y
     ddev launch
     ```
 
@@ -840,7 +1402,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     ```bash
     mkdir my-processwire-site && cd my-processwire-site
     ddev config --project-type=php --webserver-type=apache-fpm
-    ddev start
+    ddev start -y
     ddev composer create-project "processwire/processwire:^3"
     ddev launch
     ```
@@ -857,7 +1419,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
     # git clone -b dev https://github.com/processwire/processwire.git .
 
     ddev config --webserver-type=apache-fpm
-    ddev start
+    ddev start -y
     ddev launch
     ```
 
@@ -886,13 +1448,30 @@ If you have any questions there is lots of help in the [DDEV thread in the Proce
 
     Though you can set up a Shopware 6 environment many ways, we recommend the following technique. DDEV creates a `.env.local` file for you by default; if you already have one DDEV adds necessary information to it. When `ddev composer create-project` asks if you want to include Docker configuration, answer `x`, as this approach does not use their Docker configuration.
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-shopware-site && cd my-shopware-site
     ddev config --project-type=shopware6 --docroot=public
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Install Shopware via Composer:
+
+    ```bash
     ddev composer create-project shopware/production
     # If it asks `Do you want to include Docker configuration from recipes?`
     # answer `x`, as we're using DDEV for this rather than its recipes.
+    ```
+
+    Run Shopware installation and launch:
+
+    ```bash
     ddev exec console system:install --basic-setup
     ddev launch /admin
     # Default username and password are `admin` and `shopware`
@@ -902,20 +1481,73 @@ If you have any questions there is lots of help in the [DDEV thread in the Proce
 
     For more advanced tasks like adding elasticsearch, building and watching storefront and administration, see [susi.dev](https://susi.dev/ddev-shopware-6).
 
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-shopware.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-shopware-site && cd my-shopware-site
+        ddev config --project-type=shopware6 --docroot=public
+        ddev start -y
+        ddev composer create-project shopware/production
+        ddev exec console system:install --basic-setup
+        ddev launch /admin
+        EOF
+        chmod +x setup-shopware.sh
+        ./setup-shopware.sh
+        ```
+
 ## Silverstripe CMS
 
 Use a new or existing Composer project, or clone a Git repository.
 
 === "Composer"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-silverstripe-site && cd my-silverstripe-site
     ddev config --project-type=silverstripe --docroot=public
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Install Silverstripe via Composer:
+
+    ```bash
     ddev composer create-project --prefer-dist silverstripe/installer
     ddev sake dev/build flush=all
+    ```
+
+    Launch the admin area:
+
+    ```bash
     ddev launch /admin
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-silverstripe.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-silverstripe-site && cd my-silverstripe-site
+        ddev config --project-type=silverstripe --docroot=public
+        ddev start -y
+        ddev composer create-project --prefer-dist silverstripe/installer
+        ddev sake dev/build flush=all
+        ddev launch /admin
+        EOF
+        chmod +x setup-silverstripe.sh
+        ./setup-silverstripe.sh
+        ```
 
 === "Git Clone"
 
@@ -923,7 +1555,7 @@ Use a new or existing Composer project, or clone a Git repository.
     git clone <my-silverstripe-repo> my-silverstripe-site
     cd my-silverstripe-site
     ddev config --project-type=silverstripe --docroot=public
-    ddev start
+    ddev start -y
     ddev composer install
     ddev sake dev/build flush=all
     ```
@@ -945,20 +1577,50 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
 
 === "Composer"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-statamic-site && cd my-statamic-site
     ddev config --project-type=laravel --docroot=public
+    ```
+
+    Install Statamic via Composer:
+
+    ```bash
     ddev composer create-project --prefer-dist statamic/statamic
+    ```
+
+    Create admin user and launch:
+
+    ```bash
     ddev php please make:user admin@example.com --password=admin1234 --super --no-interaction
     ddev launch /cp
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-statamic.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-statamic-site && cd my-statamic-site
+        ddev config --project-type=laravel --docroot=public
+        ddev composer create-project --prefer-dist statamic/statamic
+        ddev php please make:user admin@example.com --password=admin1234 --super --no-interaction
+        ddev launch /cp
+        EOF
+        chmod +x setup-statamic.sh
+        ./setup-statamic.sh
+        ```
+
 === "Git Clone"
 
     ```bash
     git clone <my-statamic-repo> my-statamic-site
     cd my-statamic-site
     ddev config --project-type=laravel --docroot=public
-    ddev start
+    ddev start -y
     ddev composer install
     ddev exec "php artisan key:generate"
     ddev launch /cp
@@ -969,7 +1631,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
 ```bash
 mkdir my-sulu-site && cd my-sulu-site
 ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0
-ddev start
+ddev start -y
 ddev composer create-project sulu/skeleton
 ```
 
@@ -1024,22 +1686,57 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 
 === "Composer"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-symfony-site && cd my-symfony-site
     ddev config --project-type=symfony --docroot=public
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Install Symfony via Composer:
+
+    ```bash
     ddev composer create-project symfony/skeleton
     ddev composer require webapp
     # When it asks if you want to include docker configuration, say "no" with "x"
+    ```
+
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-symfony.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-symfony-site && cd my-symfony-site
+        ddev config --project-type=symfony --docroot=public
+        ddev start -y
+        ddev composer create-project symfony/skeleton
+        ddev composer require webapp
+        ddev launch
+        EOF
+        chmod +x setup-symfony.sh
+        ./setup-symfony.sh
+        ```
 
 === "Symfony CLI"
 
     ```bash
     mkdir my-symfony-site && cd my-symfony-site
     ddev config --project-type=symfony --docroot=public
-    ddev start
+    ddev start -y
     ddev exec symfony check:requirements
     ddev exec symfony new temp --version="7.1.*" --webapp
     # 'symfony new' can't install in the current directory right away,
@@ -1054,7 +1751,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     git clone <my-symfony-repo> my-symfony-site
     cd my-symfony-site
     ddev config --project-type=symfony --docroot=public
-    ddev start
+    ddev start -y
     ddev composer install
     ddev launch
     ```
@@ -1077,12 +1774,29 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 
 === "Composer"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     PROJECT_NAME=my-typo3-site
     mkdir ${PROJECT_NAME} && cd ${PROJECT_NAME}
     ddev config --project-type=typo3 --docroot=public --php-version=8.3
-    ddev start
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Install TYPO3 via Composer:
+
+    ```bash
     ddev composer create-project "typo3/cms-base-distribution"
+    ```
+
+    Run the TYPO3 setup:
+
+    ```bash
     ddev typo3 setup \
         --admin-user-password="Demo123*" \
         --driver=mysqli \
@@ -1097,9 +1811,45 @@ DDEV automatically updates or creates the `.env.local` file with the database in
         --admin-email=admin@example.com \
         --project-name="My TYPO3 site" \
         --force
+    ```
 
+    Launch the site:
+
+    ```bash
     ddev launch /typo3/
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-typo3.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        PROJECT_NAME=my-typo3-site
+        mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
+        ddev config --project-type=typo3 --docroot=public --php-version=8.3
+        ddev start -y
+        ddev composer create-project "typo3/cms-base-distribution"
+        ddev typo3 setup \
+            --admin-user-password="Demo123*" \
+            --driver=mysqli \
+            --create-site=https://${PROJECT_NAME}.ddev.site \
+            --server-type=other \
+            --dbname=db \
+            --username=db \
+            --password=db \
+            --port=3306 \
+            --host=db \
+            --admin-username=admin \
+            --admin-email=admin@example.com \
+            --project-name="My TYPO3 site" \
+            --force
+        ddev launch /typo3/
+        EOF
+        chmod +x setup-typo3.sh
+        ./setup-typo3.sh
+        ```
 
 === "Git Clone"
 
@@ -1112,7 +1862,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
     git clone ${PROJECT_GIT_REPOSITORY} .
     ddev config --project-type=typo3 --docroot=public --php-version=8.3
-    ddev start
+    ddev start -y
     ddev composer install
     ddev exec touch public/FIRST_INSTALL
     ddev launch /typo3/install.php
@@ -1126,27 +1876,60 @@ There are several easy ways to use DDEV with WordPress:
 
     DDEV has built-in support for [WP-CLI](https://wp-cli.org/), the command-line interface for WordPress.
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-wp-site && cd my-wp-site
-
     # Create a new DDEV project inside the newly-created folder
     # (Primary URL automatically set to `https://<folder>.ddev.site`)
     ddev config --project-type=wordpress
-    ddev start
+    ```
 
-    # Download WordPress
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start -y
+    ```
+
+    Download WordPress:
+
+    ```bash
     ddev wp core download
+    ```
 
-    # Launch in browser to finish installation
-    ddev launch
+    Install WordPress (or use `ddev launch` to install via browser):
 
+    ```bash
+    # You can launch in browser to finish installation:
+    # ddev launch
     # OR use the following installation command
     # (we need to use single quotes to get the primary site URL from `.ddev/config.yaml` as variable)
     ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+    ```
 
-    # Launch WordPress admin dashboard in your browser
+    Launch WordPress admin dashboard:
+
+    ```bash
     ddev launch wp-admin/
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-wordpress.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-wp-site && cd my-wp-site
+        ddev config --project-type=wordpress
+        ddev start -y
+        ddev wp core download
+        ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+        ddev launch wp-admin/
+        EOF
+        chmod +x setup-wordpress.sh
+        ./setup-wordpress.sh
+        ```
 
 === "Bedrock"
 
@@ -1155,7 +1938,7 @@ There are several easy ways to use DDEV with WordPress:
     ```bash
     mkdir my-wp-site && cd my-wp-site
     ddev config --project-type=wordpress --docroot=web
-    ddev start
+    ddev start -y
     ddev composer create-project roots/bedrock
     ```
 
@@ -1189,7 +1972,7 @@ There are several easy ways to use DDEV with WordPress:
     git clone ${PROJECT_GIT_URL} my-wp-site
     cd my-wp-site
     ddev config --project-type=wordpress
-    ddev start
+    ddev start -y
     ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
     ddev launch wp-admin/
     ```

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -46,7 +46,7 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
 
         ```bash
         cat > setup-backdrop.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-backdrop-site && cd my-backdrop-site
         ddev config --project-type=backdrop
@@ -107,7 +107,7 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
 
         ```bash
         cat > setup-backdrop-existing.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-backdrop-site && cd my-backdrop-site
         git clone https://github.com/ddev/test-backdrop.git .
@@ -162,7 +162,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
         ```bash
         cat > setup-cakephp.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-cakephp-site && cd my-cakephp-site
         ddev config --project-type=cakephp --docroot=webroot
@@ -203,7 +203,7 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
 
         ```bash
         cat > setup-cakephp-git.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         git clone <my-cakephp-repo> my-cakephp-site
         cd my-cakephp-site
@@ -269,7 +269,7 @@ ddev launch
 
     ```bash
     cat > setup-civicrm.sh << 'EOF'
-    #!/bin/bash
+    #!/usr/bin/env bash
     set -euo pipefail
     mkdir my-civicrm-site && cd my-civicrm-site
     ddev config --project-type=php --composer-root=core --upload-dirs=public/media
@@ -338,7 +338,7 @@ Further information on the DDEV procedure can also be found in the [Contao docum
 
         ```bash
         cat > setup-contao.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-contao-site && cd my-contao-site
         ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
@@ -392,7 +392,7 @@ Further information on the DDEV procedure can also be found in the [Contao docum
 
         ```bash
         cat > setup-contao-manager.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-contao-site && cd my-contao-site
         ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
@@ -449,7 +449,7 @@ DDEV injects a number of special environment variables into the container (via `
 
         ```bash
         cat > setup-craft.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-craft-site && cd my-craft-site
         ddev config --project-type=craftcms --docroot=web
@@ -498,7 +498,7 @@ DDEV injects a number of special environment variables into the container (via `
 
         ```bash
         cat > setup-craft-existing.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         git clone https://github.com/example/example-site my-craft-site
         cd my-craft-site
@@ -559,7 +559,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
         ```bash
         cat > setup-drupal11.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-drupal-site && cd my-drupal-site
         ddev config --project-type=drupal11 --docroot=web
@@ -607,7 +607,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
         ```bash
         cat > setup-drupal-cms.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-drupal-site && cd my-drupal-site
         ddev config --project-type=drupal11 --docroot=web
@@ -657,7 +657,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
         ```bash
         cat > setup-drupal10.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-drupal-site && cd my-drupal-site
         ddev config --project-type=drupal10 --docroot=web
@@ -702,7 +702,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
         ```bash
         cat > setup-drupal67.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         git clone https://github.com/example/my-drupal-site
         cd my-drupal-site
@@ -751,7 +751,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
         ```bash
         cat > setup-drupal-git.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         PROJECT_GIT_URL=https://github.com/ddev/test-drupal11.git
         git clone ${PROJECT_GIT_URL} my-drupal-site
@@ -805,7 +805,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
         ```bash
         cat > setup-ee.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-ee-site && cd my-ee-site
         curl -o ee.zip -L $(curl -sL https://api.github.com/repos/ExpressionEngine/ExpressionEngine/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^ExpressionEngine.*\\.zip$")))[0].browser_download_url')
@@ -857,7 +857,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
         ```bash
         cat > setup-ee-git.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-ee-site && cd my-ee-site
         git clone https://github.com/ExpressionEngine/ExpressionEngine .
@@ -944,7 +944,7 @@ ddev launch $(ddev drush uli)
 
     ```bash
     cat > setup-frankenphp.sh << 'EOF'
-    #!/bin/bash
+    #!/usr/bin/env bash
     set -euo pipefail
     export FRANKENPHP_SITENAME=my-frankenphp-site
     mkdir ${FRANKENPHP_SITENAME} && cd ${FRANKENPHP_SITENAME}
@@ -1014,7 +1014,7 @@ ddev launch $(ddev drush uli)
 
         ```bash
         cat > setup-grav.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-grav-site && cd my-grav-site
         ddev config --omit-containers=db
@@ -1067,7 +1067,7 @@ ddev launch $(ddev drush uli)
 
         ```bash
         cat > setup-grav-git.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-grav-site && cd my-grav-site
         git clone -b master https://github.com/getgrav/grav.git .
@@ -1142,7 +1142,7 @@ Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/insta
 
     ```bash
     cat > setup-ibexa.sh << 'EOF'
-    #!/bin/bash
+    #!/usr/bin/env bash
     set -euo pipefail
     mkdir my-ibexa-site && cd my-ibexa-site
     ddev config --project-type=php --docroot=public --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
@@ -1192,7 +1192,7 @@ ddev launch /administrator
 
     ```bash
     cat > setup-joomla.sh << 'EOF'
-    #!/bin/bash
+    #!/usr/bin/env bash
     set -euo pipefail
     mkdir my-joomla-site && cd my-joomla-site
     curl -o joomla.zip -L $(curl -sL https://api.github.com/repos/joomla/joomla-cms/releases/latest | docker run -i --rm ddev/ddev-utilities jq -r '.assets | map(select(.name | test("^Joomla.*Stable-Full_Package\\.zip$")))[0].browser_download_url')
@@ -1244,7 +1244,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
 
         ```bash
         cat > setup-kirby.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-kirby-site && cd my-kirby-site
         ddev config --omit-containers=db --webserver-type=apache-fpm
@@ -1289,7 +1289,7 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
 
         ```bash
         cat > setup-kirby-existing.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         cd my-kirby-site
         ddev config --omit-containers=db --webserver-type=apache-fpm
@@ -1343,7 +1343,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
         ```bash
         cat > setup-laravel.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-laravel-site && cd my-laravel-site
         ddev config --project-type=laravel --docroot=public
@@ -1389,7 +1389,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
         ```bash
         cat > setup-laravel-sqlite.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-laravel-site && cd my-laravel-site
         ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
@@ -1429,7 +1429,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
         ```bash
         cat > switch-laravel-sqlite.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
         ddev restart
@@ -1503,7 +1503,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
         ```bash
         cat > setup-laravel-installer.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-laravel-site && cd my-laravel-site
         ddev config --project-type=laravel --docroot=public
@@ -1562,7 +1562,7 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
         ```bash
         cat > setup-laravel-git.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         git clone <my-laravel-repo> my-laravel-site
         cd my-laravel-site
@@ -1662,7 +1662,7 @@ Change the admin name and related information as needed.
 
     ```bash
     cat > setup-magento.sh << 'EOF'
-    #!/bin/bash
+    #!/usr/bin/env bash
     set -euo pipefail
     export MAGENTO_HOSTNAME=my-magento2-site
     mkdir ${MAGENTO_HOSTNAME} && cd ${MAGENTO_HOSTNAME}
@@ -1742,7 +1742,7 @@ ddev magento setup:upgrade
 
         ```bash
         cat > setup-moodle.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-moodle-site && cd my-moodle-site
         ddev config --docroot=public --webserver-type=apache-fpm
@@ -1889,7 +1889,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
 
         ```bash
         cat > setup-openmage.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-openmage-site && cd my-openmage-site
         ddev config --project-type=magento --docroot=public_test --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
@@ -1953,7 +1953,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
 
         ```bash
         cat > setup-openmage-git.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-openmage-site && cd my-openmage-site
         git clone https://github.com/OpenMage/magento-lts .
@@ -2025,7 +2025,7 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
 
         ```bash
         cat > setup-pimcore.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-pimcore-site && cd my-pimcore-site
         ddev config --project-type=php --docroot=public --webimage-extra-packages='php${DDEV_PHP_VERSION}-amqp'
@@ -2086,7 +2086,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
 
         ```bash
         cat > setup-processwire-zip.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-processwire-site && cd my-processwire-site
         curl -LJOf https://github.com/processwire/processwire/archive/master.zip
@@ -2131,7 +2131,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
 
         ```bash
         cat > setup-processwire.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-processwire-site && cd my-processwire-site
         ddev config --project-type=php --webserver-type=apache-fpm
@@ -2177,7 +2177,7 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
 
         ```bash
         cat > setup-processwire-git.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-processwire-site && cd my-processwire-site
         git clone https://github.com/processwire/processwire.git .
@@ -2252,7 +2252,7 @@ If you have any questions there is lots of help in the [DDEV thread in the Proce
 
         ```bash
         cat > setup-shopware.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-shopware-site && cd my-shopware-site
         ddev config --project-type=shopware6 --docroot=public
@@ -2302,7 +2302,7 @@ Use a new or existing Composer project, or clone a Git repository.
 
         ```bash
         cat > setup-silverstripe.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-silverstripe-site && cd my-silverstripe-site
         ddev config --project-type=silverstripe --docroot=public
@@ -2368,7 +2368,7 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
 
         ```bash
         cat > setup-statamic.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-statamic-site && cd my-statamic-site
         ddev config --project-type=laravel --docroot=public
@@ -2466,7 +2466,7 @@ ddev launch /admin
 
     ```bash
     cat > setup-sulu.sh << 'EOF'
-    #!/bin/bash
+    #!/usr/bin/env bash
     set -euo pipefail
     mkdir my-sulu-site && cd my-sulu-site
     ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0
@@ -2525,7 +2525,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 
         ```bash
         cat > setup-symfony.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-symfony-site && cd my-symfony-site
         ddev config --project-type=symfony --docroot=public
@@ -2631,7 +2631,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
 
         ```bash
         cat > setup-typo3.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         PROJECT_NAME=my-typo3-site
         mkdir -p ${PROJECT_NAME} && cd ${PROJECT_NAME}
@@ -2725,7 +2725,7 @@ There are several easy ways to use DDEV with WordPress:
 
         ```bash
         cat > setup-wordpress.sh << 'EOF'
-        #!/bin/bash
+        #!/usr/bin/env bash
         set -euo pipefail
         mkdir my-wp-site && cd my-wp-site
         ddev config --project-type=wordpress

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -64,31 +64,63 @@ You can start a new [Backdrop](https://backdropcms.org) project or configure an 
 
     You can start using DDEV with an existing project, too—but make sure you have a database backup handy!
 
+    Create project directory and clone your repository:
 
     ```bash
     mkdir my-backdrop-site && cd my-backdrop-site
-
-    # Use your own repository URL, this is an example
     git clone https://github.com/ddev/test-backdrop.git .
+    ```
 
-    # Set up the DDEV environment:
+    Configure DDEV:
+
+    ```bash
     ddev config --project-type=backdrop
+    ```
 
-    # Add the official Bee CLI add-on
+    Add the official Bee CLI add-on:
+
+    ```bash
     ddev add-on get backdrop-ops/ddev-backdrop-bee
+    ```
 
-    # Start the project
+    Start DDEV (this may take a minute):
+
+    ```bash
     ddev start -y
+    ```
 
-    # Import a database backup:
+    Import database and files backups:
+
+    ```bash
     ddev import-db --file=/path/to/db.sql.gz
-
-    # Import files backup
     ddev import-files --source=/path/to/files.tar.gz
+    ```
 
-    # open the site in your browser
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-backdrop-existing.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-backdrop-site && cd my-backdrop-site
+        git clone https://github.com/ddev/test-backdrop.git .
+        ddev config --project-type=backdrop
+        ddev add-on get backdrop-ops/ddev-backdrop-bee
+        ddev start -y
+        ddev import-db --file=/path/to/db.sql.gz
+        ddev import-files --source=/path/to/files.tar.gz
+        ddev launch
+        EOF
+        chmod +x setup-backdrop-existing.sh
+        ./setup-backdrop-existing.sh
+        ```
 
 ## CakePHP
 
@@ -165,6 +197,25 @@ Please note that you will need to change the PHP version to 7.4 to be able to wo
     ddev cake
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-cakephp-git.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        git clone <my-cakephp-repo> my-cakephp-site
+        cd my-cakephp-site
+        ddev config --project-type=cakephp --docroot=webroot
+        ddev start -y
+        ddev composer install
+        ddev cake
+        ddev launch
+        EOF
+        chmod +x setup-cakephp-git.sh
+        ./setup-cakephp-git.sh
+        ```
 
 ## CiviCRM (Standalone)
 
@@ -413,24 +464,53 @@ DDEV injects a number of special environment variables into the container (via `
 
     You can start using DDEV with an existing Craft project, too. All you need is the codebase and a database backup!
 
+    Clone the repository (or navigate to a local project directory):
+
     ```bash
-    # Clone an existing repository (or navigate to a local project directory):
     git clone https://github.com/example/example-site my-craft-site
     cd my-craft-site
+    ```
 
-    # Set up the DDEV environment, substituting your existing web root:
+    Configure DDEV:
+
+    ```bash
     ddev config --project-type=craftcms --docroot=web
+    ```
 
-    # Boot the project and install Composer packages:
+    Start DDEV and install Composer packages:
+
+    ```bash
     ddev start -y
     ddev composer install
+    ```
 
-    # Import a database backup and open the site in your browser:
+    Import database backup and launch:
+
+    ```bash
     ddev craft db/restore /path/to/db.sql.gz
     ddev launch
     ```
 
     Craft CMS projects use MySQL 8.0, by default. You can override this setting (and the PHP version) during setup with [`config` command flags](./usage/commands.md#config) or after setup via the [configuration files](./configuration/config.md).
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-craft-existing.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        git clone https://github.com/example/example-site my-craft-site
+        cd my-craft-site
+        ddev config --project-type=craftcms --docroot=web
+        ddev start -y
+        ddev composer install
+        ddev craft db/restore /path/to/db.sql.gz
+        ddev launch
+        EOF
+        chmod +x setup-craft-existing.sh
+        ./setup-craft-existing.sh
+        ```
 
 ### Running Craft in a Subdirectory
 
@@ -593,32 +673,98 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
 === "Drupal 6/7"
 
+    Clone your Drupal repository:
+
     ```bash
     git clone https://github.com/example/my-drupal-site
     cd my-drupal-site
-    ddev config # Follow the prompts to select type and docroot
+    ```
+
+    Configure DDEV (follow prompts):
+
+    ```bash
+    ddev config
+    ```
+
+    Start DDEV and launch:
+
+    ```bash
     ddev start -y
     ddev launch /install.php
     ```
 
-    Drupal 7 doesn’t know how to redirect from the front page to `/install.php` if the database is not set up but the settings files *are* set up, so launching with `/install.php` gets you started with an installation. You can also run `drush site-install`, then `ddev exec drush site-install --yes`.
+    Drupal 7 doesn't know how to redirect from the front page to `/install.php` if the database is not set up but the settings files *are* set up, so launching with `/install.php` gets you started with an installation. You can also run `drush site-install`, then `ddev exec drush site-install --yes`.
 
     See [Importing a Database](./usage/managing-projects.md#importing-a-database).
 
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-drupal67.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        git clone https://github.com/example/my-drupal-site
+        cd my-drupal-site
+        ddev config
+        ddev start -y
+        ddev launch /install.php
+        EOF
+        chmod +x setup-drupal67.sh
+        ./setup-drupal67.sh
+        ```
+
 === "Git Clone"
+
+    Clone your Drupal repository:
 
     ```bash
     PROJECT_GIT_URL=https://github.com/ddev/test-drupal11.git
     git clone ${PROJECT_GIT_URL} my-drupal-site
     cd my-drupal-site
+    ```
+
+    Configure and start DDEV:
+
+    ```bash
     ddev config --project-type=drupal11 --docroot=web
     ddev start -y
-    ddev composer install # If a composer build
+    ```
+
+    Install dependencies and set up Drupal:
+
+    ```bash
+    ddev composer install
     ddev drush site:install --account-name=admin --account-pass=admin -y
+    ```
+
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
 
     Read more about: [Drupal Core](https://new.drupal.org/about/overview/technical) & [Documentation](https://www.drupal.org/docs)
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-drupal-git.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        PROJECT_GIT_URL=https://github.com/ddev/test-drupal11.git
+        git clone ${PROJECT_GIT_URL} my-drupal-site
+        cd my-drupal-site
+        ddev config --project-type=drupal11 --docroot=web
+        ddev start -y
+        ddev composer install
+        ddev drush site:install --account-name=admin --account-pass=admin -y
+        ddev launch
+        EOF
+        chmod +x setup-drupal-git.sh
+        ./setup-drupal-git.sh
+        ```
 
 ## ExpressionEngine
 
@@ -736,12 +882,23 @@ In this example, inside the web container the normal `php` CLI use used for CLI 
 
 The `generic` `webserver_type` is used here, so the `ddev-webserver` does not start the `nginx` or `php-fpm` daemons, and the `frankenphp` process does all the work.
 
+Create the project directory and configure DDEV:
+
 ```bash
 export FRANKENPHP_SITENAME=my-frankenphp-site
 mkdir ${FRANKENPHP_SITENAME} && cd ${FRANKENPHP_SITENAME}
 ddev config --project-type=drupal11 --webserver-type=generic --docroot=web --php-version=8.4
-ddev start -y
+```
 
+Start DDEV (this may take a minute):
+
+```bash
+ddev start -y
+```
+
+Create FrankenPHP configuration:
+
+```bash
 cat <<'EOF' > .ddev/config.frankenphp.yaml
 web_extra_daemons:
     - name: "frankenphp"
@@ -753,47 +910,177 @@ web_extra_exposed_ports:
       http_port: 80
       https_port: 443
 EOF
+```
 
+Create Dockerfile for FrankenPHP:
+
+```bash
 cat <<'DOCKERFILEEND' >.ddev/web-build/Dockerfile.frankenphp
 RUN curl -s https://frankenphp.dev/install.sh | sh
 RUN mv frankenphp /usr/local/bin/
 RUN mkdir -p /usr/local/etc && ln -s /etc/php/${DDEV_PHP_VERSION}/fpm /usr/local/etc/php
 DOCKERFILEEND
+```
 
+Install Drupal and configure:
+
+```bash
 ddev composer create-project drupal/recommended-project
 ddev composer require drush/drush
 ddev restart
 ddev drush site:install demo_umami --account-name=admin --account-pass=admin -y
+```
+
+Launch your site:
+
+```bash
 ddev launch
-# or automatically log in with
+# or automatically log in with:
 ddev launch $(ddev drush uli)
 ```
+
+??? tip "Prefer to run as a script?"
+    To run the whole setup as a script, examine and run this script:
+
+    ```bash
+    cat > setup-frankenphp.sh << 'EOF'
+    #!/bin/bash
+    set -euo pipefail
+    export FRANKENPHP_SITENAME=my-frankenphp-site
+    mkdir ${FRANKENPHP_SITENAME} && cd ${FRANKENPHP_SITENAME}
+    ddev config --project-type=drupal11 --webserver-type=generic --docroot=web --php-version=8.4
+    ddev start -y
+
+    cat <<'INNEREOF' > .ddev/config.frankenphp.yaml
+    web_extra_daemons:
+        - name: "frankenphp"
+          command: "frankenphp php-server --listen=0.0.0.0:80 --root=\"/var/www/html/${DDEV_DOCROOT:-}\" -v -a"
+          directory: /var/www/html
+    web_extra_exposed_ports:
+        - name: "frankenphp"
+          container_port: 80
+          http_port: 80
+          https_port: 443
+    INNEREOF
+
+    cat <<'INNEREOF' >.ddev/web-build/Dockerfile.frankenphp
+    RUN curl -s https://frankenphp.dev/install.sh | sh
+    RUN mv frankenphp /usr/local/bin/
+    RUN mkdir -p /usr/local/etc && ln -s /etc/php/${DDEV_PHP_VERSION}/fpm /usr/local/etc/php
+    INNEREOF
+
+    ddev composer create-project drupal/recommended-project
+    ddev composer require drush/drush
+    ddev restart
+    ddev drush site:install demo_umami --account-name=admin --account-pass=admin -y
+    ddev launch
+    EOF
+    chmod +x setup-frankenphp.sh
+    ./setup-frankenphp.sh
+    ```
 
 ## Grav
 
 === "Composer"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-grav-site && cd my-grav-site
     ddev config --omit-containers=db
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
     ddev start -y
+    ```
+
+    Install Grav via Composer:
+
+    ```bash
     ddev composer create-project getgrav/grav
+    ```
+
+    Install the admin plugin and launch:
+
+    ```bash
     ddev exec gpm install admin -y
     ddev launch
     ```
 
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-grav.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-grav-site && cd my-grav-site
+        ddev config --omit-containers=db
+        ddev start -y
+        ddev composer create-project getgrav/grav
+        ddev exec gpm install admin -y
+        ddev launch
+        EOF
+        chmod +x setup-grav.sh
+        ./setup-grav.sh
+        ```
+
 === "Git Clone"
+
+    Create the project directory and clone Grav:
 
     ```bash
     mkdir my-grav-site && cd my-grav-site
     git clone -b master https://github.com/getgrav/grav.git .
+    ```
+
+    Configure DDEV:
+
+    ```bash
     ddev config --omit-containers=db
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
     ddev start -y
+    ```
+
+    Install dependencies and initialize Grav:
+
+    ```bash
     ddev composer install
     ddev exec grav install
+    ```
+
+    Install the admin plugin and launch:
+
+    ```bash
     ddev exec gpm install admin -y
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-grav-git.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-grav-site && cd my-grav-site
+        git clone -b master https://github.com/getgrav/grav.git .
+        ddev config --omit-containers=db
+        ddev start -y
+        ddev composer install
+        ddev exec grav install
+        ddev exec gpm install admin -y
+        ddev launch
+        EOF
+        chmod +x setup-grav-git.sh
+        ./setup-grav-git.sh
+        ```
 
 !!!tip "How to update?"
     Upgrade Grav core:
@@ -814,19 +1101,60 @@ Visit the [Grav Documentation](https://learn.getgrav.org/17) for more informatio
 
 Install [Ibexa DXP](https://www.ibexa.co) OSS Edition.
 
+Create the project directory and configure DDEV:
+
 ```bash
 mkdir my-ibexa-site && cd my-ibexa-site
 ddev config --project-type=php --docroot=public --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
+```
+
+Start DDEV (this may take a minute):
+
+```bash
 ddev start -y
+```
+
+Install Ibexa via Composer:
+
+```bash
 ddev composer create-project ibexa/oss-skeleton
+```
+
+Run Ibexa installation:
+
+```bash
 ddev exec console ibexa:install
 ddev exec console ibexa:graphql:generate-schema
+```
+
+Launch the admin interface:
+
+```bash
 ddev launch /admin/login
 ```
 
 In the web browser, log into your account using `admin` and `publish`.
 
 Visit [Ibexa documentation](https://doc.ibexa.co/en/latest/getting_started/install_with_ddev/) for more cases.
+
+??? tip "Prefer to run as a script?"
+    To run the whole setup as a script, examine and run this script:
+
+    ```bash
+    cat > setup-ibexa.sh << 'EOF'
+    #!/bin/bash
+    set -euo pipefail
+    mkdir my-ibexa-site && cd my-ibexa-site
+    ddev config --project-type=php --docroot=public --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
+    ddev start -y
+    ddev composer create-project ibexa/oss-skeleton
+    ddev exec console ibexa:install
+    ddev exec console ibexa:graphql:generate-schema
+    ddev launch /admin/login
+    EOF
+    chmod +x setup-ibexa.sh
+    ./setup-ibexa.sh
+    ```
 
 ## Joomla
 
@@ -884,40 +1212,93 @@ Start a new [Kirby CMS](https://getkirby.com) project or use an existing one.
 
 === "New projects"
 
-    Create a new Kirby CMS project from the official [Starterkit](https://github.com/getkirby/starterkit) using DDEV’s [`composer create-project` command](../users/usage/commands.md#composer):
+    Create a new Kirby CMS project from the official [Starterkit](https://github.com/getkirby/starterkit) using DDEV's [`composer create-project` command](../users/usage/commands.md#composer):
+
+    Create the project directory and configure DDEV:
 
     ```bash
-    # Create a new project directory and navigate into it
     mkdir my-kirby-site && cd my-kirby-site
-
-    # Set up the DDEV environment
     ddev config --omit-containers=db --webserver-type=apache-fpm
+    ```
 
-    # Spin up the project and install the Kirby Starterkit
+    Start DDEV (this may take a minute):
+
+    ```bash
     ddev start -y
-    ddev composer create-project getkirby/starterkit
+    ```
 
-    # Open the site in your browser
+    Install the Kirby Starterkit:
+
+    ```bash
+    ddev composer create-project getkirby/starterkit
+    ```
+
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-kirby.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-kirby-site && cd my-kirby-site
+        ddev config --omit-containers=db --webserver-type=apache-fpm
+        ddev start -y
+        ddev composer create-project getkirby/starterkit
+        ddev launch
+        EOF
+        chmod +x setup-kirby.sh
+        ./setup-kirby.sh
+        ```
 
 === "Existing projects"
 
     You can start using DDEV with an existing project as well:
 
+    Navigate to your existing project directory:
+
     ```bash
-    # Navigate to a existing project directory (or clone/download an existing project):
     cd my-kirby-site
+    ```
 
-    # Set up the DDEV environment
+    Configure DDEV:
+
+    ```bash
     ddev config --omit-containers=db --webserver-type=apache-fpm
+    ```
 
-    # Spin up the project
+    Start DDEV (this may take a minute):
+
+    ```bash
     ddev start -y
+    ```
 
-    # Open the site in your browser
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-kirby-existing.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        cd my-kirby-site
+        ddev config --omit-containers=db --webserver-type=apache-fpm
+        ddev start -y
+        ddev launch
+        EOF
+        chmod +x setup-kirby-existing.sh
+        ./setup-kirby-existing.sh
+        ```
 
 !!!tip "Installing Kirby"
     Read more about developing your Kirby project with DDEV in our [extensive DDEV guide](https://getkirby.com/docs/cookbook/setup/ddev).
@@ -978,81 +1359,223 @@ The Laravel project type can be used for [StarterKits](https://laravel.com/docs/
 
     To use the SQLite configuration provided by Laravel:
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-laravel-site && cd my-laravel-site
     ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
     ddev start -y
+    ```
+
+    Install Laravel via Composer:
+
+    ```bash
     ddev composer create-project "laravel/laravel:^12"
+    ```
+
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
 
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-laravel-sqlite.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-laravel-site && cd my-laravel-site
+        ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
+        ddev start -y
+        ddev composer create-project "laravel/laravel:^12"
+        ddev launch
+        EOF
+        chmod +x setup-laravel-sqlite.sh
+        ./setup-laravel-sqlite.sh
+        ```
+
     To switch an existing Laravel project to SQLite:
+
+    Configure for SQLite and restart:
 
     ```bash
     ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
     ddev restart
+    ```
+
+    Run post-install scripts:
+
+    ```bash
     ddev composer run-script post-root-package-install
     ddev dotenv set .env --db-connection=sqlite
     ddev composer run-script post-create-project-cmd
+    ```
+
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
 
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > switch-laravel-sqlite.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
+        ddev restart
+        ddev composer run-script post-root-package-install
+        ddev dotenv set .env --db-connection=sqlite
+        ddev composer run-script post-create-project-cmd
+        ddev launch
+        EOF
+        chmod +x switch-laravel-sqlite.sh
+        ./switch-laravel-sqlite.sh
+        ```
+
 === "Laravel Installer"
+
+    Create the project directory and configure DDEV:
 
     ```bash
     mkdir my-laravel-site && cd my-laravel-site
-
-    # To use MariaDB, apply the following command
     ddev config --project-type=laravel --docroot=public
+    # For SQLite instead, use:
+    # ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
+    ```
 
-    # To use SQLite, uncomment and use the following command instead
-    #ddev config --project-type=laravel --docroot=public --omit-containers=db --disable-settings-management=true
+    Create Dockerfile to add Laravel installer:
 
-    # Temporarily add the Laravel installer
-    # as /usr/local/bin/laravel in the web container
+    ```bash
     cat <<'DOCKERFILEEND' >.ddev/web-build/Dockerfile.laravel
     ARG COMPOSER_HOME=/usr/local/composer
     RUN composer global require laravel/installer
     RUN ln -s $COMPOSER_HOME/vendor/bin/laravel /usr/local/bin/laravel
     DOCKERFILEEND
+    ```
 
-    # Start the project
+    Start DDEV (this may take a minute):
+
+    ```bash
     ddev start -y
+    ```
 
-    # Follow the prompts, select a starter kit of your choice (or none),
-    # and agree to run npm commands
-    # (SQLite is used here as other database types would fail due to
-    # the .env file not being ready, which DDEV will fix on 'ddev restart')
+    Run Laravel installer (follow prompts and select starter kit):
+
+    ```bash
     ddev exec laravel new temp --database=sqlite
+    # SQLite is used here as other database types would fail due to
+    # the .env file not being ready, which DDEV will fix on 'ddev restart'
+    ```
 
-    # 'laravel new' can't install in the current directory right away,
-    # so we use 'rsync' to move the installed files one level up
+    Move files and clean up:
+
+    ```bash
     ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'
-
-    # Remove the Laravel installer and the .env file
     rm -f .ddev/web-build/Dockerfile.laravel .env
+    ```
 
-    # Restart the project
+    Restart and finalize:
+
+    ```bash
     ddev restart
-
-    # Execute the post-install actions and launch the project
     ddev composer run-script post-root-package-install
     ddev composer run-script post-create-project-cmd
+    ```
+
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
 
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-laravel-installer.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-laravel-site && cd my-laravel-site
+        ddev config --project-type=laravel --docroot=public
+
+        cat <<'INNEREOF' >.ddev/web-build/Dockerfile.laravel
+        ARG COMPOSER_HOME=/usr/local/composer
+        RUN composer global require laravel/installer
+        RUN ln -s $COMPOSER_HOME/vendor/bin/laravel /usr/local/bin/laravel
+        INNEREOF
+
+        ddev start -y
+        ddev exec laravel new temp --database=sqlite
+        ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'
+        rm -f .ddev/web-build/Dockerfile.laravel .env
+        ddev restart
+        ddev composer run-script post-root-package-install
+        ddev composer run-script post-create-project-cmd
+        ddev launch
+        EOF
+        chmod +x setup-laravel-installer.sh
+        ./setup-laravel-installer.sh
+        ```
+
 === "Git Clone"
+
+    Clone your Laravel repository:
 
     ```bash
     git clone <my-laravel-repo> my-laravel-site
     cd my-laravel-site
+    ```
+
+    Configure and start DDEV:
+
+    ```bash
     ddev config --project-type=laravel --docroot=public
     ddev start -y
+    ```
+
+    Install dependencies and run post-install scripts:
+
+    ```bash
     ddev composer install
     ddev composer run-script post-root-package-install
     ddev composer run-script post-create-project-cmd
+    ```
+
+    Launch the site:
+
+    ```bash
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-laravel-git.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        git clone <my-laravel-repo> my-laravel-site
+        cd my-laravel-site
+        ddev config --project-type=laravel --docroot=public
+        ddev start -y
+        ddev composer install
+        ddev composer run-script post-root-package-install
+        ddev composer run-script post-create-project-cmd
+        ddev launch
+        EOF
+        chmod +x setup-laravel-git.sh
+        ./setup-laravel-git.sh
+        ```
 
 !!!tip "Add Vite support?"
     Since Laravel v9.19, Vite is included as the default [asset bundler](https://laravel.com/docs/vite). See the [Vite Integration](usage/vite.md#laravel) documentation for complete setup instructions.
@@ -1312,10 +1835,22 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
 
 === "Composer"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-openmage-site && cd my-openmage-site
     ddev config --project-type=magento --docroot=public_test --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
     ddev start -y
+    ```
+
+    Initialize and configure Composer:
+
+    ```bash
     ddev composer init --name "openmage/composer-test" --description "OpenMage starter project" --type "project" -l "OSL-3.0" -s "dev" -q
     ddev composer config extra.magento-root-dir "public_test"
     ddev composer config extra.enable-patching true
@@ -1325,34 +1860,112 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
     ddev composer config allow-plugins.aydin-hassan/magento-core-composer-installer true
     ddev composer config allow-plugins.openmage/composer-plugin true
     ddev composer require --no-update "aydin-hassan/magento-core-composer-installer":"^2.1.0" "openmage/magento-lts":"^20.13"
+    ```
+
+    Download the OpenMage install command and install dependencies:
+
+    ```bash
     ddev exec wget -O .ddev/commands/web/openmage-install https://raw.githubusercontent.com/OpenMage/magento-lts/refs/heads/main/.ddev/commands/web/openmage-install
     ddev composer install
-    # Silent OpenMage install with sample data
-    # See `ddev openmage-install -h` for more options
+    ```
+
+    Run OpenMage silent installation with sample data:
+
+    ```bash
     ddev openmage-install -q
-    # Login using `admin` user and `veryl0ngpassw0rd` password
+    ```
+
+    Launch the admin interface (login with `admin` and `veryl0ngpassw0rd`):
+
+    ```bash
     ddev launch /admin
     ```
 
     !!!note "Make sure that `docroot` is set correctly"
         DDEV config `--docroot` has to match Composer config `extra.magento-root-dir`.
 
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-openmage.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-openmage-site && cd my-openmage-site
+        ddev config --project-type=magento --docroot=public_test --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
+        ddev start -y
+        ddev composer init --name "openmage/composer-test" --description "OpenMage starter project" --type "project" -l "OSL-3.0" -s "dev" -q
+        ddev composer config extra.magento-root-dir "public_test"
+        ddev composer config extra.enable-patching true
+        ddev composer config extra.magento-core-package-type "magento-source"
+        ddev composer config allow-plugins.cweagans/composer-patches true
+        ddev composer config allow-plugins.magento-hackathon/magento-composer-installer true
+        ddev composer config allow-plugins.aydin-hassan/magento-core-composer-installer true
+        ddev composer config allow-plugins.openmage/composer-plugin true
+        ddev composer require --no-update "aydin-hassan/magento-core-composer-installer":"^2.1.0" "openmage/magento-lts":"^20.13"
+        ddev exec wget -O .ddev/commands/web/openmage-install https://raw.githubusercontent.com/OpenMage/magento-lts/refs/heads/main/.ddev/commands/web/openmage-install
+        ddev composer install
+        ddev openmage-install -q
+        ddev launch /admin
+        EOF
+        chmod +x setup-openmage.sh
+        ./setup-openmage.sh
+        ```
+
 === "Git Clone (for contributors)"
+
+    Create the project directory and clone the repository:
 
     ```bash
     mkdir my-openmage-site && cd my-openmage-site
     git clone https://github.com/OpenMage/magento-lts .
+    ```
+
+    Configure and start DDEV:
+
+    ```bash
     ddev config --project-type=magento --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
     ddev start -y
+    ```
+
+    Install Composer dependencies:
+
+    ```bash
     ddev composer install
-    # Silent OpenMage install with sample data
-    # See `ddev openmage-install -h` for more options
+    ```
+
+    Run OpenMage silent installation with sample data:
+
+    ```bash
     ddev openmage-install -q
-    # Login using `admin` user and `veryl0ngpassw0rd` password
+    ```
+
+    Launch the admin interface (login with `admin` and `veryl0ngpassw0rd`):
+
+    ```bash
     ddev launch /admin
     ```
 
     Note that OpenMage itself provides several custom DDEV commands, including `openmage-install`, `openmage-admin`, `phpmd`, `rector`, `phpcbf`, `phpstan`, `vendor-patches`, and `php-cs-fixer`.
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-openmage-git.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-openmage-site && cd my-openmage-site
+        git clone https://github.com/OpenMage/magento-lts .
+        ddev config --project-type=magento --php-version=8.1 --web-environment-add=MAGE_IS_DEVELOPER_MODE=1
+        ddev start -y
+        ddev composer install
+        ddev openmage-install -q
+        ddev launch /admin
+        EOF
+        chmod +x setup-openmage-git.sh
+        ./setup-openmage-git.sh
+        ```
 
 ## Pimcore
 
@@ -1360,12 +1973,28 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
 
     Using the [Pimcore skeleton](https://github.com/pimcore/skeleton) repository:
 
+    Create the project directory and configure DDEV:
+
     ``` bash
     mkdir my-pimcore-site && cd my-pimcore-site
     ddev config --project-type=php --docroot=public --webimage-extra-packages='php${DDEV_PHP_VERSION}-amqp'
+    ```
 
+    Start DDEV (this may take a minute):
+
+    ```bash
     ddev start -y
+    ```
+
+    Install Pimcore via Composer:
+
+    ```bash
     ddev composer create-project pimcore/skeleton
+    ```
+
+    Run Pimcore installation:
+
+    ```bash
     ddev exec pimcore-install \
         --mysql-username=db \
         --mysql-password=db \
@@ -1373,14 +2002,52 @@ Visit [OpenMage Docs](https://docs.openmage.org) for more installation details.
         --mysql-database=db \
         --admin-password=admin \
         --admin-username=admin
+    ```
+
+    Create consumer daemon configuration:
+
+    ```bash
     echo "web_extra_daemons:
       - name: consumer
         command: 'while true; do /var/www/html/bin/console messenger:consume pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update --memory-limit=250M --time-limit=3600; done'
         directory: /var/www/html" >.ddev/config.pimcore.yaml
+    ```
 
+    Restart and launch:
+
+    ```bash
     ddev restart
     ddev launch /admin
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-pimcore.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-pimcore-site && cd my-pimcore-site
+        ddev config --project-type=php --docroot=public --webimage-extra-packages='php${DDEV_PHP_VERSION}-amqp'
+        ddev start -y
+        ddev composer create-project pimcore/skeleton
+        ddev exec pimcore-install \
+            --mysql-username=db \
+            --mysql-password=db \
+            --mysql-host-socket=db \
+            --mysql-database=db \
+            --admin-password=admin \
+            --admin-username=admin
+        echo "web_extra_daemons:
+          - name: consumer
+            command: 'while true; do /var/www/html/bin/console messenger:consume pimcore_core pimcore_maintenance pimcore_scheduled_tasks pimcore_image_optimize pimcore_asset_update --memory-limit=250M --time-limit=3600; done'
+            directory: /var/www/html" >.ddev/config.pimcore.yaml
+        ddev restart
+        ddev launch /admin
+        EOF
+        chmod +x setup-pimcore.sh
+        ./setup-pimcore.sh
+        ```
 
 ## ProcessWire
 
@@ -1388,40 +2055,139 @@ To get started with [ProcessWire](https://processwire.com/), create a new direct
 
 === "ZIP File"
 
+    Create the project directory:
+
     ```bash
     mkdir my-processwire-site && cd my-processwire-site
+    ```
+
+    Download and extract ProcessWire:
+
+    ```bash
     curl -LJOf https://github.com/processwire/processwire/archive/master.zip
     unzip processwire-master.zip && rm -f processwire-master.zip && mv processwire-master/* . && mv processwire-master/.* . 2>/dev/null && rm -rf processwire-master
+    ```
+
+    Configure and start DDEV:
+
+    ```bash
     ddev config --project-type=php --webserver-type=apache-fpm
     ddev start -y
+    ```
+
+    Launch ProcessWire:
+
+    ```bash
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-processwire-zip.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-processwire-site && cd my-processwire-site
+        curl -LJOf https://github.com/processwire/processwire/archive/master.zip
+        unzip processwire-master.zip && rm -f processwire-master.zip && mv processwire-master/* . && mv processwire-master/.* . 2>/dev/null && rm -rf processwire-master
+        ddev config --project-type=php --webserver-type=apache-fpm
+        ddev start -y
+        ddev launch
+        EOF
+        chmod +x setup-processwire-zip.sh
+        ./setup-processwire-zip.sh
+        ```
 
 === "Composer"
 
+    Create the project directory and configure DDEV:
+
     ```bash
     mkdir my-processwire-site && cd my-processwire-site
     ddev config --project-type=php --webserver-type=apache-fpm
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
     ddev start -y
+    ```
+
+    Install ProcessWire via Composer:
+
+    ```bash
     ddev composer create-project "processwire/processwire:^3"
+    ```
+
+    Launch ProcessWire:
+
+    ```bash
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-processwire.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-processwire-site && cd my-processwire-site
+        ddev config --project-type=php --webserver-type=apache-fpm
+        ddev start -y
+        ddev composer create-project "processwire/processwire:^3"
+        ddev launch
+        EOF
+        chmod +x setup-processwire.sh
+        ./setup-processwire.sh
+        ```
 
 === "Git"
 
+    Create the project directory:
+
     ```bash
     mkdir my-processwire-site && cd my-processwire-site
+    ```
 
-    # clone the main branch (stable release) into the current directory
+    Clone ProcessWire (main branch for stable release):
+
+    ```bash
     git clone https://github.com/processwire/processwire.git .
-
-    # clone the dev branch (latest features) into the current directory
+    # For latest features, use dev branch instead:
     # git clone -b dev https://github.com/processwire/processwire.git .
+    ```
 
+    Configure and start DDEV:
+
+    ```bash
     ddev config --webserver-type=apache-fpm
     ddev start -y
+    ```
+
+    Launch ProcessWire:
+
+    ```bash
     ddev launch
     ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-processwire-git.sh << 'EOF'
+        #!/bin/bash
+        set -euo pipefail
+        mkdir my-processwire-site && cd my-processwire-site
+        git clone https://github.com/processwire/processwire.git .
+        ddev config --webserver-type=apache-fpm
+        ddev start -y
+        ddev launch
+        EOF
+        chmod +x setup-processwire-git.sh
+        ./setup-processwire-git.sh
+        ```
 
 When the installation wizard prompts for database settings, enter:
 
@@ -1628,10 +2394,22 @@ The Laravel project type can be used for [Statamic](https://statamic.com/) like 
 
 ## Sulu
 
+Create the project directory and configure DDEV:
+
 ```bash
 mkdir my-sulu-site && cd my-sulu-site
 ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0
+```
+
+Start DDEV (this may take a minute):
+
+```bash
 ddev start -y
+```
+
+Install Sulu via Composer:
+
+```bash
 ddev composer create-project sulu/skeleton
 ```
 
@@ -1650,6 +2428,8 @@ Create your default webspace configuration `mv config/webspaces/website.xml conf
 
 Alternatively, use the following commands to adjust the values for `<name>` and `<key>` to match your project setup:
 
+Configure webspace settings:
+
 ```bash
 export SULU_PROJECT_NAME="My Sulu Site"
 export SULU_PROJECT_KEY="my-sulu-site"
@@ -1661,13 +2441,16 @@ ddev exec "sed -i -e 's|<name>.*</name>|<name>${SULU_PROJECT_NAME}</name>|g' -e 
 !!!warning "Caution"
     Changing the `<key>` for a webspace later on causes problems. It is recommended to decide on the value for the key before the database is build in the next step.
 
-Now build the database. Building with the `dev` argument adds the user `admin` with the password `admin` to your project.
+Build the database with the `dev` argument (adds user `admin` with password `admin`):
 
 ```bash
-# Set APP_ENV and DATABASE_URL in .env.local
 ddev dotenv set .env.local --app-env=dev --database-url="mysql://db:db@db:3306/db?serverVersion=8.0&charset=utf8mb4"
 ddev exec bin/adminconsole sulu:build dev --no-interaction
-# Login using `admin` user and `admin` password
+```
+
+Launch Sulu (login with `admin` and `admin`):
+
+```bash
 ddev launch /admin
 ```
 
@@ -1676,6 +2459,30 @@ ddev launch /admin
 
     ```bash
     ddev execute bin/adminconsole sulu:build prod
+    ```
+
+??? tip "Prefer to run as a script?"
+    To run the whole setup as a script, examine and run this script:
+
+    ```bash
+    cat > setup-sulu.sh << 'EOF'
+    #!/bin/bash
+    set -euo pipefail
+    mkdir my-sulu-site && cd my-sulu-site
+    ddev config --project-type=php --docroot=public --upload-dirs=uploads --database=mysql:8.0
+    ddev start -y
+    ddev composer create-project sulu/skeleton
+    export SULU_PROJECT_NAME="My Sulu Site"
+    export SULU_PROJECT_KEY="my-sulu-site"
+    export SULU_PROJECT_CONFIG_FILE="config/webspaces/my-sulu-site.xml"
+    ddev exec "mv config/webspaces/website.xml ${SULU_PROJECT_CONFIG_FILE}"
+    ddev exec "sed -i -e 's|<name>.*</name>|<name>${SULU_PROJECT_NAME}</name>|g' -e 's|<key>.*</key>|<key>${SULU_PROJECT_KEY}</key>|g' ${SULU_PROJECT_CONFIG_FILE}"
+    ddev dotenv set .env.local --app-env=dev --database-url="mysql://db:db@db:3306/db?serverVersion=8.0&charset=utf8mb4"
+    ddev exec bin/adminconsole sulu:build dev --no-interaction
+    ddev launch /admin
+    EOF
+    chmod +x setup-sulu.sh
+    ./setup-sulu.sh
     ```
 
 ## Symfony

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -231,7 +231,7 @@ ddev config --project-type=php --composer-root=core --upload-dirs=public/media
 Start DDEV (this may take a minute):
 
 ```bash
-ddev start -y
+ddev start
 ```
 
 Download and extract CiviCRM:
@@ -893,7 +893,7 @@ ddev config --project-type=drupal11 --webserver-type=generic --docroot=web --php
 Start DDEV (this may take a minute):
 
 ```bash
-ddev start -y
+ddev start
 ```
 
 Create FrankenPHP configuration:
@@ -1111,7 +1111,7 @@ ddev config --project-type=php --docroot=public --web-environment-add DATABASE_U
 Start DDEV (this may take a minute):
 
 ```bash
-ddev start -y
+ddev start
 ```
 
 Install Ibexa via Composer:
@@ -1177,7 +1177,7 @@ ddev config --project-type=php --webserver-type=apache-fpm --upload-dirs=images
 Start DDEV (this may take a minute):
 
 ```bash
-ddev start -y
+ddev start
 ```
 
 Install Joomla and launch:
@@ -1623,7 +1623,7 @@ ddev add-on get ddev/ddev-opensearch
 Start DDEV (this may take a minute):
 
 ```bash
-ddev start -y
+ddev start
 ```
 
 Install Magento via Composer:
@@ -2404,7 +2404,7 @@ ddev config --project-type=php --docroot=public --upload-dirs=uploads --database
 Start DDEV (this may take a minute):
 
 ```bash
-ddev start -y
+ddev start
 ```
 
 Install Sulu via Composer:


### PR DESCRIPTION
## The Issue

Copying a selected quickstart into a terminal (at least on iTerm2 on macOS) results in only part of the paste being executed. This seems to be partly a function of certain commands (like `ddev composer create-project` and the start of mutagen daemon) eating stdin so eating the next item, but also may be related to the terminal, as I couldn't reproduce on Ubuntu with Terminator.

## How This PR Solves The Issue

* Revise quickstarts in quickstart.md to more tutorial and separate section copy/paste
* Provide a scripted all-in-one technique

    <img width="731" height="697" alt="image" src="https://github.com/user-attachments/assets/470731b6-e1e0-4b7c-ae38-b05a5e9a830e" />

    1. **Break multi-command blocks into separate sections**: Each command or
       logical group of commands now has its own code block with explanatory
       text between them, making copy-paste safer and more user-friendly.

    2. **Add "Prefer to run as a script?" collapsible tips**: Every quickstart
       section now includes an inline script creation option using heredoc
       syntax, allowing users to create and run a complete setup script instead
       of copy-pasting individual commands.

    3. **Change all `ddev start` to `ddev start -y`**: Suppresses interactive
       prompts throughout all quickstart examples, ensuring non-interactive
       execution in both step-by-step and script approaches.

    **All quickstarts updated with this pattern:**

    - Backdrop (New, Existing)
    - CakePHP (Composer, Git Clone)
    - CiviCRM Standalone
    - Contao (Composer, Contao Manager)
    - Craft CMS (New, Existing)
    - Drupal (6/7, 10, 11, CMS, Git Clone)
    - ExpressionEngine (ZIP, Git Checkout)
    - FrankenPHP (Generic)
    - Grav (Composer, Git Clone)
    - Ibexa DXP
    - Joomla
    - Kirby CMS (New, Existing)
    - Laravel (Composer, Composer SQLite, Switch to SQLite, Installer, Git Clone)
    - Magento 2
    - Moodle Composer
    - OpenMage (Composer, Git Clone)
    - Pimcore Composer
    - ProcessWire (ZIP, Composer, Git)
    - Shopware Composer
    - Silverstripe
    - Statamic
    - Sulu
    - Symfony Composer
    - TYPO3 Composer
    - WordPress WP-CLI

## Manual Testing Instructions

* Review the changes, rendered at https://ddev--7765.org.readthedocs.build/en/7765/users/quickstart/
* Try some of the scripted approaches
* Pay attention to whether Claude Code misbehaved on anything.

I think the tutorial technique improves the overall communication

## Automated Testing Overview

These still all do the same thing, so the quickstart tests should not be affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)