### PR TITLE
fix(start): use image digest for rebuild detection, fix rand and ssh-agent data races, for #8145

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1486,15 +1486,17 @@ func (app *DdevApp) composeBuild(args ...string) (string, error) {
 	return out, fmt.Errorf("docker-compose build failed after %d attempts: %v, output='%s', stderr='%s'", composeBuildMaxRetries, lastErr, out, stderr)
 }
 
-// buildContextFingerprint returns a SHA-256 hash of the build context directories
-// (.webimageBuild, .dbimageBuild) and base image names. This is used to detect
+// buildContextFingerprint returns an SHA-256 hash of the build context directories
+// (.webimageBuild, .dbimageBuild) and base image IDs. This is used to detect
 // when docker-compose build can be skipped because nothing has changed.
+// Image IDs (sha256 digests) are used instead of tag names so that
+// rebuilt images with the same tag are still detected as changed.
 func (app *DdevApp) buildContextFingerprint() string {
 	dirs := []string{
 		app.GetConfigPath(".webimageBuild"),
 		app.GetConfigPath(".dbimageBuild"),
 	}
-	hash, err := fileutil.HashDirs(dirs, app.WebImage, app.GetDBImage())
+	hash, err := fileutil.HashDirs(dirs, dockerutil.ImageID(app.WebImage), dockerutil.ImageID(app.GetDBImage()))
 	if err != nil {
 		util.Warning("unable to hash build context directories: %v", err)
 		return ""
@@ -1772,10 +1774,9 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 	}
 
-	// Run chown + SSH agent concurrently with config/build steps below.
+	// Run chown concurrently with config/build steps below.
 	// chown operates on volumes, compose build operates on images — independent.
 	var chownErr error
-	var sshErr error
 	var chownWg sync.WaitGroup
 	chownWg.Go(func() {
 		util.Debug("Exec %s", chownCmd)
@@ -1785,13 +1786,9 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 			return
 		}
 		util.Debug("Done %s: output=%s", chownCmd, chownOut)
-
-		if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "ddev-ssh-agent") {
-			sshErr = app.EnsureSSHAgentContainer()
-		}
 	})
 
-	// While chown + SSH run in background, do config and compose build
+	// While chown runs in background, do config and compose build.
 	// Warn user if there are deprecated items used in the config
 	app.CheckDeprecations()
 
@@ -1835,6 +1832,10 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		return err
 	}
 
+	// Wait for background image pull to finish before fingerprinting, so
+	// ImageID() reflects the freshly-pulled digest rather than a stale local one.
+	pullWg.Wait()
+
 	// Build extra layers on web and db images if necessary.
 	// Skip the build entirely if the build context hasn't changed and built images exist.
 	buildHashFile := app.GetConfigPath(".build-hash")
@@ -1856,14 +1857,17 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 		}
 	}
 
-	// Wait for background image pull and chown + SSH to finish before proceeding
-	pullWg.Wait()
+	// Wait for background chown to finish before proceeding.
+	// SSH agent runs after chown (needs volumes ready) and after WriteDockerComposeYAML
+	// (reads app.ComposeYaml) — so it runs sequentially here to avoid a data race.
 	chownWg.Wait()
 	if chownErr != nil {
 		return chownErr
 	}
-	if sshErr != nil {
-		return sshErr
+	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "ddev-ssh-agent") {
+		if err = app.EnsureSSHAgentContainer(); err != nil {
+			return err
+		}
 	}
 
 	if buildNeeded {

--- a/pkg/dockerutil/images.go
+++ b/pkg/dockerutil/images.go
@@ -58,7 +58,7 @@ func FindImagesByLabels(labels map[string]string, danglingOnly bool) ([]image.Su
 }
 
 // ImageID returns the content-addressable ID (sha256:...) of a local image,
-// falling back to the tag name if the image is not found locally.
+// falling back to the tag name on any error.
 func ImageID(imageName string) string {
 	ctx, apiClient, err := GetDockerClient()
 	if err != nil {

--- a/pkg/dockerutil/images.go
+++ b/pkg/dockerutil/images.go
@@ -57,6 +57,20 @@ func FindImagesByLabels(labels map[string]string, danglingOnly bool) ([]image.Su
 	return images.Items, nil
 }
 
+// ImageID returns the content-addressable ID (sha256:...) of a local image,
+// falling back to the tag name if the image is not found locally.
+func ImageID(imageName string) string {
+	ctx, apiClient, err := GetDockerClient()
+	if err != nil {
+		return imageName
+	}
+	info, err := apiClient.ImageInspect(ctx, imageName)
+	if err != nil {
+		return imageName
+	}
+	return info.ID
+}
+
 // RemoveImage removes an image with force
 func RemoveImage(tag string) error {
 	ctx, apiClient, err := GetDockerClient()

--- a/pkg/nodeps/utils.go
+++ b/pkg/nodeps/utils.go
@@ -10,7 +10,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 	"unicode"
 
 	"golang.org/x/term"
@@ -50,18 +49,15 @@ func RemoveItemFromSlice(slice []string, item string) []string {
 	return slice
 }
 
-// From https://www.calhoun.io/creating-random-strings-in-go/
-// nolint: revive
-var seededRand *rand.Rand = rand.New(
-	rand.NewSource(time.Now().UnixNano()))
-
 // RandomString creates a random string with a set length
+// From https://www.calhoun.io/creating-random-strings-in-go/
+// We don't need rand.Rand here for seed, see https://pkg.go.dev/math/rand#Seed
 func RandomString(length int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyz"
 
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = charset[seededRand.Intn(len(charset))]
+		b[i] = charset[rand.Intn(len(charset))]
 	}
 	return string(b)
 }


### PR DESCRIPTION
## The Issue

- After we merged #8145

1. When a Docker image tag is moved to a different image (e.g. after a second push or a `docker tag`), `ddev start` doesn't rebuild the project images because the old fingerprint still matches the tag name.

2. Race condition in https://github.com/ddev/ddev/actions/runs/25064604457/job/73428302255#step:13:563

    Two concurrent goroutines (`PopulateGlobalCustomCommandFiles` and `StartDdevRouter → `PushGlobalTraefikConfig` → ListFilesInVolume`) both call `RandomString()`, which uses a shared `*rand.Rand` instance (`seededRand`) without locking:

    ```
    WARNING: DATA RACE
    Read at 0x00c0002bf500 by goroutine 122:
      math/rand.(*rngSource).Uint64()
          /opt/hostedtoolcache/go/1.26.2/x64/src/math/rand/rng.go:239 +0x30
      ...
      github.com/ddev/ddev/pkg/nodeps.RandomString()
          /home/runner/work/ddev/ddev/pkg/nodeps/utils.go:64 +0x28a
      github.com/ddev/ddev/pkg/ddevapp.performTaskInContainer()
          /home/runner/work/ddev/ddev/pkg/ddevapp/commands.go:86 +0x2b0
      github.com/ddev/ddev/pkg/ddevapp.PopulateGlobalCustomCommandFiles()
          /home/runner/work/ddev/ddev/pkg/ddevapp/commands.go:57 +0x46b
      github.com/ddev/ddev/pkg/ddevapp.(*DdevApp).Start.func8()
          /home/runner/work/ddev/ddev/pkg/ddevapp/ddevapp.go:2139 +0x29

    Previous write at 0x00c0002bf500 by goroutine 123:
      math/rand.(*rngSource).Uint64()
          /opt/hostedtoolcache/go/1.26.2/x64/src/math/rand/rng.go:239 +0x44
      ...
      github.com/ddev/ddev/pkg/nodeps.RandomString()
          /home/runner/work/ddev/ddev/pkg/nodeps/utils.go:64 +0x144
      github.com/ddev/ddev/pkg/dockerutil.ListFilesInVolume()
          /home/runner/work/ddev/ddev/pkg/dockerutil/volumes.go:266 +0x16e
      github.com/ddev/ddev/pkg/ddevapp.PushGlobalTraefikConfig()
          /home/runner/work/ddev/ddev/pkg/ddevapp/traefik.go:397 +0x4c0d
      github.com/ddev/ddev/pkg/ddevapp.StartDdevRouter()
          /home/runner/work/ddev/ddev/pkg/ddevapp/router.go:150 +0xc66
      github.com/ddev/ddev/pkg/ddevapp.(*DdevApp).Start.func9()
          /home/runner/work/ddev/ddev/pkg/ddevapp/ddevapp.go:2145 +0x66
    ```

3. Race condition in https://github.com/ddev/ddev/actions/runs/25065414461/job/73431107278#step:13:16538

    The chown goroutine called `EnsureSSHAgentContainer()` after finishing chown, but `EnsureSSHAgentContainer()` reads `app.ComposeYaml` while the main goroutine was concurrently writing it inside `WriteDockerComposeYAML()`:

    ```
    WARNING: DATA RACE
    Read at 0x00c0002e47b0 by goroutine 12619:
      github.com/ddev/ddev/pkg/ddevapp.(*DdevApp).GetWebEnvVar()
          /home/runner/work/ddev/ddev/pkg/ddevapp/ddevapp.go:734 +0xf5
      ...
      github.com/ddev/ddev/pkg/ddevapp.(*DdevApp).EnsureSSHAgentContainer()
          /home/runner/work/ddev/ddev/pkg/ddevapp/ssh_auth.go:55 +0x6c5
      github.com/ddev/ddev/pkg/ddevapp.(*DdevApp).Start.func4()
          /home/runner/work/ddev/ddev/pkg/ddevapp/ddevapp.go:1790 +0x6f8

    Previous write at 0x00c0002e47b0 by goroutine 12613:
      github.com/ddev/ddev/pkg/ddevapp.(*DdevApp).WriteDockerComposeYAML()
          /home/runner/work/ddev/ddev/pkg/ddevapp/compose_yaml.go:85 +0x94a
      github.com/ddev/ddev/pkg/ddevapp.(*DdevApp).Start()
          /home/runner/work/ddev/ddev/pkg/ddevapp/ddevapp.go:1814 +0x43ca
    ```

## How This PR Solves The Issue

**For 1:** `buildContextFingerprint()` now calls `dockerutil.ImageID()` to resolve each tag to its `sha256:` content-addressable digest before hashing. If a tag is re-pointed to a different image, the digest changes and the build is triggered. `pullWg.Wait()` is placed before the fingerprint check so the digest reflects the freshly-pulled image rather than a stale local one.

**For 2:** Remove the shared `*rand.Rand` instance (`seededRand`) and replace all calls with the package-level `rand.Intn()`, which has been auto-seeded and internally locked since Go 1.20. This project requires Go 1.25, so it is guaranteed safe, see https://pkg.go.dev/math/rand#Seed

**For 3:** Move `EnsureSSHAgentContainer()` out of the chown goroutine and run it sequentially after `chownWg.Wait()`, which happens after `WriteDockerComposeYAML()` completes. This preserves the chown parallelism while eliminating the read/write race on `app.ComposeYaml`.

## Manual Testing Instructions

Using this PR, the webserver image is rebuilt on tag change:

```
$ ddev poweroff

$ ddev version -j | jq -r .raw.web
ddev/ddev-webserver:20260427_stasadev_dockerfile

$ ddev start

$ docker pull ddev/ddev-webserver:v1.25.2

$ docker images ddev/ddev-webserver:v1.25.2 -q
fc4767e92965

$ docker images ddev/ddev-webserver:20260427_stasadev_dockerfile -q
d19724abd31d

$ docker tag ddev/ddev-webserver:v1.25.2 ddev/ddev-webserver:20260427_stasadev_dockerfile

# now 20260427_stasadev_dockerfile points to a different image
$ docker images ddev/ddev-webserver:20260427_stasadev_dockerfile -q
fc4767e92965

$ ddev start
...
Building project images............
...

$ ddev start
# no "Building project images..." — hash is unchanged

# move the tag back

$ docker pull ddev/ddev-webserver:20260427_stasadev_dockerfile

$ docker images ddev/ddev-webserver:20260427_stasadev_dockerfile -q
d19724abd31d

$ ddev start
...
Building project images.....
...
```
