### PR TITLE
fix(add-ons): autocomplete for path

### DIFF
--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -886,9 +886,9 @@ func GetAddonTarballURL(ownerRepo, gitRef string, defaultBranch bool, prNumber i
 func GetAddonNamesFunc(numArgs int) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 		// Don't provide completions if the user keeps hitting space after
-		// exhausting all of the valid arguments.
+		// exhausting all the valid arguments.
 		if numArgs > 0 && len(args)+1 > numArgs {
-			return nil, cobra.ShellCompDirectiveDefault
+			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		addons, err := ListAvailableAddonsFromRegistry()

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -888,13 +888,13 @@ func GetAddonNamesFunc(numArgs int) func(*cobra.Command, []string, string) ([]st
 		// Don't provide completions if the user keeps hitting space after
 		// exhausting all of the valid arguments.
 		if numArgs > 0 && len(args)+1 > numArgs {
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			return nil, cobra.ShellCompDirectiveDefault
 		}
 
 		addons, err := ListAvailableAddonsFromRegistry()
 		if err != nil {
-			// If we can't get addons, return no completions
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			// If we can't get add-ons, fall back to file completion
+			return nil, cobra.ShellCompDirectiveDefault
 		}
 
 		// Extract addon names in owner/repo format
@@ -907,7 +907,7 @@ func GetAddonNamesFunc(numArgs int) func(*cobra.Command, []string, string) ([]st
 			}
 		}
 
-		return addonNames, cobra.ShellCompDirectiveNoFileComp
+		return addonNames, cobra.ShellCompDirectiveDefault
 	}
 }
 


### PR DESCRIPTION
## The Issue

Autocomplete doesn't work for:

```bash
# press <TAB> after entering this:
ddev add-on get /home/stas/
```

This makes it harder to install an add-on from a directory.

## How This PR Solves The Issue

Adds it back.

## Manual Testing Instructions

```bash
# press <TAB> after entering this:
ddev add-on get /home/stas/
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
