### PR TITLE
test(linux): wait for nc to bind before asserting in port-diagnose tests

### DIFF
--- a/cmd/ddev/cmd/utility-port-diagnose_test.go
+++ b/cmd/ddev/cmd/utility-port-diagnose_test.go
@@ -62,7 +62,10 @@ func startNCListener(t *testing.T, port string) func() {
 		cmd = exec.Command(ncPath, "-l", "-k", "-p", port)
 	}
 	require.NoError(t, cmd.Start(), "failed to start nc on port %s", port)
-	waitForPortListening(t, port)
+	// Wait for a busy port on Linux, nc may be flaky
+	if nodeps.IsLinux() {
+		waitForPortListening(t, port)
+	}
 	return func() {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()

--- a/cmd/ddev/cmd/utility-port-diagnose_test.go
+++ b/cmd/ddev/cmd/utility-port-diagnose_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/globalconfig"
@@ -28,6 +29,23 @@ func getFreePort(t *testing.T) string {
 	return port
 }
 
+// waitForPortListening blocks until something has bound port (nc's listener is up)
+// or 2s elapses, closing the race against nc's asynchronous bind(). It probes by
+// binding rather than connecting: a TCP connection would consume nc's single
+// accepted connection on builds where -k is unsupported, freeing the port before
+// findPortProcesses runs.
+func waitForPortListening(t *testing.T, port string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		l, err := net.Listen("tcp", "127.0.0.1:"+port)
+		if err != nil {
+			return true // bind failed → port already in use → nc is up
+		}
+		_ = l.Close()
+		return false
+	}, 2*time.Second, 10*time.Millisecond, "port %s never started listening", port)
+}
+
 // startNCListener starts nc listening on the given port and returns a cleanup function.
 // Skips the test if nc is not available.
 func startNCListener(t *testing.T, port string) func() {
@@ -44,6 +62,7 @@ func startNCListener(t *testing.T, port string) func() {
 		cmd = exec.Command(ncPath, "-l", "-k", "-p", port)
 	}
 	require.NoError(t, cmd.Start(), "failed to start nc on port %s", port)
+	waitForPortListening(t, port)
 	return func() {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()


### PR DESCRIPTION
## The Issue

Random failures in
- https://github.com/ddev/ddev/actions/runs/26836746919/job/79132651991#step:14:27406
- https://github.com/ddev/ddev/actions/runs/26836747464/job/79132659959?pr=8443#step:14:28433

```
=== RUN   TestFindPortProcessesNC_Linux
    utility-port-diagnose_test.go:186: 
        	Error Trace:	/home/runner/work/ddev/ddev/cmd/ddev/cmd/utility-port-diagnose_test.go:186
        	Error:      	Should NOT be empty, but was []
        	Test:       	TestFindPortProcessesNC_Linux
        	Messages:   	expected to find nc on port 46175
--- FAIL: TestFindPortProcessesNC_Linux (0.04s)
```

`TestFindPortProcessesNC_Linux` failed intermittently in CI with `expected to find nc on port NNNNN` and an empty result. There is no tracked GitHub issue; this addresses the CI flakiness directly.

The tests start `nc` with `cmd.Start()`, which returns as soon as the process is spawned — before `nc` has run `socket()`/`bind()`/`listen()`. They then immediately called `findPortProcesses(port)`. Every detector counts only sockets in LISTEN state (`-sTCP:LISTEN` for lsof, state `0A` in `/proc/net/tcp`), so whenever the test goroutine won the race against `nc`'s scheduling it saw nothing and failed. The failure is load-dependent: it essentially never reproduces on an idle dev machine but surfaces on busy CI runners executing many packages in parallel.

## How This PR Solves The Issue

Adds `waitForPortListening`, called from the shared `startNCListener` helper, which blocks until the port is actually bound before the test queries it.

It probes readiness by attempting to bind the port (a failed bind means the port is already in use) rather than by opening a TCP connection. A connection would consume `nc`'s single accepted connection on builds where `-k` is unsupported, freeing the port before detection runs. Keeping the shared gate a bind-probe also leaves it independent of detection, so the macOS test's graceful skip (when non-sudo lsof cannot see `nc`) is preserved. The wait uses `require.Eventually` with a 2s budget and 10ms tick.

## Manual Testing Instructions

    go test -count=10 -run 'TestFindPortProcessesNC' ./cmd/ddev/cmd/

All runs pass; previously the Linux variant failed intermittently under load.

## Automated Testing Overview

No new test case - this hardens existing tests (`TestFindPortProcessesNC_Linux`) against a startup race. Verified locally with `go vet ./cmd/ddev/cmd/` (clean) and
`go test -count=5 -run TestFindPortProcessesNC_Linux ./cmd/ddev/cmd/` (pass).

## Release/Deployment Notes

Test-only change. No runtime, user-facing, or deployment impact.