### PR TITLE
test(windows): fix TestUtilityAddonUpdateCheckerCmd, for #8373

### DIFF
--- a/cmd/ddev/cmd/utility-addon-update-checker_test.go
+++ b/cmd/ddev/cmd/utility-addon-update-checker_test.go
@@ -24,7 +24,7 @@ func TestUtilityAddonUpdateCheckerCmd(t *testing.T) {
 		// Script may exit non-zero when add-on is out of date; ignore the error.
 		out, _ := exec.RunHostCommand(DdevBin, "utility", "addon-update-checker", "--dir", dir)
 		require.Contains(t, out, "Running add-on update checker in:")
-		require.Contains(t, out, dir)
+		require.Contains(t, out, filepath.Base(dir))
 	})
 
 	// Test 2: workspace with subdirectories each containing install.yaml — runs in each


### PR DESCRIPTION
## The Issue

- For #8373

https://buildkite.com/ddev/ddev-windows-mutagen/builds/6244#019e048e-2c01-41da-8a94-c5212930e6f7

```
=== RUN   TestUtilityAddonUpdateCheckerCmd/SingleAddon
    utility-addon-update-checker_test.go:27:
        	Error Trace:	C:/Users/testbot/tmp/buildkite/tb-win11-10-1/ddev/ddev-windows-mutagen/cmd/ddev/cmd/utility-addon-update-checker_test.go:27
        	Error:      	"Running add-on update checker in: /c/Users/testbot/tmp/ddevtest/SingleAddon1212370145\nERROR: Actions needed:\n- README.md is missing, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/README_ADDON.md?plain=1\n- install.yaml should contain `ddev_version_constraint: '>= v1.24.10'` or higher, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/install.yaml\n- tests/ directory should contain at least one .bats test file, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/tests/test.bats\n- .github/workflows/tests.yml is missing, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/.github/workflows/tests.yml\n- GitHub template missing: .github/ISSUE_TEMPLATE/bug_report.yml, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/.github/ISSUE_TEMPLATE/bug_report.yml?plain=1\n- GitHub template missing: .github/ISSUE_TEMPLATE/feature_request.yml, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml?plain=1\n- GitHub template missing: .github/PULL_REQUEST_TEMPLATE.md, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1\n- LICENSE is missing, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/LICENSE\n- .gitattributes is missing, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/.gitattributes\n- .editorconfig is missing, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/.editorconfig\nExit code: 1\n" does not contain "C:\\Users\\testbot\\tmp\\ddevtest\\SingleAddon1212370145"
        	Test:       	TestUtilityAddonUpdateCheckerCmd/SingleAddon
```

## How This PR Solves The Issue

It's not important to translate the full path here to `/c/Users/...`, checking the directory name is enough.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
