### PR TITLE
docs: Add Xcode iOS simulator info (#8371) [skip ci]

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -200,6 +200,7 @@ WantedBy
 Webhosting
 WebSocket
 WRN
+Xcode
 XDebug
 XDG
 Xhprof

--- a/docs/content/users/install/configuring-browsers.md
+++ b/docs/content/users/install/configuring-browsers.md
@@ -41,7 +41,7 @@ The steps to install the root CA depend on the browser, but they generally follo
 Testing any DDEV site via Safari through the iOS simulator will lead to TLS errors due to the mkcert CA certificate not being trusted. You will need to manually install the CA certificate into the simulator device.
 
 1. Go to Library > Application Support > mkcert.
-2. Drag the rootCA.pem file onto the iOS simulator session.
+2. Drag the `rootCA.pem` file onto the iOS simulator session.
 3. Go to iOS Settings > General > About > Certificate Trust Settings and confirm that the mkcert certificate has full trust.
 
 This should now allow valid TLS connections to any DDEV domain/site.

--- a/docs/content/users/install/configuring-browsers.md
+++ b/docs/content/users/install/configuring-browsers.md
@@ -35,3 +35,13 @@ The steps to install the root CA depend on the browser, but they generally follo
 
 !!!note "Still having issues?"
     Check out [this specific mkcert thread](https://github.com/FiloSottile/mkcert/issues/370) for additional troubleshooting.
+
+## Xcode iOS simulator
+
+Testing any DDEV site via Safari through the iOS simulator will lead to TLS errors due to the mkcert CA certificate not being trusted. You will need to manually install the CA certificate into the simulator device.
+
+1. Go to Library > Application Support > mkcert.
+2. Drag the rootCA.pem file onto the iOS simulator session.
+3. Go to iOS Settings > General > About > Certificate Trust Settings and confirm that the mkcert certificate has full trust.
+
+This should now allow valid TLS connections to any DDEV domain/site.

--- a/docs/content/users/install/configuring-browsers.md
+++ b/docs/content/users/install/configuring-browsers.md
@@ -36,12 +36,13 @@ The steps to install the root CA depend on the browser, but they generally follo
 !!!note "Still having issues?"
     Check out [this specific mkcert thread](https://github.com/FiloSottile/mkcert/issues/370) for additional troubleshooting.
 
-## Xcode iOS simulator
+## Xcode iOS Simulator
 
 Testing any DDEV site via Safari through the iOS simulator will lead to TLS errors due to the mkcert CA certificate not being trusted. You will need to manually install the CA certificate into the simulator device.
 
-1. Go to Library > Application Support > mkcert.
-2. Drag the `rootCA.pem` file onto the iOS simulator session.
-3. Go to iOS Settings > General > About > Certificate Trust Settings and confirm that the mkcert certificate has full trust.
+1. Run `mkcert -CAROOT` and open that directory in Finder. On macOS, the default location is typically `~/Library/Application Support/mkcert`.
+2. Drag the `rootCA.pem` file from that directory onto the iOS simulator session.
+3. In the iOS simulator, open **Settings** and install the downloaded certificate profile. Depending on the iOS version, use **Profile Downloaded** or go to **General > VPN & Device Management** (or **Profiles**) and install the mkcert/root CA profile.
+4. After the profile is installed, go to **Settings > General > About > Certificate Trust Settings** and enable full trust for the mkcert certificate.
 
 This should now allow valid TLS connections to any DDEV domain/site.


### PR DESCRIPTION
## The Issue

- Enhancement of #1931 

Adds the original solution/steps from @jessedobbelaere to the docs for allowing TLS connections to DDEV sites in the iOS simulator.

## How This PR Solves The Issue

Instructions added for adding the mkcert CA certificate for trusting TLS connections.

Rendered at https://ddev--8371.org.readthedocs.build/en/8371/users/install/configuring-browsers/#adding-the-ddev-root-certificate-authority-to-browsers
