### PR TITLE
fix: recreate service on `ddev utility rebuild -s`, support profile services

### DIFF
--- a/cmd/ddev/cmd/debug-rebuild.go
+++ b/cmd/ddev/cmd/debug-rebuild.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
@@ -65,12 +68,23 @@ var DebugRebuildCmd = &cobra.Command{
 
 		if withoutCache {
 			output.UserOut.Printf("Rebuilding project images without Docker cache...")
-			additionalImages, findErr := app.FindAllImages()
-			if findErr != nil {
-				util.Warning("Unable to find project images: %v", findErr)
-			}
-			if pullErr := ddevapp.PullBaseContainerImages(additionalImages, true); pullErr != nil {
-				util.Warning("Unable to pull Docker images: %v", pullErr)
+			if buildAll {
+				additionalImages, findErr := app.FindAllImages()
+				if findErr != nil {
+					util.Warning("Unable to find project images: %v", findErr)
+				}
+				if pullErr := ddevapp.PullBaseContainerImages(additionalImages, true); pullErr != nil {
+					util.Warning("Unable to pull Docker images: %v", pullErr)
+				}
+			} else {
+				// Only pull the base image for the service being rebuilt, not the whole project.
+				serviceImages, findErr := app.FindServiceImages(services)
+				if findErr != nil {
+					util.Warning("Unable to find images for service %s: %v", service, findErr)
+				}
+				if pullErr := dockerutil.PullImages(serviceImages, true); pullErr != nil {
+					util.Warning("Unable to pull Docker images: %v", pullErr)
+				}
 			}
 		} else {
 			output.UserOut.Printf("Rebuilding project images using Docker cache...")
@@ -78,15 +92,16 @@ var DebugRebuildCmd = &cobra.Command{
 
 		buildProject, loadErr := dockerutil.LoadComposeProject([]string{composeRenderedPath}, api.ProjectLoadOptions{
 			ProjectName: app.GetComposeProjectName(),
+			Profiles:    []string{`*`},
 		})
 		if loadErr != nil {
 			util.Failed("Failed to load compose project: %v", loadErr)
 		}
-		buildCtx, buildSvc, svcErr := dockerutil.NewComposeService()
+		composeCtx, composeSvc, svcErr := dockerutil.NewComposeService()
 		if svcErr != nil {
 			util.Failed("Failed to create compose service: %v", svcErr)
 		}
-		err = buildSvc.Build(buildCtx, buildProject, api.BuildOptions{
+		err = composeSvc.Build(composeCtx, buildProject, api.BuildOptions{
 			Progress: display.ModePlain,
 			NoCache:  withoutCache,
 			Services: services,
@@ -120,27 +135,43 @@ var DebugRebuildCmd = &cobra.Command{
 			"com.docker.compose.service": service,
 		}
 
-		// Restart the specified service using compose, if it is running
+		// Recreate the specified service using compose, if it is running
 		if container, err := dockerutil.FindContainerByLabels(labels); err == nil && container != nil {
-			output.UserOut.Printf("Restarting service %s...", service)
+			output.UserOut.Printf("Recreating service %s...", service)
 
-			// Restart the specific service via compose
-			restartCtx, restartSvc, restartErr := dockerutil.NewComposeService()
-			if restartErr != nil {
-				util.Failed("Failed to create compose service: %v", restartErr)
+			// Narrow to the target service and drop its dependency edges so we don't disturb other services.
+			recreateProject, selErr := buildProject.WithSelectedServices([]string{service}, types.IgnoreDependencies)
+			if selErr != nil {
+				util.Failed("Failed to select service %s: %v", service, selErr)
 			}
-			restartTimeout := 60 * time.Second
-			err = restartSvc.Restart(restartCtx, buildProject.Name, api.RestartOptions{
-				Project:  buildProject,
-				Services: []string{service},
-				Timeout:  &restartTimeout,
+
+			// Recreate rather than restart: a plain restart keeps the old container and image,
+			// so the rebuilt image would never be applied, and a fresh container avoids
+			// startup-delay healthchecks triggered by restarting a previously-healthy container.
+			progress := display.ModeQuiet
+			if globalconfig.DdevVerbose {
+				progress = display.ModePlain
+			}
+			recreateTimeout := time.Duration(app.GetMaxContainerWaitTime()) * time.Second
+			err = composeSvc.Up(composeCtx, recreateProject, api.UpOptions{
+				Create: api.CreateOptions{
+					Services: []string{service},
+					Recreate: api.RecreateForce,
+					Timeout:  &recreateTimeout,
+					Build:    &api.BuildOptions{Progress: progress},
+				},
+				Start: api.StartOptions{
+					Project:  recreateProject,
+					Services: []string{service},
+				},
 			})
 			if err != nil {
-				util.Failed("Failed to restart service %s: %v", service, err)
+				util.Failed("Failed to recreate service %s: %v", service, err)
 			}
 
-			output.UserOut.Printf("Waiting for project container [%v] to become ready...", service)
-			err = app.WaitByLabels(labels)
+			wait := output.StartWait(fmt.Sprintf("Waiting for containers to become ready: %v", []string{service}))
+			err = app.Wait([]string{service})
+			wait.Complete(err)
 			if err != nil {
 				util.Failed("Failed to wait for project container [%v] to become ready: %v", service, err)
 			}
@@ -151,7 +182,7 @@ var DebugRebuildCmd = &cobra.Command{
 					util.Failed("Failed to start %s: %v", nodeps.RouterContainer, err)
 				}
 			}
-			util.Success("Restarted %s service for %s", service, app.GetName())
+			util.Success("Recreated %s service for %s", service, app.GetName())
 		}
 	},
 }

--- a/cmd/ddev/cmd/debug-rebuild_test.go
+++ b/cmd/ddev/cmd/debug-rebuild_test.go
@@ -114,24 +114,21 @@ RUN shuf -i 0-99999 -n1 > /random-db.txt
 	_, err = exec.RunHostCommand(DdevBin, "utility", "rebuild", "--service", "db")
 	require.NoError(t, err)
 
-	// It should remain the same for web
-	err = app.Restart()
-	require.NoError(t, err)
-	freshRandomWebNew, _, err := app.Exec(&ddevapp.ExecOpts{
-		Cmd: "cat /random-web.txt",
-	})
-	require.NoError(t, err)
-	assert.Equal(freshRandomWeb, freshRandomWebNew)
-
-	// And we should see a new value for db
-	err = app.Restart()
-	require.NoError(t, err)
+	// rebuild --service recreates the container with the freshly-built image,
+	// so the new value must be visible immediately, without an extra restart.
 	freshRandomDBNew, _, err := app.Exec(&ddevapp.ExecOpts{
 		Cmd:     "cat /random-db.txt",
 		Service: "db",
 	})
 	require.NoError(t, err)
 	assert.NotEqual(freshRandomDB, freshRandomDBNew)
+
+	// web was not rebuilt, so it must remain unchanged and untouched by the db rebuild.
+	freshRandomWebNew, _, err := app.Exec(&ddevapp.ExecOpts{
+		Cmd: "cat /random-web.txt",
+	})
+	require.NoError(t, err)
+	assert.Equal(freshRandomWeb, freshRandomWebNew)
 
 	// Repeat the same with all services, but use cache
 	_, err = exec.RunHostCommand(DdevBin, "utility", "rebuild", "--all", "--cache")
@@ -155,4 +152,13 @@ RUN shuf -i 0-99999 -n1 > /random-db.txt
 	})
 	require.NoError(t, err)
 	assert.Equal(cachedRandomDB, freshRandomDBNew)
+
+	// Rebuilding an optional, profile-gated service (xhgui) must work too. This
+	// exercises the profile-aware project load; without it the recreation step
+	// fails with "no such service: xhgui".
+	out, err := exec.RunHostCommand(DdevBin, "xhgui", "on")
+	require.NoError(t, err, "xhgui on failed: %s", out)
+	out, err = exec.RunHostCommand(DdevBin, "utility", "rebuild", "--service", "xhgui")
+	require.NoError(t, err, "rebuild --service xhgui failed: %s", out)
+	require.Contains(t, out, "Recreated xhgui service")
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2388,11 +2388,20 @@ func PullBaseContainerImages(additionalImages []string, pullAlways bool) error {
 
 // FindAllImages returns an array of image tags for all containers in the compose file
 func (app *DdevApp) FindAllImages() ([]string, error) {
+	return app.FindServiceImages(nil)
+}
+
+// FindServiceImages returns an array of image tags for the named services in the
+// compose file. A nil/empty serviceNames returns images for all services.
+func (app *DdevApp) FindServiceImages(serviceNames []string) ([]string, error) {
 	var images []string
 	if app.ComposeYaml == nil || app.ComposeYaml.Services == nil {
 		return images, nil
 	}
-	for _, service := range app.ComposeYaml.Services {
+	for name, service := range app.ComposeYaml.Services {
+		if len(serviceNames) > 0 && !slices.Contains(serviceNames, name) {
+			continue
+		}
 		image := service.Image
 		if image == "" {
 			continue


### PR DESCRIPTION
## The Issue

- From Drupal Slack https://drupal.slack.com/archives/C5TQRQZRR/p1781083258776979

After the move to the Docker Compose SDK, `ddev utility rebuild -s <service>` broke for profile-gated services (for example `xhgui`, started via `ddev xhgui on`, or services behind `ddev start --profiles=...`): the build succeeds but the restart fails with `no such service`. The project was loaded without enabling compose profiles, so profile-gated services ended up in `DisabledServices`. Compose `Build` re-enables the services it is given, but `Restart` does not, so it could not find them.

A plain `restart` is also the wrong operation for a rebuild: it reuses the existing container (and therefore the old image), so the freshly built image is never applied, and restarting a previously-healthy container can trigger a long healthcheck startup delay (the `ddev-xhgui` healthcheck sleeps ~59s when it sees a previously-healthy marker).

---

We should figure out what's wrong with healthcheck https://discord.com/channels/664580571770388500/1385079277753597992/1385293828587655278

> I also noticed that `ddev debug rebuild` may take longer with healthcheck. Some services may get stuck showing starting status. But I never found out why and how to solve it.

> (`ddev debug rebuild` doesn't wait for anything if the project is stopped.)

---

DDEV v1.25.2:

(And it's stuck for around a minute while waiting `Waiting for project container [xhgui] to become ready...`, this is another bug, which is also fixed in this PR.)

```
$ ddev start && ddev xhgui on && ddev utility rebuild -s xhgui
...
WARN[0000] No services to build
Rebuilt xhgui service cache for demo in 0s
Executing `/home/stas/.ddev/bin/docker-compose -f /home/stas/code/pet/demo/.ddev/.ddev-docker-compose-full.yaml --progress plain restart xhgui`
 Container ddev-demo-xhgui Restarting
 Container ddev-demo-xhgui Started
Waiting for project container [xhgui] to become ready...
ddev-router already running, pushing new config...
Waiting for ddev-router to become ready... ready in 0.5s
Restarted xhgui service for demo
```

DDEV HEAD:

```text
$ ddev start && ddev xhgui on && ddev utility rebuild -s xhgui
...
No services to build
Rebuilt xhgui service cache for demo in 4s
Restarting service xhgui...
Failed to restart service xhgui: no such service: xhgui
```

## How This PR Solves The Issue

- Load the compose project with all profiles enabled (`Profiles: ["*"]`) so profile-gated services are resolvable for the recreate step. This matches how the rest of the codebase loads the full rendered project for down/stop.
- Recreate the service with `Up` + `RecreateForce` (scoped to the service via `WithSelectedServices(..., IgnoreDependencies)`) instead of `Restart`. This  applies the freshly built image and starts a fresh container, which also avoids the previously-healthy healthcheck startup delay.
- For a targeted `-s <service>` rebuild, pull only that service's base image  instead of every project image (added `DdevApp.FindServiceImages`).
- Use the project's container wait timeout instead of a hard-coded 60s, and show the elapsed wait time (`Waiting for containers to become ready: [xhgui]... ready in 1.5s`).

## Manual Testing Instructions

This PR:

(And see that it's not stuck on the `Waiting for containers to become ready` line anymore.)

```bash
$ ddev start && ddev xhgui on && ddev utility rebuild -s xhgui
...
No services to build
Rebuilt xhgui service cache for demo in 2s
Recreating service xhgui...
[+] up 1/1
 ✔ Container ddev-demo-xhgui Recreated          0.7s
Waiting for containers to become ready: [xhgui]... ready in 1.5s # timeout instead of a hard-coded 60s, and show the elapsed wait time
ddev-router already running, pushing new config...
Recreated xhgui service for demo
```

## Automated Testing Overview

`TestDebugRebuildCmd` is extended:

- After `ddev utility rebuild --service db`, it now asserts the new image is live immediately (reads `/random-db.txt` without an intervening `app.Restart()`), proving the recreate applies the freshly built image. The old `restart`-based code would have passed only because the test restarted before checking.
- Adds a profile-gated case: `ddev xhgui on` then `ddev utility rebuild --service xhgui`, asserting success and the `Recreated xhgui service` message. This exercises the profile-aware project load that the bug fix depends on.

## Release/Deployment Notes

`ddev utility rebuild -s <service>` now recreates the service (applying the freshly built image) instead of restarting it, and targeted rebuilds pull only the relevant service's base image rather than all project images. No config or data changes.