### PR TITLE
ci(buildkite): fix MSYS path conversion breaking public-variables fetch on Windows, for #8410

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -15,15 +15,14 @@ if [[ ${BUILDKITE_MESSAGE:-} == *"[skip buildkite]"* ]] || [[ ${BUILDKITE_MESSAG
   exit 0
 fi
 
-# Prevent MSYS (Git for Windows bash) from converting git ref:path syntax to Windows paths
-export MSYS_NO_PATHCONV=1
 git fetch --depth=1 --no-tags https://github.com/ddev/ddev public-variables:refs/public-variables-tmp
 while IFS= read -r varname; do
   [[ "$varname" == "README.md" ]] && continue
-  value=$(git show "refs/public-variables-tmp:.github/public-variables/$varname")
+  # MSYS_NO_PATHCONV prevents Git for Windows bash from mangling the ref:path syntax
+  value=$(MSYS_NO_PATHCONV=1 git show "refs/public-variables-tmp:.github/public-variables/$varname")
   echo "$varname=${value}"
   export "$varname=$value"
-done < <(git ls-tree --name-only refs/public-variables-tmp:.github/public-variables/)
+done < <(MSYS_NO_PATHCONV=1 git ls-tree --name-only refs/public-variables-tmp:.github/public-variables/)
 git update-ref -d refs/public-variables-tmp
 
 export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -15,6 +15,8 @@ if [[ ${BUILDKITE_MESSAGE:-} == *"[skip buildkite]"* ]] || [[ ${BUILDKITE_MESSAG
   exit 0
 fi
 
+# Prevent MSYS (Git for Windows bash) from converting git ref:path syntax to Windows paths
+export MSYS_NO_PATHCONV=1
 git fetch --depth=1 --no-tags https://github.com/ddev/ddev public-variables:refs/public-variables-tmp
 while IFS= read -r varname; do
   [[ "$varname" == "README.md" ]] && continue


### PR DESCRIPTION
## The Issue

- For #8410

I noticed this:

https://buildkite.com/ddev/ddev-windows-mutagen/builds/6262#019e3ae8-cc35-47ef-947e-bdbb69f93057/L50

```
From https://github.com/ddev/ddev
 * [new branch]          public-variables -> refs/public-variables-tmp
fatal: Not a valid object name refs\public-variables-tmp;.github\public-variables\
```

## How This PR Solves The Issue

Adds `MSYS_NO_PATHCONV=1`.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
