### PR TITLE
fix(ddev-webserver): `ddev stop` takes 10s due to bash deferring SIGTERM during foreground cat, fixes #8295

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/pre-start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/pre-start.sh
@@ -17,4 +17,9 @@ fi
 # Kill process 1 + process group if this exist or fails
 trap "trap - SIGTERM && kill -- -1" SIGINT SIGTERM EXIT SIGHUP SIGQUIT
 
-cat < ${logpipe}
+# Run cat in background so bash can process signals during `wait`.
+# If cat runs in the foreground, bash defers SIGTERM until cat exits,
+# which never happens because nobody closes the write end of the pipe —
+# causing Docker to wait the full stop_grace_period before sending SIGKILL.
+cat < ${logpipe} &
+wait

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260427_stasadev_dockerfile" // Note that this can be overridden by make
+var WebTag = "20260508_rfay_faster_poweroff" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

* Fixes #8295 

`ddev stop` always takes ~10 seconds.  So `ddev poweroff` takes a long time

## How This PR Solves The Issue

* #8234 exposed excellent output showing container stop during `ddev stop` and `ddev poweroff`, so it was clear what was happening. The web container was taking 10s to stop... for no particular reason.

`pre-start.sh` runs as PID 1 in the web container. It sets a SIGTERM trap to `kill -- -1` (kill all processes in the container), then blocks on `cat < ${logpipe}`.

The bug: **bash does not process signal traps while a foreground command is running.** With `cat` in the foreground, the SIGTERM trap never fires when Docker sends SIGTERM to PID 1. `kill -- -1` never runs, supervisord is never told to stop, nobody closes the write end of the named pipe, `cat` never gets EOF — a complete deadlock. Docker waits the full 10-second default grace period and then sends SIGKILL.

Fix: background `cat` and use `wait` instead. `wait` is a bash builtin that does allow signal processing, so SIGTERM fires the trap immediately, `kill -- -1` stops all container processes, and the container exits cleanly in under a second.

Confirmed: `supervisorctl stop all` inside the container stops all processes (nginx, php-fpm, cron, mailpit) near-instantly, so there was never a problem with the supervised processes themselves — only with the signal never reaching the trap.

### Timing

With v1.25.2: 11.5s to `ddev stop`

```
rfay@rfay-mba-m4:~/workspace/d11$ DDEV=/opt/homebrew/bin/ddev
rfay@rfay-mba-m4:~/workspace/d11$ $DDEV --version
ddev version v1.25.2
rfay@rfay-mba-m4:~/workspace/d11$ $DDEV start
...
$ time $DDEV stop
 Container ddev-d11-db Removed
 Container ddev-d11-web Removed
 Network ddev-d11_default Removed
Project d11 has been stopped.

real	0m11.556s
user	0m0.444s
sys	0m0.805s
```

With this PR, 1.4s to `ddev stop`

```
rfay@rfay-mba-m4:~/workspace/ddev$ DDEV=/Users/rfay/workspace/ddev/.gotmp/bin/darwin_arm64/ddev
rfay@rfay-mba-m4:~/workspace/ddev$ $DDEV --version
ddev version v1.25.2-28-g261434cf8
rfay@rfay-mba-m4:~/workspace/ddev$ $DDEV start
...
rfay@rfay-mba-m4:~/workspace/ddev$ time $DDEV stop d11
 Container ddev-d11-db Removed
 Container ddev-d11-web Removed
 Network ddev-d11_default Removed
Project d11 has been stopped.

real	0m1.399s
user	0m0.443s
sys	0m0.326s
```


## Manual Testing Instructions

- `ddev start` a project
- `time ddev stop — should complete in ~1.5s instead of ~11.5s
- `ddev start && time ddev stop` — should be way faster
- `ddev logs` and `ddev logs -f` should work the same

## Automated Testing Overview

No changes

## Release/Deployment Notes

* Release notes can mention that `ddev stop` and `ddev poweroff` are much faster

