### PR TITLE
fix(drupal): use configured project type for settings.php version selection

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -19,8 +19,8 @@ import (
 )
 
 // DefaultDrupalSettingsVersion is the version used for settings.php/settings.ddev.php
-// when no known Drupal version is detected
-const DefaultDrupalSettingsVersion = "10"
+// when using the generic "drupal" type and no Drupal version can be detected from the codebase
+const DefaultDrupalSettingsVersion = "11"
 
 // DrupalSettings encapsulates all the configurations for a Drupal site.
 type DrupalSettings struct {
@@ -313,18 +313,29 @@ func setDrupalSiteSettingsPaths(app *DdevApp) {
 	app.SiteDdevSettingsFile = filepath.Join(settingsFileBasePath, drupalConfig.SitePath, drupalConfig.SiteSettingsDdev)
 }
 
-// GetDrupalVersion finds the drupal8+ version so it can be used
+// GetDrupalVersion finds the drupal version so it can be used
 // for setting requirements.
-// It can only work if there is configured Drupal8+ code
+// For explicit versioned types (drupal6-drupal12), returns the version from app.Type.
+// For the generic "drupal" type, detects from core/lib/Drupal.php if available.
 func GetDrupalVersion(app *DdevApp) (string, error) {
-	// For drupal6/7 we use the apptype provided as version
+	// For explicitly versioned types, return the version from the configured type
 	switch app.Type {
 	case nodeps.AppTypeDrupal6:
 		return "6", nil
 	case nodeps.AppTypeDrupal7:
 		return "7", nil
+	case nodeps.AppTypeDrupal8:
+		return "8", nil
+	case nodeps.AppTypeDrupal9:
+		return "9", nil
+	case nodeps.AppTypeDrupal10:
+		return "10", nil
+	case nodeps.AppTypeDrupal11:
+		return "11", nil
+	case nodeps.AppTypeDrupal12:
+		return "12", nil
 	}
-	// Otherwise figure out the version from existing code
+	// For generic "drupal" type, detect from existing code
 	f := filepath.Join(app.GetAbsDocroot(false), "core/lib/Drupal.php")
 	hasVersion, matches, err := fileutil.GrepStringInFile(f, `const VERSION = '([0-9]+)`)
 	v := ""

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -18,10 +18,6 @@ import (
 	copy2 "github.com/otiai10/copy"
 )
 
-// DefaultDrupalSettingsVersion is the version used for settings.php/settings.ddev.php
-// when using the generic "drupal" type and no Drupal version can be detected from the codebase
-const DefaultDrupalSettingsVersion = "11"
-
 // DrupalSettings encapsulates all the configurations for a Drupal site.
 type DrupalSettings struct {
 	DeployName       string
@@ -123,7 +119,7 @@ func writeDrupalSettingsPHP(app *DdevApp) error {
 	} else {
 		drupalVersion, err := GetDrupalVersion(app)
 		if err != nil || drupalVersion == "" {
-			drupalVersion = DefaultDrupalSettingsVersion
+			drupalVersion = nodeps.DefaultDrupalSettingsVersion
 		}
 		appType = "drupal" + drupalVersion
 	}
@@ -190,7 +186,7 @@ func writeDrupalSettingsDdevPhp(settings *DrupalSettings, filePath string, app *
 
 	drupalVersion, err := GetDrupalVersion(app)
 	if err != nil || drupalVersion == "" {
-		drupalVersion = DefaultDrupalSettingsVersion
+		drupalVersion = nodeps.DefaultDrupalSettingsVersion
 	}
 	t, err := template.New("settings.ddev.php").ParseFS(bundledAssets, path.Join("drupal", "drupal"+drupalVersion, "settings.ddev.php"))
 	if err != nil {

--- a/pkg/ddevapp/settings_test.go
+++ b/pkg/ddevapp/settings_test.go
@@ -291,6 +291,55 @@ func TestDrupalBackdropCreateGitIgnoreIfNoneExists(t *testing.T) {
 	}
 }
 
+// TestDrupalSettingsVersionWithoutCode verifies that when no Drupal codebase is present
+// (e.g., before composer create-project), the settings files written match the configured
+// project type rather than the default fallback version.
+func TestDrupalSettingsVersionWithoutCode(t *testing.T) {
+	type versionStrings struct {
+		settingsPhp     string
+		settingsDdevPhp string
+	}
+	versionExpectations := map[string]versionStrings{
+		nodeps.AppTypeDrupal8:  {"DDEV-created Drupal 8 settings.php", "Drupal 8 settings.ddev.php"},
+		nodeps.AppTypeDrupal9:  {"DDEV-created Drupal 9 settings.php", "Drupal 9 settings.ddev.php"},
+		nodeps.AppTypeDrupal10: {"DDEV-created Drupal 10 settings.php", "Drupal 10 settings.ddev.php"},
+		nodeps.AppTypeDrupal11: {"DDEV-created Drupal 11 settings.php", "Drupal 11 settings.ddev.php"},
+		nodeps.AppTypeDrupal12: {"DDEV-created Drupal 12 settings.php", "Drupal 12 settings.ddev.php"},
+	}
+
+	dir := testcommon.CreateTmpDir(t.Name())
+	app, err := ddevapp.NewApp(dir, true)
+	require.NoError(t, err)
+
+	err = os.MkdirAll(filepath.Join(dir, app.Docroot, "sites", "default"), 0777)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = app.Stop(true, false)
+		require.NoError(t, err)
+		_ = os.RemoveAll(dir)
+	})
+
+	for appType, expected := range versionExpectations {
+		app.Type = appType
+		settingsPath := filepath.Join(dir, app.Docroot, "sites", "default", "settings.php")
+		settingsDdevPath := filepath.Join(dir, app.Docroot, "sites", "default", "settings.ddev.php")
+		_ = os.Remove(settingsPath)
+		_ = os.Remove(settingsDdevPath)
+
+		_, err = app.CreateSettingsFile()
+		require.NoError(t, err, "appType=%s", appType)
+
+		found, err := fileutil.FgrepStringInFile(settingsPath, expected.settingsPhp)
+		require.NoError(t, err, "appType=%s", appType)
+		require.True(t, found, "Expected to find %q in settings.php for appType=%s but did not", expected.settingsPhp, appType)
+
+		found, err = fileutil.FgrepStringInFile(settingsDdevPath, expected.settingsDdevPhp)
+		require.NoError(t, err, "appType=%s", appType)
+		require.True(t, found, "Expected to find %q in settings.ddev.php for appType=%s but did not", expected.settingsDdevPhp, appType)
+	}
+}
+
 // TestDrupalBackdropConsistentHash makes sure that the hash_salt provided in
 // settings.ddev.php is consistent across multiple `ddev start` but
 // different between two project names

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -85,6 +85,10 @@ var ValidWebserverTypes = map[string]bool{
 
 const AppTypeDrupalLatestStable = AppTypeDrupal11
 
+// DefaultDrupalSettingsVersion is the version used for settings.php/settings.ddev.php
+// when using the generic "drupal" type and no Drupal version can be detected from the codebase
+const DefaultDrupalSettingsVersion = "11"
+
 // App types
 const (
 	AppTypeNone        = ""


### PR DESCRIPTION
## The Issue

When using an explicit project type like `drupal12` (e.g. `ddev config --project-type=drupal12 --docroot=web`) before running `composer create-project`, the `core/lib/Drupal.php` file does not yet exist. `GetDrupalVersion` fell through to reading that file, got nothing, and fell back to `DefaultDrupalSettingsVersion` (was `"10"`), so the wrong `settings.php` and `settings.ddev.php` templates were written.

This was discovered in development and testing of
* https://github.com/joachim-n/drupal-core-development-project/pull/47

(where the Drupal core code didn't exist and wasn't discoverable at time of `ddev config` or `ddev start`)

## How This PR Solves The Issue

- `GetDrupalVersion` now returns the version directly from `app.Type` for all explicitly versioned types (`drupal8`–`drupal12`). Filesystem detection via `core/lib/Drupal.php` is now only used for the generic `drupal` type (the floating alias for the current stable).
- Raises `DefaultDrupalSettingsVersion` from `"10"` to `"11"` so the generic `drupal` type also gets a current fallback.

## Manual Testing Instructions

1. `mkdir ~/tmp/drupal12test && cd ~/tmp/drupal12test`
2. `ddev config --project-type=drupal12 --docroot=web` (do NOT run composer first)
3. `ddev start`
4. Verify `web/sites/default/settings.php` contains `DDEV-created Drupal 12 settings.php`
5. Verify `web/sites/default/settings.ddev.php` contains `Drupal 12 settings.ddev.php`

## Automated Testing Overview

Added `TestDrupalSettingsVersionWithoutCode` in `settings_test.go` which creates an app for each explicit Drupal type (8–12) with no codebase present and asserts that both `settings.php` and `settings.ddev.php` contain the version-specific identifying string for that type.

## Release/Deployment Notes

No impact on existing projects that already have settings files written. Only affects fresh `ddev config` + `ddev start` before `composer create-project` has been run.