### PR TITLE
docs(windows): add WSL2 installation step to Docker docs

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -215,17 +215,26 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ```powershell
     # Install WSL2; reboot if prompted, then continue:
     wsl --install --no-distribution
+
     # Update WSL2 if previously installed:
     wsl --update
     ```
 
-    For best performance, store your projects in WSL2's Linux filesystem (ext4) rather than the Windows filesystem (NTFS). Create a Ubuntu distro for this (skip if you’re using Traditional Windows):
+    Create an Ubuntu distro (skip if you're using Traditional Windows):
 
     ```powershell
+    # You'll be asked to set a username and password for the distro:
     wsl --install Ubuntu --name DDEV
-    # "DDEV" is just a suggested name — use any name you like.
-    # You’ll be asked to set a username and password for the distro.
     ```
+
+    !!!tip "\"DDEV\" is just a suggested name — use any name you like."
+        Verify the "DDEV" distro is set as default:
+
+        ```powershell { .no-copy }
+        > wsl -l -v
+          NAME                   STATE           VERSION
+        * DDEV                   Stopped         2
+        ```
 
     ### Step 2: Install DDEV
 
@@ -271,12 +280,6 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         choco install ddev
         ```
 
-    !!!tip "Tips for using DDEV in WSL2"
-        - Run `ddev` commands **inside WSL2** (e.g. inside Ubuntu), never in PowerShell or Git Bash.
-        - Keep your projects in the WSL2 filesystem (e.g. `/home/<your_username>/projects`), **not** in the Windows filesystem (`/mnt/c`). The Linux filesystem is faster and has proper permissions.
-        - You **must** use WSL2, not WSL version 1. Use `wsl.exe -l -v` to check — distros should show version 2.
-        - Custom hostnames (non `ddev.site`) are managed via the Windows hosts file at `C:\Windows\System32\drivers\etc\hosts`, not within WSL2.
-
     ??? tip "Installer in Silent Mode"
         The Windows installer supports silent mode for automated installations and testing:
 
@@ -295,15 +298,6 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         ```
 
         The `/S` flag makes the installation completely silent. Use `/distro=<name>` to specify your WSL2 distribution name (required for WSL2 options).
-
-    ??? "What if my browser (especially Firefox) doesn’t trust `https` URLs?"
-        DDEV uses [mkcert](https://github.com/FiloSottile/mkcert) to generate a local certificate authority (CA), and `mkcert -install` registers it with most browsers automatically. Firefox and some other browsers manage their own certificate stores and require a manual import.
-
-        To diagnose certificate trust issues, run `ddev utility tls-diagnose`.
-
-        To manually import the CA: run `mkcert.exe -CAROOT` to find the directory containing `rootCA.pem`, then import that file via your browser’s certificate manager (usually under Security settings → View Certificates → Authorities → Import).
-
-        See [Configuring Browsers](configuring-browsers.md) for full details.
 
     ??? "Manual Installation"
 
@@ -327,6 +321,28 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
         !!!note "Path to certificates"
             If you get the prompt `Installing to the system store is not yet supported on this Linux`, you may need to add `/usr/sbin` to the `$PATH` so that `/usr/sbin/update-ca-certificates` can be found.
+
+    ### Step 3: Start working in WSL2
+
+    *(Skip if using Traditional Windows.)*
+
+    Open your distro from the Start menu (or run `wsl` in PowerShell) to get a Linux terminal. Run all `ddev` commands here — never in PowerShell or Git Bash.
+
+    **Store your [projects](../project.md) inside WSL2** (e.g. `/home/<username>/projects`), not on `C:\` drive (`/mnt/c` in WSL2) — faster and avoids permission issues.
+
+    From Windows Explorer: **Linux → DDEV → home → [username]**.
+
+    !!!note "Custom hostnames"
+        Custom hostnames with a non-default [TLD](../configuration/config.md#project_tld) (non `ddev.site`) are managed via the Windows hosts file at `C:\Windows\System32\drivers\etc\hosts`, not within WSL2.
+
+    ??? "What if my browser (especially Firefox) doesn’t trust `https` URLs?"
+        DDEV uses [mkcert](https://github.com/FiloSottile/mkcert) to generate a local certificate authority (CA), and `mkcert -install` registers it with most browsers automatically. Firefox and some other browsers manage their own certificate stores and require a manual import.
+
+        To diagnose certificate trust issues, run `ddev utility tls-diagnose`.
+
+        To manually import the CA: run `mkcert.exe -CAROOT` to find the directory containing `rootCA.pem`, then import that file via your browser’s certificate manager (usually under Security settings → View Certificates → Authorities → Import).
+
+        See [Configuring Browsers](configuring-browsers.md) for full details.
 
 === "Codespaces"
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -228,13 +228,14 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ```
 
     !!!tip "\"DDEV\" is just a suggested name — use any name you like."
-        Verify the "DDEV" distro is set as default:
 
-        ```powershell { .no-copy }
-        > wsl -l -v
-          NAME                   STATE           VERSION
-        * DDEV                   Stopped         2
-        ```
+    Verify the "DDEV" distro is set as default:
+
+    ```powershell { .no-copy }
+    > wsl -l -v
+      NAME                   STATE           VERSION
+    * DDEV                   Stopped         2
+    ```
 
     ### Step 2: Install DDEV
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -214,7 +214,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ```powershell
     # Install WSL2; reboot if prompted, then continue:
-    wsl --install
+    wsl --install --no-distribution
     # Update WSL2 if previously installed:
     wsl --update
     ```

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -208,16 +208,20 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     | **Docker Desktop / Rancher Desktop with WSL2** | Already have Docker Desktop or Rancher Desktop installed | WSL2 + Docker Desktop or Rancher Desktop |
     | **Traditional Windows** | PowerShell/Git Bash workflow | Docker Desktop or Rancher Desktop (no separate WSL2 distro needed) |
 
-    ### Step 1: Install WSL2 (Docker CE and Docker Desktop modes only)
-
-    If you’re using **Traditional Windows**, skip to [Step 2: Install DDEV](#step-2-install-ddev).
+    ### Step 1: Install WSL2
 
     In PowerShell, run:
 
     ```powershell
+    # Install WSL2; reboot if prompted, then continue:
     wsl --install
-    # Reboot if prompted, then continue:
+    # Update WSL2 if previously installed:
     wsl --update
+    ```
+
+    For best performance, store your projects in WSL2's Linux filesystem (ext4) rather than the Windows filesystem (NTFS). Create a Ubuntu distro for this (skip if you’re using Traditional Windows):
+
+    ```powershell
     wsl --install Ubuntu --name DDEV
     # "DDEV" is just a suggested name — use any name you like.
     # You’ll be asked to set a username and password for the distro.

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -209,48 +209,32 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     ## Windows
 
-    For initial installation of DDEV on Windows, you can use one of the following Docker providers:
+    For DDEV on Windows, choose one of these Docker providers:
 
-    * Docker CE inside WSL2 - The most popular, performant, and best-supported way to run DDEV on Windows. No additional software is required; Docker CE will be installed by the DDEV installer. This approach does not work for traditional Windows (non-WSL2) installations.
-    * Docker Desktop for Windows - A popular choice that works with both traditional Windows and WSL2. It has extensive automated testing with DDEV, but has some performance and reliability problems. It is not open-source and may require a license for many users. This approach works for both traditional Windows and WSL2 installations.
-    * Rancher Desktop for Windows - A free and open-source Docker provider that has been manually tested with DDEV on traditional Windows, but does not have automated testing. This approach works for both traditional Windows and WSL2 installations.
+    * **Docker CE inside WSL2** - The most popular, performant, and best-supported way to run DDEV on Windows. The [DDEV installer](ddev-installation.md#windows) installs Docker CE automatically. Requires WSL2.
+    * **Docker Desktop for Windows** - Works with both WSL2 and traditional Windows. Extensive automated testing with DDEV, but has some performance and reliability problems. Not open-source; may require a license for many users.
+    * **Rancher Desktop for Windows** - Free and open-source. Manually tested with DDEV on traditional Windows; no automated testing. Works with both WSL2 and traditional Windows.
 
-    ### Using the Windows Installer
+    ### Install WSL2
 
-    The easiest way to install DDEV on Windows is to use the Windows installer, which can handle different installation scenarios:
+    WSL2 is required for Docker CE, and needed for Docker Desktop and Rancher Desktop when using WSL2 integration. If you're using **Traditional Windows** (Docker Desktop or Rancher Desktop without a WSL2 distro), skip this section.
 
-    1. **Download the Windows installer**. Make sure to download the correct installer for your system architecture:
+    In PowerShell, run:
 
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; text-align: center;">
-        [Download for AMD64 :material-microsoft-windows:<br>(Intel/AMD) :material-download:](https://ddev.com/download/ddev_windows_amd64_installer.exe "For computers with Intel or AMD processors (most common)"){ .md-button .md-button--primary }
-        [Download for ARM64 :material-microsoft-windows:<br>(Snapdragon) :material-download:](https://ddev.com/download/ddev_windows_arm64_installer.exe "For computers with ARM processors like Qualcomm Snapdragon"){ .md-button .md-button--primary }
-        </div>
+    ```powershell
+    wsl --install
+    # Reboot if prompted, then continue:
+    wsl --update
+    wsl --install Ubuntu --name DDEV
+    # "DDEV" is just a suggested name — use any name you like.
+    # You'll be asked to set a username and password for the distro.
+    ```
 
-        - **AMD64 (x86-64)**: Most traditional Windows PCs (Intel/AMD processors)
-        - **ARM64**: Windows on ARM devices like Microsoft Surface Pro X, Surface Pro 9 (5G), or other ARM-based Windows devices
+    ### Docker CE inside WSL2
 
-        Or browse all versions on the [DDEV releases page](https://github.com/ddev/ddev/releases).
+    The [DDEV Windows installer](ddev-installation.md#windows) automatically installs Docker CE in your WSL2 environment — no manual Docker installation is needed. After installing WSL2 above, proceed to [install DDEV](ddev-installation.md#windows).
 
-        !!!tip "Check your system architecture"
-            Not sure which architecture you have? Open PowerShell and run: `$env:PROCESSOR_ARCHITECTURE`. It will show `AMD64` or `ARM64`. Alternatively, in WSL2/Ubuntu run `uname -m` which shows `x86_64` for AMD64 or `aarch64` for ARM64.
-
-    2. **Run the installer** and choose your installation type:
-       - **Docker CE inside WSL2** (Recommended): The installer will automatically install Docker CE in your WSL2 environment. This is the fastest and most reliable option.
-       - **Docker Desktop**: Choose this if you already have Docker Desktop installed or prefer to use it.
-       - **Rancher Desktop**: Choose this if you already have Rancher Desktop installed.
-       - **Traditional Windows**: Choose this for non-WSL2 installations (requires Docker Desktop or Rancher Desktop).
-
-    The installer will automatically configure DDEV for your chosen Docker provider and WSL2 environment.
-
-    ### Manual Installation Options
-
-    If you prefer to install manually or need more control over the installation process, you can use the following approaches:
-
-    #### Docker CE inside WSL2
-
-    No additional software is required to run DDEV on Windows with Docker CE inside WSL2. The DDEV installer will install Docker CE for you. This is the most popular, performant, and best-supported way to run DDEV on Windows.
-
-    To install manually, open your WSL2 terminal (Ubuntu) and run:
+    To install Docker CE manually instead, open your WSL2 terminal (Ubuntu) and run:
 
     ```bash
     # Ensure sudo credentials are cached for copy/paste of this block
@@ -308,7 +292,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
         Review the script, then run it: `bash /tmp/install-docker.sh`
 
-    #### Docker Desktop for Windows
+    ### Docker Desktop for Windows
 
     1. Download and install Docker Desktop from [docker.com](https://www.docker.com/products/docker-desktop).
     2. During installation, ensure "Use WSL 2 instead of Hyper-V" is selected.
@@ -317,7 +301,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     5. Apply the changes and restart Docker Desktop if prompted.
     6. Verify that `docker ps` works in git-bash, PowerShell, or WSL2, wherever you're using it.
 
-    #### Rancher Desktop for Windows
+    ### Rancher Desktop for Windows
 
     1. Download and install [Rancher Desktop](https://rancherdesktop.io/).
     2. During installation, choose **Docker** as the container runtime and disable Kubernetes.

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -222,17 +222,26 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     ```powershell
     # Install WSL2; reboot if prompted, then continue:
     wsl --install --no-distribution
+
     # Update WSL2 if previously installed:
     wsl --update
     ```
 
-    For best performance, store your projects in WSL2's Linux filesystem (ext4) rather than the Windows filesystem (NTFS). Create a Ubuntu distro for this (skip if you're using Traditional Windows):
+    Create an Ubuntu distro (skip if you're using Traditional Windows):
 
     ```powershell
+    # You'll be asked to set a username and password for the distro:
     wsl --install Ubuntu --name DDEV
-    # "DDEV" is just a suggested name — use any name you like.
-    # You'll be asked to set a username and password for the distro.
     ```
+
+    !!!tip "\"DDEV\" is just a suggested name — use any name you like."
+        Verify the "DDEV" distro is set as default:
+
+        ```powershell { .no-copy }
+        > wsl -l -v
+          NAME                   STATE           VERSION
+        * DDEV                   Stopped         2
+        ```
 
     ### Docker CE inside WSL2
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -221,7 +221,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     ```powershell
     # Install WSL2; reboot if prompted, then continue:
-    wsl --install
+    wsl --install --no-distribution
     # Update WSL2 if previously installed:
     wsl --update
     ```

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -235,13 +235,14 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     ```
 
     !!!tip "\"DDEV\" is just a suggested name — use any name you like."
-        Verify the "DDEV" distro is set as default:
 
-        ```powershell { .no-copy }
-        > wsl -l -v
-          NAME                   STATE           VERSION
-        * DDEV                   Stopped         2
-        ```
+    Verify the "DDEV" distro is set as default:
+
+    ```powershell { .no-copy }
+    > wsl -l -v
+      NAME                   STATE           VERSION
+    * DDEV                   Stopped         2
+    ```
 
     ### Docker CE inside WSL2
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -245,7 +245,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     ### Docker CE inside WSL2
 
-    The [DDEV Windows installer](ddev-installation.md#windows) automatically installs Docker CE in your WSL2 environment — no manual Docker installation is needed. After installing WSL2 above, proceed to [install DDEV](ddev-installation.md#windows).
+    The [DDEV Windows installer](ddev-installation.md#step-2-install-ddev) automatically installs Docker CE in your WSL2 environment — no manual Docker installation is needed. After installing WSL2 above, proceed to [install DDEV](ddev-installation.md#step-2-install-ddev).
 
     To install Docker CE manually instead, open your WSL2 terminal (Ubuntu) and run:
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -217,14 +217,18 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     ### Install WSL2
 
-    WSL2 is required for Docker CE, and needed for Docker Desktop and Rancher Desktop when using WSL2 integration. If you're using **Traditional Windows** (Docker Desktop or Rancher Desktop without a WSL2 distro), skip this section.
-
     In PowerShell, run:
 
     ```powershell
+    # Install WSL2; reboot if prompted, then continue:
     wsl --install
-    # Reboot if prompted, then continue:
+    # Update WSL2 if previously installed:
     wsl --update
+    ```
+
+    For best performance, store your projects in WSL2's Linux filesystem (ext4) rather than the Windows filesystem (NTFS). Create a Ubuntu distro for this (skip if you're using Traditional Windows):
+
+    ```powershell
     wsl --install Ubuntu --name DDEV
     # "DDEV" is just a suggested name — use any name you like.
     # You'll be asked to set a username and password for the distro.


### PR DESCRIPTION
## The Issue

I tried to install DDEV on Windows and followed https://docs.ddev.com/en/stable/users/install/docker-installation/#windows

There's no mention of `wsl --install`, so obviously my installation failed.

## How This PR Solves The Issue

**`docker-installation.md`**:

- Replaces the installer-first Windows section with an "Install WSL2" section as the starting point
- Adds `wsl --install --no-distribution` and `wsl --update` steps
- Adds distro creation step with a tip to verify the result
- Points to the DDEV installer for Docker CE instead of duplicating its instructions
- Cleans up Docker provider list and heading levels

**`ddev-installation.md`**:

- Splits the WSL2 install commands into cleaner separate blocks
- Changes `wsl --install` to `wsl --install --no-distribution`
- Adds distro verification (name tip + `wsl -l -v` output) in a single tip block
- Replaces the "Tips for using DDEV in WSL2" catch-all admonition with a proper **Step 3: Start working in WSL2**
- Step 3 covers: opening the terminal, where to run commands, where to store projects, custom hostnames note, and browser trust question
- Moves Silent Mode and Manual Installation to under Step 2 where they belong

## Manual Testing Instructions

https://ddev--8355.org.readthedocs.build/en/8355/users/install/docker-installation/#windows

https://ddev--8355.org.readthedocs.build/en/8355/users/install/ddev-installation/#windows

## Automated Testing Overview


## Release/Deployment Notes
