### PR TITLE
test: Reenable Drupal 12 bats test (#8346) [skip ci]

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -38,7 +38,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Add tests you want to skip here, delimited by pipe (e.g., symfony-composer|symfony-cli)
   # Search for _skip_if_embargoed to see how this is used
-  DDEV_EMBARGO_TESTS: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS }}
+  DDEV_EMBARGO_TESTS: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
 
 permissions:
   actions: write

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -38,7 +38,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Add tests you want to skip here, delimited by pipe (e.g., symfony-composer|symfony-cli)
   # Search for _skip_if_embargoed to see how this is used
-  DDEV_EMBARGO_TESTS: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || 'drupal12-composer' }}
+  DDEV_EMBARGO_TESTS: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS }}
 
 permissions:
   actions: write


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

Drush 14.x is compatible with the Drupal main branch again. There is no need for any changes in the bats test itself, the embargo just has to be lifted and the Drupal 12 bats test reenabled again. 

## The Issue

- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
