### PR TITLE
test(share): improve cloudflared debug output on unmarshal errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,10 +194,10 @@ EOF
 
 ### Creating PRs with `gh`
 
-When creating or editing PRs with `gh pr create` or `gh pr edit`, use the same template structure from `.github/PULL_REQUEST_TEMPLATE.md` for the `--body` argument. Use a HEREDOC for the body to preserve markdown formatting:
+When creating or editing PRs with `gh pr create` or `gh pr edit`, use the same template structure from `.github/PULL_REQUEST_TEMPLATE.md`. **Always write the body to a temporary file and use `--body-file`** — inline HEREDOCs inside `$(...)` are unreliable in bash and will fail when the body contains single quotes or special characters.
 
 ```bash
-gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
+cat > ~/tmp/pr_body.md <<'EOF'
 ## The Issue
 
 - Fixes #<issue_number>
@@ -220,7 +220,7 @@ gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
 
 [Impact assessment]
 EOF
-)"
+gh pr create --title "<type>: <description>" --body-file ~/tmp/pr_body.md
 ```
 
 ### Pre-Commit Checklist

--- a/cmd/ddev/cmd/share_test.go
+++ b/cmd/ddev/cmd/share_test.go
@@ -196,9 +196,16 @@ func TestShareCmdCloudflared(t *testing.T) {
 		elapsed += pollInterval
 
 		stdoutOutput := stdoutBuf.String()
+		stderrOutput := stderrBuf.String()
+
 		if strings.Contains(stdoutOutput, "Tunnel URL:") && strings.Contains(stdoutOutput, "trycloudflare.com") {
 			t.Logf("Cloudflared tunnel established after %v", elapsed)
 			break
+		}
+		// Detect cloudflare quick-tunnel API errors early so we can log and fail with context.
+		if strings.Contains(stderrOutput, "Error unmarshaling QuickTunnel") || strings.Contains(stderrOutput, "failed to unmarshal quick Tunnel") {
+			t.Logf("Stdout so far:\n%s", stdoutOutput)
+			t.Fatalf("cloudflare quick-tunnel API returned an unmarshal error (possible transient 500):\n%s", stderrOutput)
 		}
 		t.Logf("Still waiting for tunnel... (%v/%v)", elapsed, maxWait)
 	}
@@ -226,8 +233,10 @@ func TestShareCmdCloudflared(t *testing.T) {
 	t.Logf("Stderr output:\n%s", stderrOutput)
 
 	// Verify URL was displayed
-	require.Contains(t, stdoutOutput, "Tunnel URL:")
-	require.Contains(t, stdoutOutput, "trycloudflare.com")
+	require.Contains(t, stdoutOutput, "Tunnel URL:",
+		"cloudflared did not output a tunnel URL; stderr output:\n%s", stderrOutput)
+	require.Contains(t, stdoutOutput, "trycloudflare.com",
+		"tunnel URL does not contain trycloudflare.com; stderr output:\n%s", stderrOutput)
 }
 
 // TestShareCmdProviderSystem tests the script-based provider system


### PR DESCRIPTION
## The Issue

During a Buildkite run ([macOS arm64 mutagen build #13484](https://buildkite.com/ddev/ddev-macos-arm64-mutagen/builds/13484#019e0f5c-1321-4e1e-a126-e345454345b8/L14596)), TestShareCmdCloudflared failed with a generic "does not contain Tunnel URL:" message. The actual cause was cloudflare's quick-tunnel API returning an HTTP 500 unmarshal error, which was buried in stderr and only visible after reading through all the output manually.

## How This PR Solves The Issue

- During the polling loop, detects unmarshal error patterns (Error unmarshaling QuickTunnel, failed to unmarshal quick Tunnel) in stderr and calls t.Fatalf immediately with full stderr context, rather than waiting out the remaining timeout.
- Adds stderr content to the final require.Contains failure messages so the cause is visible inline if a failure slips past the polling check.

## Manual Testing Instructions

- Run: DDEV_TEST_SHARE_CMD=true go test -v -run TestShareCmdCloudflared ./cmd/ddev/cmd/ with cloudflared installed.
- To simulate the failure: mock a cloudflared binary that outputs the unmarshal error line and verify the test fails immediately with full context.

## Automated Testing Overview

Test-only change. No new test infrastructure needed.

## Release/Deployment Notes

No user-facing changes. Test diagnostic improvement only.
