### PR TITLE
fix: flush Mutagen before container chmod and after settings file write, fixes #8340 (#8341) [skip ci]

### DIFF
--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -358,15 +358,13 @@ func (app *DdevApp) CreateSettingsFile() (string, error) {
 				util.Warning("Failed to write .gitignore in %s: %v", filepath.Dir(app.SiteDdevSettingsFile), err)
 			}
 		}
-		return settingsPath, nil
-	}
-
-	// If the project is not running, it makes no sense to sync it
-	if s, _ := app.SiteStatus(); s == SiteRunning {
-		err = app.MutagenSyncFlush()
-		if err != nil {
-			return "", err
+		// Sync any newly written settings files into the container.
+		if s, _ := app.SiteStatus(); s == SiteRunning {
+			if err = app.MutagenSyncFlush(); err != nil {
+				return "", err
+			}
 		}
+		return settingsPath, nil
 	}
 
 	return "", nil

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -581,6 +581,12 @@ func drupalEnsureWritePerms(app *DdevApp) error {
 	// So we chmod +w the two files that a Drupal install may set read-only
 	// *inside* the container, allowing mutagen access to it again
 	if app.IsMutagenEnabled() && status == SiteRunning {
+		// Flush Mutagen so any host-side settings files are in the container
+		// before we attempt to chmod them. Without this, sites/default may not
+		// exist in the container yet (e.g. after an interrupted ddev start).
+		if err := app.MutagenSyncFlush(); err != nil {
+			util.Warning("Unable to flush Mutagen before setting permissions: %v", err)
+		}
 		settingsFiles := []string{
 			path.Join(app.GetAbsDocroot(true), `sites/default`),
 			path.Join(app.GetAbsDocroot(true), `sites/default/settings.php`),


### PR DESCRIPTION

## The Issue

- Fixes #8340

On macOS with Mutagen, `ddev config` on a running project (e.g. after an interrupted `ddev start`) could fail with:
`chmod: cannot access '/var/www/html/web/sites/default': No such file or directory`

Drupal is strict about settings file permissions, so this is not just a spurious warning.

## How This PR Solves The Issue

Two related problems fixed:

1. `drupalEnsureWritePerms` runs `chmod u+w sites/default settings.php` inside the container to re-enable Mutagen sync after a Drupal install sets them read-only. But if Mutagen hasn't synced those paths from host to container yet, the chmod fails with "No such file or directory". Fix: flush Mutagen before the container chmod so host-side files are present first.

2. `CreateSettingsFile` had a `MutagenSyncFlush()` call that was unreachable for any app type with a `settingsCreator` (Drupal, WordPress, etc.) due to an early return. So newly written settings files were never guaranteed to reach the container. Fix: move the flush inside the `settingsCreator` branch, before the return.

## Manual Testing Instructions

- macOS with Mutagen enabled, Drupal 12 project
- Interrupt a `ddev start` before Mutagen finishes syncing
- Run `ddev config` — should no longer warn about chmod failure
- Verify settings.php appears inside the container after `ddev config`

## Automated Testing Overview

No new tests; existing settings and Mutagen tests cover the affected paths.

## Release/Deployment Notes

Affects macOS Mutagen users with Drupal projects. No configuration changes.
