### PR TITLE
fix(installer): prevent CI timeout in WSL2 Docker CE installer test

### DIFF
--- a/winpkg/ddev_windows_installer.nsi
+++ b/winpkg/ddev_windows_installer.nsi
@@ -114,20 +114,55 @@ Function InitializeDebugLog
     ${EndIf}
 FunctionEnd
 
-; LogPrint - DetailPrint wrapper that also writes to debug log
+; LogPrint - DetailPrint wrapper that also writes to debug log with timestamp
 ; Usage: Push "message" ; Call LogPrint
 Function LogPrint
     Exch $R0  ; Get message from stack
     Push $R1
-    
-    ; Always do DetailPrint
-    DetailPrint "$R0"
-    
-    ; Write to log file if handle is open
-    ${If} $DEBUG_LOG_HANDLE != ""
-        FileWrite $DEBUG_LOG_HANDLE "$R0$\r$\n"
+    Push $R2  ; for formatted timestamp
+    Push $0   ; save GetTime output registers
+    Push $1
+    Push $2
+    Push $3
+    Push $4
+    Push $5
+    Push $6
+
+    ; Get current local time: $0=day $1=month $2=year $3=dayofweek $4=hour $5=min $6=sec
+    ${GetTime} "" "L" $0 $1 $2 $3 $4 $5 $6
+
+    ; Zero-pad hour, minute, second
+    StrLen $R1 $4
+    ${If} $R1 == 1
+        StrCpy $4 "0$4"
     ${EndIf}
-    
+    StrLen $R1 $5
+    ${If} $R1 == 1
+        StrCpy $5 "0$5"
+    ${EndIf}
+    StrLen $R1 $6
+    ${If} $R1 == 1
+        StrCpy $6 "0$6"
+    ${EndIf}
+
+    StrCpy $R2 "$4:$5:$6"
+
+    Pop $6
+    Pop $5
+    Pop $4
+    Pop $3
+    Pop $2
+    Pop $1
+    Pop $0
+
+    ; Write to installer window and log file with timestamp prefix
+    DetailPrint "$R2 $R0"
+
+    ${If} $DEBUG_LOG_HANDLE != ""
+        FileWrite $DEBUG_LOG_HANDLE "$R2 $R0$\r$\n"
+    ${EndIf}
+
+    Pop $R2
     Pop $R1
     Pop $R0
 FunctionEnd
@@ -504,7 +539,9 @@ Page custom DockerCheckPage DockerCheckPageLeave
 !define MUI_FINISHPAGE_RUN_FUNCTION "LaunchSponsors"
 !define MUI_FINISHPAGE_TITLE "DDEV Installation Complete"
 !define MUI_FINISHPAGE_TEXT "Thank you for installing DDEV!$\r$\n$\r$\nPlease consider supporting DDEV so we can continue supporting you."
-!define MUI_FINISHPAGE_RUN_CHECKED  ; Pre-check the box to encourage action
+; MUI_FINISHPAGE_RUN_CHECKED is intentionally omitted: in silent (/S) mode NSIS
+; automatically calls the run function when this is defined, which opens a browser
+; window and can delay installer exit, causing CI timeout failures.
 !insertmacro MUI_PAGE_FINISH
 
 ; Uninstaller pages
@@ -1574,19 +1611,6 @@ Function InstallWSL2Common
         Call SetupMkcertInWSL2
     ${EndIf}
 
-    ; Final validation - ensure DDEV is actually working
-    Push "Performing final validation of DDEV installation..."
-    Call LogPrint
-    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO ddev version'
-    Pop $1
-    Pop $0
-    ${If} $1 != 0
-        Push "ERROR: Final DDEV validation failed - exit code: $1, output: $0"
-        Call LogPrint
-        Push "Installation validation failed. DDEV may not be working properly. Error: $0"
-        Call ShowErrorAndAbort
-    ${EndIf}
-    
     ; Configure WSL2 security settings to prevent Windows security warnings
     Push "Configuring WSL2 security settings to prevent Windows executable warnings..."
     Call LogPrint

--- a/winpkg/installer_test.go
+++ b/winpkg/installer_test.go
@@ -141,8 +141,10 @@ func TestWindowsInstallerWSL2(t *testing.T) {
 			out, _ := exec.RunHostCommand("tasklist.exe", "/FI", "IMAGENAME eq msiexec.exe")
 			t.Logf("MSI processes running: %s", out)
 
-			// Run installer with a 10-minute timeout to prevent infinite hangs
-			const installerTimeout = 10 * time.Minute
+			// Run installer with a 20-minute timeout to prevent infinite hangs.
+			// Fresh Docker CE apt-get installs + docker-compose download can
+			// legitimately take 10+ minutes on a loaded CI machine.
+			const installerTimeout = 20 * time.Minute
 			ctx, cancel := context.WithTimeout(context.Background(), installerTimeout)
 			defer cancel()
 


### PR DESCRIPTION
## The Issue

I imagine this is actually a test fix, but it changes the Windows installer slightly in silent mode. 

The `TestWindowsInstallerWSL2/DockerCE` test was timing out after 10 minutes. The installer debug log showed all installation steps completed successfully, but the NSIS process hadn't exited.

Claimed cause: after `.onInstSuccess` writes "Installation completed successfully", NSIS processes `MUI_PAGE_FINISH`. Because `MUI_FINISHPAGE_RUN_CHECKED` was defined, NSIS **automatically calls `LaunchSponsors` in silent (`/S`) mode**, which calls `ExecShell "open" URL`. On a loaded CI machine where apt-get + docker-compose download had already consumed ~9:55, this final step pushed the total past the 10-minute timeout.

Failure examples in https://buildkite.com/ddev/ddev-windows-mutagen/builds/6212, this happens fairly often.

## How This PR Solves The Issue

- **Remove `MUI_FINISHPAGE_RUN_CHECKED`**: `LaunchSponsors` should never run automatically in silent mode; added a comment explaining why
- **Remove the duplicate `ddev version` call** ("Final validation") — it was identical to the "Verifying DDEV installation" check 20 lines earlier; the first call may trigger a docker-compose download
- **Add `HH:MM:SS` timestamps to every `LogPrint` entry** so future timeout failures show exactly which step was slow (previously no per-step timing was available)
- **Increase the test timeout from 10 to 20 minutes** to give real headroom for slow CI runs without masking genuinely hung installers

## Manual Testing Instructions

- Run the installer normally (interactive, non-silent) and confirm:
  - Installation completes successfully
  - The "Support DDEV - Open GitHub Sponsors page" checkbox on the Finish page is **unchecked by default** (previously it was pre-checked)
  - Checking it and clicking Finish still opens the sponsors page
- Run the installer in silent mode (`ddev_windows_amd64_installer.exe /docker-ce /distro=... /S`) and confirm:
  - Installation completes successfully
  - No browser window opens during or after the install

## Automated Testing Overview

The existing `TestWindowsInstallerWSL2/DockerCE` and `TestWindowsInstallerTraditional` tests in `winpkg/installer_test.go` cover the silent-mode install path. The timeout increase gives the WSL2 Docker CE test room to pass on slow CI machines.

## Release/Deployment Notes

No user-visible behavior change except the Finish page sponsor checkbox is now unchecked by default (instead of pre-checked). Silent installs are unaffected functionally.