### PR TITLE
docs(mutagen): explain how to reset to the default mode, fixes #8367

### DIFF
--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -36,6 +36,9 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
     On macOS and traditional Windows, Mutagen is enabled globally by default. 
 
     To disable Mutagen on a single project, run `ddev config --performance-mode=none && ddev restart`.
+
+    To revert Mutagen back to default gloablly controlled mode on a single project run `ddev config --performance-mode="" && ddev restart`.
+    (Then DDEV engine decides if it go on or off by itself)
     
     To disable Mutagen globally on all ddev projects, run `ddev mutagen reset && ddev config global --performance-mode=none && ddev config --performance-mode=none`. To then use Mutagen on a specific project, run [`ddev stop`](../usage/commands.md#stop), enable it with `ddev config --performance-mode=mutagen`, and [`ddev start`](../usage/commands.md#start) again.
 

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -37,7 +37,7 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
 
     To disable Mutagen on a single project, run `ddev config --performance-mode=none && ddev restart`.
 
-    To revert Mutagen back to default gloablly controlled mode on a single project run `ddev config --performance-mode="" && ddev restart`.
+    To revert Mutagen back to the default globally controlled mode for a single project, run `ddev config --performance-mode-reset && ddev restart`.
     
     (This removes the configuration line so global settings are used instead.)
     

--- a/docs/content/users/install/performance.md
+++ b/docs/content/users/install/performance.md
@@ -38,7 +38,8 @@ Mutagen is enabled by default on Mac and traditional Windows, and it can be disa
     To disable Mutagen on a single project, run `ddev config --performance-mode=none && ddev restart`.
 
     To revert Mutagen back to default gloablly controlled mode on a single project run `ddev config --performance-mode="" && ddev restart`.
-    (Then DDEV engine decides if it go on or off by itself)
+    
+    (This removes the configuration line so global settings are used instead.)
     
     To disable Mutagen globally on all ddev projects, run `ddev mutagen reset && ddev config global --performance-mode=none && ddev config --performance-mode=none`. To then use Mutagen on a specific project, run [`ddev stop`](../usage/commands.md#stop), enable it with `ddev config --performance-mode=mutagen`, and [`ddev start`](../usage/commands.md#start) again.
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- Fixes #8367

Documentation page does not show how revert mutagen back to globally controlled configuration.

Use case: if a developer on a non-mutagen enabled environment  wants to generate mutagen configuration, then edit it (e.g. add additional ignored folder) and then remove it (or enabled it by mistake), they don't know how.

## How This PR Solves The Issue

Adds revert command to documentation that deletes the line `performance-mode=<value>` so global configuration is used.

## Manual Testing Instructions

Please check my markdown formatting and order.

https://ddev--8368.org.readthedocs.build/en/8368/users/install/performance/#mutagen

## Automated Testing Overview

Nil.

## Release/Deployment Notes

Nil.
