### PR TITLE
chore(claude): fix PreToolUse hook matcher for git commit static analysis (#8345) [skip ci]

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,10 +68,11 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash(git commit:*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(git commit*)",
             "command": "make staticrequired"
           }
         ]


### PR DESCRIPTION
## The Issue

`make staticrequired` doesn't run on `git commit`.

## How This PR Solves The Issue

Fixes it per https://code.claude.com/docs/en/hooks#how-a-hook-resolves

## Manual Testing Instructions

Ask Claude to create a commit, now it doesn't create it immediately because of `make staticrequired`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
