### PR TITLE
fix(describe): show actual Xdebug runtime status in ddev describe, fixes #8159

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -310,7 +310,7 @@ func (app *DdevApp) Describe(short bool) (map[string]any, error) {
 
 	appDesc["router_http_port"] = app.GetPrimaryRouterHTTPPort()
 	appDesc["router_https_port"] = app.GetPrimaryRouterHTTPSPort()
-	appDesc["xdebug_enabled"] = app.XdebugEnabled
+	appDesc["xdebug_enabled"] = app.GetXdebugStatus()
 	appDesc["webimg"] = app.WebImage
 	appDesc["dbimg"] = app.GetDBImage()
 	appDesc["services"] = map[string]map[string]any{}
@@ -4057,4 +4057,38 @@ func genericImportFilesAction(app *DdevApp, uploadDir, importPath, extPath strin
 	}
 
 	return nil
+}
+
+// GetXdebugStatus returns whether xdebug is currently active.
+func (app *DdevApp) GetXdebugStatus() bool {
+	status, _ := app.SiteStatus()
+	if status != SiteRunning {
+		return app.XdebugEnabled
+	}
+
+	// Check for both extension presence and whether it's actually "active"
+	// following same logic as pkg/ddevapp/global_dotddev_assets/commands/web/xdebug
+	// v3: php -r 'echo ini_get("xdebug.mode");' contains "debug"
+	// v2: php -r 'echo ini_get("xdebug.remote_enable");' is "1"
+	out, _, err := app.Exec(&ExecOpts{
+		Cmd: `php -r '
+			if (!extension_loaded("xdebug")) {
+				echo "0";
+			} else {
+				$v = phpversion("xdebug");
+				if ($v[0] >= "3") {
+					echo strpos(ini_get("xdebug.mode"), "debug") !== false ? "1" : "0";
+				} else {
+					echo ini_get("xdebug.remote_enable") == "1" ? "1" : "0";
+				}
+			}
+		'`,
+	})
+	if err != nil {
+		return app.XdebugEnabled
+	}
+	if strings.HasPrefix(out, "1") {
+		return true
+	}
+	return false
 }

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -4737,3 +4737,66 @@ func constructContainerName(containerType string, app *ddevapp.DdevApp) (string,
 	name := dockerutil.ContainerName(c)
 	return name, nil
 }
+
+// TestGetXdebugStatus checks behavior of GetXdebugStatus,
+// both when the site is stopped and when it is running
+func TestGetXdebugStatus(t *testing.T) {
+	if nodeps.IsWSL2() && dockerutil.IsDockerDesktop() {
+		t.Skip("Skipping on WSL2/Docker Desktop because this test doesn't work although manual testing works")
+	}
+	origDir, _ := os.Getwd()
+
+	testcommon.ClearDockerEnv()
+
+	projDir := testcommon.CreateTmpDir(t.Name())
+	defer os.RemoveAll(projDir)
+
+	app, err := ddevapp.NewApp(projDir, false)
+	require.NoError(t, err)
+
+	if app.GetWebserverType() == nodeps.AppTypeGeneric {
+		t.Skip("Xdebug is not tested on generic webserver")
+	}
+
+	app.Type = nodeps.AppTypePHP
+	app.XdebugEnabled = true
+	err = app.WriteConfig()
+	require.NoError(t, err)
+
+	// Create a simple index.php so the web container has something to serve
+	err = fileutil.TemplateStringToFile("<?php\nphpinfo();\n", nil, filepath.Join(app.AppRoot, "index.php"))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = app.Stop(true, false)
+		_ = os.Chdir(origDir)
+		_ = os.RemoveAll(projDir)
+	})
+
+	err = app.Init(app.AppRoot)
+	require.NoError(t, err)
+
+	// When site is not running, GetXdebugStatus should reflect the config setting
+	got := app.GetXdebugStatus()
+	require.True(t, got, "expected GetXdebugStatus to return true when xdebug_enabled=true and site not running")
+
+	app.XdebugEnabled = false
+	got = app.GetXdebugStatus()
+	require.False(t, got, "expected GetXdebugStatus to return false when xdebug_enabled=false and site not running")
+
+	// Now test with the site running
+	err = app.Restart()
+	require.NoError(t, err)
+
+	// Enable Xdebug and verify status
+	_, _, err = app.Exec(&ddevapp.ExecOpts{Cmd: "enable_xdebug"})
+	require.NoError(t, err)
+	got = app.GetXdebugStatus()
+	require.True(t, got, "expected GetXdebugStatus to return true after enable_xdebug")
+
+	// Disable Xdebug and verify status
+	_, _, err = app.Exec(&ddevapp.ExecOpts{Cmd: "disable_xdebug"})
+	require.NoError(t, err)
+	got = app.GetXdebugStatus()
+	require.False(t, got, "expected GetXdebugStatus to return false after disable_xdebug")
+}


### PR DESCRIPTION
## The Issue
- Fixes #8159

## How This PR Solves The Issue

The `ddev describe` command was showing the configured value for Xdebug (`xdebug_enabled` from config), which was misleading when the runtime status differed.

This change introduces `GetXdebugStatus` function that checks the actual runtime status following the same logic as
`pkg/ddevapp/global_dotddev_assets/commands/web/xdebug`

## Manual Testing Instructions
```sh
# Assume xdebug_enabled=false in .ddev/config.yaml (default)
$ ddev describe -j | jq -r .raw.xdebug_enabled
false

$ ddev start
$ ddev xdebug on
$ ddev describe -j | jq -r .raw.xdebug_enabled
true

$ ddev xdebug off
$ ddev describe -j | jq -r .raw.xdebug_enabled
false

# If site is stopped, failback to configurated value
$ ddev xdebug on
$ ddev stop
$ ddev describe -j | jq -r .raw.xdebug_enabled
false
```

## Automated Testing Overview
`go test -v ./pkg/ddevapp -run TestGetXdebugStatus`

## Release/Deployment Notes
