### PR TITLE
fix: warn instead of silently ignoring RemoveProjectInfo error, for #8339 (#8342) [skip ci]

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -3439,7 +3439,9 @@ func deleteImages(app *DdevApp) {
 
 // RemoveGlobalProjectInfo deletes the project from DdevProjectList
 func (app *DdevApp) RemoveGlobalProjectInfo() {
-	_ = globalconfig.RemoveProjectInfo(app.Name)
+	if err := globalconfig.RemoveProjectInfo(app.Name); err != nil {
+		util.Warning("Unable to remove project info for %s: %v", app.Name, err)
+	}
 }
 
 // GetHTTPURL returns the HTTP URL for an app.


### PR DESCRIPTION
## The Issue

- Related to #8339

If `WriteProjectList()` fails during `ddev delete`, the project remained in `project_list.yaml` and reappeared as `stopped` in `ddev list` on the next invocation. The error was silently discarded with `_ =`, giving no indication anything went wrong.

## How This PR Solves The Issue

Surface the error from `RemoveGlobalProjectInfo()` as a `util.Warning` so the failure is visible to the user. The fix is one line — swapping `_ =` for an error check.

## Manual Testing Instructions

- Run `ddev delete -O` on any project
- Normal case: no warning, project removed from list as before
- Failure case (e.g. simulate by making `~/.ddev/project_list.yaml` read-only): warning is now printed instead of silently leaving the project in the list

## Automated Testing Overview

No new tests; the change is a one-line error surface. Existing delete tests cover the happy path.

## Release/Deployment Notes

No behaviour change in the success path. Failure path now emits a warning rather than silently continuing.