### PR TITLE
refactor(debug): detect stale Docker daemon state via ContainerTop, refs #8311

### DIFF
--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -775,11 +775,19 @@ func RunSimpleContainerExtended(name string, config *container.Config, hostConfi
 		// On Lima/Colima, ContainerInspect may report State.Running=true even after
 		// the container has exited, causing the polling loop to exhaust the deadline.
 		// Observed only in tests, not reported by users; possibly a Lima/Colima bug.
+		// As a tie-breaker, once Running=true has persisted longer than any realistic
+		// RunSimpleContainer workload, cross-check with ContainerTop: if the daemon
+		// reports no processes (or errors) while State still claims Running, the
+		// container is really gone and the daemon's state is stale.
+		const topCheckThreshold = 30 * time.Second
+		const topDisagreementsToFail = 2
 		waitCtx, waitCancel := context.WithTimeout(ctx, timeout)
 		defer waitCancel()
 		tickChan := time.NewTicker(500 * time.Millisecond)
 		defer tickChan.Stop()
 		var lastKnownState *container.State
+		var runningSince time.Time
+		topDisagreements := 0
 		attempt := 0
 		for {
 			attempt++
@@ -797,6 +805,21 @@ func RunSimpleContainerExtended(name string, config *container.Config, hostConfi
 				if !info.Container.State.Running {
 					exitCode = info.Container.State.ExitCode
 					break
+				}
+				if runningSince.IsZero() {
+					runningSince = time.Now()
+				}
+				if time.Since(runningSince) > topCheckThreshold {
+					topResult, topErr := apiClient.ContainerTop(waitCtx, c.ID, client.ContainerTopOptions{})
+					if topErr != nil || len(topResult.Processes) == 0 {
+						topDisagreements++
+						util.Debug("RunSimpleContainer: container %s (%s) Inspect reports Running=true but ContainerTop disagrees (topErr=%v processes=%d consecutiveDisagreements=%d)", name, TruncateID(c.ID), topErr, len(topResult.Processes), topDisagreements)
+						if topDisagreements >= topDisagreementsToFail {
+							return c.ID, "", fmt.Errorf("container %s (%s) has stale Docker daemon state: ContainerTop reports no processes (topErr=%v) after %v but Inspect still claims Running=true (lastKnownState=%+v)", name, TruncateID(c.ID), topErr, time.Since(runningSince), lastKnownState)
+						}
+					} else {
+						topDisagreements = 0
+					}
 				}
 			}
 			select {


### PR DESCRIPTION
## The Issue

- Refs #8311

On Lima/Colima, `TestMutagenConfigChange` (and other tests that hit `RunSimpleContainer`, most often the `start-chown-*` path) intermittently fail with:

    timed out after 10m0s waiting for container start-chown-xPRzer
    (34c368ee2201) to stop: context deadline exceeded

The debug trace we landed in #8317 shows the Docker daemon repeatedly returning `State.Running=true` with a fixed `Pid`, `StartedAt` in the past, `FinishedAt=0001-01-01T00:00:00Z`, and `Health=nil` for 1200+ consecutive `ContainerInspect` calls spread across 10 minutes. `chown -R` on two small volumes cannot legitimately take that long, and we previously used to use `ContainerWait` (see ee5f436445) - it failed identically. The evidence points to the Lima/Colima Docker daemon holding a stale "Running" view of a container that has actually exited, rather than the in-container command hanging.

https://buildkite.com/ddev/macos-lima/builds/6228#019d982a-9549-4b27-b5aa-6a87f32677e7

```
2026-04-17T00:12:56.203 Exec chown -R 501:20 /mnt/ddev-global-cache /var/lib/mysql
2026-04-17T00:22:56.297 RunSimpleContainer: container start-chown-xPRzer (34c368ee2201) attempt=1201 inspectElapsedTime=207.333µs inspectErr=Get "http://%2FUsers%2Ftestbot%2F.lima%2Flima-vz%2Fsock%2Fdocker.sock/v1.54/containers/34c368ee220177ac6e0dea6baf3e9ecf32ccae0c814428f24d2cb75abb77c838/json": context deadline exceeded lastKnownState=&{Status:running Running:true Paused:false Restarting:false OOMKilled:false Dead:false Pid:327937 ExitCode:0 Error: StartedAt:2026-04-17T06:12:56.343003363Z FinishedAt:0001-01-01T00:00:00Z Health:<nil>} lastKnownHealth=<nil>
    mutagen_test.go:241:
        	Error Trace:	/Users/testbot/tmp/buildkite-agent/builds/tb-macos-arm64-7/ddev/macos-lima/pkg/ddevapp/mutagen_test.go:241
        	Error:      	Received unexpected error:
        	            	failed to 'chown -R 501:20 /mnt/ddev-global-cache /var/lib/mysql' inside volumes: timed out after 10m0s waiting for container start-chown-xPRzer (34c368ee2201) to stop: context deadline exceeded, output=
        	Test:       	TestMutagenConfigChange
2026-04-17T00:23:06.579 Paused Mutagen sync session 'TestPkgDrupal11'
2026-04-17T00:23:06.579 Removing merged config for project with command 'rm -rf /mnt/ddev-global-cache/traefik/config/TestPkgDrupal11_merged.yaml'
2026-04-17T00:23:06.863 Cleaning ddev-global-cache with command 'rm -rf /mnt/ddev-global-cache/*/TestPkgDrupal11-{web,db} /mnt/ddev-global-cache/traefik/*/TestPkgDrupal11.{crt,key} /mnt/ddev-global-cache/traefik/config/TestPkgDrupal11_merged.yaml'
2026-04-17T00:23:07.729 Terminated Mutagen sync session 'TestPkgDrupal11'
Not trying to remove hostnames from hosts file because DDEV_NONINTERACTIVE=true
Volume TestPkgDrupal11-mariadb for project TestPkgDrupal11 was deleted
Volume TestPkgDrupal11_project_mutagen for project TestPkgDrupal11 was deleted
2026-04-17T00:23:08.387 Deleted Docker image sha256:d1bcb032815f1109a76c4cf83488c6cfeb3a25953281afe4cac2dc75070e03a1
Image ddev/ddev-webserver:20260410_stasadev_yarn_timeout-TestPkgDrupal11-built for project TestPkgDrupal11 was deleted
2026-04-17T00:23:08.615 Deleted Docker image sha256:0bbf29eebe4f06c46dbd0a4b6c55945268b9e4adbeee639beb8b5e872a5613fd
Image ddev/ddev-dbserver-mariadb-11.8:v1.25.1-TestPkgDrupal11-built for project TestPkgDrupal11 was deleted
Project TestPkgDrupal11 was deleted. Your code and configuration are unchanged.
=== FAIL: TestMutagenConfigChange (664.62s)
```

## How This PR Solves The Issue

Adds a `ContainerTop` tie-breaker to the `RunSimpleContainerExtended` wait loop. Once `State.Running=true` has persisted longer than 30s (much longer than any realistic `RunSimpleContainer` workload), each tick also calls `ContainerTop`. If `ContainerTop` returns an error or reports zero processes while `Inspect` still claims the container is running, we count a disagreement. After two consecutive disagreements, we return a distinctive error naming the divergence so it is trivially greppable in CI logs:

    container <name> (<id>) has stale Docker daemon state: ContainerTop
    reports no processes (topErr=...) after <duration> but Inspect still
    claims Running=true (lastKnownState=...)

This fails in ~31s instead of 10min and replaces the generic `context deadline exceeded` with a message that attributes the fault to the Docker daemon rather than the in-container command.

## Why two signals disagree

`ContainerInspect` reads the daemon's cached container state. `ContainerTop` (HTTP `/containers/{id}/top`) proxies to the host kernel to enumerate processes in the container's PID namespace. If the namespace is gone, the daemon cannot list processes - regardless of what its cached state field says. Two independent code paths, one ground-truth signal: the kernel's view of the PID namespace.

## Next steps

After we collect a few CI failures with the new error message, we can split into two follow-ups based on which side the data lands on:

**If `ContainerTop` confirms no processes (stale daemon state):**

- File an upstream issue against lima-vm/lima (and/or abiosoft/colima) with the debug trace as minimal repro. The signal is strong: two Docker API endpoints giving contradictory answers about the same container is a daemon bug, not a client bug.
- Consider promoting `ContainerTop` from tie-breaker to primary exit signal on Lima/Colima specifically, with `Inspect` as fallback for the exit code.
- Investigate whether issuing a `ContainerStop` or `ContainerKill` against the "running" container causes the daemon to refresh its state; if so, we could auto-recover rather than fail.

**If `ContainerTop` reports processes (container genuinely running >30s):**

- The daemon is not lying and our "chown cannot take that long" assumption is wrong on Lima volumes. Profile the chown target - on Lima, volumes backed by virtiofs/9p can be very slow for metadata-heavy operations like recursive chown.
- Consider scoping the chown more tightly, or setting ownership at volume creation time rather than on every start.
- Bump `topCheckThreshold` or skip the tie-breaker for known-slow workloads.