### PR TITLE
docs(configuration): Link to "php.ini" "my.cnf" etc. page

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -128,7 +128,7 @@ The type and version of the database engine the project should use.
 | -- | -- | --
 | :octicons-file-directory-16: project | MariaDB 11.8 | Can be MariaDB 5.5–10.8, 10.11, 11.4, 11.8 and MySQL 5.5–8.0, 8.4, or PostgreSQL 9–18.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats. For very old database types see [Using DDEV to spin up a legacy PHP application](https://ddev.com/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev/).
 
-See the [`Extending and Customizing Environments`](../extend/customization-extendibility.md) section for information on Database specific configuration files such as the [`my.cnf`](../extend/customization-extendibility.md#custom-mysqlmariadb-configuration-mycnf) file of MySQL/MariaDB and [`postgresql.conf`](../extend/customization-extendibility.md#custom-postgresql-configuration) file of PostgreSQL.
+Configuring database specific configuration files such as the [`my.cnf`](../extend/customization-extendibility.md#custom-mysqlmariadb-configuration-mycnf) file of MySQL/MariaDB and [`postgresql.conf`](../extend/customization-extendibility.md#custom-postgresql-configuration) file of PostgreSQL are supported.
 
 ## `dbimage_extra_packages`
 
@@ -500,7 +500,7 @@ The PHP version the project should use.
 
 You can only specify the major version (`7.3`), not a minor version (`7.3.2`), from those explicitly available.
 
-See the [`Extending and Customizing Environments`](../extend/customization-extendibility.md) section for information on PHP specific configuration files such as the [`php.ini`](../extend/customization-extendibility.md#custom-php-configuration-phpini).
+PHP specific configuration files such as the [`php.ini`](../extend/customization-extendibility.md#custom-php-configuration-phpini) are supported.
 
 ## `project_tld`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -128,6 +128,8 @@ The type and version of the database engine the project should use.
 | -- | -- | --
 | :octicons-file-directory-16: project | MariaDB 11.8 | Can be MariaDB 5.5–10.8, 10.11, 11.4, 11.8 and MySQL 5.5–8.0, 8.4, or PostgreSQL 9–18.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats. For very old database types see [Using DDEV to spin up a legacy PHP application](https://ddev.com/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev/).
 
+See the [`Extending and Customizing Environments`](../extend/customization-extendibility.md) section for information on Database specific configuration files such as the [`my.cnf`](../extend/customization-extendibility.md#custom-mysqlmariadb-configuration-mycnf) file of MySQL/MariaDB and [`postgresql.conf`](../extend/customization-extendibility.md#custom-postgresql-configuration) file of PostgreSQL.
+
 ## `dbimage_extra_packages`
 
 Extra Debian packages for the project’s database container. (This is rarely used.)

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -498,7 +498,7 @@ The PHP version the project should use.
 
 You can only specify the major version (`7.3`), not a minor version (`7.3.2`), from those explicitly available.
 
-The PHP specific configuration files such as the [`php.ini`](../extend/customization-extendibility#custom-php-configuration-phpini) as also supported.
+See the [`Extending and Customizing Environments`](../extend/customization-extendibility.md) section for information on PHP specific configuration files such as the [`php.ini`](../extend/customization-extendibility.md#custom-php-configuration-phpini).
 
 ## `project_tld`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -498,6 +498,8 @@ The PHP version the project should use.
 
 You can only specify the major version (`7.3`), not a minor version (`7.3.2`), from those explicitly available.
 
+The PHP specific configuration files such as the [`php.ini`](../extend/customization-extendibility#custom-php-configuration-phpini) as also supported.
+
 ## `project_tld`
 
 Default Top-Level-Domain (`TLD`) to be used for a project’s domains, or globally for all project domains. This defaults to `ddev.site` and it's easiest to work with DDEV using the default setting.


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

It's not intuitive from search engines on how to find information about setting the configuration files of PHP and database, when the configuration options documentation page is the first result. 

## How This PR Solves The Issue

So we might want to link from the configuration documentation page to the relevant sections with Extending and Customizing Environments page, so users can see how to set their "php.ini", "my.cnf" etc. files.

Also the Extending and Customizing Environments page also back links to configuration page for the php version, so it makes sense that the link should work both ways. Additionally, this should hopefully improve the semantic context/vector between the two pages so SEO is improved :-)

## Manual Testing Instructions

Please spellcheck, grammar check and feel free to adjust wording:

PHP Version section:

https://ddev--8386.org.readthedocs.build/en/8386/users/configuration/config/#php_version

Database section:

https://ddev--8386.org.readthedocs.build/en/8386/users/configuration/config/#database

## Automated Testing Overview

Nil.

## Release/Deployment Notes

Nil.
