### PR TITLE
fix(test): skip TestCheckLiveConnectivityWithProject on Rancher/Colima/Lima, fix misleading WSL2 labels

### DIFF
--- a/cmd/ddev/cmd/utility-tls-diagnose.go
+++ b/cmd/ddev/cmd/utility-tls-diagnose.go
@@ -124,8 +124,8 @@ func runTLSDiagnose() int {
 	}
 
 	if app != nil && app.AppRoot != "" {
-		linuxConnIssues, windowsConnIssues := checkLiveConnectivity(caRoot, app)
-		if linuxConnIssues || windowsConnIssues {
+		hostConnIssues, windowsConnIssues := checkLiveConnectivity(caRoot, app)
+		if hostConnIssues || windowsConnIssues {
 			hasIssues = true
 		}
 	}
@@ -913,10 +913,10 @@ func checkCertFile(certPath string, caPool *x509.CertPool, expectedHostnames []s
 }
 
 // checkLiveConnectivity checks HTTPS connectivity to a running project.
-// Returns (linuxIssues, windowsIssues) where linuxIssues covers the Linux/WSL2/macOS-side
-// tls.Dial check and windowsIssues covers the Windows-side PowerShell check (WSL2 only;
-// always false on non-WSL2 systems).
-func checkLiveConnectivity(caRoot string, app *ddevapp.DdevApp) (linuxIssues bool, windowsIssues bool) {
+// Returns (hostIssues, windowsIssues) where hostIssues covers the host-side
+// tls.Dial check (Linux/macOS/WSL2) and windowsIssues covers the Windows-side
+// PowerShell check (WSL2 only; always false on non-WSL2 systems).
+func checkLiveConnectivity(caRoot string, app *ddevapp.DdevApp) (hostIssues bool, windowsIssues bool) {
 	output.UserOut.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 	output.UserOut.Println("Live Connectivity")
 	output.UserOut.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
@@ -947,7 +947,7 @@ func checkLiveConnectivity(caRoot string, app *ddevapp.DdevApp) (linuxIssues boo
 		sysPool, sysErr := x509.SystemCertPool()
 		if sysErr != nil {
 			tlsFail("Cannot load CA for live check: %v", err)
-			linuxIssues = true
+			hostIssues = true
 			caPool = nil
 		} else {
 			caPool = sysPool
@@ -956,7 +956,7 @@ func checkLiveConnectivity(caRoot string, app *ddevapp.DdevApp) (linuxIssues boo
 	}
 
 	if caPool != nil {
-		// Linux/WSL2/macOS-side TLS check via tls.Dial
+		// Host-side TLS check via tls.Dial (Linux/macOS/WSL2)
 		addr := fmt.Sprintf("localhost:%s", httpsPort)
 		tlsConfig := &tls.Config{
 			ServerName: hostname,
@@ -966,7 +966,7 @@ func checkLiveConnectivity(caRoot string, app *ddevapp.DdevApp) (linuxIssues boo
 		if err != nil {
 			tlsFail("TLS connection to %s (SNI: %s) failed: %v", addr, hostname, err)
 			output.UserOut.Println("    → Router may not be running or certificate is not trusted")
-			linuxIssues = true
+			hostIssues = true
 		} else {
 			conn.Close()
 			output.UserOut.Printf("  ✓ TLS verified: localhost:%s with SNI %s%s\n", httpsPort, hostname, caPoolNote)
@@ -1026,7 +1026,7 @@ try {
 	}
 
 	output.UserOut.Println()
-	return linuxIssues, windowsIssues
+	return hostIssues, windowsIssues
 }
 
 // loadCACertPool loads the mkcert rootCA.pem into an x509.CertPool.

--- a/cmd/ddev/cmd/utility-tls-diagnose_test.go
+++ b/cmd/ddev/cmd/utility-tls-diagnose_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
@@ -347,16 +348,18 @@ func TestCheckCertificateFilesRotatedCA(t *testing.T) {
 // checkLiveConnectivity against it, then stops it. This is the most realistic
 // integration test: it exercises tls.Dial against a real DDEV HTTPS endpoint.
 //
-// On WSL2, checkLiveConnectivity performs two independent checks:
-//   - Linux/WSL2-side: tls.Dial to localhost (what the DDEV process can reach)
-//   - Windows-side: PowerShell Invoke-WebRequest (what Chrome/Edge would see)
-//
-// Both are asserted separately so a failure on one side doesn't obscure the other.
+// checkLiveConnectivity always performs a host-side check (tls.Dial to localhost).
+// On WSL2 it additionally runs a Windows-side check via PowerShell Invoke-WebRequest
+// to verify what Chrome/Edge would see. Both are asserted separately.
 func TestCheckLiveConnectivityWithProject(t *testing.T) {
 	if len(TestSites) == 0 {
 		t.Skip("no TestSites configured")
 	}
 	caRoot := realCARoot(t)
+
+	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && (dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop()) {
+		t.Skip("skipping on Lima/Colima/Rancher Desktop: localhost port forwarding is unpredictable")
+	}
 
 	site := TestSites[0]
 	app, err := ddevapp.NewApp(site.Dir, false)
@@ -368,12 +371,12 @@ func TestCheckLiveConnectivityWithProject(t *testing.T) {
 	require.NoError(t, app.Start(), "failed to start TestSites[0]")
 
 	restore := util.CaptureUserOut()
-	linuxIssues, windowsIssues := checkLiveConnectivity(caRoot, app)
+	hostIssues, windowsIssues := checkLiveConnectivity(caRoot, app)
 	out := restore()
 
-	// Linux/WSL2-side TLS must always succeed on a properly configured machine.
-	require.False(t, linuxIssues, "Linux/WSL2-side TLS connection to running project must succeed")
-	require.Contains(t, out, "TLS verified", "output must confirm Linux-side TLS success")
+	// Host-side TLS must always succeed on a properly configured machine.
+	require.False(t, hostIssues, "Host-side TLS connection to running project must succeed")
+	require.Contains(t, out, "TLS verified", "output must confirm TLS success")
 
 	if nodeps.IsWSL2() {
 		caRootIsWindowsMount := strings.HasPrefix(caRoot, "/mnt/")
@@ -406,10 +409,10 @@ func TestCheckLiveConnectivityNotRunning(t *testing.T) {
 	_ = app.Stop(false, false)
 
 	restore := util.CaptureUserOut()
-	linuxIssues, windowsIssues := checkLiveConnectivity(caRoot, app)
+	hostIssues, windowsIssues := checkLiveConnectivity(caRoot, app)
 	out := restore()
 
-	require.False(t, linuxIssues, "a stopped project is not a Linux-side TLS issue — should return no issues")
+	require.False(t, hostIssues, "a stopped project is not a host-side TLS issue — should return no issues")
 	require.False(t, windowsIssues, "a stopped project is not a Windows-side TLS issue — should return no issues")
 	require.Contains(t, out, "not running", "output should explain why connectivity was skipped")
 }


### PR DESCRIPTION
## The Issue

Rancher Desktop (Lima-based) intermittently fails `TestCheckLiveConnectivityWithProject` because `tls.Dial` to `localhost` is unreliable on Lima-based runtimes — the same fundamental networking constraint that causes `extra_expose_test.go`, `traefik_test.go`, and `router_test.go` to all skip on Rancher/Colima/Lima.

Additionally, the test and function were written with a WSL2-centric mindset: the return value was named `linuxIssues` and assertion messages said "Linux/WSL2-side TLS connection must succeed", which is confusing/wrong on macOS Rancher Desktop.

## How This PR Solves The Issue

- Adds the standard `IsColima() || IsLima() || IsRancherDesktop()` skip (guarded by `DDEV_RUN_TEST_ANYWAY`) to `TestCheckLiveConnectivityWithProject`, matching the pattern used elsewhere in the test suite.
- Renames `linuxIssues` → `hostIssues` in `checkLiveConnectivity` and all callers/tests.
- Updates test assertion messages from "Linux/WSL2-side" to "host-side" so failures on macOS report something accurate.

## Manual Testing Instructions

- On a Rancher Desktop macOS machine, run `go test -v -run TestCheckLiveConnectivityWithProject ./cmd/ddev/cmd/` — it should now skip.
- On a normal Docker Desktop macOS or Linux machine the test should still pass.
- Run `DDEV_RUN_TEST_ANYWAY=true go test -v -run TestCheckLiveConnectivityWithProject ./cmd/ddev/cmd/` on Rancher to force it to run.

## Automated Testing Overview

No new tests. The existing `TestCheckLiveConnectivityWithProject` test already covers the fixed code path and was verified passing on Linux Docker before this commit.

## Release/Deployment Notes

Test-only change. No impact on DDEV behavior or released binaries.