### PR TITLE
fix(ddev-dbserver): unlink stale socket before mysqld init

### DIFF
--- a/containers/ddev-dbserver/files/create_base_db.sh
+++ b/containers/ddev-dbserver/files/create_base_db.sh
@@ -26,51 +26,68 @@ mysqld_version=${mysqld_version%.*}
 echo version=$mysqld_version
 # Oracle mysql 5.7+ deprecates mysql_install_db
 if [ "${mysqld_version}" = "5.7" ] || [[  "${mysqld_version%%%.*}" =~ ^8.[04]$ ]]; then
-    mysqld --defaults-file=/var/tmp/my.cnf --initialize-insecure --datadir=${DATADIR:-/var/lib/mysql} --server-id=0
+  mysqld --defaults-file=/var/tmp/my.cnf --initialize-insecure --datadir=${DATADIR:-/var/lib/mysql} --server-id=0
 else
-    # mysql 5.5 requires running mysql_install_db in /usr/local/mysql
-    if command -v mysqld | grep usr.local; then
-        cd /usr/local/mysql
-    fi
-    mysql_install_db --defaults-file=/var/tmp/my.cnf --force --datadir=${DATADIR:-/var/lib/mysql}
+  # mysql 5.5 requires running mysql_install_db in /usr/local/mysql
+  if command -v mysqld | grep usr.local; then
+    cd /usr/local/mysql
+  fi
+  mysql_install_db --defaults-file=/var/tmp/my.cnf --force --datadir=${DATADIR:-/var/lib/mysql}
 fi
+# Drop the runtime socket symlink the Dockerfile pre-creates, so mysqld can
+# bind its own socket here (recent MariaDB refuses to bind when the path
+# already exists).
+rm -f ${MYSQL_UNIX_PORT}
+
+# Route mysqld's error log to a known path and dump it on failure; otherwise
+# log_error from /etc/my.cnf hides the real reason mysqld died.
+ERRLOG=/var/tmp/mysqld-init.err
+: >${ERRLOG} && chmod ugo+rw ${ERRLOG}
 echo "Starting mysqld --skip-networking --socket=${MYSQL_UNIX_PORT}"
-mysqld --defaults-file=/var/tmp/my.cnf --user=root --socket=${MYSQL_UNIX_PORT} --innodb_log_file_size=48M --skip-networking --datadir=${DATADIR:-/var/lib/mysql} --server-id=0 --skip-log-bin &
+mysqld --defaults-file=/var/tmp/my.cnf --user=root --socket=${MYSQL_UNIX_PORT} --innodb_log_file_size=48M --log-error=${ERRLOG} --skip-networking --datadir=${DATADIR:-/var/lib/mysql} --server-id=0 --skip-log-bin &
 pid="$!"
+
+dump_errlog() {
+  echo "===== mysqld error log (${ERRLOG}) ====="
+  cat ${ERRLOG} 2>/dev/null || echo "(error log not readable)"
+  echo "===== end mysqld error log ====="
+}
 
 # Wait for the server to respond to mysqladmin ping, or fail if it never does,
 # or if the process dies.
 for i in {120..0}; do
-	if mysqladmin ping -uroot --socket=${MYSQL_UNIX_PORT} 2>/dev/null; then
-		break
-	fi
-	# Test to make sure we got it started in the first place. kill -s 0 just tests to see if process exists.
-	if ! kill -s 0 $pid 2>/dev/null; then
-		echo "mysqld initialization startup failed"
-		exit 3
-	fi
-	sleep 1
+  if mysqladmin ping -uroot --socket=${MYSQL_UNIX_PORT} 2>/dev/null; then
+    break
+  fi
+  # Test to make sure we got it started in the first place. kill -s 0 just tests to see if process exists.
+  if ! kill -s 0 $pid 2>/dev/null; then
+    echo "mysqld initialization startup failed"
+    dump_errlog
+    exit 3
+  fi
+  sleep 1
 done
 if [ "$i" -eq 0 ]; then
-	echo 'mysqld initialization startup process timed out.'
-	exit 4
+  echo 'mysqld initialization startup process timed out.'
+  dump_errlog
+  exit 4
 fi
 
 
 mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -uroot  --socket=${MYSQL_UNIX_PORT} mysql
 
 mysql -uroot --socket=${MYSQL_UNIX_PORT} <<EOF
-	CREATE DATABASE IF NOT EXISTS $MYSQL_DATABASE;
-	CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD';
-	CREATE USER '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD';
+  CREATE DATABASE IF NOT EXISTS $MYSQL_DATABASE;
+  CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD';
+  CREATE USER '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD';
 
-	GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'%';
-	GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'localhost';
+  GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'%';
+  GRANT ALL ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'localhost';
 
-	CREATE USER 'root'@'%' IDENTIFIED BY '$MYSQL_ROOT_PASSWORD';
-	GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;
-	FLUSH PRIVILEGES;
-	FLUSH TABLES;
+  CREATE USER 'root'@'%' IDENTIFIED BY '$MYSQL_ROOT_PASSWORD';
+  GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;
+  FLUSH PRIVILEGES;
+  FLUSH TABLES;
 EOF
 
 mysqladmin -uroot --socket=${MYSQL_UNIX_PORT} password root
@@ -97,8 +114,8 @@ ${backuptool} --backup --stream=${streamtool} --user=root --password=root --sock
 rm -f /tmp/raw_mysql_version.txt
 
 if ! kill -s TERM "$pid" || ! wait "$pid"; then
-	echo >&2 'Database initialization process failed.'
-	exit 5
+  echo >&2 'Database initialization process failed.'
+  exit 5
 fi
 
 echo "The startup database files (in mariabackup/xtradb format) are now in $OUTDIR"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -26,7 +26,7 @@ var WebTag = "20260508_rfay_faster_poweroff" // Note that this can be overridden
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "v1.25.2"
+var BaseDBTag = "20260522_stasadev_myqld_socket"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/actions/runs/26281022766/job/77356939196#step:7:6709

```
 > [18/26] RUN /create_base_db.sh:
3.940 + for i in {120..0}
3.940 + mysqladmin ping -uroot --socket=/var/tmp/mysql.sock
3.944 + kill -s 0 62
3.944 + sleep 1
4.945 + for i in {120..0}
4.945 + mysqladmin ping -uroot --socket=/var/tmp/mysql.sock
4.948 + kill -s 0 62
4.948 + echo 'mysqld initialization startup failed'
4.948 mysqld initialization startup failed
4.948 + exit 3
------
Dockerfile:120
--------------------
 118 |
 119 |     # Build a starter base db
 120 | >>> RUN /create_base_db.sh
 121 |
 122 |     RUN chmod ugo+x /healthcheck.sh
--------------------
ERROR: failed to build: failed to solve: process "/bin/bash -c /create_base_db.sh" did not complete successfully: exit code: 3
make: *** [Makefile:58: mariadb_11.8_both] Error 1
```

`create_base_db.sh` couldn't tell us why it failed because `/etc/my.cnf` sets `log_error=/var/lib/mysql/mysqld.err`, so mysqld's real failure was written to a file the script never printed. Capturing the error log surfaced:

```
[ERROR] Can't start server : Bind on unix socket: Address already in use
[ERROR] Do you already have another server running on socket: /var/tmp/mysql.sock ?
```

The Dockerfile pre-creates `/var/tmp/mysql.sock` as a symlink to `/tmp/mysqlx.sock` (for runtime use) before `create_base_db.sh` runs. MariaDB <=11.8.6 silently unlinked an existing socket path before `bind()`;

11.8.7, 10.11.17, 11.4.11 changed that behavior ([MDEV-5479](https://jira.mariadb.org/browse/MDEV-5479), "mysqld daemon should check if any process uses the socket file before removing") and refuses to bind, aborting startup. 11.8.6 and earlier are unaffected.

## How This PR Solves The Issue

- Removes the stale `${MYSQL_UNIX_PORT}` path right before launching mysqld in `create_base_db.sh`, so mysqld can create its own socket during base-DB initialization. The runtime symlink is restored normally on first container start.
- Routes mysqld's `--log-error` to `/var/tmp/mysqld-init.err` during the base-DB step and dumps it on failure, so future startup failures show their real cause inline in the build output instead of disappearing into a file inside the dying container.

## Manual Testing Instructions

1. `cd containers/ddev-dbserver`
2. `make mariadb_11.8_amd64 DOCKER_ARGS="--no-cache"` - should now build successfully (previously failed at `[18/26] RUN /create_base_db.sh`).
3. Confirm a quick smoke test of the resulting image still starts mysqld and accepts a connection.

## Automated Testing Overview

No new automated tests. The fix is exercised by the existing image build pipeline; any regression on the socket-bind path will show up as a build failure on `mariadb_*` targets just as it did here, but now with the real mysqld error in the build log.

## Release/Deployment Notes