### PR TITLE
docs(providers): align --environment examples and flags, fixes #8402

### DIFF
--- a/cmd/ddev/cmd/pull.go
+++ b/cmd/ddev/cmd/pull.go
@@ -18,14 +18,14 @@ var PullCmd = &cobra.Command{
 	Long: `Pull files and database using a configured provider plugin.
 	Running pull will connect to the configured provider and download + import the
 	database and files.`,
-	Example: `ddev pull pantheon
-ddev pull platform
+	Example: `ddev pull upsun
 ddev pull pantheon -y
-ddev pull upsun -y
-ddev pull platform --skip-files -y
-ddev pull localfile --skip-db -y
-ddev pull lagoon --environment=LAGOON_PROJECT=amazeeio-ddev,LAGOON_ENVIRONMENT=pull
-ddev pull platform --environment=PLATFORM_ENVIRONMENT=main,PLATFORMSH_CLI_TOKEN=abcdef
+ddev pull upsun --skip-files -y
+ddev pull acquia --skip-db -y
+ddev pull upsun --skip-import
+ddev pull upsun --environment="PLATFORM_ENVIRONMENT=main,UPSUN_CLI_TOKEN=abcdeyourtoken"
+ddev pull pantheon --environment="DDEV_PANTHEON_ENVIRONMENT=dev,TERMINUS_MACHINE_TOKEN=abcdeyourtoken"
+ddev pull lagoon --environment="LAGOON_PROJECT=your-project,LAGOON_ENVIRONMENT=main"
 `,
 
 	Args: cobra.ExactArgs(1),

--- a/cmd/ddev/cmd/push.go
+++ b/cmd/ddev/cmd/push.go
@@ -19,12 +19,13 @@ var PushCmd = &cobra.Command{
 	Running push will connect to the configured provider and export and upload the
 	database and/or files. It is very useful for pushing to non-production
 	environments, but should rarely be used to push to production.`,
-	Example: `ddev push pantheon
-ddev push platform
+	Example: `ddev push upsun
 ddev push pantheon -y
-ddev push platform --skip-files -y
+ddev push upsun --skip-files -y
 ddev push acquia --skip-db -y
-ddev push platform --environment=PLATFORM_ENVIRONMENT=main,PLATFORMSH_CLI_TOKEN=abcdef
+ddev push upsun --environment="PLATFORM_ENVIRONMENT=main,UPSUN_CLI_TOKEN=abcdeyourtoken"
+ddev push pantheon --environment="DDEV_PANTHEON_ENVIRONMENT=dev,TERMINUS_MACHINE_TOKEN=abcdeyourtoken"
+ddev push lagoon --environment="LAGOON_PROJECT=your-project,LAGOON_ENVIRONMENT=main"
 `,
 	Args: cobra.ExactArgs(1),
 	PreRun: func(_ *cobra.Command, _ []string) {
@@ -145,6 +146,8 @@ ddev push %s --skip-files -y`, subCommandName, subCommandName, subCommandName),
 		subCommand.Flags().Bool("skip-db", false, "Skip pushing database archive")
 		subCommand.Flags().Bool("skip-files", false, "Skip pushing file archive")
 		subCommand.Flags().Bool("skip-import", false, "Downloads file and/or database archives, but does not import them")
+		// This flag is irrelevant for push
+		_ = subCommand.Flags().MarkHidden("skip-import")
 		subCommand.Flags().String("environment", "", "Add/override environment variables during pull. Commas and equals are not allowed in the names or values.")
 	}
 }

--- a/docs/content/users/providers/acquia.md
+++ b/docs/content/users/providers/acquia.md
@@ -51,4 +51,17 @@ DDEV’s Acquia integration pulls database and files from an existing project in
 
 ## Usage
 
-`ddev pull acquia` will connect to the Acquia Cloud Platform to download the database and files; note that it will download the latest available backup on the requested environment, rather than use a fresh copy of the database. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* `ddev pull acquia` will connect to the Acquia Cloud Platform to download the database and files; note that it will download the latest available backup on the requested environment, rather than use a fresh copy of the database. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* To pull from a specific environment without permanently changing your project config, pass environment variables using `--environment`:
+
+    ```bash
+    ddev pull acquia --environment="ACQUIA_ENVIRONMENT_ID=yoursite.dev"
+    ```
+
+    You can combine multiple variables:
+
+    ```bash
+    ddev pull acquia --environment="ACQUIA_ENVIRONMENT_ID=yoursite.dev,ACQUIA_API_KEY=xxxxxxxx,ACQUIA_API_SECRET=xxxxx"
+    ```
+
+* If you need to change the `acquia.yaml` recipe, you can change it to suit your needs, but remember to remove the `#ddev-generated` line from the top of the file.

--- a/docs/content/users/providers/acquia.md
+++ b/docs/content/users/providers/acquia.md
@@ -51,7 +51,7 @@ DDEV’s Acquia integration pulls database and files from an existing project in
 
 ## Usage
 
-* `ddev pull acquia` will connect to the Acquia Cloud Platform to download the database and files; note that it will download the latest available backup on the requested environment, rather than use a fresh copy of the database. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* [`ddev pull acquia`](../usage/commands.md#pull) will connect to the Acquia Cloud Platform to download the database and files; note that it will download the latest available backup on the requested environment, rather than use a fresh copy of the database. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
 * To pull from a specific environment without permanently changing your project config, pass environment variables using `--environment`:
 
     ```bash

--- a/docs/content/users/providers/lagoon.md
+++ b/docs/content/users/providers/lagoon.md
@@ -9,14 +9,14 @@ DDEV provides integration with [Lagoon](https://lagoon.sh/), allowing users to q
 
     ```yaml
     web_environment:
-        - LAGOON_PROJECT=<project-name>
-        - LAGOON_ENVIRONMENT=<environment-name>
+        - LAGOON_PROJECT=your-project
+        - LAGOON_ENVIRONMENT=main
     ```
 
     You can also do this with:
 
     ```bash
-    ddev config --web-environment-add="LAGOON_PROJECT=<project-name>,LAGOON_ENVIRONMENT=<environment-name>"
+    ddev config --web-environment-add="LAGOON_PROJECT=your-project,LAGOON_ENVIRONMENT=main"
     ```
 
 3. Syncing is done via [`lagoon-sync`](https://github.com/uselagoon/lagoon-sync) which must be configured in your `.lagoon.yml` or `.lagoon-sync.yml`, see the [DDEV example `.lagoon.yml`](https://github.com/ddev/test-amazeeio-lagoon/blob/main/.lagoon.yml#L27-L37).
@@ -24,9 +24,21 @@ DDEV provides integration with [Lagoon](https://lagoon.sh/), allowing users to q
 5. Run `ddev auth ssh` to make your SSH key available in the project’s web container.
 6. Run [`ddev restart`](../usage/commands.md#restart).
 7. Run `ddev pull lagoon`. After you agree to the prompt, the current upstream databases and files will be downloaded.
-8. Optionally run `ddev push lagoon` to push local files and database to Lagoon. The [`ddev push`](../usage/commands.md#push). This must be done with great care if you're pushing to a production environment, but is great for pushing to branch environments.
+8. Optionally use `ddev push lagoon` to push local files and database to Lagoon. The [`ddev push`](../usage/commands.md#push) command must be done with great care if you're pushing to a production environment, but is great for pushing to branch environments.
 
 ## Usage
 
-* `ddev pull lagoon` will connect to the Lagoon environment to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` or `--skip-db` flags.
-* If you need to change the `.ddev/providers/lagoon.yaml` recipe, you can change it to suit your needs, but remember to remove the `#ddev-generated` line from the top of the file.
+* `ddev pull lagoon` will connect to the Lagoon environment to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* To pull from a specific environment without permanently changing your project config, pass environment variables using `--environment`:
+
+    ```bash
+    ddev pull lagoon --environment="LAGOON_ENVIRONMENT=main"
+    ```
+
+    You can combine multiple variables:
+
+    ```bash
+    ddev pull lagoon --environment="LAGOON_PROJECT=your-project,LAGOON_ENVIRONMENT=main"
+    ```
+
+* If you need to change the `lagoon.yaml` recipe, you can change it to suit your needs, but remember to remove the `#ddev-generated` line from the top of the file.

--- a/docs/content/users/providers/lagoon.md
+++ b/docs/content/users/providers/lagoon.md
@@ -28,7 +28,7 @@ DDEV provides integration with [Lagoon](https://lagoon.sh/), allowing users to q
 
 ## Usage
 
-* `ddev pull lagoon` will connect to the Lagoon environment to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* [`ddev pull lagoon`](../usage/commands.md#pull) will connect to the Lagoon environment to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
 * To pull from a specific environment without permanently changing your project config, pass environment variables using `--environment`:
 
     ```bash

--- a/docs/content/users/providers/pantheon.md
+++ b/docs/content/users/providers/pantheon.md
@@ -85,7 +85,7 @@ ddev pull pantheon --environment=DDEV_USE_PANTHEON_BACKUP=true
 
 ## Usage
 
-* `ddev pull pantheon` will connect to Pantheon to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* [`ddev pull pantheon`](../usage/commands.md#pull) will connect to Pantheon to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
 * To pull from a specific environment without permanently changing your project config, pass environment variables using `--environment`:
 
     ```bash

--- a/docs/content/users/providers/pantheon.md
+++ b/docs/content/users/providers/pantheon.md
@@ -17,7 +17,7 @@ If you have DDEV installed, and have an active Pantheon account with an active s
 
         ```yaml
         web_environment:
-            - TERMINUS_MACHINE_TOKEN=your_token
+            - TERMINUS_MACHINE_TOKEN=abcdeyourtoken
         ```
 
     !!!tip "What if I have more than one API token?"
@@ -25,7 +25,7 @@ If you have DDEV installed, and have an active Pantheon account with an active s
 
         ```yaml
         web_environment:
-            - TERMINUS_MACHINE_TOKEN=your_token
+            - TERMINUS_MACHINE_TOKEN=abcdeyourtoken
         ```
 
 2. Choose a Pantheon site and environment you want to use with DDEV. You can usually use the site name, but in some environments you may need the site ID, which is the long third component of your site dashboard URL. So if the site dashboard is at `https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/`, the site ID is `009a2cda-2c22-4eee-8f9d-96f017321555`.
@@ -40,16 +40,13 @@ If you have DDEV installed, and have an active Pantheon account with an active s
 
     ```yaml
     web_environment:
-        - DDEV_PANTHEON_SITE=yourprojectname
+        - DDEV_PANTHEON_SITE=your-project
         - DDEV_PANTHEON_ENVIRONMENT=dev
     ```
 
-    You can also do this with `ddev config --web-environment-add="DDEV_PANTHEON_SITE=yourprojectname,DDEV_PANTHEON_ENVIRONMENT=dev"`.
+    You can also do this with `ddev config --web-environment-add="DDEV_PANTHEON_SITE=your-project,DDEV_PANTHEON_ENVIRONMENT=dev"`.
 
     You can usually use the site name, but in some environments you may need the site ID, which is the long third component of your site dashboard URL. So if the site dashboard is at `https://dashboard.pantheon.io/sites/009a2cda-2c22-4eee-8f9d-96f017321555#dev/`, the site ID is `009a2cda-2c22-4eee-8f9d-96f017321555`.
-
-    Instead of setting the environment variables in configuration files, you can use
-    `ddev pull pantheon --environment=DDEV_PANTHEON_SITE=yourprojectname,DDEV_PANTHEON_ENVIRONMENT=dev` for example.
 
     !!!note "Legacy Variable Names"
         The old `PANTHEON_SITE` and `PANTHEON_ENVIRONMENT` variable names are still supported for backward compatibility but are deprecated. These names conflict with Pantheon's own environment variables, which can cause applications to misidentify their runtime environment. Using `DDEV_PANTHEON_SITE` and `DDEV_PANTHEON_ENVIRONMENT` is strongly recommended.
@@ -85,3 +82,20 @@ ddev pull pantheon --environment=DDEV_USE_PANTHEON_BACKUP=true
 
 !!!warning "Backup freshness"
     Existing backups may not include the very latest data. Check your Pantheon dashboard to see when the last backup was created. Fresh dumps are generated on-demand and reflect the current state of your database.
+
+## Usage
+
+* `ddev pull pantheon` will connect to Pantheon to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* To pull from a specific environment without permanently changing your project config, pass environment variables using `--environment`:
+
+    ```bash
+    ddev pull pantheon --environment="DDEV_PANTHEON_ENVIRONMENT=dev"
+    ```
+
+    You can combine multiple variables:
+
+    ```bash
+    ddev pull pantheon --environment="DDEV_PANTHEON_SITE=your-project,DDEV_PANTHEON_ENVIRONMENT=dev,DDEV_USE_PANTHEON_BACKUP=true,TERMINUS_MACHINE_TOKEN=abcdeyourtoken"
+    ```
+
+* If you need to change the `pantheon.yaml` recipe, you can change it to suit your needs, but remember to remove the `#ddev-generated` line from the top of the file.

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -104,7 +104,7 @@ ddev pull platform --environment="PLATFORM_PRIMARY_RELATIONSHIP=main"
 
 ## Usage
 
-* `ddev pull platform` will connect to Upsun Fixed to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* [`ddev pull platform`](../usage/commands.md#pull) will connect to Upsun Fixed to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
 * To pull from a specific environment without permanently changing your project config, pass environment variables using `--environment`:
 
     ```bash

--- a/docs/content/users/providers/platform.md
+++ b/docs/content/users/providers/platform.md
@@ -50,21 +50,21 @@ You need to obtain and configure an API token first. This is only needed once.
 
             ```yaml
             web_environment:
-                - PLATFORM_PROJECT=nf4amudfn23biyourproject
+                - PLATFORM_PROJECT=abc12def34567
                 - PLATFORM_ENVIRONMENT=main
             ```
 
         * Or with a command from your terminal:
 
             ```bash
-            ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23bi,PLATFORM_ENVIRONMENT=main"
+            ddev config --web-environment-add="PLATFORM_PROJECT=abc12def34567,PLATFORM_ENVIRONMENT=main"
             ```
 
     For more information about how to set environment variables for containers and services see [Environment Variables for Containers and Services](../extend/customization-extendibility.md#environment-variables-for-containers-and-services).
 
 3. Run [`ddev restart`](../usage/commands.md#restart).
 4. Run `ddev pull platform`. After you agree to the prompt, the current upstream databases and files will be downloaded.
-5. Optionally use `ddev push platform` to push local files and database to Upsun. The [`ddev push`](../usage/commands.md#push) command can potentially damage your production site, so use it against a known environment and not against your production site..
+5. Optionally use `ddev push platform` to push local files and database to Upsun Fixed. The [`ddev push`](../usage/commands.md#push) command can potentially damage your production site, so we don't recommend using it.
 
 ### Managing Multiple Apps
 
@@ -104,5 +104,17 @@ ddev pull platform --environment="PLATFORM_PRIMARY_RELATIONSHIP=main"
 
 ## Usage
 
-* `ddev pull platform` will connect to Upsun to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* `ddev pull platform` will connect to Upsun Fixed to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* To pull from a specific environment without permanently changing your project config, pass environment variables using `--environment`:
+
+    ```bash
+    ddev pull platform --environment="PLATFORM_ENVIRONMENT=main"
+    ```
+
+    You can combine multiple variables:
+
+    ```bash
+    ddev pull platform --environment="PLATFORM_PROJECT=abc12def34567,PLATFORM_ENVIRONMENT=main,PLATFORM_APP=app,PLATFORM_PRIMARY_RELATIONSHIP=main,PLATFORMSH_CLI_TOKEN=abcdeyourtoken"
+    ```
+
 * If you need to change the `platform.yaml` recipe, you can change it or copy it to suit your needs, but remember to remove the `#ddev-generated` line from the top of the file.

--- a/docs/content/users/providers/upsun.md
+++ b/docs/content/users/providers/upsun.md
@@ -50,14 +50,14 @@ You need to obtain and configure an API token first. This only needs to be done 
 
             ```yaml
             web_environment:
-                - PLATFORM_PROJECT=nf4amudfn23biyourproject
+                - PLATFORM_PROJECT=abc12def34567
                 - PLATFORM_ENVIRONMENT=main
             ```
 
         * Or with a command from your terminal:
 
             ```bash
-            ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23bi,PLATFORM_ENVIRONMENT=main"
+            ddev config --web-environment-add="PLATFORM_PROJECT=abc12def34567,PLATFORM_ENVIRONMENT=main"
             ```
 
     For more information about how to set environment variables for containers and services see [Environment Variables for Containers and Services](../extend/customization-extendibility.md#environment-variables-for-containers-and-services).
@@ -105,4 +105,16 @@ ddev pull upsun --environment="PLATFORM_PRIMARY_RELATIONSHIP=main"
 ## Usage
 
 * `ddev pull upsun` will connect to Upsun to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* To pull from a specific environment without permanently changing your project config, pass environment variables using `--environment`:
+
+    ```bash
+    ddev pull upsun --environment="PLATFORM_ENVIRONMENT=main"
+    ```
+
+    You can combine multiple variables:
+
+    ```bash
+    ddev pull upsun --environment="PLATFORM_PROJECT=abc12def34567,PLATFORM_ENVIRONMENT=main,PLATFORM_APP=app,PLATFORM_PRIMARY_RELATIONSHIP=main,UPSUN_CLI_TOKEN=abcdeyourtoken"
+    ```
+
 * If you need to change the `upsun.yaml` recipe, you can change it to suit your needs, but remember to remove the `#ddev-generated` line from the top of the file.

--- a/docs/content/users/providers/upsun.md
+++ b/docs/content/users/providers/upsun.md
@@ -104,7 +104,7 @@ ddev pull upsun --environment="PLATFORM_PRIMARY_RELATIONSHIP=main"
 
 ## Usage
 
-* `ddev pull upsun` will connect to Upsun to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
+* [`ddev pull upsun`](../usage/commands.md#pull) will connect to Upsun to download database and files. To skip downloading and importing either file or database assets, use the `--skip-files` and `--skip-db` flags.
 * To pull from a specific environment without permanently changing your project config, pass environment variables using `--environment`:
 
     ```bash

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1116,44 +1116,54 @@ Flags:
 * `--skip-confirmation`, `-y`: Skip confirmation step.
 * `--skip-db`: Skip pulling database archive.
 * `--skip-files`: Skip pulling file archive.
-* `--skip-import`: Download archive(s) without importing than.
+* `--skip-import`: Download archive(s) without importing them.
 
 Example:
 
 ```shell
-# Pull a backup from the configured Pantheon project to use locally
-ddev pull pantheon
-
 # Pull a backup from the configured Upsun project to use locally
 ddev pull upsun
 
-# Pull a backup from the configured Pantheon project without confirming
+# Pull from Pantheon without confirming
 ddev pull pantheon -y
 
-# Pull the Upsun database *only* without confirming
+# Pull the Upsun database only without confirming
 ddev pull upsun --skip-files -y
 
-# Pull the localfile integration’s files *only* without confirming
-ddev pull localfile --skip-db -y
+# Pull the Acquia files only without confirming
+ddev pull acquia --skip-db -y
 
-# Pull from Upsun specifying the environment variables UPSUN_ENVIRONMENT and UPSUN_CLI_TOKEN on the command line
-ddev pull upsun --environment=UPSUN_ENVIRONMENT=main,UPSUN_CLI_TOKEN=abcdef
+# Download archives from Upsun without importing them
+ddev pull upsun --skip-import
+
+# Pull from Upsun overriding environment and token on the command line
+ddev pull upsun --environment="PLATFORM_ENVIRONMENT=main,UPSUN_CLI_TOKEN=abcdeyourtoken"
+
+# Pull from Pantheon overriding environment and token on the command line
+ddev pull pantheon --environment="DDEV_PANTHEON_ENVIRONMENT=dev,TERMINUS_MACHINE_TOKEN=abcdeyourtoken"
+
+# Pull from Lagoon overriding project and environment on the command line
+ddev pull lagoon --environment="LAGOON_PROJECT=your-project,LAGOON_ENVIRONMENT=main"
 ```
 
 ## `push`
 
 Push files and database using a configured [provider plugin](./../providers/index.md).
 
+Flags:
+
+* `--environment=ENV1=val1,ENV2=val2`
+* `--skip-confirmation`, `-y`: Skip confirmation step.
+* `--skip-db`: Skip pushing database archive.
+* `--skip-files`: Skip pushing file archive.
+
 Example:
 
 ```shell
-# Push local files and database to the configured Pantheon project
-ddev push pantheon
-
 # Push local files and database to the configured Upsun project
 ddev push upsun
 
-# Push files and database to Pantheon without confirming
+# Push to Pantheon without confirming
 ddev push pantheon -y
 
 # Push database only to Upsun without confirming
@@ -1161,6 +1171,15 @@ ddev push upsun --skip-files -y
 
 # Push files only to Acquia without confirming
 ddev push acquia --skip-db -y
+
+# Push to Upsun overriding environment and token on the command line
+ddev push upsun --environment="PLATFORM_ENVIRONMENT=main,UPSUN_CLI_TOKEN=abcdeyourtoken"
+
+# Push to Pantheon overriding environment and token on the command line
+ddev push pantheon --environment="DDEV_PANTHEON_ENVIRONMENT=dev,TERMINUS_MACHINE_TOKEN=abcdeyourtoken"
+
+# Push to Lagoon overriding project and environment on the command line
+ddev push lagoon --environment="LAGOON_PROJECT=your-project,LAGOON_ENVIRONMENT=main"
 ```
 
 ## `querious`

--- a/pkg/ddevapp/dotddev_assets/providers/acquia.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/acquia.yaml
@@ -25,22 +25,22 @@
 # 5. Add the ACQUIA_ENVIRONMENT_ID environment variable to your project `.ddev/config.yaml`, for example:
 #    ```yaml
 #    web_environment:
-#        - ACQUIA_ENVIRONMENT_ID=project1.dev
+#        - ACQUIA_ENVIRONMENT_ID=yoursite.dev
 #    ```
-#    You can also do this with `ddev config --web-environment-add="ACQUIA_ENVIRONMENT_ID=project1.dev"`.
+#    You can also do this with `ddev config --web-environment-add="ACQUIA_ENVIRONMENT_ID=yoursite.dev"`.
 #
 #    On the Acquia Cloud Platform you can find this out by navigating to the environments page,
 #    clicking on the header and look for the "SSH URL" line.
-#    Eg. `project1.dev@cool-projects.acquia-sites.com` would have a project ID of `project1.dev`
+#    Eg. `yoursite.dev@cool-projects.acquia-sites.com` would have a project ID of `yoursite.dev`
 #
 # 6. `ddev restart`
 # 7. Use `ddev pull acquia` to pull the project database and files.
+#    To pull from a specific environment without permanently changing your project config, use `--environment`:
+#    `ddev pull acquia --environment="ACQUIA_ENVIRONMENT_ID=yoursite.dev"`
+#    or with multiple variables: `ddev pull acquia --environment="ACQUIA_ENVIRONMENT_ID=yoursite.dev,ACQUIA_API_KEY=xxxxxxxx,ACQUIA_API_SECRET=xxxxx"`
 # 8. Optionally use `ddev push acquia` to push local files and database to Acquia. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
 # Debugging: Use `ddev exec acli command` and `ddev exec acli auth:login`
-
-# Instead of setting the environment variables in configuration files, you can use
-# `ddev pull acquia --environment=ACQUIA_ENVIRONMENT_ID=yourproject.dev` for example
 
 info_command:
   command: |

--- a/pkg/ddevapp/dotddev_assets/providers/lagoon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/lagoon.yaml
@@ -7,17 +7,20 @@
 # 2. Add LAGOON_PROJECT and LAGOON_ENVIRONMENT variables to your project in 'web_environment' or a '.ddev/.env'
 #    ```yaml
 #    web_environment:
-#        - LAGOON_PROJECT=<project-name>
-#        - LAGOON_ENVIRONMENT=<environment-name>
+#        - LAGOON_PROJECT=your-project
+#        - LAGOON_ENVIRONMENT=main
 #    ```
-#    You can also do this with `ddev config --web-environment-add="LAGOON_PROJECT=<project-name>,LAGOON_ENVIRONMENT=<environment-name>"`.
+#    You can also do this with `ddev config --web-environment-add="LAGOON_PROJECT=your-project,LAGOON_ENVIRONMENT=main"`.
 # 3. Syncing is done via lagoon-sync which must be configured in your .lagoon.yml or .lagoon-sync.yml,
 #    see the DDEV example .lagoon.yml at https://github.com/ddev/test-amazeeio-lagoon/blob/main/.lagoon.yml#L27-L37
 # 4. Configure an SSH key for your Lagoon user https://docs.lagoon.sh/using-lagoon-advanced/ssh/
-# 5. `ddev auth ssh`.
+# 5. Run `ddev auth ssh`.
 # 6. `ddev restart`
-# 7. `ddev pull lagoon`. After you agree to the prompt, the current upstream databases and files will be downloaded.
-# 8. Optionally `ddev push lagoon` to push local files and database to Lagoon. This must be done with great care
+# 7. Run `ddev pull lagoon`. After you agree to the prompt, the current upstream databases and files will be downloaded.
+#    To pull from a specific environment without permanently changing your project config, use `--environment`:
+#    `ddev pull lagoon --environment="LAGOON_ENVIRONMENT=main"`
+#    or with multiple variables: `ddev pull lagoon --environment="LAGOON_PROJECT=your-project,LAGOON_ENVIRONMENT=main"`
+# 8. Optionally use `ddev push lagoon` to push local files and database to Lagoon. This must be done with great care
 #    if you're pushing to a production environment, but is great for pushing to branch environments.
 
 info_command:

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
@@ -22,10 +22,10 @@
 # 2. Add DDEV_PANTHEON_SITE and DDEV_PANTHEON_ENVIRONMENT variables to your project `.ddev/config.yaml`:
 #    ```yaml
 #    web_environment:
-#        - DDEV_PANTHEON_SITE=yourproject
+#        - DDEV_PANTHEON_SITE=your-project
 #        - DDEV_PANTHEON_ENVIRONMENT=dev
 #    ```
-#    You can also do this with `ddev config --web-environment-add="DDEV_PANTHEON_SITE=yourproject,DDEV_PANTHEON_ENVIRONMENT=dev"`.
+#    You can also do this with `ddev config --web-environment-add="DDEV_PANTHEON_SITE=your-project,DDEV_PANTHEON_ENVIRONMENT=dev"`.
 #
 #    You can usually use the site name, but in some environments you may need the site uuid,
 #    which is the long 3rd component of your site dashboard URL. So if the site dashboard is at
@@ -45,12 +45,11 @@
 # 6. `ddev restart`
 #
 # 7. Run `ddev pull pantheon`. The ddev environment will download the Pantheon database and files using terminus and will import the database and files into the ddev environment. You should now be able to access the project locally.
+#    To pull from a specific environment without permanently changing your project config, use `--environment`:
+#    `ddev pull pantheon --environment="DDEV_PANTHEON_ENVIRONMENT=dev"`
+#    or with multiple variables: `ddev pull pantheon --environment="DDEV_PANTHEON_SITE=your-project,DDEV_PANTHEON_ENVIRONMENT=dev,DDEV_USE_PANTHEON_BACKUP=true,TERMINUS_MACHINE_TOKEN=abcdeyourtoken"`
 #
 # 8. Optionally use `ddev push pantheon` to push local files and database to Pantheon. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
-#
-
-# Instead of setting the environment variables in configuration files, you can use
-# `ddev pull pantheon --environment=DDEV_PANTHEON_SITE=yourproject,DDEV_PANTHEON_ENVIRONMENT=dev` for example
 #
 # To use existing backups instead of generating fresh database dumps (faster), add:
 # `DDEV_USE_PANTHEON_BACKUP=true` to your web_environment or use

--- a/pkg/ddevapp/dotddev_assets/providers/platform.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/platform.yaml
@@ -40,14 +40,17 @@
 #    if your branch is the same as your environment and the project is specified in .platform/local/project.yaml.
 #    ```yaml
 #    web_environment:
-#        - PLATFORM_PROJECT=nf4amudfn23biyourproject
+#        - PLATFORM_PROJECT=abc12def34567
 #        - PLATFORM_ENVIRONMENT=main
 #        - PLATFORM_APP=app
 #    ```
-#    You can also do this with `ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23biyourproject,PLATFORM_ENVIRONMENT=main,PLATFORM_APP=app"`.
+#    You can also do this with `ddev config --web-environment-add="PLATFORM_PROJECT=abc12def34567,PLATFORM_ENVIRONMENT=main,PLATFORM_APP=app"`.
 #
 # 4. `ddev restart`
-# 5. Run `ddev pull platform`. After you agree to the prompt, the current upstream database and files will be downloaded.
+# 5. Run `ddev pull platform`. After you agree to the prompt, the current upstream databases and files will be downloaded.
+#    To pull from a specific environment without permanently changing your project config, use `--environment`:
+#    `ddev pull platform --environment="PLATFORM_ENVIRONMENT=main"`
+#    or with multiple variables: `ddev pull platform --environment="PLATFORM_PROJECT=abc12def34567,PLATFORM_ENVIRONMENT=main,PLATFORM_APP=app,PLATFORM_PRIMARY_RELATIONSHIP=main,PLATFORMSH_CLI_TOKEN=abcdeyourtoken"`
 # 6. Optionally use `ddev push platform` to push local files and database to Upsun. Note that `ddev push` is a command that can potentially damage your production site, so use it against an environment you want to use it against.
 
 # If you have more than one database on your Upsun Fixed project,
@@ -56,8 +59,6 @@
 # Do this by setting PLATFORM_PRIMARY_RELATIONSHIP, for example, `ddev config --web-environment-add=PLATFORM_PRIMARY_RELATIONSHIP=main`
 # or run `ddev pull platform` with the environment variable, for example
 # `ddev pull platform -y --environment=PLATFORM_PRIMARY_RELATIONSHIP=main`
-# If you need to change this `platform.yaml` recipe, you can change it to suit your needs, but remember to remove the "ddev-generated" line from the top.
-
 # Debugging: Use `ddev exec platform` to use the `platform` CLI inside the web container to see what Upsun knows about
 # your configuration and whether it's working correctly.
 

--- a/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/upsun.yaml
@@ -40,14 +40,17 @@
 #    if your branch is the same as your environment and the project is specified in .upsun/local/project.yaml.
 #    ```yaml
 #    web_environment:
-#        - PLATFORM_PROJECT=nf4amudfn23biyourproject
+#        - PLATFORM_PROJECT=abc12def34567
 #        - PLATFORM_ENVIRONMENT=main
 #        - PLATFORM_APP=app
 #    ```
-#    You can also do this with `ddev config --web-environment-add="PLATFORM_PROJECT=nf4amudfn23biyourproject,PLATFORM_ENVIRONMENT=main,PLATFORM_APP=app"`.
+#    You can also do this with `ddev config --web-environment-add="PLATFORM_PROJECT=abc12def34567,PLATFORM_ENVIRONMENT=main,PLATFORM_APP=app"`.
 #
 # 4. `ddev restart`
-# 5. Run `ddev pull upsun`. After you agree to the prompt, the current upstream database and files will be downloaded.
+# 5. Run `ddev pull upsun`. After you agree to the prompt, the current upstream databases and files will be downloaded.
+#    To pull from a specific environment without permanently changing your project config, use `--environment`:
+#    `ddev pull upsun --environment="PLATFORM_ENVIRONMENT=main"`
+#    or with multiple variables: `ddev pull upsun --environment="PLATFORM_PROJECT=abc12def34567,PLATFORM_ENVIRONMENT=main,PLATFORM_APP=app,PLATFORM_PRIMARY_RELATIONSHIP=main,UPSUN_CLI_TOKEN=abcdeyourtoken"`
 # 6. Optionally use `ddev push upsun` to push local files and database to Upsun. Note that `ddev push` is a command that can potentially damage your production site, so this is not recommended.
 
 # If you have more than one database on your Upsun project,


### PR DESCRIPTION
## The Issue

- Fixes #8402

The `--environment` flag usage was inconsistently documented across provider docs, YAML recipes, and the `pull`/`push` command reference. Examples used placeholder values like `<project-name>` or bare tokens without quoting.

## How This PR Solves The Issue

Provider docs, YAML recipes, and CLI examples were aligned: all `--environment` usage now shows quoted values and realistic placeholder names. The `--skip-import` flag (download-only, not applicable to push) is now hidden on `ddev push` subcommands.

## Manual Testing Instructions

- Check the docs:
  https://ddev--8403.org.readthedocs.build/en/8403/users/usage/commands/#pull
  https://ddev--8403.org.readthedocs.build/en/8403/users/usage/commands/#push
  https://ddev--8403.org.readthedocs.build/en/8403/users/providers/acquia/#usage
  https://ddev--8403.org.readthedocs.build/en/8403/users/providers/lagoon/#usage
  https://ddev--8403.org.readthedocs.build/en/8403/users/providers/pantheon/#usage
  https://ddev--8403.org.readthedocs.build/en/8403/users/providers/platform/#usage
  https://ddev--8403.org.readthedocs.build/en/8403/users/providers/upsun/#usage
- Run `ddev pull --help` and `ddev push --help` to verify examples render correctly.
- Run `ddev push <provider> --help` and confirm `--skip-import` is not listed.

## Automated Testing Overview

No automated tests needed - this is a docs and CLI help text change only.

## Release/Deployment Notes

No functional behavior changes. The `--skip-import` flag is now hidden (not removed) on push subcommands, so any scripts passing it will still work without error.