### PR TITLE
feat: add support for global Dockerfiles, fixes #8406 (#8405) [skip ci]

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -117,19 +117,19 @@ Multi-stage builds are useful to anyone who has struggled to optimize Dockerfile
 
 ### Global Dockerfiles
 
-DDEV supports global web-build files for the web container and database container. Files placed in `~/.ddev/web-build/` and `~/.ddev/db-build/` will be applied to all DDEV web containers and database containers respectively. Files placed there apply to every project on the workstation and are useful for machine-specific customizations like corporate proxy certificates, private package registries, or developer tools you always want available.
+DDEV supports global web-build files for the web container and database container. Files placed in `$HOME/.ddev/web-build/` and `$HOME/.ddev/db-build/` will be applied to all DDEV web containers and database containers respectively. Files placed there apply to every project on the workstation and are useful for machine-specific customizations like corporate proxy certificates, private package registries, or developer tools you always want available. See [Global Files](../usage/architecture.md#global-files) to find out where this directory actually lives on your system, since it isn’t always `$HOME/.ddev`.
 
 Global files are inserted *before* project-level files, so project-level files run after them. Context files (non-Dockerfiles) in the global directories are also available as `ADD`/`COPY` sources, with project-level files taking precedence on name conflicts.
 
 For example, to install a custom CA certificate on every project:
 
 ```bash
-mkdir -p ~/.ddev/web-build
-cat > ~/.ddev/web-build/pre.Dockerfile << 'EOF'
+mkdir -p $HOME/.ddev/web-build
+cat > $HOME/.ddev/web-build/pre.Dockerfile << 'EOF'
 COPY my-ca.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 EOF
-cp /path/to/my-ca.crt ~/.ddev/web-build/my-ca.crt
+cp /path/to/my-ca.crt $HOME/.ddev/web-build/my-ca.crt
 ```
 
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with [`ddev restart --no-cache`](../usage/commands.md#restart) or [`ddev utility rebuild`](../usage/commands.md#utility-rebuild). `ddev utility rebuild` is also great because it shows you the entire process of the build for debugging.

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -117,7 +117,7 @@ Multi-stage builds are useful to anyone who has struggled to optimize Dockerfile
 
 ### Global Dockerfiles
 
-All of the above variants are also supported in `~/.ddev/web-build/` and `~/.ddev/db-build/`. Files placed there apply to every project on the machine and are useful for machine-specific customizations like corporate proxy certificates, private package registries, or developer tools you always want available.
+DDEV supports global web-build files for the web container and database container. Files placed in `~/.ddev/web-build/` and `~/.ddev/db-build/` will be applied to all DDEV web containers and database containers respectively. Files placed there apply to every project on the workstation and are useful for machine-specific customizations like corporate proxy certificates, private package registries, or developer tools you always want available.
 
 Global files are inserted *before* project-level files, so project-level files run after them. Context files (non-Dockerfiles) in the global directories are also available as `ADD`/`COPY` sources, with project-level files taking precedence on name conflicts.
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -115,6 +115,23 @@ Finally, to support [Multi-stage builds](https://docs.docker.com/build/building/
 
 Multi-stage builds are useful to anyone who has struggled to optimize Dockerfiles while keeping them easy to read and maintain.
 
+### Global Dockerfiles
+
+All of the above variants are also supported in `~/.ddev/web-build/` and `~/.ddev/db-build/`. Files placed there apply to every project on the machine and are useful for machine-specific customizations like corporate proxy certificates, private package registries, or developer tools you always want available.
+
+Global files are inserted *before* project-level files, so project-level files run after them. Context files (non-Dockerfiles) in the global directories are also available as `ADD`/`COPY` sources, with project-level files taking precedence on name conflicts.
+
+For example, to install a custom CA certificate on every project:
+
+```bash
+mkdir -p ~/.ddev/web-build
+cat > ~/.ddev/web-build/pre.Dockerfile << 'EOF'
+COPY my-ca.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+EOF
+cp /path/to/my-ca.crt ~/.ddev/web-build/my-ca.crt
+```
+
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with [`ddev restart --no-cache`](../usage/commands.md#restart) or [`ddev utility rebuild`](../usage/commands.md#utility-rebuild). `ddev utility rebuild` is also great because it shows you the entire process of the build for debugging.
 
 Examples of possible Dockerfiles are `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example`, created in your project when you run [`ddev config`](../usage/commands.md#config).

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -90,53 +90,38 @@ webimage_extra_packages: [locales-all]
 
 ## Adding Extra Dockerfiles for `webimage` and `dbimage`
 
-For more complex requirements, you can add:
+For more complex requirements, add your own Dockerfile content to `.ddev/web-build` (for `webimage`) or `.ddev/db-build` (for `dbimage`). DDEV merges those files with its own build steps into one generated Dockerfile per image, at `.ddev/.webimageBuild/Dockerfile` and `.ddev/.dbimageBuild/Dockerfile`, which you never edit directly.
 
-* `.ddev/web-build/Dockerfile`
-* `.ddev/web-build/Dockerfile.*`
-* `.ddev/db-build/Dockerfile`
-* `.ddev/db-build/Dockerfile.*`
+DDEV writes example files for you to copy and rename:
 
-These files’ content will be inserted into the constructed Dockerfile for each image. They are inserted *after* most of the rest of the things that are done to build the image, and are done in alphabetical order, so `Dockerfile` is inserted first, followed by `Dockerfile.*` in alphabetical order.
+* `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example` in the project, when you run [`ddev config`](../usage/commands.md#config)
+* `$HOME/.ddev/web-build/pre.Dockerfile.example` and `$HOME/.ddev/db-build/pre.Dockerfile.example` for [global Dockerfiles](#global-dockerfiles)
 
-For certain use cases, you might need to add directives very early on the Dockerfile like proxy settings or SSL termination. You can use `pre.` variants for this that are inserted *before* what DDEV adds to build the image:
+!!!warning "The Dockerfile builds an image, it doesn’t run in your project"
+    While the Dockerfile is executing, your code is not mounted and the container is not running, the image is being built. So for example, an `npm install` in `/var/www/html` will not do anything to your project because the code is not there at image building time.
 
-* `.ddev/web-build/pre.Dockerfile.*`
-* `.ddev/web-build/pre.Dockerfile`
-* `.ddev/db-build/pre.Dockerfile.*`
-* `.ddev/db-build/pre.Dockerfile`
+### Insertion Order
 
-Finally, to support [Multi-stage builds](https://docs.docker.com/build/building/multi-stage/) and other more complex use cases, you can use `prepend.` variants that are inserted *before* everything else, *on top* of the generated Dockerfile.
+The file name decides where its content lands in the generated Dockerfile, and [global files](#global-dockerfiles) in `$HOME/.ddev/*-build` are always inserted before the project’s files in `.ddev/*-build`:
 
-* `.ddev/web-build/prepend.Dockerfile.*`
-* `.ddev/web-build/prepend.Dockerfile`
-* `.ddev/db-build/prepend.Dockerfile.*`
-* `.ddev/db-build/prepend.Dockerfile`
+| # | Content                                                                                       | Notes                                                                                                                                                                                    |
+|---|-----------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1 | `prepend.Dockerfile`, `prepend.Dockerfile.*`<br>([global](#global-dockerfiles), then project) | Above DDEV’s `FROM` line, for [multi-stage builds](#multi-stage-builds). Only `$BASE_IMAGE` is declared this early, see [Build Time Environment Variables](#build-time-environment-variables) |
+| 2 | DDEV’s `FROM $BASE_IMAGE`, build arguments, and user creation                                  | The in-image user mirrors your host user, using `$username`, `$uid`, and `$gid`                                                                                                                                                                                        |
+| 3 | `pre.Dockerfile`, `pre.Dockerfile.*`<br>([global](#global-dockerfiles), then project)         | For directives that have to come early, like proxy settings, SSL termination, [CA certificates](#global-dockerfiles), or [EOL PHP versions](#adding-eol-versions-of-php)                 |
+| 4 | DDEV’s own build steps                                                                        | PHP version, `webimage_extra_packages` or `dbimage_extra_packages`, Composer update, database clients                                                                                     |
+| 5 | `Dockerfile`, `Dockerfile.*`<br>([global](#global-dockerfiles), then project)                 | The usual choice for most customizations                                                                                                                                                 |
+| 6 | DDEV’s finishing steps                                                                        | Permission fixes on the web image, which have to run after everything else                                                                                                               |
 
-Multi-stage builds are useful to anyone who has struggled to optimize Dockerfiles while keeping them easy to read and maintain.
+Within each group, files are inserted in alphabetical order, so `Dockerfile` comes first, then `Dockerfile.*` alphabetically.
 
-### Global Dockerfiles
+To see the result, read the generated Dockerfile, or force a rebuild with [`ddev restart --no-cache`](../usage/commands.md#restart) or [`ddev utility rebuild`](../usage/commands.md#utility-rebuild), which shows the whole build output for debugging.
 
-DDEV supports global web-build files for the web container and database container. Files placed in `$HOME/.ddev/web-build/` and `$HOME/.ddev/db-build/` will be applied to all DDEV web containers and database containers respectively. Files placed there apply to every project on the workstation and are useful for machine-specific customizations like corporate proxy certificates, private package registries, or developer tools you always want available. See [Global Files](../usage/architecture.md#global-files) to find out where this directory actually lives on your system, since it isn’t always `$HOME/.ddev`.
+### Copying Files into the Image
 
-Global files are inserted *before* project-level files, so project-level files run after them. Context files (non-Dockerfiles) in the global directories are also available as `ADD`/`COPY` sources, with project-level files taking precedence on name conflicts.
+The `.ddev/*-build` directory is the Docker "context", so if a file named `file.txt` exists in `.ddev/web-build`, you can use `COPY file.txt /` in the Dockerfile.
 
-For example, to install a custom CA certificate on every project:
-
-```bash
-mkdir -p $HOME/.ddev/web-build
-cat > $HOME/.ddev/web-build/pre.Dockerfile << 'EOF'
-COPY my-ca.crt /usr/local/share/ca-certificates/
-RUN update-ca-certificates
-EOF
-cp /path/to/my-ca.crt $HOME/.ddev/web-build/my-ca.crt
-```
-
-Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with [`ddev restart --no-cache`](../usage/commands.md#restart) or [`ddev utility rebuild`](../usage/commands.md#utility-rebuild). `ddev utility rebuild` is also great because it shows you the entire process of the build for debugging.
-
-Examples of possible Dockerfiles are `.ddev/web-build/Dockerfile.example` and `.ddev/db-build/Dockerfile.example`, created in your project when you run [`ddev config`](../usage/commands.md#config).
-
-You can use the `.ddev/*-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/web-build`, you can use `ADD file.txt /` in the Dockerfile.
+### Examples
 
 An example web image `.ddev/web-build/Dockerfile` might be:
 
@@ -168,18 +153,20 @@ RUN chmod -R ugo+rw $COMPOSER_HOME
 ENV COMPOSER_HOME=""
 ```
 
-An example [Multi-stage](https://docs.docker.com/build/building/multi-stage/) web image could have a  `.ddev/web-build/prepend.Dockerfile`:
+### Multi-Stage Builds
+
+[Multi-stage builds](https://docs.docker.com/build/building/multi-stage/) help keep a Dockerfile optimized without making it hard to read and maintain. They need a `prepend.` file, because the extra `FROM` statement has to be on top of the generated Dockerfile. An example web image could have a `.ddev/web-build/prepend.Dockerfile`:
 
 ```dockerfile
 # If we want to use any of the build time environment variables injected by ddev
 # on the prepend.Dockerfile* variants we need to manually declare them to make
 # them available using the ARG instruction.
-# Only $BASE_IMAGE is already added as it must be global to be used on FROM 
-# statements. 
+# Only $BASE_IMAGE is already added as it must be global to be used on FROM
+# statements.
 FROM $BASE_IMAGE AS build-stage-go
 
 # While we are not using $uid and $gid in the code below, this serves as an example
-# of how any of the other DDEV's build variables must be defined. 
+# of how any of the other DDEV's build variables must be defined.
 ARG uid
 ARG gid
 
@@ -199,7 +186,26 @@ And then a `Dockerfile`:
 COPY --from=build-stage-go /usr/local/go /usr/local
 ```
 
-**Remember that the Dockerfile is building a Docker image that will be used later with DDEV.** At the time the Dockerfile is executing, your code is not mounted and the container is not running, the image is being built. So for example, an `npm install` in `/var/www/html` will not do anything to your project because the code is not there at image building time.
+### Global Dockerfiles
+
+The same files work in `$HOME/.ddev/web-build/` and `$HOME/.ddev/db-build/`, where they apply to every project on the machine, which is handy for things like corporate certificates or private package registries. Global files are inserted _before_ the project’s own files, and the global directory is a Docker “context” too, where a project file of the same name wins.
+
+!!!tip "Your global directory may live elsewhere"
+    See [Global Files](../usage/architecture.md#global-files), it isn’t always `$HOME/.ddev`.
+
+For example, to install a custom CA certificate in every project’s web image:
+
+```bash
+cat > $HOME/.ddev/web-build/pre.Dockerfile.vpn << 'EOF'
+COPY my-ca.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+EOF
+# The COPY source has to be in the same directory, it's the Docker "context"
+cp /path/to/my-ca.crt $HOME/.ddev/web-build/my-ca.crt
+ddev restart
+```
+
+A `pre.` file is used here so the certificate is in place before DDEV’s own build steps run.
 
 ### Build Time Environment Variables
 

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -142,8 +142,14 @@ ddev version | grep global-ddev-dir
 `commands` directory
 : Directory for storing DDEV commands that should be available in containers, like `npm`, `artisan`, `cake` and `drush` for example. These are organized in subdirectories named for where they’ll be used: `db`, `host`, and `web`. You can add your own [custom commands](../extend/custom-commands.md) here.
 
+`db-build` directory
+: Like the per-project `db-build` directory, can be used to provide a [custom Dockerfile](../extend/customizing-images.md#global-dockerfiles) for the database container, applied to **every** project on this machine.
+
 `homeadditions` directory
 : Like the per-project `homeadditions` directory, files you add here will automatically be copied into the web container’s home directory. Files from the _global_ homeadditions directory will be copied into **every** web container’s home directory.
+
+`web-build` directory
+: Like the per-project `web-build` directory, can be used to provide a [custom Dockerfile](../extend/customizing-images.md#global-dockerfiles) for the web container, applied to **every** project on this machine.
 
 #### Hidden Global Files
 

--- a/docs/content/users/usage/networking.md
+++ b/docs/content/users/usage/networking.md
@@ -96,7 +96,7 @@ The standard approach:
     ```
 
     !!!tip "Apply to all projects"
-        Place your Dockerfiles in `~/.ddev/web-build/` and `~/.ddev/db-build/` to apply them to every project on your machine. See [Global Dockerfiles](../extend/customizing-images.md#global-dockerfiles) for details.
+        Place your Dockerfiles in `$HOME/.ddev/web-build/` and `$HOME/.ddev/db-build/` to apply them to every project on your machine. See [Global Dockerfiles](../extend/customizing-images.md#global-dockerfiles) and [Global Files](architecture.md#global-files) for details.
 
 4. If you're using Node.js/npm make it trust both the DDEV `mkcert` CA and your corporate CA by combining the two into a single file and then making the environment variable `NODE_EXTRA_CA_CERTS` point to that file. Add a post-start hook to concatenate the required files into the needed `/usr/local/share/ca-certificates/node_ca_certs.pem`. For example, in a `.ddev/config.vpn.yaml` add `post-start` hook:
 

--- a/docs/content/users/usage/networking.md
+++ b/docs/content/users/usage/networking.md
@@ -95,6 +95,9 @@ The standard approach:
     RUN update-ca-certificates
     ```
 
+    !!!tip "Apply to all projects"
+        Place your Dockerfiles in `~/.ddev/web-build/` and `~/.ddev/db-build/` to apply them to every project on your machine. See [Global Dockerfiles](../extend/customizing-images.md#global-dockerfiles) for details.
+
 4. If you're using Node.js/npm make it trust both the DDEV `mkcert` CA and your corporate CA by combining the two into a single file and then making the environment variable `NODE_EXTRA_CA_CERTS` point to that file. Add a post-start hook to concatenate the required files into the needed `/usr/local/share/ca-certificates/node_ca_certs.pem`. For example, in a `.ddev/config.vpn.yaml` add `post-start` hook:
 
     ```yaml

--- a/docs/content/users/usage/networking.md
+++ b/docs/content/users/usage/networking.md
@@ -96,7 +96,7 @@ The standard approach:
     ```
 
     !!!tip "Apply to all projects"
-        Place your Dockerfiles in `$HOME/.ddev/web-build/` and `$HOME/.ddev/db-build/` to apply them to every project on your machine. See [Global Dockerfiles](../extend/customizing-images.md#global-dockerfiles) and [Global Files](architecture.md#global-files) for details.
+        Put these Dockerfiles in `$HOME/.ddev/web-build/` and `$HOME/.ddev/db-build/` to apply them to every project, see [Global Dockerfiles](../extend/customizing-images.md#global-dockerfiles).
 
 4. If you're using Node.js/npm make it trust both the DDEV `mkcert` CA and your corporate CA by combining the two into a single file and then making the environment variable `NODE_EXTRA_CA_CERTS` point to that file. Add a post-start hook to concatenate the required files into the needed `/usr/local/share/ca-certificates/node_ca_certs.pem`. For example, in a `.ddev/config.vpn.yaml` add `post-start` hook:
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1472,7 +1472,7 @@ EOF
 	}
 
 	// Global assets copied first so project-level files overwrite on name conflicts
-	if globalDockerfilePath != "" {
+	if globalDockerfilePath != "" && fileutil.IsDirectory(globalDockerfilePath) {
 		err = copy2.Copy(globalDockerfilePath, filepath.Dir(fullpath), copy2.Options{
 			Skip: func(_ os.FileInfo, src, _ string) (bool, error) {
 				// Do not copy file if it's not a context file

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1105,7 +1105,7 @@ stopasgroup=true
 	// MariaDB 11.4+ has enabled SSL verification by default, which can cause issues.
 	extraWebContent = extraWebContent + "\nRUN log-stderr.sh mariadb-skip-ssl-wrapper-install.sh || true\n"
 
-	err = WriteBuildDockerfile(app, app.GetConfigPath(".webimageBuild/Dockerfile"), app.GetConfigPath("web-build"), app.WebImageExtraPackages, app.ComposerVersion, extraWebContent)
+	err = WriteBuildDockerfile(app, app.GetConfigPath(".webimageBuild/Dockerfile"), filepath.Join(globalconfig.GetGlobalDdevDir(), "web-build"), app.GetConfigPath("web-build"), app.WebImageExtraPackages, app.ComposerVersion, extraWebContent)
 	if err != nil {
 		return "", err
 	}
@@ -1176,7 +1176,7 @@ EOF
 `, app.GetMaxContainerWaitTime(), uid, gid)
 	}
 
-	err = WriteBuildDockerfile(app, app.GetConfigPath(".dbimageBuild/Dockerfile"), app.GetConfigPath("db-build"), app.DBImageExtraPackages, "", extraDBContent)
+	err = WriteBuildDockerfile(app, app.GetConfigPath(".dbimageBuild/Dockerfile"), filepath.Join(globalconfig.GetGlobalDdevDir(), "db-build"), app.GetConfigPath("db-build"), app.DBImageExtraPackages, "", extraDBContent)
 
 	// CopyEmbedAssets of postgres healthcheck has to be done after we WriteBuildDockerfile
 	// because that deletes the .dbimageBuild directory
@@ -1210,8 +1210,8 @@ EOF
 
 // WriteBuildDockerfile writes a Dockerfile to be used in the
 // docker-compose 'build'
-// It may include the contents of .ddev/<container>-build
-func WriteBuildDockerfile(app *DdevApp, fullpath string, userDockerfilePath string, extraPackages []string, composerVersion string, extraContent string) error {
+// It may include the contents of ~/.ddev/<container>-build and .ddev/<container>-build
+func WriteBuildDockerfile(app *DdevApp, fullpath string, globalDockerfilePath string, userDockerfilePath string, extraPackages []string, composerVersion string, extraContent string) error {
 	// Start with user-built dockerfile if there is one.
 	err := os.MkdirAll(filepath.Dir(fullpath), 0755)
 	if err != nil {
@@ -1223,6 +1223,27 @@ func WriteBuildDockerfile(app *DdevApp, fullpath string, userDockerfilePath stri
 #ddev-generated - Do not modify this file; your modifications will be overwritten.
 ARG BASE_IMAGE="scratch"
 `
+	// If there are global prepend.Dockerfile* files, insert their contents
+	if globalDockerfilePath != "" {
+		files, err := filepath.Glob(filepath.Join(globalDockerfilePath, "prepend.Dockerfile*"))
+		if err != nil {
+			return err
+		}
+
+		for _, file := range files {
+			// Skip example files
+			if strings.HasSuffix(file, ".example") {
+				continue
+			}
+			globalContents, err := fileutil.ReadFileIntoString(file)
+			if err != nil {
+				return err
+			}
+
+			contents = contents + "\n\n### From global Dockerfile " + file + ":\n" + globalContents
+		}
+	}
+
 	// If there are user prepend.Dockerfile* files, insert their contents
 	if userDockerfilePath != "" {
 		files, err := filepath.Glob(filepath.Join(userDockerfilePath, "prepend.Dockerfile*"))
@@ -1263,6 +1284,27 @@ RUN (groupadd --gid "$gid" "$username" || groupadd "$username" || true) && \
     useradd -G tty -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username" || \
     useradd -G tty -l -m -s "/bin/bash" --comment '' "$username")
 `
+
+	// If there are global pre.Dockerfile* files, insert their contents
+	if globalDockerfilePath != "" {
+		files, err := filepath.Glob(filepath.Join(globalDockerfilePath, "pre.Dockerfile*"))
+		if err != nil {
+			return err
+		}
+
+		for _, file := range files {
+			// Skip example files
+			if strings.HasSuffix(file, ".example") {
+				continue
+			}
+			globalContents, err := fileutil.ReadFileIntoString(file)
+			if err != nil {
+				return err
+			}
+
+			contents = contents + "\n\n### From global Dockerfile " + file + ":\n" + globalContents
+		}
+	}
 
 	// If there are user pre.Dockerfile* files, insert their contents
 	if userDockerfilePath != "" {
@@ -1371,6 +1413,35 @@ EOF
 		}
 	}
 
+	// If there are global Dockerfile* files, append their contents
+	if globalDockerfilePath != "" {
+		files, err := filepath.Glob(filepath.Join(globalDockerfilePath, "Dockerfile*"))
+		if err != nil {
+			return err
+		}
+
+		for _, file := range files {
+			// Skip example files
+			if strings.HasSuffix(file, ".example") {
+				continue
+			}
+
+			globalContents, err := fileutil.ReadFileIntoString(file)
+			if err != nil {
+				return err
+			}
+
+			// Backward compatible fix, remove unnecessary BASE_IMAGE references
+			re, err := regexp.Compile(`ARG BASE_IMAGE.*\n|FROM \$BASE_IMAGE.*\n`)
+			if err != nil {
+				return err
+			}
+
+			globalContents = re.ReplaceAllString(globalContents, "")
+			contents = contents + "\n\n### From global Dockerfile " + file + ":\n" + globalContents
+		}
+	}
+
 	// If there are user dockerfiles, appends their contents
 	if userDockerfilePath != "" {
 		files, err := filepath.Glob(filepath.Join(userDockerfilePath, "Dockerfile*"))
@@ -1397,6 +1468,19 @@ EOF
 
 			userContents = re.ReplaceAllString(userContents, "")
 			contents = contents + "\n\n### From user Dockerfile " + file + ":\n" + userContents
+		}
+	}
+
+	// Global assets copied first so project-level files overwrite on name conflicts
+	if globalDockerfilePath != "" {
+		err = copy2.Copy(globalDockerfilePath, filepath.Dir(fullpath), copy2.Options{
+			Skip: func(_ os.FileInfo, src, _ string) (bool, error) {
+				// Do not copy file if it's not a context file
+				return isNotDockerfileContextFile(globalDockerfilePath, src)
+			},
+		})
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -114,6 +114,23 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 		},
 		{
 			collectFiles: func() ([]string, error) {
+				allFiles, err := filepath.Glob(filepath.Join(globalconfig.GetGlobalDdevDir(), "db-build", "*Dockerfile*"))
+				if err != nil {
+					return nil, err
+				}
+				// Filter to only valid Dockerfile patterns
+				return slices.DeleteFunc(allFiles, func(file string) bool {
+					base := filepath.Base(file)
+					return !strings.HasPrefix(base, "Dockerfile") &&
+						!strings.HasPrefix(base, "pre.Dockerfile") &&
+						!strings.HasPrefix(base, "prepend.Dockerfile")
+				}), nil
+			},
+			checkOnlyWhen: func() bool { return !slices.Contains(app.OmitContainers, "db") },
+			displayName:   "Database (global)",
+		},
+		{
+			collectFiles: func() ([]string, error) {
 				allFiles, err := filepath.Glob(filepath.Join(ddevDir, "db-build", "*Dockerfile*"))
 				if err != nil {
 					return nil, err
@@ -249,6 +266,22 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 			},
 			checkOnlyWhen: routerEnabled,
 			displayName:   "Router",
+		},
+		{
+			collectFiles: func() ([]string, error) {
+				allFiles, err := filepath.Glob(filepath.Join(globalconfig.GetGlobalDdevDir(), "web-build", "*Dockerfile*"))
+				if err != nil {
+					return nil, err
+				}
+				// Filter to only valid Dockerfile patterns
+				return slices.DeleteFunc(allFiles, func(file string) bool {
+					base := filepath.Base(file)
+					return !strings.HasPrefix(base, "Dockerfile") &&
+						!strings.HasPrefix(base, "pre.Dockerfile") &&
+						!strings.HasPrefix(base, "prepend.Dockerfile")
+				}), nil
+			},
+			displayName: "Web server (global)",
 		},
 		{
 			collectFiles: func() ([]string, error) {

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1545,6 +1545,10 @@ func TestCustomBuildDockerfiles(t *testing.T) {
 	switchDir := site.Chdir()
 	defer switchDir()
 
+	// Create temporary XDG_CONFIG_HOME for isolated testing
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
+	defer testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
+
 	runTime := util.TimeTrackC(fmt.Sprintf("%s TestCustomBuildDockerfiles", site.Name))
 
 	err := app.Init(site.Dir)
@@ -1614,6 +1618,16 @@ FROM $BASE_IMAGE AS test5
 		err = ddevapp.WriteImageDockerfile(app.GetConfigPath(item+"-build/Dockerfile.test5"), []byte(`
 COPY --from=stage /tmp/`+"added-by-busybox-"+item+"-stage.txt /var/tmp/"+"added-by-busybox-"+item+"-stage.txt"+`
 COPY --from=test5 /var/tmp/`+"added-by-"+item+"-test5.txt /var/tmp/"+"added-by-"+item+"-test5.txt"))
+		assert.NoError(err)
+
+		// Testing global ~/.ddev/<service>-build/pre.Dockerfile support,
+		// including a context file added via COPY from the global build directory.
+		// WriteImageDockerfile is called first so it creates the directory.
+		err = ddevapp.WriteImageDockerfile(filepath.Join(globalconfig.GetGlobalDdevDir(), item+"-build", "pre.Dockerfile.global"), []byte(`
+COPY global-junkfile /var/tmp/global-junkfile-`+item+`
+RUN touch /var/tmp/`+"added-by-"+item+"-global-pre.txt"))
+		assert.NoError(err)
+		err = fileutil.TemplateStringToFile("global-context-file", nil, filepath.Join(globalconfig.GetGlobalDdevDir(), item+"-build", "global-junkfile"))
 		assert.NoError(err)
 	}
 
@@ -1718,6 +1732,18 @@ RUN mkdir -p "/var/tmp/my-arch-info-is-${TARGETOS}-${TARGETARCH}-${TARGETPLATFOR
 			Cmd:     "ls /tmp/added-by-busybox-" + item + "-stage-other.txt 2>/dev/null",
 		})
 		assert.Error(err)
+
+		// Global pre.Dockerfile and its context file should have been applied
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
+			Service: item,
+			Cmd:     "ls /var/tmp/added-by-" + item + "-global-pre.txt >/dev/null",
+		})
+		assert.NoError(err)
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
+			Service: item,
+			Cmd:     "ls /var/tmp/global-junkfile-" + item + " >/dev/null",
+		})
+		assert.NoError(err)
 	}
 
 	// Dockerfiles should not be copied

--- a/pkg/ddevapp/dotddev_assets/db-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/db-build/README.txt
@@ -20,4 +20,6 @@ Examine the resultant generated Dockerfile (which you will never edit directly),
 
 You can use the `.ddev/db-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/db-build`, you can use `ADD file.txt /` in the Dockerfile.
 
+Global variants in `~/.ddev/db-build/` are also supported and apply to all projects on this machine. Global files are inserted *before* project-level files.
+
 See https://docs.ddev.com/en/stable/users/extend/customizing-images/ for advanced examples.

--- a/pkg/ddevapp/dotddev_assets/db-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/db-build/README.txt
@@ -20,6 +20,6 @@ Examine the resultant generated Dockerfile (which you will never edit directly),
 
 You can use the `.ddev/db-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/db-build`, you can use `ADD file.txt /` in the Dockerfile.
 
-Global variants in `~/.ddev/db-build/` are also supported and apply to all projects on this machine. Global files are inserted *before* project-level files.
+Global variants in `$HOME/.ddev/db-build/` are also supported and apply to all projects on this machine. Global files are inserted *before* project-level files. See https://docs.ddev.com/en/stable/users/usage/architecture/#global-files to find out where this directory actually lives on your system, since it isn't always `$HOME/.ddev`.
 
 See https://docs.ddev.com/en/stable/users/extend/customizing-images/ for advanced examples.

--- a/pkg/ddevapp/dotddev_assets/db-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/db-build/README.txt
@@ -18,8 +18,8 @@ See https://docs.docker.com/build/building/multi-stage/
 
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.dbimageBuild/Dockerfile`. You can force a rebuild with `ddev utility rebuild -s db`.
 
-You can use the `.ddev/db-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/db-build`, you can use `ADD file.txt /` in the Dockerfile.
+You can use the `.ddev/db-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/db-build`, you can use `COPY file.txt /` in the Dockerfile.
 
-Global variants in `$HOME/.ddev/db-build/` are also supported and apply to all projects on this machine. Global files are inserted *before* project-level files. See https://docs.ddev.com/en/stable/users/usage/architecture/#global-files to find out where this directory actually lives on your system, since it isn't always `$HOME/.ddev`.
+Global variants in `$HOME/.ddev/db-build/` are also supported and apply to all projects on this machine. Global files are inserted *before* these project-level files. See https://docs.ddev.com/en/stable/users/extend/customizing-images/#global-dockerfiles
 
 See https://docs.ddev.com/en/stable/users/extend/customizing-images/ for advanced examples.

--- a/pkg/ddevapp/dotddev_assets/web-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/web-build/README.txt
@@ -20,4 +20,6 @@ Examine the resultant generated Dockerfile (which you will never edit directly),
 
 You can use the `.ddev/web-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/web-build`, you can use `ADD file.txt /` in the Dockerfile.
 
+Global variants in `~/.ddev/web-build/` are also supported and apply to all projects on this machine. Global files are inserted *before* project-level files.
+
 See https://docs.ddev.com/en/stable/users/extend/customizing-images/ for advanced examples.

--- a/pkg/ddevapp/dotddev_assets/web-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/web-build/README.txt
@@ -20,6 +20,6 @@ Examine the resultant generated Dockerfile (which you will never edit directly),
 
 You can use the `.ddev/web-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/web-build`, you can use `ADD file.txt /` in the Dockerfile.
 
-Global variants in `~/.ddev/web-build/` are also supported and apply to all projects on this machine. Global files are inserted *before* project-level files.
+Global variants in `$HOME/.ddev/web-build/` are also supported and apply to all projects on this machine. Global files are inserted *before* project-level files. See https://docs.ddev.com/en/stable/users/usage/architecture/#global-files to find out where this directory actually lives on your system, since it isn't always `$HOME/.ddev`.
 
 See https://docs.ddev.com/en/stable/users/extend/customizing-images/ for advanced examples.

--- a/pkg/ddevapp/dotddev_assets/web-build/README.txt
+++ b/pkg/ddevapp/dotddev_assets/web-build/README.txt
@@ -18,8 +18,8 @@ See https://docs.docker.com/build/building/multi-stage/
 
 Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile`. You can force a rebuild with `ddev utility rebuild -s web`.
 
-You can use the `.ddev/web-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/web-build`, you can use `ADD file.txt /` in the Dockerfile.
+You can use the `.ddev/web-build` directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `.ddev/web-build`, you can use `COPY file.txt /` in the Dockerfile.
 
-Global variants in `$HOME/.ddev/web-build/` are also supported and apply to all projects on this machine. Global files are inserted *before* project-level files. See https://docs.ddev.com/en/stable/users/usage/architecture/#global-files to find out where this directory actually lives on your system, since it isn't always `$HOME/.ddev`.
+Global variants in `$HOME/.ddev/web-build/` are also supported and apply to all projects on this machine. Global files are inserted *before* these project-level files. See https://docs.ddev.com/en/stable/users/extend/customizing-images/#global-dockerfiles
 
 See https://docs.ddev.com/en/stable/users/extend/customizing-images/ for advanced examples.

--- a/pkg/ddevapp/global_dotddev_assets/db-build/README.txt
+++ b/pkg/ddevapp/global_dotddev_assets/db-build/README.txt
@@ -1,0 +1,27 @@
+#ddev-generated
+Files in this directory will be used to customize the dbimage of every project on this machine, you can add:
+
+* $HOME/.ddev/db-build/Dockerfile
+* $HOME/.ddev/db-build/Dockerfile.*
+
+Additionally, you can use `pre.` variants that are inserted before what DDEV adds:
+
+* $HOME/.ddev/db-build/pre.Dockerfile
+* $HOME/.ddev/db-build/pre.Dockerfile.*
+
+Finally, you can also use `prepend.` variants that are inserted on top of the Dockerfile allowing for Multi-stage builds and other more complex use cases:
+
+* $HOME/.ddev/db-build/prepend.Dockerfile
+* $HOME/.ddev/db-build/prepend.Dockerfile.*
+
+See https://docs.docker.com/build/building/multi-stage/
+
+These files are inserted before the project's own `.ddev/db-build` files, which are applied last.
+
+Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.dbimageBuild/Dockerfile` in each project. You can force a rebuild with `ddev utility rebuild -s db`.
+
+You can use this directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `$HOME/.ddev/db-build`, you can use `COPY file.txt /` in the Dockerfile. A project file of the same name wins.
+
+This directory isn't always `$HOME/.ddev`, see https://docs.ddev.com/en/stable/users/usage/architecture/#global-files
+
+See https://docs.ddev.com/en/stable/users/extend/customizing-images/#global-dockerfiles for advanced examples.

--- a/pkg/ddevapp/global_dotddev_assets/db-build/pre.Dockerfile.example
+++ b/pkg/ddevapp/global_dotddev_assets/db-build/pre.Dockerfile.example
@@ -1,0 +1,8 @@
+## #ddev-generated
+## Copy this pre.Dockerfile.example to pre.Dockerfile to customize the dbimage
+## of every project on this machine.
+## `pre.` files are inserted before DDEV's own build steps; name it Dockerfile
+## instead to append after them. Project `.ddev/db-build` files are applied last.
+## Files you COPY have to be in this directory, it's the Docker "context".
+# COPY my-ca.crt /usr/local/share/ca-certificates/
+# RUN update-ca-certificates

--- a/pkg/ddevapp/global_dotddev_assets/web-build/README.txt
+++ b/pkg/ddevapp/global_dotddev_assets/web-build/README.txt
@@ -1,0 +1,27 @@
+#ddev-generated
+Files in this directory will be used to customize the webimage of every project on this machine, you can add:
+
+* $HOME/.ddev/web-build/Dockerfile
+* $HOME/.ddev/web-build/Dockerfile.*
+
+Additionally, you can use `pre.` variants that are inserted before what DDEV adds:
+
+* $HOME/.ddev/web-build/pre.Dockerfile
+* $HOME/.ddev/web-build/pre.Dockerfile.*
+
+Finally, you can also use `prepend.` variants that are inserted on top of the Dockerfile allowing for Multi-stage builds and other more complex use cases:
+
+* $HOME/.ddev/web-build/prepend.Dockerfile
+* $HOME/.ddev/web-build/prepend.Dockerfile.*
+
+See https://docs.docker.com/build/building/multi-stage/
+
+These files are inserted before the project's own `.ddev/web-build` files, which are applied last.
+
+Examine the resultant generated Dockerfile (which you will never edit directly), at `.ddev/.webimageBuild/Dockerfile` in each project. You can force a rebuild with `ddev utility rebuild -s web`.
+
+You can use this directory as the Docker “context” directory as well. So for example, if a file named `file.txt` exists in `$HOME/.ddev/web-build`, you can use `COPY file.txt /` in the Dockerfile. A project file of the same name wins.
+
+This directory isn't always `$HOME/.ddev`, see https://docs.ddev.com/en/stable/users/usage/architecture/#global-files
+
+See https://docs.ddev.com/en/stable/users/extend/customizing-images/#global-dockerfiles for advanced examples.

--- a/pkg/ddevapp/global_dotddev_assets/web-build/pre.Dockerfile.example
+++ b/pkg/ddevapp/global_dotddev_assets/web-build/pre.Dockerfile.example
@@ -1,0 +1,8 @@
+## #ddev-generated
+## Copy this pre.Dockerfile.example to pre.Dockerfile to customize the webimage
+## of every project on this machine.
+## `pre.` files are inserted before DDEV's own build steps; name it Dockerfile
+## instead to append after them. Project `.ddev/web-build` files are applied last.
+## Files you COPY have to be in this directory, it's the Docker "context".
+# COPY my-ca.crt /usr/local/share/ca-certificates/
+# RUN update-ca-certificates


### PR DESCRIPTION
## The Issue

* Fixes #8406 

DDEV supports per-project Dockerfile customization via `.ddev/web-build/` and `.ddev/db-build/`, but there is no way to apply the same Dockerfile additions across all projects on a host. Users who want a shared base (CA certs, system tooling, extra apt packages, etc.) have to copy the same files into every project they maintain.

DDEV already establishes a "global parallels per-project" pattern in several other places (`~/.ddev/commands/` ↔ `.ddev/commands/`, `~/.ddev/homeadditions/` ↔ `.ddev/homeadditions/`, `~/.ddev/router-build/`), but the per-project `web-build`/`db-build` mechanism has no global counterpart. This PR fills that gap.

## How This PR Solves The Issue

Nothing about the override mechanism itself is new — this PR re-applies DDEV's existing per-project Dockerfile-inclusion logic to a new global location. The supported filename patterns (`prepend.Dockerfile*`, `pre.Dockerfile*`, `Dockerfile*`) and the ordering semantics are inherited unchanged from the existing user block in `WriteBuildDockerfile`:

- `WriteBuildDockerfile` (`pkg/ddevapp/config.go`) takes a new `globalDockerfilePath` argument. At each existing per-project insertion point (prepend / pre / post-FROM), a structurally identical global block is inserted *before* the user block, so per-project files continue to take precedence on name conflicts.
- The call sites in `config.go` pass `filepath.Join(globalconfig.GetGlobalDdevDir(), "<container>-build")` alongside the existing project path — mirroring how `commands/`, `homeadditions/`, and `router-build/` are already wired.
- `config_custom.go` adds `web-build` and `db-build` entries to the "Custom configuration detected" reporter, modeled on the existing global `commands/` and `homeadditions/` entries, so users can see the global block is active.
- `dotddev_assets/{web,db}-build/README.txt` and `customizing-images.md` / `networking.md` are updated to document the new global location.

## Manual Testing Instructions

https://ddev--8405.org.readthedocs.build/en/8405/users/extend/customizing-images/#global-dockerfiles

1. Place a test file at `~/.ddev/web-build/pre.Dockerfile.global` containing, e.g., `RUN echo "global hello" > /tmp/global-hello`.
2. In any DDEV project run `ddev start`. The "Custom configuration detected" output should list the global file.
3. `ddev exec cat /tmp/global-hello` should print `global hello`.
4. Add a project-level `.ddev/web-build/Dockerfile` with the same filename as one in `~/.ddev/web-build/` and confirm the project-level content takes precedence.
5. Repeat for `~/.ddev/db-build/`.

## Automated Testing Overview

`pkg/ddevapp/config_test.go::TestCustomBuildDockerfiles` is extended to:

- Isolate global state with `testcommon.CopyGlobalDdevDir` / `ResetGlobalDdevDir`.
- Write a `pre.Dockerfile.global` and a context file into `~/.ddev/{web,db}-build/`.
- After `ddev start`, assert via `ddev exec` that both the touched marker file and the `COPY`-ed context file are present in the running containers — exercising both the Dockerfile inclusion and the build-context wiring.

## Release/Deployment Notes

Purely additive. Existing projects without `~/.ddev/web-build/` or `~/.ddev/db-build/` see no behavior change. No migration is required.
