### PR TITLE
test: rework local HTTP test helpers with clearer failure output

### DIFF
--- a/cmd/ddev/cmd/logs_test.go
+++ b/cmd/ddev/cmd/logs_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
@@ -60,8 +61,10 @@ func TestCmdLogs(t *testing.T) {
 	assert.NoError(err)
 
 	url := app.GetPrimaryURL() + "/logtest.php"
-	_, err = testcommon.EnsureLocalHTTPContent(t, url, "Notice to demonstrate logging", 10)
-	assert.NoError(err)
+	testcommon.AssertLocalHTTPContent(t, url, "Notice to demonstrate logging",
+		testcommon.WithMessagef("logtest.php should emit the PHP notice that `ddev logs` surfaces"),
+		testcommon.WithTimeout(10*time.Second),
+	)
 
 	out, err := exec.RunHostCommand(DdevBin, "logs")
 	require.NoError(t, err)

--- a/cmd/ddev/cmd/ssh_test.go
+++ b/cmd/ddev/cmd/ssh_test.go
@@ -55,8 +55,9 @@ func TestCmdSSH(t *testing.T) {
 	err = app.Start()
 	require.NoError(t, err)
 
-	_, err = testcommon.EnsureLocalHTTPContent(t, app.GetPrimaryURL(), "Success accessing database")
-	assert.NoError(err)
+	testcommon.AssertLocalHTTPContent(t, app.GetPrimaryURL(), "Success accessing database",
+		testcommon.WithMessagef("project web container should be able to reach the database"),
+	)
 
 	stdout, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd: "pwd",

--- a/cmd/ddev/cmd/xhgui_test.go
+++ b/cmd/ddev/cmd/xhgui_test.go
@@ -55,17 +55,14 @@ func TestCmdXHGui(t *testing.T) {
 	require.Contains(t, out, "XHProf is enabled and capturing")
 	require.Contains(t, out, fmt.Sprintf("XHGui service is running and you can access it at %s", app.GetXHGuiURL()))
 
-	// Use more retries as it may fail on macOS at first
-	opts := testcommon.HTTPRequestOpts{
-		TimeoutSeconds: 2,
-	}
-
 	// Test to see if xhgui UI is working
 	// Hit the site
-	_, _, err = testcommon.GetLocalHTTPResponseWithBackoff(t, app.GetPrimaryURL(), 5, 500*time.Millisecond, opts)
+	_, _, err = testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL(),
+		testcommon.WithTimeout(2*time.Second),
+		testcommon.WithMaxAttempts(5),
+		testcommon.WithBackoff(500*time.Millisecond),
+	)
 	require.NoError(t, err, "failed to get http response from %s", app.GetPrimaryURL())
-	// Give xhprof a moment to write the results; it may be asynchronous sometimes
-	time.Sleep(2 * time.Second)
 
 	// Now hit xhgui UI
 	desc, err := app.Describe(true)
@@ -74,11 +71,14 @@ func TestCmdXHGui(t *testing.T) {
 	require.NotNil(t, desc["xhgui_https_url"])
 	xhguiURL := desc["xhgui_https_url"].(string)
 
-	out, _, err = testcommon.GetLocalHTTPResponseWithBackoff(t, xhguiURL, 5, 500*time.Millisecond, opts)
-	require.NoError(t, err)
 	// Output should contain at least one run
-	require.Contains(t, out, strings.ToLower(app.GetHostname()))
-	require.Contains(t, out, "Recent runs")
+	testcommon.RequireLocalHTTPContent(t, xhguiURL, strings.ToLower(app.GetHostname()),
+		testcommon.WithAlsoContains("Recent runs"),
+		testcommon.WithMessagef("xhgui should list a profiling run for this project"),
+		testcommon.WithTimeout(2*time.Second),
+		testcommon.WithMaxAttempts(5),
+		testcommon.WithBackoff(500*time.Millisecond),
+	)
 
 	_, err = exec.RunHostCommand(DdevBin, "xhgui", "off")
 	require.NoError(t, err)

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1074,7 +1074,9 @@ func TestPHPOverrides(t *testing.T) {
 
 	err = app.MutagenSyncFlush()
 	require.NoError(t, err, "failed to flush Mutagen sync")
-	_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL()+"/phpinfo.php", `max_input_time</td><td class="v">999`, 60)
+	testcommon.AssertLocalHTTPContent(t, app.GetHTTPURL()+"/phpinfo.php", `max_input_time</td><td class="v">999`,
+		testcommon.WithMessagef("phpinfo should reflect the max_input_time=999 PHP override"),
+	)
 }
 
 // TestPHPConfig checks some key PHP configuration items
@@ -1917,21 +1919,21 @@ func TestConfigFunctionality(t *testing.T) {
 	require.Equal(t, hostHTTPSPort, app.HostHTTPSPort)
 
 	safeURL := "http://127.0.0.1:" + hostHTTPPort + site.Safe200URIWithExpectation.URI
-	out, _, err := testcommon.GetLocalHTTPResponse(t, safeURL, 60)
-	assert.NoError(err)
-	assert.Contains(out, site.Safe200URIWithExpectation.Expect)
+	testcommon.AssertLocalHTTPContent(t, safeURL, site.Safe200URIWithExpectation.Expect,
+		testcommon.WithMessagef("safe URL should serve the expected static content"),
+	)
 
 	// This isn't very important, and is unusual
 	// On some WSL2 systems (tb-wsldd-05) it works fine locally, can't work in buildkite.
 	if !dockerutil.IsColima() && !nodeps.IsWSL2() {
 		safeURL = "https://127.0.0.1:" + hostHTTPSPort + site.Safe200URIWithExpectation.URI
-		out, _, err = testcommon.GetLocalHTTPResponse(t, safeURL, 60)
-		assert.NoError(err)
-		assert.Contains(out, site.Safe200URIWithExpectation.Expect)
+		testcommon.AssertLocalHTTPContent(t, safeURL, site.Safe200URIWithExpectation.Expect,
+			testcommon.WithMessagef("HTTPS safe URL should serve the expected static content"),
+		)
 	}
 
 	// Make sure that the db port is configured
-	out, err = exec.RunHostCommand("mysql", "-uroot", "-proot", "--database=db", "--host=127.0.0.1", "--port="+hostDBPort, "-e", "SHOW TABLES;")
+	out, err := exec.RunHostCommand("mysql", "-uroot", "-proot", "--database=db", "--host=127.0.0.1", "--port="+hostDBPort, "-e", "SHOW TABLES;")
 	require.NoError(t, err, "failed host-side mysql command, output='%v'", out)
 }
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -790,7 +791,9 @@ func TestDdevStartMultipleHostnames(t *testing.T) {
 		}
 		t.Logf("Testing these URLs: %v", urls)
 		for _, testURL := range urls {
-			_, _ = testcommon.EnsureLocalHTTPContent(t, testURL+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+			testcommon.AssertLocalHTTPContent(t, testURL+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect,
+				testcommon.WithMessagef("each configured hostname should serve the static test content"),
+			)
 		}
 
 		// Multiple projects can't run at the same time with the fqdns, so we need to clean
@@ -1071,7 +1074,9 @@ func TestDdevXdebugEnabled(t *testing.T) {
 			time.Sleep(time.Second)
 			t.Logf("Connecting to HTTP URL %s with Xdebug enabled, PHP version=%s time=%v", app.GetWebContainerDirectHTTPURL(), v, time.Now())
 			// Curl to the project's index.php or anything else
-			out, resp, err := testcommon.GetLocalHTTPResponse(t, app.GetWebContainerDirectHTTPURL(), 12)
+			out, resp, err := testcommon.GetLocalHTTPResponse(t, app.GetWebContainerDirectHTTPURL(),
+				testcommon.WithTimeout(12*time.Second),
+			)
 			if err != nil {
 				t.Logf("time=%v got resp %v output %s: %v", time.Now(), resp, out, err)
 				if resp != nil {
@@ -2468,7 +2473,9 @@ func TestDdevFullSiteSetup(t *testing.T) {
 
 		// Validate Mailpit is working and "connected"
 		mailpitAPIURL := "http://" + app.GetHostname() + ":" + app.GetMailpitHTTPPort() + "/api/v1/messages"
-		_, _ = testcommon.EnsureLocalHTTPContent(t, mailpitAPIURL, `"total":0`)
+		testcommon.AssertLocalHTTPContent(t, mailpitAPIURL, `"total":0`,
+			testcommon.WithMessagef("Mailpit API should be connected and report zero messages initially"),
+		)
 
 		settingsLocation, err := app.DetermineSettingsPathLocation()
 		assert.NoError(err)
@@ -2498,14 +2505,13 @@ func TestDdevFullSiteSetup(t *testing.T) {
 
 		// Test static content.
 		if site.Safe200URIWithExpectation.URI != "" {
-			_, err = testcommon.EnsureLocalHTTPContent(t, app.GetPrimaryURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
-			if err != nil {
-				util.Warning("err: %v", err)
-			}
+			testcommon.AssertLocalHTTPContent(t, app.GetPrimaryURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect,
+				testcommon.WithMessagef("project should serve the static test content"),
+			)
 		}
 		// Test dynamic URL + database content.
 		rawurl := app.GetPrimaryURL() + site.DynamicURI.URI
-		body, resp, err := testcommon.GetLocalHTTPResponse(t, rawurl, 120)
+		body, resp, err := testcommon.GetLocalHTTPResponse(t, rawurl, testcommon.WithTimeout(120*time.Second))
 		assert.NoError(err, "GetLocalHTTPResponse returned err on project=%s rawurl %s, resp=%v: %v", site.Name, rawurl, resp, err)
 		if err != nil && strings.Contains(err.Error(), "container ") {
 			logs, health, err := ddevapp.GetErrLogsFromApp(app, err)
@@ -2524,7 +2530,9 @@ func TestDdevFullSiteSetup(t *testing.T) {
 		}
 
 		// Make sure we can do a simple hit against the host-mount of web container.
-		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetWebContainerDirectHTTPURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
+		testcommon.AssertLocalHTTPContent(t, app.GetWebContainerDirectHTTPURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect,
+			testcommon.WithMessagef("web container host-mount should serve the static test content directly"),
+		)
 
 		// Project type 'php' should fail ImportFiles if no upload_dirs is provided
 		if app.Type == nodeps.AppTypePHP {
@@ -3525,6 +3533,7 @@ type URLRedirectExpectations struct {
 	url                 string
 	uri                 string
 	expectedRedirectURI string
+	expectStatus        int
 }
 
 // TestAppdirAlreadyInUse tests trying to start a project in an already-used
@@ -3618,17 +3627,18 @@ func TestHttpsRedirection(t *testing.T) {
 		_ = os.RemoveAll(testDir)
 	})
 
+	// redir_*.php use a 302; the /subdir trailing-slash redirect is a 301.
 	expectations := []URLRedirectExpectations{
-		{app.GetHTTPSURL(), "/redir_relative.php", "/landed.php"},
-		{app.GetHTTPURL(), "/redir_relative.php", "/landed.php"},
+		{app.GetHTTPSURL(), "/redir_relative.php", "/landed.php", http.StatusFound},
+		{app.GetHTTPURL(), "/redir_relative.php", "/landed.php", http.StatusFound},
 	}
 
 	// The simple redirect logic in `landed.php` and /subdir can only handle default ports 80 and 443
 	if app.GetPrimaryRouterHTTPSPort() == "443" && app.GetPrimaryRouterHTTPPort() == "80" {
-		expectations = append(expectations, URLRedirectExpectations{app.GetHTTPSURL(), "/redir_abs.php", "/landed.php"})
-		expectations = append(expectations, URLRedirectExpectations{app.GetHTTPURL(), "/redir_abs.php", "/landed.php"})
-		expectations = append(expectations, URLRedirectExpectations{app.GetHTTPSURL(), "/subdir", "/subdir/"})
-		expectations = append(expectations, URLRedirectExpectations{app.GetHTTPURL(), "/subdir", "/subdir/"})
+		expectations = append(expectations, URLRedirectExpectations{app.GetHTTPSURL(), "/redir_abs.php", "/landed.php", http.StatusFound})
+		expectations = append(expectations, URLRedirectExpectations{app.GetHTTPURL(), "/redir_abs.php", "/landed.php", http.StatusFound})
+		expectations = append(expectations, URLRedirectExpectations{app.GetHTTPSURL(), "/subdir", "/subdir/", http.StatusMovedPermanently})
+		expectations = append(expectations, URLRedirectExpectations{app.GetHTTPURL(), "/subdir", "/subdir/", http.StatusMovedPermanently})
 	}
 
 	projectTypes := ddevapp.GetValidAppTypes()
@@ -3664,8 +3674,10 @@ func TestHttpsRedirection(t *testing.T) {
 				reqURL := parts.url + parts.uri
 				// t.Logf("TestHttpsRedirection trying URL %s with webserver_type=%s", reqURL, webserverType)
 				// Add extra hit to avoid occasional nil result
-				_, _, _ = testcommon.GetLocalHTTPResponse(t, reqURL, 60)
-				out, resp, err := testcommon.GetLocalHTTPResponse(t, reqURL, 60)
+				out, resp, err := testcommon.GetLocalHTTPResponse(t, reqURL,
+					testcommon.WithExpectStatus(parts.expectStatus),
+					testcommon.WithMaxAttempts(2),
+				)
 
 				require.NotNil(t, resp, "resp was nil for projectType=%s webserver_type=%s url=%s, err=%v, out='%s'", projectType, webserverType, reqURL, err, out)
 				if resp != nil {
@@ -4147,10 +4159,11 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 			// Make sure access from host is successful
 			// But "localhost" is only for inside container.
 			if parts.Host != "localhost" {
-				// Dummy attempt to get webserver "warmed up" before real try.
-				// Forced by M1 constant EOFs
-				_, _, _ = testcommon.GetLocalHTTPResponse(t, site.Safe200URIWithExpectation.URI, 60)
-				_, _ = testcommon.EnsureLocalHTTPContent(t, item+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect, 60)
+				// Retry to ride out the occasional M1 EOF on the first hit.
+				testcommon.AssertLocalHTTPContent(t, item+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect,
+					testcommon.WithMessagef("each external URL should be reachable from the host with expected content"),
+					testcommon.WithMaxAttempts(2),
+				)
 			}
 
 			if _, err := strconv.ParseInt(hostParts[0], 10, 64); err != nil {

--- a/pkg/ddevapp/extra_expose_test.go
+++ b/pkg/ddevapp/extra_expose_test.go
@@ -67,8 +67,7 @@ func TestExtraPortExpose(t *testing.T) {
 	for i, p := range portsToTest {
 		baseURL := netutil.BaseURLFromFullURL(app.GetPrimaryURL())
 		url := fmt.Sprintf("%s:%s/testfile.html", baseURL, p)
-		out, resp, err := testcommon.GetLocalHTTPResponse(t, url)
-		require.NoError(t, err, "failed to get hit url %s, out=%s, resp=%v err=%v", url, out, resp, err)
-		require.Contains(t, out, fmt.Sprintf("this is test%d", i+1))
+		testcommon.RequireLocalHTTPContent(t, url, fmt.Sprintf("this is test%d", i+1),
+			testcommon.WithMessagef("exposed port %s should serve testfile.html", p))
 	}
 }

--- a/pkg/ddevapp/mailpit_test.go
+++ b/pkg/ddevapp/mailpit_test.go
@@ -77,12 +77,16 @@ func TestMailpit(t *testing.T) {
 	require.NotNil(t, desc["mailpit_url"])
 	require.NotNil(t, desc["mailpit_https_url"])
 
-	resp, err := testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation)
-	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
-	// Colima tests on github don't respect https
+	testcommon.RequireLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation,
+		testcommon.WithMessagef("Mailpit HTTP API should show the sent email (default ports)"),
+		testcommon.WithMaxAttempts(5),
+	)
+	// Colima tests on GitHub don't respect https
 	if !dockerutil.IsColima() && !dockerutil.IsLima() {
-		resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_https_url"].(string)+"/api/v1/messages", expectation)
-		require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
+		testcommon.RequireLocalHTTPContent(t, desc["mailpit_https_url"].(string)+"/api/v1/messages", expectation,
+			testcommon.WithMessagef("Mailpit HTTPS API should show the sent email (default ports)"),
+			testcommon.WithMaxAttempts(5),
+		)
 	}
 	// Change the global ports to make sure that works
 	globalconfig.DdevGlobalConfig.RouterMailpitHTTPPort = "28023"
@@ -108,17 +112,17 @@ func TestMailpit(t *testing.T) {
 	require.NotNil(t, desc["mailpit_url"])
 	require.NotNil(t, desc["mailpit_https_url"])
 
-	// The API may not be ready the first time we hit it, especially on Rancher Desktop
-	opts := testcommon.HTTPRequestOpts{
-		MaxRetries: 5,
-	}
-
-	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation, opts)
-	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
+	// The API may not be ready at first (especially on Rancher Desktop); retry.
+	testcommon.RequireLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation,
+		testcommon.WithMessagef("Mailpit HTTP API should show the sent email after changing global ports"),
+		testcommon.WithMaxAttempts(5),
+	)
 	// Colima tests on GitHub don't respect https
 	if !dockerutil.IsColima() && !dockerutil.IsLima() {
-		resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_https_url"].(string)+"/api/v1/messages", expectation)
-		require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
+		testcommon.RequireLocalHTTPContent(t, desc["mailpit_https_url"].(string)+"/api/v1/messages", expectation,
+			testcommon.WithMessagef("Mailpit HTTPS API should show the sent email after changing global ports"),
+			testcommon.WithMaxAttempts(5),
+		)
 	}
 
 	// Change the ports on the project to make sure that works
@@ -140,11 +144,16 @@ func TestMailpit(t *testing.T) {
 	require.NotNil(t, desc["mailpit_url"])
 	require.NotNil(t, desc["mailpit_https_url"])
 
-	resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation, opts)
-	require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
-	// Colima tests on github don't respect https
+	// The API may not be ready at first (especially on Rancher Desktop); retry.
+	testcommon.RequireLocalHTTPContent(t, desc["mailpit_url"].(string)+"/api/v1/messages", expectation,
+		testcommon.WithMessagef("Mailpit HTTP API should show the sent email after changing project ports"),
+		testcommon.WithMaxAttempts(5),
+	)
+	// Colima tests on GitHub don't respect https
 	if !dockerutil.IsColima() && !dockerutil.IsLima() {
-		resp, err = testcommon.EnsureLocalHTTPContent(t, desc["mailpit_https_url"].(string)+"/api/v1/messages", expectation)
-		require.NoError(t, err, "Error getting mailpit_url: %v resp=%v", err, resp)
+		testcommon.RequireLocalHTTPContent(t, desc["mailpit_https_url"].(string)+"/api/v1/messages", expectation,
+			testcommon.WithMessagef("Mailpit HTTPS API should show the sent email after changing project ports"),
+			testcommon.WithMaxAttempts(5),
+		)
 	}
 }

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -277,10 +277,16 @@ func TestUseEphemeralPort(t *testing.T) {
 		}, "HTTPS port must be between %d and %d, got %d", expectedEphemeralHTTPSPort, expectedEphemeralHTTPSPort+2, actualHTTPSPort)
 
 		// Make sure that both http and https URLs have proper content
-		_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPURL(), testString, -1)
+		testcommon.AssertLocalHTTPContent(t, app.GetHTTPURL(), testString,
+			testcommon.WithMessagef("project should serve expected content over HTTP on its ephemeral port"),
+			testcommon.WithTimeout(0),
+		)
 		require.Contains(t, app.GetHTTPURL(), app.GetHostname())
 		if globalconfig.GetCAROOT() != "" {
-			_, _ = testcommon.EnsureLocalHTTPContent(t, app.GetHTTPSURL(), testString, -1)
+			testcommon.AssertLocalHTTPContent(t, app.GetHTTPSURL(), testString,
+				testcommon.WithMessagef("project should serve expected content over HTTPS on its ephemeral port"),
+				testcommon.WithTimeout(0),
+			)
 			require.Contains(t, app.GetHTTPSURL(), app.GetHostname())
 		}
 	}
@@ -514,8 +520,9 @@ func TestTraefikMonitorPortAlwaysLocalhost(t *testing.T) {
 
 	// Test that the dashboard is accessible via localhost
 	localhostDashboardURL := "http://127.0.0.1:" + monitorPort + "/api/overview"
-	_, err = testcommon.EnsureLocalHTTPContent(t, localhostDashboardURL, "")
-	assert.NoError(err, "Traefik dashboard should be accessible via localhost at %s", localhostDashboardURL)
+	testcommon.AssertLocalHTTPContent(t, localhostDashboardURL, "",
+		testcommon.WithMessagef("Traefik dashboard should be accessible via localhost at %s", localhostDashboardURL),
+	)
 
 	// Note: The dashboard may also be accessible via project hostnames on the monitor port
 	// (e.g., http://project.ddev.site:10999) because the hostname resolves to localhost.

--- a/pkg/ddevapp/traefik_test.go
+++ b/pkg/ddevapp/traefik_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
@@ -95,8 +96,9 @@ func TestTraefikSimple(t *testing.T) {
 	for _, u := range allURLs {
 		// Use something here for wildcard
 		u = strings.Replace(u, `*`, `somewildcard`, 1)
-		_, err = testcommon.EnsureLocalHTTPContent(t, u+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
-		assert.NoError(err, "failed EnsureLocalHTTPContent() %s: %v", u+site.Safe200URIWithExpectation.URI, err)
+		testcommon.AssertLocalHTTPContent(t, u+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect,
+			testcommon.WithMessagef("Traefik should route each project hostname to the static test content"),
+		)
 	}
 }
 
@@ -154,14 +156,19 @@ func TestTraefikVirtualHost(t *testing.T) {
 	for _, u := range allURLs {
 		// Use something here for wildcard
 		u = strings.Replace(u, `*`, `somewildcard`, 1)
-		_, err = testcommon.EnsureLocalHTTPContent(t, u+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
-		assert.NoError(err, "failed EnsureLocalHTTPContent() %s: %v", u+site.Safe200URIWithExpectation.URI, err)
+		testcommon.AssertLocalHTTPContent(t, u+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect,
+			testcommon.WithMessagef("Traefik virtual host should route each project hostname to the static test content"),
+		)
 	}
 
 	// Test Reachability to nginx special VIRTUAL_HOST
-	_, _ = testcommon.EnsureLocalHTTPContent(t, "http://extra.ddev.site", "Welcome to nginx")
+	testcommon.AssertLocalHTTPContent(t, "http://extra.ddev.site", "Welcome to nginx",
+		testcommon.WithMessagef("nginx VIRTUAL_HOST extra.ddev.site should be reachable over HTTP"),
+	)
 	if globalconfig.GetCAROOT() != "" {
-		_, _ = testcommon.EnsureLocalHTTPContent(t, "https://extra.ddev.site", "Welcome to nginx")
+		testcommon.AssertLocalHTTPContent(t, "https://extra.ddev.site", "Welcome to nginx",
+			testcommon.WithMessagef("nginx VIRTUAL_HOST extra.ddev.site should be reachable over HTTPS"),
+		)
 	}
 }
 
@@ -310,7 +317,9 @@ func TestCustomGlobalConfig(t *testing.T) {
 	middlewaresURL := "http://" + dockerIP + ":" + monitorPort + "/api/http/middlewares"
 
 	// Query Traefik API for middlewares - the custom middleware should be listed
-	body, resp, err := testcommon.GetLocalHTTPResponse(t, middlewaresURL, 30)
+	body, resp, err := testcommon.GetLocalHTTPResponse(t, middlewaresURL,
+		testcommon.WithTimeout(30*time.Second),
+	)
 	require.NoError(t, err, "Failed to query Traefik API for middlewares")
 	require.Equal(t, 200, resp.StatusCode, "Traefik API should return 200")
 	require.Contains(t, body, testMiddlewareName,
@@ -396,8 +405,9 @@ http:
 	require.Contains(t, mergedConfigContent, "middlewares:", "Merged config should contain middlewares section")
 
 	// Verify project still works correctly with custom config
-	_, err = testcommon.EnsureLocalHTTPContent(t, app.GetPrimaryURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect)
-	require.NoError(t, err, "Project should still be accessible with merged traefik config")
+	testcommon.RequireLocalHTTPContent(t, app.GetPrimaryURL()+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect,
+		testcommon.WithMessagef("Project should still be accessible with merged traefik config"),
+	)
 
 	// Test that HTTP to HTTPS redirect actually works
 	// Get the HTTP URLs

--- a/pkg/ddevapp/xhprof_xhgui_test.go
+++ b/pkg/ddevapp/xhprof_xhgui_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
@@ -79,12 +80,6 @@ func TestDdevXhprofPrependEnabled(t *testing.T) {
 		webserverKeys = []string{nodeps.WebserverDefault}
 	}
 
-	// Use more retries as it may fail on macOS at first
-	opts := testcommon.HTTPRequestOpts{
-		TimeoutSeconds: 2,
-		MaxRetries:     5,
-	}
-
 	for _, webserverKey := range webserverKeys {
 		app.WebserverType = webserverKey
 
@@ -116,14 +111,20 @@ func TestDdevXhprofPrependEnabled(t *testing.T) {
 			require.NoError(t, err)
 			require.Contains(t, stdout, "xhprof.output_dir", "xhprof should be enabled but is not enabled for %s", v)
 
-			out, _, err := testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL(), opts)
-			require.NoError(t, err, "Failed to get base URL webserver_type=%s, php_version=%s", webserverKey, v)
-			require.Contains(t, out, "module_xhprof")
+			testcommon.RequireLocalHTTPContent(t, app.GetPrimaryURL(), "module_xhprof",
+				testcommon.WithMessagef("failed to get base URL webserver_type=%s, php_version=%s", webserverKey, v),
+				testcommon.WithTimeout(2*time.Second),
+				testcommon.WithMaxAttempts(5),
+				testcommon.WithBackoff(500*time.Millisecond),
+			)
 
-			out, _, err = testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL()+"/xhprof/", opts)
-			require.NoError(t, err)
 			// Output should contain at least one run
-			require.Contains(t, out, ".ddev.xhprof</a><small>")
+			testcommon.RequireLocalHTTPContent(t, app.GetPrimaryURL()+"/xhprof/", ".ddev.xhprof</a><small>",
+				testcommon.WithMessagef("xhprof output page should list a captured run for this project"),
+				testcommon.WithTimeout(2*time.Second),
+				testcommon.WithMaxAttempts(5),
+				testcommon.WithBackoff(500*time.Millisecond),
+			)
 
 			// Disable all to avoid confusion
 			_, _, err = app.Exec(&ddevapp.ExecOpts{
@@ -192,12 +193,6 @@ func TestDdevXhprofXhguiEnabled(t *testing.T) {
 		webserverKeys = []string{nodeps.WebserverDefault}
 	}
 
-	// Use more retries as it may fail on macOS at first
-	opts := testcommon.HTTPRequestOpts{
-		TimeoutSeconds: 2,
-		MaxRetries:     5,
-	}
-
 	for _, webserverKey := range webserverKeys {
 		app.WebserverType = webserverKey
 
@@ -235,18 +230,21 @@ func TestDdevXhprofXhguiEnabled(t *testing.T) {
 			require.NoError(t, err)
 			assert.Contains(stdout, "xhprof.output_dir", "xhprof should be enabled but is not enabled for %s", v)
 
-			out, _, err := testcommon.GetLocalHTTPResponse(t, app.GetPrimaryURL(), opts)
-			require.NoError(t, err, "Failed to get base URL webserver_type=%s, php_version=%s", webserverKey, v)
-			require.Contains(t, out, "module_xhprof")
+			testcommon.RequireLocalHTTPContent(t, app.GetPrimaryURL(), "module_xhprof",
+				testcommon.WithMessagef("failed to get base URL webserver_type=%s, php_version=%s", webserverKey, v),
+				testcommon.WithTimeout(2*time.Second),
+				testcommon.WithMaxAttempts(5),
+				testcommon.WithBackoff(500*time.Millisecond),
+			)
 
-			// NOW try using xhgui
-
-			xhguiURL := app.GetXHGuiURL()
-			out, _, err = testcommon.GetLocalHTTPResponse(t, xhguiURL, opts)
-			require.NoError(t, err)
 			// Output should contain at least one run
-			require.Contains(t, out, strings.ToLower(t.Name()+"."+nodeps.DdevDefaultTLD))
-			require.Contains(t, out, "Recent runs")
+			testcommon.RequireLocalHTTPContent(t, app.GetXHGuiURL(), strings.ToLower(t.Name()+"."+nodeps.DdevDefaultTLD),
+				testcommon.WithAlsoContains("Recent runs"),
+				testcommon.WithMessagef("xhgui should list a profiling run for this project"),
+				testcommon.WithTimeout(2*time.Second),
+				testcommon.WithMaxAttempts(5),
+				testcommon.WithBackoff(500*time.Millisecond),
+			)
 
 			// Disable all to avoid confusion
 			_, _, err = app.Exec(&ddevapp.ExecOpts{

--- a/pkg/testcommon/http.go
+++ b/pkg/testcommon/http.go
@@ -1,0 +1,343 @@
+package testcommon
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+)
+
+// RequestOption configures a local HTTP request.
+type RequestOption func(*requestConfig)
+
+// LocalHTTPResponse holds the status and headers we return to callers. The body
+// is returned separately as a string, so there is no open response body to leak
+// (unlike *http.Response).
+type LocalHTTPResponse struct {
+	StatusCode int
+	Header     http.Header
+}
+
+// GetLocalHTTPResponse requests rawURL on the local Docker IP and returns the
+// body and the response status/headers. A status other than expected (default
+// 200, see WithExpectStatus) comes back as an error, with the body still
+// returned. Like assert, it never fails the test. By default, it makes a single
+// request; use WithMaxAttempts/WithBackoff/WithTimeout/WithExpectStatus to tune it.
+func GetLocalHTTPResponse(t *testing.T, rawURL string, opts ...RequestOption) (string, *LocalHTTPResponse, error) {
+	t.Helper()
+	return getLocalHTTPResponse(t, rawURL, newRequestConfig(opts...), nil)
+}
+
+// RequireLocalHTTPContent checks that rawURL returns the expected status (default
+// 200, see WithExpectStatus) and a body containing wantContent, stopping the test
+// (t.FailNow) if not, like require.Contains. By default, it makes a single request;
+// use WithMaxAttempts to keep trying until the content shows up (handy when it
+// appears a moment later, e.g. a xhprof run written after the response). To look
+// at the response yourself, use GetLocalHTTPResponse instead.
+func RequireLocalHTTPContent(t *testing.T, rawURL string, wantContent string, opts ...RequestOption) {
+	t.Helper()
+	checkLocalHTTPContent(t, true, rawURL, wantContent, opts...)
+}
+
+// AssertLocalHTTPContent is the non-fatal version of RequireLocalHTTPContent (like
+// assert.Contains): it marks the test failed but lets it keep running, and returns
+// whether the content was found. Prefer it in loops where you want to check every
+// URL instead of stopping at the first failure.
+func AssertLocalHTTPContent(t *testing.T, rawURL string, wantContent string, opts ...RequestOption) bool {
+	t.Helper()
+	return checkLocalHTTPContent(t, false, rawURL, wantContent, opts...)
+}
+
+// WithTimeout sets the per-request timeout. Zero or negative disables it.
+func WithTimeout(d time.Duration) RequestOption {
+	return func(c *requestConfig) {
+		if d < 0 {
+			d = 0
+		}
+		c.timeout = d
+	}
+}
+
+// WithMaxAttempts sets the total number of requests to make (the first try plus
+// any retries); values below 1 become 1. Use it to keep trying until the expected
+// content shows up or a temporary error goes away.
+func WithMaxAttempts(n int) RequestOption {
+	return func(c *requestConfig) {
+		if n < 1 {
+			n = 1
+		}
+		c.maxAttempts = n
+	}
+}
+
+// WithBackoff doubles the delay after each attempt (starting at initial, capped at
+// the timeout) instead of the fixed 1s delay. Zero or negative initial keeps the
+// default 1s start delay.
+func WithBackoff(initial time.Duration) RequestOption {
+	return func(c *requestConfig) {
+		if initial > 0 {
+			c.tick = initial
+		}
+		c.backoff = true
+	}
+}
+
+// WithExpectStatus sets the status code treated as success; any other code is an
+// error (and triggers a retry). Defaults to 200 (http.StatusOK).
+func WithExpectStatus(code int) RequestOption {
+	return func(c *requestConfig) {
+		c.expectStatus = code
+	}
+}
+
+// WithAlsoContains adds more substrings the body must contain, on top of the
+// wantContent passed to Assert/RequireLocalHTTPContent. All must be present, and
+// retries continue until they are. No effect on GetLocalHTTPResponse.
+func WithAlsoContains(substrings ...string) RequestOption {
+	return func(c *requestConfig) {
+		c.alsoContains = append(c.alsoContains, substrings...)
+	}
+}
+
+// WithMessagef adds a printf-style message shown when an Assert/RequireLocalHTTPContent
+// check fails. No effect on GetLocalHTTPResponse.
+func WithMessagef(format string, args ...any) RequestOption {
+	return func(c *requestConfig) {
+		c.msgFormat = format
+		c.msgArgs = args
+	}
+}
+
+// requestConfig holds the resolved options for a local HTTP request.
+type requestConfig struct {
+	// timeout is the per-request HTTP client timeout (zero means no timeout).
+	timeout time.Duration
+	// maxAttempts is the total number of requests to make (>= 1).
+	maxAttempts int
+	// tick is the delay between attempts.
+	tick time.Duration
+	// backoff doubles the delay after each attempt (capped at timeout) when set.
+	backoff bool
+	// expectStatus is the status code treated as success.
+	expectStatus int
+	// alsoContains are extra substrings the body must contain, on top of the
+	// wantContent argument (see WithAlsoContains).
+	alsoContains []string
+	// msgFormat/msgArgs are an optional message shown on a content-check failure.
+	msgFormat string
+	msgArgs   []any
+}
+
+// Default request settings, each overridden by the matching With... option.
+const (
+	defaultHTTPTimeout  = 60 * time.Second // per-request timeout; see WithTimeout
+	defaultHTTPTick     = time.Second      // initial delay between attempts; see WithBackoff
+	defaultHTTPAttempts = 1                // total attempts; see WithMaxAttempts
+	defaultHTTPStatus   = http.StatusOK    // status treated as success; see WithExpectStatus
+
+	// macOSMinAttempts is the attempt floor getLocalHTTPResponse applies on a
+	// brief 5xx on macOS (php-fpm SIGBUS), so even a single-shot request retries
+	// once.
+	macOSMinAttempts = 2
+)
+
+// newRequestConfig starts from the defaults above and applies opts.
+func newRequestConfig(opts ...RequestOption) requestConfig {
+	c := requestConfig{
+		timeout:      defaultHTTPTimeout,
+		tick:         defaultHTTPTick,
+		maxAttempts:  defaultHTTPAttempts,
+		expectStatus: defaultHTTPStatus,
+	}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	return c
+}
+
+// checkLocalHTTPContent fetches rawURL (retrying per WithMaxAttempts until every
+// wanted substring appears) and checks the body contains them all. The wanted
+// substrings are wantContent plus any from WithAlsoContains. fatal picks require
+// (t.FailNow) vs assert behavior; it returns whether all were found.
+func checkLocalHTTPContent(t *testing.T, fatal bool, rawURL string, wantContent string, opts ...RequestOption) bool {
+	t.Helper()
+	cfg := newRequestConfig(opts...)
+	// wantContent is the main substring; WithAlsoContains adds more. An empty
+	// wantContent is skipped, so we only check the extras (or just the status if
+	// there are none).
+	var wants []string
+	if wantContent != "" {
+		wants = append(wants, wantContent)
+	}
+	wants = append(wants, cfg.alsoContains...)
+	missingFrom := func(body string) []string {
+		var missing []string
+		for _, w := range wants {
+			if !strings.Contains(body, w) {
+				missing = append(missing, w)
+			}
+		}
+		return missing
+	}
+	contentOK := func(body string) bool { return len(missingFrom(body)) == 0 }
+
+	body, resp, err := getLocalHTTPResponse(t, rawURL, cfg, contentOK)
+
+	missing := missingFrom(body)
+	if err == nil && len(missing) == 0 {
+		return true
+	}
+	userMsg := ""
+	if cfg.msgFormat != "" {
+		userMsg = fmt.Sprintf(cfg.msgFormat, cfg.msgArgs...)
+	}
+	t.Errorf("%s", describeHTTPFailure(rawURL, resp, body, err, missing, userMsg))
+	if fatal {
+		t.FailNow()
+	}
+	return false
+}
+
+// getLocalHTTPResponse makes up to cfg.maxAttempts requests (waiting cfg.tick
+// between them) until one succeeds. A request succeeds when there is no error
+// and, if contentOK is given, contentOK(body) is true - so callers can wait for
+// expected content, not just a working request. Each retry is logged via t.Logf.
+func getLocalHTTPResponse(t *testing.T, rawURL string, cfg requestConfig, contentOK func(body string) bool) (string, *LocalHTTPResponse, error) {
+	t.Helper()
+	address, host, err := localDockerAddress(rawURL)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var body string
+	var resp *LocalHTTPResponse
+	delay := cfg.tick
+	for attempt := 1; ; attempt++ {
+		body, resp, err = httpGetLocal(address, host, cfg)
+		success := err == nil && (contentOK == nil || contentOK(body))
+		limit := cfg.maxAttempts
+		// macOS php-fpm sometimes crashes (SIGBUS) and returns a brief 502/503;
+		// give it one extra try even for a single-shot request.
+		if nodeps.IsMacOS() && resp != nil && resp.StatusCode >= 500 && limit < macOSMinAttempts {
+			limit = macOSMinAttempts
+		}
+		if success || attempt >= limit {
+			return body, resp, err
+		}
+		reason := "expected content not present yet"
+		if err != nil {
+			reason = err.Error()
+		}
+		t.Logf("GET %s: attempt %d/%d failed, retrying in %s: %s", rawURL, attempt, limit, delay, reason)
+		time.Sleep(delay)
+		// With backoff on, wait longer next time, but never past the timeout.
+		if cfg.backoff {
+			if delay *= 2; delay > cfg.timeout {
+				delay = cfg.timeout
+			}
+		}
+	}
+}
+
+// httpGetLocal makes a single GET to address, sending host as the Host header and
+// TLS server name, and does not follow redirects. A status other than expectStatus
+// is returned as an error, with the body still returned. The response body is read
+// and closed here, so the caller gets a plain string and nothing to close.
+func httpGetLocal(address, host string, cfg requestConfig) (string, *LocalHTTPResponse, error) {
+	// ServerName makes TLS verify the cert for host; ErrUseLastResponse stops the
+	// client from following redirects. Refs:
+	// https://stackoverflow.com/a/47169975/215713 and
+	// https://stackoverflow.com/a/38150816/215713
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{ServerName: host}},
+		Timeout:   cfg.timeout,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, address, nil)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create GET request for %s: %w", address, err)
+	}
+	req.Host = host
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", nil, fmt.Errorf("unable to read response body from %s: %w", address, err)
+	}
+	body := string(bodyBytes)
+	result := &LocalHTTPResponse{StatusCode: resp.StatusCode, Header: resp.Header}
+	if resp.StatusCode != cfg.expectStatus {
+		return body, result, fmt.Errorf("status code for %s was %d, not %d", address, resp.StatusCode, cfg.expectStatus)
+	}
+	return body, result, nil
+}
+
+// localDockerAddress points rawURL at the local Docker IP but keeps the original
+// hostname for the Host header and TLS server name.
+func localDockerAddress(rawURL string) (address, host string, err error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse URL %s: %w", rawURL, err)
+	}
+	dockerIP, err := dockerutil.GetDockerIP()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get Docker IP: %w", err)
+	}
+	host = u.Hostname()
+	// Read the port before overwriting u.Host, because u.Port() reads it from there.
+	port := u.Port()
+	u.Host = dockerIP
+	if port != "" {
+		u.Host = dockerIP + ":" + port
+	}
+	return u.String(), host, nil
+}
+
+// describeHTTPFailure builds the failure message: a Fail line with the caller's
+// message, then the request, status, headers, body, and the reason(s) it failed
+// (missing substrings and/or a request error).
+func describeHTTPFailure(rawURL string, resp *LocalHTTPResponse, body string, err error, missing []string, userMsg string) string {
+	status := 0
+	var header http.Header
+	if resp != nil {
+		status = resp.StatusCode
+		header = resp.Header
+	}
+	var reasons []string
+	if err != nil {
+		reasons = append(reasons, err.Error())
+	}
+	if len(missing) > 0 {
+		reasons = append(reasons, fmt.Sprintf("body does not contain %q", missing))
+	}
+	if len(reasons) == 0 {
+		reasons = append(reasons, "unexpected response")
+	}
+	if userMsg == "" {
+		userMsg = "HTTP request failed"
+	}
+	parts := []string{
+		fmt.Sprintf("Fail: %s", userMsg),
+		fmt.Sprintf("GET: %s", rawURL),
+		fmt.Sprintf("Status: %d", status),
+		fmt.Sprintf("Error: %s", strings.Join(reasons, "; ")),
+		fmt.Sprintf("Headers: %q", header),
+		fmt.Sprintf("Body: %q", body),
+	}
+	return strings.Join(parts, "\n")
+}

--- a/pkg/testcommon/http_test.go
+++ b/pkg/testcommon/http_test.go
@@ -1,0 +1,179 @@
+package testcommon
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewRequestConfig verifies option resolution and defaults. No Docker needed.
+func TestNewRequestConfig(t *testing.T) {
+	// Defaults.
+	c := newRequestConfig()
+	require.Equal(t, defaultHTTPTimeout, c.timeout)
+	require.Equal(t, defaultHTTPTick, c.tick)
+	require.Equal(t, defaultHTTPAttempts, c.maxAttempts)
+	require.Equal(t, defaultHTTPStatus, c.expectStatus)
+	require.False(t, c.backoff)
+	require.Empty(t, c.alsoContains)
+
+	// WithMaxAttempts sets total attempts; values below 1 clamp to 1.
+	require.Equal(t, 5, newRequestConfig(WithMaxAttempts(5)).maxAttempts)
+	require.Equal(t, 1, newRequestConfig(WithMaxAttempts(0)).maxAttempts)
+	require.Equal(t, 1, newRequestConfig(WithMaxAttempts(-3)).maxAttempts)
+
+	// WithTimeout clamps negatives to 0 (disabled).
+	require.Equal(t, 5*time.Second, newRequestConfig(WithTimeout(5*time.Second)).timeout)
+	require.Equal(t, time.Duration(0), newRequestConfig(WithTimeout(-1)).timeout)
+
+	// WithExpectStatus overrides the success status.
+	require.Equal(t, http.StatusFound, newRequestConfig(WithExpectStatus(http.StatusFound)).expectStatus)
+
+	// WithBackoff enables backoff and sets the starting tick (positive only).
+	bc := newRequestConfig(WithBackoff(500 * time.Millisecond))
+	require.True(t, bc.backoff)
+	require.Equal(t, 500*time.Millisecond, bc.tick)
+	require.Equal(t, defaultHTTPTick, newRequestConfig(WithBackoff(0)).tick)
+
+	// WithAlsoContains accumulates across calls.
+	require.Equal(t, []string{"a", "b", "c"},
+		newRequestConfig(WithAlsoContains("a", "b"), WithAlsoContains("c")).alsoContains)
+
+	// WithMessagef stores the format and args.
+	mc := newRequestConfig(WithMessagef("x %d", 7))
+	require.Equal(t, "x %d", mc.msgFormat)
+	require.Equal(t, []any{7}, mc.msgArgs)
+}
+
+// TestLocalDockerAddress checks that localDockerAddress points the URL at the
+// Docker IP while keeping the original port and path, and returns the original
+// hostname (used for the Host header and TLS server name).
+func TestLocalDockerAddress(t *testing.T) {
+	// A URL with a port keeps it.
+	addr, host, err := localDockerAddress("https://example.ddev.site:8142/run")
+	require.NoError(t, err)
+	require.Equal(t, "example.ddev.site", host)
+	require.True(t, strings.HasPrefix(addr, "https://"), "scheme must be preserved, got %s", addr)
+	require.Contains(t, addr, ":8142", "port must be preserved, got %s", addr)
+	require.True(t, strings.HasSuffix(addr, "/run"), "path must be preserved, got %s", addr)
+	require.NotContains(t, addr, "example.ddev.site", "host should be replaced by the Docker IP, got %s", addr)
+
+	// A URL without a port must not gain one.
+	addr, host, err = localDockerAddress("http://example.ddev.site/")
+	require.NoError(t, err)
+	require.Equal(t, "example.ddev.site", host)
+	require.True(t, strings.HasPrefix(addr, "http://"), "scheme must be preserved, got %s", addr)
+	require.True(t, strings.HasSuffix(addr, "/"), "path must be preserved, got %s", addr)
+	require.NotContains(t, addr, "example.ddev.site", "host should be replaced by the Docker IP, got %s", addr)
+	u, err := url.Parse(addr)
+	require.NoError(t, err)
+	require.Empty(t, u.Port(), "no port should be added, got %s", addr)
+}
+
+// TestDescribeHTTPFailure verifies the failure message layout. No Docker needed.
+func TestDescribeHTTPFailure(t *testing.T) {
+	resp := &LocalHTTPResponse{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"text/html"}}}
+	msg := describeHTTPFailure("https://x.ddev.site:8142", resp, "the body", nil, []string{"Recent runs"}, "want a run")
+	require.Contains(t, msg, "Fail: want a run")
+	require.Contains(t, msg, "GET: https://x.ddev.site:8142")
+	require.Contains(t, msg, "Status: 200")
+	require.Contains(t, msg, `Error: body does not contain ["Recent runs"]`)
+	require.Contains(t, msg, "Content-Type", "response headers should be in the message")
+	require.Contains(t, msg, `Body: "the body"`)
+
+	// A transport error and an empty caller message fall back sensibly.
+	msg = describeHTTPFailure("https://x.ddev.site", nil, "", fmt.Errorf("dial tcp: boom"), nil, "")
+	require.Contains(t, msg, "Fail: HTTP request failed")
+	require.Contains(t, msg, "Status: 0")
+	require.Contains(t, msg, "Error: dial tcp: boom")
+}
+
+// TestGetLocalHTTPResponse brings up a project and exercises GetLocalHTTPResponse,
+// AssertLocalHTTPContent, and RequireLocalHTTPContent against it. Needs Docker.
+func TestGetLocalHTTPResponse(t *testing.T) {
+	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && (nodeps.IsWindows() || dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() || nodeps.IsWSL2MirroredMode()) {
+		t.Skip("Skipping on Windows/Colima/Lima/Rancher/WSL2-mirrored as it always seems to fail")
+	}
+	ensureDdevBin()
+
+	// We have to get globalconfig read so CA is known and installed.
+	err := globalconfig.ReadGlobalConfig()
+	require.NoError(t, err)
+
+	assert := asrt.New(t)
+
+	origDir, _ := os.Getwd()
+
+	dockerutil.EnsureDdevNetwork()
+
+	// It's not ideal to copy/paste this archive around, but we don't actually care about the contents
+	// of the archive for this test, only that it exists and can be extracted. This should (knock on wood)
+	//not need to be updated over time.
+	site := TestSites[0]
+	site.Name = t.Name()
+
+	_, _ = exec.RunCommand(DdevBin, []string{"stop", "-RO", site.Name})
+
+	err = site.Prepare()
+	require.NoError(t, err, "Prepare() failed on TestSite.Prepare() site=%s, err=%v", site.Name, err)
+
+	app := &ddevapp.DdevApp{}
+	err = app.Init(site.Dir)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+		_ = app.Stop(true, false)
+
+		app.RouterHTTPSPort = ""
+		app.RouterHTTPPort = ""
+		_ = app.WriteConfig()
+
+		site.Cleanup()
+	})
+
+	for _, pair := range []PortPair{{"8000", "8043"}, {"8080", "8443"}} {
+		ClearDockerEnv()
+		app.RouterHTTPPort = pair.HTTPPort
+		app.RouterHTTPSPort = pair.HTTPSPort
+		err = app.WriteConfig()
+		assert.NoError(err)
+
+		startErr := app.StartAndWait(5)
+		assert.NoError(startErr, "app.StartAndWait failed for port pair %v", pair)
+		if startErr != nil {
+			logs, health, _ := ddevapp.GetErrLogsFromApp(app, startErr)
+			t.Fatalf("healthcheck:\n%s\n\nlogs from broken container:\n=======\n%s\n========\n", health, logs)
+		}
+
+		// Exercise all three helpers (getter + non-fatal + fatal) against the live
+		// site. The plain-HTTP URL always works; the HTTPS one needs mkcert, so
+		// check it only when that's set up.
+		checkURL := func(reqURL string) {
+			out, _, getErr := GetLocalHTTPResponse(t, reqURL)
+			assert.NoError(getErr)
+			assert.Contains(out, site.Safe200URIWithExpectation.Expect)
+			AssertLocalHTTPContent(t, reqURL, site.Safe200URIWithExpectation.Expect,
+				WithMessagef("safe URL should serve the expected static content"))
+			RequireLocalHTTPContent(t, reqURL, site.Safe200URIWithExpectation.Expect,
+				WithMessagef("safe URL should serve the expected static content"))
+		}
+
+		checkURL(app.GetHTTPURL() + site.Safe200URIWithExpectation.URI)
+		if globalconfig.GetCAROOT() != "" {
+			checkURL(app.GetHTTPSURL() + site.Safe200URIWithExpectation.URI)
+		}
+	}
+}

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -2,11 +2,7 @@ package testcommon
 
 import (
 	"crypto/sha256"
-	"crypto/tls"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -14,7 +10,6 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/ddev/ddev/pkg/archive"
 	"github.com/ddev/ddev/pkg/ddevapp"
@@ -25,7 +20,6 @@ import (
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	copy2 "github.com/otiai10/copy"
-	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,14 +76,6 @@ type TestSite struct {
 	// FullSiteArchiveExtPath is the path that should be extracted from inside an archive when
 	// importing the files from a full site archive
 	FullSiteArchiveExtPath string
-}
-
-// HTTPRequestOpts contains options for HTTP requests
-type HTTPRequestOpts struct {
-	// TimeoutSeconds is the number of seconds to wait for a response before timing out
-	TimeoutSeconds int
-	// MaxRetries is the number of times to retry the request
-	MaxRetries int
 }
 
 // Prepare downloads and extracts a site codebase to a temporary directory.
@@ -444,161 +430,6 @@ func GetCachedArchive(_, _, internalExtractionPath, sourceURL string) (string, s
 	return extractPath, archiveFullPath, nil
 }
 
-// GetLocalHTTPResponse takes a URL and optional parameters,
-// hits the local Docker for it, returns result
-// Returns error (with the body) if not 200 status code.
-// Parameters can be either:
-// - HTTPRequestOpts struct with TimeoutSeconds and MaxRetries fields
-// - int representing timeout seconds (for backward compatibility)
-func GetLocalHTTPResponse(t *testing.T, rawurl string, params ...any) (string, *http.Response, error) {
-	options := parseHTTPRequestOpts(60, params...)
-
-	timeoutTime := time.Duration(options.TimeoutSeconds) * time.Second
-	assert := asrt.New(t)
-
-	u, err := url.Parse(rawurl)
-	if err != nil {
-		t.Fatalf("Failed to parse url %s: %v", rawurl, err)
-	}
-	port := u.Port()
-
-	dockerIP, err := dockerutil.GetDockerIP()
-	assert.NoError(err)
-
-	fakeHost := u.Hostname()
-	// Add the port if there is one.
-	u.Host = dockerIP
-	if port != "" {
-		u.Host = u.Host + ":" + port
-	}
-	localAddress := u.String()
-
-	// Use ServerName: fakeHost to verify basic usage of certificate.
-	// This technique is from https://stackoverflow.com/a/47169975/215713
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{ServerName: fakeHost},
-	}
-
-	// Do not follow redirects, https://stackoverflow.com/a/38150816/215713
-	client := &http.Client{
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-		Transport: transport,
-		Timeout:   timeoutTime,
-	}
-
-	var lastErr error
-	var resp *http.Response
-	var bodyString string
-
-	for attempt := 1; attempt <= options.MaxRetries; attempt++ {
-		req, err := http.NewRequest("GET", localAddress, nil)
-		if err != nil {
-			return "", nil, fmt.Errorf("failed to NewRequest GET %s: %v", localAddress, err)
-		}
-		req.Host = fakeHost
-
-		resp, err = client.Do(req)
-		if err != nil {
-			lastErr = err
-			if attempt < options.MaxRetries {
-				time.Sleep(time.Second)
-				continue
-			}
-			return "", resp, err
-		}
-
-		bodyBytes, err := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-		if err != nil {
-			lastErr = fmt.Errorf("unable to ReadAll resp.body: %v", err)
-			if attempt < options.MaxRetries {
-				time.Sleep(time.Second)
-				continue
-			}
-			return "", resp, lastErr
-		}
-
-		bodyString = string(bodyBytes)
-		if resp.StatusCode != 200 {
-			lastErr = fmt.Errorf("http status code for '%s' was %d, not 200", localAddress, resp.StatusCode)
-			if attempt < options.MaxRetries {
-				time.Sleep(time.Second)
-				continue
-			}
-			return bodyString, resp, lastErr
-		}
-
-		// Success
-		return bodyString, resp, nil
-	}
-
-	// This should never be reached, but just in case
-	return bodyString, resp, lastErr
-}
-
-// GetLocalHTTPResponseWithBackoff calls GetLocalHTTPResponse with an external
-// retry/backoff strategy. It takes a number of attempts and an initialDelay
-// duration. params follow the same conventions as GetLocalHTTPResponse
-// (HTTPRequestOpts or int timeout). The inner call has MaxRetries forced to 1
-// to avoid nested retries.
-func GetLocalHTTPResponseWithBackoff(t *testing.T, rawurl string, attempts int, initialDelay time.Duration, params ...any) (string, *http.Response, error) {
-	if attempts < 1 {
-		attempts = 1
-	}
-	// Build options from params but force inner MaxRetries to 1 to avoid nested retries.
-	innerOpts := parseHTTPRequestOpts(60, params...)
-	innerOpts.MaxRetries = 1
-
-	var lastBody string
-	var lastResp *http.Response
-	var lastErr error
-	delay := initialDelay
-
-	for attempt := 1; attempt <= attempts; attempt++ {
-		body, resp, err := GetLocalHTTPResponse(t, rawurl, innerOpts)
-		if err == nil {
-			return body, resp, nil
-		}
-		lastBody = body
-		lastResp = resp
-		lastErr = err
-
-		if attempt < attempts {
-			// Log and sleep with exponential backoff
-			t.Logf("GetLocalHTTPResponseWithBackoff attempt %d/%d failed for %s: %v; retrying after %s", attempt, attempts, rawurl, err, delay)
-			time.Sleep(delay)
-			// Double the delay for next attempt
-			delay *= 2
-		}
-	}
-
-	return lastBody, lastResp, lastErr
-}
-
-// EnsureLocalHTTPContent will verify a URL responds with a 200, expected content string, and optional parameters.
-// Parameters can be either:
-// - HTTPRequestOpts struct with TimeoutSeconds and MaxRetries fields
-// - int representing timeout seconds (for backward compatibility)
-func EnsureLocalHTTPContent(t *testing.T, rawurl string, expectedContent string, params ...any) (*http.Response, error) {
-	options := parseHTTPRequestOpts(40, params...)
-	assert := asrt.New(t)
-
-	body, resp, err := GetLocalHTTPResponse(t, rawurl, options)
-	// We see intermittent php-fpm SIGBUS failures, only on macOS.
-	// That results in a 502/503. If we get a 502/503 on macOS, try again.
-	// It seems to be a 502 with nginx-fpm and a 503 with apache-fpm
-	if nodeps.IsMacOS() && resp != nil && (resp.StatusCode >= 500) {
-		t.Logf("Received %d error on macOS, retrying GetLocalHTTPResponse", resp.StatusCode)
-		time.Sleep(time.Second)
-		body, resp, err = GetLocalHTTPResponse(t, rawurl, options)
-	}
-	assert.NoError(err, "GetLocalHTTPResponse returned err on rawurl %s, resp=%v, body=%v: %v", rawurl, resp, body, err)
-	assert.Contains(body, expectedContent, "request %s got resp=%v, body:\n========\n%s\n==========\n", rawurl, resp, body)
-	return resp, err
-}
-
 // CheckGoroutineOutput makes sure that goroutines
 // aren't beyond specified level
 func CheckGoroutineOutput(t *testing.T, out string) {
@@ -616,35 +447,4 @@ func CheckGoroutineOutput(t *testing.T, out string) {
 type PortPair struct {
 	HTTPPort  string
 	HTTPSPort string
-}
-
-// parseHTTPRequestOpts extracts HTTPRequestOpts from interface{} parameters with defaults
-func parseHTTPRequestOpts(defaultTimeout int, params ...any) HTTPRequestOpts {
-	var options HTTPRequestOpts
-
-	// Handle different parameter types for backward compatibility
-	if len(params) > 0 {
-		switch param := params[0].(type) {
-		case HTTPRequestOpts:
-			options = param
-		case int:
-			// Backward compatibility: int parameter is timeout in seconds
-			options.TimeoutSeconds = param
-		default:
-			options.TimeoutSeconds = defaultTimeout // Default if invalid type
-		}
-	}
-	// Set defaults if not provided
-	if options.TimeoutSeconds == 0 {
-		options.TimeoutSeconds = defaultTimeout
-	}
-	// Negative timeout means no timeout
-	if options.TimeoutSeconds < 0 {
-		options.TimeoutSeconds = 0
-	}
-	if options.MaxRetries < 1 {
-		options.MaxRetries = 1
-	}
-
-	return options
 }

--- a/pkg/testcommon/testcommon_test.go
+++ b/pkg/testcommon/testcommon_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
-	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -104,83 +103,6 @@ func TestValidTestSite(t *testing.T) {
 	currentDir, _ := os.Getwd()
 
 	assert.Equal(currentDir, site.Dir)
-}
-
-// TestGetLocalHTTPResponse() brings up a project and hits a URL to get the response
-func TestGetLocalHTTPResponse(t *testing.T) {
-	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && (nodeps.IsWindows() || dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() || nodeps.IsWSL2MirroredMode()) {
-		t.Skip("Skipping on Windows/Colima/Lima/Rancher/WSL2-mirrored as it always seems to fail")
-	}
-	ensureDdevBin()
-
-	// We have to get globalconfig read so CA is known and installed.
-	err := globalconfig.ReadGlobalConfig()
-	require.NoError(t, err)
-
-	assert := asrt.New(t)
-
-	origDir, _ := os.Getwd()
-
-	dockerutil.EnsureDdevNetwork()
-
-	// It's not ideal to copy/paste this archive around, but we don't actually care about the contents
-	// of the archive for this test, only that it exists and can be extracted. This should (knock on wood)
-	//not need to be updated over time.
-	site := TestSites[0]
-	site.Name = t.Name()
-
-	_, _ = exec.RunCommand(DdevBin, []string{"stop", "-RO", site.Name})
-
-	err = site.Prepare()
-	require.NoError(t, err, "Prepare() failed on TestSite.Prepare() site=%s, err=%v", site.Name, err)
-
-	app := &ddevapp.DdevApp{}
-	err = app.Init(site.Dir)
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		_ = os.Chdir(origDir)
-		_ = app.Stop(true, false)
-
-		app.RouterHTTPSPort = ""
-		app.RouterHTTPPort = ""
-		_ = app.WriteConfig()
-
-		site.Cleanup()
-	})
-
-	for _, pair := range []PortPair{{"8000", "8043"}, {"8080", "8443"}} {
-		ClearDockerEnv()
-		app.RouterHTTPPort = pair.HTTPPort
-		app.RouterHTTPSPort = pair.HTTPSPort
-		err = app.WriteConfig()
-		assert.NoError(err)
-
-		startErr := app.StartAndWait(5)
-		assert.NoError(startErr, "app.StartAndWait failed for port pair %v", pair)
-		if startErr != nil {
-			logs, health, _ := ddevapp.GetErrLogsFromApp(app, startErr)
-			t.Fatalf("healthcheck:\n%s\n\nlogs from broken container:\n=======\n%s\n========\n", health, logs)
-		}
-
-		safeURL := app.GetHTTPURL() + site.Safe200URIWithExpectation.URI
-
-		// Extra dummy GetLocalHTTPResponse is for mac M1 to try to prime it.
-		_, _, _ = GetLocalHTTPResponse(t, safeURL, 60)
-		out, _, err := GetLocalHTTPResponse(t, safeURL, 60)
-		assert.NoError(err)
-		assert.Contains(out, site.Safe200URIWithExpectation.Expect)
-
-		// Skip the https version if we don't have mkcert working
-		if globalconfig.GetCAROOT() != "" {
-			safeURL = app.GetHTTPSURL() + site.Safe200URIWithExpectation.URI
-			out, _, err = GetLocalHTTPResponse(t, safeURL, 60)
-			assert.NoError(err)
-			assert.Contains(out, site.Safe200URIWithExpectation.Expect)
-			// This does the same thing as previous, but worth exercising it here.
-			_, _ = EnsureLocalHTTPContent(t, safeURL, site.Safe200URIWithExpectation.Expect)
-		}
-	}
 }
 
 // TestGetCachedArchive tests download and extraction of archives for test sites


### PR DESCRIPTION
## The Issue

A random CI failure in `TestDdevXhprofXhguiEnabled` https://github.com/ddev/ddev/actions/runs/26869346344/job/79240513140#step:14:20770

I always thought that it's hard to understand any failure from `GetLocalHTTPResponse` and `EnsureLocalHTTPContent`.
It dumped the whole response body but never said which URL was requested, what status code came back, or what headers were returned:

```text
xhprof_xhgui_test.go:248:
Error Trace:	/home/runner/work/ddev/ddev/pkg/ddevapp/xhprof_xhgui_test.go:248
Error:      	"<!DOCTYPE html>\n<html>\n<head>\n    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n    <title>XHGui - Run list\n</title>\n    <link href=\"/css/bootstrap.min.css\" rel=\"stylesheet\" media=\"screen\">\n    <link href=\"/css/datepicker.css\" rel=\"stylesheet\" media=\"screen\">\n    <link href=\"/css/xhgui.css\" rel=\"stylesheet\" media=\"screen\">\n    </head>\n<body>\n    <div class=\"navbar navbar-static-top\">\n        <div class=\"navbar-inner\">\n            <div class=\"container-fluid\">\n                <a class=\"btn btn-navbar\" data-toggle=\"collapse\" data-target=\".nav-collapse\">\n                    <span class=\"icon-bar\"></span>\n                    <span class=\"icon-bar\"></span>\n                    <span class=\"icon-bar\"></span>\n                </a>\n                <a class=\"brand\" href=\"/\">XHG</a>\n                <div class=\"nav-collapse collapse\">\n                    <ul class=\"nav\">\n                        <li><a href=\"/\">Recent</a></li>\n                        <li><a href=\"/?sort=wt\">Longest wall time</a></li>\n                        <li><a href=\"/?sort=cpu\">Most CPU</a></li>\n                        <li><a href=\"/?sort=mu\">Most memory</a></li>\n                        <li><a href=\"/custom\">Custom View</a></li>\n                        <li><a href=\"/watch\">Watch Functions</a></li>\n                        <li><a href=\"/waterfall\">Waterfall</a></li>\n                    </ul>\n                </div><!--/.nav-collapse -->\n            </div>\n        </div>\n    </div>\n\n    <div class=\"container-fluid\">\n        \n        <h1>Recent runs</h1>\n\n\n<div class=\"hero-unit\">\n    <h3>Looks like you haven't done any profiling</h3>\n    <p>To get started with XHGUI you'll need to collect some profiling data.</p>\n    <p>See <a href=\"https://github.com/perftools/xhgui#profiling-a-web-request-or-cli-script\">Profiling a Web Request or CLI script</a> section of the readme file\n    </p>\n</div>\n\n\n\n\n        <hr>\n\n        <footer class=\"row-fluid footer-text\">\n            <span class=\"span4\">© Paul Reinheimer &amp; Mark Story 2012</span>\n            <span class=\"span4\">1,000,000 µs = 1 second</span>\n            <span class=\"span4\">1,048,576 bytes = 1 MB</span>\n        </footer>\n    </div>\n\n    <script src=\"/js/jquery.js\"></script>\n    <script src=\"/js/bootstrap.min.js\"></script>\n    <script src=\"/js/bootstrap-tooltip.js\"></script>\n    <script src=\"/js/bootstrap-datepicker.js\"></script>\n    <script src=\"/js/d3.js\"></script>\n    <script src=\"/js/jquery.tablesorter.js\"></script>\n    <script src=\"/js/jquery.stickytableheaders.js\"></script>\n    <script src=\"/js/xhgui-charts.js\"></script>\n    <script src=\"/js/xhgui.js\"></script>\n    \n    </body>\n</html>\n" does not contain "testddevxhprofxhguienabled.ddev.site"
Test:       	TestDdevXhprofXhguiEnabled
```

The local-HTTP test helpers had also grown redundant and error-prone:

- `GetLocalHTTPResponse` was fine.
- `GetLocalHTTPResponseWithBackoff` mostly repeated it with an outer retry loop.
- `EnsureLocalHTTPContent` had no `assert` vs `require` split, so several callers silently ignored its returned error.

## How This PR Solves The Issue

Moves the helpers into a dedicated `pkg/testcommon/http.go` with a small, options-based API:

- `GetLocalHTTPResponse(t, url, opts...)` - returns body/status/headers/err and never fails the test (like assert).
- `RequireLocalHTTPContent(t, url, want, opts...)` - fatal content check (like `require.Contains`).
- `AssertLocalHTTPContent(t, url, want, opts...)` bool - non-fatal content check (like `assert.Contains`).

Options replace the old timeout/retry parameters: `WithTimeout`, `WithMaxAttempts` (total attempts; retries on an error or missing content), `WithBackoff`, `WithExpectStatus`, `WithAlsoContains`, `WithMessagef`.

`GetLocalHTTPResponseWithBackoff` and `EnsureLocalHTTPContent` are removed.

Content-check failures now print the request, status, headers, body, and the exact reason, with the caller's message first:

```text
Fail: xhgui should list a profiling run for this project
GET: https://...:8142
Status: 200
Error: body does not contain ["Recent runs"]
Headers: map["Content-Type":["text/html; charset=UTF-8"] ...]
Body: "..."
```

Also in this change:

- On macOS a transient 5xx (php-fpm SIGBUS) gets one automatic extra attempt, even for a single-shot request.
- Each retry is logged via `t.Logf` so slow or flaky polls are visible.
- Updated every caller to the new API, mapping each to require vs assert based on its original behavior and adding a WithMessagef description.

## Manual Testing Instructions

Dummy test for "blahblahblah" in the output::

Before:

```
    xhprof_xhgui_test.go:249: 
        	Error Trace:	/home/runner/work/ddev/ddev/pkg/ddevapp/xhprof_xhgui_test.go:249
        	Error:      	"<!DOCTYPE html>\n<html>\n<head>\n    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n    <title>XHGui - Run list\n</title>\n    <link href=\"/css/bootstrap.min.css\" rel=\"stylesheet\" media=\"screen\">\n    <link href=\"/css/datepicker.css\" rel=\"stylesheet\" media=\"screen\">\n    <link href=\"/css/xhgui.css\" rel=\"stylesheet\" media=\"screen\">\n    </head>\n<body>\n    <div class=\"navbar navbar-static-top\">\n        <div class=\"navbar-inner\">\n            <div class=\"container-fluid\">\n                <a class=\"btn btn-navbar\" data-toggle=\"collapse\" data-target=\".nav-collapse\">\n                    <span class=\"icon-bar\"></span>\n                    <span class=\"icon-bar\"></span>\n                    <span class=\"icon-bar\"></span>\n                </a>\n                <a class=\"brand\" href=\"/\">XHG</a>\n                <div class=\"nav-collapse collapse\">\n                    <ul class=\"nav\">\n                        <li><a href=\"/\">Recent</a></li>\n                        <li><a href=\"/?sort=wt\">Longest wall time</a></li>\n                        <li><a href=\"/?sort=cpu\">Most CPU</a></li>\n                        <li><a href=\"/?sort=mu\">Most memory</a></li>\n                        <li><a href=\"/custom\">Custom View</a></li>\n                        <li><a href=\"/watch\">Watch Functions</a></li>\n                        <li><a href=\"/waterfall\">Waterfall</a></li>\n                    </ul>\n                </div><!--/.nav-collapse -->\n            </div>\n        </div>\n    </div>\n\n    <div class=\"container-fluid\">\n        \n        <h1>Recent runs</h1>\n\n<div class=\"searchbar clearfix\">\n    <a href=\"/run/delete_all\" class=\"pull-right btn btn-small delete-all\" title=\"Delete all\">\n        <i class=\"icon-trash\"></i> Delete all\n    </a>\n\n    <a href=\"#\" class=\"pull-right btn btn-small search-expand\" title=\"Show search form\">\n        <i class=\"icon-search\"></i> Search\n    </a>\n\n    <form action=\"/\" method=\"get\" class=\"row hide search-form form-inline\">\n        <a href=\"#\" class=\"search-collapse close\" title=\"Hide search form\">&times;</a>\n        <div class=\"control-group span4\">\n            <label class=\"control-label\" for=\"start_date\">Date range</label>\n            <div class=\"controls\">\n                <input type=\"text\" data-date-format=\"yyyy-mm-dd\" id=\"date_start\" name=\"date_start\" class=\"datepicker span2\" value=\"\">\n                <input type=\"text\" id=\"date_end\" data-date-format=\"yyyy-mm-dd\" name=\"date_end\" class=\"datepicker span2\" value=\"\">\n            </div>\n        </div>\n        <div class=\"control-group span4\">\n            <label class=\"control-label\" for=\"server-name\">Server Name</label>\n            <div class=\"controls\">\n                                    <input type=\"text\" id=\"server-name\" name=\"server_name\" value=\"\">\n                            </div>\n            <label class=\"control-label\" for=\"url\">URL</label>\n            <div class=\"controls\">\n                <input type=\"text\" id=\"url\" name=\"url\" value=\"\">\n            </div>\n        </div>\n        <div class=\"form-actions\">\n            <button type=\"submit\" class=\"btn btn-primary\">Search</button>\n        </div>\n    </form>\n</div>\n\n\n    <div class=\"row-fluid\">\n    <table class=\"table table-hover\">\n        <thead>\n            <tr>\n                                <th>\n                  Server Name\n                </th>\n                <th>\n                  Method\n                </th>\n                <th>URL</th>\n                <th>\n                    \n<a class=\"sort-link \" href=\"/?direction=asc&amp;sort=time\">Time</a>\n\n                </th>\n                <th class=\"right\">\n                    <span class=\"tip\" title=\"Wall time\">\n                        \n<a class=\"sort-link \" href=\"/?direction=asc&amp;sort=wt\">wt</a>\n\n                    </span>\n                </th>\n                <th class=\"right\">\n                    <span class=\"tip\" title=\"CPU time\">\n                        \n<a class=\"sort-link \" href=\"/?direction=asc&amp;sort=cpu\">cpu</a>\n\n                    </span>\n                </th>\n                <th class=\"right\">\n                    <span class=\"tip\" title=\"Memory Usage\">\n                        \n<a class=\"sort-link \" href=\"/?direction=asc&amp;sort=mu\">mu</a>\n\n                    </span>\n                </th>\n                <th class=\"right\">\n                    <span class=\"tip\" title=\"Peak Memory\">\n                        \n<a class=\"sort-link \" href=\"/?direction=asc&amp;sort=pmu\">pmu</a>\n\n                    </span>\n                </th>\n                <th>\n                    Ops\n                </th>\n            </tr>\n        </thead>\n        <tbody>\n                <tr>\n                        <td>\n              <a href=\"/?server_name=testddevxhprofxhguienabled.ddev.site\">\n                testddevxhprofxhguienabled.ddev.site\n              </a>\n            </td>\n            <td>\n              <a href=\"/run/view?id=6a204a4e58550e33a20169e8\">\n                GET\n              </a>\n            </td>\n            <td>\n                <a     href=\"/url/view?server_name=testddevxhprofxhguienabled.ddev.site&amp;url=%2F\"\n    title=\"/\">\n    /\n</a>\n\n            </td>\n            <td>\n              <a href=\"/run/view?id=6a204a4e58550e33a20169e8\">\n                Jun 3rd 18:37:50\n              </a> \n              <a href=\"/run/view?id=6a204a4e58550e33a20169e8&amp;filter=1\">\n                [filter]\n              </a>\n            </td>\n            <td class=\"right\">464,397&nbsp;<span class=\"units\">µs</span></td>\n            <td class=\"right\">65,814&nbsp;<span class=\"units\">µs</span></td>\n            <td class=\"right\">-1,680&nbsp;<span class=\"units\">bytes</span></td>\n            <td class=\"right\">206,776&nbsp;<span class=\"units\">bytes</span></td>\n            <td>\n                <a href=\"/run/delete?id=6a204a4e58550e33a20169e8\">\n                    <i class=\"icon-trash\"></i>\n                </a>\n            </td>\n        </tr>\n                </tbody>\n    </table>\n</div>\n\n    \n\n\n\n<div class=\"pagination\">\n<ul>\n    <li class=\"disabled\"><span>&laquo;</span><li>\n\n        <li class=\"active\"><span>1</span></li>\n    \n    <li class=\"disabled\"><span>&raquo;</span></li>\n</ul>\n</div>\n\n\n\n        <hr>\n\n        <footer class=\"row-fluid footer-text\">\n            <span class=\"span4\">© Paul Reinheimer &amp; Mark Story 2012</span>\n            <span class=\"span4\">1,000,000 µs = 1 second</span>\n            <span class=\"span4\">1,048,576 bytes = 1 MB</span>\n        </footer>\n    </div>\n\n    <script src=\"/js/jquery.js\"></script>\n    <script src=\"/js/bootstrap.min.js\"></script>\n    <script src=\"/js/bootstrap-tooltip.js\"></script>\n    <script src=\"/js/bootstrap-datepicker.js\"></script>\n    <script src=\"/js/d3.js\"></script>\n    <script src=\"/js/jquery.tablesorter.js\"></script>\n    <script src=\"/js/jquery.stickytableheaders.js\"></script>\n    <script src=\"/js/xhgui-charts.js\"></script>\n    <script src=\"/js/xhgui.js\"></script>\n    \n    </body>\n</html>\n" does not contain "blahblahblah"
        	Test:       	TestDdevXhprofXhguiEnabled
```

After:

```
    xhprof_xhgui_test.go:241: GET https://testddevxhprofxhguienabled.ddev.site:8142: attempt 1/5 failed, retrying in 500ms: expected content not present yet
    xhprof_xhgui_test.go:241: GET https://testddevxhprofxhguienabled.ddev.site:8142: attempt 2/5 failed, retrying in 1s: expected content not present yet
    xhprof_xhgui_test.go:241: GET https://testddevxhprofxhguienabled.ddev.site:8142: attempt 3/5 failed, retrying in 2s: expected content not present yet
    xhprof_xhgui_test.go:241: GET https://testddevxhprofxhguienabled.ddev.site:8142: attempt 4/5 failed, retrying in 2s: expected content not present yet
    xhprof_xhgui_test.go:241: Fail: xhgui should list a profiling run for this project
        GET: https://testddevxhprofxhguienabled.ddev.site:8142
        Status: 200
        Error: body does not contain ["blahblahblah"]
        Headers: map["Cache-Control":["public, max-age=0"] "Content-Length":["6909"] "Content-Type":["text/html; charset=UTF-8"] "Date":["Wed, 03 Jun 2026 15:35:33 GMT"] "Expires":["Thu, 19 Nov 1981 08:52:00 GMT"] "Pragma":["no-cache"] "Server":["nginx"] "Set-Cookie":["PHPSESSID=u4imca34evq3cmimvrjat0joc0; path=/"] "X-Powered-By":["PHP/8.3.23"]]
        Body: "<!DOCTYPE html>\n<html>\n<head>\n    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n    <title>XHGui - Run list\n</title>\n    <link href=\"/css/bootstrap.min.css\" rel=\"stylesheet\" media=\"screen\">\n    <link href=\"/css/datepicker.css\" rel=\"stylesheet\" media=\"screen\">\n    <link href=\"/css/xhgui.css\" rel=\"stylesheet\" media=\"screen\">\n    </head>\n<body>\n    <div class=\"navbar navbar-static-top\">\n        <div class=\"navbar-inner\">\n            <div class=\"container-fluid\">\n                <a class=\"btn btn-navbar\" data-toggle=\"collapse\" data-target=\".nav-collapse\">\n                    <span class=\"icon-bar\"></span>\n                    <span class=\"icon-bar\"></span>\n                    <span class=\"icon-bar\"></span>\n                </a>\n                <a class=\"brand\" href=\"/\">XHG</a>\n                <div class=\"nav-collapse collapse\">\n                    <ul class=\"nav\">\n                        <li><a href=\"/\">Recent</a></li>\n                        <li><a href=\"/?sort=wt\">Longest wall time</a></li>\n                        <li><a href=\"/?sort=cpu\">Most CPU</a></li>\n                        <li><a href=\"/?sort=mu\">Most memory</a></li>\n                        <li><a href=\"/custom\">Custom View</a></li>\n                        <li><a href=\"/watch\">Watch Functions</a></li>\n                        <li><a href=\"/waterfall\">Waterfall</a></li>\n                    </ul>\n                </div><!--/.nav-collapse -->\n            </div>\n        </div>\n    </div>\n\n    <div class=\"container-fluid\">\n        \n        <h1>Recent runs</h1>\n\n<div class=\"searchbar clearfix\">\n    <a href=\"/run/delete_all\" class=\"pull-right btn btn-small delete-all\" title=\"Delete all\">\n        <i class=\"icon-trash\"></i> Delete all\n    </a>\n\n    <a href=\"#\" class=\"pull-right btn btn-small search-expand\" title=\"Show search form\">\n        <i class=\"icon-search\"></i> Search\n    </a>\n\n    <form action=\"/\" method=\"get\" class=\"row hide search-form form-inline\">\n        <a href=\"#\" class=\"search-collapse close\" title=\"Hide search form\">&times;</a>\n        <div class=\"control-group span4\">\n            <label class=\"control-label\" for=\"start_date\">Date range</label>\n            <div class=\"controls\">\n                <input type=\"text\" data-date-format=\"yyyy-mm-dd\" id=\"date_start\" name=\"date_start\" class=\"datepicker span2\" value=\"\">\n                <input type=\"text\" id=\"date_end\" data-date-format=\"yyyy-mm-dd\" name=\"date_end\" class=\"datepicker span2\" value=\"\">\n            </div>\n        </div>\n        <div class=\"control-group span4\">\n            <label class=\"control-label\" for=\"server-name\">Server Name</label>\n            <div class=\"controls\">\n                                    <input type=\"text\" id=\"server-name\" name=\"server_name\" value=\"\">\n                            </div>\n            <label class=\"control-label\" for=\"url\">URL</label>\n            <div class=\"controls\">\n                <input type=\"text\" id=\"url\" name=\"url\" value=\"\">\n            </div>\n        </div>\n        <div class=\"form-actions\">\n            <button type=\"submit\" class=\"btn btn-primary\">Search</button>\n        </div>\n    </form>\n</div>\n\n\n    <div class=\"row-fluid\">\n    <table class=\"table table-hover\">\n        <thead>\n            <tr>\n                                <th>\n                  Server Name\n                </th>\n                <th>\n                  Method\n                </th>\n                <th>URL</th>\n                <th>\n                    \n<a class=\"sort-link \" href=\"/?direction=asc&amp;sort=time\">Time</a>\n\n                </th>\n                <th class=\"right\">\n                    <span class=\"tip\" title=\"Wall time\">\n                        \n<a class=\"sort-link \" href=\"/?direction=asc&amp;sort=wt\">wt</a>\n\n                    </span>\n                </th>\n                <th class=\"right\">\n                    <span class=\"tip\" title=\"CPU time\">\n                        \n<a class=\"sort-link \" href=\"/?direction=asc&amp;sort=cpu\">cpu</a>\n\n                    </span>\n                </th>\n                <th class=\"right\">\n                    <span class=\"tip\" title=\"Memory Usage\">\n                        \n<a class=\"sort-link \" href=\"/?direction=asc&amp;sort=mu\">mu</a>\n\n                    </span>\n                </th>\n                <th class=\"right\">\n                    <span class=\"tip\" title=\"Peak Memory\">\n                        \n<a class=\"sort-link \" href=\"/?direction=asc&amp;sort=pmu\">pmu</a>\n\n                    </span>\n                </th>\n                <th>\n                    Ops\n                </th>\n            </tr>\n        </thead>\n        <tbody>\n                <tr>\n                        <td>\n              <a href=\"/?server_name=testddevxhprofxhguienabled.ddev.site\">\n                testddevxhprofxhguienabled.ddev.site\n              </a>\n            </td>\n            <td>\n              <a href=\"/run/view?id=6a2049bf01fd007aff717b47\">\n                GET\n              </a>\n            </td>\n            <td>\n                <a     href=\"/url/view?server_name=testddevxhprofxhguienabled.ddev.site&amp;url=%2F\"\n    title=\"/\">\n    /\n</a>\n\n            </td>\n            <td>\n              <a href=\"/run/view?id=6a2049bf01fd007aff717b47\">\n                Jun 3rd 18:35:26\n              </a> \n              <a href=\"/run/view?id=6a2049bf01fd007aff717b47&amp;filter=1\">\n                [filter]\n              </a>\n            </td>\n            <td class=\"right\">550,489&nbsp;<span class=\"units\">µs</span></td>\n            <td class=\"right\">116,247&nbsp;<span class=\"units\">µs</span></td>\n            <td class=\"right\">-1,680&nbsp;<span class=\"units\">bytes</span></td>\n            <td class=\"right\">206,776&nbsp;<span class=\"units\">bytes</span></td>\n            <td>\n                <a href=\"/run/delete?id=6a2049bf01fd007aff717b47\">\n                    <i class=\"icon-trash\"></i>\n                </a>\n            </td>\n        </tr>\n                </tbody>\n    </table>\n</div>\n\n    \n\n\n\n<div class=\"pagination\">\n<ul>\n    <li class=\"disabled\"><span>&laquo;</span><li>\n\n        <li class=\"active\"><span>1</span></li>\n    \n    <li class=\"disabled\"><span>&raquo;</span></li>\n</ul>\n</div>\n\n\n\n        <hr>\n\n        <footer class=\"row-fluid footer-text\">\n            <span class=\"span4\">© Paul Reinheimer &amp; Mark Story 2012</span>\n            <span class=\"span4\">1,000,000 µs = 1 second</span>\n            <span class=\"span4\">1,048,576 bytes = 1 MB</span>\n        </footer>\n    </div>\n\n    <script src=\"/js/jquery.js\"></script>\n    <script src=\"/js/bootstrap.min.js\"></script>\n    <script src=\"/js/bootstrap-tooltip.js\"></script>\n    <script src=\"/js/bootstrap-datepicker.js\"></script>\n    <script src=\"/js/d3.js\"></script>\n    <script src=\"/js/jquery.tablesorter.js\"></script>\n    <script src=\"/js/jquery.stickytableheaders.js\"></script>\n    <script src=\"/js/xhgui-charts.js\"></script>\n    <script src=\"/js/xhgui.js\"></script>\n    \n    </body>\n</html>\n"
```

Dummy test for 404 page:

Before:

```
    xhprof_xhgui_test.go:246: 
        	Error Trace:	/home/runner/work/ddev/ddev/pkg/ddevapp/xhprof_xhgui_test.go:246
        	Error:      	Received unexpected error:
        	            	http status code for 'https://127.0.0.1:8142/foobar' was 404, not 200
        	Test:       	TestDdevXhprofXhguiEnabled
```

After:

```
    xhprof_xhgui_test.go:241: GET https://testddevxhprofxhguienabled.ddev.site:8142/foobar: attempt 1/5 failed, retrying in 500ms: status code for https://127.0.0.1:8142/foobar was 404, not 200
    xhprof_xhgui_test.go:241: GET https://testddevxhprofxhguienabled.ddev.site:8142/foobar: attempt 2/5 failed, retrying in 1s: status code for https://127.0.0.1:8142/foobar was 404, not 200
    xhprof_xhgui_test.go:241: GET https://testddevxhprofxhguienabled.ddev.site:8142/foobar: attempt 3/5 failed, retrying in 2s: status code for https://127.0.0.1:8142/foobar was 404, not 200
    xhprof_xhgui_test.go:241: GET https://testddevxhprofxhguienabled.ddev.site:8142/foobar: attempt 4/5 failed, retrying in 2s: status code for https://127.0.0.1:8142/foobar was 404, not 200
    xhprof_xhgui_test.go:241: Fail: xhgui should list a profiling run for this project
        GET: https://testddevxhprofxhguienabled.ddev.site:8142/foobar
        Status: 404
        Error: status code for https://127.0.0.1:8142/foobar was 404, not 200; body does not contain ["Recent runs"]
        Headers: map["Cache-Control":["no-store, no-cache, must-revalidate"] "Content-Length":["901"] "Content-Type":["text/html;charset=UTF-8"] "Date":["Wed, 03 Jun 2026 16:06:40 GMT"] "Expires":["Thu, 19 Nov 1981 08:52:00 GMT"] "Pragma":["no-cache"] "Server":["nginx"] "Set-Cookie":["PHPSESSID=14k4949mntupuimb57o0ivh6v7; path=/"] "X-Powered-By":["PHP/8.3.23"]]
        Body: "<html>\n    <head>\n        <title>Page Not Found</title>\n        <style>\n            body{\n                margin:0;\n                padding:30px;\n                font:12px/1.5 Helvetica,Arial,Verdana,sans-serif;\n            }\n            h1{\n                margin:0;\n                font-size:48px;\n                font-weight:normal;\n                line-height:48px;\n            }\n            strong{\n                display:inline-block;\n                width:65px;\n            }\n        </style>\n    </head>\n    <body>\n        <h1>Page Not Found</h1>\n        <p>\n            The page you are looking for could not be found. Check the address bar\n            to ensure your URL is spelled correctly. If all else fails, you can\n            visit our home page at the link below.\n        </p>\n        <a href='http://testddevxhprofxhguienabled.ddev.site/'>Visit the Home Page</a>\n    </body>\n</html>"

```

## Automated Testing Overview

- New unit tests in `pkg/testcommon/http_test.go`: `TestNewRequestConfig` (option resolution and defaults), `TestLocalDockerAddress` (URL keeps port/path, host swapped for the Docker IP, no port added when absent), and `TestDescribeHTTPFailure` (failure-message layout).
- `TestGetLocalHTTPResponse` now exercises all three helpers over HTTP (always) and HTTPS (when `mkcert` is set up).
- Existing integration tests still cover the real request paths.

## Release/Deployment Notes

Test-only change under `pkg/testcommon`.