### PR TITLE
docs: add details on changing from Homebrew to a specific version (#8459) [skip ci]

### DIFF
--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -189,11 +189,15 @@ For Debian/Ubuntu/WSL2 with DDEV installed via apt, you can run `sudo apt-get up
 
 #### Homebrew
 
-If you’re using Homebrew, first run `brew unlink ddev` to get rid of the version you have there. Then use one of these options:
+Homebrew itself abandoned the ability to specify versions a few years ago, so the Homebrew install must be removed first: run `brew unlink ddev` to get rid of the version you have there. Then use one of these options:
 
 1. Download the version you want from the [releases page](https://github.com/ddev/ddev/releases) and place it in your `$PATH`.
 2. Use the [install_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev.sh) script with the version number argument. For example, if you want `v1.23.5`, run `curl -fsSL https://ddev.com/install.sh | bash -s v1.23.5`.
 3. If you want the very latest, unreleased version of DDEV, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD`.
+
+To go back to using homebrew, delete the installed `ddev` with `rm -f $(which ddev)`, and then install `ddev` from scratch with Homebrew.
+
+Your projects are not affected by these changes.
 
 ### Why do I have an old DDEV?
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -195,7 +195,7 @@ Homebrew itself abandoned the ability to specify versions a few years ago, so th
 2. Use the [install_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev.sh) script with the version number argument. For example, if you want `v1.23.5`, run `curl -fsSL https://ddev.com/install.sh | bash -s v1.23.5`.
 3. If you want the very latest, unreleased version of DDEV, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD`.
 
-To go back to using Homebrew, delete the installed `ddev` with `rm -f $(which ddev)`, and then install `ddev` from scratch with Homebrew.
+To go back to using Homebrew, first delete the installed `ddev` with `rm -f $(which ddev) $(which ddev-hostname)`, and then install `ddev` from scratch with Homebrew.
 
 Your projects are not affected by these changes.
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -189,13 +189,35 @@ For Debian/Ubuntu/WSL2 with DDEV installed via apt, you can run `sudo apt-get up
 
 #### Homebrew
 
-Homebrew itself abandoned the ability to specify versions a few years ago, so the Homebrew install must be removed first: run `brew unlink ddev` to get rid of the version you have there. Then use one of these options:
+Homebrew itself abandoned the ability to specify versions a few years ago, but you can still install an older release by checking out its formula from the tap's own git history, then pinning it so `brew upgrade` doesn't move it:
 
-1. Download the version you want from the [releases page](https://github.com/ddev/ddev/releases) and place it in your `$PATH`.
-2. Use the [install_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev.sh) script with the version number argument. For example, if you want `v1.23.5`, run `curl -fsSL https://ddev.com/install.sh | bash -s v1.23.5`.
-3. If you want the very latest, unreleased version of DDEV, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD`.
+```bash
+# downgrade to v1.23.5
+cd "$(brew --repository ddev/ddev)"
+git checkout "$(git rev-list -n 1 --grep='v1.23.5' HEAD)"
+HOMEBREW_NO_AUTO_UPDATE=1 brew reinstall ddev/ddev/ddev
+brew pin ddev/ddev/ddev
+git switch master
+```
 
-To go back to using Homebrew, first delete the installed `ddev` with `rm -f $(which ddev) $(which ddev-hostname)`, and then install `ddev` from scratch with Homebrew.
+To go back to the latest release:
+
+```bash
+brew unpin ddev/ddev/ddev
+brew update && brew upgrade ddev/ddev/ddev
+```
+
+If you want the very latest, unreleased version of DDEV instead, install from `HEAD`:
+
+```bash
+# switch to HEAD
+brew uninstall --force ddev
+brew install ddev/ddev/ddev --HEAD
+
+# go back to the latest release
+brew uninstall --force ddev
+brew install ddev/ddev/ddev
+```
 
 Your projects are not affected by these changes.
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -195,7 +195,7 @@ Homebrew itself abandoned the ability to specify versions a few years ago, so th
 2. Use the [install_ddev.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev.sh) script with the version number argument. For example, if you want `v1.23.5`, run `curl -fsSL https://ddev.com/install.sh | bash -s v1.23.5`.
 3. If you want the very latest, unreleased version of DDEV, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD`.
 
-To go back to using homebrew, delete the installed `ddev` with `rm -f $(which ddev)`, and then install `ddev` from scratch with Homebrew.
+To go back to using Homebrew, delete the installed `ddev` with `rm -f $(which ddev)`, and then install `ddev` from scratch with Homebrew.
 
 Your projects are not affected by these changes.
 

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -189,7 +189,7 @@ For Debian/Ubuntu/WSL2 with DDEV installed via apt, you can run `sudo apt-get up
 
 #### Homebrew
 
-Homebrew itself abandoned the ability to specify versions a few years ago, but you can still install an older release by checking out its formula from the tap's own git history, then pinning it so `brew upgrade` doesn't move it:
+Homebrew itself abandoned the ability to specify versions a few years ago, but you can still install an older release by checking out its formula from the tap's own Git history, then pinning it so `brew upgrade` doesn't move it:
 
 ```bash
 # downgrade to v1.23.5


### PR DESCRIPTION
I don't mind having my issue reports edited, but this looks a lot like LLM output. Please don't replace my words with LLM text, or make it look like I used an LLM. None of what is below is by me.

-----------------------------------



## The Issue

No issue was filed. The FAQ's Homebrew instructions for installing a specific
DDEV version were out of date and confusing: they told people to `brew unlink
ddev` and then hand-manage a second, un-brewed `ddev` binary in `$PATH`, with
no clean way back to Homebrew short of `rm -f $(which ddev) $(which
ddev-hostname)`.

Raised in Slack with @rfay: <https://drupal.slack.com/archives/C5TQRQZRR/p1781018452491059>

## How This PR Solves The Issue

Replaces the Homebrew section of "How can I install a specific version of
DDEV?" with a Homebrew-native technique, based on @stasadev's review
suggestions:

- To downgrade: check out the desired release's commit in the `ddev/ddev`
  tap's own git history, `brew reinstall` from that checked-out formula, then
  `brew pin` it so a later `brew upgrade` doesn't silently move it back to
  latest. `HOMEBREW_NO_AUTO_UPDATE=1` guards the `reinstall` step, since
  Homebrew's own auto-update can otherwise touch a tap that's mid-checkout.
- To go back: `brew unpin` and `brew upgrade`.
- For the unreleased `--HEAD` build: `brew uninstall --force ddev` +
  `brew install ddev/ddev/ddev --HEAD`, and the same pair in reverse to
  return to the latest release — replacing the old `brew unlink &&
  brew install ... --HEAD` combination, which had no matching way back.

This keeps everything inside Homebrew's own bookkeeping instead of leaving a
second, manually-managed `ddev` binary on `$PATH`.

## Manual Testing Instructions

This needs a Mac or Linux box with Homebrew and `ddev/ddev/ddev` already
installed. The key thing to verify isn't just that the reinstall changes the
version — it's that `brew pin` actually makes the downgrade survive a
subsequent `brew upgrade`, since that's the step most likely to be silently
broken.

1. Record the current version: `ddev --version`.
2. Pick an older tagged release, e.g. `v1.23.5`, and follow the FAQ's
   downgrade steps exactly:

   ```bash
   cd "$(brew --repository ddev/ddev)"
   git checkout "$(git rev-list -n 1 --grep='v1.23.5' HEAD)"
   HOMEBREW_NO_AUTO_UPDATE=1 brew reinstall ddev/ddev/ddev
   brew pin ddev/ddev/ddev
   git switch master
   ```

3. Confirm `ddev --version` now reports `v1.23.5`.
4. **This is the step that actually proves the fix**: run
   `brew update && brew upgrade` (a generic, non-targeted upgrade, as a user
   would run for routine maintenance) and check `ddev --version` again — it
   must still report `v1.23.5`. If `brew pin` weren't holding, this step
   would silently bump it back to latest.
5. Follow the FAQ's "go back" steps:

   ```bash
   brew unpin ddev/ddev/ddev
   brew update && brew upgrade ddev/ddev/ddev
   ```

   Confirm `ddev --version` now reports the latest release again.
6. Confirm the tap repo was left clean: `git -C "$(brew --repository
   ddev/ddev)" status` should show it on `master` with no local changes.
7. Separately, test the `--HEAD` path:

   ```bash
   brew uninstall --force ddev
   brew install ddev/ddev/ddev --HEAD
   ddev --version   # should show a HEAD build
   brew uninstall --force ddev
   brew install ddev/ddev/ddev
   ddev --version   # back to the latest release
   ```

8. Throughout, confirm an existing DDEV project (e.g. `ddev start` in a test
   project) keeps working across all of the above — nothing here should
   touch project configuration or database data.

## Automated Testing Overview

None. This is a documentation-only change describing manual Homebrew
commands; there's no DDEV code path to unit- or integration-test.

## Release/Deployment Notes

Docs only, no code or behavior changes.
