### PR TITLE
feat: forward known AI agent ENVs on exec, fixes #8378

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2545,6 +2545,8 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		}
 	}
 
+	opts.Env = append(opts.Env, agentDetectionEnv(opts.Env)...)
+
 	// Cases to handle
 	// - Free form, all unquoted. Like `ls -l -a`
 	// - Quoted to delay pipes and other features to container, like `"ls -l -a | grep junk"`

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2616,6 +2616,8 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		}
 	}
 
+	opts.Env = append(opts.Env, agentDetectionEnv(opts.Env)...)
+
 	// Cases to handle
 	// - Free form, all unquoted. Like `ls -l -a`
 	// - Quoted to delay pipes and other features to container, like `"ls -l -a | grep junk"`

--- a/pkg/ddevapp/exec_env.go
+++ b/pkg/ddevapp/exec_env.go
@@ -1,0 +1,48 @@
+package ddevapp
+
+import (
+	"os"
+	"strings"
+)
+
+var agentDetectionEnvVars = []string{
+	"AI_AGENT",
+	"CURSOR_AGENT",
+	"GEMINI_CLI",
+	"CODEX_SANDBOX",
+	"CODEX_CI",
+	"CODEX_THREAD_ID",
+	"AUGMENT_AGENT",
+	"AMP_CURRENT_THREAD_ID",
+	"OPENCODE_CLIENT",
+	"OPENCODE",
+	"CLAUDECODE",
+	"CLAUDE_CODE",
+	"CLAUDE_CODE_IS_COWORK",
+	"COPILOT_MODEL",
+	"COPILOT_ALLOW_ALL",
+	"COPILOT_CLI",
+	"REPL_ID",
+	"ANTIGRAVITY_AGENT",
+	"PI_CODING_AGENT",
+	"KIRO_AGENT_PATH",
+}
+
+func agentDetectionEnv(existingEnv []string) []string {
+	seen := make(map[string]bool, len(existingEnv))
+	for _, envVar := range existingEnv {
+		name, _, _ := strings.Cut(envVar, "=")
+		seen[name] = true
+	}
+
+	env := make([]string, 0, len(agentDetectionEnvVars))
+	for _, name := range agentDetectionEnvVars {
+		if seen[name] {
+			continue
+		}
+		if value, ok := os.LookupEnv(name); ok {
+			env = append(env, name+"="+value)
+		}
+	}
+	return env
+}

--- a/pkg/ddevapp/exec_env_test.go
+++ b/pkg/ddevapp/exec_env_test.go
@@ -1,0 +1,49 @@
+package ddevapp
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentDetectionEnv(t *testing.T) {
+	unsetAgentDetectionEnv(t)
+	t.Setenv("AI_AGENT", "codex")
+	t.Setenv("CLAUDE_CODE", "1")
+	t.Setenv("COPILOT_GITHUB_TOKEN", "secret")
+
+	env := agentDetectionEnv(nil)
+	require.Contains(t, env, "AI_AGENT=codex")
+	require.Contains(t, env, "CLAUDE_CODE=1")
+	require.NotContains(t, env, "COPILOT_GITHUB_TOKEN=secret")
+}
+
+func TestAgentDetectionEnvPreservesExplicitEnv(t *testing.T) {
+	unsetAgentDetectionEnv(t)
+	t.Setenv("AI_AGENT", "host-agent")
+
+	env := agentDetectionEnv([]string{"AI_AGENT=explicit-agent"})
+	require.Empty(t, env)
+}
+
+func TestAgentDetectionEnvUnsetVariables(t *testing.T) {
+	unsetAgentDetectionEnv(t)
+
+	env := agentDetectionEnv(nil)
+	require.Empty(t, env)
+}
+
+func unsetAgentDetectionEnv(t *testing.T) {
+	t.Helper()
+
+	for _, name := range agentDetectionEnvVars {
+		originalValue, wasSet := os.LookupEnv(name)
+		require.NoError(t, os.Unsetenv(name))
+		if wasSet {
+			t.Cleanup(func() {
+				require.NoError(t, os.Setenv(name, originalValue))
+			})
+		}
+	}
+}


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- Fixes #8378 

## How This PR Solves The Issue

Forward the well-known agent ENVs listed in https://github.com/laravel/agent-detector#supported-agents on exec to all DDEV services.

Apart from COPILOT_GITHUB_TOKEN. I don't think we should automatically forward authentication information like that.

## Manual Testing Instructions

- Start any DDEV project.
- Run:
  ```
  AI_AGENT=manual-test ddev exec 'echo $AI_AGENT'
  AI_AGENT=manual-test ddev exec -s db 'echo $AI_AGENT'
  ```

Expected result: both commands print manual-test.

## Automated Testing Overview

`go test -v ./pkg/ddevapp -run 'TestAgentDetectionEnv'`

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
