### PR TITLE
ci: run golangci-lint

### DIFF
--- a/pkg/output/output_setup.go
+++ b/pkg/output/output_setup.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -80,8 +81,7 @@ func ParseBoolFlag(long string, short string) bool {
 	longPrefix := "--" + long + "="
 	shortPrefix := "-" + short + "="
 
-	for i := len(args) - 1; i >= 0; i-- {
-		arg := args[i]
+	for _, arg := range slices.Backward(args) {
 		switch {
 		case arg == "--"+long, arg == "-"+short:
 			return true


### PR DESCRIPTION
## The Issue

New check from golangci-lint 2.12.0:

```
$ make golangci-lint
golangci-lint: 
pkg/output/output_setup.go:83:6: slicesbackward: backward loop over slice can be modernized using slices.Backward (modernize)
        for i := len(args) - 1; i >= 0; i-- {
            ^
1 issues:
* modernize: 1
make: *** [Makefile:345: golangci-lint] Error 1
```

## How This PR Solves The Issue

Fixes it.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
