### PR TITLE
ci(linux): use full homebrew formulae name, fixes #8450

### DIFF
--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -231,9 +231,7 @@ echo "capath=/etc/ssl/certs/" >>~/.curlrc
 
 source ~/.bashrc
 
-brew tap bats-core/bats-core >/dev/null
-brew tap ddev/ddev >/dev/null
-for item in bats-core ddev docker-compose ghr golangci-lint bats-assert bats-file bats-support; do
+for item in bats-core bats-core/bats-core/bats-assert bats-core/bats-core/bats-file bats-core/bats-core/bats-support ddev/ddev/ddev golangci-lint; do
   brew install $item >/dev/null || brew upgrade $item >/dev/null
 done
 

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
 
-# Requires bats-assert and bats-support
-# brew tap bats-core/bats-core &&
-# brew install bats-core bats-assert bats-support
 setup() {
   load setup.sh
 }

--- a/containers/ddev-webserver/tests/ddev-webserver/project_type.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/project_type.bats
@@ -3,9 +3,6 @@
 # Run these tests from the repo root directory, for example
 # bats tests
 
-# Requires bats-assert and bats-support
-# brew tap bats-core/bats-core &&
-# brew install bats-core bats-assert bats-support jq mkcert yq
 setup() {
   load setup.sh
 }

--- a/containers/ddev-webserver/tests/ddev-webserver/setup.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# brew install bats-core bats-core/bats-core/bats-assert bats-core/bats-core/bats-file bats-core/bats-core/bats-support
+
 bats_require_minimum_version 1.11.0
 set -eu -o pipefail
 TEST_BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"


### PR DESCRIPTION
## The Issue

- Fixes #8450

## How This PR Solves The Issue

- Updates the `linux-setup.sh` to use full names for Homebrew trust.
- Removes unused `docker-compose` and `ghr` formulae.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
