### PR TITLE
fix(windows): remove wslu from installer, fixes #8326

### DIFF
--- a/docs/content/developers/scripts/wsl2-test-runner-setup.sh
+++ b/docs/content/developers/scripts/wsl2-test-runner-setup.sh
@@ -23,7 +23,7 @@ fi
 
 set -x
 sudo apt-get update -qq >/dev/null && sudo apt-get upgrade -qq -y >/dev/null
-sudo apt-get install -qq -y apt-transport-https autojump bats build-essential ca-certificates ccache clang curl dirmngr etckeeper expect git gnupg htop icinga2 jq libcurl4-gnutls-dev libnss3-tools lsb-release mariadb-client mkcert monitoring-plugins-contrib nagios-plugins postgresql-client unzip vim wslu xdg-utils zip >/dev/null
+sudo apt-get install -qq -y apt-transport-https autojump bats build-essential ca-certificates ccache clang curl dirmngr etckeeper expect git gnupg htop icinga2 jq libcurl4-gnutls-dev libnss3-tools lsb-release mariadb-client mkcert monitoring-plugins-contrib nagios-plugins postgresql-client unzip vim xdg-utils zip >/dev/null
 
 # docker-ce if required
 if [ "${BUILDKITE_DOCKER_TYPE:-}" = "wsl2" ]; then

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -54,8 +54,8 @@ if (Test-Path "$env:LOCALAPPDATA\Programs\DDEV\ddev_uninstall.exe") {
 wsl -u root -e bash -c "apt-get update && apt-get install -y curl"
 wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg /etc/apt/sources.list.d/ddev.list && curl -fsSL https://pkg.ddev.com/apt/gpg.key | tee /etc/apt/keyrings/ddev.asc > /dev/null && chmod a+r /etc/apt/keyrings/ddev.asc"
 wsl -u root -e bash -c "printf 'Types: deb\nURIs: https://pkg.ddev.com/apt/\nSuites: *\nComponents: *\nSigned-By: /etc/apt/keyrings/ddev.asc\n' > /etc/apt/sources.list.d/ddev.sources"
-wsl -u root -e bash -c "apt-get update && apt-get install -y wslu"
-wsl -u root -e bash -c "apt-get install -y --no-install-recommends ddev ddev-wsl2"
+
+wsl -u root -e bash -c "apt-get update && apt-get install -y --no-install-recommends ddev ddev-wsl2"
 
 wsl mkcert.exe -install
 $env:CAROOT = & wsl mkcert.exe -CAROOT

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -57,7 +57,7 @@ wsl -u root -e bash -c "printf 'Types: deb\nURIs: https://download.docker.com/li
 
 wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg /etc/apt/sources.list.d/ddev.list && curl -fsSL https://pkg.ddev.com/apt/gpg.key | tee /etc/apt/keyrings/ddev.asc > /dev/null && chmod a+r /etc/apt/keyrings/ddev.asc"
 wsl -u root -e bash -c "printf 'Types: deb\nURIs: https://pkg.ddev.com/apt/\nSuites: *\nComponents: *\nSigned-By: /etc/apt/keyrings/ddev.asc\n' > /etc/apt/sources.list.d/ddev.sources"
-wsl -u root -e bash -c "apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io wslu"
+wsl -u root -e bash -c "apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io"
 wsl -u root -e bash -c "apt-get install -y --no-install-recommends ddev ddev-wsl2"
 wsl bash -c 'sudo usermod -aG docker $USER'
 

--- a/winpkg/ddev_windows_installer.nsi
+++ b/winpkg/ddev_windows_installer.nsi
@@ -1378,10 +1378,10 @@ Function InstallWSL2Common
 
     ${If} $INSTALL_OPTION == "wsl2-docker-desktop"
         ; Install packages needed for Docker Desktop (including ddev)
-        StrCpy $0 "docker-ce-cli wslu ddev"
+        StrCpy $0 "docker-ce-cli ddev"
     ${Else}
         ; Install full Docker CE packages (including ddev)
-        StrCpy $0 "docker-ce docker-ce-cli containerd.io wslu ddev"
+        StrCpy $0 "docker-ce docker-ce-cli containerd.io ddev"
     ${EndIf}
     
     ; Update status
@@ -1390,7 +1390,7 @@ Function InstallWSL2Common
     Pop $2
 
     ; Install packages in multiple steps for better progress feedback
-    Push "WSL($SELECTED_DISTRO): Installing essential packages (1/4)..."
+    Push "WSL($SELECTED_DISTRO): Installing essential packages (1/3)..."
     Call LogPrint
     Push "Please be patient - installing essential packages..."
     Call LogPrint
@@ -1409,7 +1409,7 @@ Function InstallWSL2Common
     Pop $1
     Pop $2
 
-    Push "WSL($SELECTED_DISTRO): Installing Docker components (2/4)..."
+    Push "WSL($SELECTED_DISTRO): Installing Docker components (2/3)..."
     Call LogPrint
     Push "Please be patient - installing Docker components..."
     Call LogPrint
@@ -1427,26 +1427,12 @@ Function InstallWSL2Common
         Call ShowErrorAndAbort
     ${EndIf}
 
-    Push "WSL($SELECTED_DISTRO): Installing WSL utilities (3/4)..."
-    Call LogPrint
-    Push "Please be patient - installing WSL utilities..."
-    Call LogPrint
-    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash -c "DEBIAN_FRONTEND=noninteractive apt-get install -y wslu 2>&1"'
-    Pop $1
-    Pop $2
-    ${If} $1 != 0
-        Push "ERROR: Failed to install WSL utilities - exit code: $1, output: $2"
-        Call LogPrint
-        Push "Failed to install WSL utilities. Error: $2"
-        Call ShowErrorAndAbort
-    ${EndIf}
-    
     ; Update status
     nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO bash -c "echo \"PROGRESS: Installing DDEV\" >> /tmp/ddev_installation_status.txt"'
     Pop $1
     Pop $2
 
-    Push "WSL($SELECTED_DISTRO): Installing DDEV (4/4)..."
+    Push "WSL($SELECTED_DISTRO): Installing DDEV (3/3)..."
     Call LogPrint
     Push "Please be patient - installing DDEV..."
     Call LogPrint


### PR DESCRIPTION
## The Issue

- Fixes #8326

We don't use any of `wslu` utilities in our code as of today:

```
$ dpkg -L wslu
/.
/usr
/usr/bin
/usr/bin/wslact
/usr/bin/wslfetch
/usr/bin/wslsys
/usr/bin/wslupath
/usr/bin/wslusc
/usr/bin/wslvar
/usr/bin/wslview
/usr/share
/usr/share/doc
/usr/share/doc/wslu
/usr/share/doc/wslu/README.eo.md.gz
/usr/share/doc/wslu/README.hans.md.gz
/usr/share/doc/wslu/README.hant.md.gz
/usr/share/doc/wslu/README.md.gz
/usr/share/doc/wslu/changelog.Debian.gz
/usr/share/doc/wslu/copyright
/usr/share/man
/usr/share/man/man1
/usr/share/man/man1/wslact.1.gz
/usr/share/man/man1/wslfetch.1.gz
/usr/share/man/man1/wslsys.1.gz
/usr/share/man/man1/wslupath.1.gz
/usr/share/man/man1/wslusc.1.gz
/usr/share/man/man1/wslvar.1.gz
/usr/share/man/man1/wslview.1.gz
/usr/share/man/man7
/usr/share/man/man7/wslu.7.gz
/usr/share/wslu
/usr/share/wslu/get_dpi.ps1
/usr/share/wslu/runHidden.vbs
/usr/share/wslu/sudo.ps1
/usr/share/wslu/wsl-gui.ico
/usr/share/wslu/wsl-term.ico
/usr/share/wslu/wsl.ico
/usr/share/wslu/wslusc-helper.sh
/usr/share/wslu/wslview.desktop
```

## How This PR Solves The Issue

Removes `wslu`

## Manual Testing Instructions

Run Windows Installer with WSL2 (Ubuntu 26.04 and Ubuntu 24.04).

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
