### PR TITLE
build: pin Node.js to 24.15.0, fixes #8436

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -85,7 +85,8 @@ ENV DDEV_PHP_VERSION=$PHP_DEFAULT_VERSION
 ARG PHP_VERSIONS="php8.2 php8.3 php8.4 php8.5"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 ARG DRUSH_VERSION=8.5.0
-ENV NODE_VERSION=24
+# TODO: remove this Node.js pin once https://github.com/nodejs/node/issues/63487 is resolved
+ENV NODE_VERSION=24.15.0
 # composer normally screams about running as root, we don't need that.
 ENV COMPOSER_ALLOW_SUPERUSER=1
 ENV COMPOSER_PROCESS_TIMEOUT=2000

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
 ARG DOCKER_ORG=ddev
-FROM ${DOCKER_ORG}/ddev-php-base:20260524_stasadev_docker_rootless AS ddev-webserver-base
+FROM ${DOCKER_ORG}/ddev-php-base:20260531_stasadev_node_pin AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260524_stasadev_docker_rootless" // Note that this can be overridden by make
+var WebTag = "20260531_stasadev_node_pin" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- Fixes #8436

## How This PR Solves The Issue

Uses Node.js 24.15.0 until this issue is resolved:

- https://github.com/nodejs/node/issues/63487

## Manual Testing Instructions

```
$ docker run --rm ddev/ddev-webserver:20260531_stasadev_node_pin bash -c "node --version && npm --version"
v24.15.0
11.12.1
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
