### PR TITLE
test(wsl2): fix TestHostDBPort

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -4282,7 +4282,11 @@ func TestHostDBPort(t *testing.T) {
 				out = strings.ReplaceAll(out, "\r", "")
 				out = strings.ReplaceAll(out, " ", "")
 				lines := strings.Split(out, "\n")
-				assert.Equal("1", lines[0])
+				// Newer mariadb clients may emit an unrelated stderr warning
+				// (e.g. about --ssl-verify-server-cert with a passwordless
+				// login) that gets mixed into CombinedOutput, so check for the
+				// SELECT result on any line rather than locking to lines[0].
+				assert.Contains(lines, "1", "expected '1' in output, got: %v", lines)
 			}
 
 			// Running the test host custom command "showport" ensures that the DDEV_HOST_DB_PORT


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/actions/runs/25500749856/job/74832719857#step:9:9397

```
2026-05-07T15:23:06.201 Ensuring write permissions for TestPkgDrupal11
    ddevapp_test.go:4285: 
        	Error Trace:	/home/testuser/workspace/ddev/pkg/ddevapp/ddevapp_test.go:4285
        	Error:      	Not equal: 
        	            	expected: "1"
        	            	actual  : "WARNING:option--ssl-verify-server-certisdisabled,becauseofaninsecurepasswordlesslogin."
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-1
        	            	+WARNING:option--ssl-verify-server-certisdisabled,becauseofaninsecurepasswordlesslogin.
        	Test:       	TestHostDBPort
```

## How This PR Solves The Issue

Changes the assert line.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
