### PR TITLE
refactor: improve CheckAvailableSpace reliability and output, fixes #8388

### DIFF
--- a/cmd/ddev/cmd/utility-dockercheck.go
+++ b/cmd/ddev/cmd/utility-dockercheck.go
@@ -170,7 +170,10 @@ ddev ut dockercheck`,
 			util.Success("Able to use internet inside container.")
 		}
 
-		dockerutil.CheckAvailableSpace()
+		if err := dockerutil.CheckAvailableSpace(); err != nil {
+			util.Warning("Warning: %v", err)
+			hasWarnings = true
+		}
 
 		// Test buildx with a trivial build on the host
 		if buildxErr == nil {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -884,7 +884,9 @@ func (app *DdevApp) GetDBDumpCommand() string {
 // ImportDB takes a source sql dump and imports it to an active site's database container.
 func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool, noDrop bool, targetDB string) error {
 	_ = app.DockerEnv()
-	dockerutil.CheckAvailableSpace()
+	if err := dockerutil.CheckAvailableSpace(); err != nil {
+		util.Warning("Warning: %v", err)
+	}
 
 	if targetDB == "" {
 		targetDB = "db"
@@ -1737,7 +1739,9 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
-	dockerutil.CheckAvailableSpace()
+	if err := dockerutil.CheckAvailableSpace(); err != nil {
+		util.Warning("Warning: %v", err)
+	}
 
 	// Copy any homeadditions content into .ddev/.homeadditions
 	tmpHomeadditionsPath := app.GetConfigPath(".homeadditions")

--- a/pkg/dockerutil/requirements.go
+++ b/pkg/dockerutil/requirements.go
@@ -87,7 +87,7 @@ func CanRunWithoutDocker() bool {
 
 // CheckAvailableSpace outputs a warning if Docker space is low
 func CheckAvailableSpace() {
-	_, out, _ := RunSimpleContainer(versionconstants.UtilitiesImage, "check-available-space-"+util.RandString(6), []string{"sh", "-c", `df / | awk '!/Mounted/ {print $4, $5;}'`}, []string{}, []string{}, []string{}, "", true, false, nil, nil, nil)
+	_, out, _ := RunSimpleContainer(versionconstants.UtilitiesImage, "check-available-space-"+util.RandString(6), []string{"sh", "-c", `df -P / | awk '!/Mounted/ {print $4, $5;}'`}, []string{}, []string{}, []string{}, "", true, false, nil, nil, nil)
 	out = strings.Trim(out, "% \r\n")
 	parts := strings.Split(out, " ")
 	if len(parts) != 2 {

--- a/pkg/dockerutil/requirements.go
+++ b/pkg/dockerutil/requirements.go
@@ -7,7 +7,6 @@ import (
 	osexec "os/exec"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -85,21 +84,25 @@ func CanRunWithoutDocker() bool {
 	return false
 }
 
-// CheckAvailableSpace outputs a warning if Docker space is low
-func CheckAvailableSpace() {
-	_, out, _ := RunSimpleContainer(versionconstants.UtilitiesImage, "check-available-space-"+util.RandString(6), []string{"sh", "-c", `df -P / | awk '!/Mounted/ {print $4, $5;}'`}, []string{}, []string{}, []string{}, "", true, false, nil, nil, nil)
-	out = strings.Trim(out, "% \r\n")
-	parts := strings.Split(out, " ")
-	if len(parts) != 2 {
-		util.Warning("Unable to determine Docker space usage: %s", out)
-		return
+// CheckAvailableSpace returns an error if Docker space is low
+func CheckAvailableSpace() error {
+	// stat -f -c "%a %b %S" / outputs three space-separated values:
+	// %a = free blocks available to non-root, %b = total blocks, %S = block size in bytes
+	_, out, _ := RunSimpleContainer(versionconstants.UtilitiesImage, "check-available-space-"+util.RandString(6), []string{"stat", "-f", "-c", "%a %b %S", "/"}, []string{}, []string{}, []string{}, "", true, false, nil, nil, nil)
+	var availBlocks, totalBlocks, blockSize int64
+	if n, err := fmt.Sscanf(strings.TrimSpace(out), "%d %d %d", &availBlocks, &totalBlocks, &blockSize); n != 3 || err != nil {
+		return fmt.Errorf("unable to determine available disk space from %q: %v", out, err)
 	}
-	spacePercent, _ := strconv.Atoi(parts[1])
-	spaceAbsolute, _ := strconv.Atoi(parts[0]) // Note that this is in KB
-
-	if spaceAbsolute < nodeps.MinimumDockerSpaceWarning {
-		util.Error("Your Docker install has only %d available disk space, less than %d warning level (%d%% used). Please increase disk image size. More info at %s", spaceAbsolute, nodeps.MinimumDockerSpaceWarning, spacePercent, "https://docs.ddev.com/en/stable/users/usage/troubleshooting/#out-of-disk-space")
+	spaceAvail := availBlocks * blockSize
+	spaceTotal := totalBlocks * blockSize
+	if spaceTotal == 0 {
+		return fmt.Errorf("unable to determine available disk space: total space is zero")
 	}
+	if spaceAvail < nodeps.MinimumDockerSpaceWarning {
+		spacePercent := int((spaceTotal - spaceAvail) * 100 / spaceTotal)
+		return fmt.Errorf("your Docker install has only %s available disk space, less than %s warning level (%d%% used). Please increase disk image size. More info at %s", util.FormatBytes(spaceAvail), util.FormatBytes(nodeps.MinimumDockerSpaceWarning), spacePercent, "https://docs.ddev.com/en/stable/users/usage/troubleshooting/#out-of-disk-space")
+	}
+	return nil
 }
 
 // CheckDockerAuth checks if Docker authentication is properly configured

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -137,7 +137,7 @@ const (
 	DefaultDefaultContainerTimeout  = "120"
 	InternetDetectionTimeoutDefault = 3000
 	TraefikMonitorPortDefault       = "10999"
-	MinimumDockerSpaceWarning       = 5000000 // 5GB in KB (to compare against df reporting in KB)
+	MinimumDockerSpaceWarning       = 5 * 1000 * 1000 * 1000 // 5GB in bytes
 )
 
 // IsValidPHPVersion is a helper function to determine if a PHP version is valid, returning

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -137,7 +137,7 @@ const (
 	DefaultDefaultContainerTimeout  = "120"
 	InternetDetectionTimeoutDefault = 3000
 	TraefikMonitorPortDefault       = "10999"
-	MinimumDockerSpaceWarning       = 5 * 1000 * 1000 * 1000 // 5GB in bytes
+	MinimumDockerSpaceWarning       = 5 * 1024 * 1024 * 1024 // 5GiB in bytes
 )
 
 // IsValidPHPVersion is a helper function to determine if a PHP version is valid, returning

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -589,13 +589,12 @@ func ExtractCurlBody(curlOutput string) string {
 	return curlOutput
 }
 
-// FormatBytes converts bytes to a human-readable string using SI decimal units (1000-based).
+// FormatBytes converts bytes to a human-readable string
 // Returns format like: "2.3GB", "156.7MB", "1.5KB", "0B"
 // SI (metric):  1 KB  = 1000 bytes (KB/MB/GB)    - used by macOS Finder and storage manufacturers.
 // IEC 80000-13: 1 KiB = 1024 bytes (KiB/MiB/GiB) - used by Linux tools and Windows (mislabeled as GB).
-// We use SI because most DDEV users are on macOS, so numbers match what they see in Finder.
 func FormatBytes(bytes int64) string {
-	const unit = 1000
+	const unit = 1024
 	if bytes < unit {
 		return fmt.Sprintf("%dB", bytes)
 	}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -589,10 +589,13 @@ func ExtractCurlBody(curlOutput string) string {
 	return curlOutput
 }
 
-// FormatBytes converts bytes to a human-readable string
+// FormatBytes converts bytes to a human-readable string using SI decimal units (1000-based).
 // Returns format like: "2.3GB", "156.7MB", "1.5KB", "0B"
+// SI (metric):  1 KB  = 1000 bytes (KB/MB/GB)    - used by macOS Finder and storage manufacturers.
+// IEC 80000-13: 1 KiB = 1024 bytes (KiB/MiB/GiB) - used by Linux tools and Windows (mislabeled as GB).
+// We use SI because most DDEV users are on macOS, so numbers match what they see in Finder.
 func FormatBytes(bytes int64) string {
-	const unit = 1024
+	const unit = 1000
 	if bytes < unit {
 		return fmt.Sprintf("%dB", bytes)
 	}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -425,16 +425,16 @@ func TestFormatBytes(t *testing.T) {
 	}{
 		{"Zero bytes", 0, "0B"},
 		{"Small bytes", 512, "512B"},
-		{"Exactly 1KB", 1000, "1.0KB"},
-		{"Multiple KB", 2500, "2.5KB"},
-		{"Exactly 1MB", 1000 * 1000, "1.0MB"},
-		{"Fractional MB", 1000*1000 + 500*1000, "1.5MB"},
-		{"Large MB", 157300000, "157.3MB"},
-		{"Exactly 1GB", 1000 * 1000 * 1000, "1.0GB"},
-		{"Fractional GB", int64(1000*1000*1000) + int64(500*1000*1000), "1.5GB"},
-		{"Multiple GB", int64(5) * 1000 * 1000 * 1000, "5.0GB"},
-		{"Exactly 1TB", int64(1000) * 1000 * 1000 * 1000, "1.0TB"},
-		{"Large volume", 982700000, "982.7MB"}, // Approximate d11 volume size
+		{"Exactly 1KB", 1024, "1.0KB"},
+		{"Multiple KB", 2560, "2.5KB"},
+		{"Exactly 1MB", 1024 * 1024, "1.0MB"},
+		{"Fractional MB", 1024*1024 + 512*1024, "1.5MB"},
+		{"Large MB", 157286400, "150.0MB"},
+		{"Exactly 1GB", 1024 * 1024 * 1024, "1.0GB"},
+		{"Fractional GB", int64(1024*1024*1024) + int64(512*1024*1024), "1.5GB"},
+		{"Multiple GB", int64(5) * 1024 * 1024 * 1024, "5.0GB"},
+		{"Exactly 1TB", int64(1024) * 1024 * 1024 * 1024, "1.0TB"},
+		{"Large volume", 982700000, "937.2MB"}, // Approximate d11 volume size
 	}
 
 	for _, tt := range tests {

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -425,16 +425,16 @@ func TestFormatBytes(t *testing.T) {
 	}{
 		{"Zero bytes", 0, "0B"},
 		{"Small bytes", 512, "512B"},
-		{"Exactly 1KB", 1024, "1.0KB"},
-		{"Multiple KB", 2560, "2.5KB"},
-		{"Exactly 1MB", 1024 * 1024, "1.0MB"},
-		{"Fractional MB", 1024*1024 + 512*1024, "1.5MB"},
-		{"Large MB", 157286400, "150.0MB"},
-		{"Exactly 1GB", 1024 * 1024 * 1024, "1.0GB"},
-		{"Fractional GB", int64(1024*1024*1024) + int64(512*1024*1024), "1.5GB"},
-		{"Multiple GB", int64(5) * 1024 * 1024 * 1024, "5.0GB"},
-		{"Exactly 1TB", int64(1024) * 1024 * 1024 * 1024, "1.0TB"},
-		{"Large volume", 982700000, "937.2MB"}, // Approximate d11 volume size
+		{"Exactly 1KB", 1000, "1.0KB"},
+		{"Multiple KB", 2500, "2.5KB"},
+		{"Exactly 1MB", 1000 * 1000, "1.0MB"},
+		{"Fractional MB", 1000*1000 + 500*1000, "1.5MB"},
+		{"Large MB", 157300000, "157.3MB"},
+		{"Exactly 1GB", 1000 * 1000 * 1000, "1.0GB"},
+		{"Fractional GB", int64(1000*1000*1000) + int64(500*1000*1000), "1.5GB"},
+		{"Multiple GB", int64(5) * 1000 * 1000 * 1000, "5.0GB"},
+		{"Exactly 1TB", int64(1000) * 1000 * 1000 * 1000, "1.0TB"},
+		{"Large volume", 982700000, "982.7MB"}, // Approximate d11 volume size
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- Fixes #8388

When a long device name was being tested for free space available, the output from df was wrapping. This caused the subsequent awk command not to see the free/total space, and following checks with the resulting variables to fail.

## How This PR Solves The Issue

- Replace `df / | awk` with `stat -f -c "%a %b %S"` run directly
  (no shell wrapper needed), avoiding awk dependency and df wrapping issues
- Return error from CheckAvailableSpace instead of calling util.Error directly;
  callers now display via util.Warning
- Switch MinimumDockerSpaceWarning from KB to bytes (SI: 5 * 1024 * 1024 * 1024)
- Show human-readable sizes in the space warning message

## Manual Testing Instructions

`ddev utility dockercheck` should no longer display the "Your Docker install has only 0 available disk space, less than 5000000 warning level (0% used). Please increase disk image size. More info at https://docs.ddev.com/en/stable/users/usage/troubleshooting/#out-of-disk-space" when run on a system with a device name exceeding ~23 characters.

## Automated Testing Overview

No test added. Not sure if this corner case deserves one/how one would do so...perhaps a loopback device with a long name? I don't know the exact length of the device name required to reproduce the issue.

## Release/Deployment Notes

N/A
