### PR TITLE
ci: add DDEV_EMBARGO_PHP_VERSIONS to skip specific PHP versions in TestPHPConfig [skip ci]

### DIFF
--- a/.github/workflows/test-all-project-types.yml
+++ b/.github/workflows/test-all-project-types.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: false
         default: ''
+      ddev_embargo_php_versions:
+        description: 'Comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        type: string
+        required: false
+        default: ''
       testargs:
         description: 'TESTARGS value'
         type: string
@@ -107,6 +112,7 @@ jobs:
       gotest_short: "" # run tests for all project types
       testargs: ${{ needs.prepare-testargs.outputs.testargs }}
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   all-project-types-custom:

--- a/.github/workflows/test-apache-fpm.yml
+++ b/.github/workflows/test-apache-fpm.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: false
         default: ''
+      ddev_embargo_php_versions:
+        description: 'Comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        type: string
+        required: false
+        default: ''
       testargs:
         description: 'TESTARGS value'
         type: string
@@ -69,6 +74,7 @@ jobs:
       ddev_test_webserver_type: "apache-fpm"
       gotest_short: "5" # means use TYPO3 as the default codebase
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   apache-fpm-custom:

--- a/.github/workflows/test-docker-rootless.yml
+++ b/.github/workflows/test-docker-rootless.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: false
         default: ''
+      ddev_embargo_php_versions:
+        description: 'Comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        type: string
+        required: false
+        default: ''
       testargs:
         description: 'TESTARGS value'
         type: string
@@ -69,6 +74,7 @@ jobs:
       ddev_test_docker_rootless: "true"
       ddev_test_no_bind_mounts: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   docker-rootless-custom:

--- a/.github/workflows/test-mutagen.yml
+++ b/.github/workflows/test-mutagen.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: false
         default: ''
+      ddev_embargo_php_versions:
+        description: 'Comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        type: string
+        required: false
+        default: ''
       testargs:
         description: 'TESTARGS value'
         type: string
@@ -68,6 +73,7 @@ jobs:
     with:
       ddev_test_use_mutagen: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   mutagen-custom:

--- a/.github/workflows/test-nginx-fpm.yml
+++ b/.github/workflows/test-nginx-fpm.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: false
         default: ''
+      ddev_embargo_php_versions:
+        description: 'Comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        type: string
+        required: false
+        default: ''
       testargs:
         description: 'TESTARGS value'
         type: string
@@ -70,6 +75,7 @@ jobs:
       ddev_skip_nodejs_test: "false"
       testargs: ""
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   nginx-fpm-custom:

--- a/.github/workflows/test-no-bind-mounts.yml
+++ b/.github/workflows/test-no-bind-mounts.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: false
         default: ''
+      ddev_embargo_php_versions:
+        description: 'Comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        type: string
+        required: false
+        default: ''
       testargs:
         description: 'TESTARGS value'
         type: string
@@ -68,6 +73,7 @@ jobs:
     with:
       ddev_test_no_bind_mounts: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   no-bind-mounts-custom:

--- a/.github/workflows/test-podman-rootless-mutagen.yml
+++ b/.github/workflows/test-podman-rootless-mutagen.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: false
         default: ''
+      ddev_embargo_php_versions:
+        description: 'Comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        type: string
+        required: false
+        default: ''
       testargs:
         description: 'TESTARGS value'
         type: string
@@ -70,6 +75,7 @@ jobs:
       ddev_test_podman_rootless: "true"
       ddev_test_use_mutagen: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   podman-rootless-mutagen-testcmd:
@@ -81,6 +87,7 @@ jobs:
       ddev_test_podman_rootless: "true"
       ddev_test_use_mutagen: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   podman-rootless-mutagen-custom:

--- a/.github/workflows/test-podman-rootless.yml
+++ b/.github/workflows/test-podman-rootless.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: false
         default: ''
+      ddev_embargo_php_versions:
+        description: 'Comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        type: string
+        required: false
+        default: ''
       testargs:
         description: 'TESTARGS value'
         type: string
@@ -69,6 +74,7 @@ jobs:
       make_target: "testpkg"
       ddev_test_podman_rootless: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   podman-rootless-testcmd:
@@ -79,6 +85,7 @@ jobs:
       make_target: "testcmd"
       ddev_test_podman_rootless: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   podman-rootless-custom:

--- a/.github/workflows/test-pull-push-providers.yml
+++ b/.github/workflows/test-pull-push-providers.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: false
         default: ''
+      ddev_embargo_php_versions:
+        description: 'Comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        type: string
+        required: false
+        default: ''
       testargs:
         description: 'TESTARGS value'
         type: string
@@ -69,6 +74,7 @@ jobs:
       pull_push_providers: "true"
       testargs: "-run 'Test.*(Push|Pull)'"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   pull-push-providers-custom:

--- a/.github/workflows/test-race-detection.yml
+++ b/.github/workflows/test-race-detection.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: false
         default: ''
+      ddev_embargo_php_versions:
+        description: 'Comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        type: string
+        required: false
+        default: ''
       testargs:
         description: 'TESTARGS value'
         type: string
@@ -71,6 +76,7 @@ jobs:
       testargs: "-race"
       ddev_test_use_mutagen: "true"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   race-detection-custom:

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -83,6 +83,11 @@ on:
         required: false
         type: string
         default: ''
+      ddev_embargo_php_versions:
+        description: 'DDEV_EMBARGO_PHP_VERSIONS value - comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        required: false
+        type: string
+        default: ''
       debug_enabled:
         description: 'Run the build with tmate set "debug_enabled"'
         required: false
@@ -136,6 +141,7 @@ jobs:
       DDEV_NONINTERACTIVE: "true"
       DDEV_SKIP_NODEJS_TEST: ${{ inputs.ddev_skip_nodejs_test }}
       DDEV_EMBARGO_TESTS: ${{ inputs.ddev_embargo_tests }}
+      DDEV_EMBARGO_PHP_VERSIONS: ${{ inputs.ddev_embargo_php_versions }}
       GOTEST_SHORT: ${{ inputs.gotest_short }}
       MAKE_TARGET: ${{ inputs.make_target }}
       TESTARGS: ${{ inputs.testargs }}
@@ -225,6 +231,7 @@ jobs:
           echo "GOTEST_SHORT=${GOTEST_SHORT}"
           echo "DDEV_SKIP_NODEJS_TEST=${DDEV_SKIP_NODEJS_TEST}"
           echo "DDEV_EMBARGO_TESTS=${DDEV_EMBARGO_TESTS}"
+          echo "DDEV_EMBARGO_PHP_VERSIONS=${DDEV_EMBARGO_PHP_VERSIONS}"
           echo "DDEV_TEST_USE_MUTAGEN=${DDEV_TEST_USE_MUTAGEN}"
           echo "DDEV_TEST_WEBSERVER_TYPE=${DDEV_TEST_WEBSERVER_TYPE}"
           echo "DDEV_TEST_NO_BIND_MOUNTS=${DDEV_TEST_NO_BIND_MOUNTS}"

--- a/.github/workflows/test-wsl2-nat.yml
+++ b/.github/workflows/test-wsl2-nat.yml
@@ -26,6 +26,11 @@ on:
         type: string
         required: false
         default: ''
+      ddev_embargo_php_versions:
+        description: 'Comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        type: string
+        required: false
+        default: ''
       testargs:
         description: 'TESTARGS value'
         type: string
@@ -71,6 +76,7 @@ jobs:
       make_target: "testpkg"
       networking: "nat"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   wsl2-nat-testcmd:
@@ -80,6 +86,7 @@ jobs:
       make_target: "testcmd"
       networking: "nat"
       ddev_embargo_tests: ${{ inputs.ddev_embargo_tests || vars.DDEV_EMBARGO_TESTS || '' }}
+      ddev_embargo_php_versions: ${{ inputs.ddev_embargo_php_versions || vars.DDEV_EMBARGO_PHP_VERSIONS || '' }}
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   wsl2-nat-custom:

--- a/.github/workflows/test-wsl2-reusable.yml
+++ b/.github/workflows/test-wsl2-reusable.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: ''
+      ddev_embargo_php_versions:
+        description: 'DDEV_EMBARGO_PHP_VERSIONS value - comma-separated list of PHP versions to skip in TestPHPConfig (e.g., "8.4,8.3")'
+        required: false
+        type: string
+        default: ''
       debug_enabled:
         description: 'Run the build with tmate set "debug_enabled"'
         required: false
@@ -77,6 +82,7 @@ jobs:
       MAKE_TARGET: ${{ inputs.make_target }}
       MAKEARGS: ${{ inputs.makeargs }}
       DDEV_EMBARGO_TESTS: ${{ inputs.ddev_embargo_tests }}
+      DDEV_EMBARGO_PHP_VERSIONS: ${{ inputs.ddev_embargo_php_versions }}
       DDEV_SKIP_NODEJS_TEST: 'true'
       # Always clone from base repository to get upstream tags
       GITHUB_CLONE_URL: https://github.com/${{ github.repository }}
@@ -179,5 +185,6 @@ jobs:
           $make_target = "${{ env.MAKE_TARGET }}"
           $makeargs = "${{ env.MAKEARGS }}"
           $embargo = "${{ env.DDEV_EMBARGO_TESTS }}"
+          $embargo_php = "${{ env.DDEV_EMBARGO_PHP_VERSIONS }}"
           $skip_nodejs = "${{ env.DDEV_SKIP_NODEJS_TEST }}"
-          wsl -u testuser -- bash -exc "export GOTEST_SHORT='$gotest_short' TESTARGS='$testargs' MAKE_TARGET='$make_target' MAKEARGS='$makeargs' DDEV_EMBARGO_TESTS='$embargo' DDEV_SKIP_NODEJS_TEST='$skip_nodejs' && cd ~/workspace/ddev && bash -e .github/workflows/wsl2-test.sh"
+          wsl -u testuser -- bash -exc "export GOTEST_SHORT='$gotest_short' TESTARGS='$testargs' MAKE_TARGET='$make_target' MAKEARGS='$makeargs' DDEV_EMBARGO_TESTS='$embargo' DDEV_EMBARGO_PHP_VERSIONS='$embargo_php' DDEV_SKIP_NODEJS_TEST='$skip_nodejs' && cd ~/workspace/ddev && bash -e .github/workflows/wsl2-test.sh"

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1111,6 +1111,18 @@ func TestPHPConfig(t *testing.T) {
 	// TODO: php8.5: Remove this exclusion when php85 has solr
 	phpKeys = util.SubtractSlices(phpKeys, []string{nodeps.PHP85})
 
+	// Skip any PHP versions embargoed via DDEV_EMBARGO_PHP_VERSIONS (comma-separated, e.g. "8.4,8.3")
+	var embargoedVersions []string
+	for _, v := range phpKeys {
+		if util.IsPHPVersionEmbargoed(v) {
+			embargoedVersions = append(embargoedVersions, v)
+		}
+	}
+	if len(embargoedVersions) > 0 {
+		t.Logf("Skipping PHP versions embargoed by DDEV_EMBARGO_PHP_VERSIONS=%s: %v", os.Getenv("DDEV_EMBARGO_PHP_VERSIONS"), embargoedVersions)
+		phpKeys = util.SubtractSlices(phpKeys, embargoedVersions)
+	}
+
 	sort.Strings(phpKeys)
 
 	err = fileutil.CopyFile(filepath.Join(origDir, "testdata/"+t.Name()+"/.ddev/.env"), filepath.Join(site.Dir, ".ddev/.env"))

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -603,6 +603,35 @@ func FormatBytes(bytes int64) string {
 	return fmt.Sprintf("%.1f%s", float64(bytes)/float64(div), units[exp])
 }
 
+// IsPHPVersionEmbargoed checks if a PHP version is in the DDEV_EMBARGO_PHP_VERSIONS environment variable.
+// DDEV_EMBARGO_PHP_VERSIONS should contain a comma-separated list of PHP versions to skip in TestPHPConfig.
+// Whitespace around version strings is automatically trimmed.
+// Returns true if the PHP version should be skipped, false otherwise.
+//
+// This is used in TestPHPConfig to skip specific PHP versions affected by upstream bugs without
+// disabling the entire test. Set the DDEV_EMBARGO_PHP_VERSIONS GitHub Actions repo variable to
+// activate for all CI runs, or pass via workflow_dispatch input ddev_embargo_php_versions.
+//
+// Usage:
+//
+//	# Skip a single PHP version
+//	DDEV_EMBARGO_PHP_VERSIONS="8.4" go test -run TestPHPConfig ./pkg/ddevapp
+//
+//	# Skip multiple PHP versions
+//	DDEV_EMBARGO_PHP_VERSIONS="8.4,8.3" go test -run TestPHPConfig ./pkg/ddevapp
+func IsPHPVersionEmbargoed(phpVersion string) bool {
+	embargoList := os.Getenv("DDEV_EMBARGO_PHP_VERSIONS")
+	if embargoList == "" {
+		return false
+	}
+	for v := range strings.SplitSeq(embargoList, ",") {
+		if strings.TrimSpace(v) == phpVersion {
+			return true
+		}
+	}
+	return false
+}
+
 // IsTestEmbargoed checks if a test name is in the DDEV_EMBARGO_TESTS environment variable.
 // DDEV_EMBARGO_TESTS should contain a pipe-separated list of test names to skip.
 // Returns true if the test should be skipped, false otherwise.


### PR DESCRIPTION
## The Issue

- Works around a CI failure in `TestPHPConfig` (part of `TestAllProjectTypes`) caused by an upstream bug in the sury.org PHP package repository: https://codeberg.org/oerdnj/deb.sury.org/issues/104
- Example failing run: https://github.com/ddev/ddev/actions/runs/25752461237/job/75632175445

## How This PR Solves The Issue

Adds a `DDEV_EMBARGO_PHP_VERSIONS` environment variable (comma-separated list, e.g. `"8.4,8.3"`) that skips specific PHP versions within `TestPHPConfig` without disabling the entire test. This mirrors the existing `DDEV_EMBARGO_TESTS` pattern used for whole-test skipping.

- `pkg/util/utils.go`: adds `IsPHPVersionEmbargoed()` helper with full doc comment and usage examples
- `pkg/ddevapp/config_test.go`: `TestPHPConfig` filters out embargoed versions before iterating, logs which versions were skipped
- All CI workflow files: add `ddev_embargo_php_versions` as a `workflow_dispatch` input and pass through `vars.DDEV_EMBARGO_PHP_VERSIONS` repo variable

**To activate:** set GitHub Actions repo variable `DDEV_EMBARGO_PHP_VERSIONS` to the affected version (e.g. `8.4`) in repo settings. To clear: delete or empty the variable — no code change needed.

## Manual Testing Instructions

1. `DDEV_EMBARGO_PHP_VERSIONS="8.4" go test -run TestPHPConfig ./pkg/ddevapp` — verify PHP 8.4 is logged as skipped and remaining versions run
2. `DDEV_EMBARGO_PHP_VERSIONS="" go test -run TestPHPConfig ./pkg/ddevapp` — verify all versions run normally
3. Set `DDEV_EMBARGO_PHP_VERSIONS` as a repo variable and trigger a workflow dispatch to confirm it propagates

## Automated Testing Overview

No new tests added — the change is a filtering step inside `TestPHPConfig` itself. The existing test exercises all remaining versions.

## Release/Deployment Notes

No user-facing changes. This is a CI mechanism only. The variable has no effect when unset.
