### PR TITLE
test: add details to TestCmdAddonPHP

### DIFF
--- a/cmd/ddev/cmd/addon_test.go
+++ b/cmd/ddev/cmd/addon_test.go
@@ -195,8 +195,8 @@ func TestCmdAddonPHP(t *testing.T) {
 		addonList = strings.TrimSpace(addonList)
 		addons := strings.SplitSeq(addonList, "\n")
 		for item := range addons {
-			_, err = exec.RunHostCommand(DdevBin, "add-on", "remove", item)
-			require.NoError(t, err)
+			out, err := exec.RunHostCommand(DdevBin, "add-on", "remove", item)
+			asrt.NoError(t, err, "failed to remove add-on %q: output=%s", item, out)
 		}
 
 		_ = os.Chdir(origDir)

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -171,9 +171,6 @@ func ProcessAddonAction(action string, installDesc InstallDesc, app *DdevApp, ve
 	if app == nil {
 		return fmt.Errorf("app is required to ProcessAddonAction")
 	}
-	if err := app.MutagenSyncFlush(); err != nil {
-		return fmt.Errorf("unable to flush Mutagen: %v", err)
-	}
 	// Check if the action starts with <?php
 	if strings.HasPrefix(strings.TrimSpace(action), "<?php") {
 		return processPHPAction(action, installDesc, app, verbose)

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -171,6 +171,9 @@ func ProcessAddonAction(action string, installDesc InstallDesc, app *DdevApp, ve
 	if app == nil {
 		return fmt.Errorf("app is required to ProcessAddonAction")
 	}
+	if err := app.MutagenSyncFlush(); err != nil {
+		return fmt.Errorf("unable to flush Mutagen: %v", err)
+	}
 	// Check if the action starts with <?php
 	if strings.HasPrefix(strings.TrimSpace(action), "<?php") {
 		return processPHPAction(action, installDesc, app, verbose)


### PR DESCRIPTION
## The Issue

https://buildkite.com/ddev/macos-lima/builds/6445#019e4f7f-a814-42b1-a165-e6e41256d23d/L17722

```
=== NAME  TestCmdAddonPHP
    addon_test.go:199:
        	Error Trace:	/Users/testbot/tmp/buildkite-agent/builds/tb-macos-arm64-5/ddev/macos-lima/cmd/ddev/cmd/addon_test.go:199
        	            				/opt/homebrew/Cellar/go/1.26.3/libexec/src/strings/iter.go:54
        	            				/Users/testbot/tmp/buildkite-agent/builds/tb-macos-arm64-5/ddev/macos-lima/cmd/ddev/cmd/addon_test.go:197
        	            				/opt/homebrew/Cellar/go/1.26.3/libexec/src/testing/testing.go:1317
        	            				/opt/homebrew/Cellar/go/1.26.3/libexec/src/testing/testing.go:1667
        	            				/opt/homebrew/Cellar/go/1.26.3/libexec/src/testing/testing.go:2030
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestCmdAddonPHP
```

No details here, and `require.NoError` is used in a loop, which means that not all add-ons were removed, which resulted in a leftover later:

https://buildkite.com/ddev/macos-lima/builds/6445#019e4f7f-a814-42b1-a165-e6e41256d23d/L17979

```
2026-05-22T06:46:36.304 Health log from failed ddev-testcmdwordpress-complex-php-addon-1 container:
    autocompletion_test.go:411:
        	Error Trace:	/Users/testbot/tmp/buildkite-agent/builds/tb-macos-arm64-5/ddev/macos-lima/cmd/ddev/cmd/autocompletion_test.go:411
```

## How This PR Solves The Issue

- Uses `asrt` instead of `require` in cleanup for `TestCmdAddonPHP`, require prevented removal for all add-ons
- Adds output details, why `ddev add-on remove` failed - we can't do anything without understanding why it failed

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
