### PR TITLE
feat(docker-rootless): remove no-bind-mounts requirement, test gvisor-tap-vsock

### DIFF
--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -197,19 +197,29 @@ include if exists <local/${filename}>
 }
 EOF
   sudo systemctl restart apparmor.service
+  # Set the default network driver to "gvisor-tap-vsock" (see https://github.com/moby/moby/releases/tag/docker-v29.5.0)
   # Allow loopback https://github.com/moby/moby/issues/47684#issuecomment-2166149845
   mkdir -p ~/.config/systemd/user/docker.service.d
   cat << 'EOF' > ~/.config/systemd/user/docker.service.d/override.conf
 [Service]
+Environment="DOCKERD_ROOTLESS_ROOTLESSKIT_NET=gvisor-tap-vsock"
 Environment="DOCKERD_ROOTLESS_ROOTLESSKIT_DISABLE_HOST_LOOPBACK=false"
 EOF
   # Install rootless docker
   # Download the rootless installer script
   curl -fsSL https://get.docker.com/rootless -o /tmp/docker-rootless-install.sh
-  # Get Docker version from docker --version (format: "Docker version 29.1.3, build f52814d454")
+
+  # Get Docker rootful version from docker --version (format: "Docker version 29.1.3, build f52814d454")
   DOCKER_VERSION=$(docker --version | sed -E 's/Docker version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-  # Replace STABLE_LATEST with the current Docker version to match rootful installation
-  sed -i "s/STABLE_LATEST=\"[0-9.]*\"/STABLE_LATEST=\"${DOCKER_VERSION}\"/" /tmp/docker-rootless-install.sh
+
+  # Install the latest Docker rootless for now (because of using gvisor-tap-vsock)
+  DOCKER_VERSION=""
+
+  if [ "${DOCKER_VERSION}" != "" ]; then
+    # Replace STABLE_LATEST with the current Docker version to match rootful installation
+    sed -i "s/STABLE_LATEST=\"[0-9.]*\"/STABLE_LATEST=\"${DOCKER_VERSION}\"/" /tmp/docker-rootless-install.sh
+  fi
+
   # Execute the modified script
   sh /tmp/docker-rootless-install.sh
   cat /etc/subuid
@@ -224,7 +234,7 @@ source ~/.bashrc
 brew tap bats-core/bats-core >/dev/null
 brew tap ddev/ddev >/dev/null
 for item in bats-core ddev docker-compose ghr golangci-lint bats-assert bats-file bats-support; do
-    brew install $item >/dev/null || brew upgrade $item >/dev/null
+  brew install $item >/dev/null || brew upgrade $item >/dev/null
 done
 
 mkcert -install

--- a/.github/workflows/test-docker-rootless.yml
+++ b/.github/workflows/test-docker-rootless.yml
@@ -62,7 +62,6 @@ jobs:
     secrets: inherit
     with:
       ddev_test_docker_rootless: "true"
-      ddev_test_no_bind_mounts: "true"
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
   docker-rootless-custom:
@@ -75,5 +74,4 @@ jobs:
       testargs: ${{ inputs.testargs }}
       gotest_short: ${{ inputs.gotest_short }}
       ddev_test_docker_rootless: "true"
-      ddev_test_no_bind_mounts: "true"
       debug_enabled: ${{ inputs.debug_enabled || false }}

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -53,6 +53,17 @@ RUN rm -f /tmp/debsuryorg-archive-keyring.deb && \
 RUN apt-get -qq update
 ### -------------------------------END base---------------------------------------
 
+### --------------------------ddev-keep-root-build--------------------------------
+### Build the ddev-keep-root.so shim in a separate stage so gcc is not added to
+### the shipped images. The shim lets a process keep running as root; see
+### ddev-keep-root.c for details.
+FROM base AS ddev-keep-root-build
+SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]
+RUN apt-get -qq update && \
+    apt-get -qq install --no-install-recommends --no-install-suggests -y gcc libc6-dev && \
+    gcc -shared -fPIC -O2 -Wall -o /ddev-keep-root.so /usr/local/src/ddev/ddev-keep-root.c -ldl
+### ------------------------END ddev-keep-root-build------------------------------
+
 ### ------------------------ddev-php-extension-build------------------------------
 ### Uncomment the lines below to enable custom PHP extension builds:
 #FROM base AS ddev-php-extension-build
@@ -94,6 +105,11 @@ RUN apt-get -qq update && apt-get -qq install --no-install-recommends --no-insta
     msmtp \
     nginx \
     sqlite3
+
+# Add the ddev-keep-root.so shim (see ddev-keep-root.c). It does nothing unless
+# DDEV_KEEP_ROOT is set, and DDEV deletes it from the web image unless it is
+# needed (apache-fpm on Docker rootless + bind mounts); see WriteBuildDockerfile.
+COPY --from=ddev-keep-root-build /ddev-keep-root.so /usr/local/lib/ddev/ddev-keep-root.so
 
 RUN curl -L --fail -o /usr/local/bin/n -sSL https://raw.githubusercontent.com/tj/n/master/bin/n && chmod ugo+wx /usr/local/bin/n
 # Install node without cache, make a symlink for nodejs

--- a/containers/ddev-php-base/generic-files/usr/local/src/ddev/ddev-keep-root.c
+++ b/containers/ddev-php-base/generic-files/usr/local/src/ddev/ddev-keep-root.c
@@ -1,0 +1,55 @@
+// ddev-keep-root.c
+//
+// #ddev-generated
+//
+// Small LD_PRELOAD library that stops a process from dropping privileges. It
+// turns setuid/setgid/initgroups/... into no-ops that return success, so the
+// process keeps its current user (in practice, root).
+//
+// It only does this when the DDEV_KEEP_ROOT environment variable is set.
+// Otherwise each call goes to the real libc function, so the library is safe
+// to load into any process.
+//
+// DDEV needs this for Docker rootless. There the host user maps to container
+// UID 0, so bind-mounted files (including .git) look root-owned and the web
+// container runs as 0:0. Apache (Debian) refuses to run as root unless it was
+// built with -DBIG_SECURITY_HOLE. Instead of rebuilding Apache, start.sh
+// LD_PRELOADs this library for apache2 and keeps User/Group at a non-root user
+// (so Apache's startup root check passes); the library then blocks the
+// privilege drop, so Apache stays root and can read and write the root-owned
+// files.
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <grp.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static int ddev_keep_root(void) {
+    const char *v = getenv("DDEV_KEEP_ROOT");
+    return v != NULL && (*v == '1' || *v == 't' || *v == 'T' || *v == 'y' || *v == 'Y');
+}
+
+// Each interceptor returns success and does nothing when DDEV_KEEP_ROOT is set,
+// otherwise it calls the real libc function found via dlsym(RTLD_NEXT).
+#define DDEV_NOOP_WHEN_KEEP_ROOT(name, args_decl, args_call) \
+    int name args_decl { \
+        static int (*real) args_decl = NULL; \
+        if (ddev_keep_root()) \
+            return 0; \
+        if (real == NULL) \
+            real = (int (*) args_decl) dlsym(RTLD_NEXT, #name); \
+        return real args_call; \
+    }
+
+DDEV_NOOP_WHEN_KEEP_ROOT(setuid, (uid_t uid), (uid))
+DDEV_NOOP_WHEN_KEEP_ROOT(seteuid, (uid_t uid), (uid))
+DDEV_NOOP_WHEN_KEEP_ROOT(setgid, (gid_t gid), (gid))
+DDEV_NOOP_WHEN_KEEP_ROOT(setegid, (gid_t gid), (gid))
+DDEV_NOOP_WHEN_KEEP_ROOT(setreuid, (uid_t ruid, uid_t euid), (ruid, euid))
+DDEV_NOOP_WHEN_KEEP_ROOT(setregid, (gid_t rgid, gid_t egid), (rgid, egid))
+DDEV_NOOP_WHEN_KEEP_ROOT(setresuid, (uid_t ruid, uid_t euid, uid_t suid), (ruid, euid, suid))
+DDEV_NOOP_WHEN_KEEP_ROOT(setresgid, (gid_t rgid, gid_t egid, gid_t sgid), (rgid, egid, sgid))
+DDEV_NOOP_WHEN_KEEP_ROOT(setgroups, (size_t size, const gid_t *list), (size, list))
+DDEV_NOOP_WHEN_KEEP_ROOT(initgroups, (const char *user, gid_t group), (user, group))

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
 ARG DOCKER_ORG=ddev
-FROM ${DOCKER_ORG}/ddev-php-base:20260502_akibaat_folder_permissions AS ddev-webserver-base
+FROM ${DOCKER_ORG}/ddev-php-base:20260524_stasadev_docker_rootless AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -67,8 +67,14 @@ if [ "${DDEV_PROJECT_TYPE}" = "drupal6" ] || [ "${DDEV_PROJECT_TYPE}" = "drupal7
   ln -sf /usr/local/bin/drush8 "$HOME/.local/bin/drush"
 fi
 
-# Change the apache run user to current user/group
-printf "\nexport APACHE_RUN_USER=$(id -un)\nexport APACHE_RUN_GROUP=$(id -gn)\n" >>/etc/apache2/envvars
+# Apache refuses to run as root, but Docker rootless runs the container as root
+# to reach root-owned bind mounts. When the ddev-keep-root shim is present (DDEV
+# adds it only for this case), LD_PRELOAD it so Apache can stay root.
+if [ "$(id -u)" = "0" ] && [ -f /usr/local/lib/ddev/ddev-keep-root.so ]; then
+  printf "\nexport LD_PRELOAD=/usr/local/lib/ddev/ddev-keep-root.so\nexport DDEV_KEEP_ROOT=true\n" >>/etc/apache2/envvars
+else
+  printf "\nexport APACHE_RUN_USER=$(id -un)\nexport APACHE_RUN_GROUP=$(id -gn)\n" >>/etc/apache2/envvars
+fi
 
 a2enmod access_compat alias auth_basic authn_core authn_file authz_core authz_host authz_user autoindex deflate dir env filter mime mpm_event negotiation reqtimeout rewrite setenvif status
 a2enconf charset localized-error-pages other-vhosts-access-log security serve-cgi-bin

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -67,8 +67,14 @@ if [ "${DDEV_PROJECT_TYPE}" = "drupal6" ] || [ "${DDEV_PROJECT_TYPE}" = "drupal7
   ln -sf /usr/local/bin/drush8 "$HOME/.local/bin/drush"
 fi
 
-# Change the apache run user to current user/group
-printf "\nexport APACHE_RUN_USER=$(id -un)\nexport APACHE_RUN_GROUP=$(id -gn)\n" >>/etc/apache2/envvars
+# Apache refuses to run as root, but Docker rootless runs the container as root
+# to reach root-owned bind mounts. When the ddev-keep-root shim is present (DDEV
+# adds it only for this case), LD_PRELOAD it so Apache can stay root.
+if [ "$(id -u)" = "0" ] && [ -f /usr/local/lib/ddev/ddev-keep-root.so ]; then
+  printf "\nexport LD_PRELOAD=/usr/local/lib/ddev/ddev-keep-root.so\nexport DDEV_KEEP_ROOT=true\n" >>/etc/apache2/envvars
+else
+  printf "\nexport APACHE_RUN_USER=$(id -un)\nexport APACHE_RUN_GROUP=$(id -gn)\n" >>/etc/apache2/envvars
+fi
 
 a2enmod access_compat alias auth_basic authn_core authn_file authz_core authz_host authz_user autoindex deflate dir env filter mime mpm_event negotiation reqtimeout rewrite setenvif status
 a2enconf charset localized-error-pages other-vhosts-access-log security serve-cgi-bin

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -12,6 +12,7 @@ import (
 	composeTypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/docker/compose/v5/pkg/api"
@@ -263,6 +264,9 @@ func fixupComposeYaml(project *composeTypes.Project, app *DdevApp) (*composeType
 
 	isPodman := dockerutil.IsPodman()
 	isRootless := dockerutil.IsRootless()
+	isDockerRootless := dockerutil.IsDockerRootless()
+	isMutagenEnabled := app.IsMutagenEnabled()
+	isNoBindMounts := globalconfig.DdevGlobalConfig.NoBindMounts
 	isSELinux := dockerutil.IsSELinux()
 	uid, gid, _ := dockerutil.GetContainerUser()
 	userGroup := uid + ":" + gid
@@ -328,10 +332,18 @@ func fixupComposeYaml(project *composeTypes.Project, app *DdevApp) (*composeType
 			service.Ports[i] = port
 		}
 
-		// Podman: set the user namespace mode for the container
-		// https://docs.podman.io/en/v4.6.1/markdown/options/userns.container.html#userns-mode
-		if isPodman && isRootless && service.User == userGroup {
-			service.UserNSMode = "keep-id"
+		if isRootless && service.User == userGroup {
+			if isPodman {
+				// Podman: set the user namespace mode for the container
+				// https://docs.podman.io/en/v4.6.1/markdown/options/userns.container.html#userns-mode
+				service.UserNSMode = "keep-id"
+			} else if isDockerRootless {
+				// Docker rootless maps the host user to container UID 0, so
+				// bind-mounted files (including .git) appear root-owned. Run as root for consistency.
+				if name == "web" && !isNoBindMounts {
+					service.User = "0:0"
+				}
+			}
 		}
 
 		if isPodman {
@@ -359,10 +371,22 @@ func fixupComposeYaml(project *composeTypes.Project, app *DdevApp) (*composeType
 			}
 		}
 
+		// Mutagen uses `docker cp` to install its agent; under rootless Docker this triggers
+		// `remount-ro ... operation not permitted` when restoring RO bind mounts (user-namespace
+		// mount flags are locked by the kernel). Drop read_only on bind mounts to avoid this.
+		if isDockerRootless && isMutagenEnabled && name == "web" {
+			for i, vol := range service.Volumes {
+				if vol.Type == composeTypes.VolumeTypeBind && vol.ReadOnly {
+					vol.ReadOnly = false
+					service.Volumes[i] = vol
+				}
+			}
+		}
+
 		// Add SELinux labels to bind mounts when SELinux is enabled
 		if isSELinux {
 			for i, vol := range service.Volumes {
-				if vol.Type == "bind" {
+				if vol.Type == composeTypes.VolumeTypeBind {
 					// Initialize Bind struct if needed
 					if vol.Bind == nil {
 						vol.Bind = &composeTypes.ServiceVolumeBind{}

--- a/pkg/ddevapp/compose_yaml_test.go
+++ b/pkg/ddevapp/compose_yaml_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/versionconstants"
 	asrt "github.com/stretchr/testify/assert"
@@ -240,6 +241,23 @@ func TestFixupComposeYaml(t *testing.T) {
 	assert.Equal(1, webService.Networks["default"].Priority)
 	require.NotNil(t, webService.Networks["dummy"])
 	assert.Equal(2, webService.Networks["dummy"].Priority)
+
+	// Verify the rootless user handling added by fixupComposeYaml: Docker rootless
+	// runs the web service as 0:0 when bind mounts are active (the host user maps
+	// to container UID 0), Podman rootless uses userns keep-id, and every other
+	// case keeps the container user. Only the web service is ever forced to 0:0.
+	uid, gid, _ := dockerutil.GetContainerUser()
+	userGroup := uid + ":" + gid
+	switch {
+	case dockerutil.IsDockerRootless() && !globalconfig.DdevGlobalConfig.NoBindMounts:
+		require.Equal(t, "0:0", webService.User, "web should run as 0:0 on Docker rootless with bind mounts")
+	case dockerutil.IsPodmanRootless():
+		require.Equal(t, userGroup, webService.User)
+		require.Equal(t, "keep-id", webService.UserNSMode, "web should use userns keep-id on Podman rootless")
+	default:
+		require.Equal(t, userGroup, webService.User)
+	}
+	require.Equal(t, userGroup, app.ComposeYaml.Services["db"].User, "only the web service is set to 0:0; db keeps the container user")
 
 	hostDockerInternal := dockerutil.GetHostDockerInternal()
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1396,6 +1396,17 @@ RUN mkdir -p /run/php /var/run/nginx /var/run/supervisor /var/run/apache2 /var/l
     chgrp "$gid" /usr/local/bin/composer && chmod g+rwx,o-w /usr/local/bin/composer && \
     mkdir -p /tmp/xhprof && chmod -R ugo+w /etc/php /var/lib/php /tmp/xhprof
 `
+		// The ddev-keep-root.so shim is only used to run Apache as root, which
+		// happens with apache-fpm on Docker rootless + bind mounts (the web
+		// container runs as 0:0). In every other case delete it: it disables
+		// setuid/setgid for any process that loads it, so it should not be present.
+		if !dockerutil.IsDockerRootless() || globalconfig.DdevGlobalConfig.NoBindMounts || app.WebserverType != nodeps.WebserverApacheFPM {
+			contents = contents + `
+### DDEV-injected removal of the ddev-keep-root shim (only needed for apache-fpm on Docker rootless)
+RUN rm -f /usr/local/lib/ddev/ddev-keep-root.so
+`
+		}
+
 		// Files from containers/ddev-webserver/ddev-webserver-base-files/var/www/html
 		// are added to host on `ddev start` when using Podman with Mutagen enabled
 		if dockerutil.IsPodman() && app.IsMutagenEnabled() {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1547,15 +1547,6 @@ func (app *DdevApp) Start() error {
 		return fmt.Errorf("mutagen is not compatible with use-hardened-images")
 	}
 
-	if app.WebserverType == nodeps.WebserverApacheFPM && dockerutil.IsDockerRootless() && !globalconfig.DdevGlobalConfig.NoBindMounts {
-		// See https://github.com/moby/moby/issues/45919 (rootless bind mount ownership)
-		// See https://github.com/moby/moby/issues/2259 (Apache refuses to run as root)
-		return fmt.Errorf(`%[1]s refuses to run as root (Docker rootless maps host user to container root).
-Run "ddev config global --no-bind-mounts=true" so Apache runs with the appropriate user, or
-run "ddev config --webserver-type=%[2]s" to switch to %[2]s`,
-			nodeps.WebserverApacheFPM, nodeps.WebserverNginxFPM)
-	}
-
 	if _, err := dockerutil.DownloadDockerBuildxIfNeeded(); err != nil {
 		return err
 	}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1547,10 +1547,13 @@ func (app *DdevApp) Start() error {
 		return fmt.Errorf("mutagen is not compatible with use-hardened-images")
 	}
 
-	if dockerutil.IsDockerRootless() && !globalconfig.DdevGlobalConfig.NoBindMounts {
-		// See https://github.com/moby/moby/issues/45919
-		// See https://github.com/moby/moby/issues/2259
-		return fmt.Errorf("bind mounts can't be used with Docker Rootless.\nRun `ddev config global --no-bind-mounts` and try again")
+	if app.WebserverType == nodeps.WebserverApacheFPM && dockerutil.IsDockerRootless() && !globalconfig.DdevGlobalConfig.NoBindMounts {
+		// See https://github.com/moby/moby/issues/45919 (rootless bind mount ownership)
+		// See https://github.com/moby/moby/issues/2259 (Apache refuses to run as root)
+		return fmt.Errorf(`%[1]s refuses to run as root (Docker rootless maps host user to container root).
+Run "ddev config global --no-bind-mounts=true" so Apache runs with the appropriate user, or
+run "ddev config --webserver-type=%[2]s" to switch to %[2]s`,
+			nodeps.WebserverApacheFPM, nodeps.WebserverNginxFPM)
 	}
 
 	if _, err := dockerutil.DownloadDockerBuildxIfNeeded(); err != nil {

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -39,6 +39,11 @@ const mutagenConfigFileHashLabelName = `com.ddev.config-hash`
 func SetMutagenVolumeOwnership(app *DdevApp) error {
 	// Make sure that if we have a volume mount it's got proper ownership
 	uidStr, gidStr, _ := dockerutil.GetContainerUser()
+	// Docker rootless runs the web container as root (see fixupComposeYaml);
+	// chown to root so Mutagen-synced files and bind-mounted .git share the same owner.
+	if dockerutil.IsDockerRootless() && !globalconfig.DdevGlobalConfig.NoBindMounts {
+		uidStr, gidStr = "0", "0"
+	}
 	util.Verbose("Chowning Mutagen Docker volume for user %s", uidStr)
 	// Use -f to suppress errors from transient .mutagen-temporary-staging-* files
 	// that may appear/disappear during an active or resuming sync session.

--- a/pkg/ddevapp/rootless_test.go
+++ b/pkg/ddevapp/rootless_test.go
@@ -1,0 +1,95 @@
+package ddevapp_test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApacheRunsAsRoot verifies which user the apache2 process runs as with
+// webserver-type=apache-fpm. Under Docker rootless with bind mounts the web
+// container runs as 0:0 and the ddev-keep-root shim keeps apache2 at UID 0
+// (Apache otherwise refuses to run as root). In every other case the shim is
+// removed from the image (see WriteBuildDockerfile) and apache2 runs as the
+// container user.
+func TestApacheRunsAsRoot(t *testing.T) {
+	origDir, _ := os.Getwd()
+
+	testDir := testcommon.CreateTmpDir(t.Name())
+	projName := t.Name()
+
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+		app, err := ddevapp.GetActiveApp(projName)
+		if err == nil {
+			_ = app.Stop(true, false)
+		}
+		_ = os.RemoveAll(testDir)
+		testcommon.ClearDockerEnv()
+	})
+
+	// Clean up any existing name conflicts
+	app, err := ddevapp.GetActiveApp(projName)
+	if err == nil {
+		err = app.Stop(true, false)
+		require.NoError(t, err)
+	}
+
+	app, err = ddevapp.NewApp(testDir, false)
+	require.NoError(t, err)
+	app.Type = nodeps.AppTypePHP
+	app.Name = projName
+	app.WebserverType = nodeps.WebserverApacheFPM
+	err = app.WriteConfig()
+	require.NoError(t, err)
+
+	defer util.TimeTrackC(fmt.Sprintf("%s %s", projName, t.Name()))()
+
+	// If Apache could not run as root this Restart would fail, because the web
+	// container would never become healthy.
+	err = app.Restart()
+	require.NoError(t, err)
+
+	// Apache runs as root only on Docker rootless with bind mounts (where the
+	// web container runs as 0:0); otherwise it runs as the container user.
+	uid, _, _ := dockerutil.GetContainerUser()
+	expectedUID := uid
+	keepRoot := dockerutil.IsDockerRootless() && !globalconfig.DdevGlobalConfig.NoBindMounts
+	if keepRoot {
+		expectedUID = "0"
+	}
+
+	// List the UID of every apache2 process. Empty output means apache2 is not
+	// running (for example because it refused to run as root).
+	out, _, err := app.Exec(&ddevapp.ExecOpts{
+		Service: "web",
+		Cmd:     "ps -o uid= -C apache2",
+	})
+	require.NoError(t, err)
+	uids := strings.Fields(out)
+	require.NotEmpty(t, uids, "no apache2 processes found; apache2 may have failed to start")
+	for _, u := range uids {
+		require.Equal(t, expectedUID, u, "apache2 running as unexpected uid; ps output: %q", out)
+	}
+
+	// The ddev-keep-root shim must exist in the image only when it is needed.
+	out, _, err = app.Exec(&ddevapp.ExecOpts{
+		Service: "web",
+		Cmd:     "test -f /usr/local/lib/ddev/ddev-keep-root.so && echo present || echo absent",
+	})
+	require.NoError(t, err)
+	if keepRoot {
+		require.Equal(t, "present", strings.TrimSpace(out))
+	} else {
+		require.Equal(t, "absent", strings.TrimSpace(out))
+	}
+}

--- a/pkg/dockerutil/containers_test.go
+++ b/pkg/dockerutil/containers_test.go
@@ -171,26 +171,33 @@ func TestGetContainerUser(t *testing.T) {
 	uid, gid, username := dockerutil.GetContainerUser()
 
 	for _, service := range []string{"web", "db"} {
+		expectedUID, expectedGID, expectedUsername := uid, gid, username
+		// Rootless Docker maps the host user to UID 0 inside the container's user namespace,
+		// so the web service is explicitly set to 0:0 when bind mounts are active (see compose_yaml.go).
+		if service == "web" && dockerutil.IsDockerRootless() && !globalconfig.DdevGlobalConfig.NoBindMounts {
+			expectedUID, expectedGID, expectedUsername = "0", "0", "root"
+		}
+
 		out, _, err := app.Exec(&ddevapp.ExecOpts{
 			Service: service,
 			Cmd:     "id -un",
 		})
 		require.NoError(t, err)
-		require.Equal(t, username, strings.Trim(out, "\r\n"))
+		require.Equal(t, expectedUsername, strings.Trim(out, "\r\n"))
 
 		out, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: service,
 			Cmd:     "id -u",
 		})
 		require.NoError(t, err)
-		require.Equal(t, uid, strings.Trim(out, "\r\n"))
+		require.Equal(t, expectedUID, strings.Trim(out, "\r\n"))
 
 		out, _, err = app.Exec(&ddevapp.ExecOpts{
 			Service: service,
 			Cmd:     "id -g",
 		})
 		require.NoError(t, err)
-		require.Equal(t, gid, strings.Trim(out, "\r\n"))
+		require.Equal(t, expectedGID, strings.Trim(out, "\r\n"))
 	}
 }
 

--- a/pkg/dockerutil/host_docker_internal.go
+++ b/pkg/dockerutil/host_docker_internal.go
@@ -134,10 +134,13 @@ func GetHostDockerInternal() *HostDockerInternal {
 			message = "IsLinux uses 'host-gateway' in extra_hosts"
 
 			if IsDockerRootless() {
-				// Docker rootless doesn't update "host-gateway" value
-				// https://github.com/moby/moby/issues/47684#issuecomment-2166149845
-				ipAddress = "10.0.2.2"
-				message = "IsDockerRootless"
+				rootlessHostIP, netDriver, err := getDockerRootlessHostIP()
+				if err != nil {
+					message = fmt.Sprintf("IsDockerRootless; unable to determine host IP: %v", err)
+				} else {
+					ipAddress = rootlessHostIP
+					message = fmt.Sprintf("IsDockerRootless with RootlessKit net driver '%s'", netDriver)
+				}
 			}
 
 		default:
@@ -296,4 +299,31 @@ func getDockerLinuxBridgeIP() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no gateway found in Docker bridge network")
+}
+
+// getDockerRootlessHostIP returns the IP at which the host's loopback is reachable
+// from containers under Docker rootless, and the RootlessKit network driver name.
+// See https://github.com/moby/moby/issues/47684#issuecomment-2166149845
+// See https://github.com/moby/moby/blob/master/contrib/dockerd-rootless.sh
+// See https://github.com/rootless-containers/rootlesskit/blob/master/docs/network.md
+func getDockerRootlessHostIP() (string, string, error) {
+	serverVersion, err := GetServerVersion()
+	if err != nil {
+		return "", "", err
+	}
+	netDriver := ""
+	for _, component := range serverVersion.Components {
+		if strings.EqualFold(component.Name, "rootlesskit") {
+			netDriver = component.Details["NetworkDriver"]
+			break
+		}
+	}
+	switch netDriver {
+	case "":
+		return "", "", fmt.Errorf("unable to determine RootlessKit network driver from 'docker version'")
+	case "gvisor-tap-vsock":
+		return "10.0.2.1", netDriver, nil
+	default:
+		return "10.0.2.2", netDriver, nil
+	}
 }

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260502_akibaat_folder_permissions" // Note that this can be overridden by make
+var WebTag = "20260524_stasadev_docker_rootless" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

Docker rootless used to require `no-bind-mounts` in DDEV:
  - `no-bind-mounts` forces Mutagen, which adds overhead.
  - `no-bind-mounts` does not mount the `.git` directory, so `git` inside the container is not useful.

Existing limitations:
  - Docker rootless maps the host user to container UID 0, so bind-mounted files appear root-owned, and Apache (Debian) refuses to run as root. This was the blocker for `apache-fpm`; `nginx-fpm` and `php-fpm` run as root without issues.

Docker [29.5.0](https://github.com/moby/moby/releases/tag/docker-v29.5.0) also introduced `gvisor-tap-vsock` as the new default network driver for rootless mode.

## How This PR Solves The Issue

Docker rootless maps the host user to container UID 0, so bind-mounted files (including `.git`) appear root-owned. The web container now runs as `0:0` under Docker rootless without `no-bind-mounts`, so all files share one owner. (Podman keeps using `keep-id` and is unchanged.)

To let `apache-fpm` run as root without rebuilding Apache, a tiny `LD_PRELOAD` shim (`ddev-keep-root.so`) turns the privilege-dropping calls (`setuid`/`setgid`/`initgroups`/...) into no-ops. It is:
  - built once in `ddev-php-base` (in a throwaway stage, so `gcc` is never shipped) and installed at `/usr/local/lib/ddev/ddev-keep-root.so`;
  - loaded only for the `apache2` process (via `/etc/apache2/envvars` in `start.sh`), and only when the container runs as UID 0 and the shim is present;
  - removed from the per-project web image (`WriteBuildDockerfile`) in every case except `apache-fpm` on Docker rootless with bind mounts, so it cannot be misused elsewhere;
  - inert unless `DDEV_KEEP_ROOT` is set, so it is harmless if loaded into any other process.

Apache's `User`/`Group` stay at the non-root default (`www-data`), so its config-time root check passes, and the shim then prevents the actual privilege drop so the process keeps UID 0 and can read/write the root-owned bind mounts.

`SetMutagenVolumeOwnership` also chowns to root under the same condition, so Mutagen-synced files stay consistent with bind-mounted `.git`.

For Docker rootless + Mutagen, `read_only` is dropped from web service bind mounts to avoid `remount-ro ... operation not permitted` when Mutagen installs its agent via `docker cp`.

CI now sets `DOCKERD_ROOTLESS_ROOTLESSKIT_NET=gvisor-tap-vsock`, installs the latest rootless Docker, and removes the `no-bind-mounts` requirement from rootless test jobs.

DDEV sets `host.docker.internal` to `10.0.2.1` for `gvisor-tap-vsock` for Xdebug.

## Manual Testing Instructions

Using Docker rootless, both `nginx-fpm` and `apache-fpm` should now work in every case below.

No Mutagen, with bind mounts:

```bash
ddev config global --performance-mode=none --no-bind-mounts=false

# should work
ddev config --webserver-type=nginx-fpm && ddev start

# the shim is removed from the image when it is not needed
ddev exec 'ls -l /usr/local/lib/ddev/ddev-keep-root.so'  # No such file

# should show root inside the container
ddev exec "id -a"

# should work (previously failed: "Apache refuses to run as root")
ddev config --webserver-type=apache-fpm && ddev restart

# the shim is here
ddev exec 'ls -l /usr/local/lib/ddev/ddev-keep-root.so'

# should work
ddev exec touch file.txt

# should show root inside the container
ddev exec "id -a"

# on the host, the file is owned by your user (rootless maps container root -> host user)
ls -la file.txt

# Apache itself runs as root via the shim (all processes show "root",
# even though apache2.conf says "User www-data")
ddev exec 'ps -o user,comm -C apache2'

ddev exec 'grep APACHE_RUN_USER /etc/apache2/envvars; grep -E "^User" /etc/apache2/apache2.conf'
```

With Mutagen, with bind mounts:

```bash
ddev config global --performance-mode=mutagen --no-bind-mounts=false

# should work
ddev config --webserver-type=nginx-fpm && ddev start

# the shim is removed from the image when it is not needed
ddev exec 'ls -l /usr/local/lib/ddev/ddev-keep-root.so'  # No such file

# should show root inside the container
ddev exec "id -a"

# should work (previously failed: "Apache refuses to run as root")
ddev config --webserver-type=apache-fpm && ddev restart

# the shim is here
ddev exec 'ls -l /usr/local/lib/ddev/ddev-keep-root.so'

# should work
ddev exec touch file.txt

# should show root inside the container
ddev exec "id -a"
```

No bind mounts:

```bash
ddev config global --no-bind-mounts=true

# should work
ddev config --webserver-type=nginx-fpm && ddev start

# the shim is removed from the image when it is not needed
ddev exec 'ls -l /usr/local/lib/ddev/ddev-keep-root.so'  # No such file

# should show your user, not root
ddev exec "id -a"

# should work
ddev config --webserver-type=apache-fpm && ddev restart

# should work
ddev exec touch file.txt

# should show your user, not root
ddev exec "id -a"

# the shim is removed from the image when it is not needed
ddev exec 'ls -l /usr/local/lib/ddev/ddev-keep-root.so'  # No such file

# Apache runs as your user, not root
ddev exec 'ps -o user,comm -C apache2'
ddev exec 'grep APACHE_RUN_USER /etc/apache2/envvars; grep -E "^User" /etc/apache2/apache2.conf'
```

## Automated Testing Overview

- The CI `test-docker-rootless` workflow now runs without `ddev_test_no_bind_mounts: "true"`, testing the native bind-mount path with the `gvisor-tap-vsock` network driver.
- `TestGetContainerUser` now expects the `web` service to run as `root` under Docker rootless with bind mounts.
- `TestFixupComposeYaml` now asserts the rootless user handling: the `web` service is `0:0` under Docker rootless with bind mounts, `keep-id` under Podman rootless, and the container user otherwise - while `db` always keeps the container user (confirming only `web` is forced to `0:0`).
- New `TestApacheRunsAsRoot` (`pkg/ddevapp/rootless_test.go`) starts an `apache-fpm` project and checks `ps -o uid= -C apache2`: every `apache2` process runs as `root` under Docker rootless with bind mounts, or as the container user otherwise. It also asserts the `ddev-keep-root.so` shim is present in the image only when needed and removed in every other case.

## Release/Deployment Notes

- Docker rootless no longer requires `no-bind-mounts` for either `nginx-fpm` (the default) or `apache-fpm`, so `.git` is available inside the container.
- The previous behavior is preserved: `ddev config global --no-bind-mounts=true` still works and keeps the web container running as your (non-root) user. Anyone who prefers not to have root inside the container can keep using it (it enables Mutagen and does not mount `.git`).
- New `ddev-php-base` and `ddev-webserver` image tags (`20260524_stasadev_docker_rootless`) ship the `ddev-keep-root.so` shim. The hardened (`-prod`) image gets the same treatment.
- The shim exists in the running web image only for `apache-fpm` on Docker rootless with bind mounts; it is removed otherwise and is inert unless `DDEV_KEEP_ROOT` is set.
- Podman behavior is unchanged (`keep-id`).