### PR TITLE
docs(config): improve wording for database and docker_buildx_version, for #8387

### DIFF
--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -126,9 +126,11 @@ The type and version of the database engine the project should use.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | `mariadb:11.8` | Can be MariaDB 5.5–10.8, 10.11, 11.4, 11.8 and MySQL 5.5–8.0, 8.4, or PostgreSQL 9–18.<br>See [Database Server Types](../extend/database-types.md) for examples and caveats. For very old database types see [Using DDEV to spin up a legacy PHP application](https://ddev.com/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev/).
+| :octicons-file-directory-16: project | `mariadb:11.8` | The following database types are currently supported:<br>- MariaDB 5.5-10.8, 10.11, 11.4, 11.8<br>- MySQL 5.5-8.0, 8.4<br>- Postgres 9-18
 
-Set with `ddev config --database=<database type>:<version>`.
+See [Database Server Types](../extend/database-types.md) for examples (e.g. `ddev config --database=mariadb:11.8`) and caveats (e.g. how to migrate from one database version to another).
+
+!!!tip "For very old database types, see [Using DDEV to spin up a legacy PHP application](https://ddev.com/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev/)."
 
 ## `dbimage_extra_packages`
 
@@ -190,6 +192,9 @@ When `true`, DDEV will not issue the normal warning on `ddev start`: "You have M
 
 ## `docker_buildx_version`
 
+!!!warning "Advanced Usage"
+    `docker_buildx_version` should only be changed for troubleshooting purposes or if you can't install `docker-buildx` on your system.
+
 Controls which `docker-buildx` plugin DDEV uses.
 
 | Type | Default | Usage
@@ -197,9 +202,6 @@ Controls which `docker-buildx` plugin DDEV uses.
 | :octicons-globe-16: global | `system` | `system` or a version string like `0.33.0`
 
 When set to `system` (the default), DDEV uses whatever `docker-buildx` is already installed on your system and never downloads anything.
-
-!!!warning "Troubleshooting Only!"
-    This should only be used in specific cases like troubleshooting. Please don't experiment with it unless directed to do so.
 
 ## `docroot`
 


### PR DESCRIPTION
## The Issue

- For #8387

I don't like how it looks:

https://docs.ddev.com/en/stable/users/configuration/config/#database

<img width="736" height="332" alt="image" src="https://github.com/user-attachments/assets/e69e3cbf-affa-4857-86ee-c276e98276de" />

## How This PR Solves The Issue

Changes positioning and explanation.

## Manual Testing Instructions

https://ddev--8409.org.readthedocs.build/en/8409/users/configuration/config/#database

<img width="718" height="425" alt="image" src="https://github.com/user-attachments/assets/4977618f-46f4-4bf1-b2a7-17c3e2eb0776" />

https://ddev--8409.org.readthedocs.build/en/8409/users/configuration/config/#docker_buildx_version

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
