### PR TITLE
fix(exec): allocate TTY only when stdout is also a terminal, for #8234

### DIFF
--- a/cmd/ddev/cmd/exec_test.go
+++ b/cmd/ddev/cmd/exec_test.go
@@ -207,6 +207,19 @@ func TestCmdExec(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal("This file was piped into ddev exec", string(content))
 
+	// Regression check for \r injection when stdin is a TTY but stdout is piped.
+	// script(1) supplies the TTY stdin that `go test` doesn't.
+	if !nodeps.IsLinux() {
+		t.Log("Skipping TTY regression check: requires Linux")
+	} else if !util.IsCommandAvailable("script") {
+		t.Log("Skipping TTY regression check: script(1) not found in PATH")
+	} else {
+		t.Log("Running TTY regression check via script(1)")
+		out, err := exec.RunHostCommand("script", "-qec", fmt.Sprintf("%s exec echo hello | cat -A", DdevBin), "/dev/null")
+		assert.NoError(err)
+		assert.NotContains(out, "^M", "ddev exec must not inject \\r when stdout is piped, even if stdin is a terminal")
+	}
+
 	// Make sure that redirection of output from ddev exec works
 	f, err := os.CreateTemp("", "")
 	err = f.Close()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -39,7 +39,6 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/otiai10/copy"
-	"golang.org/x/term"
 )
 
 const (
@@ -2692,7 +2691,8 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		return "", "", execLoadErr
 	}
 
-	tty := opts.Tty && isatty.IsTerminal(os.Stdin.Fd())
+	// Allocate a TTY only when both stdin and stdout are real terminals.
+	tty := opts.Tty && isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(stdout.Fd())
 	runOpts := api.RunOptions{
 		Service:     opts.Service,
 		Command:     opts.RawCmd,
@@ -2776,7 +2776,7 @@ func (app *DdevApp) ExecWithTty(opts *ExecOpts) error {
 	if loadErr != nil {
 		return loadErr
 	}
-	tty := term.IsTerminal(int(os.Stdin.Fd()))
+	tty := isatty.IsTerminal(os.Stdin.Fd())
 	restore, stdinErr := dockerutil.SetExecStdin(os.Stdin, tty)
 	if stdinErr != nil {
 		return stdinErr


### PR DESCRIPTION
## The Issue

- For #8234

After the migration to the docker-compose Go library, `ddev exec` started emitting CRLF line endings whenever stdin happened to be a terminal, even if stdout was piped to another command on the host.

v1.25.2:

```
$ ddev exec echo hello | cat -A
hello$
```

DDEV HEAD:

```
$ ddev exec echo hello | cat -A
hello^M$
        %
```

The extra CR broke any downstream consumer that compared output byte-for-byte.

## How This PR Solves The Issue

The compose library allocates a real TTY inside the container whenever `opts.Tty` is true and stdin is a terminal. With a container TTY in place, the container shell's stdout goes through ONLCR line discipline and every `\n` becomes `\r\n` - that's what the host captures when its own stdout is a pipe.

The old docker-compose CLI gated raw-TTY mode on its own stdout fd as well. This PR restores that behavior by requiring both stdin **and** stdout to be real terminals before allocating a container TTY in `DdevApp.Exec()`.

Also switches `ExecWithTty`'s IsTerminal check from `golang.org/x/term` to `mattn/go-isatty` for consistency with the dominant TTY-detection library in the codebase.

## Manual Testing Instructions

1. Start any DDEV project
2. Run `ddev exec echo hello | cat -A`
3. Expected: a single `$` at end of line, no `^M` anywhere. Regression: `hello^M$`
4. Repeat with `ddev exec echo hello > /tmp/out.txt` and verify the file contains exactly `hello\n` (no `\r`)

## Automated Testing Overview

Adds a Linux-only regression assertion in `TestCmdExec`. Under `go test` the child's stdin is normally not a terminal, so the bug wouldn't reproduce on its own; the new check uses util-linux `script(1)` to allocate a real PTY for stdin and pipes stdout through `cat -A` so any spurious CR shows up as a visible `^M` in the captured output. macOS and Windows are skipped - the bug is in pure Go logic and runs identically across OSes, so Linux coverage is enough.

## Release/Deployment Notes

Behavioral change only for `ddev exec` invocations whose stdout is not a terminal. Output is again plain `\n`-terminated, matching the pre-compose-library behavior. No impact on interactive use.