### PR TITLE
feat(docker): always pull images with `--no-cache`

### DIFF
--- a/cmd/ddev/cmd/debug-rebuild.go
+++ b/cmd/ddev/cmd/debug-rebuild.go
@@ -72,6 +72,13 @@ var DebugRebuildCmd = &cobra.Command{
 		if withoutCache {
 			buildArgs = append(buildArgs, "--no-cache")
 			output.UserOut.Printf("Rebuilding project images without Docker cache...")
+			additionalImages, findErr := app.FindAllImages()
+			if findErr != nil {
+				util.Warning("Unable to find project images: %v", findErr)
+			}
+			if pullErr := ddevapp.PullBaseContainerImages(additionalImages, true); pullErr != nil {
+				util.Warning("Unable to pull Docker images: %v", pullErr)
+			}
 		} else {
 			output.UserOut.Printf("Rebuilding project images using Docker cache...")
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1587,7 +1587,7 @@ Fix with 'ddev config global --required-docker-compose-version="" --use-docker-c
 	// Pull images in background while config prep continues
 	var pullWg sync.WaitGroup
 	pullWg.Go(func() {
-		if pullErr := PullBaseContainerImages(additionalImages, false); pullErr != nil {
+		if pullErr := PullBaseContainerImages(additionalImages, app.NoCache); pullErr != nil {
 			util.Warning("Unable to pull Docker images: %v", pullErr)
 		}
 	})


### PR DESCRIPTION
## The Issue

When we rebuild Docker images in PRs we need to run:

```bash
ddev utility download-images
ddev restart
```

And recently I had to use `ddev restart --no-cache` to catch a bug described in #8359 (`ddev start` doesn't rebuild the project images because the old fingerprint still matches the tag name).

Which made me think: why doesn't `ddev restart --no-cache` pull anything?

It seems like a natural thing to do, and it's easier to run one command instead of two.

## How This PR Solves The Issue

Adds pull when we use `--no-cache`.

## Manual Testing Instructions

Look at `docker-compose pull` output in:

```bash
ddev start --no-cache
ddev restart --no-cache
ddev utility rebuild
```

And no `docker-compose pull` output (when we already have all the images) in:

```bash
ddev start
ddev restart
ddev utility rebuild --cache
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
