### PR TITLE
chore(composer): add `COMPOSER_NO_BLOCKING`

### DIFF
--- a/cmd/ddev/cmd/composer-create-project.go
+++ b/cmd/ddev/cmd/composer-create-project.go
@@ -248,7 +248,7 @@ ddev composer create-project --prefer-dist --no-interaction --no-dev psr/log .
 				Tty:     isatty.IsTerminal(os.Stdin.Fd()),
 				// Disable security blocking to allow installing any packages,
 				// this is a new feature in Composer 2.9+
-				Env: []string{"XDEBUG_MODE=off", "COMPOSER_NO_SECURITY_BLOCKING=1"},
+				Env: []string{"XDEBUG_MODE=off", "COMPOSER_NO_BLOCKING=1", "COMPOSER_NO_SECURITY_BLOCKING=1"},
 			})
 
 			if err != nil {

--- a/pkg/ddevapp/composer.go
+++ b/pkg/ddevapp/composer.go
@@ -53,6 +53,7 @@ func getComposerEnv() []string {
 	// List of Composer environment variables to pass through from host
 	// https://getcomposer.org/doc/03-cli.md#environment-variables
 	composerEnvVars := []string{
+		"COMPOSER_NO_BLOCKING",
 		"COMPOSER_NO_SECURITY_BLOCKING",
 	}
 

--- a/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
+++ b/pkg/ddevapp/dotddev_assets/providers/pantheon.yaml
@@ -165,5 +165,5 @@ files_push_command:
     if [ -n "${PANTHEON_ENVIRONMENT:-}" ] && [ -z "${DDEV_PANTHEON_ENVIRONMENT:-}" ]; then
       DDEV_PANTHEON_ENVIRONMENT="${PANTHEON_ENVIRONMENT}"
     fi
-    COMPOSER_NO_SECURITY_BLOCKING=1 terminus self:plugin:install terminus-rsync-plugin
+    COMPOSER_NO_BLOCKING=1 COMPOSER_NO_SECURITY_BLOCKING=1 terminus self:plugin:install terminus-rsync-plugin
     terminus rsync -y ${DDEV_FILES_DIR}/ ${DDEV_PANTHEON_SITE}.${DDEV_PANTHEON_ENVIRONMENT}:files


### PR DESCRIPTION
## The Issue

Thanks to @rpkoller we know about https://blog.packagist.com/composer-2-10-release/

And https://getcomposer.org/doc/03-cli.md#composer-no-security-blocking

> `COMPOSER_NO_SECURITY_BLOCKING`
> DEPRECATED, use `COMPOSER_NO_BLOCKING` instead.

## How This PR Solves The Issue

Adds support for `COMPOSER_NO_BLOCKING`.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
