### PR TITLE
docs: switch to properdocs and mkdocs-materialx, fixes #8216

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -27,7 +27,7 @@ echo ""
 echo "🔍 Development tools status:"
 echo "  golangci-lint: $(command -v golangci-lint &> /dev/null && echo '✅ installed' || echo '❌ not found')"
 echo "  markdownlint:  $(command -v markdownlint &> /dev/null && echo '✅ installed' || echo '❌ not found')"
-echo "  mkdocs:        $(command -v mkdocs &> /dev/null && echo '✅ installed' || echo '⚠️  not installed (optional, will be skipped)')"
+echo "  mkdocs:        $(command -v properdocs &> /dev/null && echo '✅ installed' || echo '⚠️  not installed (optional, will be skipped)')"
 
 if [ "$DOCKER_AVAILABLE" = true ]; then
     echo "  Docker:        ✅ available"

--- a/.envrc
+++ b/.envrc
@@ -23,7 +23,7 @@ if [[ -d "$DEV_TOOLS_DIR/python/bin" && -d "$DEV_TOOLS_DIR/node/bin" ]]; then
 else
   # Check if any development tools are missing and show helpful message
   missing_tools=()
-  if ! command -v mkdocs >/dev/null 2>&1; then missing_tools+=("mkdocs"); fi
+  if ! command -v properdocs >/dev/null 2>&1; then missing_tools+=("properdocs"); fi
   if ! command -v pyspelling >/dev/null 2>&1; then missing_tools+=("pyspelling"); fi
   if ! command -v markdownlint >/dev/null 2>&1; then missing_tools+=("markdownlint"); fi
   if ! command -v textlint >/dev/null 2>&1; then missing_tools+=("textlint"); fi

--- a/.github/workflows/docscheck.yml
+++ b/.github/workflows/docscheck.yml
@@ -85,4 +85,4 @@ jobs:
         run: |
           sudo pip3 install setuptools
           sudo pip3 install -r docs/mkdocs-pip-requirements
-          mkdocs build -d /tmp/mkdocsbuild
+          properdocs build -d /tmp/mkdocsbuild -f mkdocs.yml

--- a/.github/workflows/docspublish.yml
+++ b/.github/workflows/docspublish.yml
@@ -17,6 +17,6 @@ jobs:
           python-version: 3.x
       - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
       - run: pip install -r docs/mkdocs-pip-requirements
-      - run: mkdocs build
+      - run: properdocs build -f mkdocs.yml
       - run: ls -l .nojekyll || true
-      - run: mkdocs gh-deploy --force --no-history
+      - run: properdocs gh-deploy --force --no-history -f mkdocs.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
   # build.commands is used to make !ENV syntax work in mkdocs.yml
   commands:
     - pip install -r docs/mkdocs-pip-requirements
-    - mkdocs build --site-dir $READTHEDOCS_OUTPUT/html
+    - properdocs build --site-dir $READTHEDOCS_OUTPUT/html -f mkdocs.yml
 
 python:
   install:

--- a/Makefile
+++ b/Makefile
@@ -206,9 +206,9 @@ markdownlint:
 # Install mkdocs locally using
 # https://docs.ddev.com/en/stable/developers/testing-docs/
 mkdocs:
-	@echo "mkdocs: "
-	@CMD="mkdocs build -d /tmp/mkdocsbuild"; \
-	if command -v mkdocs >/dev/null 2>&1; then \
+	@echo "properdocs: "
+	@CMD="properdocs build -d /tmp/mkdocsbuild -f mkdocs.yml"; \
+	if command -v properdocs >/dev/null 2>&1; then \
 		$$CMD ; \
 	else \
 		echo "Not running mkdocs because it's not installed (see .envrc file)"; \
@@ -218,8 +218,8 @@ mkdocs:
 # It does require installing mkdocs and its requirements
 # See https://docs.ddev.com/en/stable/developers/testing-docs/
 mkdocs-serve:
-	@if command -v mkdocs >/dev/null ; then \
-		mkdocs serve; \
+	@if command -v properdocs >/dev/null ; then \
+		properdocs serve -f mkdocs.yml; \
 	else \
 		echo "mkdocs is not installed (see .envrc file)" && exit 2; \
 	fi; \

--- a/docs/content/assets/extra.css
+++ b/docs/content/assets/extra.css
@@ -115,3 +115,53 @@ dt {
 img[alt="Figurative Mark"], img[alt="Word/Figurative Mark"] {
     height: 150px
 }
+
+/* materialx uses color-mix() on --mx-topbar-bg in modern browsers, washing out the header.
+   Higher specificity (2 attrs) overrides the @supports color-mix block (1 attr). */
+[data-md-color-scheme][data-mx-topbar=primary] {
+    --mx-topbar-bg: var(--md-primary-fg-color);
+}
+
+/* Keep the sponsor announce banner dark in both light and dark modes */
+[data-md-component="announce"] .md-banner {
+    background-color: #1e2127;
+}
+
+/* materialx (10.0.8) added hover/focus underlines to content links; revert to original */
+.md-typeset a:hover,
+.md-typeset a:focus {
+    text-decoration: none;
+}
+
+/* materialx (10.0.3) added indentation guides to TOC; revert to original */
+[dir=ltr] .md-nav--secondary .md-nav__item .md-nav__list,
+[dir=rtl] .md-nav--secondary .md-nav__item .md-nav__list {
+    border: none;
+}
+
+/* materialx (10.0.3) added zebra-striping to tables; revert to original */
+.md-typeset table:not([class]) tbody tr:nth-of-type(odd) {
+    background-color: transparent;
+}
+
+/* materialx glass sidebar effect (semi-transparent + blur + rounded); revert to original solid */
+.md-sidebar--primary,
+.md-sidebar--secondary {
+    background-color: var(--md-default-bg-color);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    border-radius: 0;
+}
+
+/* materialx active sidebar link uses --md-primary-fg-color (dark indigo) as text in dark mode,
+   giving near-zero contrast on the dark sidebar background */
+[data-md-color-scheme="slate"] .md-nav--primary .md-nav__item .md-nav__link--active {
+    color: var(--md-typeset-a-color);
+    background-color: var(--md-default-fg-color--lightest);
+}
+
+/* materialx sets primary nav link padding to .35rem (vs .2rem for secondary), making the left
+   sidebar items taller than the right TOC; match them */
+.md-nav--primary .md-nav__link {
+    padding: .2rem .6rem;
+}

--- a/docs/content/developers/testing-docs.md
+++ b/docs/content/developers/testing-docs.md
@@ -42,7 +42,7 @@ For documentation development and testing, install the required tools once using
 scripts/install-dev-tools.sh
 ```
 
-This installs `mkdocs`, `pyspelling`, `markdownlint`, `textlint`, `linkspector`, and `aspell` to `$HOME/.ddev-dev-tools/`.
+This installs `properdocs`, `pyspelling`, `markdownlint`, `textlint`, `linkspector`, and `aspell` to `$HOME/.ddev-dev-tools/`.
 
 The project's `.envrc` automatically adds these tools to your PATH when you're in the DDEV directory. If you want the tools available globally, add this to your shell profile (`.bashrc`, `.bash_profile`, or `.zshrc`):
 

--- a/docs/mkdocs-pip-requirements
+++ b/docs/mkdocs-pip-requirements
@@ -3,9 +3,7 @@ numpy>=1.25.2
 pandas>=2.0.3
 matplotlib>=3.7.2
 Babel>=2.9.1
-# Temporarily pin click until this is resolved in MkDocs,
-# see https://github.com/mkdocs/mkdocs/issues/4032
-click>=7.1.2,<=8.2.1
+click>=7.1.2
 future>=0.18.2
 gitdb>=4.0.7
 GitPython>=3.1.14
@@ -18,11 +16,11 @@ lunr>=0.6.2
 Markdown>=3.3.4
 MarkupSafe>=2.1.1
 mdx-truly-sane-lists>=1.2
-mkdocs>=1.5.1
+properdocs>=1.6.7
 mkdocs-git-authors-plugin>=0.6.4
 mkdocs-git-committers-plugin-2>=0.4.1
 mkdocs-git-revision-date-localized-plugin>=0.9
-mkdocs-material>=9
+mkdocs-materialx>=10
 mkdocs-material-extensions>=1
 mkdocs-minify-plugin>=0.4.1
 mkdocs-redirects>=1.0.4

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -122,7 +122,7 @@
     {% endif %}
 
     <!-- Button to open search modal -->
-    {% if "material/search" in config.plugins %}
+    {% if "materialx/search" in config.plugins %}
       <label class="md-header__button md-icon" for="__search">
         {% set icon = config.theme.icon.search or "material/magnify" %}
         {% include ".icons/" ~ icon ~ ".svg" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,8 +19,9 @@ docs_dir: docs/content
 
 # Configuration
 theme:
-  name: material
+  name: materialx
   custom_dir: docs/overrides
+  topbar_style: primary
   icon:
     edit: material/pencil
   palette:

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -81,18 +81,7 @@ install_python_tools() {
 
   source "$PYTHON_ENV/bin/activate"
 
-  # Download mkdocs requirements from repository
-  log_info "Fetching mkdocs requirements from DDEV repository..."
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL https://github.com/ddev/ddev/raw/refs/heads/main/docs/mkdocs-pip-requirements \
-      -o "$INSTALL_DIR/mkdocs-requirements.txt"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q https://github.com/ddev/ddev/raw/refs/heads/main/docs/mkdocs-pip-requirements \
-      -O "$INSTALL_DIR/mkdocs-requirements.txt"
-  else
-    log_error "Neither curl nor wget found. Cannot download requirements."
-    exit 1
-  fi
+  cp "$(dirname "$0")/../docs/mkdocs-pip-requirements" "$INSTALL_DIR/mkdocs-requirements.txt"
 
   # Create combined requirements file
   cat >"$INSTALL_DIR/python-requirements.txt" <<'EOF'
@@ -143,7 +132,7 @@ verify_installation() {
   export PATH="$PYTHON_ENV/bin:$NODE_ENV/bin:$PATH"
 
   local tools=(
-    "mkdocs"
+    "properdocs"
     "pyspelling"
     "markdownlint"
     "textlint"


### PR DESCRIPTION
## The Issue

- Fixes #8216

## How This PR Solves The Issue

- mkdocs -> properdocs https://github.com/orgs/ProperDocs/discussions/33
- mkdocs-material -> mkdocs-materialx https://jaywhj.github.io/mkdocs-materialx/changelog/index.html

CSS overrides for:
- MaterialX's new "Liquid Glass" styling (semi-transparent sidebars, color-mixed header, link underlines on hover, TOC indent guides, table zebra-striping, dark-mode active link contrast) are reverted in extra.css to preserve the original appearance as closely as possible.

## Manual Testing Instructions

https://ddev--8369.org.readthedocs.build/en/8369/ (compare it to https://docs.ddev.com/en/latest/)

```bash
rm -rf $HOME/.ddev-dev-tools
scripts/install-dev-tools.sh
cd ..
cd ddev
make mkdocs-serve
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
