### PR TITLE
ci(pr): migrate to ddev/commit-message-checker@v3

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Type
-        uses: gsactions/commit-message-checker@v2
+        uses: ddev/commit-message-checker@v3
         with:
           pattern: '^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\([a-z][a-z0-9-]*\))?!?:\s(?!.*  )[A-Za-z''"`].*[A-Za-z0-9\]\)''"`](?:, (?:fixes|for) #\d+)*$'
           flags: ''


### PR DESCRIPTION
## The Issue

`gsactions/commit-message-checker@v2` is unmaintained.

## How This PR Solves The Issue

Uses our fork:

- https://github.com/ddev/commit-message-checker/pull/2

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
