### PR TITLE
fix(dbserver): use wrapper scripts for MariaDB 11.x+ MySQL compat, fixes #6861

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -34,11 +34,6 @@ RUN <<EOF
     fi
 EOF
 
-# MariaDB 11.x moved MySQL symlinks into separate packages
-RUN set -x; if ( command -v mariadbd && ! command -v mysqld ); then \
-    apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" mariadb-server-compat mariadb-client-compat; \
-    fi
-
 # Older versions of mariadb have been removed from
 # the mariadb apt repository, so we don't want to
 # look there when doing apt-get update. And we don't use new packages from there.
@@ -115,6 +110,9 @@ ARG MYSQL_UNIX_PORT=/var/tmp/mysql.sock
 RUN mkdir -p /var/log /var/tmp/mysqlbase /etc/mysql/conf.d && chmod -R ugo+wx /var/log /var/tmp/mysqlbase /etc/mysql/conf.d
 RUN  ln -sf /tmp/mysqlx.sock ${MYSQL_UNIX_PORT}
 RUN if ! id mysql &>/dev/null ; then useradd -u 112 mysql; fi
+
+# Install MySQL compatibility wrappers for MariaDB 11.x+ (needed by create_base_db.sh and at runtime)
+RUN /mariadb-compat-install.sh
 
 # Build a starter base db
 RUN /create_base_db.sh

--- a/containers/ddev-dbserver/files/create_base_db.sh
+++ b/containers/ddev-dbserver/files/create_base_db.sh
@@ -29,7 +29,7 @@ if [ "${mysqld_version}" = "5.7" ] || [[  "${mysqld_version%%%.*}" =~ ^8.[04]$ ]
   mysqld --defaults-file=/var/tmp/my.cnf --initialize-insecure --datadir=${DATADIR:-/var/lib/mysql} --server-id=0
 else
   # mysql 5.5 requires running mysql_install_db in /usr/local/mysql
-  if command -v mysqld | grep usr.local; then
+  if command -v mysqld | grep -q /usr/local/mysql; then
     cd /usr/local/mysql
   fi
   mysql_install_db --defaults-file=/var/tmp/my.cnf --force --datadir=${DATADIR:-/var/lib/mysql}

--- a/containers/ddev-dbserver/files/mariadb-compat-install.sh
+++ b/containers/ddev-dbserver/files/mariadb-compat-install.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
 # This script installs MySQL compatibility wrappers for MariaDB commands.
-# Two packages provide these commands:
-# - mariadb-server-compat: server commands (mysqld, mysqld_multi, etc.)
-# - mariadb-client-compat: client commands (mysql, mysqladmin, etc.)
-# These packages show deprecation warnings.
+# It detects whether wrappers are needed by checking for the mariadbd binary
+# (present in MariaDB 11.x+ where MySQL symlinks were moved to separate packages).
 #
 # The script creates wrappers for all MariaDB commands and points them to the
 # correct binaries, avoiding deprecation warnings such as:
@@ -12,12 +10,25 @@
 
 set -eu -o pipefail
 
-DDEV_DATABASE_FAMILY=${DDEV_DATABASE%:*}
-ADD_WRAPPER=true
-# Don't add wrappers if using MySQL
-if [ "${DDEV_DATABASE_FAMILY}" = "mysql" ]; then
-  ADD_WRAPPER=false
+# Nothing to do if mariadbd doesn't exist (not MariaDB 11.x+)
+if ! command -v mariadbd >/dev/null 2>&1; then
+  echo "MariaDB compatibility wrappers: not applicable for this database"
+  exit 0
 fi
+
+# mysqld already exists natively, no wrappers needed
+if command -v mysqld >/dev/null 2>&1; then
+  echo "MariaDB compatibility wrappers: not needed (mysqld already present)"
+  exit 0
+fi
+
+if [[ ":${PATH}:" != *":/usr/local/bin:"* ]]; then
+  echo "ERROR: /usr/local/bin is not in PATH; wrappers installed there would not be accessible" >&2
+  exit 1
+fi
+mkdir -p /usr/local/bin
+
+ADD_WRAPPER=true
 
 add_or_remove_mariadb_wrapper() {
   local mysql_binary="$1"
@@ -26,18 +37,14 @@ add_or_remove_mariadb_wrapper() {
 
   # Remove mode: delete wrapper if it exists and is our script
   if [ "${ADD_WRAPPER}" = "false" ]; then
-    # Check if it's our wrapper by looking for #ddev-generated marker
     if [ -x "$script_path" ] && head -n 3 "$script_path" 2>/dev/null | grep -q "#ddev-generated"; then
       rm -f "$script_path"
     fi
     return
   fi
 
-  # Install mode: create wrapper if needed
-
   # Only proceed if target command exists (e.g., mariadb, mariadbd)
   if ! command -v "$mariadb_binary" >/dev/null 2>&1; then
-    # If target doesn't exist, remove our wrapper if it exists
     if [ -x "$script_path" ] && head -n 3 "$script_path" 2>/dev/null | grep -q "#ddev-generated"; then
       rm -f "$script_path"
     fi
@@ -99,10 +106,8 @@ add_or_remove_mariadb_wrapper mysqlrepair mariadb-check
 add_or_remove_mariadb_wrapper mysqlshow mariadb-show
 add_or_remove_mariadb_wrapper mysqlslap mariadb-slap
 
-if [ "${ADD_WRAPPER}" = "false" ]; then
-  echo "MariaDB compatibility wrappers removed for ${DDEV_DATABASE}"
-elif [ ${#INSTALLED_WRAPPERS[@]} -gt 0 ]; then
-  echo "MariaDB compatibility wrappers installed for ${DDEV_DATABASE}: ${INSTALLED_WRAPPERS[*]}"
+if [ ${#INSTALLED_WRAPPERS[@]} -gt 0 ]; then
+  echo "MariaDB compatibility wrappers installed: ${INSTALLED_WRAPPERS[*]}"
 else
-  echo "MariaDB compatibility wrappers already present for ${DDEV_DATABASE}"
+  echo "MariaDB compatibility wrappers: none needed (already present)"
 fi

--- a/containers/ddev-dbserver/test/image_general.bats
+++ b/containers/ddev-dbserver/test/image_general.bats
@@ -12,6 +12,25 @@ function setup {
   containercheck
 }
 
+@test "verify mariadb compat wrappers exist for ${DB_TYPE} ${DB_VERSION}" {
+  if [ "${DB_TYPE}" != "mariadb" ]; then
+    skip "MariaDB compat wrappers only apply to MariaDB"
+  fi
+  # Wrappers are only installed for MariaDB 11.x+ (where mariadbd exists but mysqld does not natively)
+  if ! docker exec ${CONTAINER_NAME} bash -c "command -v mariadbd >/dev/null 2>&1"; then
+    skip "mariadbd not present, wrappers not applicable for ${DB_TYPE} ${DB_VERSION}"
+  fi
+  for cmd in mysql mysqld mysqldump mysqladmin mysqlcheck; do
+    run docker exec ${CONTAINER_NAME} bash -c "command -v ${cmd} >/dev/null 2>&1"
+    [ "$status" -eq 0 ]
+  done
+  # Verify no deprecation warning from mysqld
+  run docker exec ${CONTAINER_NAME} bash -c "mysqld --version 2>&1"
+  [ "$status" -eq 0 ]
+  echo "# mysqld output: $output" >&3
+  [[ "$output" != *"Deprecated program name"* ]]
+}
+
 @test "verify apt keys are not expiring within ${DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION:-90} days" {
   if [ "${DDEV_IGNORE_EXPIRING_KEYS:-}" = "true" ]; then
     skip "Skipping because DDEV_IGNORE_EXPIRING_KEYS is set"

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-skip-ssl-wrapper-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mariadb-skip-ssl-wrapper-install.sh
@@ -14,8 +14,8 @@ set -eu -o pipefail
 DDEV_DATABASE_FAMILY=${DDEV_DATABASE%:*}
 ADD_WRAPPER=true
 
-# Don't add wrappers if not using MariaDB
-if [ "${DDEV_DATABASE_FAMILY}" != "mariadb" ]; then
+# Don't add wrappers if using MySQL
+if [ "${DDEV_DATABASE_FAMILY}" = "mysql" ]; then
   ADD_WRAPPER=false
 fi
 
@@ -65,8 +65,8 @@ add_or_remove_ssl_wrapper() {
     return
   fi
 
-  # Don't overwrite if executable file already exists and is not our wrapper
-  if [ -x "$script_path" ] && ! head -n 3 "$script_path" 2>/dev/null | grep -q "#ddev-generated"; then
+  # Don't overwrite if executable file already exists
+  if [ -x "$script_path" ]; then
     return
   fi
 
@@ -77,8 +77,10 @@ exec -a $mariadb_binary "$real_binary_path" "\$@" --skip-ssl-verify-server-cert
 EOF
 
   chmod +x "$script_path"
-  echo "Created SSL wrapper for $mariadb_binary at $script_path"
+  INSTALLED_WRAPPERS+=("$mariadb_binary")
 }
+
+INSTALLED_WRAPPERS=()
 
 # MariaDB client commands that typically connect to databases and may support SSL options
 add_or_remove_ssl_wrapper mariadb
@@ -94,8 +96,10 @@ add_or_remove_ssl_wrapper mariadb-show
 add_or_remove_ssl_wrapper mariadb-slap
 add_or_remove_ssl_wrapper mariadbcheck
 
-if [ "${ADD_WRAPPER}" = "true" ]; then
-  echo "MariaDB skip SSL verification wrappers installed for ${DDEV_DATABASE}"
-else
+if [ "${ADD_WRAPPER}" = "false" ]; then
   echo "MariaDB skip SSL verification wrappers removed for ${DDEV_DATABASE}"
+elif [ ${#INSTALLED_WRAPPERS[@]} -gt 0 ]; then
+  echo "MariaDB skip SSL verification wrappers installed for ${DDEV_DATABASE}: ${INSTALLED_WRAPPERS[*]}"
+else
+  echo "MariaDB skip SSL verification wrappers already present for ${DDEV_DATABASE}"
 fi

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -120,6 +120,51 @@ setup() {
   assert_success
 }
 
+@test "verify mariadb compat wrappers are installed and produce no deprecation warnings" {
+  for cmd in mysql mysqld mysqldump mysqladmin mysqlcheck; do
+    run docker exec "$CONTAINER_NAME" bash -c "command -v $cmd"
+    assert_success
+  done
+  run docker exec "$CONTAINER_NAME" bash -c "mysql --version 2>&1"
+  assert_success
+  refute_output --partial "Deprecated program name"
+}
+
+@test "verify mariadb compat wrappers are removed for MySQL and reinstalled for MariaDB" {
+  # Remove wrappers by switching to MySQL
+  run docker exec -e DDEV_DATABASE="mysql:8.0" "$CONTAINER_NAME" mariadb-compat-install.sh
+  assert_success
+  run docker exec "$CONTAINER_NAME" bash -c "[ -f /usr/local/bin/mysql ] && head -n 3 /usr/local/bin/mysql | grep -q '#ddev-generated' && echo 'wrapper exists' || echo 'wrapper absent'"
+  assert_output "wrapper absent"
+  # Reinstall wrappers by switching back to MariaDB
+  run docker exec -e DDEV_DATABASE="mariadb:11.8" "$CONTAINER_NAME" mariadb-compat-install.sh
+  assert_success
+  run docker exec "$CONTAINER_NAME" bash -c "command -v mysql"
+  assert_success
+}
+
+@test "verify mariadb skip-ssl wrappers are installed and contain --skip-ssl-verify-server-cert" {
+  for cmd in mariadb mariadb-admin mariadb-dump; do
+    run docker exec "$CONTAINER_NAME" bash -c "command -v $cmd"
+    assert_success
+    run docker exec "$CONTAINER_NAME" bash -c "grep -q -- '--skip-ssl-verify-server-cert' /usr/local/bin/$cmd"
+    assert_success
+  done
+}
+
+@test "verify mariadb skip-ssl wrappers are removed for MySQL and reinstalled for MariaDB" {
+  # Remove wrappers by switching to MySQL
+  run docker exec -e DDEV_DATABASE="mysql:8.0" "$CONTAINER_NAME" mariadb-skip-ssl-wrapper-install.sh
+  assert_success
+  run docker exec "$CONTAINER_NAME" bash -c "[ -f /usr/local/bin/mariadb ] && head -n 3 /usr/local/bin/mariadb | grep -q '#ddev-generated' && echo 'wrapper exists' || echo 'wrapper absent'"
+  assert_output "wrapper absent"
+  # Reinstall wrappers by switching back to MariaDB
+  run docker exec -e DDEV_DATABASE="mariadb:11.8" "$CONTAINER_NAME" mariadb-skip-ssl-wrapper-install.sh
+  assert_success
+  run docker exec "$CONTAINER_NAME" bash -c "grep -q -- '--skip-ssl-verify-server-cert' /usr/local/bin/mariadb"
+  assert_success
+}
+
 @test "verify python is installed" {
   run docker exec "${CONTAINER_NAME}" python --version
   assert_success

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -121,7 +121,7 @@ setup() {
 }
 
 @test "verify mariadb compat wrappers are installed and produce no deprecation warnings" {
-  for cmd in mysql mysqld mysqldump mysqladmin mysqlcheck; do
+  for cmd in mysql mysqldump mysqladmin mysqlcheck; do
     run docker exec "$CONTAINER_NAME" bash -c "command -v $cmd"
     assert_success
   done
@@ -132,12 +132,12 @@ setup() {
 
 @test "verify mariadb compat wrappers are removed for MySQL and reinstalled for MariaDB" {
   # Remove wrappers by switching to MySQL
-  run docker exec -e DDEV_DATABASE="mysql:8.0" "$CONTAINER_NAME" mariadb-compat-install.sh
+  run docker exec -u root -e DDEV_DATABASE="mysql:8.0" "$CONTAINER_NAME" mariadb-compat-install.sh
   assert_success
   run docker exec "$CONTAINER_NAME" bash -c "[ -f /usr/local/bin/mysql ] && head -n 3 /usr/local/bin/mysql | grep -q '#ddev-generated' && echo 'wrapper exists' || echo 'wrapper absent'"
   assert_output "wrapper absent"
   # Reinstall wrappers by switching back to MariaDB
-  run docker exec -e DDEV_DATABASE="mariadb:11.8" "$CONTAINER_NAME" mariadb-compat-install.sh
+  run docker exec -u root -e DDEV_DATABASE="mariadb:11.8" "$CONTAINER_NAME" mariadb-compat-install.sh
   assert_success
   run docker exec "$CONTAINER_NAME" bash -c "command -v mysql"
   assert_success
@@ -154,12 +154,12 @@ setup() {
 
 @test "verify mariadb skip-ssl wrappers are removed for MySQL and reinstalled for MariaDB" {
   # Remove wrappers by switching to MySQL
-  run docker exec -e DDEV_DATABASE="mysql:8.0" "$CONTAINER_NAME" mariadb-skip-ssl-wrapper-install.sh
+  run docker exec -u root -e DDEV_DATABASE="mysql:8.0" "$CONTAINER_NAME" mariadb-skip-ssl-wrapper-install.sh
   assert_success
   run docker exec "$CONTAINER_NAME" bash -c "[ -f /usr/local/bin/mariadb ] && head -n 3 /usr/local/bin/mariadb | grep -q '#ddev-generated' && echo 'wrapper exists' || echo 'wrapper absent'"
   assert_output "wrapper absent"
   # Reinstall wrappers by switching back to MariaDB
-  run docker exec -e DDEV_DATABASE="mariadb:11.8" "$CONTAINER_NAME" mariadb-skip-ssl-wrapper-install.sh
+  run docker exec -u root -e DDEV_DATABASE="mariadb:11.8" "$CONTAINER_NAME" mariadb-skip-ssl-wrapper-install.sh
   assert_success
   run docker exec "$CONTAINER_NAME" bash -c "grep -q -- '--skip-ssl-verify-server-cert' /usr/local/bin/mariadb"
   assert_success

--- a/pkg/ddevapp/global_dotddev_assets/commands/db/mysql
+++ b/pkg/ddevapp/global_dotddev_assets/commands/db/mysql
@@ -8,9 +8,4 @@
 ## DBTypes: mysql,mariadb
 ## ExecRaw: true
 
-# Prefer 'mariadb' instead of 'mysql' (older versions of MariaDB only have the 'mysql' binary)
-if [[ "${DDEV_DATABASE}" == "mariadb"* ]] && command -v mariadb >/dev/null 2>&1; then
-    mariadb "$@"
-else
-    mysql "$@"
-fi
+mysql "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/db/mysqldump.example
+++ b/pkg/ddevapp/global_dotddev_assets/commands/db/mysqldump.example
@@ -8,9 +8,4 @@
 ## DBTypes: mysql,mariadb
 ## ExecRaw: true
 
-# Prefer mariadb-dump instead of mysqldump if available
-if [[ "${DDEV_DATABASE}" == "mariadb"* ]] && command -v mariadb-dump >/dev/null 2>&1; then
-    mariadb-dump "$@"
-else
-    mysqldump "$@"
-fi
+mysqldump "$@"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,13 +20,13 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260601_stasadev_n_install" // Note that this can be overridden by make
+var WebTag = "20260608_stasadev_mariadb_compat" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20260607_mariadb_12_3"
+var BaseDBTag = "20260608_stasadev_mariadb_compat"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION
## The Issue

- Fixes #6861

MariaDB 11.x+ moved MySQL symlinks into separate `mariadb-server-compat` / `mariadb-client-compat` packages, causing MySQL commands to fail in the dbserver unless those packages were installed. The previous fix used `apt-get install` of those compat packages, but they trigger deprecation warnings like "mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead."

## How This PR Solves The Issue

Replaces the inline `apt-get install mariadb-server-compat mariadb-client-compat` in `ddev-dbserver/Dockerfile` with a dedicated `mariadb-compat-install.sh` script (matching the approach already used in the webserver). The script creates lightweight `#ddev-generated` wrapper scripts in `/usr/local/bin/` that exec the native MariaDB binaries under their MySQL-compatible names, avoiding both the missing-binary problem and deprecation warnings.

Also tightens the `grep usr.local` path check in `create_base_db.sh` to `grep -q /usr/local/mysql`, which previously matched the new wrapper at `/usr/local/bin/mysqld` and caused a spurious `cd /usr/local/mysql` failure.

Fixes both webserver wrapper scripts (`mariadb-compat-install.sh` and `mariadb-skip-ssl-wrapper-install.sh`) to correctly report "already present" instead of "installed/removed" on subsequent runs, and tightens the skip-ssl script's overwrite guard to match the compat script (skip if any executable already exists, not just non-ddev-generated ones).

Simplifies `commands/db/mysql` and `commands/db/mysqldump.example` to call `mysql`/`mysqldump` directly, removing the `mariadb`/`mariadb-dump` preference logic - the wrappers now handle deprecation warnings transparently so the conditional is no longer needed.

## Manual Testing Instructions

1. Run `ddev start` with a MariaDB 11.x or 12.x project
2. Confirm `ddev exec -s db mysqld --version` and `ddev exec -s db mysql --version` work without deprecation warnings
3. Confirm `ddev exec -s db mysqldump --version` works
4. Run `ddev snapshot` and restore to verify backup/restore still functions

## Automated Testing Overview

- Added a bats test in `containers/ddev-dbserver/test/image_general.bats` that verifies the MariaDB compat wrappers (`mysql`, `mysqld`, `mysqldump`, `mysqladmin`, `mysqlcheck`) are present and that `mysqld --version` produces no deprecation warning. Skips automatically for non-MariaDB and older versions where wrappers are not needed.
- Added four bats tests in `containers/ddev-webserver/tests/ddev-webserver/general.bats`: verifying the MariaDB compat wrappers are installed without deprecation warnings, the compat install/remove toggle, the skip-SSL wrappers contain `--skip-ssl-verify-server-cert`, and the skip-SSL install/remove toggle.

## Release/Deployment Notes

Requires rebuilding both `ddev-dbserver` and `ddev-webserver` images. The `versionconstants.go` image tags are updated to point at the new builds. No config changes required for end users.