### PR TITLE
ci(docs): enable zensical strict mode, use dynamic Pages base URL, for #8421

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -84,4 +84,4 @@ jobs:
       - name: Test zensical
         run: |
           pip install -r docs/requirements.txt
-          zensical build
+          zensical build --clean --strict

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Pages
+        id: pages
         uses: actions/configure-pages@v6
 
       - name: Checkout main branch
@@ -61,25 +62,25 @@ jobs:
         working-directory: checkout-main
         run: |
           if [ "${{ steps.checkout-stable.outcome }}" = "success" ]; then
-            site_url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/en/latest/"
+            site_url="${{ steps.pages.outputs.base_url }}/en/latest/"
           else
-            site_url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+            site_url="${{ steps.pages.outputs.base_url }}/"
           fi
           sed -i "s|site_url:.*|site_url: ${site_url}|" mkdocs.yml
           grep site_url mkdocs.yml
           if [ "${{ steps.checkout-stable.outcome }}" = "success" ]; then
-            READTHEDOCS_VERSION_NAME=latest zensical build --clean
+            READTHEDOCS_VERSION_NAME=latest zensical build --clean --strict
           else
-            zensical build --clean
+            zensical build --clean --strict
           fi
 
       - name: Build stable docs
         if: steps.checkout-stable.outcome == 'success'
         working-directory: checkout-stable
         run: |
-          sed -i "s|site_url:.*|site_url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/en/stable/|" mkdocs.yml
+          sed -i "s|site_url:.*|site_url: ${{ steps.pages.outputs.base_url }}/en/stable/|" mkdocs.yml
           grep site_url mkdocs.yml
-          zensical build --clean
+          zensical build --clean --strict
 
       - name: Assemble combined site
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,7 @@ build:
       - grep site_url mkdocs.yml
     build:
       html:
-        - zensical build --clean
+        - zensical build --clean --strict
     post_build:
       - mkdir -p $READTHEDOCS_OUTPUT/html/
       - cp -rv site/* $READTHEDOCS_OUTPUT/html/

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ markdownlint:
 # https://docs.ddev.com/en/stable/developers/testing-docs/
 zensical:
 	@echo "zensical: "
-	@CMD="zensical build"; \
+	@CMD="zensical build --strict"; \
 	if command -v zensical >/dev/null 2>&1; then \
 		$$CMD ; \
 	else \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,9 +83,6 @@ plugins:
 not_in_nav: |
   developers/tmp/*
 
-# Fail the entire build if the validation fails
-strict: true
-
 # Validation
 validation:
   omitted_files: warn


### PR DESCRIPTION
## The Issue

- For #8421

1. I noticed that the strict check in `mkdocs.yml` didn't work - it only works with the `--strict` flag.
2. I hardcoded the `github.io` URL in GitHub Pages, so if we decide to set a custom domain in https://github.com/ddev/ddev/settings/pages, it won't work.

## How This PR Solves The Issue

1. Adds the `--strict` flag to `zensical build`
2. Uses `steps.pages.outputs.base_url` as the GitHub Pages URL

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
