### PR TITLE
docs(configuration): Add `ddev config --database=<database type>:<version>` example command (#8387) [skip ci]

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -128,7 +128,7 @@ The type and version of the database engine the project should use.
 | -- | -- | --
 | :octicons-file-directory-16: project | `mariadb:11.8` | Can be MariaDB 5.5–10.8, 10.11, 11.4, 11.8 and MySQL 5.5–8.0, 8.4, or PostgreSQL 9–18.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats. For very old database types see [Using DDEV to spin up a legacy PHP application](https://ddev.com/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev/).
 
-Set with `ddev config --database=<database type>:<version>`, for example `mariadb:11.8`.
+Set with `ddev config --database=<database type>:<version>`.
 
 ## `dbimage_extra_packages`
 

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -126,7 +126,9 @@ The type and version of the database engine the project should use.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | MariaDB 11.8 | Can be MariaDB 5.5–10.8, 10.11, 11.4, 11.8 and MySQL 5.5–8.0, 8.4, or PostgreSQL 9–18.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats. For very old database types see [Using DDEV to spin up a legacy PHP application](https://ddev.com/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev/).
+| :octicons-file-directory-16: project | `mariadb:11.8` | Can be MariaDB 5.5–10.8, 10.11, 11.4, 11.8 and MySQL 5.5–8.0, 8.4, or PostgreSQL 9–18.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats. For very old database types see [Using DDEV to spin up a legacy PHP application](https://ddev.com/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev/).
+
+Set with `ddev config --database=<database type>:<version>`, for example `mariadb:11.8`.
 
 ## `dbimage_extra_packages`
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

Its not apparent how to set an array [config setting](https://docs.ddev.com/en/stable/users/configuration/config/) via ddev config cli and there seems to not be a consistent way, for example some values are are comma delimited while others use a colon delimiter. Also the title "[Database Server Types](https://docs.ddev.com/en/stable/users/extend/database-types/)" link in the table does not suggest to me that it contains the cli command examples.

## How This PR Solves The Issue

So i think it's best to document each specific way. For this PR, i am only suggesting the database array config section since this section is in the OOTB ddev config yaml file and so most common array config people might want to change.

PS: I also set the default value in the table to the cli string value so more self documenting, then no specific example is required. (but for happy for any adjustments!)  

## Manual Testing Instructions

Please spellcheck, grammar check and feel free to adjust wording:

https://ddev--8387.org.readthedocs.build/en/8387/users/configuration/config/#database

## Automated Testing Overview

Nil.

## Release/Deployment Notes

Nil.