### PR TITLE
fix(download-images): pull webserver image, for #8304

### DIFF
--- a/cmd/ddev/cmd/debug-download-images.go
+++ b/cmd/ddev/cmd/debug-download-images.go
@@ -51,7 +51,8 @@ ddev utility download-images --all
 		if err != nil {
 			util.Success("Downloading basic images")
 			additionalImages = []string{
-				// Provide at least the default database image
+				// Pull the default web and db images
+				docker.GetWebImage(),
 				docker.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion),
 			}
 		} else {


### PR DESCRIPTION
## The Issue

Webserver image is not pulled if you are outside the project directory:

```
$ cd ~ && ddev utility download-images
Downloading basic images 
[+] pull 5/5
 ✔ Image ddev/ddev-utilities:latest              Pulled                     2.0s
 ✔ Image ddev/ddev-dbserver-mariadb-11.8:v1.25.2 Pulled                     2.1s
 ✔ Image ddev/ddev-ssh-agent:v1.25.2             Pulled                     1.8s
 ✔ Image ddev/ddev-xhgui:v1.25.2                 Pulled                     2.0s
 ✔ Image ddev/ddev-traefik-router:v1.25.2        Pulled                     1.8s
Successfully downloaded DDEV images
```

- Caused by changes in #8304

## How This PR Solves The Issue

Adds pulling for `ddev/ddev-webserver`.

## Manual Testing Instructions

```bash
cd ~ && ddev utility download-images
# see "Image ddev/ddev-webserver:20260427_stasadev_dockerfile Pulled"
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
