### PR TITLE
fix(ssh): use RawCmd to avoid double-sourcing bashrc, fixes #5232

### DIFF
--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -43,11 +43,14 @@ ddev ssh -d /var/www/html`,
 		// that may not have Bash.
 		shell := app.GetXDdevExtension(serviceType).SSHShell
 
-		err = app.ExecWithTty(&ddevapp.ExecOpts{
-			Service: serviceType,
-			Cmd:     shell + " -l",
-			Dir:     sshDirArg,
-			User:    serviceUser,
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
+			Service:   serviceType,
+			RawCmd:    []string{shell, "-l"},
+			Dir:       sshDirArg,
+			User:      serviceUser,
+			Tty:       true,
+			NoCapture: true,
+			SkipHooks: true,
 		})
 		if err != nil {
 			var statusErr cli.StatusError

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2618,6 +2618,8 @@ type ExecOpts struct {
 	Env []string
 	// User is the user to run as inside the container
 	User string
+	// SkipHooks skips pre-exec and post-exec hook processing.
+	SkipHooks bool
 }
 
 // Exec executes a given command in the container of given type without allocating a pty
@@ -2648,9 +2650,11 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		}
 	}
 
-	err = app.ProcessHooks("pre-exec")
-	if err != nil {
-		return "", "", fmt.Errorf("failed to process pre-exec hooks: %v", err)
+	if !opts.SkipHooks {
+		err = app.ProcessHooks("pre-exec")
+		if err != nil {
+			return "", "", fmt.Errorf("failed to process pre-exec hooks: %v", err)
+		}
 	}
 
 	// Cases to handle
@@ -2727,67 +2731,13 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	if err != nil {
 		return stdoutResult, stderrResult, err
 	}
-	hookErr := app.ProcessHooks("post-exec")
-	if hookErr != nil {
-		return stdoutResult, stderrResult, fmt.Errorf("failed to process post-exec hooks: %v", hookErr)
+	if !opts.SkipHooks {
+		hookErr := app.ProcessHooks("post-exec")
+		if hookErr != nil {
+			return stdoutResult, stderrResult, fmt.Errorf("failed to process post-exec hooks: %v", hookErr)
+		}
 	}
 	return stdoutResult, stderrResult, err
-}
-
-// ExecWithTty executes a given command in the container of given type.
-// It allocates a pty for interactive work.
-func (app *DdevApp) ExecWithTty(opts *ExecOpts) error {
-	_ = app.DockerEnv()
-
-	if opts.Service == "" {
-		opts.Service = "web"
-	}
-
-	state, err := dockerutil.GetContainerStateByName(fmt.Sprintf("ddev-%s-%s", app.Name, opts.Service))
-	if err != nil || state != "running" {
-		return fmt.Errorf("service %s is not running in project %s (state=%s)", opts.Service, app.Name, state)
-	}
-
-	if opts.Cmd == "" {
-		return fmt.Errorf("no command provided")
-	}
-
-	// Cases to handle
-	// - Free form, all unquoted. Like `ls -l -a`
-	// - Quoted to delay pipes and other features to container, like `"ls -l -a | grep junk"`
-	// Note that a set quoted on the host in ddev exec will come through as a single arg
-
-	// Use Bash for our containers, sh for 3rd-party containers
-	// that may not have Bash.
-	shell := "bash"
-	if !nodeps.ArrayContainsString([]string{"web", "db"}, opts.Service) {
-		shell = "sh"
-	}
-
-	withTtyProject, loadErr := dockerutil.LoadComposeProject([]string{app.DockerComposeFullRenderedYAMLPath()}, api.ProjectLoadOptions{
-		ProjectName: app.GetComposeProjectName(),
-	})
-	if loadErr != nil {
-		return loadErr
-	}
-	tty := isatty.IsTerminal(os.Stdin.Fd())
-	restore, stdinErr := dockerutil.SetExecStdin(os.Stdin, tty)
-	if stdinErr != nil {
-		return stdinErr
-	}
-	defer restore()
-	withTtyCtx, withTtySvc, svcErr := dockerutil.NewComposeService()
-	if svcErr != nil {
-		return svcErr
-	}
-	return dockerutil.ExitCodeToError(withTtySvc.Exec(withTtyCtx, withTtyProject.Name, api.RunOptions{
-		Service:     opts.Service,
-		Command:     []string{shell, "-c", opts.Cmd},
-		Tty:         tty,
-		Interactive: true,
-		User:        opts.User,
-		WorkingDir:  opts.Dir,
-	}))
 }
 
 func (app *DdevApp) ExecOnHostOrService(service string, cmd string) error {
@@ -3894,7 +3844,7 @@ func (app *DdevApp) GetProvider(providerName string) (*Provider, error) {
 	return app.ProviderInstance, err
 }
 
-// GetWorkingDir will determine the appropriate working directory for an Exec/ExecWithTty command
+// GetWorkingDir will determine the appropriate working directory for an Exec command
 // by consulting with the project configuration. If no dir is specified for the service, an
 // empty string will be returned.
 func (app *DdevApp) GetWorkingDir(service string, dir string) string {

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3236,9 +3236,14 @@ func TestDdevExec(t *testing.T) {
 	_, stderr, err = app.Exec(errorOpts)
 	assert.Error(err)
 	assert.Contains(stderr, "this: not found")
-	err = app.ExecWithTty(errorOpts)
+	// The Tty/NoCapture interactive path (used by `ddev ssh`) should also surface errors.
+	_, _, err = app.Exec(&ddevapp.ExecOpts{
+		Service:   "busybox",
+		Cmd:       "this is an error;",
+		Tty:       true,
+		NoCapture: true,
+	})
 	assert.Error(err)
-	assert.Contains(stderr, "this: not found")
 
 	// Now kill the busybox service and make sure that responses to app.Exec are correct
 	ctx, apiClient, err := dockerutil.GetDockerClient()


### PR DESCRIPTION
## The Issue

- Fixes #5232

`ddev ssh` wrapped the login shell in `bash -c`, causing `~/.bashrc.d/*` to be sourced twice.

`app.ExecWithTty` is not used anywhere except in `ddev ssh`, and `app.Exec` already covers the same functionality.

## How This PR Solves The Issue

Replace `ExecWithTty` (removed) with `Exec` using `RawCmd` so the login shell runs directly without a wrapping `bash -c`. Added `SkipHooks` to `ExecOpts` to preserve the existing behavior of not running exec hooks on `ddev ssh`.

## Manual Testing Instructions

```bash
mkdir -p .ddev/homeadditions/.bashrc.d/
echo 'echo "bashrc.d sourced"' > .ddev/homeadditions/.bashrc.d/test.bash
ddev restart
ddev ssh
```

DDEV HEAD:

```
$ ddev ssh
bashrc.d sourced
bashrc.d sourced
stas@demo-web:/var/www/html$
```

This PR:

```
$ ddev ssh
bashrc.d sourced
stas@demo-web:/var/www/html$
```

## Automated Testing Overview

Updated `TestDdevExec` to cover the interactive `Tty`/`NoCapture` path.

## Release/Deployment Notes

`ExecWithTty` is removed; callers should use `Exec` with `Tty: true` and `NoCapture: true`.
