### PR TITLE
chore(assets): add `.ddev/addon-metadata/README.txt` (#8343) [skip ci]

### DIFF
--- a/pkg/ddevapp/dotddev_assets/addon-metadata/README.txt
+++ b/pkg/ddevapp/dotddev_assets/addon-metadata/README.txt
@@ -1,0 +1,5 @@
+#ddev-generated
+Contains metadata about add-on services that have been added to the project.
+This allows commands like `ddev add-on list --installed` and `ddev add-on remove` to work.
+
+See https://docs.ddev.com/en/stable/users/extend/using-add-ons/


### PR DESCRIPTION
## The Issue

Prepare a project directory:

```
mkdir test1 && cd test1
ddev config --auto
git init
git add -A
```

And run this:

```
$ ddev add-on get ddev/ddev-adminer
$ ddev add-on remove ddev/ddev-adminer

$ git clean -df
Removing .ddev/addon-metadata/
```

or this:

```
$ ddev add-on list --installed
No registered add-ons were found.

$ git clean -df
Removing .ddev/addon-metadata/
```

## How This PR Solves The Issue

I always use `git checkout . && git clean -df` on test DDEV projects to clean up every change I made. And it's annoying to see:

```
Removing .ddev/addon-metadata/
```

I've been ignoring it for a few years, time to fix it by providing the `.ddev/addon-metadata/README.txt` file, which is going to keep the directory when I run `git clean -df`

## Manual Testing Instructions

```bash
ddev config --auto
ddev add-on get ddev/ddev-adminer
ddev add-on remove ddev/ddev-adminer
git clean -df
ls -l .ddev/addon-metadata/README.txt # the file should be here
```

```bash
ddev config --auto
ddev add-on list --installed
git clean -df
ls -l .ddev/addon-metadata/README.txt # the file should be here
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
