### PR TITLE
ci: improve Buildkite test result visibility for FAIL/PASS/SKIP (#8338) [skip ci]

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -9,7 +9,7 @@ export GIT_PAGER=""
 # We can skip builds with commit message of [skip buildkite] or [skip ci]
 DDEV_COMMIT_MESSAGE=$(git log -1 --pretty=%s 2>/dev/null || echo "")
 if [[ ${BUILDKITE_MESSAGE:-} == *"[skip buildkite]"* ]] || [[ ${BUILDKITE_MESSAGE:-} == *"[skip ci]"* ]] || [[ ${DDEV_COMMIT_MESSAGE} == *"[skip buildkite]"* ]] || [[ ${DDEV_COMMIT_MESSAGE} == *"[skip ci]"* ]]; then
-  echo "Skipping build because message has '[skip buildkite]' or '[skip ci]':"
+  echo "+++ SKIP: Build skipped due to commit message"
   echo "BUILDKITE_MESSAGE=${BUILDKITE_MESSAGE:-}"
   echo "DDEV_COMMIT_MESSAGE=${DDEV_COMMIT_MESSAGE}"
   exit 0
@@ -318,7 +318,8 @@ if [ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ]; then
   MERGE_BASE=$(git merge-base HEAD refs/remotes/origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-})
   # Check if there are any changes in the specified directories or files since the merge base
   if ! git diff --name-only "$MERGE_BASE" | grep -E '^(\.buildkite/|Makefile$|pkg/|cmd/|vendor/|winpkg/|go\.)' >/dev/null; then
-    echo "Skipping buildkite build since no code changes found"
+    echo "+++ SKIP: No relevant code changes found"
+    echo "No changes in: .buildkite/, Makefile, pkg/, cmd/, vendor/, winpkg/, go.*"
     exit 0
   fi
 

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -354,7 +354,7 @@ echo "--- Running tests..."
 if [ "${os:-}" = "windows" ]; then
   echo "--- Running Windows installer tests first..."
   export DDEV_TEST_USE_REAL_INSTALLER=true
-  make testwininstaller TESTARGS="${TESTARGS:-}" | sed -u 's/^--- /=== /; /\//!s/^=== RUN /--- RUN /'
+  make testwininstaller TESTARGS="${TESTARGS:-}" | sed -u 's/^--- FAIL:/+++ FAIL:/; /\//!s/^=== RUN /--- RUN /'
   INSTALLER_RV=$?
   if [ $INSTALLER_RV -ne 0 ]; then
     echo "Windows installer tests failed with status=$INSTALLER_RV"
@@ -363,7 +363,7 @@ if [ "${os:-}" = "windows" ]; then
   echo "Windows installer tests completed successfully"
 fi
 
-make ${MAKE_TARGET:-test} TESTARGS="${TESTARGS:-}" TESTPKG="${TESTPKG:-}" TESTFILE="${TESTFILE:-}" | sed -u 's/^--- /=== /; /\//!s/^=== RUN /--- RUN /'
+make ${MAKE_TARGET:-test} TESTARGS="${TESTARGS:-}" TESTPKG="${TESTPKG:-}" TESTFILE="${TESTFILE:-}" | sed -u 's/^--- FAIL:/+++ FAIL:/; /\//!s/^=== RUN /--- RUN /'
 RV=$?
 echo "test.sh completed with status=$RV"
 ddev poweroff || true


### PR DESCRIPTION
## The Issue

Buildkite pipeline log only showed `RUN TestName` section headers in the timeline. `FAIL:`, `PASS:`, and `SKIP:` test results were hidden inside collapsed sections and not visible by default. Build-level skips (due to `[skip ci]` or no relevant code changes) appeared as silent green passes.

## How This PR Solves The Issue

The sed pipeline in `.buildkite/test.sh` previously converted all `--- ` prefixes (including `FAIL:`, `PASS:`, `SKIP:`) to `=== `, which are plain text in Buildkite — not section headers. Only `=== RUN` was converted back to `--- RUN` (a section header), so RUN was the only entry visible in the timeline.

Changes:
- `--- FAIL:` → `+++ FAIL:` — Buildkite `+++` sections are always expanded, making failures immediately visible in the timeline
- `--- PASS:` and `--- SKIP:` — left as `---` so they appear as collapsible section headers in the timeline
- Build-level skips now emit `+++ SKIP: ...` so the skip reason is expanded and visible without clicking into the log

## Manual Testing Instructions

- Trigger a Buildkite build and verify that FAIL/PASS/SKIP results are visible in the timeline alongside RUN entries
- Trigger a build on a PR with no relevant code changes and verify the skip reason is clearly visible in the Buildkite log

## Automated Testing Overview

No automated tests — this is a CI configuration change. Validated by reviewing the sed transformation logic and Buildkite section marker semantics (`---` = collapsible, `+++` = always expanded).

## Release/Deployment Notes

No impact on DDEV functionality. CI display only.