### PR TITLE
feat: add typo3-password command for TYPO3 projects

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/web/typo3-password
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/typo3-password
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+
+## Description: Set a TYPO3 backend user password
+## Usage: typo3-password <username> [password]
+## Example: "ddev typo3-password admin" or "ddev typo3-password admin 'MyNewPass2024#'"
+## ProjectTypes: typo3
+## MutagenSync: true
+
+if [ -z "$1" ]; then
+    echo "Usage: ddev typo3-password <username> [password]"
+    echo ""
+    echo "Set a new password for an existing TYPO3 backend user."
+    echo "If password is omitted, you will be prompted to enter it."
+    echo ""
+    echo "Example: ddev typo3-password admin 'MyNewPass2024#'"
+    exit 1
+fi
+
+USERNAME="$1"
+PASSWORD="$2"
+
+# Check if user exists
+USER_COUNT=$(mysql -N -u db -pdb db -e "SELECT COUNT(*) FROM be_users WHERE username='${USERNAME//\'/\\\'}';")
+if [ "$USER_COUNT" -eq 0 ]; then
+    echo "Error: Backend user '${USERNAME}' not found."
+    echo ""
+    echo "Available users:"
+    mysql -t -u db -pdb db -e "SELECT uid, username, email, IF(admin, 'yes', 'no') AS admin, IF(disable, 'disabled', 'active') AS status FROM be_users WHERE deleted=0;"
+    exit 1
+fi
+
+# Prompt for password if not provided
+if [ -z "$PASSWORD" ]; then
+    read -s -p "New password: " PASSWORD
+    echo ""
+    if [ -z "$PASSWORD" ]; then
+        echo "Error: Password must not be empty."
+        exit 1
+    fi
+    read -s -p "Confirm password: " PASSWORD_CONFIRM
+    echo ""
+    if [ "$PASSWORD" != "$PASSWORD_CONFIRM" ]; then
+        echo "Error: Passwords do not match."
+        exit 1
+    fi
+fi
+
+# Validate password length
+if [ ${#PASSWORD} -lt 8 ]; then
+    echo "Error: Password must have at least 8 characters."
+    exit 1
+fi
+
+# Generate password hash via PHP
+HASH=$(php -r "echo password_hash(\$argv[1], PASSWORD_ARGON2ID);" "$PASSWORD")
+
+if [ -z "$HASH" ]; then
+    echo "Error: Failed to generate password hash."
+    exit 1
+fi
+
+# Update password in database
+mysql -u db -pdb db -e "UPDATE be_users SET password='${HASH}', tstamp=UNIX_TIMESTAMP() WHERE username='${USERNAME//\'/\\\'}' AND deleted=0;"
+
+if [ $? -eq 0 ]; then
+    echo "Password for '${USERNAME}' updated successfully."
+else
+    echo "Error: Failed to update password."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds a built-in `ddev typo3-password` command to set the password for existing TYPO3 backend users
- Restricted to TYPO3 project types via `ProjectTypes: typo3`
- Interactive mode with password confirmation when password argument is omitted

## Motivation

TYPO3's CLI lacks a command to change an existing backend user's password. The available options are:

| Option | Limitation |
|--------|-----------|
| `ddev typo3 backend:resetpassword` | Requires email delivery to be configured |
| `ddev typo3 backend:createadmin` | Creates new user, can't update existing |
| Manual DB update via `ddev mysql` | Error-prone, requires knowledge of password hashing |

This is a frequent pain point in DDEV development environments — after importing a database, restoring a snapshot, or simply forgetting a password.

**Shell escaping:** `ddev exec` passes commands through two shells (host + container), which mangles special characters like `!`, `$`, `` ` `` in passwords. This command avoids the issue by passing the password via PHP's `$argv` instead of string interpolation.

> **Note:** I've also submitted a [PR to helhum/typo3-console](https://github.com/helhum/TYPO3-Console/pull/3) to add a native `backend:setpassword` CLI command. Even if that gets merged, a DDEV convenience command remains valuable as it avoids the shell escaping issues entirely.

## Usage

```bash
# Interactive (recommended — prompts for password with confirmation)
ddev typo3-password admin

# With argument
ddev typo3-password admin 'NewPass2024#'

# Non-existent user shows helpful error
ddev typo3-password unknown
# Error: Backend user 'unknown' not found.
# Available users:
# +-----+----------+-------------------+-------+--------+
# | uid | username | email             | admin | status |
# +-----+----------+-------------------+-------+--------+
# |   1 | admin    | admin@example.com | yes   | active |
# +-----+----------+-------------------+-------+--------+
```

## Implementation details

- Password hashing via `php -r "..." "$PASSWORD"` using `$argv` (not string interpolation) to avoid shell escaping issues
- Uses `PASSWORD_ARGON2ID` (TYPO3's default hash algorithm)
- Validates user existence, password length (min 8 chars), and password confirmation in interactive mode
- Shows available users when the specified username is not found

## Test plan

- [ ] `ddev typo3-password admin 'Test1234#'` — sets password, confirms success
- [ ] `ddev typo3-password admin` — prompts for password interactively with confirmation
- [ ] `ddev typo3-password unknown` — shows error and lists available users
- [ ] `ddev typo3-password admin 'short'` — rejects password shorter than 8 characters
- [ ] Login with new password in TYPO3 backend
- [ ] Command not visible in non-TYPO3 projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)