### PR TITLE
feat: use docker-compose library, optionally download docker-buildx, fixes #7915, for #8295

### DIFF
--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 os=$(go env GOOS)
 
-rm -rf ~/.ddev/Test* ~/.ddev/global_config.yaml ~/.ddev/project_list.yaml ~/.ddev/homeadditions ~/.ddev/commands ~/.ddev/bin/docker-compose* ~/.ddev/traefik ~/tmp/ddevtest
+rm -rf ~/.ddev/Test* ~/.ddev/global_config.yaml ~/.ddev/project_list.yaml ~/.ddev/homeadditions ~/.ddev/commands ~/.ddev/bin/docker-buildx* ~/.ddev/bin/docker-compose* ~/.ddev/traefik ~/tmp/ddevtest
 
 # Latest git won't let you do much in a non-safe directory
 git config --global --add safe.directory '*' || true

--- a/cmd/ddev/cmd/cmd_version.go
+++ b/cmd/ddev/cmd/cmd_version.go
@@ -28,12 +28,9 @@ var versionCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		_, err := dockerutil.DownloadDockerComposeIfNeeded()
-		if err != nil {
-			util.Failed("Failed to check for and download docker-compose: %v", err)
-		}
+		_, buildxErr := dockerutil.DownloadDockerBuildxIfNeeded()
 
-		v := version.GetVersionInfo()
+		v, dockerErr := version.GetVersionInfo()
 
 		// If in a project context, show the project's actual web image instead of the default.
 		if app, err := ddevapp.GetActiveApp(""); err == nil {
@@ -63,6 +60,12 @@ var versionCmd = &cobra.Command{
 		t.Render()
 		output.UserOut.WithField("raw", v).Println(out.String())
 		amplitude.CheckSetUp()
+
+		if dockerErr != nil {
+			util.Failed("Docker error: %v\nFor help go to: https://docs.ddev.com/en/stable/users/install/docker-installation/#troubleshooting-docker", dockerErr)
+		} else if buildxErr != nil {
+			util.Failed("Docker buildx error: %v", buildxErr)
+		}
 	},
 }
 

--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
-	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/versionconstants"
 	asrt "github.com/stretchr/testify/assert"
@@ -36,17 +35,16 @@ func TestCmdVersion(t *testing.T) {
 	dockerAPIVersion, err := dockerutil.GetDockerAPIVersion()
 	require.NoError(t, err)
 	assert.Equal(dockerAPIVersion, raw["docker-api"])
-	composeVersion, err := dockerutil.GetDockerComposeVersion()
+	buildxVersion, err := dockerutil.GetDockerBuildxVersion()
 	require.NoError(t, err)
-	assert.Equal(composeVersion, raw["docker-compose"])
+	assert.Equal(buildxVersion, raw["docker-buildx"])
 
 	assert.Contains(versionData["msg"], versionconstants.DdevVersion)
 	assert.Contains(versionData["msg"], versionconstants.WebImg)
 	assert.Contains(versionData["msg"], versionconstants.WebTag)
 	assert.Contains(versionData["msg"], versionconstants.DBImg)
 	assert.Contains(versionData["msg"], docker.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion))
-	assert.NotEmpty(globalconfig.DockerComposeVersion)
 	assert.Contains(versionData["msg"], dockerVersion)
 	assert.Contains(versionData["msg"], dockerAPIVersion)
-	assert.Contains(versionData["msg"], globalconfig.DockerComposeVersion)
+	assert.Contains(versionData["msg"], buildxVersion)
 }

--- a/cmd/ddev/cmd/config-global.go
+++ b/cmd/ddev/cmd/config-global.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	configTypes "github.com/ddev/ddev/pkg/config/types"
-	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	globalconfigTypes "github.com/ddev/ddev/pkg/globalconfig/types"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -189,20 +188,14 @@ func handleGlobalConfig(cmd *cobra.Command, _ []string) {
 		dirty = true
 	}
 
-	if cmd.Flag("required-docker-compose-version").Changed {
-		val, _ := cmd.Flags().GetString("required-docker-compose-version")
-		globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = val
+	if cmd.Flag("docker-buildx-version").Changed {
+		val, _ := cmd.Flags().GetString("docker-buildx-version")
+		globalconfig.DdevGlobalConfig.DockerBuildxVersion = val
 		dirty = true
 	}
 	if cmd.Flag("project-tld").Changed {
 		val, _ := cmd.Flags().GetString("project-tld")
 		globalconfig.DdevGlobalConfig.ProjectTldGlobal = val
-		dirty = true
-	}
-
-	if cmd.Flag("use-docker-compose-from-path").Changed {
-		val, _ := cmd.Flags().GetBool("use-docker-compose-from-path")
-		globalconfig.DdevGlobalConfig.UseDockerComposeFromPath = val
 		dirty = true
 	}
 
@@ -345,12 +338,8 @@ func init() {
 
 	configGlobalCommand.Flags().String("table-style", "default", fmt.Sprintf(`Table style for "ddev list" and "ddev describe", possible values are "%s"`, strings.Join(globalconfig.ValidTableStyleList(), `", "`)))
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("table-style", configCompletionFunc(globalconfig.ValidTableStyleList()))
-	configGlobalCommand.Flags().String("required-docker-compose-version", "", "Override default docker-compose version (used only in development testing)")
-	_ = configGlobalCommand.Flags().MarkHidden("required-docker-compose-version")
 	configGlobalCommand.Flags().String("project-tld", nodeps.DdevDefaultTLD, "Set the default top-level domain to be used for all projects, can be overridden by project configuration")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("project-tld", configCompletionFunc([]string{nodeps.DdevDefaultTLD}))
-	configGlobalCommand.Flags().Bool("use-docker-compose-from-path", false, fmt.Sprintf("If true, use docker-compose from path instead of private %s (used only in development testing)", fileutil.ShortHomeJoin(globalconfig.GetDDEVBinDir(), "docker-compose")))
-	_ = configGlobalCommand.Flags().MarkHidden("use-docker-compose-from-path")
 	configGlobalCommand.Flags().Bool("no-bind-mounts", false, "If true, don't use bind-mounts. Useful for environments like remote Docker where bind-mounts are impossible")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("no-bind-mounts", configCompletionFunc([]string{"true", "false"}))
 	configGlobalCommand.Flags().String("xdebug-ide-location", "", "For less usual IDE locations specify where the IDE is running for Xdebug to reach it (for advanced use only)")
@@ -363,9 +352,6 @@ func init() {
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("mailpit-http-port", configCompletionFunc([]string{nodeps.DdevDefaultMailpitHTTPPort}))
 	configGlobalCommand.Flags().String("mailpit-https-port", nodeps.DdevDefaultMailpitHTTPSPort, "The default Mailpit HTTPS port for all projects, can be overridden by project configuration")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("mailpit-https-port", configCompletionFunc([]string{nodeps.DdevDefaultMailpitHTTPSPort}))
-	configGlobalCommand.Flags().String("router", globalconfigTypes.RouterTypeTraefik, fmt.Sprintf("The only valid router types are %s", strings.Join(globalconfigTypes.GetValidRouterTypes(), ", ")))
-	_ = configGlobalCommand.Flags().MarkDeprecated("router", "\nThe only router used now is traefik, so --router is no longer needed")
-	_ = configGlobalCommand.Flags().MarkHidden("router")
 	configGlobalCommand.Flags().String("traefik-monitor-port", nodeps.TraefikMonitorPortDefault, `Can be used to change the Traefik monitor port in case of port conflicts, for example "ddev config global --traefik-monitor-port=11999"`)
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("traefik-monitor-port", configCompletionFunc([]string{nodeps.TraefikMonitorPortDefault}))
 	configGlobalCommand.Flags().String("share-default-provider", "", `The default share provider for all projects (ngrok, cloudflared, or custom), can be overridden by project configuration`)
@@ -374,5 +360,19 @@ func init() {
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("no-tui", configCompletionFunc([]string{"true", "false"}))
 	configGlobalCommand.Flags().Bool("omit-snapshot-on-delete", false, "If true, omit the snapshot on 'ddev delete' by default")
 	_ = configGlobalCommand.RegisterFlagCompletionFunc("omit-snapshot-on-delete", configCompletionFunc([]string{"true", "false"}))
+
+	// Hidden flags
+	configGlobalCommand.Flags().String("docker-buildx-version", "system", `docker-buildx version: "system" uses the installed plugin (default, no download), or specify a version like "0.33.0" to download it`)
+	_ = configGlobalCommand.RegisterFlagCompletionFunc("docker-buildx-version", configCompletionFunc([]string{"system"}))
+	_ = configGlobalCommand.Flags().MarkHidden("docker-buildx-version")
+
+	// Deprecated flags
+	configGlobalCommand.Flags().String("required-docker-compose-version", "", "")
+	_ = configGlobalCommand.Flags().MarkDeprecated("required-docker-compose-version", "docker-compose is now embedded")
+	configGlobalCommand.Flags().Bool("use-docker-compose-from-path", false, "")
+	_ = configGlobalCommand.Flags().MarkDeprecated("use-docker-compose-from-path", "docker-compose is now embedded")
+	configGlobalCommand.Flags().String("router", globalconfigTypes.RouterTypeTraefik, "")
+	_ = configGlobalCommand.Flags().MarkDeprecated("router", "traefik is the only router")
+
 	ConfigCommand.AddCommand(configGlobalCommand)
 }

--- a/cmd/ddev/cmd/config-global_test.go
+++ b/cmd/ddev/cmd/config-global_test.go
@@ -40,7 +40,7 @@ func TestCmdGlobalConfig(t *testing.T) {
 	// nolint: errcheck
 	t.Cleanup(func() {
 		// Even though the global config is going to be deleted, make sure it's sane before leaving
-		args := []string{"config", "global", "--omit-containers", "", "--performance-mode-reset", "--simple-formatting=false", "--table-style=default", `--required-docker-compose-version=""`, `--use-docker-compose-from-path=false`, `--xdebug-ide-location`, "", `--traefik-monitor-port=10999`}
+		args := []string{"config", "global", "--omit-containers", "", "--performance-mode-reset", "--simple-formatting=false", "--table-style=default", `--xdebug-ide-location`, "", `--traefik-monitor-port=10999`, `--docker-buildx-version=system`}
 		globalconfig.DdevGlobalConfig.OmitContainersGlobal = nil
 		out, err := exec.RunHostCommand(DdevBin, args...)
 		assert.NoError(err, "error running ddev config global; output=%s", out)
@@ -77,8 +77,6 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.Contains(out, "simple-formatting=false")
 	assert.Contains(out, "use-hardened-images=false")
 	assert.Contains(out, "fail-on-hook-fail=false")
-	assert.Contains(out, fmt.Sprintf("required-docker-compose-version=%s", globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion))
-	assert.Contains(out, "use-docker-compose-from-path=false")
 	assert.Contains(out, "project-tld="+globalconfig.DdevGlobalConfig.ProjectTldGlobal)
 	assert.Contains(out, "xdebug-ide-location=")
 	assert.Contains(out, "wsl2-no-windows-hosts-mgt=false")
@@ -89,6 +87,7 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.Contains(out, "traefik-monitor-port=10999")
 	assert.Contains(out, "omit-project-name-by-default=false")
 	assert.Contains(out, "omit-snapshot-on-delete=false")
+	assert.Contains(out, "docker-buildx-version=system")
 
 	// Update a config
 	// Don't include no-bind-mounts because global testing
@@ -110,11 +109,8 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.Contains(out, "simple-formatting=true")
 	assert.Contains(out, "use-hardened-images=true")
 	assert.Contains(out, "fail-on-hook-fail=true")
-	assert.Contains(out, fmt.Sprintf("required-docker-compose-version=%s", globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion))
-	assert.Contains(out, "use-docker-compose-from-path=false")
 	assert.Contains(out, "project-tld=")
 	assert.Contains(out, "wsl2-no-windows-hosts-mgt=false")
-
 	assert.Contains(out, "xdebug-ide-location=container")
 	assert.Contains(out, "wsl2-no-windows-hosts-mgt=false")
 	assert.Contains(out, "router-http-port=8081")
@@ -122,6 +118,7 @@ func TestCmdGlobalConfig(t *testing.T) {
 	assert.Contains(out, "mailpit-http-port=18025")
 	assert.Contains(out, "mailpit-https-port=10826")
 	assert.Contains(out, "traefik-monitor-port=11999")
+	assert.Contains(out, "docker-buildx-version=system")
 
 	globalconfig.EnsureGlobalConfig()
 	assert.False(globalconfig.DdevGlobalConfig.InstrumentationOptIn)

--- a/cmd/ddev/cmd/debug-compose-config_test.go
+++ b/cmd/ddev/cmd/debug-compose-config_test.go
@@ -18,7 +18,7 @@ services:
 `
 
 // TestComposeConfigCmd ensures the compose-config command behaves
-// as expected with a with a basic docker-compose.override.yaml.
+// as expected with a basic docker-compose.override.yaml.
 func TestComposeConfigCmd(t *testing.T) {
 	// Create a temporary directory and switch to it.
 	tmpdir := testcommon.CreateTmpDir(t.Name())

--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/docker"
-	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
@@ -29,12 +28,8 @@ ddev utility download-images --all
 			util.Failed("Cannot specify project name with --all")
 		}
 
-		_, err := dockerutil.DownloadDockerComposeIfNeeded()
-		if err != nil {
-			util.Failed("Unable to download docker-compose: %v", err)
-		}
 		if globalconfig.DdevGlobalConfig.IsMutagenEnabled() {
-			err = ddevapp.DownloadMutagenIfNeeded()
+			err := ddevapp.DownloadMutagenIfNeeded()
 			if err != nil {
 				util.Warning("Unable to download Mutagen: %v", err)
 			}

--- a/cmd/ddev/cmd/debug-rebuild.go
+++ b/cmd/ddev/cmd/debug-rebuild.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
-	exec2 "github.com/ddev/ddev/pkg/exec"
-	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/docker/compose/v5/cmd/display"
+	"github.com/docker/compose/v5/pkg/api"
 	"github.com/spf13/cobra"
 )
 
@@ -38,14 +38,9 @@ var DebugRebuildCmd = &cobra.Command{
 			util.Failed("--all flag cannot be used with --service flag")
 		}
 
-		_, err := dockerutil.DownloadDockerComposeIfNeeded()
+		_, err := dockerutil.DownloadDockerBuildxIfNeeded()
 		if err != nil {
-			util.Failed("could not download docker-compose: %v", err)
-		}
-
-		composeBinaryPath, err := globalconfig.GetDockerComposePath()
-		if err != nil {
-			util.Failed("could not GetDockerComposePath(): %v", err)
+			util.Failed("Failed to download docker-buildx: %v", err)
 		}
 
 		app, err := ddevapp.GetActiveApp(projectName)
@@ -63,14 +58,12 @@ var DebugRebuildCmd = &cobra.Command{
 		composeRenderedPath := app.DockerComposeFullRenderedYAMLPath()
 		withoutCache := !cmd.Flags().Changed("cache")
 
-		buildArgs := []string{"-f", composeRenderedPath, "--progress", "plain", "build"}
-
+		var services []string
 		if !buildAll {
-			buildArgs = append(buildArgs, service)
+			services = []string{service}
 		}
 
 		if withoutCache {
-			buildArgs = append(buildArgs, "--no-cache")
 			output.UserOut.Printf("Rebuilding project images without Docker cache...")
 			additionalImages, findErr := app.FindAllImages()
 			if findErr != nil {
@@ -83,10 +76,23 @@ var DebugRebuildCmd = &cobra.Command{
 			output.UserOut.Printf("Rebuilding project images using Docker cache...")
 		}
 
-		output.UserOut.Printf("Executing `%s %v`", composeBinaryPath, prettyCmd(buildArgs))
-		err = exec2.RunInteractiveCommand(composeBinaryPath, buildArgs)
+		buildProject, loadErr := dockerutil.LoadComposeProject([]string{composeRenderedPath}, api.ProjectLoadOptions{
+			ProjectName: app.GetComposeProjectName(),
+		})
+		if loadErr != nil {
+			util.Failed("Failed to load compose project: %v", loadErr)
+		}
+		buildCtx, buildSvc, svcErr := dockerutil.NewComposeService()
+		if svcErr != nil {
+			util.Failed("Failed to create compose service: %v", svcErr)
+		}
+		err = buildSvc.Build(buildCtx, buildProject, api.BuildOptions{
+			Progress: display.ModePlain,
+			NoCache:  withoutCache,
+			Services: services,
+		})
 		if err != nil {
-			util.Failed("Failed to execute `%s %v`: %v", composeBinaryPath, prettyCmd(buildArgs), err)
+			util.Failed("Failed to build project: %v", err)
 		}
 
 		buildDuration := util.FormatDuration(buildDurationStart())
@@ -114,14 +120,25 @@ var DebugRebuildCmd = &cobra.Command{
 			"com.docker.compose.service": service,
 		}
 
-		// Restart the specified service using docker-compose, if it is running
+		// Restart the specified service using compose, if it is running
 		if container, err := dockerutil.FindContainerByLabels(labels); err == nil && container != nil {
-			restartArgs := []string{"-f", composeRenderedPath, "--progress", "plain", "restart", service}
-			output.UserOut.Printf("Executing `%s %v`", composeBinaryPath, prettyCmd(restartArgs))
-			err = exec2.RunInteractiveCommand(composeBinaryPath, restartArgs)
-			if err != nil {
-				util.Failed("Failed to execute `%s %v`: %v", composeBinaryPath, prettyCmd(restartArgs), err)
+			output.UserOut.Printf("Restarting service %s...", service)
+
+			// Restart the specific service via compose
+			restartCtx, restartSvc, restartErr := dockerutil.NewComposeService()
+			if restartErr != nil {
+				util.Failed("Failed to create compose service: %v", restartErr)
 			}
+			restartTimeout := 60 * time.Second
+			err = restartSvc.Restart(restartCtx, buildProject.Name, api.RestartOptions{
+				Project:  buildProject,
+				Services: []string{service},
+				Timeout:  &restartTimeout,
+			})
+			if err != nil {
+				util.Failed("Failed to restart service %s: %v", service, err)
+			}
+
 			output.UserOut.Printf("Waiting for project container [%v] to become ready...", service)
 			err = app.WaitByLabels(labels)
 			if err != nil {

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -3,12 +3,12 @@ package cmd
 import (
 	"errors"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/docker/cli/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -90,9 +90,9 @@ ddev exec -s db -u root ls -la /root`,
 
 		if err != nil {
 			exitCode := 1
-			var exiterr *exec.ExitError
-			if errors.As(err, &exiterr) {
-				exitCode = exiterr.ExitCode()
+			var statusErr cli.StatusError
+			if errors.As(err, &statusErr) {
+				exitCode = statusErr.StatusCode
 			}
 			if !quiet {
 				util.Error("Failed to execute command `%s`: %v", opts.Cmd, err)

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -60,7 +60,7 @@ ddev restart --all`,
 
 func init() {
 	RestartCmd.Flags().BoolP("skip-confirmation", "y", false, "Skip any confirmation steps")
-	RestartCmd.Flags().BoolP("no-cache", "", false, "Build Docker images without using cache")
+	RestartCmd.Flags().BoolP("no-cache", "", false, "Rebuild custom Docker image layers without cache")
 	RestartCmd.Flags().BoolVarP(&restartAll, "all", "a", false, "Restart all projects")
 	RootCmd.AddCommand(RestartCmd)
 }

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -87,11 +87,6 @@ Support: https://docs.ddev.com/en/stable/users/support/`,
 			}
 		}
 
-		err = dockerutil.CheckDockerBuildxVersion(dockerutil.DockerRequirements)
-		if err != nil {
-			util.Failed("Docker buildx check failed: %v", err)
-		}
-
 		updateFile := filepath.Join(globalconfig.GetGlobalDdevDir(), ".update")
 
 		// Do periodic detection of whether an update is available for DDEV users.

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"os"
-	"os/exec"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/docker/cli/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -49,8 +50,9 @@ ddev ssh -d /var/www/html`,
 			User:    serviceUser,
 		})
 		if err != nil {
-			if exiterr, ok := err.(*exec.ExitError); ok {
-				os.Exit(exiterr.ExitCode())
+			var statusErr cli.StatusError
+			if errors.As(err, &statusErr) {
+				os.Exit(statusErr.StatusCode)
 			}
 			util.Failed("ddev ssh failed: %v", err)
 		}

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -170,7 +170,7 @@ func emitReachProjectMessage(project *ddevapp.DdevApp) {
 func init() {
 	StartCmd.Flags().BoolVarP(&startAll, "all", "a", false, "Start all projects")
 	StartCmd.Flags().BoolP("skip-confirmation", "y", false, "Skip any confirmation steps")
-	StartCmd.Flags().BoolP("no-cache", "", false, "Build Docker images without using cache")
+	StartCmd.Flags().BoolP("no-cache", "", false, "Rebuild custom Docker image layers without cache")
 	StartCmd.Flags().String("profiles", "", "Start optional comma-separated docker compose profiles")
 	StartCmd.Flags().BoolP("select", "s", false, "Interactively select a project to start")
 	err := StartCmd.Flags().MarkHidden("select")

--- a/cmd/ddev/cmd/utility-dockercheck.go
+++ b/cmd/ddev/cmd/utility-dockercheck.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/ddev/ddev/pkg/dockerutil"
 	exec2 "github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/version"
 	"github.com/ddev/ddev/pkg/versionconstants"
@@ -27,10 +29,9 @@ ddev ut dockercheck`,
 
 		hasWarnings := false
 
-		// Ensure docker-compose is available before getting version info
-		_, dockerComposeErr := dockerutil.DownloadDockerComposeIfNeeded()
+		_, buildxErr := dockerutil.DownloadDockerBuildxIfNeeded()
 
-		versionInfo := version.GetVersionInfo()
+		versionInfo, _ := version.GetVersionInfo()
 		bashPath := util.FindBashPath()
 		util.Success("Docker platform: %v", versionInfo["docker-platform"])
 		switch versionInfo["docker-platform"] {
@@ -82,13 +83,17 @@ ddev ut dockercheck`,
 			}
 		}
 
-		buildxErr := dockerutil.CheckDockerBuildxVersion(dockerutil.DockerRequirements)
-		if buildxErr != nil {
-			util.Warning("Docker buildx version check: %v", buildxErr)
+		buildxCheckErr := dockerutil.CheckDockerBuildxVersion()
+		if buildxCheckErr != nil {
+			util.Warning("Docker buildx version check: %v", buildxCheckErr)
 			hasWarnings = true
 		} else {
-			buildxVersion, _ := dockerutil.GetBuildxVersion()
-			util.Success("docker buildx version %s meets requirements for minimum %s", buildxVersion, dockerutil.DockerRequirements.BuildxVersion)
+			buildxVersion, _ := dockerutil.GetDockerBuildxVersion()
+			buildxLocation, _ := dockerutil.GetDockerBuildxLocation()
+			util.Success("docker buildx version %s (%s) meets requirements for minimum %s", buildxVersion, buildxLocation, versionconstants.DockerBuildxMinVersion)
+			if globalconfig.GetRequiredDockerBuildxVersion() != "" {
+				util.Warning("Using a specific docker-buildx plugin as specified in %q", globalconfig.GetGlobalConfigPath())
+			}
 		}
 
 		dockerContextName, dockerHost, err := dockerutil.GetDockerContextNameAndHost()
@@ -122,13 +127,6 @@ ddev ut dockercheck`,
 		}
 		if dockerCertPath != "" {
 			util.Success("DOCKER_CERT_PATH=%s", dockerCertPath)
-		}
-
-		if dockerComposeErr != nil {
-			util.Warning("Docker compose check failed: %v", dockerComposeErr)
-			hasWarnings = true
-		} else {
-			util.Success("docker-compose: %s", versionInfo["docker-compose"])
 		}
 
 		dockerVersion, err := dockerutil.GetDockerVersion()
@@ -176,11 +174,18 @@ ddev ut dockercheck`,
 
 		// Test buildx with a trivial build on the host
 		if buildxErr == nil {
-			out, err = exec2.RunHostCommand(bashPath, "-c", fmt.Sprintf("echo 'FROM %s' | docker buildx build --quiet -f- -t ddev-buildx-test:latest . && docker rmi -f ddev-buildx-test:latest", versionconstants.UtilitiesImage))
+			// Use RunCLIPluginCommand to execute buildx build via Docker CLI plugin infrastructure
+			stdin := strings.NewReader(fmt.Sprintf("FROM %s", versionconstants.UtilitiesImage))
+			out, err = dockerutil.RunCLIPluginCommand("buildx", stdin, "build", "--no-cache", "-f-", "-t", "ddev-buildx-test:latest", ".")
 			if err != nil {
 				util.Warning("Unable to perform trivial build with buildx: %v; output=%s", err, out)
 				hasWarnings = true
 			} else {
+				// Clean up the test image using Docker API
+				cleanupErr := dockerutil.RemoveImage("ddev-buildx-test:latest")
+				if cleanupErr != nil {
+					util.Debug("Failed to clean up test image: %v", cleanupErr)
+				}
 				util.Success("docker buildx is working correctly (trivial build succeeded)")
 			}
 		} else {
@@ -198,7 +203,11 @@ ddev ut dockercheck`,
 		}
 
 		if hasWarnings {
-			util.Failed("Docker provider checks completed with warnings. Please address the issues above.")
+			util.Error("Docker provider checks completed with warnings. Please address the issues above.")
+			if buildxErr != nil {
+				util.Error("Docker buildx error: %v", buildxErr)
+			}
+			output.UserErr.Exit(1)
 		}
 	},
 }

--- a/cmd/ddev/cmd/utility-dockercheck_test.go
+++ b/cmd/ddev/cmd/utility-dockercheck_test.go
@@ -16,7 +16,6 @@ func TestUtilityDockercheckCmd(t *testing.T) {
 	require.Contains(t, out, "Using Docker context:")
 	require.Contains(t, out, "Using Docker host:")
 	require.Regexp(t, "TLS (not configured|enabled)", out)
-	require.Contains(t, out, "docker-compose:")
 	require.Contains(t, out, "docker buildx version")
 	require.Contains(t, out, "Docker version:")
 	require.Contains(t, out, "Docker API version:")

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -188,6 +188,19 @@ Whether to disable the standard warning issued when a project is using `performa
 
 When `true`, DDEV will not issue the normal warning on `ddev start`: "You have Mutagen enabled and your 'php' project type doesn't have `upload_dirs` set". See [Mutagen and User-Generated Uploads](../install/performance.md#mutagen-and-user-generated-uploads) for context on why DDEV avoids doing the Mutagen sync on `upload_dirs`.
 
+## `docker_buildx_version`
+
+Controls which `docker-buildx` plugin DDEV uses.
+
+| Type | Default | Usage
+| -- | -- | --
+| :octicons-globe-16: global | `system` | `system` or a version string like `0.33.0`
+
+When set to `system` (the default), DDEV uses whatever `docker-buildx` is already installed on your system and never downloads anything.
+
+!!!warning "Troubleshooting Only!"
+    This should only be used in specific cases like troubleshooting. Please don't experiment with it unless directed to do so.
+
 ## `docroot`
 
 Relative path to the document root containing `index.php` or `index.html`.
@@ -510,19 +523,6 @@ Default Top-Level-Domain (`TLD`) to be used for a project’s domains, or global
 
 See [Hostnames and Wildcards and DDEV, Oh My!](https://ddev.com/blog/ddev-name-resolution-wildcards/) for more information on DDEV hostname resolution.
 
-## `required_docker_compose_version`
-
-Specific docker-compose version for download.
-
-| Type | Default | Usage
-| -- | -- | --
-| :octicons-globe-16: global | &zwnj; | &zwnj;
-
-If set to `v2.8.3`, for example, it will download and use that version instead of the expected version for docker-compose.
-
-!!!warning "Troubleshooting Only!"
-    This should only be used in specific cases like troubleshooting. Please don't experiment with it unless directed to do so.
-
 ## `router_bind_all_interfaces`
 
 Whether to bind `ddev-router`'s ports on all network interfaces.
@@ -652,19 +652,6 @@ Whether to use DNS instead of editing `/etc/hosts`.
 When `false`, DDEV will always update the `/etc/hosts` file with the project hostname instead of using DNS for name resolution.
 
 See [Using DDEV Offline](../usage/offline.md).
-
-## `use_docker_compose_from_path`
-
-Whether to use the system-installed docker-compose. You can otherwise use [`required_docker_compose_version`](#required_docker_compose_version) to specify a version for download.
-
-| Type | Default | Usage
-| -- | -- | --
-| :octicons-globe-16: global | `false` | Can `true` or `false`.
-
-When `true`, DDEV will use the docker-compose found in on your system’s path instead of using its private, known-good, docker-compose version.
-
-!!!warning "Troubleshooting Only!"
-    This should only be used in specific cases like troubleshooting. (It is used in the Docker Compose automated tests.)
 
 ## `use_hardened_images`
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -82,6 +82,8 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     brew install docker-buildx
     ```
 
+    More information in [Docker buildx requirement](https://ddev.com/blog/docker-buildx-requirement-v1-25-1/).
+
     #### Migrating Projects Between Docker Providers
 
     * OrbStack has built-in migration of images and volumes from Docker Desktop.
@@ -191,6 +193,8 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     ### Docker Buildx
 
     DDEV requires the [Docker buildx plugin](https://github.com/docker/buildx). Docker CE installed from the official Docker repository includes it. If `docker buildx version` doesn't work, install the `docker-buildx-plugin` package from the Docker repository (e.g. `sudo apt-get install docker-buildx-plugin` on Debian/Ubuntu) or follow any of the installation instructions from [Docker buildx](https://github.com/docker/buildx#installing).
+
+    More information in [Docker buildx requirement](https://ddev.com/blog/docker-buildx-requirement-v1-25-1/).
 
     ### Docker Rootless
 
@@ -326,6 +330,8 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     ### Docker Buildx
 
     DDEV requires the [Docker buildx plugin](https://github.com/docker/buildx). Docker CE inside WSL2, Docker Desktop, and Rancher Desktop all include it. If `docker buildx version` doesn't work, install the `docker-buildx-plugin` package inside WSL2 (e.g. `sudo apt-get install docker-buildx-plugin` on Ubuntu).
+
+    More information in [Docker buildx requirement](https://ddev.com/blog/docker-buildx-requirement-v1-25-1/).
 
 === "Codespaces"
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -54,7 +54,6 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     Rancher Desktop is an easy-to-install free and open-source Docker provider. Install from [Rancher Desktop](https://rancherdesktop.io/). It has automated testing with DDEV. When installing, choose only the Docker option and turn off Kubernetes.
 
-
     ### Colima
 
     [Colima](https://github.com/abiosoft/colima) is a free and open-source project which bundles Lima.

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -141,7 +141,7 @@ ddev version | grep global-ddev-dir
 : This YAML file defines your project list that lets DDEV keep track of the projects you’ve added.
 
 `bin` directory
-: This is where DDEV stores private executable binaries it needs, like `mutagen` and `docker-compose`.
+: This is where DDEV stores private executable binaries it needs, like [`mutagen`](../configuration/config.md#performance_mode) and [`docker-buildx`](../configuration/config.md#docker_buildx_version).
 
 `commands` directory
 : Directory for storing DDEV commands that should be available in containers, like `npm`, `artisan`, `cake` and `drush` for example. These are organized in subdirectories named for where they’ll be used: `db`, `host`, and `web`. You can add your own [custom commands](../extend/custom-commands.md) here.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -398,6 +398,7 @@ Flags:
 * `--default-container-timeout`: Default time in seconds that DDEV waits for all containers to become ready on start (see [default](../configuration/config.md#default_container_timeout)).
 * `--disable-settings-management`: Prevent DDEV from creating or updating CMS settings files.
 * `--disable-upload-dirs-warning`: Disable warnings about `upload-dirs` not being set when using `--performance-mode=mutagen`.
+* `--docker-buildx-version`: Control which `docker-buildx` plugin to use (see [default](../configuration/config.md#docker_buildx_version)).
 * `--docroot`: Provide the relative docroot of the project, like `docroot` or `htdocs` or `web`, defaults to empty, the current directory.
 * `--fail-on-hook-fail`: Decide whether `ddev start` should be interrupted by a failing hook.
 * `--host-db-port`: The `db` container’s localhost-bound port.
@@ -1200,7 +1201,7 @@ Restart one or several projects.
 Flags:
 
 * `--all`, `-a`: Restart all projects.
-* `--no-cache`: Build Docker images without using cache.
+* `--no-cache`: Rebuild custom Docker image layers without cache.
 
 Example:
 
@@ -1400,7 +1401,7 @@ Start a DDEV project.
 Flags:
 
 * `--all`, `-a`: Start all projects.
-* `--no-cache`: Build Docker images without using cache.
+* `--no-cache`: Rebuild custom Docker image layers without cache.
 * `--profiles=<optional-compose-profile-list>`: Start services labeled with the Docker Compose profiles in comma-separated list of profiles.
 * `--skip-confirmation`, `-y`: Skip any confirmation steps.
 

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 // WriteDockerComposeYAML writes a .ddev-docker-compose-base.yaml and related to the .ddev directory.
@@ -69,20 +70,19 @@ func (app *DdevApp) WriteDockerComposeYAML() error {
 	if err != nil {
 		return err
 	}
-	var action []string
-	for _, envFile := range envFiles {
-		action = append(action, "--env-file", envFile)
-	}
-	fullContents, _, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: files,
-		Profiles:     []string{`*`},
-		Action:       append(action, "config"),
+	project, err := dockerutil.LoadComposeProject(files, api.ProjectLoadOptions{
+		ProjectName: app.GetComposeProjectName(),
+		Profiles:    []string{`*`},
+		EnvFiles:    envFiles,
 	})
 	if err != nil {
 		return err
 	}
+	if err = project.CheckContainerNameUnicity(); err != nil {
+		return err
+	}
 
-	app.ComposeYaml, err = fixupComposeYaml(fullContents, app)
+	app.ComposeYaml, err = fixupComposeYaml(project, app)
 	if err != nil {
 		return err
 	}
@@ -225,12 +225,7 @@ func injectDdevLabels(project *composeTypes.Project, app *DdevApp) {
 
 // fixupComposeYaml makes minor changes to the `docker-compose config` output
 // to make sure extra services are always compatible with ddev.
-func fixupComposeYaml(yamlStr string, app *DdevApp) (*composeTypes.Project, error) {
-	project, err := dockerutil.CreateComposeProject(yamlStr)
-	if err != nil {
-		return project, err
-	}
-
+func fixupComposeYaml(project *composeTypes.Project, app *DdevApp) (*composeTypes.Project, error) {
 	envFiles, err := app.EnvFiles()
 	if err != nil {
 		return project, err

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2,7 +2,9 @@ package ddevapp
 
 import (
 	"bytes"
+	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -30,6 +32,8 @@ import (
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
+	"github.com/docker/compose/v5/cmd/display"
+	"github.com/docker/compose/v5/pkg/api"
 	"github.com/mattn/go-isatty"
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/api/types/container"
@@ -1435,44 +1439,76 @@ func (app *DdevApp) GetDBImage() string {
 // The race condition causes intermittent failures with "parent snapshot ... does not exist: not found"
 // when multiple services share base layers and build in parallel.
 //
-// args are optional extra arguments to pass to the build command (e.g., service name, "--no-cache")
+// args are optional: service names or "--no-cache"
 // Returns the stdout output on success, or an error if all retries are exhausted.
 func (app *DdevApp) composeBuild(args ...string) (string, error) {
-	progress := "plain"
-
-	action := []string{"--progress=" + progress, "build"}
-	if app.NoCache {
-		action = append(action, "--no-cache")
+	noCache := app.NoCache
+	var services []string
+	for _, arg := range args {
+		if arg == "--no-cache" {
+			noCache = true
+		} else if !strings.HasPrefix(arg, "-") {
+			services = append(services, arg)
+		}
 	}
-	action = append(action, args...)
+
+	project, err := dockerutil.LoadComposeProject([]string{app.DockerComposeFullRenderedYAMLPath()}, api.ProjectLoadOptions{
+		ProjectName: app.GetComposeProjectName(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("docker-compose build failed: %v", err)
+	}
+
+	goCtx, _, err := dockerutil.GetDockerClient()
+	if err != nil {
+		return "", fmt.Errorf("docker-compose build failed: %v", err)
+	}
 
 	var lastErr error
 	var out, stderr string
 
 	for attempt := 1; attempt <= composeBuildMaxRetries; attempt++ {
-		util.Debug("Executing docker-compose -f %s %s (attempt %d/%d)", app.DockerComposeFullRenderedYAMLPath(), strings.Join(action, " "), attempt, composeBuildMaxRetries)
+		util.Debug("Executing docker-compose build -f %s (attempt %d/%d)", app.DockerComposeFullRenderedYAMLPath(), attempt, composeBuildMaxRetries)
 
-		out, stderr, lastErr = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-			ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
-			Action:       action,
-			Progress:     true,
-			Timeout:      time.Hour * 1,
+		ctx, cancel := context.WithTimeout(goCtx, time.Hour)
+		defer cancel()
+
+		stopDots := util.ShowDots()
+
+		out, stderr, lastErr = dockerutil.CaptureOutput(func(svc api.Compose) error {
+			return svc.Build(ctx, project, api.BuildOptions{
+				Progress: display.ModePlain,
+				NoCache:  noCache,
+				Services: services,
+			})
 		})
+
+		stopDots()
+
+		timedOut := errors.Is(ctx.Err(), context.DeadlineExceeded)
+		cancel()
+
+		if timedOut {
+			return out, fmt.Errorf("docker-compose build timed out after 1 hour: %v", lastErr)
+		}
 
 		if lastErr == nil {
 			// Success
-			if globalconfig.DdevVerbose {
+			if globalconfig.DdevVerbose && out != "" {
 				util.Debug("docker-compose build output:\n%s\n\n", out)
 			}
 			return out, nil
 		}
 
-		// Check if this is the known BuildKit snapshot race condition
-		errorText := fmt.Sprintf("%v %s", lastErr, stderr)
+		// Check if this is the known BuildKit snapshot race condition.
+		// BuildKit progress (and its error lines) is written to the compose service stdout,
+		// not stderr — see compose/pkg/compose/build_bake.go and build_classic.go which both
+		// fall back to s.stdout(). Match against lastErr, out, and stderr so the trigger
+		// fires regardless of where the snapshot text surfaces.
+		errorText := fmt.Sprintf("%v %s %s", lastErr, out, stderr)
 		isSnapshotRace := strings.Contains(errorText, "parent snapshot") && strings.Contains(errorText, "does not exist")
 
 		if !isSnapshotRace {
-			// Not a snapshot race error, fail immediately without retry
 			return out, fmt.Errorf("docker-compose build failed: %v, output='%s', stderr='%s'", lastErr, out, stderr)
 		}
 
@@ -1482,7 +1518,6 @@ func (app *DdevApp) composeBuild(args ...string) (string, error) {
 		}
 	}
 
-	// All retries exhausted
 	return out, fmt.Errorf("docker-compose build failed after %d attempts: %v, output='%s', stderr='%s'", composeBuildMaxRetries, lastErr, out, stderr)
 }
 
@@ -1515,6 +1550,10 @@ func (app *DdevApp) Start() error {
 		// See https://github.com/moby/moby/issues/45919
 		// See https://github.com/moby/moby/issues/2259
 		return fmt.Errorf("bind mounts can't be used with Docker Rootless.\nRun `ddev config global --no-bind-mounts` and try again")
+	}
+
+	if _, err := dockerutil.DownloadDockerBuildxIfNeeded(); err != nil {
+		return err
 	}
 
 	if err := globalconfig.CheckForMultipleGlobalDdevDirs(); err != nil {
@@ -1550,19 +1589,6 @@ func (app *DdevApp) Start() error {
 	// See https://github.com/ddev/ddev/pull/5508
 	dockerutil.RemoveNetworkDuplicates(app.GetDefaultNetworkName())
 
-	if err = dockerutil.CheckDockerCompose(); err != nil {
-		if os.IsTimeout(err) || strings.Contains(err.Error(), "timeout") {
-			util.Failed(`Failed to download updated docker-compose binary.
-This might be due to network issues or a slow response.
-Please ensure your network is stable and try again:
-%v`, err)
-		} else {
-			util.Failed(`DDEV's private docker-compose binary does not exist or is set to an invalid version.
-Please use DDEV's' built-in docker-compose.
-Fix with 'ddev config global --required-docker-compose-version="" --use-docker-compose-from-path=false': %v`, err)
-		}
-	}
-
 	if nodeps.IsMacOS() {
 		failOnRosetta()
 	}
@@ -1586,13 +1612,9 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		return err
 	}
 
-	// Pull images in background while config prep continues
-	var pullWg sync.WaitGroup
-	pullWg.Go(func() {
-		if pullErr := PullBaseContainerImages(additionalImages, app.NoCache); pullErr != nil {
-			util.Warning("Unable to pull Docker images: %v", pullErr)
-		}
-	})
+	if pullErr := PullBaseContainerImages(additionalImages, app.NoCache); pullErr != nil {
+		util.Warning("Unable to pull Docker images: %v", pullErr)
+	}
 
 	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
 		// OK to start if dbType is empty (nonexistent) or if it matches
@@ -1832,10 +1854,6 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		return err
 	}
 
-	// Wait for background image pull to finish before fingerprinting, so
-	// ImageID() reflects the freshly-pulled digest rather than a stale local one.
-	pullWg.Wait()
-
 	// Build extra layers on web and db images if necessary.
 	// Skip the build entirely if the build context hasn't changed and built images exist.
 	buildHashFile := app.GetConfigPath(".build-hash")
@@ -1931,9 +1949,24 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	}
 
 	util.Debug("Executing docker-compose -f %s up -d", app.DockerComposeFullRenderedYAMLPath())
-	_, _, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
-		Action:       []string{"up", "-d"},
+
+	upProject, upErr := dockerutil.LoadComposeProject([]string{app.DockerComposeFullRenderedYAMLPath()}, api.ProjectLoadOptions{
+		ProjectName: app.GetComposeProjectName(),
+	})
+	if upErr != nil {
+		return upErr
+	}
+	upCtx, upSvc, upErr := dockerutil.NewComposeService()
+	if upErr != nil {
+		return upErr
+	}
+	progress := display.ModeQuiet
+	if globalconfig.DdevVerbose {
+		progress = display.ModePlain
+	}
+	err = upSvc.Up(upCtx, upProject, api.UpOptions{
+		Create: api.CreateOptions{Build: &api.BuildOptions{Progress: progress}},
+		Start:  api.StartOptions{Project: upProject},
 	})
 	if err != nil {
 		return err
@@ -2266,14 +2299,29 @@ func (app *DdevApp) StartOptionalProfiles(profiles []string) error {
 		}
 	}
 
-	_, stderr, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
-		Profiles:     profiles,
-		Action:       []string{"up", "-d"},
+	upProject, err := dockerutil.LoadComposeProject([]string{app.DockerComposeFullRenderedYAMLPath()}, api.ProjectLoadOptions{
+		ProjectName: app.GetComposeProjectName(),
+		Profiles:    profiles,
 	})
-
 	if err != nil {
-		util.Warning("Failed to start optional compose profiles '%s': %v, stderr='%s'", profiles, err, stderr)
+		util.Warning("Failed to start optional compose profiles '%s': %v", profiles, err)
+		return err
+	}
+	upCtx, upSvc, err := dockerutil.NewComposeService()
+	if err != nil {
+		util.Warning("Failed to start optional compose profiles '%s': %v", profiles, err)
+		return err
+	}
+	progress := display.ModeQuiet
+	if globalconfig.DdevVerbose {
+		progress = display.ModePlain
+	}
+	err = upSvc.Up(upCtx, upProject, api.UpOptions{
+		Create: api.CreateOptions{Build: &api.BuildOptions{Progress: progress}},
+		Start:  api.StartOptions{Project: upProject},
+	})
+	if err != nil {
+		util.Warning("Failed to start optional compose profiles '%s': %v", profiles, err)
 		return err
 	}
 
@@ -2575,7 +2623,7 @@ type ExecOpts struct {
 }
 
 // Exec executes a given command in the container of given type without allocating a pty
-// Returns ComposeCmd results of stdout, stderr, err
+// Returns stdout, stderr, err
 // If Nocapture arg is true, stdout/stderr will be empty and output directly to stdout/stderr
 func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	_ = app.DockerEnv()
@@ -2607,31 +2655,6 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		return "", "", fmt.Errorf("failed to process pre-exec hooks: %v", err)
 	}
 
-	baseComposeExecCmd := []string{"exec"}
-	if opts.Dir != "" {
-		baseComposeExecCmd = append(baseComposeExecCmd, "-w", opts.Dir)
-	}
-
-	if !isatty.IsTerminal(os.Stdin.Fd()) || !opts.Tty {
-		baseComposeExecCmd = append(baseComposeExecCmd, "-T")
-	}
-
-	if opts.Detach {
-		baseComposeExecCmd = append(baseComposeExecCmd, "--detach")
-	}
-
-	if opts.User != "" {
-		baseComposeExecCmd = append(baseComposeExecCmd, "-u", opts.User)
-	}
-
-	if len(opts.Env) > 0 {
-		for _, envVar := range opts.Env {
-			baseComposeExecCmd = append(baseComposeExecCmd, "-e", envVar)
-		}
-	}
-
-	baseComposeExecCmd = append(baseComposeExecCmd, opts.Service)
-
 	// Cases to handle
 	// - Free form, all unquoted. Like `ls -l -a`
 	// - Quoted to delay pipes and other features to container, like `"ls -l -a | grep junk"`
@@ -2657,21 +2680,50 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		stderr = opts.Stderr
 	}
 
+	execProject, execLoadErr := dockerutil.LoadComposeProject([]string{app.DockerComposeFullRenderedYAMLPath()}, api.ProjectLoadOptions{
+		ProjectName: app.GetComposeProjectName(),
+	})
+	if execLoadErr != nil {
+		return "", "", execLoadErr
+	}
+
+	tty := opts.Tty && isatty.IsTerminal(os.Stdin.Fd())
+	runOpts := api.RunOptions{
+		Service:     opts.Service,
+		Command:     opts.RawCmd,
+		Tty:         tty,
+		Interactive: true,
+		Detach:      opts.Detach,
+		WorkingDir:  opts.Dir,
+		User:        opts.User,
+		Environment: opts.Env,
+	}
+
 	var stdoutResult, stderrResult string
-	var outRes, errRes string
-	r := append(baseComposeExecCmd, opts.RawCmd...)
 	if opts.NoCapture || opts.Tty {
-		err = dockerutil.ComposeWithStreams(&dockerutil.ComposeCmdOpts{
-			ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
-			Action:       r,
-		}, os.Stdin, stdout, stderr)
+		restore, stdinErr := dockerutil.SetExecStdin(os.Stdin, tty)
+		if stdinErr != nil {
+			return "", "", stdinErr
+		}
+		defer restore()
+		execCtx, execSvc, svcErr := dockerutil.NewComposeServiceWithStreams(stdout, stderr)
+		if svcErr != nil {
+			return "", "", svcErr
+		}
+		err = dockerutil.ExitCodeToError(execSvc.Exec(execCtx, execProject.Name, runOpts))
 	} else {
-		outRes, errRes, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-			ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
-			Action:       r,
+		if !isatty.IsTerminal(os.Stdin.Fd()) {
+			// Forward piped stdin so exec commands can read it even without Tty.
+			restore, _ := dockerutil.SetExecStdin(os.Stdin, false)
+			defer restore()
+		}
+		captureCtx, _, captureCtxErr := dockerutil.GetDockerClient()
+		if captureCtxErr != nil {
+			return "", "", captureCtxErr
+		}
+		stdoutResult, stderrResult, err = dockerutil.CaptureOutput(func(svc api.Compose) error {
+			return dockerutil.ExitCodeToError(svc.Exec(captureCtx, execProject.Name, runOpts))
 		})
-		stdoutResult = outRes
-		stderrResult = errRes
 	}
 	if err != nil {
 		return stdoutResult, stderrResult, err
@@ -2697,25 +2749,6 @@ func (app *DdevApp) ExecWithTty(opts *ExecOpts) error {
 		return fmt.Errorf("service %s is not running in project %s (state=%s)", opts.Service, app.Name, state)
 	}
 
-	args := []string{"exec"}
-
-	// In the case where this is being used without an available tty,
-	// make sure we use the -T to turn off tty to avoid panic in docker-compose v2.2.3
-	// see https://stackoverflow.com/questions/70855915/fix-panic-provided-file-is-not-a-console-from-docker-compose-in-github-action
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		args = append(args, "-T")
-	}
-
-	if opts.Dir != "" {
-		args = append(args, "-w", opts.Dir)
-	}
-
-	if opts.User != "" {
-		args = append(args, "-u", opts.User)
-	}
-
-	args = append(args, opts.Service)
-
 	if opts.Cmd == "" {
 		return fmt.Errorf("no command provided")
 	}
@@ -2732,12 +2765,30 @@ func (app *DdevApp) ExecWithTty(opts *ExecOpts) error {
 		shell = "sh"
 	}
 
-	args = append(args, shell, "-c", opts.Cmd)
-
-	return dockerutil.ComposeWithStreams(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
-		Action:       args,
-	}, os.Stdin, os.Stdout, os.Stderr)
+	withTtyProject, loadErr := dockerutil.LoadComposeProject([]string{app.DockerComposeFullRenderedYAMLPath()}, api.ProjectLoadOptions{
+		ProjectName: app.GetComposeProjectName(),
+	})
+	if loadErr != nil {
+		return loadErr
+	}
+	tty := term.IsTerminal(int(os.Stdin.Fd()))
+	restore, stdinErr := dockerutil.SetExecStdin(os.Stdin, tty)
+	if stdinErr != nil {
+		return stdinErr
+	}
+	defer restore()
+	withTtyCtx, withTtySvc, svcErr := dockerutil.NewComposeService()
+	if svcErr != nil {
+		return svcErr
+	}
+	return dockerutil.ExitCodeToError(withTtySvc.Exec(withTtyCtx, withTtyProject.Name, api.RunOptions{
+		Service:     opts.Service,
+		Command:     []string{shell, "-c", opts.Cmd},
+		Tty:         tty,
+		Interactive: true,
+		User:        opts.User,
+		WorkingDir:  opts.Dir,
+	}))
 }
 
 func (app *DdevApp) ExecOnHostOrService(service string, cmd string) error {
@@ -3074,11 +3125,20 @@ func (app *DdevApp) Pause() error {
 
 	_ = SyncAndPauseMutagenSession(app)
 
-	if _, _, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
-		Profiles:     []string{`*`},
-		Action:       []string{"stop"},
-	}); err != nil {
+	if err := func() error {
+		stopProject, stopErr := dockerutil.LoadComposeProject([]string{app.DockerComposeFullRenderedYAMLPath()}, api.ProjectLoadOptions{
+			ProjectName: app.GetComposeProjectName(),
+			Profiles:    []string{`*`},
+		})
+		if stopErr != nil {
+			return stopErr
+		}
+		stopCtx, stopSvc, stopErr := dockerutil.NewComposeService()
+		if stopErr != nil {
+			return stopErr
+		}
+		return stopSvc.Stop(stopCtx, stopProject.Name, api.StopOptions{Project: stopProject})
+	}(); err != nil {
 		return err
 	}
 

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -19,6 +19,8 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/docker/compose/v5/cmd/display"
+	"github.com/docker/compose/v5/pkg/api"
 	"github.com/moby/moby/api/types/container"
 )
 
@@ -158,10 +160,23 @@ func StartDdevRouter() error {
 		}
 
 		// Run docker-compose up -d against the ddev-router full compose file
-		_, _, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-			ProjectName:  RouterComposeProjectName,
-			ComposeFiles: []string{routerComposeFullPath},
-			Action:       []string{"up", "--build", "-d"},
+		routerProject, loadErr := dockerutil.LoadComposeProject([]string{routerComposeFullPath}, api.ProjectLoadOptions{
+			ProjectName: RouterComposeProjectName,
+		})
+		if loadErr != nil {
+			return fmt.Errorf("failed to start ddev-router: %v", loadErr)
+		}
+		upCtx, routerSvc, svcErr := dockerutil.NewComposeService()
+		if svcErr != nil {
+			return fmt.Errorf("failed to start ddev-router: %v", svcErr)
+		}
+		progress := display.ModeQuiet
+		if globalconfig.DdevVerbose {
+			progress = display.ModePlain
+		}
+		err = routerSvc.Up(upCtx, routerProject, api.UpOptions{
+			Create: api.CreateOptions{Build: &api.BuildOptions{Progress: progress}},
+			Start:  api.StartOptions{Project: routerProject},
 		})
 		if err != nil {
 			return fmt.Errorf("failed to start ddev-router: %v", err)
@@ -283,15 +298,13 @@ func generateRouterCompose(activeApps []*DdevApp) (string, error) {
 		return "", err
 	}
 	files := append([]string{RouterComposeYAMLPath()}, userFiles...)
-	fullContents, _, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: files,
-		Action:       []string{"config"},
+	project, err := dockerutil.LoadComposeProject(files, api.ProjectLoadOptions{
+		ProjectName: RouterComposeProjectName,
 	})
 	if err != nil {
 		return "", err
 	}
-	project, err := dockerutil.CreateComposeProject(fullContents)
-	if err != nil {
+	if err = project.CheckContainerNameUnicity(); err != nil {
 		return "", err
 	}
 	injectDdevLabels(project, nil)
@@ -299,6 +312,7 @@ func generateRouterCompose(activeApps []*DdevApp) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	fullContentsBytes = util.EscapeDollarSign(fullContentsBytes)
 	_, err = fullHandle.Write(fullContentsBytes)
 	if err != nil {
 		return "", err

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
+	"github.com/docker/compose/v5/cmd/display"
+	"github.com/docker/compose/v5/pkg/api"
 	"github.com/moby/moby/api/types/container"
 )
 
@@ -59,13 +61,18 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 
 	_ = app.DockerEnv()
 
-	_, _, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ProjectName:  SSHAuthName,
-		ComposeFiles: []string{composeFile},
-		Action:       []string{"down"},
+	downProject, loadErr := dockerutil.LoadComposeProject([]string{composeFile}, api.ProjectLoadOptions{
+		ProjectName: SSHAuthName,
 	})
-	if err != nil {
-		util.Warning("failed to docker-compose down on %s: %v", composeFile, err)
+	if loadErr != nil {
+		util.Warning("failed to load compose project for %s: %v", composeFile, loadErr)
+	} else {
+		downCtx, downSvc, svcErr := dockerutil.NewComposeService()
+		if svcErr != nil {
+			util.Warning("failed to create compose service: %v", svcErr)
+		} else if downErr := downSvc.Down(downCtx, downProject.Name, api.DownOptions{Project: downProject}); downErr != nil {
+			util.Warning("failed to docker-compose down on %s: %v", composeFile, downErr)
+		}
 	}
 
 	err = dockerutil.Pull(ddevImages.GetSSHAuthImage())
@@ -74,10 +81,23 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 	}
 
 	// Now restart ddev-ssh-agent
-	_, _, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ProjectName:  SSHAuthName,
-		ComposeFiles: []string{composeFile},
-		Action:       []string{"up", "--build", "-d"},
+	upProject, err := dockerutil.LoadComposeProject([]string{composeFile}, api.ProjectLoadOptions{
+		ProjectName: SSHAuthName,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start ddev-ssh-agent: %v", err)
+	}
+	upCtx, upSvc, err := dockerutil.NewComposeService()
+	if err != nil {
+		return fmt.Errorf("failed to start ddev-ssh-agent: %v", err)
+	}
+	progress := display.ModeQuiet
+	if globalconfig.DdevVerbose {
+		progress = display.ModePlain
+	}
+	err = upSvc.Up(upCtx, upProject, api.UpOptions{
+		Create: api.CreateOptions{Build: &api.BuildOptions{Progress: progress}},
+		Start:  api.StartOptions{Project: upProject},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start ddev-ssh-agent: %v", err)
@@ -121,8 +141,8 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 	}
 	defer util.CheckClose(f)
 
-	context := "./.sshimageBuild"
-	err := WriteBuildDockerfile(app, filepath.Join(globalconfig.GetGlobalDdevDir(), context, "Dockerfile"), "", nil, "", "")
+	buildContextDir := "./.sshimageBuild"
+	err := WriteBuildDockerfile(app, filepath.Join(globalconfig.GetGlobalDdevDir(), buildContextDir, "Dockerfile"), "", nil, "", "")
 	if err != nil {
 		return "", err
 	}
@@ -139,7 +159,7 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 		"UID":              uid,
 		"GID":              gid,
 		"Timezone":         timezone,
-		"BuildContext":     context,
+		"BuildContext":     buildContextDir,
 		"IsPodmanRootless": dockerutil.IsPodmanRootless(),
 	}
 	t, err := template.New("ssh_auth_compose_template.yaml").Funcs(getTemplateFuncMap()).ParseFS(bundledAssets, "ssh_auth_compose_template.yaml")
@@ -161,15 +181,13 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 		return "", err
 	}
 	files := append([]string{SSHAuthComposeYAMLPath()}, userFiles...)
-	fullContents, _, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: files,
-		Action:       []string{"config"},
+	project, err := dockerutil.LoadComposeProject(files, api.ProjectLoadOptions{
+		ProjectName: SSHAuthName,
 	})
 	if err != nil {
 		return "", err
 	}
-	project, err := dockerutil.CreateComposeProject(fullContents)
-	if err != nil {
+	if err = project.CheckContainerNameUnicity(); err != nil {
 		return "", err
 	}
 	injectDdevLabels(project, nil)
@@ -177,6 +195,7 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	fullContentsBytes = util.EscapeDollarSign(fullContentsBytes)
 	_, err = fullHandle.Write(fullContentsBytes)
 	if err != nil {
 		return "", err

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
+	"github.com/docker/compose/v5/pkg/api"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
@@ -108,13 +109,19 @@ func Cleanup(app *DdevApp) error {
 	// There can be awkward cases where we're doing an app.Stop() but the rendered
 	// yaml does not exist, all in testing situations.
 	if fileutil.FileExists(app.DockerComposeFullRenderedYAMLPath()) {
-		_, _, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-			ComposeFiles: []string{app.DockerComposeFullRenderedYAMLPath()},
-			Profiles:     []string{`*`},
-			Action:       []string{"down"},
+		project, loadErr := dockerutil.LoadComposeProject([]string{app.DockerComposeFullRenderedYAMLPath()}, api.ProjectLoadOptions{
+			ProjectName: app.GetComposeProjectName(),
+			Profiles:    []string{`*`},
 		})
-		if err != nil {
-			util.Warning("Failed to docker-compose down: %v", err)
+		if loadErr != nil {
+			util.Warning("Failed to load compose project for down: %v", loadErr)
+		} else {
+			downCtx, svc, svcErr := dockerutil.NewComposeService()
+			if svcErr != nil {
+				util.Warning("Failed to create compose service: %v", svcErr)
+			} else if downErr := svc.Down(downCtx, project.Name, api.DownOptions{Project: project, RemoveOrphans: true}); downErr != nil {
+				util.Warning("Failed to docker-compose down: %v", downErr)
+			}
 		}
 	}
 

--- a/pkg/dockerutil/docker_buildx.go
+++ b/pkg/dockerutil/docker_buildx.go
@@ -1,0 +1,160 @@
+package dockerutil
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/ddev/ddev/pkg/versionconstants"
+	"github.com/moby/moby/client/pkg/versions"
+)
+
+// DownloadDockerBuildxIfNeeded downloads the proper version of docker-buildx
+// if it's either not yet installed or doesn't meet the minimum version requirement.
+// Returns downloaded bool (true if it did the download) and err.
+func DownloadDockerBuildxIfNeeded() (bool, error) {
+	// Don't download anything if there are problems with Docker
+	_, err := getDockerManagerInstance()
+	if err != nil {
+		return false, err
+	}
+
+	dockerBuildxResetMsg := fmt.Sprintf(`
+To use the system docker-buildx (no download, recommended):
+  ddev config global --docker-buildx-version=system
+
+To download a specific docker-buildx (only if you can't use the system buildx):
+  ddev config global --docker-buildx-version=%s
+
+More details in https://ddev.com/blog/docker-buildx-requirement-v1-25-1/`, versionconstants.DockerBuildxRecommendedVersion)
+
+	requiredVersion := globalconfig.GetRequiredDockerBuildxVersion()
+	err = CheckDockerBuildxVersion()
+	if err != nil {
+		err = fmt.Errorf("%w\n%s", err, dockerBuildxResetMsg)
+	}
+	// If no required version is set, then we don't need to download
+	// but if there was an error checking the version, report it
+	if requiredVersion == "" {
+		return false, err
+	}
+	currentVersion, _ := GetDockerBuildxVersion()
+	// Skip the download if the version matches and DDEV's own binary already exists.
+	destinationPath, _ := globalconfig.GetDockerBuildxDestination()
+	_, destStatErr := os.Stat(destinationPath)
+	if currentVersion == requiredVersion && destStatErr == nil {
+		return false, err
+	}
+	// If we get here, we need to download the required version.
+	// If that fails, report the error but also include any error
+	// from the version check (e.g., if docker-buildx isn't found at all)
+	downloadErr := DownloadDockerBuildx()
+	if downloadErr == nil {
+		// Reset the plugins to pick up the new binary
+		_ = ResetCLIPlugins()
+		if err = CheckDockerBuildxVersion(); err != nil {
+			return false, fmt.Errorf("%w\n%s", err, dockerBuildxResetMsg)
+		}
+		return true, nil
+	}
+	return false, fmt.Errorf("unable to download required docker-buildx version %q: %w\n%s", requiredVersion, downloadErr, dockerBuildxResetMsg)
+}
+
+// DownloadDockerBuildx gets the docker-buildx binary and puts it into
+// ~/.ddev/bin
+func DownloadDockerBuildx() error {
+	globalBinDir := globalconfig.GetDDEVBinDir()
+	destFile, _ := globalconfig.GetDockerBuildxDestination()
+
+	buildxURL, shasumURL, err := dockerBuildxDownloadLink()
+	if err != nil {
+		return err
+	}
+	util.Debug("Downloading '%s' to '%s' ...", buildxURL, destFile)
+
+	_ = os.Remove(destFile)
+
+	_ = os.MkdirAll(globalBinDir, 0777)
+	err = util.DownloadFile(destFile, buildxURL, globalconfig.IsInteractive(), shasumURL)
+	if err != nil {
+		_ = os.Remove(destFile)
+		return err
+	}
+	output.UserErr.Printf("Download complete.")
+
+	err = util.Chmod(destFile, 0755)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetDockerBuildxVersion returns the version of the Docker buildx plugin.
+func GetDockerBuildxVersion() (string, error) {
+	plugin, err := GetCLIPlugin("buildx")
+	if err != nil {
+		return "", err
+	}
+	// Strip leading "v" prefix if present for semver compatibility
+	return strings.TrimPrefix(plugin.Version, "v"), nil
+}
+
+// GetDockerBuildxLocation returns the path to the Docker buildx plugin.
+func GetDockerBuildxLocation() (string, error) {
+	plugin, err := GetCLIPlugin("buildx")
+	if err != nil {
+		return "", err
+	}
+	return plugin.Path, nil
+}
+
+// CheckDockerBuildxVersion checks that the Docker buildx plugin is installed
+// and meets the minimum version requirement.
+func CheckDockerBuildxVersion() error {
+	defer util.TimeTrack()()
+
+	v, err := GetDockerBuildxVersion()
+	if err != nil {
+		return fmt.Errorf("compose build requires buildx %s or later: %v", versionconstants.DockerBuildxMinVersion, err)
+	}
+
+	pluginPath, _ := GetDockerBuildxLocation()
+
+	if versions.LessThan(v, versionconstants.DockerBuildxMinVersion) {
+		return fmt.Errorf("compose build requires buildx %s or later.\nInstalled docker-buildx: %s (plugin path: %q)", versionconstants.DockerBuildxMinVersion, v, pluginPath)
+	}
+
+	return nil
+}
+
+// dockerBuildxDownloadLink returns the URL and SHASUM-file link for docker-buildx
+func dockerBuildxDownloadLink() (buildxURL string, shasumURL string, err error) {
+	arch := runtime.GOARCH
+
+	if arch != "arm64" && arch != "amd64" {
+		return "", "", fmt.Errorf("only ARM64 and AMD64 architectures are supported for docker-buildx, not %s", arch)
+	}
+	flavor := runtime.GOOS + "-" + arch
+	version := globalconfig.GetRequiredDockerBuildxVersion()
+	if version == "" {
+		return "", "", fmt.Errorf("docker-buildx version is not set in global config")
+	}
+	binaryURL := fmt.Sprintf("https://github.com/docker/buildx/releases/download/v%[1]s/buildx-v%[1]s.%[2]s", version, flavor)
+	if nodeps.IsWindows() {
+		binaryURL = binaryURL + ".exe"
+	}
+	shasumURL = fmt.Sprintf("https://github.com/docker/buildx/releases/download/v%s/checksums.txt", version)
+	// darwin binaries are not included in the buildx checksums file, skip sha verification
+	// see https://github.com/docker/buildx/issues/2727
+	if nodeps.IsMacOS() {
+		shasumURL = ""
+	}
+
+	return binaryURL, shasumURL, nil
+}

--- a/pkg/dockerutil/docker_buildx_test.go
+++ b/pkg/dockerutil/docker_buildx_test.go
@@ -1,0 +1,105 @@
+package dockerutil_test
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/ddev/ddev/pkg/versionconstants"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDockerBuildxDownload verifies that we can download a particular docker-buildx version
+func TestDockerBuildxDownload(t *testing.T) {
+	_, err := dockerutil.DownloadDockerBuildxIfNeeded()
+	require.NoError(t, err)
+
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
+
+	t.Cleanup(func() {
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
+	})
+
+	// Remove previous binary
+	previousDockerBuildx, _ := globalconfig.GetDockerBuildxDestination()
+	_ = os.RemoveAll(previousDockerBuildx)
+
+	// Nothing should be downloaded for "system"
+	globalconfig.DdevGlobalConfig.DockerBuildxVersion = "system"
+	downloaded, err := dockerutil.DownloadDockerBuildxIfNeeded()
+	require.NoError(t, err)
+	require.False(t, downloaded)
+
+	// Nothing should be downloaded for ""
+	globalconfig.DdevGlobalConfig.DockerBuildxVersion = ""
+	downloaded, err = dockerutil.DownloadDockerBuildxIfNeeded()
+	require.NoError(t, err)
+	require.False(t, downloaded)
+
+	// Set a specific version to trigger a download
+	globalconfig.DdevGlobalConfig.DockerBuildxVersion = versionconstants.DockerBuildxRecommendedVersion
+
+	downloaded, err = dockerutil.DownloadDockerBuildxIfNeeded()
+	require.NoError(t, err)
+	require.True(t, downloaded)
+	v, err := dockerutil.GetDockerBuildxVersion()
+	require.NoError(t, err)
+	require.Equal(t, globalconfig.GetRequiredDockerBuildxVersion(), v)
+	require.Equal(t, v, versionconstants.DockerBuildxRecommendedVersion)
+
+	// Make sure it doesn't download a second time
+	downloaded, err = dockerutil.DownloadDockerBuildxIfNeeded()
+	require.NoError(t, err)
+	require.False(t, downloaded)
+}
+
+// TestGetBuildxVersion tests that the buildx version can be retrieved.
+func TestGetBuildxVersion(t *testing.T) {
+	v, err := dockerutil.GetDockerBuildxVersion()
+	require.NoError(t, err)
+	require.NotEmpty(t, v, "expected non-empty buildx version")
+	// Version should not have a v prefix (we strip it)
+	require.NotEqual(t, "v", string(v[0]), "expected version without 'v' prefix, got %q", v)
+}
+
+// TestGetBuildxLocation tests that the buildx plugin path can be retrieved.
+func TestGetBuildxLocation(t *testing.T) {
+	pluginPath, err := dockerutil.GetDockerBuildxLocation()
+	require.NoError(t, err)
+	require.NotEmpty(t, pluginPath, "expected non-empty buildx plugin path")
+}
+
+// TestCheckDockerBuildx tests detection of docker-buildx.
+func TestCheckDockerBuildx(t *testing.T) {
+	ensureDdevBin()
+	buildxErr := dockerutil.CheckDockerBuildxVersion()
+
+	if buildxErr != nil {
+		out, err := exec.RunHostCommand(DdevBin, "config", "global")
+		require.NoError(t, err)
+		ddevVersion, err := exec.RunHostCommand(DdevBin, "version")
+		require.NoError(t, err)
+		require.NoError(t, buildxErr, "DockerBuildxVersion=%s global config=%s ddevVersion=%s", globalconfig.DdevGlobalConfig.DockerBuildxVersion, out, ddevVersion)
+	}
+}
+
+// TestBuildxMinVersionInSync ensures that versionconstants.DockerBuildxMinVersion stays in sync
+// with the buildxMinVersion constant in the vendored Compose library.
+// Run this test whenever docker/compose or versionconstants is updated.
+func TestBuildxMinVersionInSync(t *testing.T) {
+	data, err := os.ReadFile("../../vendor/github.com/docker/compose/v5/pkg/compose/api_versions.go")
+	require.NoError(t, err, "could not read vendored compose api_versions.go; run 'go mod vendor'")
+
+	re := regexp.MustCompile(`buildxMinVersion\s*=\s*"([^"]+)"`)
+	matches := re.FindSubmatch(data)
+	require.Len(t, matches, 2, "buildxMinVersion constant not found in vendor/github.com/docker/compose/v5/pkg/compose/api_versions.go")
+
+	composeMin := string(matches[1])
+	require.Equal(t, composeMin, versionconstants.DockerBuildxMinVersion,
+		"versionconstants.DockerBuildxMinVersion (%q) is out of sync with compose's buildxMinVersion (%q); update pkg/versionconstants/versionconstants.go",
+		versionconstants.DockerBuildxMinVersion, composeMin)
+}

--- a/pkg/dockerutil/docker_compose.go
+++ b/pkg/dockerutil/docker_compose.go
@@ -1,315 +1,170 @@
 package dockerutil
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
+	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
-	"time"
 
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/streams"
+	"github.com/docker/compose/v5/cmd/display"
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/mattn/go-isatty"
+	"github.com/sirupsen/logrus"
 )
 
-type ComposeCmdOpts struct {
-	ComposeFiles []string
-	ComposeYaml  *types.Project
-	Profiles     []string
-	Action       []string
-	Progress     bool // Add dots every second while the compose command is running
-	Timeout      time.Duration
-	ProjectName  string // Optional project name to set via -p flag
-	Env          []string
+// LoadComposeProject loads a compose project from files using the upstream compose library.
+// opts.ConfigPaths is set from files; opts.WorkingDir defaults to filepath.Dir(files[0]) if empty.
+// Uses the cached singleton compose service (no stream/progress output) and its background context.
+func LoadComposeProject(files []string, opts api.ProjectLoadOptions) (*types.Project, error) {
+	if opts.ProjectName == "" {
+		return nil, errors.New("LoadComposeProject: ProjectName must not be empty")
+	}
+	if opts.WorkingDir == "" && len(files) > 0 {
+		opts.WorkingDir = filepath.Dir(files[0])
+	}
+	opts.ConfigPaths = files
+	dm, err := getDockerManagerInstance()
+	if err != nil {
+		return nil, err
+	}
+	return dm.composeForLoad.LoadProject(dm.goContext, opts)
 }
 
-// ComposeWithStreams executes a docker-compose command but allows the caller to specify
-// stdin/stdout/stderr
-func ComposeWithStreams(cmd *ComposeCmdOpts, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
-	defer util.TimeTrack()()
-
-	var arg []string
-
-	_, err := DownloadDockerComposeIfNeeded()
-	if err != nil {
-		return err
-	}
-
-	if cmd.ProjectName != "" {
-		arg = append(arg, "-p", cmd.ProjectName)
-	}
-
-	if cmd.ComposeYaml != nil {
-		// Read from stdin
-		arg = append(arg, "-f", "-")
-	} else {
-		for _, file := range cmd.ComposeFiles {
-			arg = append(arg, "-f", file)
-		}
-	}
-
-	arg = append(arg, cmd.Action...)
-
-	path, err := globalconfig.GetDockerComposePath()
-	if err != nil {
-		return err
-	}
-	proc := exec.Command(path, arg...)
-	proc.Stdout = stdout
-	proc.Stderr = stderr
-	if cmd.ComposeYaml != nil {
-		yamlBytes, err := cmd.ComposeYaml.MarshalYAML()
-		if err != nil {
-			return err
-		}
-		yamlBytes = util.EscapeDollarSign(yamlBytes)
-		proc.Stdin = strings.NewReader(string(yamlBytes))
-	} else {
-		proc.Stdin = stdin
-	}
-	proc.Env = append(os.Environ(), cmd.Env...)
-
-	err = proc.Run()
-	return err
+// NewComposeService creates a compose service backed by the singleton Docker CLI.
+func NewComposeService() (context.Context, api.Compose, error) {
+	return NewComposeServiceWithStreams(output.UserErr.Out, output.UserErr.Out)
 }
 
-// ComposeCmd executes docker-compose commands via shell.
-// returns stdout, stderr, error/nil
-func ComposeCmd(cmd *ComposeCmdOpts) (string, string, error) {
-	var arg []string
-	var stdout bytes.Buffer
-	var stderr string
+// NewComposeServiceWithStreams creates a compose service backed by the singleton Docker CLI.
+func NewComposeServiceWithStreams(stdout, stderr io.Writer) (context.Context, api.Compose, error) {
+	dm, err := getDockerManagerInstance()
+	if err != nil {
+		return nil, nil, err
+	}
+	var ep api.EventProcessor
+	if !output.JSONOutput && isatty.IsTerminal(os.Stdout.Fd()) {
+		ep = display.Full(stdout, stderr, false)
+	} else {
+		progressOut := output.UserErr.Out
+		if output.JSONOutput {
+			progressOut = &output.JSONProgressWriter{}
+		}
+		ep = display.Plain(progressOut)
+	}
+	opts := []compose.Option{
+		compose.WithOutputStream(stdout),
+		compose.WithErrorStream(stderr),
+		compose.WithEventProcessor(ep),
+	}
+	svc, err := compose.NewComposeService(dm.cli, opts...)
+	return dm.goContext, svc, err
+}
 
-	_, err := DownloadDockerComposeIfNeeded()
+// ExitCodeToError converts the (exitCode, err) return of api.Compose.Exec /
+// RunOneOffContainer into a single error usable with errors.As(&cli.StatusError{}).
+//
+// docker/cli's container.RunExec returns cli.StatusError with StatusCode set
+// but an empty Status field
+// (vendor/github.com/docker/cli/cli/command/container/exec.go:215),
+// so callers that print err.Error() see an empty string. This helper attaches
+// a default "exit status N" message in that case while preserving any non-empty
+// Status the upstream layer already provided.
+func ExitCodeToError(exitCode int, err error) error {
+	if exitCode == 0 {
+		return err
+	}
+	msg := fmt.Sprintf("exit status %d", exitCode)
+	if err != nil && err.Error() != "" {
+		msg = err.Error()
+	}
+	return cli.StatusError{StatusCode: exitCode, Status: msg}
+}
+
+// CaptureOutput runs fn against a compose service whose stdout/stderr are buffered,
+// returning the captured strings. Use only when output text is genuinely needed (e.g. build retry detection).
+func CaptureOutput(fn func(svc api.Compose) error) (string, string, error) {
+	var stdoutBuf, stderrBuf bytes.Buffer
+	_, svc, err := NewComposeServiceWithStreams(&stdoutBuf, &stderrBuf)
 	if err != nil {
 		return "", "", err
 	}
+	err = fn(svc)
+	return cleanOutput(stdoutBuf.String()), cleanOutput(stderrBuf.String()), err
+}
 
-	if cmd.ProjectName != "" {
-		arg = append(arg, "-p", cmd.ProjectName)
+// cleanOutput strips ANSI escape codes and carriage-return overwrite sequences so
+// captured compose output is safe to embed in log messages and errors.
+func cleanOutput(s string) string {
+	s = regexp.MustCompile(`\x1b[^a-zA-Z]*[a-zA-Z]`).ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
+}
+
+// SetExecStdin installs `in` as the stdin of the singleton DockerCli for the
+// duration of one compose Exec/Run call, returning a restore closure the
+// caller MUST defer.
+//
+// Why mutate the singleton instead of using compose.WithInputStream:
+// vendor/github.com/docker/compose/v5/pkg/compose/compose.go wraps any
+// caller-supplied input through a readCloserAdapter inside wrapDockerCliWithStreams
+// (https://github.com/docker/compose/blob/v5.1.3/pkg/compose/compose.go#L283-L301).
+// That adapter drops the underlying *os.File, so streams.In.SetRawTerminal()
+// — which docker/cli's hijack setupInput needs for TTY exec — fails. The only
+// way to give compose a *os.File-backed streams.In today is to set it on the
+// shared DockerCli before the call. ddev's CLI is single-threaded for exec, so
+// the singleton mutation is safe in practice; this function is NOT safe for
+// concurrent use.
+//
+// On TTY paths we also hand compose a dup of the file descriptor so the
+// restoreTerminal->in.Close() call in
+// vendor/github.com/docker/cli/cli/command/container/hijack.go (line 211)
+// (https://github.com/docker/cli/blob/v29.4.0/cli/command/container/hijack.go#L211)
+// lands on the dup, not on the ddev process's real fd 0. The dup is closed
+// here on restore so it does not leak when compose declines to close it
+// (darwin, windows) or on non-TTY exec where setupInput returns a no-op
+// restore (line 96 in the same file).
+func SetExecStdin(in io.ReadCloser, tty bool) (restore func(), err error) {
+	dm, err := getDockerManagerInstance()
+	if err != nil {
+		return func() {}, err
 	}
-
-	if cmd.ComposeYaml != nil {
-		// Read from stdin
-		arg = append(arg, "-f", "-")
-	} else {
-		for _, file := range cmd.ComposeFiles {
-			arg = append(arg, "-f", file)
+	var dupFile *os.File
+	if tty {
+		if f, ok := in.(*os.File); ok {
+			if dup, dupErr := dupStdin(f); dupErr == nil && dup != f {
+				// dup != f filters out the windows pass-through, where dupStdin
+				// returns the original *os.File and we must not close it.
+				in = dup
+				dupFile = dup
+			}
 		}
 	}
-
-	for _, profile := range cmd.Profiles {
-		arg = append(arg, "--profile", profile)
-	}
-
-	arg = append(arg, cmd.Action...)
-
-	path, err := globalconfig.GetDockerComposePath()
-	if err != nil {
-		return "", "", err
-	}
-
-	ctx := context.Background()
-	if cmd.Timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, cmd.Timeout)
-		defer cancel()
-	}
-	proc := exec.CommandContext(ctx, path, arg...)
-	proc.Stdout = &stdout
-	if cmd.ComposeYaml != nil {
-		yamlBytes, err := cmd.ComposeYaml.MarshalYAML()
-		if err != nil {
-			return "", "", err
+	prevIn := dm.cli.In()
+	dm.cli.SetIn(streams.NewIn(in))
+	return func() {
+		dm.cli.SetIn(prevIn)
+		if dupFile != nil {
+			// Compose's hijack may have already closed the underlying fd on
+			// linux TTY paths; *os.File.Close on an already-closed fd returns
+			// an error that is safe to discard.
+			_ = dupFile.Close()
 		}
-		yamlBytes = util.EscapeDollarSign(yamlBytes)
-		proc.Stdin = strings.NewReader(string(yamlBytes))
-	} else {
-		proc.Stdin = os.Stdin
-	}
-	proc.Env = append(os.Environ(), cmd.Env...)
-
-	stderrPipe, err := proc.StderrPipe()
-	if err != nil {
-		return "", "", fmt.Errorf("failed to proc.StderrPipe(): %v", err)
-	}
-
-	if err = proc.Start(); err != nil {
-		return "", "", fmt.Errorf("failed to exec docker-compose: %v", err)
-	}
-
-	stderrOutput := bufio.NewScanner(stderrPipe)
-
-	// Ignore chatty things from docker-compose like:
-	// Container (or Volume) ... Creating or Created or Stopping or Starting or Removing
-	// Container Stopped or Created
-	// No resource found to remove (when doing a stop and no project exists)
-	ignoreRegex := "(^ *(Network|Container|Image|Volume|Service) .* (Creat|Start|Stopp|Remov|Build|Buil|Runn)(ing|t) $|.* Built$|^ *Container .*(Build|Stopp|Recreat|Creat)(ed|ing) *$|No services to build|Warning: No resource found to remove|Warning: Pulling fs layer|Waiting|Downloading|Extracting|Verifying Checksum|Download complete|Pull complete)"
-	downRE, err := regexp.Compile(ignoreRegex)
-	if err != nil {
-		util.Warning("Failed to compile regex %v: %v", ignoreRegex, err)
-	}
-
-	var done chan bool
-	if cmd.Progress {
-		done = util.ShowDots()
-	}
-	for stderrOutput.Scan() {
-		line := stderrOutput.Text()
-		if len(stderr) > 0 {
-			stderr = stderr + "\n"
-		}
-		stderr = stderr + line
-		line = strings.Trim(line, "\n\r")
-		switch {
-		case downRE.MatchString(line):
-			break
-		default:
-			output.UserOut.Println(line)
-		}
-	}
-
-	err = proc.Wait()
-	if cmd.Progress {
-		done <- true
-	}
-
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return stdout.String(), stderr, fmt.Errorf("composeCmd timed out after %v and failed to run 'COMPOSE_PROJECT_NAME=%s docker-compose %v', action='%v', err='%v', stdout='%s', stderr='%s'", cmd.Timeout, os.Getenv("COMPOSE_PROJECT_NAME"), strings.Join(arg, " "), cmd.Action, err, stdout.String(), stderr)
-	}
-	if err != nil {
-		return stdout.String(), stderr, fmt.Errorf("composeCmd failed to run 'COMPOSE_PROJECT_NAME=%s docker-compose %v', action='%v', err='%v', stdout='%s', stderr='%s'", os.Getenv("COMPOSE_PROJECT_NAME"), strings.Join(arg, " "), cmd.Action, err, stdout.String(), stderr)
-	}
-	return stdout.String(), stderr, nil
+	}, nil
 }
 
-// GetDockerComposeVersion runs docker-compose -v to get the current version
-func GetDockerComposeVersion() (string, error) {
-	if globalconfig.DockerComposeVersion != "" {
-		return globalconfig.DockerComposeVersion, nil
-	}
-
-	return GetLiveDockerComposeVersion()
-}
-
-// GetLiveDockerComposeVersion runs `docker-compose --version` and caches result
-func GetLiveDockerComposeVersion() (string, error) {
-	if globalconfig.DockerComposeVersion != "" {
-		return globalconfig.DockerComposeVersion, nil
-	}
-
-	composePath, err := globalconfig.GetDockerComposePath()
-	if err != nil {
-		return "", err
-	}
-
-	if !fileutil.FileExists(composePath) {
-		globalconfig.DockerComposeVersion = ""
-		return globalconfig.DockerComposeVersion, fmt.Errorf("docker-compose does not exist at %s", composePath)
-	}
-	out, err := exec.Command(composePath, "version", "--short").Output()
-	if err != nil {
-		return "", err
-	}
-	v := strings.Trim(string(out), "\r\n")
-
-	// docker-compose v1 and v2.3.3 return a version without the prefix "v", so add it.
-	if !strings.HasPrefix(v, "v") {
-		v = "v" + v
-	}
-
-	globalconfig.DockerComposeVersion = v
-	return globalconfig.DockerComposeVersion, nil
-}
-
-// DownloadDockerComposeIfNeeded downloads the proper version of docker-compose
-// if it's either not yet installed or has the wrong version.
-// Returns downloaded bool (true if it did the download) and err
-func DownloadDockerComposeIfNeeded() (bool, error) {
-	requiredVersion := globalconfig.GetRequiredDockerComposeVersion()
-	var err error
-	if requiredVersion == "" {
-		util.Debug("globalconfig use_docker_compose_from_path is set, so not downloading")
-		return false, nil
-	}
-	curVersion, err := GetLiveDockerComposeVersion()
-	if err != nil || curVersion != requiredVersion {
-		err = DownloadDockerCompose()
-		if err == nil {
-			return true, err
-		}
-	}
-	return false, err
-}
-
-// DownloadDockerCompose gets the docker-compose binary and puts it into
-// ~/.ddev/.bin
-func DownloadDockerCompose() error {
-	globalBinDir := globalconfig.GetDDEVBinDir()
-	destFile, _ := globalconfig.GetDockerComposePath()
-
-	composeURL, shasumURL, err := dockerComposeDownloadLink()
-	if err != nil {
-		return err
-	}
-	util.Debug("Downloading '%s' to '%s' ...", composeURL, destFile)
-
-	_ = os.Remove(destFile)
-
-	_ = os.MkdirAll(globalBinDir, 0777)
-	err = util.DownloadFile(destFile, composeURL, globalconfig.IsInteractive(), shasumURL)
-	if err != nil {
-		_ = os.Remove(destFile)
-		return err
-	}
-	output.UserErr.Printf("Download complete.")
-
-	// Remove the cached DockerComposeVersion
-	globalconfig.DockerComposeVersion = ""
-
-	err = util.Chmod(destFile, 0755)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// dockerComposeDownloadLink returns the URL and SHASUM-file link for docker-compose
-func dockerComposeDownloadLink() (composeURL string, shasumURL string, err error) {
-	arch := runtime.GOARCH
-
-	switch arch {
-	case "arm64":
-		arch = "aarch64"
-	case "amd64":
-		arch = "x86_64"
-	default:
-		return "", "", fmt.Errorf("only ARM64 and AMD64 architectures are supported for docker-compose, not %s", arch)
-	}
-	flavor := runtime.GOOS + "-" + arch
-	composerURL := fmt.Sprintf("https://github.com/docker/compose/releases/download/%s/docker-compose-%s", globalconfig.GetRequiredDockerComposeVersion(), flavor)
-	if nodeps.IsWindows() {
-		composerURL = composerURL + ".exe"
-	}
-	shasumURL = fmt.Sprintf("https://github.com/docker/compose/releases/download/%s/checksums.txt", globalconfig.GetRequiredDockerComposeVersion())
-
-	return composerURL, shasumURL, nil
-}
-
-// CreateComposeProject creates a compose project from a string
+// CreateComposeProject creates a compose project from a YAML string.
 func CreateComposeProject(yamlStr string) (*types.Project, error) {
 	project, err := loader.LoadWithContext(
 		context.Background(),
@@ -352,17 +207,17 @@ func CreateComposeProject(yamlStr string) (*types.Project, error) {
 	return project, nil
 }
 
-// PullImages pulls images in parallel if they don't exist locally
-// If pullAlways is true, it will always pull
-// Otherwise, it will only pull if the image doesn't exist
+// PullImages pulls images in parallel if they don't exist locally.
+// If pullAlways is true, it will always pull.
 func PullImages(images []string, pullAlways bool) error {
 	if len(images) == 0 {
 		return nil
 	}
 
-	composeYamlPull, err := CreateComposeProject("name: compose-yaml-pull")
-	if err != nil {
-		return err
+	// Build a minimal project directly without a YAML round-trip.
+	project := &types.Project{
+		Name:     "compose-yaml-pull",
+		Services: types.Services{},
 	}
 
 	for _, image := range images {
@@ -375,45 +230,35 @@ func PullImages(images []string, pullAlways bool) error {
 			}
 		}
 		service := sanitizeServiceName(image)
-		if _, exists := composeYamlPull.Services[service]; exists {
+		if _, exists := project.Services[service]; exists {
 			continue
 		}
-		composeYamlPull.Services[service] = types.ServiceConfig{
+		project.Services[service] = types.ServiceConfig{
 			Image: image,
 		}
 		util.Debug(`Pulling image for %s ("%s" service)`, image, service)
 	}
 
-	if len(composeYamlPull.Services) == 0 {
+	if len(project.Services) == 0 {
 		util.Debug("All images already exist locally, no pull needed")
 		return nil
 	}
 
-	if !output.JSONOutput && isatty.IsTerminal(os.Stdin.Fd()) {
-		err = ComposeWithStreams(&ComposeCmdOpts{
-			ComposeYaml: composeYamlPull,
-			Action:      []string{"pull"},
-			Env:         []string{"COMPOSE_DISABLE_ENV_FILE=1"},
-		}, nil, os.Stdout, os.Stderr)
-	} else {
-		_, _, err = ComposeCmd(&ComposeCmdOpts{
-			ComposeYaml: composeYamlPull,
-			Action:      []string{"pull"},
-			Env:         []string{"COMPOSE_DISABLE_ENV_FILE=1"},
-		})
+	pullCtx, pullSvc, pullErr := NewComposeService()
+	if pullErr != nil {
+		return pullErr
 	}
-
-	return err
+	return pullSvc.Pull(pullCtx, project, api.PullOptions{})
 }
 
-// Pull pulls image if it doesn't exist locally
+// Pull pulls image if it doesn't exist locally.
 func Pull(image string) error {
 	return PullImages([]string{image}, false)
 }
 
 // sanitizeServiceName sanitizes a string to be a valid Docker Compose service name
-// by replacing any characters that don't match [a-zA-Z0-9._-] with hyphens
-// See https://github.com/compose-spec/compose-go/blob/main/schema/compose-spec.json for allowed pattern
+// by replacing any characters that don't match [a-zA-Z0-9._-] with hyphens.
+// See https://github.com/compose-spec/compose-go/blob/main/schema/compose-spec.json for allowed pattern.
 func sanitizeServiceName(input string) string {
 	if input == "" {
 		return ""
@@ -428,4 +273,54 @@ func sanitizeServiceName(input string) string {
 	sanitized = strings.Trim(sanitized, "-")
 
 	return sanitized
+}
+
+// suppressedLogrusMessages are substrings that, when matched against a logrus
+// entry's Message, cause the entry to be silently dropped at format time. Used
+// to silence known-harmless compose noise (notably the project-level
+// "Warning: No resource found to remove" warning emitted by compose Down at
+// vendor/github.com/docker/compose/v5/pkg/compose/down.go:117).
+var suppressedLogrusMessages = []string{
+	"No resource found to remove",
+}
+
+// suppressLogrusFormatter wraps an underlying logrus.Formatter and returns
+// (nil, nil) for entries whose Message matches a suppressedLogrusMessages
+// substring. Returning empty bytes makes logrus's downstream Out.Write a
+// no-op, suppressing the entry without touching the output writer or the log
+// level. Non-matching entries are formatted by the underlying formatter.
+//
+// Installed once at package init via setupLogrusSuppression so we don't
+// mutate global state per call. Compose hardwires logrus.StandardLogger,
+// so a global filter is the only knob available; making it permanent
+// removes the per-call SetOutput race the previous implementation had.
+type suppressLogrusFormatter struct {
+	underlying logrus.Formatter
+	suppress   []string
+}
+
+func (f *suppressLogrusFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	for _, s := range f.suppress {
+		if strings.Contains(entry.Message, s) {
+			return nil, nil
+		}
+	}
+	return f.underlying.Format(entry)
+}
+
+// setupLogrusSuppression installs a suppressLogrusFormatter on the given
+// logger if one is not already installed. Idempotent; safe to call multiple
+// times.
+func setupLogrusSuppression(logger *logrus.Logger) {
+	if _, alreadyWrapped := logger.Formatter.(*suppressLogrusFormatter); alreadyWrapped {
+		return
+	}
+	logger.SetFormatter(&suppressLogrusFormatter{
+		underlying: logger.Formatter,
+		suppress:   suppressedLogrusMessages,
+	})
+}
+
+func init() {
+	setupLogrusSuppression(logrus.StandardLogger())
 }

--- a/pkg/dockerutil/docker_compose_internal_test.go
+++ b/pkg/dockerutil/docker_compose_internal_test.go
@@ -1,0 +1,145 @@
+package dockerutil
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/docker/compose/v5/cmd/display"
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSanitizeServiceNameEdges covers empty input, leading/trailing hyphens, runs of separators.
+func TestSanitizeServiceNameEdges(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"simple", "simple"},
+		{"hello/world", "hello-world"},
+		{"---leading", "leading"},
+		{"trailing---", "trailing"},
+		{"a///b", "a-b"},
+		{"docker.io/library/alpine:3.18", "docker.io-library-alpine-3.18"},
+		{"_underscore_", "_underscore_"},
+	}
+	for _, tt := range tests {
+		got := sanitizeServiceName(tt.input)
+		require.Equal(t, tt.want, got, "input=%q", tt.input)
+	}
+}
+
+// TestSanitizeServiceNameCollisionMatrix pins inputs that DO collide vs
+// inputs that look similar but DO NOT, so PullImages's "skip on collision"
+// fallback in docker_compose.go is exercised against a known-stable set.
+//
+// The collision pairs document a real footgun: `a/b/c` and `a-b-c` collapse
+// to the same sanitized form. DDEV's image set keeps registry+tag distinct
+// per image, so collisions don't occur in practice — but a future addition
+// could regress this silently. If this test starts failing, audit the new
+// image set rather than relaxing the assertion.
+func TestSanitizeServiceNameCollisionMatrix(t *testing.T) {
+	colliding := []struct {
+		a, b string
+	}{
+		{"a/b/c", "a-b-c"},
+		{"docker.io/library/alpine", "docker.io-library-alpine"},
+		{"foo:bar", "foo-bar"},
+		{"foo bar", "foo-bar"},
+	}
+	for _, c := range colliding {
+		require.Equal(t, sanitizeServiceName(c.a), sanitizeServiceName(c.b),
+			"expected %q and %q to collide", c.a, c.b)
+	}
+
+	distinct := []struct {
+		a, b string
+	}{
+		// Different tags must remain distinct (DDEV relies on this).
+		{"docker.io/library/alpine:3.18", "docker.io/library/alpine:3.19"},
+		// Different repositories on the same registry remain distinct.
+		{"docker.io/library/alpine", "docker.io/library/busybox"},
+		// Different registries remain distinct.
+		{"ghcr.io/foo/bar", "docker.io/foo/bar"},
+	}
+	for _, d := range distinct {
+		require.NotEqual(t, sanitizeServiceName(d.a), sanitizeServiceName(d.b),
+			"expected %q and %q to remain distinct after sanitization", d.a, d.b)
+	}
+}
+
+// TestProgressOptsPlainWriterRouting verifies that display.ModePlain routes
+// EventProcessor output to a buffer wired through progressOpts.
+//
+// We exercise display.Plain directly with a known buffer and feed it a
+// resource event; this is the same construction path progressOpts takes.
+// Failure here would indicate that compose's display.Plain has changed
+// behavior and DDEV's progress output is no longer reaching its expected
+// destination.
+func TestProgressOptsPlainWriterRouting(t *testing.T) {
+	var buf bytes.Buffer
+
+	ep := display.Plain(&buf)
+	require.NotNil(t, ep)
+
+	ep.On(api.Resource{
+		ID:     "ddev-progress-routing-test",
+		Status: api.Working,
+		Text:   "routing-check",
+	})
+
+	require.Contains(t, buf.String(), "routing-check",
+		"display.Plain must write events to the writer it was constructed with")
+}
+
+// TestSuppressLogrusFormatterDirect exercises the formatter installed at
+// package init by feeding it entries directly. This is the deterministic
+// counterpart to TestSuppressedLogrusNoise (which goes through the global
+// logger) and is robust against parallel tests touching logrus.
+func TestSuppressLogrusFormatterDirect(t *testing.T) {
+	f, ok := logrus.StandardLogger().Formatter.(*suppressLogrusFormatter)
+	require.True(t, ok, "package init must install suppressLogrusFormatter on logrus.StandardLogger")
+
+	// Matching message: nil bytes, no error.
+	out, err := f.Format(&logrus.Entry{Message: "Warning: No resource found to remove for project \"foo\"."})
+	require.NoError(t, err)
+	require.Empty(t, out)
+
+	// Matching substring at any position is suppressed.
+	out, err = f.Format(&logrus.Entry{Message: "prefix No resource found to remove suffix"})
+	require.NoError(t, err)
+	require.Empty(t, out)
+
+	// Non-matching message: underlying formatter runs and produces output.
+	out, err = f.Format(&logrus.Entry{
+		Message: "real warning",
+		Level:   logrus.WarnLevel,
+		Time:    time.Unix(0, 0),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+	require.Contains(t, string(out), "real warning")
+}
+
+// TestSetupLogrusSuppressionIdempotent verifies that calling setupLogrusSuppression
+// twice does not stack wrappers — a real concern if init runs more than once
+// (e.g. via test reordering) or if a future caller invokes it explicitly.
+func TestSetupLogrusSuppressionIdempotent(t *testing.T) {
+	logger := logrus.New()
+	originalFormatter := logger.Formatter
+
+	setupLogrusSuppression(logger)
+	first, ok := logger.Formatter.(*suppressLogrusFormatter)
+	require.True(t, ok)
+	require.Same(t, originalFormatter, first.underlying,
+		"first install must wrap the original formatter")
+
+	setupLogrusSuppression(logger)
+	second, ok := logger.Formatter.(*suppressLogrusFormatter)
+	require.True(t, ok)
+	require.Same(t, first, second,
+		"second install must be a no-op; otherwise we'd double-wrap and lose the original formatter")
+}

--- a/pkg/dockerutil/docker_compose_test.go
+++ b/pkg/dockerutil/docker_compose_test.go
@@ -1,11 +1,15 @@
 package dockerutil_test
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -15,6 +19,10 @@ import (
 	"github.com/ddev/ddev/pkg/testsetup"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
+	"github.com/docker/cli/cli"
+	"github.com/docker/compose/v5/cmd/display"
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/sirupsen/logrus"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,159 +43,327 @@ func init() {
 	globalconfig.EnsureGlobalConfig()
 }
 
-// TestDockerComposeDownload verifies that we can download a particular docker-compose version
-func TestDockerComposeDownload(t *testing.T) {
+// TestComposeConfig tests ComposeConfig which loads and merges compose files.
+func TestComposeConfig(t *testing.T) {
 	assert := asrt.New(t)
-	var err error
 
-	_, err = dockerutil.DownloadDockerComposeIfNeeded()
-	require.NoError(t, err)
-
-	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
+	// Create a dummy app to set up DockerEnv
+	testDir := testcommon.CreateTmpDir(t.Name())
+	app, err := ddevapp.NewApp(testDir, true)
+	assert.NoError(err)
 
 	t.Cleanup(func() {
-		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
+		_ = os.RemoveAll(testDir)
 	})
 
-	// Remove previous binary
-	previousDockerCompose, _ := globalconfig.GetDockerComposePath()
-	_ = os.RemoveAll(previousDockerCompose)
+	app.Name = "test"
 
-	// Download the normal required version specified in code
-	globalconfig.DockerComposeVersion = ""
-
-	downloaded, err := dockerutil.DownloadDockerComposeIfNeeded()
-	require.NoError(t, err)
-	require.True(t, downloaded)
-	v, err := dockerutil.GetLiveDockerComposeVersion()
-	assert.NoError(err)
-	assert.Equal(globalconfig.GetRequiredDockerComposeVersion(), v)
-
-	// Make sure it doesn't download a second time
-	downloaded, err = dockerutil.DownloadDockerComposeIfNeeded()
-	assert.NoError(err)
-	assert.False(downloaded)
-
-	for _, v := range []string{"v2.32.4"} {
-		globalconfig.DockerComposeVersion = ""
-		globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion = v
-		downloaded, err = dockerutil.DownloadDockerComposeIfNeeded()
-		require.NoError(t, err)
-		assert.True(downloaded)
-		// We have to reset version.DockerComposeVersion so it will actually check
-		// instead of using cached value.
-		globalconfig.DockerComposeVersion = ""
-		activeVersion, err := dockerutil.GetLiveDockerComposeVersion()
-		assert.NoError(err)
-		assert.Equal(globalconfig.GetRequiredDockerComposeVersion(), activeVersion)
-	}
-}
-
-// TestComposeCmd tests execution of docker-compose commands.
-func TestComposeCmd(t *testing.T) {
-	assert := asrt.New(t)
+	// Set up environment variables via DockerEnv
+	_ = app.DockerEnv()
 
 	composeFiles := []string{filepath.Join("testdata", "docker-compose.yml")}
 
-	stdout, stderr, err := dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: composeFiles,
-		Action:       []string{"config", "--services"},
+	// Test: should return project with services
+	project, err := dockerutil.LoadComposeProject(composeFiles, api.ProjectLoadOptions{
+		ProjectName: "test",
 	})
 	assert.NoError(err)
-	assert.Contains(stdout, "web")
-	assert.Contains(stdout, "db")
-	assert.Contains(stderr, "Defaulting to a blank string")
+	assert.NotNil(project)
+	_, hasWeb := project.Services["web"]
+	assert.True(hasWeb)
+	_, hasDB := project.Services["db"]
+	assert.True(hasDB)
 
+	// Test with additional override file
 	composeFiles = append(composeFiles, filepath.Join("testdata", "docker-compose.override.yml"))
-
-	stdout, stderr, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: composeFiles,
-		Action:       []string{"config", "--services"},
+	project, err = dockerutil.LoadComposeProject(composeFiles, api.ProjectLoadOptions{
+		ProjectName: "test",
 	})
 	assert.NoError(err)
-	assert.Contains(stdout, "web")
-	assert.Contains(stdout, "db")
-	assert.Contains(stdout, "foo")
-	assert.Contains(stderr, "Defaulting to a blank string")
+	assert.NotNil(project)
+	_, hasWeb = project.Services["web"]
+	assert.True(hasWeb)
+	_, hasDB = project.Services["db"]
+	assert.True(hasDB)
+	_, hasFoo := project.Services["foo"]
+	assert.True(hasFoo)
 
-	composeFiles = []string{"invalid.yml"}
-	_, _, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: composeFiles,
-		Action:       []string{"config", "--services"},
+	// Test with invalid file
+	_, err = dockerutil.LoadComposeProject([]string{"invalid.yml"}, api.ProjectLoadOptions{
+		ProjectName: "test",
 	})
 	assert.Error(err)
+
+	// Test with empty ProjectName
+	_, err = dockerutil.LoadComposeProject(composeFiles, api.ProjectLoadOptions{})
+	assert.Error(err)
+	assert.Contains(err.Error(), "ProjectName")
 }
 
-// TestComposeWithStreams tests execution of docker-compose commands with streams
-func TestComposeWithStreams(t *testing.T) {
+// TestComposeExec tests execution of docker-compose exec commands with streams
+func TestComposeExec(t *testing.T) {
 	assert := asrt.New(t)
 
-	container, _ := dockerutil.FindContainerByName(t.Name())
+	projectName := "test-compose-exec"
+
+	container, _ := dockerutil.FindContainerByName(projectName)
 	if container != nil {
 		_ = dockerutil.RemoveContainer(container.ID)
 	}
 
 	// Use the current actual web container for this, so replace in base docker-compose file
-	composeBase := filepath.Join("testdata", "TestComposeWithStreams", "test-compose-with-streams.yaml")
+	composeBase := filepath.Join("testdata", "TestComposeExec", "test-compose-exec.yaml")
 	tmpDir := testcommon.CreateTmpDir(t.Name())
-	realComposeFile := filepath.Join(tmpDir, "replaced-compose-with-streams.yaml")
+	realComposeFile := filepath.Join(tmpDir, "replaced-compose-exec.yaml")
 
-	err := fileutil.ReplaceStringInFile("TEST-COMPOSE-WITH-STREAMS-IMAGE", versionconstants.WebImg+":"+versionconstants.WebTag, composeBase, realComposeFile)
+	err := fileutil.ReplaceStringInFile("TEST-COMPOSE-EXEC-IMAGE", versionconstants.WebImg+":"+versionconstants.WebTag, composeBase, realComposeFile)
 	assert.NoError(err)
 
 	composeFiles := []string{realComposeFile}
 
 	t.Cleanup(func() {
-		_, _, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-			ComposeFiles: composeFiles,
-			Action:       []string{"down"},
-		})
-		assert.NoError(err)
+		cleanProject, cleanErr := dockerutil.LoadComposeProject(composeFiles, api.ProjectLoadOptions{ProjectName: projectName})
+		if cleanErr == nil {
+			cleanCtx, cleanSvc, svcErr := dockerutil.NewComposeService()
+			if svcErr == nil {
+				_ = cleanSvc.Down(cleanCtx, cleanProject.Name, api.DownOptions{Project: cleanProject})
+			}
+		}
 	})
 
-	_, _, err = dockerutil.ComposeCmd(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: composeFiles,
-		Action:       []string{"up", "-d"},
+	upProject, err := dockerutil.LoadComposeProject(composeFiles, api.ProjectLoadOptions{ProjectName: projectName})
+	require.NoError(t, err)
+	upCtx, upSvc, err := dockerutil.NewComposeService()
+	require.NoError(t, err)
+	err = upSvc.Up(upCtx, upProject, api.UpOptions{
+		Create: api.CreateOptions{Build: &api.BuildOptions{Progress: display.ModePlain}},
+		Start:  api.StartOptions{Project: upProject},
 	})
 	require.NoError(t, err)
 
 	_, err = dockerutil.ContainerWait(60, map[string]string{
-		"com.ddev.site-name":        t.Name(),
+		"com.ddev.site-name":        projectName,
 		"com.docker.compose.oneoff": "False",
 	})
 	if err != nil {
-		logout, _ := exec.RunCommand("docker", []string{"logs", t.Name()})
-		inspectOut, _ := exec.RunCommandPipe("sh", []string{"-c", fmt.Sprintf("docker inspect %s|jq -r '.[0].State.Health.Log'", t.Name())})
-		t.Fatalf("FAIL: TestComposeWithStreams failed to ContainerWait for container: %v, logs\n========= container logs ======\n%s\n======= end logs =======\n==== health log =====\ninspectOut\n%s\n========", err, logout, inspectOut)
+		logout, _ := exec.RunCommand("docker", []string{"logs", projectName})
+		inspectOut, _ := exec.RunCommandPipe("sh", []string{"-c", fmt.Sprintf("docker inspect %s|jq -r '.[0].State.Health.Log'", projectName)})
+		t.Fatalf("FAIL: TestComposeExec failed to ContainerWait for container: %v, logs\n========= container logs ======\n%s\n======= end logs =======\n==== health log =====\ninspectOut\n%s\n========", err, logout, inspectOut)
+	}
+
+	execProject, err := dockerutil.LoadComposeProject(composeFiles, api.ProjectLoadOptions{ProjectName: projectName})
+	require.NoError(t, err)
+
+	execFn := func(stdoutW, stderrW io.Writer, command []string) error {
+		execCtx, svc, svcErr := dockerutil.NewComposeServiceWithStreams(stdoutW, stderrW)
+		if svcErr != nil {
+			return svcErr
+		}
+		return dockerutil.ExitCodeToError(svc.Exec(execCtx, execProject.Name, api.RunOptions{
+			Service: "web",
+			Command: command,
+		}))
 	}
 
 	// Point stdout to os.Stdout and do simple ps -ef in web container
 	stdout := util.CaptureStdOut()
-	err = dockerutil.ComposeWithStreams(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: composeFiles,
-		Action:       []string{"exec", "-T", "web", "ps", "-ef"},
-	}, os.Stdin, os.Stdout, os.Stderr)
+	err = execFn(os.Stdout, os.Stderr, []string{"ps", "-ef"})
 	assert.NoError(err)
 	output := stdout()
 	assert.Contains(output, "supervisord")
 
-	// Reverse stdout and stderr and create an error and normal stdout. We should see only the error captured in stdout
+	// Reverse stdout and stderr: error output should appear on our captured stdout
 	stdout = util.CaptureStdOut()
-	err = dockerutil.ComposeWithStreams(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: composeFiles,
-		Action:       []string{"exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2"},
-	}, os.Stdin, os.Stderr, os.Stdout)
+	err = execFn(os.Stderr, os.Stdout, []string{"ls", "-d", "xx", "/var/run/apache2"})
 	assert.Error(err)
 	output = stdout()
 	assert.Contains(output, "ls: cannot access 'xx': No such file or directory")
 
-	// Flip stdout and stderr and create an error and normal stdout. We should see only the success captured in stdout
+	// Normal stdout/stderr: success output should appear on our captured stdout
 	stdout = util.CaptureStdOut()
-	err = dockerutil.ComposeWithStreams(&dockerutil.ComposeCmdOpts{
-		ComposeFiles: composeFiles,
-		Action:       []string{"exec", "-T", "web", "ls", "-d", "xx", "/var/run/apache2"},
-	}, os.Stdin, os.Stdout, os.Stderr)
+	err = execFn(os.Stdout, os.Stderr, []string{"ls", "-d", "xx", "/var/run/apache2"})
 	assert.Error(err)
 	output = stdout()
 	assert.Contains(output, "/var/run/apache2", output)
+
+	// Exit code: non-zero exit returns a cli.StatusError carrying the exit code,
+	// extractable by callers via errors.As. The Status string is also populated
+	// (docker/cli's container.RunExec leaves it empty; ExitCodeToError fills it in).
+	err = execFn(os.Stdout, os.Stderr, []string{"sh", "-c", "exit 42"})
+	require.Error(t, err)
+	var statusErr cli.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(t, 42, statusErr.StatusCode)
+	require.Contains(t, err.Error(), "42")
+
+	// Exit code 0 with a successful command must NOT produce a cli.StatusError.
+	err = execFn(os.Stdout, os.Stderr, []string{"true"})
+	require.NoError(t, err)
+	require.False(t, errors.As(err, &statusErr))
+
+	// A different non-zero exit code (1) round-trips correctly through the helper.
+	err = execFn(os.Stdout, os.Stderr, []string{"false"})
+	require.Error(t, err)
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(t, 1, statusErr.StatusCode)
+
+	execWithOpts := func(stdoutW, stderrW io.Writer, opts api.RunOptions) error {
+		opts.Service = "web"
+		execCtx, svc, svcErr := dockerutil.NewComposeServiceWithStreams(stdoutW, stderrW)
+		if svcErr != nil {
+			return svcErr
+		}
+		return dockerutil.ExitCodeToError(svc.Exec(execCtx, execProject.Name, opts))
+	}
+
+	// Working directory: pwd inside /tmp should report /tmp
+	stdout = util.CaptureStdOut()
+	err = execWithOpts(os.Stdout, os.Stderr, api.RunOptions{Command: []string{"pwd"}, WorkingDir: "/tmp"})
+	assert.NoError(err)
+	output = stdout()
+	assert.Contains(output, "/tmp")
+
+	// User override: whoami should report root
+	stdout = util.CaptureStdOut()
+	err = execWithOpts(os.Stdout, os.Stderr, api.RunOptions{Command: []string{"whoami"}, User: "root"})
+	assert.NoError(err)
+	output = stdout()
+	assert.Contains(output, "root")
+
+	// Environment variables: injected var must appear in the command output
+	stdout = util.CaptureStdOut()
+	err = execWithOpts(os.Stdout, os.Stderr, api.RunOptions{
+		Command:     []string{"sh", "-c", "echo $DDEV_COMPOSE_TEST"},
+		Environment: []string{"DDEV_COMPOSE_TEST=hello"},
+	})
+	assert.NoError(err)
+	output = stdout()
+	assert.Contains(output, "hello")
+}
+
+// TestCreateComposeProject verifies nil-map initialization for services, networks, and volumes.
+func TestCreateComposeProject(t *testing.T) {
+	yamlStr := `
+name: test-project
+services:
+  web:
+    image: alpine
+`
+	project, err := dockerutil.CreateComposeProject(yamlStr)
+	require.NoError(t, err)
+	require.NotNil(t, project.Networks)
+	require.NotNil(t, project.Services)
+	require.NotNil(t, project.Volumes)
+
+	webSvc := project.Services["web"]
+	require.NotNil(t, webSvc.Networks)
+	require.NotNil(t, webSvc.Environment)
+}
+
+// TestCreateComposeProjectInvalid verifies that invalid YAML returns an error.
+func TestCreateComposeProjectInvalid(t *testing.T) {
+	_, err := dockerutil.CreateComposeProject("not: valid: yaml: [")
+	require.Error(t, err)
+}
+
+// TestSuppressedLogrusNoise verifies, via real logrus.StandardLogger calls,
+// that the compose-noise filter installed at package init drops only matching
+// entries and lets all other entries pass through.
+func TestSuppressedLogrusNoise(t *testing.T) {
+	var buf strings.Builder
+	origOut := logrus.StandardLogger().Out
+	logrus.SetOutput(&stringWriter{&buf})
+	t.Cleanup(func() { logrus.SetOutput(origOut) })
+
+	// Compose's "No resource found to remove" warning must be silently dropped.
+	buf.Reset()
+	logrus.Warn("Warning: No resource found to remove for project \"foo\".")
+	require.NotContains(t, buf.String(), "No resource found to remove")
+
+	// Unrelated warnings still flow through to the configured output.
+	buf.Reset()
+	logrus.Warn("some other warning")
+	require.Contains(t, buf.String(), "some other warning")
+
+	// Different log levels are also suppressed when the message matches.
+	buf.Reset()
+	logrus.Info("No resource found to remove for project \"bar\".")
+	require.NotContains(t, buf.String(), "No resource found to remove")
+}
+
+// stringWriter adapts strings.Builder to io.Writer for logrus.
+type stringWriter struct{ b *strings.Builder }
+
+func (w *stringWriter) Write(p []byte) (int, error) { return w.b.Write(p) }
+
+// TestCaptureOutputErrorPassthrough verifies that errors returned by fn are propagated.
+func TestCaptureOutputErrorPassthrough(t *testing.T) {
+	sentinelErr := errors.New("expected error")
+	_, _, err := dockerutil.CaptureOutput(func(svc api.Compose) error {
+		return sentinelErr
+	})
+	require.ErrorIs(t, err, sentinelErr)
+}
+
+// TestLoadComposeProjectEmptyProjectName focuses on the input-validation
+// branch: ProjectName is mandatory and must surface a clear error.
+func TestLoadComposeProjectEmptyProjectName(t *testing.T) {
+	_, err := dockerutil.LoadComposeProject(
+		[]string{filepath.Join("testdata", "docker-compose.yml")},
+		api.ProjectLoadOptions{}, // ProjectName intentionally empty
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ProjectName",
+		"empty ProjectName must produce an error mentioning ProjectName so callers can diagnose")
+}
+
+// TestLoadComposeProjectDoesNotMutateOpts pins the value-semantics contract:
+// LoadComposeProject must not write through to the caller's opts struct.
+// If LoadComposeProject is ever changed to take *api.ProjectLoadOptions (pointer),
+// this test will start failing and the call sites must be re-audited — they
+// currently rely on being able to pass an opts literal without worrying about
+// in-place mutation across calls.
+func TestLoadComposeProjectDoesNotMutateOpts(t *testing.T) {
+	opts := api.ProjectLoadOptions{ProjectName: "test"}
+	files := []string{filepath.Join("testdata", "docker-compose.yml")}
+
+	_, _ = dockerutil.LoadComposeProject(files, opts)
+
+	require.Nil(t, opts.ConfigPaths,
+		"LoadComposeProject must not assign ConfigPaths on caller's opts")
+	require.Empty(t, opts.WorkingDir,
+		"LoadComposeProject must not assign WorkingDir on caller's opts")
+}
+
+// TestPullImagesEmpty verifies that PullImages with empty/nil input is a no-op.
+func TestPullImagesEmpty(t *testing.T) {
+	require.NoError(t, dockerutil.PullImages(nil, false))
+	require.NoError(t, dockerutil.PullImages([]string{}, false))
+	// A slice of only empty strings should also be a no-op (all skipped).
+	require.NoError(t, dockerutil.PullImages([]string{""}, false))
+}
+
+// TestSetExecStdinRestoreOnPanic verifies that SetExecStdin's restore closure
+// reinstates the original stdin even when the caller panics.
+func TestSetExecStdinRestoreOnPanic(t *testing.T) {
+	// Read the original stdin from the singleton before the call.
+	// We compare os.Stdin here as a proxy — after restore the CLI's In() will
+	// point back to whatever it was before SetExecStdin ran.
+	restore, err := dockerutil.SetExecStdin(os.Stdin, false)
+	require.NoError(t, err)
+
+	func() {
+		defer func() {
+			_ = recover()
+			restore() // must not panic itself and must restore stdin
+		}()
+		panic("synthetic panic")
+	}()
+
+	// If we get here without the process crashing, restore() ran successfully.
+	// A second call with the same arguments must also succeed, proving stdin
+	// was returned to a state that can accept another SetExecStdin call.
+	restore2, err := dockerutil.SetExecStdin(os.Stdin, false)
+	require.NoError(t, err)
+	restore2()
 }

--- a/pkg/dockerutil/docker_manager.go
+++ b/pkg/dockerutil/docker_manager.go
@@ -1,19 +1,24 @@
 package dockerutil
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"net"
 	"net/url"
+	"path/filepath"
 	"sync"
 
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/cli/version"
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
@@ -23,17 +28,19 @@ import (
 // dockerManager manages Docker client configuration and connection state
 // Some of these values are set on demand when first requested
 type dockerManager struct {
-	goContext         context.Context            // Go context for Docker API calls
-	apiClient         client.APIClient           // Docker API for making calls to Docker daemon
-	cli               *command.DockerCli         // Docker CLI for getting dockerContextName and host
-	dockerContextName string                     // Current Docker context name (e.g., "default", "desktop-linux")
-	host              string                     // Docker daemon URL (e.g., "unix:///var/run/docker.sock")
-	hostIP            string                     // IP address of Docker host
-	hostIPErr         error                      // Error from Docker host IP lookup, if any
-	info              system.Info                // Docker system information from daemon (version, OS, etc.)
-	serverVersion     client.ServerVersionResult // Docker server version information
-	cliPlugins        []manager.Plugin           // Lazily discovered CLI plugins
-	cliPluginsErr     error                      // Error from CLI plugin discovery, if any
+	goContext                  context.Context            // Go context for Docker API calls
+	apiClient                  client.APIClient           // Docker API for making calls to Docker daemon
+	cli                        *command.DockerCli         // Docker CLI for getting dockerContextName and host
+	composeForLoad             api.Compose                // compose service with io.Discard streams; used only for LoadProject - never for Up/Down/Build
+	dockerContextName          string                     // Current Docker context name (e.g., "default", "desktop-linux")
+	host                       string                     // Docker daemon URL (e.g., "unix:///var/run/docker.sock")
+	hostIP                     string                     // IP address of Docker host
+	hostIPErr                  error                      // Error from Docker host IP lookup, if any
+	info                       system.Info                // Docker system information from daemon (version, OS, etc.)
+	serverVersion              client.ServerVersionResult // Docker server version information
+	cliPlugins                 []manager.Plugin           // Lazily discovered CLI plugins
+	cliPluginsErr              error                      // Error from CLI plugin discovery, if any
+	cliPluginsExtraDirsDefault []string                   // Extra directories to search for CLI plugins
 }
 
 var (
@@ -68,6 +75,13 @@ func getDockerManagerInstance() (*dockerManager, error) {
 		if sDockerManagerErr != nil {
 			return
 		}
+		sDockerManager.cliPluginsExtraDirsDefault = sDockerManager.cli.ConfigFile().CLIPluginsExtraDirs
+		if globalconfig.GetRequiredDockerBuildxVersion() != "" {
+			// Prepend global ddev bin directory to CLI plugin search path so it takes
+			// priority over any user-configured extra dirs and ~/.docker/cli-plugins.
+			// Must be done after Initialize(), which reloads configFile from disk.
+			sDockerManager.cli.ConfigFile().CLIPluginsExtraDirs = append([]string{filepath.Join(globalconfig.GetGlobalDdevDir(), "bin")}, sDockerManager.cliPluginsExtraDirsDefault...)
+		}
 		sDockerManager.dockerContextName = sDockerManager.cli.CurrentContext()
 		sDockerManager.host = sDockerManager.cli.DockerEndpoint().Host
 		util.Verbose("getDockerManagerInstance(): dockerContextName=%s, host=%s", sDockerManager.dockerContextName, sDockerManager.host)
@@ -84,6 +98,22 @@ func getDockerManagerInstance() (*dockerManager, error) {
 		if sDockerManagerErr != nil {
 			return
 		}
+		// Inject the same client into the CLI so the compose SDK shares one HTTP transport.
+		sDockerManagerErr = command.WithAPIClient(sDockerManager.apiClient)(sDockerManager.cli)
+		if sDockerManagerErr != nil {
+			return
+		}
+		// Cache a compose service with io.Discard streams, used only for LoadProject.
+		// Must not be used for Up/Down/Build/Exec — those need stream/progress overrides via NewComposeService.
+		// Ordering invariant: getDockerManagerInstance must run after globalconfig.EnsureGlobalConfig().
+		sDockerManager.composeForLoad, sDockerManagerErr = compose.NewComposeService(
+			sDockerManager.cli,
+			compose.WithOutputStream(io.Discard),
+			compose.WithErrorStream(io.Discard),
+		)
+		if sDockerManagerErr != nil {
+			return
+		}
 		sDockerManager.serverVersion, sDockerManagerErr = sDockerManager.apiClient.ServerVersion(sDockerManager.goContext, client.ServerVersionOptions{})
 		if sDockerManagerErr != nil {
 			return
@@ -94,10 +124,7 @@ func getDockerManagerInstance() (*dockerManager, error) {
 			return
 		}
 		sDockerManager.info = info.Info
-		// A minimal cobra.Command is sufficient since we only need plugin
-		// metadata, not builtin-command conflict detection.
-		rootCmd := &cobra.Command{Use: "ddev"}
-		sDockerManager.cliPlugins, sDockerManager.cliPluginsErr = manager.ListPlugins(sDockerManager.cli, rootCmd)
+		sDockerManager.cliPlugins, sDockerManager.cliPluginsErr = manager.ListPlugins(sDockerManager.cli, &cobra.Command{})
 	})
 	return sDockerManager, sDockerManagerErr
 }
@@ -201,6 +228,20 @@ func ResetDockerHost(host string) error {
 	return nil
 }
 
+// ResetCLIPlugins resets the cached list of Docker CLI plugins in the singleton.
+func ResetCLIPlugins() error {
+	dm, err := getDockerManagerInstance()
+	if err != nil {
+		return err
+	}
+	if globalconfig.GetRequiredDockerBuildxVersion() != "" {
+		// Reset CLIPluginsExtraDirs, because globalconfig.GetGlobalDdevDir() may have been modified by tests
+		dm.cli.ConfigFile().CLIPluginsExtraDirs = append([]string{filepath.Join(globalconfig.GetGlobalDdevDir(), "bin")}, dm.cliPluginsExtraDirsDefault...)
+	}
+	dm.cliPlugins, dm.cliPluginsErr = manager.ListPlugins(dm.cli, &cobra.Command{})
+	return dm.cliPluginsErr
+}
+
 // GetServerVersion gets the cached versions of Docker provider engine
 // This is a struct which has all info from "docker version" command
 func GetServerVersion() (client.ServerVersionResult, error) {
@@ -255,4 +296,51 @@ func GetCLIPlugin(name string) (manager.Plugin, error) {
 		}
 	}
 	return manager.Plugin{}, fmt.Errorf("docker CLI plugin %q not found", name)
+}
+
+// RunCLIPluginCommand runs a Docker CLI plugin command with the specified arguments and optional stdin.
+// If stdin is not nil, it will be passed to the command's stdin.
+// Returns the combined stdout and stderr output, and any error.
+func RunCLIPluginCommand(pluginName string, stdin io.Reader, args ...string) (string, error) {
+	dm, err := getDockerManagerInstance()
+	if err != nil {
+		return "", err
+	}
+
+	// Verify plugin exists
+	_, err = GetCLIPlugin(pluginName)
+	if err != nil {
+		return "", err
+	}
+
+	// Create a minimal cobra command for manager.PluginRunCommand
+	// It needs this to check for command conflicts
+	rootCmd := &cobra.Command{}
+
+	// Build the command arguments: docker <plugin> <args...>
+	// manager.PluginRunCommand expects os.Args to be set, but we can create a command directly
+	cmd, err := manager.PluginRunCommand(dm.cli, pluginName, rootCmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to create plugin command for %q: %w", pluginName, err)
+	}
+
+	// Override the args if provided
+	if len(args) > 0 {
+		cmd.Args = append([]string{cmd.Path, pluginName}, args...)
+	}
+
+	// manager.PluginRunCommand sets Stdout/Stderr to os.Stdout/os.Stderr
+	// We need to override them to capture output
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	// Set stdin if provided
+	if stdin != nil {
+		cmd.Stdin = stdin
+	}
+
+	err = cmd.Run()
+	output := outBuf.String() + errBuf.String()
+	return output, err
 }

--- a/pkg/dockerutil/docker_manager_test.go
+++ b/pkg/dockerutil/docker_manager_test.go
@@ -35,3 +35,20 @@ func TestGetDockerIP(t *testing.T) {
 		require.Equal(t, v, result, "for %s expected %s, got %s", k, v, result)
 	}
 }
+
+// TestGetCLIPlugins tests that Docker CLI plugins can be discovered.
+func TestGetCLIPlugins(t *testing.T) {
+	plugins, err := dockerutil.GetCLIPlugins()
+	require.NoError(t, err)
+	require.NotEmpty(t, plugins, "expected at least one CLI plugin to be installed")
+
+	// buildx should be among the discovered plugins
+	found := false
+	for _, p := range plugins {
+		if p.Name == "buildx" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected 'buildx' to be among discovered CLI plugins")
+}

--- a/pkg/dockerutil/requirements.go
+++ b/pkg/dockerutil/requirements.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
@@ -19,32 +18,18 @@ import (
 )
 
 type DockerVersionMatrix struct {
-	APIVersion               string
-	Version                  string
-	BuildxVersion            string
-	PodmanVersion            string
-	ComposeVersionConstraint string
+	APIVersion    string
+	Version       string
+	PodmanVersion string
 }
 
-// DockerRequirements defines the minimum Docker version required by DDEV.
+// DockerRequirements defines the minimum Docker version recommended by DDEV.
 // We compare using the APIVersion because it's a consistent and reliable value.
 // The Version is displayed to users as it's more readable and user-friendly.
-// The values correspond to the API version matrix found here:
-// https://docs.docker.com/reference/api/engine/#api-version-matrix
-// List of supported Docker versions: https://endoflife.date/docker-engine
-//
-// PodmanVersion is the minimum Podman version supported. If it's empty, Podman is not supported.
-// Podman 4.x doesn't run properly on GitHub runners, so we require Podman 5.0+
-//
-// ComposeVersionConstraint is in sync with https://docs.docker.com/desktop/release-notes/
-// The constraint MUST HAVE a -pre of some kind on it for successful comparison.
-// See https://github.com/ddev/ddev/pull/738 and regression https://github.com/ddev/ddev/issues/1431
 var DockerRequirements = DockerVersionMatrix{
-	APIVersion:               "1.44",
-	Version:                  "25.0",
-	BuildxVersion:            "0.17.0",
-	PodmanVersion:            "5.0",
-	ComposeVersionConstraint: ">= 2.24.3",
+	APIVersion:    versionconstants.DockerMinAPIVersion,
+	Version:       versionconstants.DockerMinVersion,
+	PodmanVersion: versionconstants.PodmanMinVersion,
 }
 
 // CheckDockerVersion determines if the Docker version of the host system meets the provided
@@ -78,47 +63,6 @@ func CheckDockerVersion(dockerVersionMatrix DockerVersionMatrix) error {
 	return nil
 }
 
-// CheckDockerCompose determines if docker-compose is present and executable on the host system. This
-// relies on docker-compose being somewhere in the user's $PATH.
-func CheckDockerCompose() error {
-	defer util.TimeTrack()()
-
-	_, err := DownloadDockerComposeIfNeeded()
-	if err != nil {
-		return err
-	}
-	versionConstraint := DockerRequirements.ComposeVersionConstraint
-
-	v, err := GetDockerComposeVersion()
-	if err != nil {
-		return err
-	}
-	dockerComposeVersion, err := semver.NewVersion(v)
-	if err != nil {
-		return err
-	}
-
-	constraint, err := semver.NewConstraint(versionConstraint)
-	if err != nil {
-		return err
-	}
-
-	match, errs := constraint.Validate(dockerComposeVersion)
-	if !match {
-		if len(errs) <= 1 {
-			return errs[0]
-		}
-
-		msgs := "\n"
-		for _, err := range errs {
-			msgs = fmt.Sprint(msgs, err, "\n")
-		}
-		return fmt.Errorf("%s", msgs)
-	}
-
-	return nil
-}
-
 // CanRunWithoutDocker returns true if the command or flag can run without Docker.
 func CanRunWithoutDocker() bool {
 	if len(os.Args) < 2 {
@@ -134,8 +78,8 @@ func CanRunWithoutDocker() bool {
 	if len(os.Args) == 2 && output.ParseBoolFlag("json-output", "j") {
 		return true
 	}
-	// help and hostname should not require docker
-	if slices.Contains([]string{"help", "hostname"}, os.Args[1]) {
+	// Some commands don't require docker
+	if slices.Contains([]string{"config", "help", "hostname", "version"}, os.Args[1]) {
 		return true
 	}
 	return false
@@ -156,47 +100,6 @@ func CheckAvailableSpace() {
 	if spaceAbsolute < nodeps.MinimumDockerSpaceWarning {
 		util.Error("Your Docker install has only %d available disk space, less than %d warning level (%d%% used). Please increase disk image size. More info at %s", spaceAbsolute, nodeps.MinimumDockerSpaceWarning, spacePercent, "https://docs.ddev.com/en/stable/users/usage/troubleshooting/#out-of-disk-space")
 	}
-}
-
-// GetBuildxVersion returns the version of the Docker buildx plugin.
-func GetBuildxVersion() (string, error) {
-	plugin, err := GetCLIPlugin("buildx")
-	if err != nil {
-		return "", err
-	}
-	// Strip leading "v" prefix if present for semver compatibility
-	return strings.TrimPrefix(plugin.Version, "v"), nil
-}
-
-// GetBuildxLocation returns the path to the Docker buildx plugin.
-func GetBuildxLocation() (string, error) {
-	plugin, err := GetCLIPlugin("buildx")
-	if err != nil {
-		return "", err
-	}
-	return plugin.Path, nil
-}
-
-// CheckDockerBuildxVersion checks that the Docker buildx plugin is installed
-// and meets the minimum version requirement.
-func CheckDockerBuildxVersion(dockerVersionMatrix DockerVersionMatrix) error {
-	defer util.TimeTrack()()
-
-	v, err := GetBuildxVersion()
-	if err != nil {
-		return fmt.Errorf("compose build requires buildx %s or later: %v.\nPlease install buildx: https://github.com/docker/buildx#installing\nMore details: https://ddev.com/blog/docker-buildx-requirement-v1-25-1/", dockerVersionMatrix.BuildxVersion, err)
-	}
-
-	pluginPath, err := GetBuildxLocation()
-	if err != nil {
-		pluginPath = "unknown"
-	}
-
-	if versions.LessThan(v, dockerVersionMatrix.BuildxVersion) {
-		return fmt.Errorf("compose build requires buildx %s or later.\nInstalled docker buildx: %s (plugin path: %s)\nPlease update buildx: https://github.com/docker/buildx#installing\nMore details: https://ddev.com/blog/docker-buildx-requirement-v1-25-1/", dockerVersionMatrix.BuildxVersion, v, pluginPath)
-	}
-
-	return nil
 }
 
 // CheckDockerAuth checks if Docker authentication is properly configured

--- a/pkg/dockerutil/requirements_test.go
+++ b/pkg/dockerutil/requirements_test.go
@@ -6,67 +6,9 @@ import (
 	"testing"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
-	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
-	"github.com/ddev/ddev/pkg/globalconfig"
-	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// TestCheckCompose tests detection of docker-compose.
-func TestCheckCompose(t *testing.T) {
-	assert := asrt.New(t)
-	ensureDdevBin()
-
-	globalconfig.DockerComposeVersion = ""
-	composeErr := dockerutil.CheckDockerCompose()
-	if composeErr != nil {
-		out, err := exec.RunHostCommand(DdevBin, "config", "global")
-		require.NoError(t, err)
-		ddevVersion, err := exec.RunHostCommand(DdevBin, "version")
-		require.NoError(t, err)
-		assert.NoError(composeErr, "RequiredDockerComposeVersion=%s global config=%s ddevVersion=%s", globalconfig.DdevGlobalConfig.RequiredDockerComposeVersion, out, ddevVersion)
-	}
-}
-
-// TestGetCLIPlugins tests that Docker CLI plugins can be discovered.
-func TestGetCLIPlugins(t *testing.T) {
-	plugins, err := dockerutil.GetCLIPlugins()
-	require.NoError(t, err)
-	require.NotEmpty(t, plugins, "expected at least one CLI plugin to be installed")
-
-	// buildx should be among the discovered plugins
-	found := false
-	for _, p := range plugins {
-		if p.Name == "buildx" {
-			found = true
-			break
-		}
-	}
-	require.True(t, found, "expected 'buildx' to be among discovered CLI plugins")
-}
-
-// TestGetBuildxVersion tests that the buildx version can be retrieved.
-func TestGetBuildxVersion(t *testing.T) {
-	v, err := dockerutil.GetBuildxVersion()
-	require.NoError(t, err)
-	require.NotEmpty(t, v, "expected non-empty buildx version")
-	// Version should not have a v prefix (we strip it)
-	require.NotEqual(t, "v", string(v[0]), "expected version without 'v' prefix, got %q", v)
-}
-
-// TestGetBuildxLocation tests that the buildx plugin path can be retrieved.
-func TestGetBuildxLocation(t *testing.T) {
-	pluginPath, err := dockerutil.GetBuildxLocation()
-	require.NoError(t, err)
-	require.NotEmpty(t, pluginPath, "expected non-empty buildx plugin path")
-}
-
-// TestCheckBuildx tests that CheckDockerBuildxVersion passes on a host with buildx installed.
-func TestCheckBuildx(t *testing.T) {
-	err := dockerutil.CheckDockerBuildxVersion(dockerutil.DockerRequirements)
-	require.NoError(t, err)
-}
 
 // TestCheckDockerAuth tests the CheckDockerAuth function
 func TestCheckDockerAuth(t *testing.T) {

--- a/pkg/dockerutil/stdin_dup.go
+++ b/pkg/dockerutil/stdin_dup.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package dockerutil
+
+import (
+	"os"
+	"syscall"
+)
+
+// dupStdin duplicates the stdin file descriptor so DDEV can hand the duplicate
+// to docker-compose's exec/run hijack code without risking the real fd 0.
+//
+// Background: when a TTY exec ends, docker/cli's hijack restore path calls
+// in.Close() on the stream it was given, but only on non-darwin / non-windows
+// platforms. See restoreTerminal in
+// vendor/github.com/docker/cli/cli/command/container/hijack.go (line 211)
+// (https://github.com/docker/cli/blob/v29.4.0/cli/command/container/hijack.go#L211).
+// The close is wired in by setupInput in the same file (line 95), and only
+// when h.tty == true. Without a dup, that close lands on the ddev process's
+// real fd 0 — harmless for a one-shot exec that exits immediately, but it
+// would break any later in-process read of stdin (e.g. a second TTY exec or
+// an interactive prompt during cleanup).
+//
+// The returned *os.File MUST be closed by the caller's restore path so the
+// dup does not leak an fd on platforms where compose's restoreTerminal
+// declines to close it (darwin, windows) or on non-TTY paths (where
+// hijack's setupInput returns a no-op restore and never calls Close).
+// Closing an *os.File whose underlying fd compose already closed is a
+// well-defined no-op error and safe to ignore.
+func dupStdin(stdin *os.File) (*os.File, error) {
+	fd, err := syscall.Dup(int(stdin.Fd()))
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), "stdin"), nil
+}

--- a/pkg/dockerutil/stdin_dup_test.go
+++ b/pkg/dockerutil/stdin_dup_test.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package dockerutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDupStdinPOSIX verifies that on POSIX systems dupStdin returns a *os.File
+// backed by a NEW file descriptor: closing the returned file must not affect
+// the caller's original *os.File. Without this guarantee, compose's hijack
+// restoreTerminal would close ddev's real fd 0 on TTY exec exit.
+func TestDupStdinPOSIX(t *testing.T) {
+	// Use a real *os.File backed by os.Pipe() so the test does not depend on
+	// whatever the test harness wired stdin to.
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	dup, err := dupStdin(r)
+	require.NoError(t, err)
+	require.NotNil(t, dup)
+
+	// POSIX contract: dup must use a different fd from the source.
+	require.NotEqual(t, r.Fd(), dup.Fd(),
+		"dupStdin must return a fresh fd on POSIX so closing the dup does not steal the caller's fd")
+
+	// Closing the dup once must succeed.
+	require.NoError(t, dup.Close())
+
+	// A second close on the same *os.File must not panic. The underlying fd
+	// is already closed, so an error is fine; what we forbid is a crash.
+	require.NotPanics(t, func() { _ = dup.Close() })
+
+	// The original *os.File must still be usable after the dup was closed:
+	// this proves we did not accidentally close the caller's fd.
+	require.NoError(t, r.Close())
+}

--- a/pkg/dockerutil/stdin_dup_windows.go
+++ b/pkg/dockerutil/stdin_dup_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package dockerutil
+
+import "os"
+
+// dupStdin is a pass-through on Windows: docker/cli's restoreTerminal explicitly
+// skips the in.Close() on windows (and darwin) to avoid blocking on
+// CloseHandle, so the real fd 0 is never at risk and a dup buys nothing.
+// See restoreTerminal in
+// vendor/github.com/docker/cli/cli/command/container/hijack.go (line 211)
+// (https://github.com/docker/cli/blob/v29.4.0/cli/command/container/hijack.go#L211)
+// where the GOOS guard is enforced.
+//
+// Returning the original *os.File means the caller's restore path must NOT
+// close it; the non-windows implementation returns a fresh fd that the caller
+// owns. dupCloser in docker_compose.go handles that asymmetry.
+func dupStdin(stdin *os.File) (*os.File, error) {
+	return stdin, nil
+}

--- a/pkg/dockerutil/stdin_dup_windows_test.go
+++ b/pkg/dockerutil/stdin_dup_windows_test.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package dockerutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDupStdinWindowsPassThrough verifies that on Windows dupStdin returns
+// the SAME *os.File it was given. Returning a different file would break
+// the asymmetry SetExecStdin's restore path depends on: compose's
+// restoreTerminal explicitly skips the in.Close() on Windows, so a fresh
+// dup would leak instead of being closed by the upstream layer.
+func TestDupStdinWindowsPassThrough(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	dup, err := dupStdin(r)
+	require.NoError(t, err)
+	require.NotNil(t, dup)
+
+	// Pass-through contract: same fd as input.
+	require.Equal(t, r.Fd(), dup.Fd(),
+		"dupStdin must be a pass-through on Windows; SetExecStdin restore depends on this")
+	// Same *os.File pointer — SetExecStdin's `dup != f` filter relies on this.
+	require.Same(t, r, dup,
+		"dupStdin must return the exact same *os.File on Windows")
+}

--- a/pkg/dockerutil/testdata/TestComposeExec/test-compose-exec.yaml
+++ b/pkg/dockerutil/testdata/TestComposeExec/test-compose-exec.yaml
@@ -5,13 +5,13 @@ networks:
 
 services:
   web:
-    container_name: TestComposeWithStreams
+    container_name: test-compose-exec
     environment:
       COLUMNS: '99'
       DDEV_PROJECT_TYPE: typo3
       DDEV_ROUTER_HTTPS_PORT: '443'
       DDEV_ROUTER_HTTP_PORT: '80'
-      DDEV_URL: https://test-compose-with-streams.ddev.site
+      DDEV_URL: https://test-compose-exec.ddev.site
       DDEV_WEBSERVER_TYPE: nginx-fpm
       DDEV_XDEBUG_ENABLED: "false"
       IS_DDEV_PROJECT: "true"
@@ -21,14 +21,14 @@ services:
       HTTP_EXPOSE: 80:80,8025
       LINES: '25'
       VIRTUAL_HOST: junk.ddev.site
-    image: TEST-COMPOSE-WITH-STREAMS-IMAGE
+    image: TEST-COMPOSE-EXEC-IMAGE
     user: "33:33"
     labels:
       com.ddev.app-type: php
-      com.ddev.app-url: http://test-compose-with-streams.ddev.site
+      com.ddev.app-url: http://test-compose-exec.ddev.site
       com.ddev.approot: .
       com.ddev.platform: ddev
-      com.ddev.site-name: TestComposeWithStreams
+      com.ddev.site-name: test-compose-exec
     restart: "no"
     healthcheck:
       test: "/healthcheck.sh"

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/settings"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	"go.yaml.in/yaml/v4"
 )
 
@@ -41,6 +40,7 @@ type ProjectInfo struct {
 // GlobalConfig is the struct defining ddev's global config
 type GlobalConfig struct {
 	DeveloperMode                    bool                        `yaml:"developer_mode,omitempty"`
+	DockerBuildxVersion              string                      `yaml:"docker_buildx_version,omitempty"`
 	FailOnHookFailGlobal             bool                        `yaml:"fail_on_hook_fail"`
 	InstrumentationOptIn             bool                        `yaml:"instrumentation_opt_in"`
 	InstrumentationQueueSize         int                         `yaml:"instrumentation_queue_size,omitempty"`
@@ -59,7 +59,6 @@ type GlobalConfig struct {
 	PerformanceMode                  configTypes.PerformanceMode `yaml:"performance_mode"`
 	ProjectTldGlobal                 string                      `yaml:"project_tld"`
 	RemoteConfig                     RemoteConfig                `yaml:"remote_config,omitempty"`
-	RequiredDockerComposeVersion     string                      `yaml:"required_docker_compose_version,omitempty"`
 	Router                           string                      `yaml:"router,omitempty"`
 	RouterBindAllInterfaces          bool                        `yaml:"router_bind_all_interfaces"`
 	RouterHTTPPort                   string                      `yaml:"router_http_port"`
@@ -72,35 +71,32 @@ type GlobalConfig struct {
 	SimpleFormatting                 bool                        `yaml:"simple_formatting"`
 	TableStyle                       string                      `yaml:"table_style"`
 	TraefikMonitorPort               string                      `yaml:"traefik_monitor_port,omitempty"`
-	// This may still be used in Docker Compose automated tests
-	UseDockerComposeFromPath bool                    `yaml:"use_docker_compose_from_path,omitempty"`
-	UseHardenedImages        bool                    `yaml:"use_hardened_images"`
-	UseLetsEncrypt           bool                    `yaml:"use_letsencrypt"`
-	WSL2NoWindowsHostsMgt    bool                    `yaml:"wsl2_no_windows_hosts_mgt"`
-	WebEnvironment           []string                `yaml:"web_environment"`
-	XdebugIDELocation        string                  `yaml:"xdebug_ide_location"`
-	XHProfMode               configTypes.XHProfMode  `yaml:"xhprof_mode,omitempty"`
-	ProjectList              map[string]*ProjectInfo `yaml:"project_info,omitempty"`
+	UseHardenedImages                bool                        `yaml:"use_hardened_images"`
+	UseLetsEncrypt                   bool                        `yaml:"use_letsencrypt"`
+	WSL2NoWindowsHostsMgt            bool                        `yaml:"wsl2_no_windows_hosts_mgt"`
+	WebEnvironment                   []string                    `yaml:"web_environment"`
+	XdebugIDELocation                string                      `yaml:"xdebug_ide_location"`
+	XHProfMode                       configTypes.XHProfMode      `yaml:"xhprof_mode,omitempty"`
+	ProjectList                      map[string]*ProjectInfo     `yaml:"project_info,omitempty"`
 }
 
 // New returns a default GlobalConfig
 func New() GlobalConfig {
 	cfg := GlobalConfig{
-		RequiredDockerComposeVersion: versionconstants.RequiredDockerComposeVersionDefault,
-		InternetDetectionTimeout:     nodeps.InternetDetectionTimeoutDefault,
-		TableStyle:                   "default",
-		RouterHTTPPort:               nodeps.DdevDefaultRouterHTTPPort,
-		RouterHTTPSPort:              nodeps.DdevDefaultRouterHTTPSPort,
-		RouterMailpitHTTPPort:        nodeps.DdevDefaultMailpitHTTPPort,
-		RouterMailpitHTTPSPort:       nodeps.DdevDefaultMailpitHTTPSPort,
-		RouterXHGuiHTTPPort:          nodeps.DdevDefaultXHGuiHTTPPort,
-		RouterXHGuiHTTPSPort:         nodeps.DdevDefaultXHGuiHTTPSPort,
-		LastStartedVersion:           "v0.0",
-		NoBindMounts:                 nodeps.NoBindMountsDefault,
-		Router:                       types.RouterTypeTraefik,
-		MkcertCARoot:                 readCAROOT(),
-		TraefikMonitorPort:           nodeps.TraefikMonitorPortDefault,
-		ProjectTldGlobal:             nodeps.DdevDefaultTLD,
+		InternetDetectionTimeout: nodeps.InternetDetectionTimeoutDefault,
+		TableStyle:               "default",
+		RouterHTTPPort:           nodeps.DdevDefaultRouterHTTPPort,
+		RouterHTTPSPort:          nodeps.DdevDefaultRouterHTTPSPort,
+		RouterMailpitHTTPPort:    nodeps.DdevDefaultMailpitHTTPPort,
+		RouterMailpitHTTPSPort:   nodeps.DdevDefaultMailpitHTTPSPort,
+		RouterXHGuiHTTPPort:      nodeps.DdevDefaultXHGuiHTTPPort,
+		RouterXHGuiHTTPSPort:     nodeps.DdevDefaultXHGuiHTTPSPort,
+		LastStartedVersion:       "v0.0",
+		NoBindMounts:             nodeps.NoBindMountsDefault,
+		Router:                   types.RouterTypeTraefik,
+		MkcertCARoot:             readCAROOT(),
+		TraefikMonitorPort:       nodeps.TraefikMonitorPortDefault,
+		ProjectTldGlobal:         nodeps.DdevDefaultTLD,
 		// RemoteConfig left empty by default, will use defaults when needed but won't show in config file
 	}
 
@@ -190,23 +186,14 @@ func GetMutagenDataDirectory() string {
 	return mutagenDataDirectory
 }
 
-// GetDockerComposePath gets the full path to the docker-compose binary
-// Normally this is the one that has been downloaded to ~/.ddev/bin, but if
-// UseDockerComposeFromPath, then it will be whatever if found in $PATH
-func GetDockerComposePath() (string, error) {
-	if DdevGlobalConfig.UseDockerComposeFromPath {
-		executableName := "docker-compose"
-		path, err := exec.LookPath(executableName)
-		if err != nil {
-			return "", fmt.Errorf("no docker-compose")
-		}
-		return path, nil
-	}
-	composeBinary := "docker-compose"
+// GetDockerBuildxDestination gets the full path to the docker-buildx binary
+// which is going to be downloaded in ~/.ddev/bin
+func GetDockerBuildxDestination() (string, error) {
+	buildxBinary := "docker-buildx"
 	if nodeps.IsWindows() {
-		composeBinary = composeBinary + ".exe"
+		buildxBinary = buildxBinary + ".exe"
 	}
-	return filepath.Join(GetDDEVBinDir(), composeBinary), nil
+	return filepath.Join(GetDDEVBinDir(), buildxBinary), nil
 }
 
 // GetTableStyle returns the configured (string) table style
@@ -272,6 +259,10 @@ func ReadGlobalConfig() error {
 		DdevGlobalConfig.MkcertCARoot = readCAROOT()
 	}
 
+	if DdevGlobalConfig.DockerBuildxVersion == "" {
+		DdevGlobalConfig.DockerBuildxVersion = "system"
+	}
+
 	// If they set the internetdetectiontimeout below default, reset to default
 	// and ignore the setting.
 	if DdevGlobalConfig.InternetDetectionTimeout < nodeps.InternetDetectionTimeoutDefault {
@@ -333,9 +324,10 @@ func WriteGlobalConfig(config GlobalConfig) error {
 	}
 
 	cfgCopy := config
+
 	// Remove some items that are defaults
-	if cfgCopy.RequiredDockerComposeVersion == versionconstants.RequiredDockerComposeVersionDefault {
-		cfgCopy.RequiredDockerComposeVersion = ""
+	if cfgCopy.DockerBuildxVersion == "system" {
+		cfgCopy.DockerBuildxVersion = ""
 	}
 
 	// Overwrite PerformanceMode with effective value if empty.
@@ -521,14 +513,10 @@ func WriteGlobalConfig(config GlobalConfig) error {
 # Windows side; you may not want this if you're running your browser in WSL2 or for
 # various other reasons.
 
-# required_docker_compose_version: ""
-# This should only be used in specific cases like troubleshooting.
-# This can be used to override the default required docker-compose version
-# It should normally be left alone, but can be set to, for example, "v2.1.1"
-
-# use_docker_compose_from_path: false
-# This should only be used in specific cases like troubleshooting.
-# Whether to use the system-installed docker-compose instead of downloading a specific version
+# docker_buildx_version: "system"
+# Controls docker-buildx usage and should only be used in specific cases like troubleshooting.
+# "system" (default) uses the docker-buildx already installed.
+# Can be to a specific version like "0.33.0".
 
 # messages:
 #   ticker_interval: 20 // Interval in hours to show ticker messages, -1 disables the ticker
@@ -971,21 +959,12 @@ func IsInternetActive() bool {
 	return active
 }
 
-// DockerComposeVersion is filled with the version we find for docker-compose
-var DockerComposeVersion = ""
-
-// GetRequiredDockerComposeVersion returns the version of docker-compose we need
-// based on the compiled version, or overrides in globalconfig, like
-// required_docker_compose_version and use_docker_compose_from_path
-// In the case of UseDockerComposeFromPath there is no required version, so this
-// will return empty string.
-func GetRequiredDockerComposeVersion() string {
-	v := DdevGlobalConfig.RequiredDockerComposeVersion
-	switch {
-	case DdevGlobalConfig.UseDockerComposeFromPath:
-		v = ""
-	case DdevGlobalConfig.RequiredDockerComposeVersion != "":
-		v = DdevGlobalConfig.RequiredDockerComposeVersion
+// GetRequiredDockerBuildxVersion returns the docker-buildx version DDEV should download,
+// or empty string when docker_buildx_version is "system" (the default), meaning no download.
+func GetRequiredDockerBuildxVersion() string {
+	v := strings.TrimPrefix(DdevGlobalConfig.DockerBuildxVersion, "v")
+	if v == "system" || v == "" {
+		return ""
 	}
 	return v
 }

--- a/pkg/globalconfig/schema.json
+++ b/pkg/globalconfig/schema.json
@@ -10,6 +10,21 @@
       "description": "Not currently used.",
       "type": "boolean"
     },
+    "docker_buildx_version": {
+      "description": "docker-buildx version to use. \"system\" (default) uses the installed plugin without downloading. Set to a version like \"0.33.0\" to download it.",
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "system"
+          ]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
     "fail_on_hook_fail": {
       "description": "Whether \"ddev start\" should be interrupted by a failing hook, on a single project or for all projects if used globally.",
       "type": "boolean"
@@ -140,10 +155,6 @@
         }
       ]
     },
-    "required_docker_compose_version": {
-      "description": "Specific docker-compose version for download.",
-      "type": "string"
-    },
     "router_bind_all_interfaces": {
       "description": "Whether to bind ddev-router's ports on all network interfaces.",
       "type": "boolean"
@@ -221,10 +232,6 @@
           "type": "string"
         }
       ]
-    },
-    "use_docker_compose_from_path": {
-      "description": "Whether to use the system-installed docker-compose. You can otherwise use required_docker_compose_version to specify a version for download.",
-      "type": "boolean"
     },
     "use_hardened_images": {
       "description": "Whether to use hardened images for internet deployment.",

--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -108,6 +108,19 @@ func ParseBoolFlag(long string, short string) bool {
 	return false
 }
 
+// JSONProgressWriter is an io.Writer that routes each write through UserErr.Info
+// so compose progress lines are formatted by the active logrus formatter (e.g. JSON)
+// instead of being written as raw text.
+type JSONProgressWriter struct{}
+
+func (w *JSONProgressWriter) Write(p []byte) (int, error) {
+	msg := strings.TrimSpace(string(p))
+	if msg != "" {
+		UserErr.Info(msg)
+	}
+	return len(p), nil
+}
+
 // ColorsEnabled returns true if colored output is enabled
 // Implementation from https://no-color.org/
 func ColorsEnabled() bool {

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -16,12 +16,3 @@ package tools
 //	_ "github.com/some/new/library"
 //	_ "github.com/some/new/library/pkg/api"
 //)
-
-// For new Docker Compose SDK https://github.com/ddev/ddev/pull/8234
-import (
-	_ "github.com/docker/cli/cli"
-	_ "github.com/docker/cli/cli/streams"
-	_ "github.com/docker/compose/v5/cmd/display"
-	_ "github.com/docker/compose/v5/pkg/api"
-	_ "github.com/docker/compose/v5/pkg/compose"
-)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -143,10 +143,11 @@ func Verbose(format string, a ...any) {
 	output.UserOut.Debugf("%s %s", n.Format("2006-01-02T15:04:05.000"), s)
 }
 
-// ShowDots displays dots one per second until done gets true
-func ShowDots() chan bool {
-	done := make(chan bool)
-	go func() {
+// ShowDots displays dots one per second. Call the returned function to stop and flush the newline.
+func ShowDots() func() {
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
 		for {
 			select {
 			case <-done:
@@ -161,8 +162,11 @@ func ShowDots() chan bool {
 				time.Sleep(1 * time.Second)
 			}
 		}
-	}()
-	return done
+	})
+	return func() {
+		close(done)
+		wg.Wait()
+	}
 }
 
 // FormatPlural is a simple wrapper which returns different strings based on the count value.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,6 @@
 package version
 
 import (
-	"fmt"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -20,8 +19,13 @@ import (
 // IMPORTANT: These versions are overridden by version ldflags specifications VERSION_VARIABLES in the Makefile
 
 // GetVersionInfo returns a map containing the version info defined above.
-func GetVersionInfo() map[string]string {
-	var err error
+func GetVersionInfo() (map[string]string, error) {
+	var retErr error
+	trackErr := func(err error) {
+		if retErr == nil {
+			retErr = err
+		}
+	}
 	versionInfo := make(map[string]string)
 
 	versionInfo["DDEV version"] = versionconstants.DdevVersion
@@ -36,25 +40,34 @@ func GetVersionInfo() map[string]string {
 	versionInfo["build info"] = versionconstants.BUILDINFO
 	versionInfo["os"] = runtime.GOOS
 	versionInfo["architecture"] = runtime.GOARCH
-	if versionInfo["docker"], err = dockerutil.GetDockerVersion(); err != nil {
-		versionInfo["docker"] = fmt.Sprintf("Failed to GetDockerVersion(): %v", err)
+
+	if v, err := dockerutil.GetDockerVersion(); err != nil {
+		versionInfo["docker"] = "error"
+		trackErr(err)
+	} else {
+		versionInfo["docker"] = v
 	}
-	if versionInfo["docker-api"], err = dockerutil.GetDockerAPIVersion(); err != nil {
-		versionInfo["docker-api"] = fmt.Sprintf("Failed to GetDockerAPIVersion(): %v", err)
+	if v, err := dockerutil.GetDockerAPIVersion(); err != nil {
+		versionInfo["docker-api"] = "error"
+		trackErr(err)
+	} else {
+		versionInfo["docker-api"] = v
 	}
-	if versionInfo["docker-platform"], err = GetDockerPlatform(); err != nil {
-		versionInfo["docker-platform"] = fmt.Sprintf("Failed to GetDockerPlatform(): %v", err)
+	if v, err := GetDockerPlatform(); err != nil {
+		versionInfo["docker-platform"] = "error"
+		trackErr(err)
+	} else {
+		versionInfo["docker-platform"] = v
 	}
-	if versionInfo["docker-compose"], err = dockerutil.GetDockerComposeVersion(); err != nil {
-		versionInfo["docker-compose"] = fmt.Sprintf("Failed to GetDockerComposeVersion(): %v", err)
-	}
-	if versionInfo["docker-buildx"], err = dockerutil.GetBuildxVersion(); err != nil {
-		versionInfo["docker-buildx"] = fmt.Sprintf("Failed to GetBuildxVersion(): %v", err)
+	if v, err := dockerutil.GetDockerBuildxVersion(); err != nil {
+		versionInfo["docker-buildx"] = "error"
+	} else {
+		versionInfo["docker-buildx"] = v
 	}
 	versionInfo["mutagen"] = versionconstants.RequiredMutagenVersion
 	versionInfo["xhgui-image"] = docker.GetXhguiImage()
 
-	return versionInfo
+	return versionInfo, retErr
 }
 
 // GetDockerPlatform gets the platform used for Docker engine

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 	"testing"
 
-	exec2 "github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testsetup"
 	"github.com/ddev/ddev/pkg/versionconstants"
@@ -21,11 +20,8 @@ func init() {
 func TestGetVersionInfo(t *testing.T) {
 	assert := asrt.New(t)
 
-	// Run `ddev version` so we force download of docker-compose if we don't have one.
-	_, err := exec2.RunHostCommand(DdevBin, "version")
+	v, err := GetVersionInfo()
 	require.NoError(t, err)
-
-	v := GetVersionInfo()
 
 	assert.Equal(versionconstants.DdevVersion, v["DDEV version"])
 	assert.Contains(v["web"], versionconstants.WebImg)
@@ -37,6 +33,6 @@ func TestGetVersionInfo(t *testing.T) {
 	assert.Equal(versionconstants.BUILDINFO, v["build info"])
 	assert.NotEmpty(v["docker"])
 	assert.NotEmpty(v["docker-api"])
-	assert.NotEmpty(v["docker-compose"])
+	assert.NotEmpty(v["docker-buildx"])
 	assert.NotEmpty(v["docker-platform"])
 }

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -56,12 +56,35 @@ var BUILDINFO = "BUILDINFO should have new info"
 var MutagenVersion = ""
 
 // RequiredMutagenVersion defines the required version of Mutagen
+// This value is a hard requirement
 const RequiredMutagenVersion = "0.18.1"
 
-// RequiredDockerComposeVersionDefault defines the required version of docker-compose
-// Keep this in sync with github.com/compose-spec/compose-go/v2 in go.mod,
-// matching the version used in https://github.com/docker/compose/blob/main/go.mod for the same tag
-const RequiredDockerComposeVersionDefault = "v5.1.3"
+// DockerBuildxMinVersion defines the minimum required version of buildx.
+// Must match buildxMinVersion in vendor/github.com/docker/compose/v5/pkg/compose/api_versions.go
+// Sync enforced by TestBuildxMinVersionInSync.
+// This value is a hard requirement
+const DockerBuildxMinVersion = "0.17.0"
+
+// DockerBuildxRecommendedVersion defines the recommended version of buildx
+// to use if the installed version doesn't match the minimum.
+// This value is a recommendation, not a hard requirement
+const DockerBuildxRecommendedVersion = "0.33.0"
+
+// DockerMinVersion defines the recommended minimum version of Docker Engine
+// List of supported Docker versions: https://endoflife.date/docker-engine
+// This value is a recommendation, not a hard requirement
+const DockerMinVersion = "25.0"
+
+// DockerMinAPIVersion defines the recommended minimum API version of Docker Engine
+// Should be in sync with DockerMinVersion
+// See https://docs.docker.com/reference/api/engine/#api-version-matrix
+// This value is a recommendation, not a hard requirement
+const DockerMinAPIVersion = "1.44"
+
+// PodmanMinVersion defines the recommended minimum version of Podman.
+// Podman 4.x doesn't run properly on GitHub runners, so we recommend Podman 5.0+
+// This value is a recommendation, not a hard requirement
+const PodmanMinVersion = "5.0"
 
 // ---
 // Fallback version derivation for developer builds not using the Makefile


### PR DESCRIPTION
## The Issue

- Fixes #7915
- For #8295

Related:

- #8149 (added buildx requirement but did not implement the download or SDK switch)
- #8145 (performance optimizations caused output corruption when using the standalone compose binary on first run with no images)

## How This PR Solves The Issue

We added a requirement for `docker-buildx` in #8149. Docker Compose has required this since v2.40.2, but the requirement was only triggered when installing extra packages or using EOL PHP versions like 7.4.

This PR replaces the bundled `docker-compose` binary with the Docker Compose SDK and adds optional download of `docker-buildx` to `$HOME/.ddev/bin`.

**Docker Compose (SDK)**

- Switched from a standalone `docker-compose` binary to the Docker Compose Go library
- `cliPluginsExtraDirs` is set to `$HOME/.ddev/bin` in `docker_manager.go` so plugins stored there are found automatically (this only works with the SDK, not the standalone binary)
- Removed the goroutine for `docker-compose pull` in `ddev start` - the concurrent output was corrupted on first run when no Docker images were present, caused by the performance optimizations in #8145
- Docker Compose output is now shown as-is (with stopwatch on the right), previously filtered manually

**Docker Buildx (optional download)**

- By default, DDEV uses the system-provided `docker-buildx` (avoids overriding Docker Desktop's patched builds and keeps IDE compatibility)
- Added `--docker-buildx-version` flag to `ddev config global` to optionally download a specific buildx version to `$HOME/.ddev/bin/docker-buildx`
- `ddev config global --docker-buildx-version=` or `--docker-buildx-version=system` resets to the system buildx
- Removed the buildx check from `root.go`; buildx is now checked/downloaded only in `ddev start`, `ddev version`, `ddev utility rebuild`, and `ddev utility dockercheck`
- `ddev utility dockercheck` shows a warning when a specific buildx version is configured (useful for support requests)
- Buildx is not downloaded when Docker host is unreachable

**Other changes**

- `ddev version` now works when Docker is completely broken - shows all version details, reports the Docker error at the end
- `ddev config` now works without a working Docker (allows configuring a project or setting `--docker-buildx-version` in `ddev config global`)
- `ddev poweroff` output is significantly improved - previously showed no output while waiting, reported in #8295
- `ddev utility dockercheck` now uses `dockerutil.RunCLIPluginCommand` instead of calling `docker buildx` directly

## Manual Testing Instructions

Buildx:

```bash
ddev config global --docker-buildx-version=0.33.0 && ddev version
# Should download buildx and show 0.33.0 in docker-buildx line

ddev config global --docker-buildx-version=foo && ddev version
# Should fail with buildx error

ddev start
# Should fail with the same buildx error

ddev config global --docker-buildx-version=foo && DOCKER_HOST=foo ddev version
# Should show a Docker error, not a buildx error

ddev config global --docker-buildx-version=0.32.1 && DOCKER_HOST=foo ddev version
# Should not download anything (Docker host is wrong)

DOCKER_HOST=foo ddev version
# Should fail but show all version details

ddev config global --docker-buildx-version=0.33.0 && ddev utility dockercheck
# Should show warning about using a specific buildx version

ddev config global --docker-buildx-version=
ddev config global --docker-buildx-version=system
# Both should reset to system buildx
```

Compose:

```bash
# Remove local docker-compose, confirm it is not re-downloaded
rm ~/.ddev/bin/docker-compose && ddev version

# Run start and note the modern compose output (stopwatch on the right)
ddev start
ddev start --no-cache

# Test fresh start
ddev delete images --all
docker buildx prune
ddev start
```

Compare with DDEV HEAD, use `--no-cache` due to #8145 output differences):

```bash
DDEV_DEBUG=true ddev restart
DDEV_DEBUG=true ddev restart --json-output
DDEV_DEBUG=true ddev restart --no-cache
DDEV_DEBUG=true ddev restart --json-output --no-cache

DDEV_VERBOSE=true ddev restart
DDEV_VERBOSE=true ddev restart --json-output
DDEV_VERBOSE=true ddev restart --no-cache
DDEV_VERBOSE=true ddev restart --json-output --no-cache
```

Compare `ddev poweroff` output on DDEV HEAD vs this PR - output should now show progress instead of silence.

Run Craft CMS quickstart https://docs.ddev.com/en/stable/users/quickstart/#craft-cms, it should show the usual output for `composer install` and ask interactive questions, [see the comment below why this is important](https://github.com/ddev/ddev/pull/8234#issuecomment-4399710639).

## Automated Testing Overview

- Added `pkg/dockerutil/docker_buildx.go` with tests in `docker_buildx_test.go`
- Added `pkg/dockerutil/docker_compose_internal_test.go` for internal compose logic
- Extended `docker_compose_test.go` and `docker_manager_test.go`
- Added `stdin_dup.go` / `stdin_dup_windows.go` with tests (stdin duplication for SDK integration)

## Release/Deployment Notes

- `docker-compose` is no longer downloaded to `$HOME/.ddev/bin` - existing binaries there are ignored (I didn't add any cleanup for `$HOME/.ddev/bin/docker-compose`)
- New global hidden config option `docker-buildx-version` in `~/.ddev/global_config.yaml`
- Behavior change: buildx check is skipped in most commands; only runs on `ddev start`, `ddev version`, `ddev utility rebuild`, `ddev utility dockercheck`
