### PR TITLE
feat(add-on): add `#ddev-interactive` option for actions, fixes #8155

### DIFF
--- a/docs/content/users/extend/creating-add-ons.md
+++ b/docs/content/users/extend/creating-add-ons.md
@@ -614,6 +614,23 @@ post_install_actions:
     some-command-that-might-fail
 ```
 
+### Interactive Actions
+
+Add `#ddev-interactive` to a Bash action that needs direct terminal input or live output. DDEV runs these actions
+interactively only when stdin is a terminal and JSON output is disabled. In non-interactive environments, such as CI,
+DDEV keeps the standard buffered action behavior.
+
+```yaml
+post_install_actions:
+  - |
+    #ddev-description: Configure API credentials
+    #ddev-interactive
+    if [ "$(ddev dotenv get .env.myaddon --api-token 2>/dev/null)" = "" ]; then
+      read -p "Enter your API token: " TOKEN
+      ddev dotenv set .env.myaddon --api-token="${TOKEN}"
+    fi
+```
+
 ## Testing Your Add-on
 
 ### Bats Testing Framework

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/mattn/go-isatty"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/otiai10/copy"
@@ -232,7 +233,18 @@ func processBashHostAction(action string, installDesc InstallDesc, app *DdevApp,
 	if verbose {
 		action = "set -x; " + action
 	}
-	out, err := exec.RunHostCommand(util.FindBashPath(), "-c", action)
+
+	out := ""
+	interactiveAction := GetAddonDdevInteractive(action)
+	interactiveTerminal := isatty.IsTerminal(os.Stdin.Fd()) && !output.JSONOutput
+	if interactiveAction && interactiveTerminal {
+		if desc != "" {
+			output.UserOut.Infof("%s  %s (bash)", "\u2699\ufe0f", desc)
+		}
+		err = exec.RunInteractiveCommand(util.FindBashPath(), []string{"-c", action})
+	} else {
+		out, err = exec.RunHostCommand(util.FindBashPath(), "-c", action)
+	}
 	if err != nil {
 		warningCode := GetAddonDdevWarningExitCode(action)
 		if warningCode > 0 {
@@ -677,6 +689,11 @@ func GetAddonDdevDescription(action string) string {
 		}
 	}
 	return ""
+}
+
+// GetAddonDdevInteractive returns whether the action is marked for interactive execution
+func GetAddonDdevInteractive(action string) bool {
+	return len(nodeps.GrepStringInBuffer(action, `[\r\n]*#ddev-interactive[\r\n]+`)) > 0
 }
 
 // GetAddonDdevWarningExitCode returns the integer following #ddev-warning-exit-code in the last match in action

--- a/pkg/ddevapp/addons_test.go
+++ b/pkg/ddevapp/addons_test.go
@@ -121,6 +121,45 @@ func TestProcessAddonActionPHPDetection(t *testing.T) {
 	})
 }
 
+func TestGetAddonDdevInteractive(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		want   bool
+	}{
+		{
+			name: "interactive directive",
+			action: `
+#ddev-description: Configure credentials
+#ddev-interactive
+read -p "Enter token: " TOKEN
+`,
+			want: true,
+		},
+		{
+			name: "directive must be full line",
+			action: `
+echo "#ddev-interactive is only documentation here"
+`,
+			want: false,
+		},
+		{
+			name: "no interactive directive",
+			action: `
+#ddev-description: Configure credentials
+echo "done"
+`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ddevapp.GetAddonDdevInteractive(tt.action))
+		})
+	}
+}
+
 func TestValidatePHPIncludesAndRequires(t *testing.T) {
 	tmpDir := testcommon.CreateTmpDir(t.Name())
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- Fixes #8155 

Add-on post_install_actions cannot run interactive scripts that prompt the user for input and display output in real time. This means more complex activities are limited, and you cannot use anything downstream that has interactivity, otherwise the process will hang waiting on user input.

## How This PR Solves The Issue

Establish to suggested #ddev-interactive keyword for add-on action to switch to an interactive command when on TTY

## Manual Testing Instructions

Rendered docs: https://ddev--8381.org.readthedocs.build/en/8381/users/extend/creating-add-ons/#interactive-actions

In any DDEV project:

```
cat > ~/tmp/ddev-interactive-addon/install.yaml <<'EOF'
name: interactive-test

post_install_actions:
  - |
    #ddev-description: Configure interactive test value
    #ddev-interactive
    read -p "Enter test value: " VALUE
    echo "VALUE=${VALUE}" > interactive-test.txt
    echo "Wrote .ddev/interactive-test.txt"
EOF

cd /home/akiba/Projects/fvn/fvn.li
ddev add-on get ~/tmp/ddev-interactive-addon
cat .ddev/interactive-test.txt
```

Demo add-on: 
```
ddev add-on get rfay/ddev-interactive-test
```

## Automated Testing Overview

`go test -v ./pkg/ddevapp -run 'TestGetAddonDdevInteractive'`

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
