### PR TITLE
feat(utility): add `ddev utility addon-update-checker` command

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -16,6 +16,7 @@ CakePHP
 Callgraph
 CER
 CGroups
+CI
 CIDR
 CIFS
 CiviCRM
@@ -118,6 +119,7 @@ MinIO
 Misconfigured
 Monorepo
 MUTAGEN_DATA_DIRECTORY
+Mutagen's
 MyDevSite
 MySQL
 MySite
@@ -364,6 +366,7 @@ export
 extensibility
 extradb
 facebook
+feature's
 fi
 file
 filepath

--- a/cmd/ddev/cmd/utility-addon-update-checker.go
+++ b/cmd/ddev/cmd/utility-addon-update-checker.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	osexec "os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -73,60 +72,18 @@ ddev ut addon-update-checker -d /path/to/my-addons-workspace
 			}
 		}
 
-		// Collect directories to run in: the root itself if it has install.yaml,
-		// otherwise any immediate subdirectory that has install.yaml.
-		var dirs []string
-		if _, err := os.Stat(filepath.Join(rootDir, "install.yaml")); err == nil {
-			dirs = []string{rootDir}
-		} else {
-			entries, err := os.ReadDir(rootDir)
-			if err != nil {
-				util.Failed("Unable to read directory %s: %v", rootDir, err)
+		hostCmd := exec.HostCommand(bashPath, "-s")
+		hostCmd.Stdin = strings.NewReader(script)
+		hostCmd.Stdout = os.Stdout
+		hostCmd.Stderr = os.Stderr
+		hostCmd.Dir = rootDir
+
+		if err := hostCmd.Run(); err != nil {
+			var exiterr *osexec.ExitError
+			if errors.As(err, &exiterr) {
+				output.UserErr.Exit(exiterr.ExitCode())
 			}
-			for _, e := range entries {
-				if !e.IsDir() {
-					continue
-				}
-				subdir := filepath.Join(rootDir, e.Name())
-				if _, err := os.Stat(filepath.Join(subdir, "install.yaml")); err == nil {
-					dirs = append(dirs, subdir)
-				}
-			}
-		}
-
-		if len(dirs) == 0 {
-			util.Failed("No install.yaml found in %s or its immediate subdirectories", rootDir)
-		}
-
-		hadError := false
-		for _, dir := range dirs {
-			util.Success("\nRunning add-on update checker in: %s", dir)
-
-			hostCmd := exec.HostCommand(bashPath, "-s")
-			hostCmd.Stdin = strings.NewReader(script)
-			hostCmd.Stdout = os.Stdout
-			hostCmd.Stderr = os.Stderr
-			hostCmd.Dir = dir
-
-			exitCode := 0
-			if err := hostCmd.Run(); err != nil {
-				var exiterr *osexec.ExitError
-				if errors.As(err, &exiterr) {
-					exitCode = exiterr.ExitCode()
-				} else {
-					exitCode = 1
-				}
-				hadError = true
-			}
-			if exitCode == 0 {
-				util.Success("Exit code: %d", exitCode)
-			} else {
-				util.Error("Exit code: %d", exitCode)
-			}
-		}
-
-		if hadError {
-			output.UserErr.Exit(1)
+			util.Failed("Unable to run update checker script: %v", err)
 		}
 	},
 }

--- a/cmd/ddev/cmd/utility-addon-update-checker.go
+++ b/cmd/ddev/cmd/utility-addon-update-checker.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+var addonUpdateCheckerURLs = []string{
+	"https://ddev.com/s/addon-update-checker.sh",
+	"https://raw.githubusercontent.com/ddev/ddev-addon-template/main/.github/scripts/update-checker.sh",
+}
+
+// AddonUpdateCheckerCmd implements the "ddev utility addon-update-checker" command
+var AddonUpdateCheckerCmd = &cobra.Command{
+	Use:   "addon-update-checker",
+	Args:  cobra.NoArgs,
+	Short: "Run the DDEV add-on update checker script (for add-on developers)",
+	Long: `Fetch and run the DDEV add-on update checker script from https://ddev.com/s/addon-update-checker.sh
+This is a tool for add-on developers to verify their add-on's scripts and tooling are up to date.
+
+If the target directory contains install.yaml, the checker runs there. Otherwise, it scans immediate
+subdirectories for install.yaml and runs the checker in each one, which is useful when working in a
+workspace with multiple add-ons checked out alongside each other.`,
+	Example: `# Run in current directory (must contain install.yaml, or subdirs must)
+ddev utility addon-update-checker
+
+# Run in a specific add-on directory
+ddev ut addon-update-checker -d /path/to/my-addon
+
+# Run across all add-ons in a workspace
+ddev ut addon-update-checker -d /path/to/my-addons-workspace
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		bashPath := util.FindBashPath()
+		client := &http.Client{Timeout: 30 * time.Second}
+
+		var script string
+		for i, url := range addonUpdateCheckerURLs {
+			resp, err := client.Get(url)
+			if err != nil || resp.StatusCode != http.StatusOK {
+				if i < len(addonUpdateCheckerURLs)-1 {
+					util.Warning("Unable to fetch update checker script from %s, trying fallback", url)
+					continue
+				}
+				util.Failed("Unable to fetch update checker script: %v", err)
+			}
+			b, err := io.ReadAll(resp.Body)
+			util.CheckClose(resp.Body)
+			if err != nil {
+				util.Failed("Unable to read update checker script: %v", err)
+			}
+			script = string(b)
+			break
+		}
+
+		rootDir := cmd.Flag("dir").Value.String()
+		if rootDir == "" {
+			var err error
+			rootDir, err = os.Getwd()
+			if err != nil {
+				util.Failed("Unable to determine current directory: %v", err)
+			}
+		}
+
+		// Collect directories to run in: the root itself if it has install.yaml,
+		// otherwise any immediate subdirectory that has install.yaml.
+		var dirs []string
+		if _, err := os.Stat(filepath.Join(rootDir, "install.yaml")); err == nil {
+			dirs = []string{rootDir}
+		} else {
+			entries, err := os.ReadDir(rootDir)
+			if err != nil {
+				util.Failed("Unable to read directory %s: %v", rootDir, err)
+			}
+			for _, e := range entries {
+				if !e.IsDir() {
+					continue
+				}
+				subdir := filepath.Join(rootDir, e.Name())
+				if _, err := os.Stat(filepath.Join(subdir, "install.yaml")); err == nil {
+					dirs = append(dirs, subdir)
+				}
+			}
+		}
+
+		if len(dirs) == 0 {
+			util.Failed("No install.yaml found in %s or its immediate subdirectories", rootDir)
+		}
+
+		hadError := false
+		for _, dir := range dirs {
+			util.Success("\nRunning add-on update checker in: %s", dir)
+
+			hostCmd := exec.HostCommand(bashPath, "-s")
+			hostCmd.Stdin = strings.NewReader(script)
+			hostCmd.Stdout = os.Stdout
+			hostCmd.Stderr = os.Stderr
+			hostCmd.Dir = dir
+
+			exitCode := 0
+			if err := hostCmd.Run(); err != nil {
+				var exiterr *osexec.ExitError
+				if errors.As(err, &exiterr) {
+					exitCode = exiterr.ExitCode()
+				} else {
+					exitCode = 1
+				}
+				hadError = true
+			}
+			if exitCode == 0 {
+				util.Success("Exit code: %d", exitCode)
+			} else {
+				util.Error("Exit code: %d", exitCode)
+			}
+		}
+
+		if hadError {
+			output.UserErr.Exit(1)
+		}
+	},
+}
+
+func init() {
+	AddonUpdateCheckerCmd.Flags().StringP("dir", "d", "", "Directory of the add-on to check, or a workspace containing multiple add-on directories (defaults to current directory)")
+	DebugCmd.AddCommand(AddonUpdateCheckerCmd)
+}

--- a/cmd/ddev/cmd/utility-addon-update-checker_test.go
+++ b/cmd/ddev/cmd/utility-addon-update-checker_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUtilityAddonUpdateCheckerCmd tests basic functionality of ddev utility addon-update-checker
+func TestUtilityAddonUpdateCheckerCmd(t *testing.T) {
+	// Test 1: directory contains install.yaml directly — single run
+	t.Run("SingleAddon", func(t *testing.T) {
+		dir := testcommon.CreateTmpDir(filepath.Base(t.Name()))
+		defer testcommon.CleanupDir(dir)
+
+		err := os.WriteFile(filepath.Join(dir, "install.yaml"), []byte("name: test-addon\n"), 0644)
+		require.NoError(t, err)
+
+		// Script may exit non-zero when add-on is out of date; ignore the error.
+		out, _ := exec.RunHostCommand(DdevBin, "utility", "addon-update-checker", "--dir", dir)
+		require.Contains(t, out, dir)
+		require.Contains(t, out, "Exit code:")
+	})
+
+	// Test 2: workspace with subdirectories each containing install.yaml — runs in each
+	t.Run("MultipleAddons", func(t *testing.T) {
+		workspace := testcommon.CreateTmpDir(filepath.Base(t.Name()))
+		defer testcommon.CleanupDir(workspace)
+
+		for _, name := range []string{"addon-one", "addon-two"} {
+			subdir := filepath.Join(workspace, name)
+			require.NoError(t, os.Mkdir(subdir, 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(subdir, "install.yaml"), []byte("name: "+name+"\n"), 0644))
+		}
+
+		out, _ := exec.RunHostCommand(DdevBin, "utility", "addon-update-checker", "--dir", workspace)
+		require.Contains(t, out, "addon-one")
+		require.Contains(t, out, "addon-two")
+		// Both runs must report an exit code
+		require.Equal(t, 2, strings.Count(out, "Exit code:"))
+	})
+
+	// Test 3: no install.yaml anywhere — must fail with a clear error
+	t.Run("NoInstallYaml", func(t *testing.T) {
+		dir := testcommon.CreateTmpDir(filepath.Base(t.Name()))
+		defer testcommon.CleanupDir(dir)
+
+		out, err := exec.RunHostCommand(DdevBin, "utility", "addon-update-checker", "--dir", dir)
+		require.Error(t, err)
+		require.Contains(t, out, "No install.yaml found")
+	})
+}

--- a/cmd/ddev/cmd/utility-addon-update-checker_test.go
+++ b/cmd/ddev/cmd/utility-addon-update-checker_test.go
@@ -23,8 +23,8 @@ func TestUtilityAddonUpdateCheckerCmd(t *testing.T) {
 
 		// Script may exit non-zero when add-on is out of date; ignore the error.
 		out, _ := exec.RunHostCommand(DdevBin, "utility", "addon-update-checker", "--dir", dir)
+		require.Contains(t, out, "Running add-on update checker in:")
 		require.Contains(t, out, dir)
-		require.Contains(t, out, "Exit code:")
 	})
 
 	// Test 2: workspace with subdirectories each containing install.yaml — runs in each
@@ -41,8 +41,8 @@ func TestUtilityAddonUpdateCheckerCmd(t *testing.T) {
 		out, _ := exec.RunHostCommand(DdevBin, "utility", "addon-update-checker", "--dir", workspace)
 		require.Contains(t, out, "addon-one")
 		require.Contains(t, out, "addon-two")
-		// Both runs must report an exit code
-		require.Equal(t, 2, strings.Count(out, "Exit code:"))
+		// Both add-ons must have been checked
+		require.Equal(t, 2, strings.Count(out, "Running add-on update checker in:"))
 	})
 
 	// Test 3: no install.yaml anywhere — must fail with a clear error

--- a/docs/content/users/extend/creating-add-ons.md
+++ b/docs/content/users/extend/creating-add-ons.md
@@ -674,12 +674,20 @@ To become an officially supported add-on:
 3. Commit to maintaining the add-on
 4. Subscribe to repository activity and be responsive
 
+### Keeping Your Add-on Up to Date
+
+The [ddev-addon-template](https://github.com/ddev/ddev-addon-template) evolves over time — workflows, test scripts, tooling, and other components get updated. Run the [`ddev utility addon-update-checker`](../usage/commands.md#utility-addon-update-checker) command regularly from your add-on directory (or a workspace containing multiple add-ons) to check whether your add-on is up to date with the template:
+
+```shell
+ddev utility addon-update-checker
+```
+
 ### Best Practices
 
 - **Follow semantic versioning** for releases
 - **Maintain backward compatibility** when possible
 - **Test with different DDEV versions**
-- **Update dependencies regularly**
+- **Update dependencies regularly** — use `ddev utility addon-update-checker` to keep scripts and tooling in sync with the template
 - **Respond to user issues promptly**
 - **Keep documentation up to date**
 - **Use namespaced directories** (e.g., `myservice/scripts/` not just `scripts/`)

--- a/docs/content/users/extend/creating-add-ons.md
+++ b/docs/content/users/extend/creating-add-ons.md
@@ -676,7 +676,7 @@ To become an officially supported add-on:
 
 ### Keeping Your Add-on Up to Date
 
-The [ddev-addon-template](https://github.com/ddev/ddev-addon-template) evolves over time — workflows, test scripts, tooling, and other components get updated. Run the [`ddev utility addon-update-checker`](../usage/commands.md#utility-addon-update-checker) command regularly from your add-on directory (or a workspace containing multiple add-ons) to check whether your add-on is up to date with the template:
+The [`ddev-addon-template`](https://github.com/ddev/ddev-addon-template) evolves over time — workflows, test scripts, tooling, and other components get updated. Run the [`ddev utility addon-update-checker`](../usage/commands.md#utility-addon-update-checker) command regularly from your add-on directory (or a workspace containing multiple add-ons) to check whether your add-on is up to date with the template:
 
 ```shell
 ddev utility addon-update-checker

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1469,6 +1469,29 @@ ddev typo3 site:show
 
 A collection of utility and debugging commands, often useful for [troubleshooting](troubleshooting.md).
 
+### `utility addon-update-checker`
+
+Fetch and run the DDEV add-on update checker script from [https://ddev.com/s/addon-update-checker.sh](https://ddev.com/s/addon-update-checker.sh). This is a tool for add-on developers to verify their add-on's scripts and tooling are up to date with the [ddev-addon-template](https://github.com/ddev/ddev-addon-template).
+
+If the target directory contains `install.yaml`, the checker runs there. Otherwise, it scans immediate subdirectories for `install.yaml` and runs the checker in each one, which is useful when working in a workspace with multiple add-ons checked out alongside each other.
+
+Flags:
+
+* `--dir`, `-d`: Directory of the add-on to check, or a workspace containing multiple add-on directories (defaults to current directory).
+
+Example:
+
+```shell
+# Run in the current add-on directory
+ddev utility addon-update-checker
+
+# Run in a specific add-on directory
+ddev utility addon-update-checker -d /path/to/my-addon
+
+# Run across all add-ons in a workspace
+ddev utility addon-update-checker -d /path/to/my-addons-workspace
+```
+
 ### `utility cd`
 
 Uses shell built-in `cd` to change to a project directory. For example, `ddevcd some-project` will change directories to the project root of the project named `some-project`.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1471,7 +1471,7 @@ A collection of utility and debugging commands, often useful for [troubleshootin
 
 ### `utility addon-update-checker`
 
-Fetch and run the DDEV add-on update checker script from [https://ddev.com/s/addon-update-checker.sh](https://ddev.com/s/addon-update-checker.sh). This is a tool for add-on developers to verify their add-on's scripts and tooling are up to date with the [ddev-addon-template](https://github.com/ddev/ddev-addon-template).
+Fetch and run the DDEV add-on update checker script from [https://ddev.com/s/addon-update-checker.sh](https://ddev.com/s/addon-update-checker.sh). This is a tool for add-on developers to verify their add-on's scripts and tooling are up to date with the [`ddev-addon-template`](https://github.com/ddev/ddev-addon-template).
 
 If the target directory contains `install.yaml`, the checker runs there. Otherwise, it scans immediate subdirectories for `install.yaml` and runs the checker in each one, which is useful when working in a workspace with multiple add-ons checked out alongside each other.
 


### PR DESCRIPTION
## The Issue

Running the [DDEV add-on update checker](https://github.com/ddev/ddev-addon-template#update-checker) requires remembering the command `curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash`, which is impossible to recall without looking it up every time. On top of that, when maintaining multiple add-ons, you have to `cd` into each directory and run the command individually - there's no way to check all add-ons at once and then feed the combined output to an AI to fix everything in one go.

## How This PR Solves The Issue

Adds `ddev utility addon-update-checker`, which fetches and runs the update checker script automatically:

- If the target directory contains `install.yaml`, the checker runs there.
- Otherwise it scans immediate subdirectories for `install.yaml` and runs the checker in each one - useful for workspaces with multiple add-ons.
- Each run is clearly labeled with the directory, live output, and exit code (green for success, red for failure), with `NO_COLOR` support.
- Falls back to the raw GitHub script URL if the primary URL is unavailable.
- Uses `util.FindBashPath()` for cross-platform bash discovery.
- Supports `-d`/`--dir` flag to target a specific directory or workspace.

The workspace scanning logic lives in the bash script itself (see [ddev-addon-template#104](https://github.com/ddev/ddev-addon-template/pull/104)), so it also works when running the script directly via `curl`. The Go command simply fetches the script and runs it once in the target directory.

## Manual Testing Instructions

https://ddev--8373.org.readthedocs.build/en/8373/users/extend/creating-add-ons/#keeping-your-add-on-up-to-date
https://ddev--8373.org.readthedocs.build/en/8373/users/usage/commands/#utility-addon-update-checker

Run in a single add-on directory:

```shell
cd /path/to/my-addon   # must contain install.yaml
ddev utility addon-update-checker
```

Run across a workspace of add-ons:

```shell
ddev utility addon-update-checker -d /path/to/my-addons-workspace
```

Verify that a directory without `install.yaml` fails with a clear error:

```shell
ddev utility addon-update-checker -d /tmp
```

## Automated Testing Overview

`TestUtilityAddonUpdateCheckerCmd` in `utility-addon-update-checker_test.go` covers three cases:

- `SingleAddon`: directory with `install.yaml` — verifies the dir is reported in output.
- `MultipleAddons`: workspace with two subdirs each containing `install.yaml` — verifies both are checked.
- `NoInstallYaml`: empty directory — verifies the command fails with "No install.yaml found".

## Release/Deployment Notes

New `ddev utility addon-update-checker` subcommand. No breaking changes. Documentation added to `commands.md` and `creating-add-ons.md`.

Update https://github.com/ddev/ddev-addon-template and https://ddev.com/blog/ddev-add-on-maintenance-guide/ after the next release.