### PR TITLE
fix(zensical): retry strict build on false-positive "page does not exist" warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ markdownlint:
 # https://docs.ddev.com/en/stable/developers/testing-docs/
 zensical:
 	@echo "zensical: "
-	@CMD="zensical build --strict"; \
+	@CMD="zensical build --clean --strict"; \
 	if command -v zensical >/dev/null 2>&1; then \
 		$$CMD ; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -207,12 +207,22 @@ markdownlint:
 # https://docs.ddev.com/en/stable/developers/testing-docs/
 zensical:
 	@echo "zensical: "
-	@CMD="zensical build --clean --strict"; \
-	if command -v zensical >/dev/null 2>&1; then \
-		$$CMD ; \
-	else \
+	@if ! command -v zensical >/dev/null 2>&1; then \
 		echo "Not running zensical because it's not installed (run scripts/install-dev-tools.sh)"; \
-	fi
+		exit 0; \
+	fi; \
+	for i in 1 2 3; do \
+		out=$$(zensical build --strict 2>&1); rc=$$?; \
+		echo "$$out"; \
+		if [ $$rc -eq 0 ]; then exit 0; fi; \
+		if ! echo "$$out" | grep -q "page does not exist"; then \
+			echo "zensical: failure is not the known cache race; not retrying."; \
+			exit $$rc; \
+		fi; \
+		echo "zensical: attempt $$i hit the known cache race (see https://github.com/zensical/zensical/issues/641), retrying..."; \
+	done; \
+	echo "zensical: fast attempts exhausted; running authoritative clean build..."; \
+	zensical build --clean --strict
 
 # To see what the docs will look like, you can use `make zensical-serve`
 # It does require installing zensical: pip install zensical


### PR DESCRIPTION
## The Issue

While working on several features/fixes using Claude Code, I noticed random Zensical failures in:

https://github.com/ddev/ddev/blob/a80de54372a3b9dc0d70b9de128b03f663ddb493/.claude/settings.json#L69-L80

https://github.com/ddev/ddev/blob/a80de54372a3b9dc0d70b9de128b03f663ddb493/Makefile#L206-L215

Errors looked like:

```
Warning: page does not exist
    ╭─[ users/usage/developer-tools.md:26:114 ]
    │
 26 │ You can also add tools that are not provided by default using [`webimage_extra_packages` or a custom Dockerfile](../extend/customizing-images.md).
    │                                                                                                                  ───────────────┬───────────────  
    │                                                                                                                                 ╰───────────────── page does not exist
```

These failures blocked Claude Code even when the running command wasn't `git commit`. But it didn't happen all the time. The root cause is documented in the [Claude Code hooks docs](https://code.claude.com/docs/en/hooks#common-fields):

> `if` field: Permission rule syntax to filter when this hook runs, such as "Bash(git *)" or "Edit(*.ts)". The hook only spawns if the tool call matches the pattern, or if a Bash command is too complex to parse.

The hook was triggering unexpectedly due to commands being too complex to parse - causing spurious Zensical runs.

## How This PR Solves The Issue

Zensical's incremental cache intermittently emits false `page does not exist` warnings for valid links, which `--strict` turns into commit-blocking failures:

- https://github.com/zensical/zensical/issues/641

`--clean` avoids it but is ~9x slower (0.99s → 8.70s). So the `zensical` target now:

1. Runs the fast cached build; passes immediately in the common case.
2. Retries up to 3x, but only on the `page does not exist` race signature; any other failure exits immediately.
3. Falls back to one `--clean` build if all 3 attempts hit the race.

Safe because the bug only causes false failures, never false passes - a real broken link fails every attempt including the clean build.

## Manual Testing Instructions

Run:

```bash
for i in $(seq 1 10); do make zensical || { echo "FAILED on run $i"; break; }; done
```

```
zensical: 
Build started
No issues found
Build finished in 2.00s
zensical: 
Build started
No issues found
Build finished in 1.80s
zensical: 
Build started
No issues found
Build finished in 1.61s
zensical: 
Build started
No issues found
Build finished in 1.61s
zensical: 
Build started
No issues found
Build finished in 1.57s
zensical: 
Build started
No issues found
Build finished in 0.92s
zensical: 
Build started
Warning: page does not exist
    ╭─[ developers/building-contributing.md:26:62 ]
    │
 26 │ !!!tip "You can also [downgrade to an older version of DDEV](../users/usage/faq.md#how-can-i-install-a-specific-version-of-ddev) (perform a rollback)."                                                                                                                                               
    │                                                              ─────────────────────────────────┬────────────────────────────────  
    │                                                                                               ╰────────────────────────────────── page does not exist
────╯
Warning: page does not exist
    ╭─[ developers/building-contributing.md:91:67 ]
    │
 91 │ When DDEV detects a version change, it recommends [powering down](../users/usage/commands.md#poweroff) all running containers. Then, it will download the new images, if required.                                                                                                                    
    │                                                                   ─────────────────┬─────────────────  
    │                                                                                    ╰─────────────────── page does not exist
────╯
Warning: page does not exist
     ╭─[ developers/building-contributing.md:117:90 ]
     │
 117 │ `ddev version` should show you that you are using the correct webtag, and [`ddev start`](../users/usage/commands.md#start) will show it.
     │                                                                                          ────────────────┬───────────────  
     │                                                                                                          ╰───────────────── page does not exist
─────╯
Warning: page does not exist
    ╭─[ developers/project-types.md:26:67 ]
    │
 26 │     * `postStartAction` adds actions at the end of [`ddev start`](../users/usage/commands.md#start). You'll see several implementations of this, for things like creating needed default directories, or setting permissions on files, etc.                                                           
    │                                                                   ────────────────┬───────────────  
    │                                                                                   ╰───────────────── page does not exist
────╯
Warning: page does not exist
    ╭─[ developers/project-types.md:27:61 ]
    │
 27 │     * `importFilesAction` defines how [`ddev import-files`](../users/usage/commands.md#import-files) works for this project type.
    │                                                             ───────────────────┬───────────────────  
    │                                                                                ╰───────────────────── page does not exist
────╯
Warning: page does not exist
    ╭─[ developers/project-types.md:28:96 ]
    │
 28 │     * `defaultWorkingDirMap` allows the project type to override the project’s [`working_dir`](../users/configuration/config.md#working_dir) (where [`ddev ssh`](../users/usage/commands.md#ssh) and [`ddev exec`](../users/usage/commands.md#exec) start by default). This is mostly not done anymore, as the `working_dir` is typically the project root.                                                                                                 
    │                                                                                                ──────────────────────┬─────────────────────  
    │                                                                                                                      ╰─────────────────────── page does not exist
────╯
Warning: page does not exist
    ╭─[ developers/project-types.md:28:162 ]
    │
 28 │     * `defaultWorkingDirMap` allows the project type to override the project’s [`working_dir`](../users/configuration/config.md#working_dir) (where [`ddev ssh`](../users/usage/commands.md#ssh) and [`ddev exec`](../users/usage/commands.md#exec) start by default). This is mostly not done anymore, as the `working_dir` is typically the project root.                                                                                                 
    │                                                                                                                                                                  ───────────────┬──────────────  
    │                                                                                                                                                                                 ╰──────────────── page does not exist
────╯
Warning: page does not exist
    ╭─[ developers/project-types.md:28:212 ]
    │
 28 │     * `defaultWorkingDirMap` allows the project type to override the project’s [`working_dir`](../users/configuration/config.md#working_dir) (where [`ddev ssh`](../users/usage/commands.md#ssh) and [`ddev exec`](../users/usage/commands.md#exec) start by default). This is mostly not done anymore, as the `working_dir` is typically the project root.                                                                                                 
    │                                                                                                                                                                                                                    ───────────────┬───────────────  
    │                                                                                                                                                                                                                                   ╰───────────────── page does not exist
────╯
Warning: page does not exist
   ╭─[ developers/quickstart-maintenance.md:9:79 ]
   │
 9 │ Project Type quickstarts are pretty easy to add as just docs in [quickstarts](../users/quickstart.md),
   │                                                                               ───────────┬──────────  
   │                                                                                          ╰──────────── page does not exist
───╯
Warning: page does not exist
    ╭─[ developers/quickstart-maintenance.md:21:66 ]
    │
 21 │ The quickstart can be based on one of the existing [quickstarts](../users/quickstart.md).
    │                                                                  ───────────┬──────────  
    │                                                                             ╰──────────── page does not exist
────╯
Warning: page does not exist
    ╭─[ developers/quickstart-maintenance.md:32:152 ]
    │
 32 │ 6. If your project type includes folders that accept public files (such as images), for example, `public/media`, make sure to add them to the [config](../users/configuration/config.md#upload_dirs) command:                                                                                         
    │                                                                                                                                                        ──────────────────────┬─────────────────────  
    │                                                                                                                                                                              ╰─────────────────────── page does not exist
────╯
Warning: page does not exist
    ╭─[ developers/remote-config.md:49:124 ]
    │
 49 │ DDEV stores downloaded data locally using Go's `gob` binary encoding format in the user's [global configuration directory](../users/usage/architecture.md#global-files):                                                                                                                              
    │                                                                                                                            ─────────────────────┬─────────────────────                                                                                                                                
    │                                                                                                                                                 ╰─────────────────────── page does not exist                                                                                                          
────╯
Warning: page does not exist
     ╭─[ developers/remote-config.md:153:118 ]
     │
 153 │ Users can configure remote config behavior in `$HOME/.ddev/global_config.yaml` (see [global configuration directory](../users/usage/architecture.md#global-files)):                                                                                                                                  
     │                                                                                                                      ─────────────────────┬─────────────────────                                                                                                                                     
     │                                                                                                                                           ╰─────────────────────── page does not exist                                                                                                               
─────╯
Warning: page does not exist
     ╭─[ developers/remote-config.md:203:108 ]
     │
 203 │ 2. **Set up test configuration** in `$HOME/.ddev/global_config.yaml` (see [global configuration directory](../users/usage/architecture.md#global-files)):                                                                                                                                            
     │                                                                                                            ─────────────────────┬─────────────────────                                                                                                                                               
     │                                                                                                                                 ╰─────────────────────── page does not exist                                                                                                                         
─────╯
Warning: page does not exist
    ╭─[ developers/writing-style-guide.md:12:40 ]
    │
 12 │ In the spirit of the [Code of Conduct](../users/code-of-conduct.md), we want to be clear and encouraging for everyone that bothers to read DDEV’s documentation, rewarding the time and attention they choose to give to it.                                                                          
    │                                        ─────────────┬─────────────  
    │                                                     ╰─────────────── page does not exist
────╯
Warning: page does not exist
    ╭─[ developers/writing-style-guide.md:37:33 ]
    │
 37 │ | Learn more on the [Extending](../users/extend/customization-extendibility.md) page. | (You can also learn more about this and related topics in [Providing Custom Environment Variables to a Container](../users/extend/customization-extendibility.md).)                                           
    │                                 ───────────────────────┬──────────────────────  
    │                                                        ╰──────────────────────── page does not exist
────╯
Warning: page does not exist
    ╭─[ developers/writing-style-guide.md:37:203 ]
    │
 37 │ | Learn more on the [Extending](../users/extend/customization-extendibility.md) page. | (You can also learn more about this and related topics in [Providing Custom Environment Variables to a Container](../users/extend/customization-extendibility.md).)                                           
    │                                                                                                                                                                                                           ───────────────────────┬──────────────────────  
    │                                                                                                                                                                                                                                  ╰──────────────────────── page does not exist
────╯
Warning: page does not exist
     ╭─[ developers/writing-style-guide.md:125:45 ]
     │
 125 │ | Once you’ve [installed a Docker provider](../users/install/docker-installation.md), you’re ready to install DDEV! | Docker or an alternative is required before anything will work with DDEV. This is pretty easy on most environments; see the [Docker Installation](../users/install/docker-installation.md) page to help sort out the details.                                                                                                        
     │                                             ───────────────────┬───────────────────  
     │                                                                ╰───────────────────── page does not exist
─────╯
Warning: page does not exist
     ╭─[ developers/writing-style-guide.md:125:265 ]
     │
 125 │ | Once you’ve [installed a Docker provider](../users/install/docker-installation.md), you’re ready to install DDEV! | Docker or an alternative is required before anything will work with DDEV. This is pretty easy on most environments; see the [Docker Installation](../users/install/docker-installation.md) page to help sort out the details.                                                                                                        
     │                                                                                                                                                                                                                                                                         ───────────────────┬───────────────────                                                                                                                                            
     │                                                                                                                                                                                                                                                                                            ╰───────────────────── page does not exist                                                                                                                      
─────╯
19 issues found
Aborted because --strict flag is set
zensical: attempt 1 hit the known cache race (see https://github.com/zensical/zensical/issues/641), retrying...
Build started
No issues found
Build finished in 1.16s
zensical: 
Build started
No issues found
Build finished in 1.05s
zensical: 
Build started
No issues found
Build finished in 1.72s
zensical: 
Build started
No issues found
Build finished in 1.72s
```


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
