### PR TITLE
fix(commands): normalize $OSTYPE detection for linux, fixes #8382

### DIFF
--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -32,7 +32,7 @@ fi
 CONNECTION="name=ddev-${DDEV_PROJECT}|driver=${type}|database=${database}|user=${user}|password=${user}|savePassword=true|showSystemObjects=true|showUtilityObjects=true|prop.allowPublicKeyRetrieval=true|prop.useSSL=false|host=127.0.0.1|port=${DDEV_HOST_DB_PORT}|openConsole=true|folder=DDEV"
 
 case $OSTYPE in
-  "linux-gnu")
+  "linux-gnu" | "linux")
     # Check for different binaries. Launch the first one found.
     BINARIES=(
       /usr/bin/dbeaver{,-ce,-le,-ue,-ee}

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -64,4 +64,7 @@ case $OSTYPE in
     open -a dbeaver.app --args -con "$CONNECTION" &
     echo "Attempted to launch DBeaver.app"
     ;;
+  *)
+    echo "OS type '$OSTYPE' not identified, known types: linux-gnu, linux, darwin*, win*, msys*, cygwin."
+    ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -65,6 +65,6 @@ case $OSTYPE in
     echo "Attempted to launch DBeaver.app"
     ;;
   *)
-    echo "OS type '$OSTYPE' not identified, known types: linux-gnu, linux, darwin*, win*, msys*, cygwin."
+    echo "OS type '$OSTYPE' not identified, known types: linux*, darwin*, win*, msys*, cygwin."
     ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -66,5 +66,6 @@ case $OSTYPE in
     ;;
   *)
     echo "OS type '$OSTYPE' not identified, known types: linux*, darwin*, win*, msys*, cygwin."
+    exit 1
     ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -32,7 +32,7 @@ fi
 CONNECTION="name=ddev-${DDEV_PROJECT}|driver=${type}|database=${database}|user=${user}|password=${user}|savePassword=true|showSystemObjects=true|showUtilityObjects=true|prop.allowPublicKeyRetrieval=true|prop.useSSL=false|host=127.0.0.1|port=${DDEV_HOST_DB_PORT}|openConsole=true|folder=DDEV"
 
 case $OSTYPE in
-  "linux-gnu" | "linux")
+  "linux"*)
     # Check for different binaries. Launch the first one found.
     BINARIES=(
       /usr/bin/dbeaver{,-ce,-le,-ue,-ee}

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -104,7 +104,7 @@ case $OSTYPE in
   start "" "${binary}" "${arguments[@]}" &
   ;;
 
-"linux-gnu" | "linux")
+"linux"*)
   "${binary}" "${arguments[@]}" &>/dev/null & disown
   ;;
 *)

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -109,5 +109,6 @@ case $OSTYPE in
   ;;
 *)
   echo "OS type '$OSTYPE' not identified, known types: linux*, win*, msys*, cygwin."
+  exit 1
   ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -20,7 +20,7 @@ case $OSTYPE in
 "win"* | "msys"* | "cygwin")
   binary="/c/Program Files/HeidiSQL/heidisql.exe"
   ;;
-"linux-gnu")
+"linux-gnu" | "linux")
   BINARIES=(
     "/usr/bin/heidisql"
     "/usr/local/bin/heidisql"
@@ -104,7 +104,7 @@ case $OSTYPE in
   start "" "${binary}" "${arguments[@]}" &
   ;;
 
-"linux-gnu")
+"linux-gnu" | "linux")
   "${binary}" "${arguments[@]}" &>/dev/null & disown
   ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -107,4 +107,7 @@ case $OSTYPE in
 "linux-gnu" | "linux")
   "${binary}" "${arguments[@]}" &>/dev/null & disown
   ;;
+*)
+  echo "OS type '$OSTYPE' not identified, known types: linux-gnu, linux, win*, msys*, cygwin."
+  ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -108,6 +108,6 @@ case $OSTYPE in
   "${binary}" "${arguments[@]}" &>/dev/null & disown
   ;;
 *)
-  echo "OS type '$OSTYPE' not identified, known types: linux-gnu, linux, win*, msys*, cygwin."
+  echo "OS type '$OSTYPE' not identified, known types: linux*, win*, msys*, cygwin."
   ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/heidisql
@@ -20,7 +20,7 @@ case $OSTYPE in
 "win"* | "msys"* | "cygwin")
   binary="/c/Program Files/HeidiSQL/heidisql.exe"
   ;;
-"linux-gnu" | "linux")
+"linux"*)
   BINARIES=(
     "/usr/bin/heidisql"
     "/usr/local/bin/heidisql"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -120,7 +120,7 @@ if [ "${DDEV_DEBUG:-}" = "true" ] || [ "${DDEV_VERBOSE:-}" = "true" ]; then
 fi
 
 case $OSTYPE in
-  "linux-gnu" | "linux")
+  "linux"*)
     if command -v explorer.exe >/dev/null; then explorer.exe ${FULLURL} || true;
     elif command -v xdg-open >/dev/null; then xdg-open ${FULLURL};
     else

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -136,5 +136,6 @@ case $OSTYPE in
     ;;
   *)
     echo "OS type '$OSTYPE' not identified, known types: linux*, darwin*, win*, msys*, cygwin."
+    exit 1
     ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -120,7 +120,7 @@ if [ "${DDEV_DEBUG:-}" = "true" ] || [ "${DDEV_VERBOSE:-}" = "true" ]; then
 fi
 
 case $OSTYPE in
-  "linux-gnu")
+  "linux-gnu" | "linux")
     if command -v explorer.exe >/dev/null; then explorer.exe ${FULLURL} || true;
     elif command -v xdg-open >/dev/null; then xdg-open ${FULLURL};
     else

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -135,6 +135,6 @@ case $OSTYPE in
     start ${FULLURL}
     ;;
   *)
-    echo "OS type '$OSTYPE' not identified, known types: linux-gnu, linux, darwin*, win*, msys*, cygwin."
+    echo "OS type '$OSTYPE' not identified, known types: linux*, darwin*, win*, msys*, cygwin."
     ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -134,4 +134,7 @@ case $OSTYPE in
   "win"* | "msys"* | "cygwin")
     start ${FULLURL}
     ;;
+  *)
+    echo "OS type '$OSTYPE' not identified, known types: linux-gnu, linux, darwin*, win*, msys*, cygwin."
+    ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -12,7 +12,7 @@ IFS=$'\n'
 for ddev_path in $(which -a ddev | uniq); do
   case $ddev_path in
     "/usr/bin/ddev")
-      if [[ ${OSTYPE} = "linux-gnu"* || ${OSTYPE} = "linux"* ]]; then
+      if [[ ${OSTYPE} = "linux"* ]]; then
         packages_to_upgrade="ddev"
         if [[ -f "/usr/bin/ddev-hostname.exe" ]]; then
           packages_to_upgrade="$packages_to_upgrade ddev-wsl2"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/self-upgrade
@@ -12,7 +12,7 @@ IFS=$'\n'
 for ddev_path in $(which -a ddev | uniq); do
   case $ddev_path in
     "/usr/bin/ddev")
-      if [[ ${OSTYPE} = "linux-gnu"* ]]; then
+      if [[ ${OSTYPE} = "linux-gnu"* || ${OSTYPE} = "linux"* ]]; then
         packages_to_upgrade="ddev"
         if [[ -f "/usr/bin/ddev-hostname.exe" ]]; then
           packages_to_upgrade="$packages_to_upgrade ddev-wsl2"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -29,7 +29,7 @@ fi
 query="${driver}://db:db@127.0.0.1:${DDEV_HOST_DB_PORT}/db?Enviroment=local&Name=ddev-${DDEV_SITENAME}"
 
 case $OSTYPE in
-  "linux-gnu")
+  "linux-gnu"|"linux")
     "/mnt/c/Program Files/TablePlus/TablePlus.exe" $query >/dev/null &
     ;;
   "darwin"*)

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -42,5 +42,6 @@ case $OSTYPE in
     ;;
   *)
     echo "OS type '$OSTYPE' not identified, known types: linux*, darwin*, win*, msys*, cygwin."
+    exit 1
     ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -29,7 +29,7 @@ fi
 query="${driver}://db:db@127.0.0.1:${DDEV_HOST_DB_PORT}/db?Enviroment=local&Name=ddev-${DDEV_SITENAME}"
 
 case $OSTYPE in
-  "linux-gnu"|"linux")
+  "linux"*)
     "/mnt/c/Program Files/TablePlus/TablePlus.exe" $query >/dev/null &
     ;;
   "darwin"*)

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -41,6 +41,6 @@ case $OSTYPE in
     fi
     ;;
   *)
-    echo "OS type '$OSTYPE' not identified, known types: linux-gnu, linux, darwin*, win*, msys*, cygwin."
+    echo "OS type '$OSTYPE' not identified, known types: linux*, darwin*, win*, msys*, cygwin."
     ;;
 esac

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/tableplus
@@ -40,4 +40,7 @@ case $OSTYPE in
         open "$query" -a "/Applications/TablePlus.app/Contents/MacOS/TablePlus"
     fi
     ;;
+  *)
+    echo "OS type '$OSTYPE' not identified, known types: linux-gnu, linux, darwin*, win*, msys*, cygwin."
+    ;;
 esac


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- Fixes #8382

<!-- Provide a brief description of the issue. -->
On Linux, the $OSTYPE variable can have the value "linux" or "linux-gnu", but the OS chooser statements in several DDEV commands only match on "linux-gnu". This leads to systems like OpenSuse Tumbleweed or Ubuntu 24.04 to not being able to launch $BROWSER, DBeaver, etc. Non matches fail silently.

## How This PR Solves The Issue

This PR adds the "linux" option and a message when no options are matched.
<!-- Describe the key change(s) in this PR that address the issue above. -->

## Manual Testing Instructions
Make sure that your system's $OSTYPE is set to "linux". Apply, build and run `ddev launch` , `ddev dbeaver` etc.

## Automated Testing Overview

I don't know how to add automated tests for something like this.

## Release/Deployment Notes

Nothing to be done to deployment to my knowledge, no other effects.