### PR TITLE
fix(nginx): suppress favicon.ico and robots.txt 404 logs, fixes #7010

### DIFF
--- a/pkg/ddevapp/webserver_config_assets/nginx-site-asterios.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-asterios.conf
@@ -30,8 +30,15 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
 
     error_page 404 /index.php;
 

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
@@ -34,6 +34,16 @@ server {
         try_files $uri $uri/ @rewrite;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For Backdrop CMS: Clean URLs are handled by Backdrop core
         # Pass the original query string to maintain functionality

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-cakephp.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-cakephp.conf
@@ -29,6 +29,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-codeigniter.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-codeigniter.conf
@@ -29,6 +29,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     # Pass PHP scripts to FastCGI server
 
     error_page 404 /index.php;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
@@ -39,6 +39,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal.conf
@@ -31,6 +31,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string; # For Drupal >= 7
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
@@ -30,6 +30,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string; # For Drupal >= 7
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
@@ -30,6 +30,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string; # For Drupal >= 7
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal12.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal12.conf
@@ -30,6 +30,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string; # For Drupal >= 7
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
@@ -38,6 +38,16 @@ server {
         try_files $uri $uri/    @rewrite;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         rewrite ^/(.*)$ /index.php?q=$1;
     }

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
@@ -32,6 +32,16 @@ server {
         try_files $uri $uri/ /index.php?q=$uri&$args;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
@@ -30,6 +30,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
@@ -30,6 +30,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string; # For Drupal >= 7
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-joomla.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-joomla.conf
@@ -29,6 +29,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     # Joomla 4+ REST API endpoint
     location /api/ {
         try_files $uri $uri/ /api/index.php?$query_string;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
@@ -31,8 +31,15 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
 
     error_page 404 /index.php;
 

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
@@ -38,6 +38,16 @@ server {
         try_files $uri $uri/ /index.php$is_args$args;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location /api {
         rewrite ^/api/rest /api.php?type=rest last;
     }

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
@@ -79,6 +79,16 @@ server {
         try_files $uri $uri/ /index.php$is_args$args;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location /pub/ {
         location ~ ^/pub/media/(downloadable|customer|import|theme_customization/.*\.xml) {
             deny all;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
@@ -28,6 +28,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
@@ -30,6 +30,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-silverstripe.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-silverstripe.conf
@@ -29,6 +29,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-symfony.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-symfony.conf
@@ -29,6 +29,16 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -65,6 +65,16 @@ server {
         try_files $uri $uri/ /index.php$is_args$args;
     }
 
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
     # TYPO3 11 Backend URL rewriting support
     location = /typo3 {
         rewrite ^ /typo3/;
@@ -133,11 +143,6 @@ server {
     # Prevent clients from accessing to backup/config/source files
     location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
         deny all;
-    }
-
-    location = /favicon.ico {
-        log_not_found off;
-        access_log off;
     }
 
     # TYPO3 - Block access to composer files

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
@@ -31,14 +31,14 @@ server {
     # Global restrictions configuration file.
     # Designed to be included in any server {} block.
     location = /favicon.ico {
-        log_not_found off;
         access_log off;
+        log_not_found off;
     }
 
     location = /robots.txt {
         allow all;
-        log_not_found off;
         access_log off;
+        log_not_found off;
     }
 
     # Deny all attempts to access hidden files such as .htaccess, .htpasswd, .DS_Store (Mac).


### PR DESCRIPTION
## The Issue

- Fixes #7010

Without explicit location blocks, nginx passes `/favicon.ico` and `/robots.txt` requests through `try_files` to `index.php`, invoking PHP unexpectedly on every page load.

## How This PR Solves The Issue

Added `location = /favicon.ico` and `location = /robots.txt` blocks with `access_log off; log_not_found off;` to all 23 nginx site config templates, so these requests are handled by nginx directly without hitting PHP.

## Manual Testing Instructions

```bash
ddev config --project-type=php --docroot=public

cat > public/index.php <<'PHP'
<?php
$n = 'filename' . rand(5, 100000);
file_put_contents('/var/www/html/' . $n, $n);
PHP

ddev start

ddev launch
```

DDEV HEAD:

Two files are created - one from the actual request, one extra from missing `favicon.ico` being routed to PHP.

This PR:

Only one file is created.

## Automated Testing Overview

No new tests needed - config-only change.

## Release/Deployment Notes