### PR TITLE
test(lima): fix broken cleanup in TestCmdAddonPHP, for #8425

### DIFF
--- a/cmd/ddev/cmd/addon_test.go
+++ b/cmd/ddev/cmd/addon_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
@@ -190,13 +189,12 @@ func TestCmdAddonPHP(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		addonList, err := exec.RunHostCommand("bash", "-c", fmt.Sprintf("%s add-on list --installed -j | docker run -i --rm ddev/ddev-utilities jq -r .raw.[].Name", DdevBin))
+		installedOutput, err := exec.RunHostCommand(DdevBin, "add-on", "list", "--installed", "--json-output")
 		require.NoError(t, err)
-		addonList = strings.TrimSpace(addonList)
-		addons := strings.SplitSeq(addonList, "\n")
-		for item := range addons {
-			out, err := exec.RunHostCommand(DdevBin, "add-on", "remove", item)
-			asrt.NoError(t, err, "failed to remove add-on %q: output=%s", item, out)
+		installedManifests := getManifestMapFromLogs(t, installedOutput)
+		for name := range installedManifests {
+			out, err := exec.RunHostCommand(DdevBin, "add-on", "remove", name)
+			asrt.NoError(t, err, "failed to remove add-on %q: output=%s", name, out)
 		}
 
 		_ = os.Chdir(origDir)


### PR DESCRIPTION
## The Issue

- For #8425

https://buildkite.com/ddev/macos-lima/builds/6454#019e69ba-1815-4b56-a5e9-d140fcad0632/L10063

```
=== NAME  TestCmdAddonPHP
    addon_test.go:199:
        	Error Trace:	/Users/testbot/tmp/buildkite-agent/builds/tb-macos-arm64-6/ddev/macos-lima/cmd/ddev/cmd/addon_test.go:199
        	            				/opt/homebrew/Cellar/go/1.26.3/libexec/src/strings/iter.go:54
        	            				/Users/testbot/tmp/buildkite-agent/builds/tb-macos-arm64-6/ddev/macos-lima/cmd/ddev/cmd/addon_test.go:197
        	            				/opt/homebrew/Cellar/go/1.26.3/libexec/src/testing/testing.go:1317
        	            				/opt/homebrew/Cellar/go/1.26.3/libexec/src/testing/testing.go:1667
        	            				/opt/homebrew/Cellar/go/1.26.3/libexec/src/testing/testing.go:2030
        	            				/opt/homebrew/Cellar/go/1.26.3/libexec/src/runtime/asm_arm64.s:1447
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestCmdAddonPHP
        	Messages:   	failed to remove add-on "WARNING: IPv4 forwarding is disabled. Networking will not work.": output=The add-on 'WARNING: IPv4 forwarding is disabled. Networking will not work.' does not seem to have a manifest file; please upgrade it.
        	            	Use `ddev add-on list --installed` to see installed add-ons.
        	            	
FAIL: TestCmdAddonPHP (28.54s)
```

## How This PR Solves The Issue

Replaces `docker run -i --rm ddev/ddev-utilities jq` with `getManifestFromLogs` (reused from `TestCmdAddonInstalled`).

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
