### PR TITLE
feat(windows): support Debian and Kali WSL2 distros in GUI installer, fixes #8439, fixes #8468

### DIFF
--- a/.buildkite/dump-docker-desktop-state.sh
+++ b/.buildkite/dump-docker-desktop-state.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# dump-docker-desktop-state.sh [distro] [label]
+#
+# One-shot diagnostic dump of Docker Desktop / WSL2 integration state on a
+# Windows test runner. Used to understand Docker Desktop start/stop behavior and
+# WSL2-integration loss across Buildkite jobs. Best-effort: never fails (always
+# exits 0), every probe is guarded, so it is safe to call from a trap or
+# anywhere else.
+#
+# Usage:
+#   bash dump-docker-desktop-state.sh [distro] [label]
+
+# Disable git-bash POSIX->Windows path conversion so the slash-flags below
+# (tasklist.exe //FI, schtasks.exe //Query) and the in-distro Linux paths inside
+# the bash -c strings are passed through verbatim.
+export MSYS_NO_PATHCONV=1
+
+DISTRO="${1:-}"
+LABEL="${2:-}"
+
+echo "===== dump-docker-desktop-state ${LABEL:+[$LABEL] }$(date '+%H:%M:%S') ====="
+
+echo -n "docker desktop status:   "
+docker desktop status 2>&1 | grep -iE "Status|Could not" | head -1 || echo "(error)"
+
+echo -n "host docker ps:          "
+if docker ps --format "{{.Names}}" 2>/dev/null | tr '\n' ' '; then echo "(ok)"; else echo "(FAILED)"; fi
+
+echo "Docker Desktop-related Windows processes (name / PID):"
+tasklist.exe //FI "IMAGENAME eq Docker Desktop.exe" //FO CSV //NH 2>/dev/null | grep -i "docker" | sed 's/^/  /' || true
+tasklist.exe //FI "IMAGENAME eq com.docker.backend.exe" //FO CSV //NH 2>/dev/null | grep -i "docker" | sed 's/^/  /' || true
+tasklist.exe //FI "IMAGENAME eq com.docker.service" //FO CSV //NH 2>/dev/null | grep -i "docker" | sed 's/^/  /' || true
+
+echo -n "scheduled task DDEVStartDockerDesktopDetached: "
+schtasks.exe //Query //TN "DDEVStartDockerDesktopDetached" //FO LIST 2>/dev/null \
+    | grep -iE "Status|Last Run Time|Last Result" | tr '\n' ' ' || echo -n "(not registered)"
+echo ""
+
+echo "WSL running distros:"
+wsl.exe -l --running 2>/dev/null | tr -d '\0' | sed 's/^/  /' || echo "  (wsl error)"
+
+if [ -n "$DISTRO" ]; then
+    echo -n "distro[$DISTRO] docker ps:        "
+    if wsl.exe -d "$DISTRO" -- docker ps --format "{{.Names}}" 2>/dev/null | tr '\n' ' '; then echo "(ok)"; else echo "(FAILED)"; fi
+
+    echo -n "distro[$DISTRO] /usr/bin/docker:   "
+    wsl.exe -d "$DISTRO" -- bash -c \
+        'if [ -L /usr/bin/docker ]; then t=$(readlink /usr/bin/docker); if [ -x /usr/bin/docker ]; then echo "symlink -> $t (TARGET OK)"; else echo "symlink -> $t (TARGET BROKEN)"; fi; elif [ -f /usr/bin/docker ]; then echo "regular file (docker-ce-cli)"; else echo "MISSING"; fi' 2>/dev/null || echo "(distro error)"
+
+    echo -n "distro[$DISTRO] cli-tools binary:  "
+    wsl.exe -d "$DISTRO" -- bash -c \
+        'f=/mnt/wsl/docker-desktop/cli-tools/usr/bin/docker; if [ -x "$f" ]; then echo "EXISTS and executable"; elif [ -f "$f" ]; then echo "exists but not executable"; elif [ -d /mnt/wsl/docker-desktop/cli-tools ]; then echo "cli-tools dir exists but docker MISSING"; elif [ -d /mnt/wsl/docker-desktop ]; then echo "mount exists but cli-tools dir MISSING"; else echo "mount NOT PRESENT"; fi' 2>/dev/null || echo "(distro error)"
+
+    echo -n "distro[$DISTRO] docker.sock:       "
+    wsl.exe -d "$DISTRO" -- bash -c '[ -S /var/run/docker.sock ] && echo "exists" || echo "MISSING"' 2>/dev/null || echo "(distro error)"
+
+    echo -n "distro[$DISTRO] WSLInterop:        "
+    wsl.exe -d "$DISTRO" -- bash -c '[ -f /proc/sys/fs/binfmt_misc/WSLInterop ] && grep -q enabled /proc/sys/fs/binfmt_misc/WSLInterop 2>/dev/null && echo "registered+enabled" || echo "MISSING/disabled"' 2>/dev/null || echo "(distro error)"
+fi
+
+echo "===== end dump-docker-desktop-state ${LABEL:+[$LABEL]} ====="
+exit 0

--- a/.buildkite/installer-test.cmd
+++ b/.buildkite/installer-test.cmd
@@ -1,0 +1,10 @@
+@echo "Running Windows installer test using bash"
+
+"C:\Program Files\git\bin\bash" .buildkite/installer-test.sh
+
+if %ERRORLEVEL% EQU 0 (
+   @echo Successful installer test
+) else (
+   @echo Failure Reason Given is %errorlevel%
+   exit /b %errorlevel%
+)

--- a/.buildkite/installer-test.sh
+++ b/.buildkite/installer-test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+# Runs the Windows installer tests in their own dedicated Buildkite pipeline,
+# decoupled from .buildkite/test.sh (the traditional Windows suite). Each
+# Buildkite job runs a single matrix case selected by INSTALLER_CASE (the
+# instance/subtest name, e.g. "ddev-test-debian-ce").
+#
+# Requires a Windows-native agent (GOOS=windows) with the named test distro
+# already provisioned (see docs/content/developers/buildkite-testmachine-setup.md).
+
+set -eu -o pipefail
+
+# Disable git pager
+export GIT_PAGER=""
+
+# On Windows: at job exit, DO NOT touch Docker Desktop's run state — only dump
+# diagnostics. We previously stopped + relaunched Docker Desktop here (via a
+# scheduled task) to make it survive Buildkite Job Object teardown, but that
+# churn destabilized Docker Desktop: stopping it truncated the shared
+# /mnt/wsl/docker-desktop/docker-desktop-user-distro proxy binary to 0 bytes,
+# and the headless relaunch failed to re-copy it — leaving an unrecoverable
+# 0-byte stub that breaks WSL2 integration for ALL distros (DD's own "Restart
+# the WSL integration" cannot rebuild it; in one case Docker Desktop became
+# unstoppable and the runner had to be rebooted). Leaving Docker Desktop
+# completely alone is the fix: if it dies with the job object, the next job's
+# sanetestbot.sh does a clean full start, which re-copies the proxy binary
+# correctly. trap EXIT fires on success, failure, or set -e early exit.
+if command -v wsl.exe >/dev/null 2>&1; then
+    # Best-effort distro for diagnostics, derived from the matrix case.
+    case "${INSTALLER_CASE:-}" in
+        ddev-test-*)        DIAG_DISTRO="${INSTALLER_CASE}" ;;
+        ps1-docker-desktop) DIAG_DISTRO="ddev-test-ubuntu-desktop" ;;
+        *)                  DIAG_DISTRO="" ;;
+    esac
+    trap 'echo "=== installer-test EXIT trap: Docker Desktop state at job exit (read-only diagnostics) ===";
+        bash "$(dirname "$0")/dump-docker-desktop-state.sh" "'"${DIAG_DISTRO}"'" "job-exit" || true' EXIT
+fi
+
+# Note: [skip ci]/[skip buildkite] gating is handled by the step `if` in
+# .buildkite/windows-installer.yml, which still lets manual (UI) builds run.
+# Don't re-check the commit message here, or manual triggers of a [skip ci]
+# commit would self-skip.
+
+# Only run when relevant files changed. The relevant-paths set is per-case: the
+# ps1 script cases run only when a ps1 script (or its test/plumbing) changes; the
+# installer cases run on winpkg/ changes. Automatic (webhook) builds on a non-main
+# branch skip unless their diff matches; pushes to main and manual (UI/API) builds
+# always run. Mirrors the diff-gating in test.sh.
+case "${INSTALLER_CASE:-}" in
+  ps1-*)
+    RELEVANT='^(scripts/install_ddev_wsl2_.*\.ps1$|winpkg/wsl2_install_scripts_test\.go$|\.buildkite/installer-test\.(sh|cmd)$|\.buildkite/windows-installer\.yml$)'
+    ;;
+  *)
+    RELEVANT='^(winpkg/|\.buildkite/installer-test\.(sh|cmd)$|\.buildkite/windows-installer\.yml$)'
+    ;;
+esac
+if [ "${BUILDKITE_SOURCE:-}" = "webhook" ] && [ "${BUILDKITE_BRANCH:-}" != "main" ]; then
+  BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
+  MERGE_BASE=$(git merge-base HEAD "refs/remotes/origin/${BASE_BRANCH}" 2>/dev/null || true)
+  if [ -n "${MERGE_BASE}" ] && ! git diff --name-only "${MERGE_BASE}" | grep -E "${RELEVANT}" >/dev/null; then
+    echo "+++ SKIP: No relevant changes for INSTALLER_CASE=${INSTALLER_CASE:-<all>}"
+    exit 0
+  fi
+fi
+
+# Load public variables (e.g. signing-related vars used by the installer build)
+git fetch --depth=1 --no-tags https://github.com/ddev/ddev public-variables:refs/public-variables-tmp
+while IFS= read -r varname; do
+  [[ "$varname" == "README.md" ]] && continue
+  # MSYS_NO_PATHCONV prevents Git for Windows bash from mangling the ref:path syntax
+  value=$(MSYS_NO_PATHCONV=1 git show "refs/public-variables-tmp:.github/public-variables/$varname")
+  echo "$varname=${value}"
+  export "$varname=$value"
+done < <(MSYS_NO_PATHCONV=1 git ls-tree --name-only refs/public-variables-tmp:.github/public-variables/)
+git update-ref -d refs/public-variables-tmp
+
+export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
+
+export DDEV_NONINTERACTIVE=true
+export DDEV_DEBUG=true
+
+# Find a suitable timeout command
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT="gtimeout"
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT="timeout"
+else
+  echo "Error: Neither 'gtimeout' nor 'timeout' found in PATH." >&2
+  exit 1
+fi
+
+echo
+echo "buildkite installer test ${BUILDKITE_JOB_ID:-} at $(date) on $(hostname) as USER=${USER:-unknown} INSTALLER_CASE=${INSTALLER_CASE:-<all>} in ${PWD} golang=$(go version | awk '{print $3}')"
+
+# testbot_maintenance.sh is intentionally NOT run for the installer pipeline.
+# Its 'docker rm -f $(docker ps -aq)' kills Docker Desktop's internal containers,
+# disrupting WSL2 integration. The installer tests manage their own cleanup;
+# the heavy-handed Docker/volume pruning in testbot_maintenance.sh is both
+# unnecessary and harmful here.
+
+# Start Docker Desktop if this case uses it (provider setup), before sanetestbot.sh
+# checks it. sanetestbot.sh only checks; it does not start Docker Desktop. No-op
+# for docker-ce-inside cases.
+echo "--- ensuring Docker Desktop is started (if this case uses it)"
+${TIMEOUT} 4m bash "$(dirname "$0")/start-docker-desktop.sh" || true
+
+# Our testbot should be sane, run the testbot checker to make sure.
+echo "--- running sanetestbot.sh"
+${TIMEOUT} 5m bash "$(dirname "$0")/sanetestbot.sh"
+
+echo "~~~ Setup complete, starting test"
+
+# Dispatch on INSTALLER_CASE (one Buildkite job per matrix case):
+#   ps1-<subtest>   -> the WSL2 install-script test (no installer .exe build)
+#   ddev-test-<...> -> the GUI installer test for that instance
+#   <empty>         -> all installer cases (local/manual invocation)
+export DDEV_TEST_USE_REAL_INSTALLER=true
+case "${INSTALLER_CASE:-}" in
+  ps1-*)
+    echo "--- Running WSL2 install-script test: ${INSTALLER_CASE#ps1-}"
+    make testwsl2scripts TESTARGS="-run TestWSL2InstallScripts/${INSTALLER_CASE#ps1-} ${TESTARGS:-}" | sed -u 's/^--- FAIL:/+++ FAIL:/; /\//!s/^=== RUN /--- RUN /'
+    ;;
+  traditional)
+    echo "--- Running Traditional Windows installer test"
+    make testwininstaller TESTARGS="-run TestWindowsInstallerTraditional ${TESTARGS:-}" | sed -u 's/^--- FAIL:/+++ FAIL:/; /\//!s/^=== RUN /--- RUN /'
+    ;;
+  ddev-test-*)
+    echo "--- Running Windows installer test: ${INSTALLER_CASE}"
+    make testwininstaller TESTARGS="-run TestWindowsInstallerWSL2/${INSTALLER_CASE} ${TESTARGS:-}" | sed -u 's/^--- FAIL:/+++ FAIL:/; /\//!s/^=== RUN /--- RUN /'
+    ;;
+  "")
+    echo "--- Running all Windows installer tests"
+    make testwininstaller TESTARGS="-run TestWindowsInstaller ${TESTARGS:-}" | sed -u 's/^--- FAIL:/+++ FAIL:/; /\//!s/^=== RUN /--- RUN /'
+    ;;
+  *)
+    echo "Unknown INSTALLER_CASE=${INSTALLER_CASE}" >&2
+    exit 1
+    ;;
+esac
+RV=$?
+
+echo "installer-test.sh completed with status=$RV"
+exit $RV

--- a/.buildkite/monitor-docker-desktop.sh
+++ b/.buildkite/monitor-docker-desktop.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# monitor-docker-desktop.sh
+#
+# Continuously shows Docker Desktop health on the Windows host.
+# Run from Git Bash on the test machine:
+#   bash .buildkite/monitor-docker-desktop.sh
+#   bash .buildkite/monitor-docker-desktop.sh ddev-test-ubuntu-desktop  # custom distro
+
+DISTRO="${1:-ddev-test-ubuntu-desktop}"
+
+while true; do
+    echo "=== $(date '+%H:%M:%S') ==="
+
+    echo -n "docker desktop status:   "
+    docker desktop status 2>&1 | grep -E "Status|Could not" | head -1 || echo "(error)"
+
+    echo -n "host docker ps:          "
+    if docker ps --format "{{.Names}}" 2>/dev/null | tr '\n' ' '; then
+        echo "(ok)"
+    else
+        echo "(FAILED)"
+    fi
+
+    echo -n "distro docker ps:        "
+    wsl.exe -d "$DISTRO" -- docker ps --format "{{.Names}}" 2>/dev/null | tr '\n' ' ' \
+        && echo "(ok)" || echo "(FAILED)"
+
+    echo -n "/usr/bin/docker:         "
+    wsl.exe -d "$DISTRO" -- bash -c \
+        "if [ -L /usr/bin/docker ]; then \
+           target=\$(readlink /usr/bin/docker); \
+           if [ -x /usr/bin/docker ]; then echo \"symlink -> \$target (TARGET OK)\"; \
+           else echo \"symlink -> \$target (TARGET BROKEN)\"; fi; \
+         elif [ -f /usr/bin/docker ]; then echo \"regular file (docker-ce-cli)\"; \
+         else echo \"MISSING\"; fi" 2>/dev/null || echo "(distro error)"
+
+    echo -n "cli-tools docker binary: "
+    wsl.exe -d "$DISTRO" -- bash -c \
+        "f=/mnt/wsl/docker-desktop/cli-tools/usr/bin/docker; \
+         if [ -x \"\$f\" ]; then echo 'EXISTS and executable'; \
+         elif [ -f \"\$f\" ]; then echo 'exists but not executable'; \
+         elif [ -d /mnt/wsl/docker-desktop/cli-tools ]; then echo 'cli-tools dir exists but docker MISSING'; \
+         elif [ -d /mnt/wsl/docker-desktop ]; then echo 'mount exists but cli-tools dir MISSING'; \
+         else echo 'mount NOT PRESENT'; fi" 2>/dev/null || echo "(distro error)"
+
+    echo -n "/var/run/docker.sock:    "
+    wsl.exe -d "$DISTRO" -- bash -c \
+        "[ -S /var/run/docker.sock ] && echo 'exists' || echo 'MISSING'" 2>/dev/null || echo "(distro error)"
+
+    echo ""
+    sleep 3
+done

--- a/.buildkite/restart-docker-desktop.sh
+++ b/.buildkite/restart-docker-desktop.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# restart-docker-desktop.sh
+#
+# Restart Docker Desktop and wait for WSL2 integration to become active in
+# the given distro.
+#
+# Background: Docker Desktop loses WSL2 integration when things like
+# apt-get remove docker-ce-cli remove /usr/bin/docker, or when WSLInterop
+# is cleared from binfmt_misc. A Docker Desktop restart forces it to
+# re-inject its integration binaries into configured distros.
+#
+# IMPORTANT: Avoid 'docker desktop stop' followed by 'docker desktop start'.
+# During the stop window, /mnt/c/ (CAROOT) becomes briefly inaccessible to
+# WSL2 processes. DDEV's readCAROOT() silently returns "" in this window,
+# causing DDEV to generate a new CA not trusted by Windows — TLS failures
+# (see https://github.com/ddev/ddev/issues/8485). Use 'docker desktop restart'
+# instead, which Docker Desktop handles as a single atomic operation.
+#
+# Usage: bash restart-docker-desktop.sh <distro-name>
+# Exit:  0  integration confirmed working in <distro-name>
+#        1  timed out or unexpected error
+
+set -o pipefail
+set -o nounset
+
+DISTRO="${1:?Usage: $0 <distro-name>}"
+
+TIMEOUT_START=180     # seconds to wait for Docker Desktop to report running
+TIMEOUT_INTEGRATION=120  # seconds to wait for docker ps to work inside distro
+
+wait_for_docker_desktop_running() {
+    local elapsed=0
+    while true; do
+        local status
+        status=$(docker desktop status 2>&1 || true)
+        if echo "$status" | grep -qi "Status[[:space:]]*running"; then
+            echo "restart-docker-desktop: Docker Desktop running (${elapsed}s elapsed)"
+            return 0
+        fi
+        if [ "$elapsed" -ge "$TIMEOUT_START" ]; then
+            echo "restart-docker-desktop: ERROR: timed out after ${TIMEOUT_START}s waiting for running"
+            echo "restart-docker-desktop: last status: $status"
+            return 1
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+}
+
+echo "restart-docker-desktop: state BEFORE restart:"
+bash "$(dirname "$0")/dump-docker-desktop-state.sh" "$DISTRO" "before-restart" || true
+
+# Use 'docker desktop restart' as a single atomic operation rather than
+# separate stop+start, to minimize the window where CAROOT is inaccessible.
+echo "restart-docker-desktop: restarting Docker Desktop to restore WSL2 integration in $DISTRO..."
+docker desktop restart || true
+
+wait_for_docker_desktop_running || exit 1
+
+# Wait for both WSL2 integration in the distro AND Windows-side docker ps.
+echo "restart-docker-desktop: waiting for WSL2 integration in $DISTRO (up to ${TIMEOUT_INTEGRATION}s)..."
+elapsed=0
+while true; do
+    wsl_ok=false
+    win_ok=false
+    wsl.exe -d "$DISTRO" -- docker ps >/dev/null 2>&1 && wsl_ok=true
+    docker ps >/dev/null 2>&1 && win_ok=true
+    if [ "$wsl_ok" = "true" ] && [ "$win_ok" = "true" ]; then
+        echo "restart-docker-desktop: WSL2 integration confirmed in $DISTRO and Windows docker ps OK (${elapsed}s elapsed)"
+        bash "$(dirname "$0")/dump-docker-desktop-state.sh" "$DISTRO" "integration-restored" || true
+        exit 0
+    fi
+    if [ "$elapsed" -ge "$TIMEOUT_INTEGRATION" ]; then
+        echo "restart-docker-desktop: ERROR: timed out after ${TIMEOUT_INTEGRATION}s (wsl_ok=$wsl_ok win_ok=$win_ok)"
+        echo "restart-docker-desktop: state at integration timeout (shows whether the symlink, cli-tools mount, or socket is the problem):"
+        bash "$(dirname "$0")/dump-docker-desktop-state.sh" "$DISTRO" "integration-timeout" || true
+        exit 1
+    fi
+    echo "restart-docker-desktop: waiting... wsl_ok=$wsl_ok win_ok=$win_ok (${elapsed}s)"
+    sleep 10
+    elapsed=$((elapsed + 10))
+done

--- a/.buildkite/sanetestbot.sh
+++ b/.buildkite/sanetestbot.sh
@@ -20,19 +20,74 @@ else
    echo "Disk usage is ${DISK_AVAIL}% on $(hostname).";
 fi
 
-# Test to make sure docker is installed and working.
-# If it doesn't become ready then we just keep this testbot occupied :)
-docker ps >/dev/null
-while ! docker ps >/dev/null 2>&1 ; do
-    echo "Waiting for docker to be ready $(date)"
-    sleep 60
-done
+# Determine whether this job uses the Windows host's Docker Desktop. The WSL2
+# docker-ce (and docker-inside) installer cases run Docker CE *inside* the WSL2
+# distro and never touch the host's Docker Desktop — so they must not wait for
+# or start it, and the host docker sanity checks below would only test (and
+# block on) an unrelated, possibly-stopped Docker Desktop. Worse, starting
+# Docker Desktop for a docker-ce job makes its WSL2 integration fight the
+# in-distro docker-ce daemon over /var/run/docker.sock. Detected from the
+# installer pipeline's INSTALLER_CASE; when unset (other pipelines) prior
+# behavior is preserved.
+USES_HOST_DOCKER=true
+case "${INSTALLER_CASE:-}" in
+    *-ce|*-inside|ps1-docker-inside) USES_HOST_DOCKER=false ;;
+esac
 
-# Test that docker can allocate 80 and 443, get ddev/ddev-utilities
-docker pull ddev/ddev-utilities >/dev/null
-# Try the docker run command twice because of the really annoying mkdir /c: file exists bug
-# Apparently https://github.com/docker/for-win/issues/1560
-(sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 ddev/ddev-utilities ls //tmp/junker99 >/dev/null) || (sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 ddev/ddev-utilities ls //tmp/junker99 >/dev/null ))
+# On Windows with Docker Desktop, CHECK that Docker Desktop's frontend is running.
+# sanetestbot only *checks* the runner; starting Docker Desktop is the job of
+# start-docker-desktop.sh, which must run earlier in the pipeline. On Linux and
+# macOS Docker runs as a daemon and is expected to already be up; this block is
+# Windows-only.
+if [ "$(go env GOOS)" = "windows" ] && [ "$USES_HOST_DOCKER" = "true" ]; then
+    # Check 'docker desktop status' (the frontend), not 'docker ps' (the Engine
+    # service). On Windows the Docker Engine service (SYSTEM) keeps running even
+    # when Docker Desktop.exe (the frontend) is stopped — so docker ps succeeds
+    # even when Docker Desktop is down. WSL2 integration is managed by the
+    # frontend, so we must check 'docker desktop status'. A few retries absorb a
+    # just-started Docker Desktop still settling; we do NOT start it here.
+    dd_frontend_ok=false
+    for _retry in 1 2 3 4 5 6; do
+        dd_status=$(docker desktop status 2>&1 || true)
+        if echo "$dd_status" | grep -qi "Status[[:space:]]*running"; then
+            dd_frontend_ok=true
+            echo "$(date -u +%H:%M:%S) Docker Desktop frontend running (check $_retry)"
+            break
+        fi
+        echo "$(date -u +%H:%M:%S) Docker Desktop not running (check $_retry, status: $dd_status), retrying in 10s..."
+        sleep 10
+    done
+
+    if [ "$dd_frontend_ok" = "false" ]; then
+        dd_status=$(docker desktop status 2>&1 || true)
+        echo "ERROR: Docker Desktop frontend is not running (status: $dd_status)."
+        echo "start-docker-desktop.sh should have started it earlier in the pipeline."
+        exit 1
+    fi
+fi
+
+# Host docker sanity checks. These exercise the host's docker daemon (Docker
+# Desktop on Windows, the local daemon on macOS/Linux). Skip them for WSL2
+# docker-ce/-inside installer cases, which use Docker CE inside the distro and
+# do not use the host's Docker Desktop — running them would only block on an
+# unrelated, possibly-stopped Docker Desktop.
+if [ "$USES_HOST_DOCKER" = "true" ]; then
+    # Test to make sure docker is installed and working.
+    # If it doesn't become ready then we just keep this testbot occupied :)
+    docker ps >/dev/null
+    while ! docker ps >/dev/null 2>&1 ; do
+        echo "Waiting for docker to be ready $(date)"
+        sleep 60
+    done
+
+    # Test that docker can allocate 80 and 443, get ddev/ddev-utilities
+    docker pull ddev/ddev-utilities >/dev/null
+    # Try the docker run command twice because of the really annoying mkdir /c: file exists bug
+    # Apparently https://github.com/docker/for-win/issues/1560
+    (sleep 1 && (docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 ddev/ddev-utilities ls //tmp/junker99 >/dev/null) || (sleep 1 && docker run --rm -t -p 80:80 -p 443:443 -p 1081:1081 -p 1082:1082 -v /$HOME:/tmp/junker99 ddev/ddev-utilities ls //tmp/junker99 >/dev/null ))
+else
+    echo "Skipping host Docker Desktop checks for INSTALLER_CASE=${INSTALLER_CASE:-} (uses Docker CE inside WSL2, not the host Docker Desktop)"
+fi
 
 # Check that required commands are available.
 for command in git go make mysql ngrok; do
@@ -42,6 +97,33 @@ done
 if [ "$(go env GOOS)" = "windows"  -a "$(git config core.autocrlf)" != "false" ] ; then
  echo "git config core.autocrlf is not set to false on windows"
  exit 3
+fi
+
+# On Windows/WSL2: ensure the binfmt_misc WSLInterop entry is registered in each test distro.
+#
+# Background: WSL2 uses a binfmt_misc entry named "WSLInterop" so that Linux shells can
+# transparently invoke Windows .exe binaries. This entry is lost whenever docker-ce is
+# removed from a distro — the package's post-remove scripts clear binfmt_misc entries.
+# It is also lost when systemd remounts binfmt_misc during boot before wsl.conf [boot]
+# command has run. When the entry is absent, any .exe called from within the distro fails
+# with "cannot execute binary file: Exec format error".
+#
+# Consequence for these tests: the PS1 install scripts call `wsl -d <distro> mkcert.exe`
+# to add the mkcert CA to the Windows certificate store. If interop is broken, that call
+# silently fails, the CA is never trusted by Windows, and every subsequent PowerShell
+# HTTPS check fails with an SSL/TLS error — a hard-to-diagnose failure miles from the root cause.
+#
+# wsl-fix-interop re-registers the entry by writing the magic string to
+# /proc/sys/fs/binfmt_misc/register. It is idempotent (exits 0 if already present).
+# Requires a one-time installation per distro — see buildkite-testmachine-setup.md.
+# See https://github.com/rfay/wsl-fix-interop
+if [ "$(go env GOOS)" = "windows" ]; then
+    for distro in ddev-test-ubuntu-ce ddev-test-ubuntu-desktop ddev-test-ubuntu2404-ce ddev-test-ubuntu2404-desktop ddev-test-debian-ce ddev-test-debian-desktop; do
+        fix_out=$(wsl.exe -d "$distro" bash -c "sudo wsl-fix-interop" 2>&1) \
+            && echo "wsl-fix-interop in $distro: $fix_out" \
+            || echo "WARNING: wsl-fix-interop failed or not installed in $distro (skipping)"
+    done
+
 fi
 
 echo "-- testbot $HOSTNAME seems to be set up OK --"

--- a/.buildkite/start-docker-desktop.sh
+++ b/.buildkite/start-docker-desktop.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# start-docker-desktop.sh
+#
+# Test-runner SETUP for Windows: make sure Docker Desktop's frontend is running
+# before the docker checks/tests run. This is the Windows analogue of the
+# lima/colima/orbstack provider startup in test.sh — it is provider *setup*, not
+# a sanity check. (sanetestbot.sh only *checks* the runner; it must not start
+# anything.) Call this early, before the docker readiness wait and before
+# sanetestbot.sh.
+#
+# Only acts when this job uses the host's Docker Desktop. The WSL2 docker-ce /
+# docker-inside cases run Docker CE inside the distro and do not use the host
+# Docker Desktop, so they are skipped (detected from INSTALLER_CASE / DOCKER_TYPE).
+#
+# Starts Docker Desktop DETACHED via Start-Process so it survives the Buildkite
+# job's Windows Job Object, then waits for it to report running. Best-effort:
+# always exits 0 — the downstream docker readiness wait / sanetestbot.sh check is
+# the gate that fails the job if Docker Desktop never comes up.
+
+set -o pipefail
+
+# Non-Windows runners manage their docker provider elsewhere (test.sh's
+# lima/colima/orbstack block, or a daemon). Nothing to do here.
+[ "$(go env GOOS)" = "windows" ] || exit 0
+
+# Skip cases that run Docker CE inside the WSL2 distro and don't use the host
+# Docker Desktop.
+case "${INSTALLER_CASE:-}" in
+    *-ce | *-inside | ps1-docker-inside)
+        echo "start-docker-desktop: INSTALLER_CASE=${INSTALLER_CASE} uses Docker CE inside WSL2; not starting Docker Desktop"
+        exit 0
+        ;;
+esac
+case "${DOCKER_TYPE:-}" in
+    wsl2dockerinside | docker-ce)
+        echo "start-docker-desktop: DOCKER_TYPE=${DOCKER_TYPE} uses Docker CE inside WSL2; not starting Docker Desktop"
+        exit 0
+        ;;
+esac
+
+if docker desktop status 2>&1 | grep -qi "Status[[:space:]]*running"; then
+    echo "start-docker-desktop: Docker Desktop already running."
+    exit 0
+fi
+
+echo "$(date -u +%H:%M:%S) start-docker-desktop: Docker Desktop not running — starting it (detached)..."
+# Use Start-Process to detach Docker Desktop.exe from the Buildkite job's Windows
+# Job Object so it survives after the job ends. Never use 'docker desktop stop'
+# here — stopping truncates Docker Desktop's per-distro proxy binary and breaks
+# WSL2 integration (see git history). This script only ever STARTS.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \
+    'Start-Process -FilePath "$env:PROGRAMFILES\Docker\Docker\Docker Desktop.exe" -PassThru | Out-Null' 2>/dev/null \
+    || docker desktop start || true
+
+elapsed=0
+while ! docker desktop status 2>&1 | grep -qi "Status[[:space:]]*running"; do
+    if [ "$elapsed" -ge 180 ]; then
+        echo "start-docker-desktop: WARNING: Docker Desktop did not report running within ${elapsed}s (downstream checks will catch this)"
+        exit 0
+    fi
+    status=$(docker desktop status 2>&1 || true)
+    echo "$(date -u +%H:%M:%S) start-docker-desktop: waiting for Docker Desktop to start (${elapsed}s, status: $status)..."
+    sleep 10
+    elapsed=$((elapsed + 10))
+done
+echo "$(date -u +%H:%M:%S) start-docker-desktop: Docker Desktop is running (${elapsed}s)."
+exit 0

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -256,6 +256,12 @@ else
   exit 1
 fi
 
+# On Windows, start Docker Desktop if this job uses it, before waiting on docker.
+# This is the Windows analogue of the lima/colima/orbstack provider startup above;
+# it is provider setup, separate from the sanetestbot.sh sanity check. No-op on
+# non-Windows and on docker-ce-inside cases.
+bash "$(dirname "$0")/start-docker-desktop.sh" || true
+
 # Make sure docker is working
 echo "Waiting for docker provider to come up: $(date)"
 date && ${TIMEOUT} 3m bash -c 'while ! docker ps >/dev/null 2>&1 ; do
@@ -360,18 +366,10 @@ fi
 
 echo "--- Running tests..."
 
-# Run installer tests first on Windows
-if [ "${os:-}" = "windows" ]; then
-  echo "--- Running Windows installer tests first..."
-  export DDEV_TEST_USE_REAL_INSTALLER=true
-  make testwininstaller TESTARGS="${TESTARGS:-}" | sed -u 's/^--- FAIL:/+++ FAIL:/; /\//!s/^=== RUN /--- RUN /'
-  INSTALLER_RV=$?
-  if [ $INSTALLER_RV -ne 0 ]; then
-    echo "Windows installer tests failed with status=$INSTALLER_RV"
-    exit $INSTALLER_RV
-  fi
-  echo "Windows installer tests completed successfully"
-fi
+# Note: Windows installer tests are no longer run here. They run in their own
+# dedicated Buildkite pipeline (.buildkite/installer-test.sh +
+# .buildkite/windows-installer.yml), decoupled from this suite so they can fan
+# out across runners.
 
 make ${MAKE_TARGET:-test} TESTARGS="${TESTARGS:-}" TESTPKG="${TESTPKG:-}" TESTFILE="${TESTFILE:-}" | sed -u 's/^--- FAIL:/+++ FAIL:/; /\//!s/^=== RUN /--- RUN /'
 RV=$?

--- a/.buildkite/windows-installer.yml
+++ b/.buildkite/windows-installer.yml
@@ -1,0 +1,50 @@
+# Windows GUI installer tests, decoupled from the traditional Windows suite.
+# Used by the ddev-windows-installer pipeline.
+# See https://buildkite.com/ddev/ddev-windows-installer/settings/repository
+# Runs on main and PRs, not including forked PRs.
+#
+# Each matrix entry runs as its own parallel job. The matrix value is
+# INSTALLER_CASE; installer-test.sh dispatches on it:
+#   ddev-test-<distro>-<provider> -> GUI installer test (one WSL instance/case)
+#   ps1-<subtest>                 -> manual WSL2 install-script test (Ubuntu only)
+#
+# Requires Windows-native (os=windows) agents that already have the named test
+# distros provisioned (docs/content/developers/buildkite-testmachine-setup.md).
+# Run only ONE os=windows agent per physical machine: these runs mutate global
+# Windows state (registry CAROOT/WSLENV, machine-wide mkcert CA), so two must
+# never run on the same machine at the same time. A single agent per machine
+# guarantees that (an agent runs one job at a time), so the jobs only ever
+# overlap across separate machines.
+
+  - command: ".buildkite/installer-test.cmd"
+    label: ":windows: {{matrix}}"
+    # Skip on [skip ci]/[skip buildkite] for webhook (push) builds, but always
+    # run when triggered manually from the Buildkite UI. This lets you push with
+    # [skip ci] to keep the other heavy pipelines quiet, then trigger just this
+    # pipeline by hand.
+    if: |
+      build.message !~ /\[(skip ci|skip buildkite)\]/ || build.source == "ui"
+    agents:
+      - "os=windows"
+      - "architecture=amd64"
+    env:
+      BUILDKITE_CLEAN_CHECKOUT: true
+      DDEV_TEST_USE_REAL_INSTALLER: "true"
+      INSTALLER_CASE: "{{matrix}}"
+      # C:\buildkite-agent\hooks\environment
+      # DOCKERHUB_PULL_USERNAME
+      # DOCKERHUB_PULL_PASSWORD
+    matrix:
+      # Traditional Windows (non-WSL2) installer test:
+      - "traditional"
+
+      # Manual WSL2 install-script tests (Ubuntu only), gated to ps1 changes:
+      - "ps1-docker-inside"
+      - "ps1-docker-desktop"
+
+      - "ddev-test-ubuntu-ce"
+      - "ddev-test-ubuntu-desktop"
+      # - "ddev-test-ubuntu2404-ce"
+      # - "ddev-test-ubuntu2404-desktop"
+      - "ddev-test-debian-ce"
+      - "ddev-test-debian-desktop"

--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -58,6 +58,7 @@ DrupalEasy
 DrupalEasy's
 Dump
 DXP
+eLxr
 Enable
 EndeavourOS
 EOL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ For developer documentation, see:
 ```bash
 make                    # Build for host OS/arch. Output: .gotmp/bin/<os>_<arch>/ddev
 make linux_amd64        # Cross-compile for specific platform
+make windows_amd64      # Cross-compile + build Windows installer .exe (use this to validate Windows changes)
 ```
 
 ### Testing

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,14 @@ testonefile: $(DEFAULT_BUILD) setup
 
 testwininstaller: windows_amd64_install
 	@echo "Running Windows installer tests..."
-	export DDEV_TEST_USE_REAL_INSTALLER=true; go test -p 1 -timeout 30m -v ./winpkg -run TestWindowsInstaller $(EMBARGO_SKIP_FLAG) $(TESTARGS)
+	export DDEV_TEST_USE_REAL_INSTALLER=true; go test -p 1 -timeout 15m -v ./winpkg -run TestWindowsInstaller $(EMBARGO_SKIP_FLAG) $(TESTARGS)
+
+# testwsl2scripts tests the manual WSL2 install PowerShell scripts. Unlike
+# testwininstaller it does not build the installer .exe (the scripts install
+# ddev from the apt repo and use mkcert.exe from PATH).
+testwsl2scripts:
+	@echo "Running WSL2 install-script tests..."
+	export DDEV_TEST_USE_REAL_INSTALLER=true; go test -p 1 -timeout 15m -v ./winpkg -run TestWSL2InstallScripts $(EMBARGO_SKIP_FLAG) $(TESTARGS)
 
 setup:
 	@mkdir -p $(GOTMP)/{bin/linux_arm64,bin/linux_amd64,bin/darwin_arm64,bin/darwin_amd64,bin/windows_amd64,bin/windows_arm64,src,pkg/mod/cache,.cache}

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -22,7 +22,7 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
     * Check "Start Docker Desktop when you sign in" or the equivalent with Rancher Desktop.
     * Check "Add the *.docker.internal names to the host's /etc/hosts file"
     * Uncheck "SBOM Indexing"
-    * Under "Resources" uncheck "Resource Saver"
+    * Under "Resources" uncheck "Resource Saver" — **important**: Docker Desktop may re-enable this after a full restart. Verify it is unchecked after any Docker Desktop upgrade or manual restart. When Resource Saver is active, Docker Desktop pauses the Linux VM when no containers are running; `docker ps` and WSL2 integration fail until it is un-paused, causing spurious test failures.
 12. After starting Docker Desktop or Rancher Desktop, set the correct Docker context in the Git Bash window with `docker context use desktop-linux` (Docker Desktop) or `docker context use default` (Rancher Desktop).
 13. Log into Chrome with the user `ddevtestbot@gmail.com` and enable Chrome Remote Desktop.
 14. (Traditional Windows test runner only): Enable `gd`, `fileinfo`, and `curl` extensions in `/c/tools/php*/php.ini`.
@@ -74,6 +74,113 @@ We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testi
 10. If using Docker Desktop, start Docker Desktop.
 11. In `~/workspace/ddev/.buildkite`, run `./testbot_maintenance.sh`.
 12. In `~/workspace/ddev/.buildkite`, run `./sanetestbot.sh` to check your work.
+
+## Windows Installer Test Distros
+
+The Windows GUI installer tests run in their own dedicated Buildkite pipeline
+(`windows-installer`, driven by `.buildkite/windows-installer.yml` +
+`.buildkite/installer-test.sh`), separate from the traditional Windows suite.
+Each matrix case is a parallel job that installs DDEV into a dedicated WSL2
+distro using a specific Docker provider.
+
+These tests need a **Windows-native** (`os=windows`) `buildkite-agent` — the same
+kind of agent as the traditional Windows runner — because they drive `wsl.exe`,
+`reg.exe`, and the installer `.exe`. The matrix spreads its jobs across all
+available `os=windows` agents, so adding more such machines increases parallelism.
+
+!!!warning "One `os=windows` agent per machine"
+    An installer run mutates global Windows state (registry `CAROOT`/`WSLENV` and
+    the machine-wide `mkcert` CA root). Two installer jobs must never run on the
+    same machine at the same time. A Buildkite agent runs one job at a time, so
+    running exactly **one** `os=windows` agent per physical machine guarantees
+    this; the jobs then only overlap across separate machines.
+
+The test does **not** create distros — it resets and reuses them. Provision the
+six named instances **once per runner** (the normal install handles user
+creation; complete first-run with the `testbot` user, which is the default user
+the test harness expects):
+
+```powershell
+wsl --install Ubuntu       --name ddev-test-ubuntu-ce
+wsl --install Ubuntu       --name ddev-test-ubuntu-desktop
+wsl --install Ubuntu-24.04 --name ddev-test-ubuntu2404-ce
+wsl --install Ubuntu-24.04 --name ddev-test-ubuntu2404-desktop
+wsl --install Debian       --name ddev-test-debian-ce
+wsl --install Debian       --name ddev-test-debian-desktop
+```
+
+For the `*-desktop` instances only, enable Docker Desktop's WSL integration for
+that instance (Docker Desktop → Settings → Resources → WSL integration).
+Otherwise the `docker-desktop` cases skip gracefully. The base distro names
+above (`Ubuntu`, `Ubuntu-24.04`, `Debian`) must be available in the WSL catalog;
+verify with `wsl -l -o`.
+
+Remove `unattended-upgrades` from all test instances. Ubuntu 24.04 in particular
+runs it on boot and holds the dpkg lock while the installer is trying to run
+`apt-get`, causing intermittent failures. It serves no purpose in these
+short-lived test distros:
+
+```powershell
+foreach ($d in @("ddev-test-ubuntu-ce","ddev-test-ubuntu-desktop","ddev-test-ubuntu2404-ce","ddev-test-ubuntu2404-desktop","ddev-test-debian-ce","ddev-test-debian-desktop")) {
+    wsl -d $d -u root apt-get remove -y unattended-upgrades 2>$null
+}
+```
+
+Install [wsl-fix-interop](https://github.com/rfay/wsl-fix-interop) in all test
+instances and configure it to run on every distro boot. WSL interop (binfmt_misc)
+loses its `WSLInterop` entry whenever `docker-ce` is removed — the package's
+post-remove scripts clear binfmt_misc entries. Without it, any Windows `.exe`
+called from within WSL fails with "Exec format error", causing `mkcert.exe`
+failures and TLS test failures.
+
+First install the script and sudoers entry:
+
+```powershell
+foreach ($d in @("ddev-test-ubuntu-ce","ddev-test-ubuntu-desktop","ddev-test-ubuntu2404-ce","ddev-test-ubuntu2404-desktop","ddev-test-debian-ce","ddev-test-debian-desktop")) {
+    wsl -d $d -u root bash -c "cd /tmp && curl -fsSL https://raw.githubusercontent.com/rfay/wsl-fix-interop/main/wsl-fix-interop -o wsl-fix-interop && curl -fsSL https://raw.githubusercontent.com/rfay/wsl-fix-interop/main/install.sh -o install.sh && bash install.sh testbot"
+}
+```
+
+Then wire it into `/etc/wsl.conf` in each distro so it re-registers automatically
+on every distro boot (including after `docker-ce` removal clears binfmt_misc):
+
+```powershell
+foreach ($d in @("ddev-test-ubuntu-ce","ddev-test-ubuntu-desktop","ddev-test-ubuntu2404-ce","ddev-test-ubuntu2404-desktop","ddev-test-debian-ce","ddev-test-debian-desktop")) {
+    wsl -d $d -u root bash -c "grep -q 'wsl-fix-interop' /etc/wsl.conf 2>/dev/null || printf '\n[boot]\ncommand = /usr/local/sbin/wsl-fix-interop\n' >> /etc/wsl.conf"
+}
+```
+
+To run a single case manually (e.g. for debugging), select it by instance name,
+which is also the Go subtest name:
+
+```bash
+make testwininstaller TESTARGS="-run TestWindowsInstallerWSL2/ddev-test-debian-ce"
+```
+
+### WSL2 install-script tests
+
+The `ddev-windows-installer` pipeline also tests the manual WSL2 install
+PowerShell scripts (`scripts/install_ddev_wsl2_docker_inside.ps1` and
+`scripts/install_ddev_wsl2_docker_desktop.ps1`) against current Ubuntu, as the
+`ps1-docker-inside` and `ps1-docker-desktop` matrix cases. These run only when a
+ps1 script (or its test/plumbing) changes, plus on `main` and manual builds.
+
+They **reuse the two Ubuntu instances** above — no extra provisioning. The
+scripts now accept a `-Distro` parameter so the test passes the distro name
+directly without changing the system default:
+
+* `ps1-docker-inside` → `ddev-test-ubuntu-ce`, which must have Docker Desktop WSL
+  integration **disabled** (the script aborts if `/mnt/wsl/docker-desktop`
+  exists). This is the same state the docker-ce installer case wants.
+* `ps1-docker-desktop` → `ddev-test-ubuntu-desktop`, which must have Docker
+  Desktop running with WSL integration **enabled**.
+* `mkcert.exe` must be on the Windows PATH (already installed via choco above).
+
+Run one manually with:
+
+```bash
+make testwsl2scripts TESTARGS="-run TestWSL2InstallScripts/docker-inside"
+```
 
 ## Icinga2 monitoring setup for WSL2 instances
 

--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -220,7 +220,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     wsl --update
     ```
 
-    Create an Ubuntu distro (skip if you're using Traditional Windows):
+    Create an Ubuntu or other Debian-based WSL2 distro (skip if you're using Traditional Windows). Ubuntu is recommended:
 
     ```powershell
     # You'll be asked to set a username and password for the distro:
@@ -228,6 +228,9 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     ```
 
     !!!tip "\"DDEV\" is just a suggested name — use any name you like."
+
+    !!!tip "Other Debian-based distros also work"
+        The DDEV installer supports Ubuntu and Debian and has been tested with Kali Linux and eLxr. If you prefer one of those, substitute its name, for example `wsl --install Debian --name DDEV`.
 
     Verify the "DDEV" distro is set as default:
 
@@ -252,7 +255,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
     !!!tip "Check your system architecture"
         Not sure which architecture you have? Open PowerShell and run: `$env:PROCESSOR_ARCHITECTURE`. It will show `AMD64` or `ARM64`. Alternatively, in WSL2/Ubuntu run `uname -m` which shows `x86_64` for AMD64 or `aarch64` for ARM64.
 
-    Run the installer and select your mode. For WSL2 modes, the installer will ask which distro to use — enter the name you chose in Step 1. The installer will automatically configure DDEV for your chosen Docker provider. If you run the wrong installer for your architecture, it will detect the mismatch and direct you to download the correct one.
+    Run the installer and select your mode. For WSL2 modes, the installer will display all detected Debian-based WSL2 distros (Ubuntu, Debian, Kali, eLxr, etc.) and prompt you to select one. The installer will automatically configure DDEV for your chosen Docker provider. If you run the wrong installer for your architecture, it will detect the mismatch and direct you to download the correct one.
 
     ??? tip "Install using WinGet"
         [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/) can download and launch the installer interactively:
@@ -318,7 +321,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
         8. Check that Docker is working inside Ubuntu (or your distro) by running `docker ps` in the distro.
         9. Open the WSL2 terminal, for example `Debian` from the Windows start menu.
         10. In WSL2, run `mkcert -install`.
-        11. Note that the older manual [PowerShell script](https://github.com/ddev/ddev/blob/main/scripts/install_ddev_wsl2_docker_inside.ps1) may be instructional if you’re setting up a non-Ubuntu distro. It has been replaced by the Windows installer, but could be adapted for other distros.
+        11. Note that the older manual [PowerShell script](https://github.com/ddev/ddev/blob/main/scripts/install_ddev_wsl2_docker_inside.ps1) may be instructional if you’re setting up a non-Ubuntu distro. It has been replaced by the Windows installer, but could be adapted for other distros. Pass `-Distro <name>` when running it.
 
         !!!note "Path to certificates"
             If you get the prompt `Installing to the system store is not yet supported on this Linux`, you may need to add `/usr/sbin` to the `$PATH` so that `/usr/sbin/update-ca-certificates` can be found.

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -234,7 +234,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     wsl --update
     ```
 
-    Create an Ubuntu distro (skip if you're using Traditional Windows):
+    Create a Debian-based WSL2 distro (skip if you're using Traditional Windows). Ubuntu is recommended:
 
     ```powershell
     # You'll be asked to set a username and password for the distro:
@@ -242,6 +242,9 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     ```
 
     !!!tip "\"DDEV\" is just a suggested name — use any name you like."
+
+    !!!tip "Other Debian-based distros also work"
+        The DDEV installer supports Ubuntu and Debian and has been tested on Kali Linux and eLxr. If you prefer one of those, substitute its name, for example `wsl --install Debian --name DDEV`.
 
     Verify the "DDEV" distro is set as default:
 
@@ -322,7 +325,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     1. Download and install Docker Desktop from [docker.com](https://www.docker.com/products/docker-desktop).
     2. During installation, ensure "Use WSL 2 instead of Hyper-V" is selected.
     3. After installation, open Docker Desktop settings and navigate to **Resources → WSL Integration**.
-    4. Enable integration with your Ubuntu-based WSL2 distro (e.g., Ubuntu, Ubuntu-24.04, Ubuntu-22.04).
+    4. Enable integration with your Debian-based WSL2 distro (e.g., Ubuntu-24.04, Debian).
     5. Apply the changes and restart Docker Desktop if prompted.
     6. Verify that `docker ps` works in git-bash, PowerShell, or WSL2, wherever you're using it.
 
@@ -331,7 +334,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     1. Download and install [Rancher Desktop](https://rancherdesktop.io/).
     2. During installation, choose **Docker** as the container runtime and disable Kubernetes.
     3. After installation, open Rancher Desktop and go to **WSL Integration** in the settings.
-    4. Enable integration with your Ubuntu-based WSL2 distro (e.g., Ubuntu, Ubuntu-24.04, Ubuntu-22.04).
+    4. Enable integration with your Debian-based WSL2 distro (e.g., Ubuntu-24.04, Debian).
     5. Apply the changes and restart Rancher Desktop if needed.
     6. Verify that `docker ps` works in git-bash, PowerShell, or WSL2, wherever you're using it.
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1938,7 +1938,8 @@ func TestConfigFunctionality(t *testing.T) {
 
 	// This isn't very important, and is unusual
 	// On some WSL2 systems (tb-wsldd-05) it works fine locally, can't work in buildkite.
-	if !dockerutil.IsColima() && !nodeps.IsWSL2() {
+	// On Windows (tb-win11-06) the cert reload race with Traefik causes intermittent failures.
+	if !dockerutil.IsColima() && !nodeps.IsWSL2() && !nodeps.IsWindows() {
 		safeURL = "https://127.0.0.1:" + hostHTTPSPort + site.Safe200URIWithExpectation.URI
 		testcommon.AssertLocalHTTPContent(t, safeURL, site.Safe200URIWithExpectation.Expect,
 			testcommon.WithMessagef("HTTPS safe URL should serve the expected static content"),

--- a/scripts/install_ddev_wsl2_docker_desktop.ps1
+++ b/scripts/install_ddev_wsl2_docker_desktop.ps1
@@ -1,74 +1,100 @@
 # This PowerShell script tries to do almost all the things required to set up
-# an Ubuntu WSL2 instance for use with DDEV and Docker Desktop.
+# a Debian-based WSL2 instance for use with DDEV and Docker Desktop.
 #
 # **DDEV now ships with a GUI installer for Windows/WSL2 which is usually easier.**
 # See https://ddev.com/download
 #
 # Prerequisites:
-# - An Ubuntu-based WSL2 distro installed (preferably with `wsl --install`)
-# - The distro you want must be set as the default WSL2 distro
-# - Docker Desktop installed, running, and with WSL2 integration enabled for Ubuntu
+# - A Debian-based WSL2 distro installed, e.g. Ubuntu or Debian (preferably with `wsl --install`)
+# - Docker Desktop installed, running, and with WSL2 integration enabled for your distro
 #
-# Quick install - run this one-liner in PowerShell:
-#   iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1'))
+# The -Distro argument is required. To find available distros: wsl -l -v
+#
+# Quick install - run this one-liner in PowerShell (replace "Ubuntu" with your distro name):
+#   & ([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_desktop.ps1'))) -Distro "Ubuntu"
 #
 # Alternatively, download the script first to inspect it, then run with:
 #   Set-ExecutionPolicy Bypass -Scope Process -Force
-#   .\install_ddev_wsl2_docker_desktop.ps1
+#   .\install_ddev_wsl2_docker_desktop.ps1 -Distro "Ubuntu"
+
+param(
+    [Parameter(Mandatory=$true, HelpMessage="Name of the WSL2 distro to install into (e.g. 'Ubuntu'). Find yours with: wsl -l -v")]
+    [string]$Distro
+)
 
 # Make sure wsl is installed and working
 if (-not(wsl -l -v)) {
     throw "WSL2 does not seem to be installed yet; please install it with 'wsl --install'"
 }
-# Make sure default distro an ubuntu release
-if (-not( wsl -e grep ^NAME=.Ubuntu //etc/os-release)) {
-    throw "Your installed WSL2 distro does not seem to be Ubuntu. You can certainly use DDEV with WSL2 in another distro, but this script is oriented to Ubuntu."
+# Make sure named distro is a Debian-based release
+$osRelease = wsl -d $Distro -e cat /etc/os-release
+if (-not ($osRelease -match 'ID(_LIKE)?=.*ubuntu' -or $osRelease -match 'ID(_LIKE)?=.*debian')) {
+    throw "Distro '$Distro' does not appear to be Debian-based (Ubuntu, Debian, etc.). You can certainly use DDEV with WSL2 in another distro, but this script is oriented to Debian-based distros."
 }
 # Make sure using WSL2
-if (-not (wsl -e bash -c "env | grep WSL_INTEROP=")) {
-    throw "Your default distro is not WSL version 2, please delete it and start over again"
+if (-not (wsl -d $Distro -e bash -c "env | grep WSL_INTEROP=")) {
+    throw "Distro '$Distro' is not WSL version 2, please delete it and start over again"
 }
-if (-not(Compare-Object "root" (wsl -e whoami)) ) {
-    throw "The default user in your distro seems to be root. Please configure an ordinary default user"
+if (-not(Compare-Object "root" (wsl -d $Distro -e whoami)) ) {
+    throw "The default user in '$Distro' seems to be root. Please configure an ordinary default user"
 }
 if (-not(Get-Command docker 2>&1 ) -Or -Not(docker ps ) ) {
     throw "\n\ndocker does not seem to be installed yet, or Docker Desktop is not running. Please install it or start it."
 }
 
-if (-not(wsl -e docker ps) ) {
-    throw "Docker Desktop integration with the default distro does not seem to be enabled yet."
+if (-not(wsl -d $Distro -e docker ps) ) {
+    throw "Docker Desktop integration with '$Distro' does not seem to be enabled yet."
 }
 $ErrorActionPreference = "Stop"
+# On PowerShell 7.4+, $PSNativeCommandUseErrorActionPreference defaults to $true,
+# which would make a non-zero exit from a native command (wsl/curl/docker) a
+# terminating error and bypass the explicit "if (-not(...)) { throw ... }" guards
+# below. Set it to $false so behavior matches Windows PowerShell 5.1 (on 5.1 this
+# is just an unused variable). Native-command results are checked explicitly.
+$PSNativeCommandUseErrorActionPreference = $false
 
 # Remove old Windows ddev.exe if it exists using uninstaller
 # Check both old system-wide location and new per-user location
 if (Test-Path "$env:PROGRAMFILES\DDEV\ddev_uninstall.exe") {
     Write-Host "Removing old Windows ddev.exe installation (system-wide)"
-    Start-Process "$env:PROGRAMFILES\DDEV\ddev_uninstall.exe" -ArgumentList "/SILENT" -Wait
+    $proc = Start-Process "$env:PROGRAMFILES\DDEV\ddev_uninstall.exe" -ArgumentList "/S" -PassThru
+    if (-not $proc.WaitForExit(120000)) {
+        Write-Warning "DDEV uninstaller did not complete within 2 minutes; killing it"
+        $proc.Kill()
+    }
 }
 if (Test-Path "$env:LOCALAPPDATA\Programs\DDEV\ddev_uninstall.exe") {
     Write-Host "Removing old Windows ddev.exe installation (per-user)"
-    Start-Process "$env:LOCALAPPDATA\Programs\DDEV\ddev_uninstall.exe" -ArgumentList "/SILENT" -Wait
+    $proc = Start-Process "$env:LOCALAPPDATA\Programs\DDEV\ddev_uninstall.exe" -ArgumentList "/S" -PassThru
+    if (-not $proc.WaitForExit(120000)) {
+        Write-Warning "DDEV uninstaller did not complete within 2 minutes; killing it"
+        $proc.Kill()
+    }
 }
 
-wsl -u root -e bash -c "apt-get update && apt-get install -y curl"
-wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg /etc/apt/sources.list.d/ddev.list && curl -fsSL https://pkg.ddev.com/apt/gpg.key | tee /etc/apt/keyrings/ddev.asc > /dev/null && chmod a+r /etc/apt/keyrings/ddev.asc"
-wsl -u root -e bash -c "printf 'Types: deb\nURIs: https://pkg.ddev.com/apt/\nSuites: *\nComponents: *\nSigned-By: /etc/apt/keyrings/ddev.asc\n' > /etc/apt/sources.list.d/ddev.sources"
+wsl -d $Distro -u root -e bash -c "apt-get update && apt-get install -y curl"
+wsl -d $Distro -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg /etc/apt/sources.list.d/ddev.list && curl -fsSL https://pkg.ddev.com/apt/gpg.key | tee /etc/apt/keyrings/ddev.asc > /dev/null && chmod a+r /etc/apt/keyrings/ddev.asc"
+wsl -d $Distro -u root -e bash -c "printf 'Types: deb\nURIs: https://pkg.ddev.com/apt/\nSuites: *\nComponents: *\nSigned-By: /etc/apt/keyrings/ddev.asc\n' > /etc/apt/sources.list.d/ddev.sources"
 
-wsl -u root -e bash -c "apt-get update && apt-get install -y --no-install-recommends ddev ddev-wsl2"
+wsl -d $Distro -u root -e bash -c "apt-get update && apt-get install -y --no-install-recommends ddev ddev-wsl2"
 
-wsl mkcert.exe -install
-$env:CAROOT = & wsl mkcert.exe -CAROOT
-setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
+wsl -d $Distro mkcert.exe -install
+$env:CAROOT = & wsl -d $Distro mkcert.exe -CAROOT
+setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
-$defaultDistro = (wsl --list --quiet | Select-Object -First 1) -replace '[\r\n\x00-\x1F\x7F-\x9F]', '' -replace '^\s+|\s+$', ''
-Write-Host "Terminating default WSL2 distro: $defaultDistro"
-wsl --terminate $defaultDistro
-
-wsl bash -c 'echo CAROOT=$CAROOT'
-wsl mkcert -install
-if (-not(wsl -e docker ps)) {
-    throw "docker does not seem to be working inside the WSL2 distro yet. Check Resources->WSL Integration in Docker Desktop"
+# Convert the Windows CAROOT path to a Linux path and pass it directly to mkcert,
+# avoiding a wsl --terminate which breaks Docker Desktop integration.
+$linuxCaRoot = (& wsl -d $Distro wslpath -u ($env:CAROOT -replace '\\', '/')).Trim()
+Write-Host "Linux CAROOT: $linuxCaRoot"
+try {
+    wsl -d $Distro -u root -e bash -c "echo 'ALL ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/temp-mkcert-install && chmod 440 /etc/sudoers.d/temp-mkcert-install"
+    if ($LASTEXITCODE -ne 0) { throw "Failed to create temporary sudoers entry (exit $LASTEXITCODE)" }
+    wsl -d $Distro bash -c "CAROOT='$linuxCaRoot' mkcert -install"
+} finally {
+    wsl -d $Distro -u root rm -f /etc/sudoers.d/temp-mkcert-install
+}
+if (-not(wsl -d $Distro -e docker ps)) {
+    throw "docker does not seem to be working inside '$Distro' yet. Check Resources->WSL Integration in Docker Desktop"
 }
 
-wsl ddev version
+wsl -d $Distro ddev version

--- a/scripts/install_ddev_wsl2_docker_inside.ps1
+++ b/scripts/install_ddev_wsl2_docker_inside.ps1
@@ -1,79 +1,112 @@
 # This PowerShell script tries to do almost all the things required to set up
-# an Ubuntu WSL2 instance for use with DDEV and docker-ce installed inside WSL2.
+# a Debian-based WSL2 instance for use with DDEV and docker-ce installed inside WSL2.
 #
 # **DDEV now ships with a GUI installer for Windows/WSL2 which is usually easier.**
 # See https://ddev.com/download
 #
 # Prerequisites:
-# - An Ubuntu-based WSL2 distro installed (preferably with `wsl --install`)
-# - The distro you want must be set as the default WSL2 distro
-# - Docker Desktop must NOT be installed, or WSL2 integration must be disabled
+# - A Debian-based WSL2 distro installed, e.g. Ubuntu or Debian (preferably with `wsl --install`)
+# - Docker Desktop must NOT be installed, or WSL2 integration must be disabled for this distro
 #
-# Quick install - run this one-liner in PowerShell:
-#   iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_inside.ps1'))
+# The -Distro argument is required. To find available distros: wsl -l -v
+#
+# Quick install - run this one-liner in PowerShell (replace "Ubuntu" with your distro name):
+#   & ([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_wsl2_docker_inside.ps1'))) -Distro "Ubuntu"
 #
 # Alternatively, download the script first to inspect it, then run with:
 #   Set-ExecutionPolicy Bypass -Scope Process -Force
-#   .\install_ddev_wsl2_docker_inside.ps1
+#   .\install_ddev_wsl2_docker_inside.ps1 -Distro "Ubuntu"
+
+param(
+    [Parameter(Mandatory=$true, HelpMessage="Name of the WSL2 distro to install into (e.g. 'Ubuntu'). Find yours with: wsl -l -v")]
+    [string]$Distro
+)
 
 # Make sure wsl is installed and working
 if (-not(wsl -l -v)) {
     throw "WSL2 does not seem to be installed yet; please install it with 'wsl --install'"
 }
-# Make sure default distro an ubuntu release
-if (-not( wsl -e grep ^NAME=.Ubuntu //etc/os-release)) {
-    throw "Your installed WSL2 distro does not seem to be Ubuntu. You can certainly use DDEV with WSL2 in another distro, but this script is oriented to Ubuntu."
+# Make sure named distro is a Debian-based release
+$osRelease = wsl -d $Distro -e cat /etc/os-release
+if (-not ($osRelease -match 'ID(_LIKE)?=.*ubuntu' -or $osRelease -match 'ID(_LIKE)?=.*debian')) {
+    throw "Distro '$Distro' does not appear to be Debian-based (Ubuntu, Debian, etc.). You can certainly use DDEV with WSL2 in another distro, but this script is oriented to Debian-based distros."
 }
 # Make sure using WSL2
-if (-not (wsl -e bash -c "env | grep WSL_INTEROP=")) {
-    throw "Your default distro is not WSL version 2, please delete it and start over again"
+if (-not (wsl -d $Distro -e bash -c "env | grep WSL_INTEROP=")) {
+    throw "Distro '$Distro' is not WSL version 2, please delete it and start over again"
 }
-if (-not(Compare-Object "root" (wsl -e whoami)) ) {
-    throw "The default user in your distro seems to be root. Please configure an ordinary default user"
+if (-not(Compare-Object "root" (wsl -d $Distro -e whoami)) ) {
+    throw "The default user in '$Distro' seems to be root. Please configure an ordinary default user"
 }
 
-if (wsl bash -c "test -d /mnt/wsl/docker-desktop >/dev/null 2>&1" ) {
-    throw "Docker Desktop integration is enabled with the default distro and it must be turned off."
+if (wsl -d $Distro bash -c "test -d /mnt/wsl/docker-desktop >/dev/null 2>&1" ) {
+    throw "Docker Desktop integration is enabled with '$Distro' and it must be turned off."
 }
 $ErrorActionPreference = "Stop"
+# On PowerShell 7.4+, $PSNativeCommandUseErrorActionPreference defaults to $true,
+# which would make a non-zero exit from a native command (wsl/curl/docker) a
+# terminating error and bypass the explicit "if (-not(...)) { throw ... }" guards
+# below. Set it to $false so behavior matches Windows PowerShell 5.1 (on 5.1 this
+# is just an unused variable). Native-command results are checked explicitly.
+$PSNativeCommandUseErrorActionPreference = $false
 
 # Remove old Windows ddev.exe if it exists using uninstaller
 # Check both old system-wide location and new per-user location
 if (Test-Path "$env:PROGRAMFILES\DDEV\ddev_uninstall.exe") {
     Write-Host "Removing old Windows ddev.exe installation (system-wide)"
-    Start-Process "$env:PROGRAMFILES\DDEV\ddev_uninstall.exe" -ArgumentList "/SILENT" -Wait
+    $proc = Start-Process "$env:PROGRAMFILES\DDEV\ddev_uninstall.exe" -ArgumentList "/S" -PassThru
+    if (-not $proc.WaitForExit(120000)) {
+        Write-Warning "DDEV uninstaller did not complete within 2 minutes; killing it"
+        $proc.Kill()
+    }
 }
 if (Test-Path "$env:LOCALAPPDATA\Programs\DDEV\ddev_uninstall.exe") {
     Write-Host "Removing old Windows ddev.exe installation (per-user)"
-    Start-Process "$env:LOCALAPPDATA\Programs\DDEV\ddev_uninstall.exe" -ArgumentList "/SILENT" -Wait
+    $proc = Start-Process "$env:LOCALAPPDATA\Programs\DDEV\ddev_uninstall.exe" -ArgumentList "/S" -PassThru
+    if (-not $proc.WaitForExit(120000)) {
+        Write-Warning "DDEV uninstaller did not complete within 2 minutes; killing it"
+        $proc.Kill()
+    }
 }
 
-wsl -u root bash -c "apt-get remove -y -qq docker docker-engine docker.io containerd runc >/dev/null 2>&1"
-wsl -u root apt-get update
-wsl -u root apt-get install -y ca-certificates curl gnupg lsb-release
-wsl -u root install -m 0755 -d /etc/apt/keyrings
-wsl -u root bash -c "rm -f /etc/apt/keyrings/docker.gpg /etc/apt/sources.list.d/docker.list && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && chmod a+r /etc/apt/keyrings/docker.asc"
-wsl -u root -e bash -c "printf 'Types: deb\nURIs: https://download.docker.com/linux/ubuntu\nSuites: %s\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n' \"\$(. /etc/os-release && echo \${UBUNTU_CODENAME:-\$VERSION_CODENAME})\" | tee /etc/apt/sources.list.d/docker.sources > /dev/null"
+wsl -d $Distro -u root bash -c "apt-get remove -y -qq docker docker-engine docker.io containerd runc >/dev/null 2>&1"
+wsl -d $Distro -u root apt-get update
+wsl -d $Distro -u root apt-get install -y ca-certificates curl gnupg lsb-release
+wsl -d $Distro -u root install -m 0755 -d /etc/apt/keyrings
+# Configure the Docker apt repo. Use a PS double-quoted string with backtick-
+# escaped $ so PowerShell does not interpolate bash variables, and use bash
+# single quotes for the printf format string. This avoids the Windows
+# CreateProcess argument-splitting bug that occurs when a PS single-quoted
+# string containing " chars is passed to wsl.exe — CreateProcess treats those
+# " as argument delimiters and splits the bash command at the first ".
+wsl -d $Distro -u root -e bash -c "rm -f /etc/apt/keyrings/docker.gpg /etc/apt/sources.list.d/docker.list; . /etc/os-release; if echo `$ID `$ID_LIKE | grep -qi ubuntu; then FAMILY=ubuntu; else FAMILY=debian; fi; curl -fsSL https://download.docker.com/linux/`$FAMILY/gpg -o /etc/apt/keyrings/docker.asc && chmod a+r /etc/apt/keyrings/docker.asc && printf 'Types: deb\nURIs: https://download.docker.com/linux/%s\nSuites: %s\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n' `$FAMILY `${UBUNTU_CODENAME:-`$VERSION_CODENAME} | tee /etc/apt/sources.list.d/docker.sources > /dev/null"
 
-wsl -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg /etc/apt/sources.list.d/ddev.list && curl -fsSL https://pkg.ddev.com/apt/gpg.key | tee /etc/apt/keyrings/ddev.asc > /dev/null && chmod a+r /etc/apt/keyrings/ddev.asc"
-wsl -u root -e bash -c "printf 'Types: deb\nURIs: https://pkg.ddev.com/apt/\nSuites: *\nComponents: *\nSigned-By: /etc/apt/keyrings/ddev.asc\n' > /etc/apt/sources.list.d/ddev.sources"
-wsl -u root -e bash -c "apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io"
-wsl -u root -e bash -c "apt-get install -y --no-install-recommends ddev ddev-wsl2"
-wsl bash -c 'sudo usermod -aG docker $USER'
+wsl -d $Distro -u root -e bash -c "rm -f /etc/apt/keyrings/ddev.gpg /etc/apt/sources.list.d/ddev.list && curl -fsSL https://pkg.ddev.com/apt/gpg.key | tee /etc/apt/keyrings/ddev.asc > /dev/null && chmod a+r /etc/apt/keyrings/ddev.asc"
+wsl -d $Distro -u root -e bash -c "printf 'Types: deb\nURIs: https://pkg.ddev.com/apt/\nSuites: *\nComponents: *\nSigned-By: /etc/apt/keyrings/ddev.asc\n' > /etc/apt/sources.list.d/ddev.sources"
+wsl -d $Distro -u root -e bash -c "apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io"
+wsl -d $Distro -u root -e bash -c "apt-get install -y --no-install-recommends ddev ddev-wsl2"
+$wslUser = (wsl -d $Distro whoami).Trim()
+wsl -d $Distro -u root usermod -aG docker $wslUser
 
-wsl mkcert.exe -install
-$env:CAROOT = & wsl mkcert.exe -CAROOT
-setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up:*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
-$defaultDistro = (wsl --list --quiet | Select-Object -First 1) -replace '[\r\n\x00-\x1F\x7F-\x9F]', '' -replace '^\s+|\s+$', ''
-Write-Host "Terminating default WSL2 distro: $defaultDistro"
-wsl --terminate $defaultDistro
+wsl -d $Distro mkcert.exe -install
+$env:CAROOT = & wsl -d $Distro mkcert.exe -CAROOT
+setx CAROOT $env:CAROOT; If ($Env:WSLENV -notlike "*CAROOT/up*") { $env:WSLENV="CAROOT/up:$env:WSLENV"; setx WSLENV $Env:WSLENV }
 
-wsl bash -c 'echo CAROOT=$CAROOT'
-wsl mkcert -install
-if (-not(wsl -e docker ps)) {
-    throw "docker does not seem to be working inside the WSL2 distro yet. "
+# Convert the Windows CAROOT path to a Linux path and pass it directly to mkcert,
+# avoiding a wsl --terminate which breaks Docker Desktop integration.
+$linuxCaRoot = (& wsl -d $Distro wslpath -u ($env:CAROOT -replace '\\', '/')).Trim()
+Write-Host "Linux CAROOT: $linuxCaRoot"
+try {
+    wsl -d $Distro -u root -e bash -c "echo 'ALL ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/temp-mkcert-install && chmod 440 /etc/sudoers.d/temp-mkcert-install"
+    if ($LASTEXITCODE -ne 0) { throw "Failed to create temporary sudoers entry (exit $LASTEXITCODE)" }
+    wsl -d $Distro bash -c "CAROOT='$linuxCaRoot' mkcert -install"
+} finally {
+    wsl -d $Distro -u root rm -f /etc/sudoers.d/temp-mkcert-install
+}
+if (-not(wsl -d $Distro -e docker ps)) {
+    throw "docker does not seem to be working inside '$Distro' yet."
 }
 # If docker desktop was previously set up, the .docker can break normal use of docker client.
-wsl rm -rf ~/.docker
+wsl -d $Distro rm -rf ~/.docker
 
-wsl ddev version
+wsl -d $Distro ddev version

--- a/winpkg/ddev_windows_installer.nsi
+++ b/winpkg/ddev_windows_installer.nsi
@@ -46,6 +46,10 @@ Var /GLOBAL DEBUG_LOG_PATH
 Var /GLOBAL WSL_WINDOWS_TEMP
 Var /GLOBAL WINDOWS_TEMP
 Var /GLOBAL MKCERT_UNINSTALL_APPROVED  ; Track if user approved mkcert removal during uninstall
+Var /GLOBAL DOCKER_DISTRO_FAMILY       ; "ubuntu" or "debian" for Docker CE repo selection
+Var /GLOBAL DOCKER_SUITE               ; Debian/Ubuntu codename for Docker CE repo (e.g. bookworm, trixie, noble)
+Var /GLOBAL DISTRO_LISTBOX_HANDLE      ; Handle for distro selection ListBox
+Var /GLOBAL DISTRO_LIST                ; Pipe-separated list of detected distros
 
 !define REG_INSTDIR_ROOT "HKCU"
 !define REG_INSTDIR_KEY "Software\Microsoft\Windows\CurrentVersion\App Paths\ddev.exe"
@@ -259,53 +263,43 @@ Function DistroSelectionPage
         Abort
     ${EndIf}
 
-    ; Get Ubuntu distros before creating any controls
-    Call GetUbuntuDistros
-    Pop $R0
-    Push "Got distros: [$R0]"
+    ; Get Debian-based distros before creating any controls
+    Call GetDebianBasedDistros
+    Pop $DISTRO_LIST
+    Push "Got distros: [$DISTRO_LIST]"
     Call LogPrint
-    ${If} $R0 == ""
-        Push "ERROR: No Ubuntu-based WSL2 distributions found"
+    ${If} $DISTRO_LIST == ""
+        Push "ERROR: No Debian-based WSL2 distributions found"
         Call LogPrint
-        MessageBox MB_ICONSTOP|MB_OK "No Ubuntu-based WSL2 distributions found. Please install Ubuntu for WSL2 first.$\n$\nDebug information has been written to: $DEBUG_LOG_PATH (please include with any error report)$\n$\nYou can check this file to see what distributions were detected."
-        Push "No Ubuntu-based WSL2 distributions found. Please install Ubuntu for WSL2 first."
+        MessageBox MB_ICONSTOP|MB_OK "No Debian-based WSL2 distributions found. Please install Ubuntu or Debian for WSL2 first.$\n$\nDebug information has been written to: $DEBUG_LOG_PATH (please include with any error report)$\n$\nYou can check this file to see what distributions were detected."
+        Push "No Debian-based WSL2 distributions found. Please install Ubuntu or Debian for WSL2 first."
         Call ShowErrorAndAbort
     ${EndIf}
 
     Push "Creating label..."
     Call LogPrint
-    ${NSD_CreateLabel} 0 0 100% 24u "Select your Ubuntu-based WSL2 distribution:"
+    ${NSD_CreateLabel} 0 0 100% 24u "Select your Debian-based WSL2 distribution:"
     Pop $1
 
-    Push "Creating radio buttons..."
+    Push "Creating listbox..."
     Call LogPrint
+    ${NSD_CreateListBox} 10 30u 280u 130u ""
+    Pop $DISTRO_LISTBOX_HANDLE
 
     ; Get previously selected distro
     ReadRegStr $R8 ${REG_SETTINGS_ROOT} "${REG_SETTINGS_KEY}" "SelectedDistro"
     Push "Previously selected distro: $R8"
     Call LogPrint
 
-    ; Initialize variables for dynamic radio button creation
-    Var /GLOBAL RADIO_BUTTON_COUNT
-    Var /GLOBAL RADIO_BUTTON_HANDLES    ; Will store pipe-separated list of handles
-    Var /GLOBAL RADIO_BUTTON_LABELS     ; Will store pipe-separated list of labels
-    Var /GLOBAL SELECTED_RADIO_INDEX    ; Index of selected radio button
-    
-    StrCpy $RADIO_BUTTON_COUNT 0
-    StrCpy $RADIO_BUTTON_HANDLES ""
-    StrCpy $RADIO_BUTTON_LABELS ""
-    StrCpy $SELECTED_RADIO_INDEX 0
-
-    ; Process the pipe-separated list and create radio buttons
-    StrCpy $R1 $R0    ; Working copy of the list
-    StrCpy $R2 0      ; Current item index
-    StrCpy $R3 0      ; Y position counter
+    ; Populate the listbox and determine default selection index
+    StrCpy $R1 $DISTRO_LIST   ; Working copy
+    StrCpy $R2 0              ; Current item index
+    StrCpy $R3 0              ; Default selection index
 
     ${Do}
-        ; Find position of next pipe or end
-        StrCpy $R5 0   ; Position
+        StrCpy $R5 0
         ${Do}
-            StrCpy $R6 $R1 1 $R5  ; Get character at position
+            StrCpy $R6 $R1 1 $R5
             ${If} $R6 == "|"
             ${OrIf} $R6 == ""
                 ${Break}
@@ -313,67 +307,32 @@ Function DistroSelectionPage
             IntOp $R5 $R5 + 1
         ${Loop}
 
-        ; Extract the item
         ${If} $R5 > 0
-            StrCpy $R7 $R1 $R5    ; Extract item
-            Push "Adding radio button: [$R7]"
+            StrCpy $R7 $R1 $R5
+            Push "Adding listbox item: [$R7]"
             Call LogPrint
-            
-            ; Calculate Y position for radio button
-            IntOp $R9 $R3 * 24
-            IntOp $R9 $R9 + 30
-            
-            ; Create radio button
-            ${NSD_CreateRadioButton} 10 $R9u 280u 16u "$R7"
-            Pop $9
-            
-            ; Store handle and label in our lists
-            ${If} $RADIO_BUTTON_HANDLES == ""
-                StrCpy $RADIO_BUTTON_HANDLES "$9"
-                StrCpy $RADIO_BUTTON_LABELS "$R7"
-            ${Else}
-                StrCpy $RADIO_BUTTON_HANDLES "$RADIO_BUTTON_HANDLES|$9"
-                StrCpy $RADIO_BUTTON_LABELS "$RADIO_BUTTON_LABELS|$R7"
-            ${EndIf}
-            
-            ; Check if this matches the previously selected distro
+            ${NSD_LB_AddString} $DISTRO_LISTBOX_HANDLE "$R7"
+
             ${If} $R7 == $R8
-                StrCpy $SELECTED_RADIO_INDEX $R2
-                ${NSD_SetState} $9 ${BST_CHECKED}
-                Push "Selected distro: $R7 (previous choice)"
-                Call LogPrint
-            ${ElseIf} $R2 == 0
-            ${AndIf} $R8 == ""
-                ${NSD_SetState} $9 ${BST_CHECKED}
-                Push "Selected distro: $R7 (default)"
+                StrCpy $R3 $R2
+                Push "Will select: $R7 (index $R2, previous choice)"
                 Call LogPrint
             ${EndIf}
-            
+
             IntOp $R2 $R2 + 1
-            IntOp $R3 $R3 + 1
         ${EndIf}
 
-        ; Move past the separator
         IntOp $R5 $R5 + 1
         StrCpy $R1 $R1 "" $R5
 
-        ; Check if we're done
         ${If} $R1 == ""
             ${Break}
         ${EndIf}
     ${Loop}
 
-    StrCpy $RADIO_BUTTON_COUNT $R2
-    Push "Added $RADIO_BUTTON_COUNT radio buttons"
+    Push "Added $R2 items to listbox, selecting index $R3"
     Call LogPrint
-    
-    ; Ensure at least one radio button is selected (fallback to first one if no previous selection)
-    ${If} $R8 == ""
-        ${WordFind} "$RADIO_BUTTON_HANDLES" "|" "+1{" $R4
-        ${NSD_SetState} $R4 ${BST_CHECKED}
-        Push "No previous distro selection, defaulting to first distro"
-        Call LogPrint
-    ${EndIf}
+    SendMessage $DISTRO_LISTBOX_HANDLE ${LB_SETCURSEL} $R3 0
 
     Push "About to show dialog..."
     Call LogPrint
@@ -383,60 +342,17 @@ FunctionEnd
 Function DistroSelectionPageLeave
     Push "Getting selected distro..."
     Call LogPrint
-    
-    ; Find which radio button is selected by iterating through all handles
-    StrCpy $R1 $RADIO_BUTTON_HANDLES  ; Working copy of handles
-    StrCpy $R2 $RADIO_BUTTON_LABELS   ; Working copy of labels
-    StrCpy $R3 0                      ; Current index
-    StrCpy $SELECTED_DISTRO ""        ; Clear selection
-    
-    ${Do}
-        ; Extract current handle
-        ${WordFind} "$R1" "|" "+1{" $R4  ; Get first handle
-        ${If} $R4 == $R1
-            ; Last item (no more separators)
-            StrCpy $R5 $R1
-            StrCpy $R1 ""
-        ${Else}
-            ; More items remain
-            StrCpy $R5 $R4
-            ${WordFind} "$R1" "|" "+1}" $R1  ; Remove first item
-        ${EndIf}
-        
-        ; Extract corresponding label
-        ${WordFind} "$R2" "|" "+1{" $R6  ; Get first label
-        ${If} $R6 == $R2
-            ; Last item (no more separators)
-            StrCpy $R7 $R2
-            StrCpy $R2 ""
-        ${Else}
-            ; More items remain
-            StrCpy $R7 $R6
-            ${WordFind} "$R2" "|" "+1}" $R2  ; Remove first item
-        ${EndIf}
-        
-        ; Check if this radio button is selected
-        ${NSD_GetState} $R5 $R0
-        ${If} $R0 == ${BST_CHECKED}
-            StrCpy $SELECTED_DISTRO $R7
-            Push "Selected distro: $SELECTED_DISTRO"
-            Call LogPrint
-            ${Break}
-        ${EndIf}
-        
-        IntOp $R3 $R3 + 1
-        
-        ; Check if we're done
-        ${If} $R1 == ""
-            ${Break}
-        ${EndIf}
-    ${Loop}
-    
-    ; Fallback - should not happen if we have proper radio button logic
+
+    ; NSD_LB_GetSelection returns the text of the selected item directly
+    ${NSD_LB_GetSelection} $DISTRO_LISTBOX_HANDLE $SELECTED_DISTRO
+    Push "Selected distro: $SELECTED_DISTRO"
+    Call LogPrint
+
+    ; Fallback if nothing selected
     ${If} $SELECTED_DISTRO == ""
         Push "No distro selected - using first available"
         Call LogPrint
-        ${WordFind} "$RADIO_BUTTON_LABELS" "|" "+1{" $SELECTED_DISTRO
+        ${WordFind} "$DISTRO_LIST" "|" "+1{" $SELECTED_DISTRO
     ${EndIf}
     
     ; Store the selected distro for next time
@@ -452,6 +368,11 @@ Function DistroSelectionPageLeave
     File /oname=check_root_user.sh "scripts\check_root_user.sh"
     File /oname=mkcert_install.sh "scripts\mkcert_install.sh"
     File /oname=install_temp_sudoers.sh "scripts\install_temp_sudoers.sh"
+    File /oname=detect_docker_suite.sh "scripts\detect_docker_suite.sh"
+    File /oname=detect_docker_family.sh "scripts\detect_docker_family.sh"
+    File /oname=apt_install_with_log.sh "scripts\apt_install_with_log.sh"
+    File /oname=ensure_systemd_enabled.sh "scripts\ensure_systemd_enabled.sh"
+    File /oname=wait_for_systemd.sh "scripts\wait_for_systemd.sh"
     Push "All scripts copied to temp directory"
     Call LogPrint
     
@@ -918,6 +839,11 @@ SectionGroup /e "${PRODUCT_NAME}"
             File /oname=mkcert_install.sh "scripts\mkcert_install.sh"
             File /oname=install_temp_sudoers.sh "scripts\install_temp_sudoers.sh"
             File /oname=check_root_user.sh "scripts\check_root_user.sh"
+            File /oname=detect_docker_suite.sh "scripts\detect_docker_suite.sh"
+            File /oname=detect_docker_family.sh "scripts\detect_docker_family.sh"
+            File /oname=apt_install_with_log.sh "scripts\apt_install_with_log.sh"
+            File /oname=ensure_systemd_enabled.sh "scripts\ensure_systemd_enabled.sh"
+            File /oname=wait_for_systemd.sh "scripts\wait_for_systemd.sh"
         ${EndIf}
 
         ; Install icons
@@ -1046,10 +972,10 @@ Section Uninstall
     ${EndIf}
 SectionEnd
 
-Function GetUbuntuDistros
+Function GetDebianBasedDistros
     StrCpy $R0 ""  ; Result string
 
-    Push "=== Starting GetUbuntuDistros ==="
+    Push "=== Starting GetDebianBasedDistros ==="
     Call LogPrint
 
     Push "Checking registry key HKCU\Software\Microsoft\Windows\CurrentVersion\Lxss..."
@@ -1115,30 +1041,50 @@ Function GetUbuntuDistros
             Push "First 6 chars of '$R3': '$R4'"
             Call LogPrint
             ${If} $R4 == "Ubuntu"
-                Push "Found Ubuntu distribution (name-based): $R3"
+            ${OrIf} $R4 == "Debian"
+                Push "Found Debian-based distribution (name-based): $R3"
                 Call LogPrint
                 ${If} $R0 != ""
                     StrCpy $R0 "$R0|"
                 ${EndIf}
                 StrCpy $R0 "$R0$R3"
             ${Else}
-                Push "Distribution '$R3' does not start with 'Ubuntu' (starts with '$R4')"
+                Push "Distribution '$R3' does not start with 'Ubuntu' or 'Debian' (starts with '$R4')"
                 Call LogPrint
             ${EndIf}
         ${Else}
             Push "Found Flavor field for $R3: '$R4'"
             Call LogPrint
-            ; Check if Flavor is "ubuntu" (case-insensitive)
-            ${StrStr} $R6 $R4 "ubuntu"
-            ${If} $R6 != ""
-                Push "Found Ubuntu distribution (Flavor-based): $R3"
+            ; Check if Flavor is a known Debian-based distro identifier
+            ; (ubuntu, debian, kali, elxr — case-insensitive substring match).
+            ; Note: $R5 holds the total distro count (loop bound), do not clobber.
+            ; Use $R6 as a "matched" flag and $R7 as the per-test StrStr result.
+            StrCpy $R6 ""
+            ${StrStr} $R7 $R4 "ubuntu"
+            ${If} $R7 != ""
+                StrCpy $R6 "yes"
+            ${EndIf}
+            ${StrStr} $R7 $R4 "debian"
+            ${If} $R7 != ""
+                StrCpy $R6 "yes"
+            ${EndIf}
+            ${StrStr} $R7 $R4 "kali"
+            ${If} $R7 != ""
+                StrCpy $R6 "yes"
+            ${EndIf}
+            ${StrStr} $R7 $R4 "elxr"
+            ${If} $R7 != ""
+                StrCpy $R6 "yes"
+            ${EndIf}
+            ${If} $R6 == "yes"
+                Push "Found Debian-based distribution (Flavor-based): $R3"
                 Call LogPrint
                 ${If} $R0 != ""
                     StrCpy $R0 "$R0|"
                 ${EndIf}
                 StrCpy $R0 "$R0$R3"
             ${Else}
-                Push "Distribution '$R3' has Flavor '$R4' but does not contain 'ubuntu'"
+                Push "Distribution '$R3' has Flavor '$R4' but does not contain 'ubuntu', 'debian', 'kali', or 'elxr'"
                 Call LogPrint
             ${EndIf}
         ${EndIf}
@@ -1154,7 +1100,7 @@ FunctionEnd
 
 Function InstallWSL2CommonSetup
     ; Note: WSL distros have already been enumerated from the registry and selected by the user.
-    ; The distro type (Ubuntu) has been verified from the registry Flavor field.
+    ; The distro type (Debian-based) has been verified from the registry Flavor field.
     ; Docker connectivity has already been validated with 'docker ps'.
 
     ; List WSL distros and versions (helpful for troubleshooting)
@@ -1218,6 +1164,74 @@ Function InstallWSL2CommonSetup
     Push "Root user check passed"
     Call LogPrint
 
+    ; Install apt_install_with_log.sh helper into the distro once so the
+    ; later apt-get install steps can surface the tail of apt's output
+    ; (the NSIS output buffer truncates long apt traces mid-stream).
+    Push "Installing apt_install_with_log.sh helper into $SELECTED_DISTRO..."
+    Call LogPrint
+    Push $SELECTED_DISTRO
+    Push "apt_install_with_log.sh"
+    Call InstallScriptToDistro
+    Pop $R0
+
+    ; Ensure systemd is enabled in this distro's /etc/wsl.conf so dockerd
+    ; auto-starts and D-Bus is available (D-Bus is needed by
+    ; docker-credential-secretservice and many other tools). Distros that
+    ; ship with [boot] systemd=false cause Docker to fail
+    ; silently and credential helpers to error with "Could not connect".
+    Push "Ensuring systemd is enabled in $SELECTED_DISTRO's /etc/wsl.conf..."
+    Call LogPrint
+    Push $SELECTED_DISTRO
+    Push "ensure_systemd_enabled.sh"
+    Call InstallScriptToDistro
+    Pop $R0
+    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash /tmp/ensure_systemd_enabled.sh'
+    Pop $R1
+    Pop $R2
+    Push "ensure_systemd_enabled.sh exit=$R1: $R2"
+    Call LogPrint
+    ${If} $R1 == 2
+        Push "ERROR: could not write /etc/wsl.conf in $SELECTED_DISTRO: $R2"
+        Call LogPrint
+        Push "Could not enable systemd in /etc/wsl.conf in $SELECTED_DISTRO. Output: $R2"
+        Call ShowErrorAndAbort
+    ${EndIf}
+    ${If} $R1 == 1
+        ; systemd was just enabled — terminate the distro so it boots
+        ; with systemd as PID 1, then bring it back up.
+        Push "systemd was newly enabled; terminating $SELECTED_DISTRO so the change takes effect..."
+        Call LogPrint
+        nsExec::ExecToStack 'wsl.exe --terminate $SELECTED_DISTRO'
+        Pop $R1
+        Pop $R2
+        Push "wsl --terminate exit=$R1: $R2"
+        Call LogPrint
+        ; Bring it back up. systemd takes a few seconds to settle. Use a
+        ; helper script so we don't fight NSIS's $(...) language-string
+        ; quoting rules. After --terminate, /tmp/* on Kali/eLxr is on
+        ; the ext4 rootfs so previously-installed helpers persist, but
+        ; reinstall to be safe.
+        Push "Restarting $SELECTED_DISTRO with systemd..."
+        Call LogPrint
+        Push $SELECTED_DISTRO
+        Push "apt_install_with_log.sh"
+        Call InstallScriptToDistro
+        Pop $R0
+        Push $SELECTED_DISTRO
+        Push "wait_for_systemd.sh"
+        Call InstallScriptToDistro
+        Pop $R0
+        nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash /tmp/wait_for_systemd.sh 20'
+        Pop $R1
+        Pop $R2
+        Push "systemd readiness check exit=$R1: $R2"
+        Call LogPrint
+        ${If} $R1 != 0
+            Push "WARNING: systemd did not report ready within 20s; continuing anyway. Output: $R2"
+            Call LogPrint
+        ${EndIf}
+    ${EndIf}
+
     ${If} $INSTALL_OPTION == "wsl2-docker-desktop"
         ; Make sure we're not running docker-ce or docker.io daemon (conflicts with Docker Desktop)
         Push "Verifying Docker installation type..."
@@ -1260,9 +1274,21 @@ Function InstallWSL2CommonSetup
     Call LogPrint
     Push "Please be patient - installing required linux packages..."
     Call LogPrint
-    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root apt-get install -y ca-certificates curl gnupg gnupg2 libsecret-1-0 lsb-release pass'
+    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash /tmp/apt_install_with_log.sh prereq ca-certificates curl gnupg libsecret-1-0 lsb-release'
     Pop $1
     Pop $0
+    ; Optionally try to install 'pass' (used by docker-credential-pass);
+    ; not all minimal Debian derivatives (e.g. eLxr) carry it. A failure
+    ; here is a warning, not fatal.
+    Push "WSL($SELECTED_DISTRO): Trying optional package 'pass'..."
+    Call LogPrint
+    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash /tmp/apt_install_with_log.sh prereq-optional pass'
+    Pop $R1
+    Pop $R2
+    ${If} $R1 != 0
+        Push "WARNING: optional package 'pass' not installed (exit=$R1): $R2"
+        Call LogPrint
+    ${EndIf}
     ${If} $1 != 0
         Push "ERROR: Failed to apt-get install - exit code: $1, output: $0"
         Call LogPrint
@@ -1283,6 +1309,45 @@ Function InstallWSL2CommonSetup
         Call ShowErrorAndAbort
     ${EndIf}
 
+    ; The Docker apt repository + Docker package install are ONLY for docker-ce
+    ; mode. In docker-desktop mode, Docker (and the docker CLI) come from Docker
+    ; Desktop's WSL2 integration, so adding the Docker apt repo is unnecessary
+    ; (and installing docker-ce-cli from it would clobber Docker Desktop's
+    ; /usr/bin/docker integration symlink).
+    ${If} $INSTALL_OPTION == "wsl2-docker-ce"
+    ; Detect distro family for Docker repository selection (ubuntu vs debian)
+    Push "WSL($SELECTED_DISTRO): Detecting distro family for Docker repository..."
+    Call LogPrint
+    Push $SELECTED_DISTRO
+    Push "detect_docker_family.sh"
+    Call InstallScriptToDistro
+    Pop $R0
+    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash /tmp/detect_docker_family.sh'
+    Pop $1
+    Pop $DOCKER_DISTRO_FAMILY
+    ${If} $DOCKER_DISTRO_FAMILY == ""
+        StrCpy $DOCKER_DISTRO_FAMILY "debian"
+    ${EndIf}
+    Push "WSL($SELECTED_DISTRO): Using Docker repository for distro family: $DOCKER_DISTRO_FAMILY"
+    Call LogPrint
+
+    ; Detect Docker suite codename - handles Kali and other derivatives
+    ; whose VERSION_CODENAME is not a valid Docker repo suite
+    Push "WSL($SELECTED_DISTRO): Detecting Docker suite codename..."
+    Call LogPrint
+    Push $SELECTED_DISTRO
+    Push "detect_docker_suite.sh"
+    Call InstallScriptToDistro
+    Pop $R0
+    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash /tmp/detect_docker_suite.sh'
+    Pop $1
+    Pop $DOCKER_SUITE
+    ${If} $DOCKER_SUITE == ""
+        StrCpy $DOCKER_SUITE "bookworm"
+    ${EndIf}
+    Push "WSL($SELECTED_DISTRO): Using Docker suite: $DOCKER_SUITE"
+    Call LogPrint
+
     ; Clean up old Docker repository files if present
     Push "WSL($SELECTED_DISTRO): Removing old Docker repository files if present..."
     Call LogPrint
@@ -1293,7 +1358,7 @@ Function InstallWSL2CommonSetup
     ; Add Docker GPG key
     Push "WSL($SELECTED_DISTRO): Adding Docker repository key..."
     Call LogPrint
-    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash -c "curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && chmod a+r /etc/apt/keyrings/docker.asc"'
+    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash -c "curl -fsSL https://download.docker.com/linux/$DOCKER_DISTRO_FAMILY/gpg -o /etc/apt/keyrings/docker.asc && chmod a+r /etc/apt/keyrings/docker.asc"'
     Pop $1
     Pop $0
     ${If} $1 != 0
@@ -1306,7 +1371,7 @@ Function InstallWSL2CommonSetup
     ; Add Docker repository in deb822 format
     Push "WSL($SELECTED_DISTRO): Adding Docker apt repository..."
     Call LogPrint
-    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash -c "printf \"Types: deb\nURIs: https://download.docker.com/linux/ubuntu\nSuites: $$(. /etc/os-release && echo $${UBUNTU_CODENAME:-$$VERSION_CODENAME})\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n\" > /etc/apt/sources.list.d/docker.sources"'
+    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash -c "printf \"Types: deb\nURIs: https://download.docker.com/linux/$DOCKER_DISTRO_FAMILY\nSuites: $DOCKER_SUITE\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n\" > /etc/apt/sources.list.d/docker.sources"'
     Pop $1
     Pop $0
     ${If} $1 != 0
@@ -1314,6 +1379,10 @@ Function InstallWSL2CommonSetup
         Call LogPrint
         Push "Failed to add Docker repository. Exit code: $1, Output: $0"
         Call ShowErrorAndAbort
+    ${EndIf}
+    ${Else}
+        Push "WSL($SELECTED_DISTRO): Skipping Docker apt repository setup — Docker provided by Docker Desktop"
+        Call LogPrint
     ${EndIf}
 
     ; Clean up old DDEV repository files if present
@@ -1377,8 +1446,8 @@ Function InstallWSL2Common
     Call InstallWSL2CommonSetup
 
     ${If} $INSTALL_OPTION == "wsl2-docker-desktop"
-        ; Install packages needed for Docker Desktop (including ddev)
-        StrCpy $0 "docker-ce-cli ddev"
+        ; docker-desktop: Docker comes from Docker Desktop integration; only ddev.
+        StrCpy $0 "ddev"
     ${Else}
         ; Install full Docker CE packages (including ddev)
         StrCpy $0 "docker-ce docker-ce-cli containerd.io ddev"
@@ -1394,7 +1463,7 @@ Function InstallWSL2Common
     Call LogPrint
     Push "Please be patient - installing essential packages..."
     Call LogPrint
-    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash -c "DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl gnupg gnupg2 libsecret-1-0 lsb-release pass 2>&1"'
+    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash /tmp/apt_install_with_log.sh essential ca-certificates curl gnupg libsecret-1-0 lsb-release'
     Pop $1
     Pop $2
     ${If} $1 != 0
@@ -1403,28 +1472,44 @@ Function InstallWSL2Common
         Push "Failed to install essential packages. Error: $2"
         Call ShowErrorAndAbort
     ${EndIf}
+    ; Optionally retry 'pass' here too (idempotent if already installed).
+    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash /tmp/apt_install_with_log.sh essential-optional pass'
+    Pop $R1
+    Pop $R2
+    ${If} $R1 != 0
+        Push "WARNING: optional package 'pass' not installed (exit=$R1): $R2"
+        Call LogPrint
+    ${EndIf}
     
     ; Update status
     nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO bash -c "echo \"PROGRESS: Installing Docker components\" >> /tmp/ddev_installation_status.txt"'
     Pop $1
     Pop $2
 
-    Push "WSL($SELECTED_DISTRO): Installing Docker components (2/3)..."
-    Call LogPrint
-    Push "Please be patient - installing Docker components..."
-    Call LogPrint
     ${If} $INSTALL_OPTION == "wsl2-docker-ce"
-        nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash -c "DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io 2>&1"'
-    ${Else}
-        nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash -c "DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce-cli 2>&1"'
-    ${EndIf}
-    Pop $1
-    Pop $2
-    ${If} $1 != 0
-        Push "ERROR: Failed to install Docker components - exit code: $1, output: $2"
+        Push "WSL($SELECTED_DISTRO): Installing Docker components (2/3)..."
         Call LogPrint
-        Push "Failed to install Docker components. Error: $2"
-        Call ShowErrorAndAbort
+        Push "Please be patient - installing Docker components..."
+        Call LogPrint
+        nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash /tmp/apt_install_with_log.sh docker docker-ce docker-ce-cli containerd.io'
+        Pop $1
+        Pop $2
+        ${If} $1 != 0
+            Push "ERROR: Failed to install Docker components - exit code: $1, output: $2"
+            Call LogPrint
+            Push "Failed to install Docker components. Error: $2"
+            Call ShowErrorAndAbort
+        ${EndIf}
+    ${Else}
+        ; docker-desktop mode: Docker and the docker CLI are provided by Docker
+        ; Desktop's WSL2 integration. Do NOT install docker-ce-cli here — it owns
+        ; /usr/bin/docker, exactly where Docker Desktop injects its integration
+        ; symlink. Installing it clobbers the integration and breaks `docker`
+        ; mid-install until Docker Desktop re-injects, so the `ddev version` check
+        ; fails with a docker 500. Mirrors the ps1 docker-desktop path, which
+        ; installs only ddev.
+        Push "WSL($SELECTED_DISTRO): Skipping Docker package install — provided by Docker Desktop (2/3)..."
+        Call LogPrint
     ${EndIf}
 
     ; Update status
@@ -1436,7 +1521,7 @@ Function InstallWSL2Common
     Call LogPrint
     Push "Please be patient - installing DDEV..."
     Call LogPrint
-    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root bash -c "DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y ddev ddev-wsl2 2>&1"'
+    nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root env APT_EXTRA_ARGS=--no-install-recommends bash /tmp/apt_install_with_log.sh ddev ddev ddev-wsl2'
     Pop $1
     Pop $2
     ${If} $1 != 0
@@ -1578,6 +1663,31 @@ Function InstallWSL2Common
         ${EndIf}
     ${EndIf}
 
+    ; Verify the Docker daemon is running. We earlier ensured systemd is
+    ; enabled in /etc/wsl.conf (and restarted the distro if it wasn't),
+    ; so dockerd should already be running via the docker.service unit
+    ; that docker-ce's postinst enabled. If it isn't yet (race with the
+    ; service starting), nudge it via systemctl and poll docker info.
+    ${If} $INSTALL_OPTION == "wsl2-docker-ce"
+        Push "WSL($SELECTED_DISTRO): Verifying Docker daemon via systemd..."
+        Call LogPrint
+        nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root systemctl start docker.service'
+        Pop $1
+        Pop $0
+        Push "systemctl start docker.service exit=$1: $0"
+        Call LogPrint
+        nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO -u root sh -c "for i in 1 2 3 4 5 6 7 8 9 10; do docker info >/dev/null 2>&1 && exit 0; sleep 1; done; exit 1"'
+        Pop $1
+        Pop $0
+        ${If} $1 != 0
+            Push "WARNING: Docker daemon did not become ready within 10s. Output: $0"
+            Call LogPrint
+        ${Else}
+            Push "Docker daemon is ready."
+            Call LogPrint
+        ${EndIf}
+    ${EndIf}
+
     ; Show DDEV version
     Push "Verifying DDEV installation with 'ddev version'..."
     Call LogPrint
@@ -1648,6 +1758,11 @@ Function InstallWSL2Common
     Delete "$WINDOWS_TEMP\ddev_installer\check_root_user.sh"
     Delete "$WINDOWS_TEMP\ddev_installer\install_temp_sudoers.sh"
     Delete "$WINDOWS_TEMP\ddev_installer\mkcert_install.sh"
+    Delete "$WINDOWS_TEMP\ddev_installer\detect_docker_suite.sh"
+    Delete "$WINDOWS_TEMP\ddev_installer\detect_docker_family.sh"
+    Delete "$WINDOWS_TEMP\ddev_installer\apt_install_with_log.sh"
+    Delete "$WINDOWS_TEMP\ddev_installer\ensure_systemd_enabled.sh"
+    Delete "$WINDOWS_TEMP\ddev_installer\wait_for_systemd.sh"
     Delete "$WINDOWS_TEMP\ddev_installer\ddev_linux"
     Delete "$WINDOWS_TEMP\ddev_installer\ddev-hostname_linux"
     Delete "$WINDOWS_TEMP\ddev_installer\mkcert_linux"
@@ -2088,8 +2203,8 @@ Function ParseCommandLine
             /S                           - Silent install$\n\
             /help or /?                  - Show this help message$\n$\n\
             Examples:$\n\
-            installer.exe /docker-ce /distro=Ubuntu-22.04$\n\
-            installer.exe /docker-desktop /distro=Ubuntu-20.04$\n\
+            installer.exe /docker-ce /distro=Ubuntu$\n\
+            installer.exe /docker-desktop /distro=Ubuntu-24.04$\n\
             installer.exe /traditional$\n\
             installer.exe /traditional /S"
         Abort
@@ -2106,8 +2221,8 @@ Function ParseCommandLine
             /S                           - Silent install$\n\
             /help or /?                  - Show this help message$\n$\n\
             Examples:$\n\
-            installer.exe /docker-ce /distro=Ubuntu-22.04$\n\
-            installer.exe /docker-desktop /distro=Ubuntu-20.04$\n\
+            installer.exe /docker-ce /distro=Ubuntu$\n\
+            installer.exe /docker-desktop /distro=Ubuntu-24.04$\n\
             installer.exe /traditional$\n\
             installer.exe /traditional /S"
         Abort
@@ -2293,16 +2408,30 @@ Function ShowErrorAndAbort
     Exch $R0  ; Get error message from stack
     Push "INSTALLATION ERROR: $R0"
     Call LogPrint
-    
+
     ; Write error status to WSL2 distro if available
     ${If} $SELECTED_DISTRO != ""
         nsExec::ExecToStack 'wsl -d $SELECTED_DISTRO bash -c "echo \"ERROR: $R0\" >> /tmp/ddev_installation_status.txt"'
         Pop $1
         Pop $2
     ${EndIf}
-    
+
     ${IfNot} ${Silent}
-        MessageBox MB_ICONSTOP|MB_OK "$R0$\n$\nDebug information has been written to: $DEBUG_LOG_PATH (please include with any error report)$\n$\nPlease fix the issue and retry the installer."
+        ; Lead with the log path so it stays visible even if the error
+        ; body is long enough to scroll off-screen in the MessageBox.
+        ; Truncate the error body to keep the dialog compact; the full
+        ; error is always available in the debug log.
+        StrLen $R1 $R0
+        ${If} $R1 > 600
+            StrCpy $R2 $R0 600
+            StrCpy $R2 "$R2...$\n[truncated — see debug log for full output]"
+        ${Else}
+            StrCpy $R2 $R0
+        ${EndIf}
+        MessageBox MB_ICONSTOP|MB_OKCANCEL "DDEV installation failed.$\n$\nFull debug log (please include with any error report):$\n$DEBUG_LOG_PATH$\n$\n----- Error -----$\n$R2$\n$\nClick OK to open the debug log in Notepad, or Cancel to exit." IDOK open_log IDCANCEL skip_log
+        open_log:
+            ExecShell "open" "notepad.exe" "$DEBUG_LOG_PATH"
+        skip_log:
     ${EndIf}
     Push "Exiting installer due to error. Debug log: $DEBUG_LOG_PATH (please include with any error report)"
     Call LogPrint
@@ -2385,10 +2514,14 @@ Function un.CleanupMkcertEnvironment
         ; mkcert -uninstall was already run in un.mkcertUninstall if user approved
         ; No need to run it again here
 
-        ; Remove any remaining CAROOT directory
-        ${If} ${FileExists} "$R0"
-            DetailPrint "Removing remaining CAROOT directory: $R0"
-            RMDir /r "$R0"
+        ; Remove any remaining CAROOT directory (skip in silent mode to preserve for subsequent installs)
+        ${IfNot} ${Silent}
+            ${If} ${FileExists} "$R0"
+                DetailPrint "Removing remaining CAROOT directory: $R0"
+                RMDir /r "$R0"
+            ${EndIf}
+        ${Else}
+            DetailPrint "Preserving CAROOT directory in silent mode"
         ${EndIf}
     ${EndIf}
 

--- a/winpkg/installer_test.go
+++ b/winpkg/installer_test.go
@@ -71,39 +71,188 @@ func getInstallerDebugLogs(t *testing.T) string {
 	return fmt.Sprintf("=== Installer Debug Log: %s ===\n%s", logPath, string(content))
 }
 
+// waitForDockerDesktopWSL2Integration polls until Docker Desktop's WSL2
+// integration is active for the given distro. It first polls briefly; if
+// integration is still absent, it restarts Docker Desktop via
+// .buildkite/restart-docker-desktop.sh (which forces Docker Desktop to
+// re-inject its /usr/bin/docker symlink into all configured distros).
+// Returns true when `docker ps` succeeds inside the distro, false on timeout.
+func waitForDockerDesktopWSL2Integration(t *testing.T, distro string) bool {
+	t.Helper()
+	// Poll briefly before resorting to a Docker Desktop restart. Give Docker Desktop
+	// ~40s to inject integration naturally after sanetestbot.sh starts it. If it
+	// hasn't appeared by then, restart-docker-desktop.sh (stop+start) reliably
+	// restores it in another ~30s.
+	const quickAttempts = 4
+	const delay = 10 * time.Second
+
+	for attempt := 1; attempt <= quickAttempts; attempt++ {
+		// When Docker Desktop integration is active it symlinks /usr/bin/docker →
+		// /mnt/wsl/docker-desktop/cli-tools/usr/bin/docker (a real Linux binary).
+		// When inactive, /usr/bin/docker does not exist; PATH falls through to the
+		// /Docker/host/bin/docker stub which outputs the "integration not enabled" error.
+		out, err := exec.RunHostCommand("wsl.exe", "-d", distro, "--", "docker", "ps")
+		if err == nil {
+			// docker ps works — also verify Docker API is fully ready via docker info.
+			// docker ps can succeed while Docker Desktop is still initializing; the
+			// installer's 'ddev version' calls docker info/version and hangs with HTTP 500
+			// if the Docker daemon isn't fully ready yet.
+			infoOut, infoErr := exec.RunHostCommand("wsl.exe", "-d", distro, "--", "docker", "info", "--format", "{{.ServerVersion}}")
+			if infoErr == nil && strings.TrimSpace(infoOut) != "" {
+				t.Logf("Docker Desktop fully ready in %s (attempt %d/%d), server version: %s", distro, attempt, quickAttempts, strings.TrimSpace(infoOut))
+				return true
+			}
+			t.Logf("Docker Desktop integration present but API not fully ready in %s (attempt %d/%d): %v", distro, attempt, quickAttempts, infoErr)
+			// Fall through — retry after delay
+		}
+		t.Logf("Docker Desktop WSL2 integration not yet active for %s (attempt %d/%d): %v\nOutput: %s", distro, attempt, quickAttempts, err, out)
+
+		// On first failure, dump diagnostics to help understand the environment.
+		if attempt == 1 {
+			if diagOut, diagErr := exec.RunHostCommand("wsl.exe", "--list", "--running"); diagErr == nil {
+				t.Logf("WSL running distros:\n%s", diagOut)
+			}
+			if diagOut, _ := exec.RunHostCommand("wsl.exe", "-d", distro, "--", "bash", "-lc",
+				`echo "PATH=$PATH"; which docker 2>&1 || echo "docker not in PATH"; ls -la /var/run/docker.sock 2>&1; ls /usr/local/bin/docker /usr/bin/docker 2>&1`); diagOut != "" {
+				t.Logf("Diagnostics inside %s:\n%s", distro, diagOut)
+			}
+		}
+
+		if attempt < quickAttempts {
+			time.Sleep(delay)
+		}
+	}
+
+	// Before resorting to a full Docker Desktop restart, try fixing WSL interop.
+	// The Docker Desktop CLI at /mnt/wsl/docker-desktop/cli-tools/usr/bin/docker
+	// uses WSL interop internally. If WSLInterop was cleared from binfmt_misc
+	// (e.g. by docker-ce post-remove scripts during cleanupTestEnv), the symlink
+	// exists and the mount looks fine but the binary cannot execute. wsl-fix-interop
+	// re-registers the binfmt_misc entry and is much cheaper than a full restart.
+	t.Logf("Docker Desktop WSL2 integration absent for %s after %d attempts — trying wsl-fix-interop first", distro, quickAttempts)
+	if fixOut, fixErr := exec.RunHostCommand("wsl.exe", "-d", distro, "bash", "-c", "sudo wsl-fix-interop"); fixErr != nil {
+		t.Logf("wsl-fix-interop in %s failed: %v\n%s", distro, fixErr, fixOut)
+	} else {
+		t.Logf("wsl-fix-interop in %s: %s", distro, strings.TrimSpace(fixOut))
+	}
+	// Give interop a moment to take effect, then re-check.
+	time.Sleep(5 * time.Second)
+	if out, err := exec.RunHostCommand("wsl.exe", "-d", distro, "--", "docker", "ps"); err == nil {
+		t.Logf("Docker Desktop WSL2 integration confirmed for %s after wsl-fix-interop", distro)
+		_ = out
+		return true
+	}
+
+	// Last resort: full Docker Desktop restart via 'docker desktop restart',
+	// which re-injects the /usr/bin/docker integration symlink into the distro.
+	// (We dropped the "lightweight proxy re-inject" attempt: it ran Docker
+	// Desktop's own docker-desktop-user-distro proxy binary, but that is exactly
+	// the binary DD itself cannot run in the failure modes we hit — the 0-byte
+	// post-update stub and the noexec/permission cases — so it never succeeded
+	// and only added ~40s before this restart, which does work.)
+	t.Logf("Docker Desktop WSL2 integration absent for %s after wsl-fix-interop — performing full Docker Desktop restart", distro)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Logf("Could not get working directory: %v", err)
+		return false
+	}
+	restartScript := filepath.Join(wd, "..", ".buildkite", "restart-docker-desktop.sh")
+	// The restart script stops Docker Desktop, waits for it to stop, starts it again,
+	// and waits for WSL2 integration to appear — up to ~7 minutes total.
+	const restartTimeout = 10 * time.Minute
+	ctx, cancel := context.WithTimeout(context.Background(), restartTimeout)
+	defer cancel()
+	cmd := osexec.CommandContext(ctx, "bash", restartScript, distro)
+	restartOutBytes, restartErr := cmd.CombinedOutput()
+	restartOut := string(restartOutBytes)
+	t.Logf("Docker Desktop restart output:\n%s", restartOut)
+	if restartErr != nil {
+		t.Logf("Docker Desktop restart failed: %v", restartErr)
+		return false
+	}
+	// After restart, docker ps works but Docker Desktop may still be initializing
+	// its internal components. The NSIS installer exercises docker more thoroughly
+	// (docker info, image operations) and hangs if Docker isn't fully ready.
+	// Wait for docker info to succeed inside the distro as a stronger readiness check.
+	t.Logf("Waiting for docker info to confirm Docker is fully initialized in %s...", distro)
+	const dockerInfoAttempts = 12
+	const dockerInfoDelay = 10 * time.Second
+	for i := 1; i <= dockerInfoAttempts; i++ {
+		out, err := exec.RunHostCommand("wsl.exe", "-d", distro, "--", "docker", "info", "--format", "{{.ServerVersion}}")
+		if err == nil && strings.TrimSpace(out) != "" {
+			t.Logf("Docker fully initialized in %s (attempt %d/%d), server version: %s", distro, i, dockerInfoAttempts, strings.TrimSpace(out))
+			return true
+		}
+		t.Logf("Docker not yet fully initialized in %s (attempt %d/%d): %v", distro, i, dockerInfoAttempts, err)
+		if i < dockerInfoAttempts {
+			time.Sleep(dockerInfoDelay)
+		}
+	}
+	t.Logf("WARNING: docker info did not succeed in %s after restart — proceeding anyway", distro)
+	return true
+}
+
 // TestWindowsInstallerWSL2 tests WSL2 installation paths using a test matrix
 func TestWindowsInstallerWSL2(t *testing.T) {
 	if nodeps.IsEnvFalse("DDEV_TEST_USE_REAL_INSTALLER") {
 		t.Skip("Skipping installer test, set DDEV_TEST_USE_REAL_INSTALLER=true to run")
 	}
 
-	testCases := []struct {
+	// The test matrix is one entry per (base distro × Docker provider). The
+	// instance name is also the subtest name, so `-run` filters read identically
+	// to the WSL distro name, e.g. `-run TestWindowsInstallerWSL2/ddev-test-debian-ce`.
+	// The named instances are provisioned out-of-band on each runner (see
+	// docs/content/developers/buildkite-testmachine-setup.md); the test only
+	// resets and reuses them. baseDistro is documentation of the provisioning
+	// source and is not used at test runtime.
+	matrix := []struct {
+		instance   string // WSL instance name == subtest name
+		baseDistro string // WSL catalog distro the instance is provisioned from
+		provider   string // "docker-ce" or "docker-desktop"
+	}{
+		// "Ubuntu" in the WSL catalog installs the current LTS (Ubuntu 26.04 as of 2026).
+		{instance: "ddev-test-ubuntu-ce", baseDistro: "Ubuntu", provider: "docker-ce"},
+		{instance: "ddev-test-ubuntu-desktop", baseDistro: "Ubuntu", provider: "docker-desktop"},
+		// {instance: "ddev-test-ubuntu2404-ce", baseDistro: "Ubuntu-24.04", provider: "docker-ce"},
+		// {instance: "ddev-test-ubuntu2404-desktop", baseDistro: "Ubuntu-24.04", provider: "docker-desktop"},
+		{instance: "ddev-test-debian-ce", baseDistro: "Debian", provider: "docker-ce"},
+		{instance: "ddev-test-debian-desktop", baseDistro: "Debian", provider: "docker-desktop"},
+	}
+
+	providerArg := map[string]string{
+		"docker-ce":      "/docker-ce",
+		"docker-desktop": "/docker-desktop",
+	}
+
+	type testCase struct {
 		name          string
 		distro        string
 		installerArgs []string
-		skipCondition func() bool
-	}{
-		{
-			name:          "DockerCE",
-			distro:        "TestDockerCE",
-			installerArgs: []string{"/docker-ce", "/distro=TestDockerCE", "/S"},
-			skipCondition: func() bool { return false }, // always run
-		},
-		{
-			name:          "DockerDesktop",
-			distro:        "TestDesktop",
-			installerArgs: []string{"/docker-desktop", "/distro=TestDesktop", "/S"},
-			skipCondition: func() bool { return !isDockerProviderAvailable("TestDesktop") },
-		},
+	}
+	testCases := make([]testCase, 0, len(matrix))
+	for _, m := range matrix {
+		testCases = append(testCases, testCase{
+			name:          m.instance,
+			distro:        m.instance,
+			installerArgs: []string{providerArg[m.provider], "/distro=" + m.instance, "/S"},
+		})
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.skipCondition() {
-				t.Skipf("Skipping %s test - Desktop distro must have integration with Rancher/Docker Desktop", tc.name)
-			}
-
 			require := require.New(t)
+
+			// For docker-desktop cases verify integration is active before running
+			// the installer. Docker Desktop frequently loses WSL2 integration; this
+			// produces an actionable message instead of a cryptic installer error.
+			if strings.HasSuffix(tc.name, "-desktop") {
+				if !waitForDockerDesktopWSL2Integration(t, tc.distro) {
+					t.Skipf("SKIPPED: Docker Desktop WSL2 integration is not active for %s after retries.\n"+
+						"Re-enable it: Docker Desktop → Settings → Resources → WSL Integration → enable %s → Apply & Restart.\n"+
+						"Then verify with: wsl -d %s docker ps",
+						tc.distro, tc.distro, tc.distro)
+				}
+			}
 
 			// Dump installer debug logs on test failure (registered first, runs last)
 			t.Cleanup(func() {
@@ -119,11 +268,31 @@ func TestWindowsInstallerWSL2(t *testing.T) {
 			cleanupTestEnv(t, tc.distro)
 			configureTestWSL2Distro(t, tc.distro)
 
+			// cleanupTestEnv just removed docker-ce-cli. Desktop distros must use
+			// Docker Desktop's own /usr/bin/docker integration symlink, not the
+			// docker-ce-cli binary (which masks broken integration and then breaks
+			// mid-install). Re-verify integration here so Docker Desktop re-injects
+			// its symlink — which removing docker-ce-cli may have just deleted —
+			// before the installer needs docker.
+			if strings.HasSuffix(tc.name, "-desktop") {
+				if !waitForDockerDesktopWSL2Integration(t, tc.distro) {
+					t.Skipf("SKIPPED: Docker Desktop WSL2 integration not active for %s after cleanup/retries.\n"+
+						"Verify with: wsl -d %s docker ps", tc.distro, tc.distro)
+				}
+			}
+
 			// Ensure ddev is powered off after this test case, even if it fails
 			t.Cleanup(func() {
 				t.Logf("Cleaning up %s test - powering off ddev", tc.name)
 				_, _ = exec.RunHostCommand("wsl.exe", "-d", tc.distro, "bash", "-c", "ddev poweroff")
 				_, _ = exec.RunHostCommand("wsl.exe", "-d", tc.distro, "bash", "-c", "ddev delete -Oy tp")
+				// Remove docker-ce-cli/docker-ce on ALL distros, including docker-desktop.
+				// On desktop distros docker-ce-cli must NOT be present: it owns
+				// /usr/bin/docker (Docker Desktop's integration symlink path) and, while
+				// installed, masks broken integration (docker ps succeeds via its binary
+				// + DD's socket) so the precondition falsely passes and docker breaks
+				// mid-install. With it gone, /usr/bin/docker is Docker Desktop's own
+				// symlink, which the precondition can reliably detect and restart-repair.
 				_, _ = exec.RunHostCommand("wsl.exe", "-d", tc.distro, "-u", "root", "bash", "-c", "apt-get remove -y ddev ddev-wsl2 docker-ce-cli docker-ce")
 			})
 
@@ -141,10 +310,11 @@ func TestWindowsInstallerWSL2(t *testing.T) {
 			out, _ := exec.RunHostCommand("tasklist.exe", "/FI", "IMAGENAME eq msiexec.exe")
 			t.Logf("MSI processes running: %s", out)
 
-			// Run installer with a 20-minute timeout to prevent infinite hangs.
-			// Fresh Docker CE apt-get installs + docker-compose download can
-			// legitimately take 10+ minutes on a loaded CI machine.
-			const installerTimeout = 20 * time.Minute
+			// Run installer with a 10-minute timeout to prevent infinite hangs.
+			// Each case runs as its own decoupled Buildkite job, so an install
+			// that exceeds 10 minutes is treated as a real failure (the test then
+			// dumps the installer debug log rather than letting the job hang).
+			const installerTimeout = 15 * time.Minute
 			ctx, cancel := context.WithTimeout(context.Background(), installerTimeout)
 			defer cancel()
 
@@ -379,10 +549,28 @@ func cleanupTestEnv(t *testing.T, distroName string) {
 	//t.Logf("WSL distros list: %q", cleanOut)
 
 	if strings.Contains(cleanOut, distroName) {
+		// Ensure WSL interop is working before any .exe operations in this distro.
+		// The binfmt_misc WSLInterop entry can go missing after a distro restart or if
+		// systemd hasn't fully started. Without it, calling any Windows .exe from within
+		// WSL (e.g. mkcert.exe, reg.exe) fails with "Exec format error". In the PS1
+		// install scripts this causes mkcert.exe -install to fail silently, leaving the
+		// mkcert CA out of the Windows cert store and breaking all PowerShell HTTPS checks.
+		// wsl-fix-interop re-registers the entry idempotently. Requires one-time install
+		// per distro — see docs/content/developers/buildkite-testmachine-setup.md.
+		// See https://github.com/rfay/wsl-fix-interop
+		if fixOut, fixErr := exec.RunHostCommand("wsl.exe", "-d", distroName, "bash", "-c", "sudo wsl-fix-interop"); fixErr != nil {
+			t.Logf("wsl-fix-interop not available or failed in %s (install it per testmachine setup docs): %v\n%s", distroName, fixErr, fixOut)
+		} else {
+			t.Logf("wsl-fix-interop: %s", strings.TrimSpace(fixOut))
+		}
 
 		// Get distro back to a fairly normal pre-ddev state.
 		// Makes test run much faster than completely deleting the distro.
-		out, _ := exec.RunHostCommand("wsl.exe", "-d", distroName, "bash", "-c", "(ddev poweroff 2>/dev/null || true) && (ddev stop --unlist -a 2>/dev/null) && rm -rf ~/tp")
+		// Delete the test project fully (including Docker volumes) before unlisting.
+		// Old certs in Docker volumes from a broken-interop run are signed by a CA that
+		// is not in the Windows cert store; without this delete, DDEV reuses them and the
+		// Windows HTTPS check fails even after interop and the CA are restored.
+		out, _ := exec.RunHostCommand("wsl.exe", "-d", distroName, "bash", "-c", "(ddev delete -Oy tp 2>/dev/null || true) && (ddev poweroff 2>/dev/null || true) && (ddev stop --unlist -a 2>/dev/null) && rm -rf ~/tp")
 		t.Logf("ddev poweroff/stop/unlist: err=%v, output: %s", err, out)
 
 		// Temp allow all sudo to let mkcert -uninstall work as normal user
@@ -397,56 +585,49 @@ func cleanupTestEnv(t *testing.T, distroName string) {
 		out, err = exec.RunHostCommand("wsl.exe", "-d", distroName, "-u", "root", "bash", "-c", "rm -f /etc/sudoers.d/temp-mkcert-install /etc/apt/sources.list.d/ddev.* /etc/apt/sources.list.d/docker.*")
 		require.NoError(t, err)
 
+		// Remove docker-ce-cli/docker-ce on ALL distros, including docker-desktop.
+		// docker-desktop distros must use Docker Desktop's own /usr/bin/docker
+		// integration symlink, not the docker-ce-cli binary: while docker-ce-cli is
+		// installed it owns /usr/bin/docker and masks broken DD integration (docker ps
+		// works via its binary + DD's socket), so the integration check falsely passes
+		// and docker breaks mid-install. The post-cleanup integration re-verify (in the
+		// test) restarts Docker Desktop to re-inject the symlink that this removal deletes.
 		out, err = exec.RunHostCommand("wsl.exe", "-d", distroName, "-u", "root", "bash", "-c", "(apt-get remove -y ddev ddev-wsl2 docker-ce-cli docker-ce 2>/dev/null)")
 		t.Logf("distro cleanup: err=%v, output: %s", err, out)
+
+		// Re-run wsl-fix-interop after apt-get remove: docker-ce's post-remove scripts
+		// clear binfmt_misc entries (for QEMU multi-arch support), which also removes
+		// the WSLInterop entry. Re-register it so the next test's mkcert.exe calls work.
+		if fixOut, fixErr := exec.RunHostCommand("wsl.exe", "-d", distroName, "bash", "-c", "sudo wsl-fix-interop"); fixErr != nil {
+			t.Logf("wsl-fix-interop post-cleanup not available in %s: %v\n%s", distroName, fixErr, fixOut)
+		} else {
+			t.Logf("wsl-fix-interop post-cleanup: %s", strings.TrimSpace(fixOut))
+		}
 	}
 }
 
-// configureTestWSL2Distro configures an existing Ubuntu WSL2 distro for testing
+// configureTestWSL2Distro verifies that the pre-provisioned test WSL2 distro
+// exists. Test distros are provisioned out-of-band, once per runner (see
+// docs/content/developers/buildkite-testmachine-setup.md). The test does not
+// create them — it only resets and reuses them (see cleanupTestEnv). This
+// function fails fast with a clear message if the instance is missing.
 func configureTestWSL2Distro(t *testing.T, distroName string) {
 	require := require.New(t)
-	t.Logf("Configuring test distro: %s", distroName)
+	t.Logf("Verifying pre-provisioned test distro: %s", distroName)
 
-	// Check if distro exists, if not install it
 	out, err := exec.RunHostCommand("wsl.exe", "-l", "-q")
-	if err != nil {
-		t.Logf("Failed to list WSL distros: %v", err)
-		require.NoError(err, "Failed to list WSL distros")
-	}
+	require.NoError(err, "Failed to list WSL distros")
 
 	// Convert UTF-16 output to UTF-8 by removing null bytes
 	cleanOut := strings.ReplaceAll(out, "\x00", "")
 	if !strings.Contains(cleanOut, distroName) {
-		// Install the WSL distro without launching
-		t.Logf("Installing WSL distro %s", distroName)
-		out, err := exec.RunHostCommand("wsl.exe", "--install", distroName, "--no-launch")
-		require.NoError(err, "Failed to install WSL distro: %v, output: %s", err, out)
-
-		// Complete distro setup with root user (avoids interactive user setup)
-		t.Logf("Completing distro setup with root user only")
-		userProfile := os.Getenv("USERPROFILE")
-		// Convert Ubuntu-22.04 to ubuntu2204.exe
-		exeName := strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(distroName, "-", ""), ".", "")) + ".exe"
-		ubuntuExePath := filepath.Join(userProfile, "AppData", "Local", "Microsoft", "WindowsApps", exeName)
-		out, err = exec.RunHostCommand(ubuntuExePath, "install", "--root")
-		// Note: distro.exe install --root is undocumented but works, though it returns non-zero exit code
-		t.Logf("Distro setup output: %s, error: %v", out, err)
-
-		// Wait a moment for the distro to be fully registered
-		time.Sleep(1 * time.Second)
+		t.Fatalf("Test distro %q is not registered on this runner. Provision it once "+
+			"(wsl --install <base> --name %s) per "+
+			"docs/content/developers/buildkite-testmachine-setup.md before running installer tests.",
+			distroName, distroName)
 	}
 
-	// Create an unprivileged default user if it doesn't exist
-	t.Logf("Ensuring unprivileged default user exists")
-	out, err = exec.RunHostCommand("wsl.exe", "-d", distroName, "-u", "root", "bash", "-c", "if ! id -u testuser; then useradd -m -s /bin/bash testuser && echo 'testuser:testpass' | chpasswd && usermod -aG sudo testuser; fi")
-	require.NoError(err, "Failed to create test user: %v, output=%v", err, out)
-
-	// Set testuser as the default user using wsl --manage
-	t.Logf("Setting testuser as default user")
-	_, err = exec.RunHostCommand("wsl.exe", "--manage", distroName, "--set-default-user", "testuser")
-	require.NoError(err, "Failed to set default user: %v", err)
-
-	t.Logf("Test WSL2 distro %s configured successfully", distroName)
+	t.Logf("Test WSL2 distro %s present", distroName)
 }
 
 // testDdevInstallation verifies that ddev is properly installed in WSL2
@@ -494,6 +675,41 @@ func testBasicDdevFunctionality(t *testing.T, distroName string) {
 	_, err = exec.RunHostCommand("wsl.exe", "-d", distroName, "bash", "-c", fmt.Sprintf("echo 'Hello from DDEV!' > %s/index.html", projectDir))
 	require.NoError(err, "Failed to create index.html: %v", err)
 
+	// Ensure DDEV's mkcert_caroot is set to the correct Windows CAROOT before ddev start.
+	// Issue #8485: the NSIS installer calls SetEnvironmentVariable("CAROOT", NULL) to unset
+	// CAROOT in its own process before running mkcert.exe, which means WSL2 processes
+	// spawned from NSIS during installation run with empty CAROOT. readCAROOT() then
+	// returns "" and DDEV writes empty mkcert_caroot to ~/.ddev/global_config.yaml. When
+	// ddev start later runs, it generates a new CA at the Linux default path rather than
+	// using the Windows-side CA at CAROOT — that new CA is not in the Windows cert store.
+	// Fix: get CAROOT from cmd.exe (the test process environment, always reliable), convert
+	// to Linux path via wslpath, and force-set ddev config global. This is idempotent.
+	caRootForConfig, _ := exec.RunHostCommand("cmd.exe", "/c", "echo %CAROOT%")
+	caRootForConfig = strings.TrimSpace(caRootForConfig)
+	if caRootForConfig != "" && caRootForConfig != "%CAROOT%" {
+		// Convert Windows path to WSL path in Go rather than via wslpath.
+		// Passing a Windows path with backslashes to 'wsl.exe wslpath' causes bash
+		// to interpret \U, \t, \A, \L etc. as escape sequences, stripping the backslashes.
+		// Direct conversion: C:\Users\foo -> /mnt/c/Users/foo
+		wslCARoot := windowsPathToWSL(caRootForConfig)
+		// ddev config global has no --mkcert-caroot flag; set it directly in the YAML.
+		// This bypasses readCAROOT() which may return "" if rootCA-key.pem permissions
+		// prevent reading from WSL2 (issue #8485).
+		t.Logf("Setting DDEV mkcert_caroot to %s in global_config.yaml (CAROOT=%s)", wslCARoot, caRootForConfig)
+		setCmd := fmt.Sprintf(
+			`mkdir -p ~/.ddev; `+
+				`if grep -q "^mkcert_caroot:" ~/.ddev/global_config.yaml 2>/dev/null; then `+
+				`  sed -i "s|^mkcert_caroot:.*|mkcert_caroot: %s|" ~/.ddev/global_config.yaml; `+
+				`else `+
+				`  printf "mkcert_caroot: %s\n" >> ~/.ddev/global_config.yaml; `+
+				`fi; `+
+				`grep mkcert_caroot ~/.ddev/global_config.yaml`, wslCARoot, wslCARoot)
+		setOut, setErr := exec.RunHostCommand("wsl.exe", "-d", distroName, "bash", "-c", setCmd)
+		t.Logf("Set mkcert_caroot in global_config.yaml: err=%v out=%s", setErr, strings.TrimSpace(setOut))
+	} else {
+		t.Logf("WARNING: CAROOT not set in test process environment — DDEV may use wrong CA")
+	}
+
 	// Initialize ddev project
 	out, err = exec.RunHostCommand("wsl.exe", "-d", distroName, "bash", "-c", fmt.Sprintf("cd %s && ddev config --auto && ddev start -y", projectDir))
 	require.NoError(err, "ddev config/start failed: %v, output: %s", err, out)
@@ -506,10 +722,35 @@ func testBasicDdevFunctionality(t *testing.T, distroName string) {
 	require.Contains(out, "Hello from DDEV!")
 	t.Logf("HTTPS project responding correctly inside distro")
 
+	// Dump Windows cert store mkcert entries and compare thumbprint with rootCA.pem.
+	// A mismatch (old cert in store, new rootCA.pem on disk) is the most common reason
+	// the PowerShell HTTPS check fails even though mkcert.exe -install reports "already installed".
+	caRootDir, _ := exec.RunHostCommand("cmd.exe", "/c", "echo %CAROOT%")
+	caRootDir = strings.TrimSpace(caRootDir)
+	if storeOut, storeErr := exec.RunHostCommand("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+		"Get-ChildItem Cert:\\CurrentUser\\Root | Where-Object {$_.Subject -like '*mkcert*'} | Select-Object Subject,Thumbprint,NotBefore,NotAfter | Format-List"); storeErr == nil {
+		t.Logf("Windows cert store mkcert entries:\n%s", storeOut)
+	}
+	if caRootDir != "" && caRootDir != "%CAROOT%" {
+		if thumbOut, thumbErr := exec.RunHostCommand("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+			fmt.Sprintf("(New-Object System.Security.Cryptography.X509Certificates.X509Certificate2('%s\\rootCA.pem')).Thumbprint", caRootDir)); thumbErr == nil {
+			t.Logf("rootCA.pem thumbprint (CAROOT=%s): %s", caRootDir, strings.TrimSpace(thumbOut))
+		}
+	}
+
+	// Dump the actual TLS certificate served by the site so we can see which CA signed it.
+	// This runs regardless of trust (ServerCertificateValidationCallback={$true}) so it
+	// works even when the cert is not trusted, letting us compare the signing CA thumbprint
+	// against the Windows cert store entries logged above.
+	if certChainOut, certChainErr := exec.RunHostCommand("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+		fmt.Sprintf(`$req=[Net.HttpWebRequest]::Create("https://%s.ddev.site"); $req.ServerCertificateValidationCallback={$true}; try{$req.GetResponse().Dispose()}catch{}; $c=$req.ServicePoint.Certificate; if($c){$x=New-Object Security.Cryptography.X509Certificates.X509Certificate2($c); "Site cert thumbprint: "+$x.Thumbprint; "Site cert subject: "+$x.Subject; "Site cert issuer: "+$x.Issuer; "Site cert notbefore: "+$x.NotBefore; "Site cert notafter: "+$x.NotAfter}`, projectName)); certChainErr == nil {
+		t.Logf("Site TLS certificate (served, ignoring trust):\n%s", certChainOut)
+	}
+
 	// Test using windows PowerShell to check HTTPS
 	psInvoke := fmt.Sprintf("powershell.exe -NoProfile -ExecutionPolicy Bypass -Command Invoke-RestMethod 'https://%s.ddev.site' -ErrorAction Stop", projectName)
 	out, err = exec.RunHostCommand("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", fmt.Sprintf("Invoke-RestMethod 'https://%s.ddev.site' -ErrorAction Stop", projectName))
-	require.NoError(err, "HTTPS check from Windows failed (`%s`) (note that mkcert.exe -install must be run previously on test runner): %v, output: %s", psInvoke, err, out)
+	require.NoError(err, "HTTPS check from Windows failed (`%s`): %v, output: %s", psInvoke, err, out)
 	require.Contains(out, "Hello from DDEV!")
 	t.Logf("Project working and accessible from Windows")
 
@@ -523,6 +764,19 @@ func isDockerProviderAvailable(distroName string) bool {
 	// Check if docker ps works in the distro
 	_, err := exec.RunHostCommand("wsl.exe", "-d", distroName, "docker", "ps")
 	return err == nil
+}
+
+// windowsPathToWSL converts a Windows path to its WSL2 mount path in Go,
+// avoiding the need to call wslpath (which receives args through bash and
+// has backslashes stripped as escape sequences).
+// Example: C:\Users\testbot\AppData\Local\mkcert → /mnt/c/Users/testbot/AppData/Local/mkcert
+func windowsPathToWSL(winPath string) string {
+	if len(winPath) >= 2 && winPath[1] == ':' {
+		drive := strings.ToLower(string(winPath[0]))
+		rest := strings.ReplaceAll(winPath[2:], "\\", "/")
+		return "/mnt/" + drive + rest
+	}
+	return strings.ReplaceAll(winPath, "\\", "/")
 }
 
 // isDockerDesktopWorkingOnWindows checks if Docker Desktop is working on Windows

--- a/winpkg/scripts/apt_install_with_log.sh
+++ b/winpkg/scripts/apt_install_with_log.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Run `apt-get install -y` for the given packages, capturing full output
+# to a log file. On stdout, print a concise diagnostic (status + error
+# lines + tail) so the NSIS installer's small (~1024 byte) capture
+# buffer can show the actual cause of failure. Exits with apt-get's
+# exit code.
+#
+# Acquire::Retries=5 retries each fetch up to 5 times within a single
+# apt-get invocation. Empirically required for upstream mirrors that
+# intermittently return 502 — without it, a single transient HTTP
+# failure aborts the whole install.
+#
+# Usage: apt_install_with_log.sh <stage_name> <package> [package ...]
+#   stage_name: short tag used in the log file path, e.g. "essential",
+#               "docker", "ddev". Each stage gets its own log file so
+#               later failures don't overwrite earlier ones.
+#
+# Optional env: APT_EXTRA_ARGS — additional apt-get args, word-split.
+#   Example: APT_EXTRA_ARGS="--no-install-recommends"
+
+set -u
+
+STAGE="${1:-unknown}"
+shift || true
+
+LOGFILE="/tmp/ddev_apt_${STAGE}.log"
+
+# shellcheck disable=SC2086
+DEBIAN_FRONTEND=noninteractive apt-get \
+    -o Acquire::Retries=5 \
+    install -y ${APT_EXTRA_ARGS:-} "$@" >"$LOGFILE" 2>&1
+rc=$?
+
+# NSIS's nsExec::ExecToStack buffer is ~1024 bytes, so be brief.
+# Prefer error lines (Err:/E:/Error:/W: Failed) since those name the cause;
+# fall back to the last 12 lines if no error lines were emitted.
+echo "exit=$rc stage=$STAGE log=$LOGFILE"
+ERR_LINES=$(grep -E '^(Err|E:|Error|W: Failed)' "$LOGFILE" 2>/dev/null | head -10)
+if [ -n "$ERR_LINES" ]; then
+    echo "--- error lines ---"
+    printf '%s\n' "$ERR_LINES"
+else
+    echo "--- last 12 lines ---"
+    tail -12 "$LOGFILE"
+fi
+
+exit "$rc"

--- a/winpkg/scripts/check_docker_desktop_wsl2.ps1
+++ b/winpkg/scripts/check_docker_desktop_wsl2.ps1
@@ -1,0 +1,32 @@
+# Icinga/Nagios check for Docker Desktop WSL2 integration on DDEV test machines.
+# Returns 0 (OK) or 2 (CRITICAL) with a one-line status on stdout.
+#
+# Deploy to each Windows test machine and register as an Icinga check.
+# The listed distros are the desktop-provider test instances that require
+# Docker Desktop WSL2 integration to be enabled.
+
+$distros = @(
+    "ddev-test-ubuntu-desktop",
+    "ddev-test-ubuntu2404-desktop",
+    "ddev-test-debian-desktop"
+)
+
+$failed = @()
+$ok = @()
+
+foreach ($distro in $distros) {
+    $out = & "$env:SystemRoot\System32\wsl.exe" -d $distro -- docker ps 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $failed += $distro
+    } else {
+        $ok += $distro
+    }
+}
+
+if ($failed.Count -gt 0) {
+    Write-Output "CRITICAL: Docker Desktop WSL2 integration lost for: $($failed -join ', '). Re-enable: Docker Desktop -> Settings -> Resources -> WSL Integration -> enable each distro -> Apply & Restart."
+    exit 2
+}
+
+Write-Output "OK: Docker Desktop WSL2 integration active for all distros ($($ok -join ', '))"
+exit 0

--- a/winpkg/scripts/detect_docker_family.sh
+++ b/winpkg/scripts/detect_docker_family.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Outputs "ubuntu" or "debian" to indicate which Docker CE APT repository
+# family to use. Ubuntu and Ubuntu-based distros use the ubuntu repo;
+# all others (Debian, Kali, etc.) use the debian repo.
+
+# shellcheck source=/dev/null
+. /etc/os-release
+
+if echo "$ID $ID_LIKE" | grep -qi ubuntu; then
+    printf 'ubuntu'
+else
+    printf 'debian'
+fi

--- a/winpkg/scripts/detect_docker_suite.sh
+++ b/winpkg/scripts/detect_docker_suite.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Outputs the correct Docker APT suite (codename) for this distro.
+# For Ubuntu and Ubuntu-based distros, trusts UBUNTU_CODENAME/VERSION_CODENAME
+# directly — Docker maintains packages for all Ubuntu releases.
+# For Debian-based distros (Kali, eLxr, etc.) whose VERSION_CODENAME
+# is not a valid Docker suite, derives the suite from /etc/debian_version
+# (the Debian base release the distro tracks), then falls back to
+# /usr/share/distro-info/debian.csv, then to bookworm.
+
+# shellcheck source=/dev/null
+. /etc/os-release
+
+CODENAME="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
+
+# For Ubuntu and Ubuntu-based distros, trust the codename from os-release.
+# Docker publishes ubuntu-family packages for every Ubuntu release, so any
+# codename present in os-release is valid.
+# Check both ID and ID_LIKE: Ubuntu itself has ID=ubuntu but ID_LIKE=debian,
+# so checking only ID_LIKE would miss it.
+if echo "$ID $ID_LIKE" | grep -qi ubuntu; then
+    printf '%s' "$CODENAME"
+    exit 0
+fi
+
+# For pure Debian derivatives (Kali, eLxr, etc.) check if the codename
+# is already a valid Docker Debian suite.
+case "$CODENAME" in
+    trixie|bookworm|bullseye|buster|stretch|jessie)
+        printf '%s' "$CODENAME"
+        exit 0
+        ;;
+esac
+
+# Not a recognized Debian Docker suite (e.g. eLxr's "aria",
+# Kali's "kali-rolling"). Try /etc/debian_version, which on most Debian
+# derivatives contains the Debian base release the distro tracks.
+if [ -f /etc/debian_version ]; then
+    DEBIAN_VER=$(cat /etc/debian_version 2>/dev/null)
+    # Strip anything after a slash or non-digit (e.g. "12.5" -> "12",
+    # "trixie/sid" -> "trixie", "kali-rolling" -> "kali-rolling").
+    DEBIAN_MAJOR=$(printf '%s' "$DEBIAN_VER" | sed -n 's/^\([0-9][0-9]*\).*/\1/p')
+    case "$DEBIAN_MAJOR" in
+        13) printf 'trixie';   exit 0 ;;
+        12) printf 'bookworm'; exit 0 ;;
+        11) printf 'bullseye'; exit 0 ;;
+        10) printf 'buster';   exit 0 ;;
+        9)  printf 'stretch';  exit 0 ;;
+    esac
+    # /etc/debian_version may contain a codename directly (e.g. "trixie/sid")
+    case "$DEBIAN_VER" in
+        trixie*)   printf 'trixie';   exit 0 ;;
+        bookworm*) printf 'bookworm'; exit 0 ;;
+        bullseye*) printf 'bullseye'; exit 0 ;;
+        buster*)   printf 'buster';   exit 0 ;;
+    esac
+fi
+
+# Fall back to distro-info if installed.
+if [ -f /usr/share/distro-info/debian.csv ]; then
+    today=$(date +%Y%m%d)
+    FOUND=""
+    while IFS=, read -r _ver _codename series _created release eol _rest; do
+        [ "$_ver" = "version" ] && continue
+        if [ -z "$release" ] || [ -z "$eol" ]; then continue; fi
+        r="${release//-/}"
+        e="${eol//-/}"
+        if [ "$today" -ge "$r" ] && [ "$today" -lt "$e" ]; then
+            FOUND="$series"
+            break
+        fi
+    done < /usr/share/distro-info/debian.csv
+    if [ -n "$FOUND" ]; then
+        printf '%s' "$FOUND"
+        exit 0
+    fi
+fi
+
+# Ultimate fallback
+printf 'bookworm'

--- a/winpkg/scripts/ensure_systemd_enabled.sh
+++ b/winpkg/scripts/ensure_systemd_enabled.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Ensure /etc/wsl.conf has [boot] systemd=true. Preserves all other
+# settings. Prints a short status line so the installer log captures what
+# happened. Exit codes:
+#   0  systemd is already enabled (no action needed)
+#   1  systemd was just enabled (caller MUST wsl --terminate this distro
+#      and re-enter it so the change takes effect)
+#   2  error (could not read/write /etc/wsl.conf)
+#
+# The systemd line is normalized to exactly `systemd=true` (no surrounding
+# whitespace) so future runs can detect it idempotently.
+
+set -u
+
+CONF=/etc/wsl.conf
+
+# If systemd is already running as PID 1 (WSL enables it by default on modern
+# Ubuntu/Debian), no restart is needed regardless of whether the config file
+# explicitly says so. We still write the config for idempotency, but exit 0.
+SYSTEMD_RUNNING=false
+if [ "$(ps -p 1 -o comm= 2>/dev/null)" = "systemd" ]; then
+    SYSTEMD_RUNNING=true
+fi
+
+if ! touch "$CONF" 2>/dev/null; then
+    echo "ERROR: cannot write $CONF"
+    exit 2
+fi
+
+# Case 1: no [boot] section at all — append one.
+if ! grep -q '^\[boot\]' "$CONF"; then
+    {
+        echo ""
+        echo "[boot]"
+        echo "systemd=true"
+    } >> "$CONF"
+    echo "STATUS: added [boot] section with systemd=true to $CONF"
+    [ "$SYSTEMD_RUNNING" = "true" ] && { echo "STATUS: systemd already running as PID 1; no restart needed"; exit 0; }
+    exit 1
+fi
+
+# Case 2: [boot] section exists. Check current systemd= value, strictly
+# within the [boot] section (other sections may have unrelated keys).
+CURRENT=$(awk '
+    /^\[boot\]/   { in_boot=1; next }
+    /^\[/         { in_boot=0; next }
+    in_boot && /^[[:space:]]*systemd[[:space:]]*=/ { print; exit }
+' "$CONF")
+
+if [ -z "$CURRENT" ]; then
+    # [boot] exists but no systemd line. Insert one right after [boot].
+    awk '
+        /^\[boot\]/ && !done { print; print "systemd=true"; done=1; next }
+        { print }
+    ' "$CONF" > "${CONF}.new" && mv "${CONF}.new" "$CONF"
+    echo "STATUS: added systemd=true to existing [boot] section in $CONF"
+    [ "$SYSTEMD_RUNNING" = "true" ] && { echo "STATUS: systemd already running as PID 1; no restart needed"; exit 0; }
+    exit 1
+fi
+
+# Normalize the captured value: strip whitespace, lowercase the right side.
+VALUE=$(echo "$CURRENT" | sed 's/[[:space:]]//g' | cut -d= -f2- | tr '[:upper:]' '[:lower:]')
+if [ "$VALUE" = "true" ]; then
+    echo "STATUS: systemd already enabled in $CONF"
+    exit 0
+fi
+
+# Case 3: systemd= is set to something other than true (false, 0, etc.).
+# Rewrite that one line within [boot], leave the rest of the file alone.
+awk '
+    /^\[boot\]/   { in_boot=1; print; next }
+    /^\[/         { in_boot=0; print; next }
+    in_boot && /^[[:space:]]*systemd[[:space:]]*=/ { print "systemd=true"; next }
+    { print }
+' "$CONF" > "${CONF}.new" && mv "${CONF}.new" "$CONF"
+echo "STATUS: changed systemd setting to true in $CONF (was: $CURRENT)"
+[ "$SYSTEMD_RUNNING" = "true" ] && { echo "STATUS: systemd already running as PID 1; no restart needed"; exit 0; }
+exit 1

--- a/winpkg/scripts/wait_for_systemd.sh
+++ b/winpkg/scripts/wait_for_systemd.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Wait up to N seconds for systemd to be ready as PID 1 in this distro.
+# Considers any of running|degraded|starting as "ready enough" — the
+# installer can proceed once systemd is past basic.target so service
+# units can be started. Exits 0 on ready, 1 on timeout.
+#
+# Usage: wait_for_systemd.sh [timeout_seconds]   (default 15)
+
+set -u
+
+TIMEOUT="${1:-15}"
+STATE=""
+
+for _ in $(seq 1 "$TIMEOUT"); do
+    STATE=$(systemctl is-system-running 2>/dev/null || true)
+    case "$STATE" in
+        running|degraded|starting)
+            echo "systemd state: $STATE"
+            exit 0
+            ;;
+    esac
+    sleep 1
+done
+
+echo "systemd state: '${STATE:-unknown}' (timed out after ${TIMEOUT}s)"
+exit 1

--- a/winpkg/wsl2_install_scripts_test.go
+++ b/winpkg/wsl2_install_scripts_test.go
@@ -1,0 +1,175 @@
+//go:build windows
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWSL2InstallScripts exercises the manual WSL2 install PowerShell scripts
+// (scripts/install_ddev_wsl2_docker_inside.ps1 and
+// scripts/install_ddev_wsl2_docker_desktop.ps1) against current Ubuntu. These
+// scripts predate the GUI installer and otherwise have no automated coverage.
+//
+// The scripts operate on the *default* WSL2 distro, so each case temporarily
+// sets its target instance as the default and restores the prior default
+// afterward. The named instances are provisioned out-of-band (see
+// docs/content/developers/buildkite-testmachine-setup.md) and reused here.
+func TestWSL2InstallScripts(t *testing.T) {
+	if nodeps.IsEnvFalse("DDEV_TEST_USE_REAL_INSTALLER") {
+		t.Skip("Skipping WSL2 install-script test, set DDEV_TEST_USE_REAL_INSTALLER=true to run")
+	}
+
+	testCases := []struct {
+		name                 string
+		script               string
+		distro               string
+		requireDockerDesktop bool
+	}{
+		// docker-desktop runs first so that the docker-inside test (which
+		// manipulates WSL2 distros) cannot briefly disrupt Docker Desktop's
+		// WSL2 integration before the precondition check fires.
+		{
+			name:                 "docker-desktop",
+			script:               "../scripts/install_ddev_wsl2_docker_desktop.ps1",
+			distro:               "ddev-test-ubuntu-desktop",
+			requireDockerDesktop: true,
+		},
+		{
+			name:   "docker-inside",
+			script: "../scripts/install_ddev_wsl2_docker_inside.ps1",
+			distro: "ddev-test-ubuntu-ce",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Verify the pre-provisioned distro exists (fails fast with guidance).
+			configureTestWSL2Distro(t, tc.distro)
+
+			// For Docker Desktop cases verify integration is active before
+			// doing anything else. Docker Desktop frequently loses WSL2
+			// integration silently; catching it here produces an actionable
+			// message rather than a cryptic script error later.
+			if tc.requireDockerDesktop {
+				if !waitForDockerDesktopWSL2Integration(t, tc.distro) {
+					t.Skipf("SKIPPED: Docker Desktop WSL2 integration is not active for %s after retries.\n"+
+						"Re-enable it: Docker Desktop → Settings → Resources → WSL Integration → enable %s → Apply & Restart.\n"+
+						"Then verify with: wsl -d %s docker ps",
+						tc.distro, tc.distro, tc.distro)
+				}
+			}
+
+			// Reset the distro to a pre-ddev state for a meaningful install.
+			cleanupTestEnv(t, tc.distro)
+
+			// Re-verify integration AFTER cleanupTestEnv (mirrors TestWindowsInstallerWSL2).
+			// cleanup's apt operations / wsl-fix-interop can drop Docker Desktop's WSL2
+			// integration, and cleanupTestEnv removes docker-ce-cli so /usr/bin/docker
+			// reverts to Docker Desktop's own (possibly broken) symlink. Re-verify so
+			// Docker Desktop re-injects it (via the restart escalation) before the install
+			// script runs `docker` — otherwise the script fails with
+			// "execvpe(docker) failed: No such file or directory".
+			if tc.requireDockerDesktop {
+				if !waitForDockerDesktopWSL2Integration(t, tc.distro) {
+					t.Skipf("SKIPPED: Docker Desktop WSL2 integration not active for %s after cleanup/retries.\n"+
+						"Verify with: wsl -d %s docker ps", tc.distro, tc.distro)
+				}
+			}
+
+			// Ensure ddev is powered off after this case, even on failure.
+			t.Cleanup(func() {
+				t.Logf("Cleaning up %s test - powering off ddev", tc.name)
+				_, _ = exec.RunHostCommand("wsl.exe", "-d", tc.distro, "bash", "-c", "ddev poweroff")
+				_, _ = exec.RunHostCommand("wsl.exe", "-d", tc.distro, "bash", "-c", "ddev delete -Oy tp")
+			})
+
+			// Resolve the script's absolute path.
+			wd, err := os.Getwd()
+			require.NoError(err)
+			scriptFullPath := filepath.Join(wd, tc.script)
+			require.True(fileutil.FileExists(scriptFullPath), "Install script not found at %s", scriptFullPath)
+
+			// Run the PowerShell script with a 15-minute timeout. Docker CE
+			// installs + image pulls can legitimately take several minutes.
+			// Stream stdout/stderr line-by-line so progress is visible in the
+			// test log in real time (not only on failure after a silent hang).
+			t.Logf("Running install script: %s -Distro %s", scriptFullPath, tc.distro)
+			const scriptTimeout = 15 * time.Minute
+			ctx, cancel := context.WithTimeout(context.Background(), scriptTimeout)
+			defer cancel()
+
+			cmd := osexec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptFullPath, "-Distro", tc.distro)
+			stdoutPipe, pipeErr := cmd.StdoutPipe()
+			require.NoError(pipeErr)
+			stderrPipe, pipeErr := cmd.StderrPipe()
+			require.NoError(pipeErr)
+
+			require.NoError(cmd.Start(), "Failed to start install script %s", tc.script)
+
+			var (
+				outputBuf bytes.Buffer
+				mu        sync.Mutex
+				wg        sync.WaitGroup
+			)
+			for _, pipe := range []io.Reader{stdoutPipe, stderrPipe} {
+				wg.Add(1)
+				go func(r io.Reader) {
+					defer wg.Done()
+					sc := bufio.NewScanner(r)
+					for sc.Scan() {
+						line := sc.Text()
+						mu.Lock()
+						outputBuf.WriteString(line + "\n")
+						mu.Unlock()
+						t.Logf("[script] %s", line)
+					}
+				}(pipe)
+			}
+
+			runErr := cmd.Wait()
+			wg.Wait()
+			out := outputBuf.String()
+
+			if ctx.Err() == context.DeadlineExceeded {
+				require.Fail("Script timeout", "%s did not complete within %v, output: %s", tc.script, scriptTimeout, out)
+			}
+			require.NoError(runErr, "Install script %s failed: %v, output: %s", tc.script, runErr, out)
+			t.Logf("Install script completed successfully")
+
+			// The scripts set CAROOT and WSLENV in the Windows user environment
+			// via setx; assert they landed in the registry.
+			userCarootReg, userCarootRegErr := exec.RunHostCommand("reg.exe", "query", "HKEY_CURRENT_USER\\Environment", "/v", "CAROOT")
+			require.NoError(userCarootRegErr, "CAROOT should be set in registry after running %s", tc.script)
+			caRootValue := parseRegQueryValue(userCarootReg)
+			require.NotEmpty(caRootValue, "CAROOT registry value should not be empty after running %s", tc.script)
+			t.Logf("CAROOT registry value: %q", caRootValue)
+
+			userWslenvReg, userWslenvRegErr := exec.RunHostCommand("reg.exe", "query", "HKEY_CURRENT_USER\\Environment", "/v", "WSLENV")
+			require.NoError(userWslenvRegErr, "WSLENV should be set in registry after running %s", tc.script)
+			wslenvValue := parseRegQueryValue(userWslenvReg)
+			require.Contains(wslenvValue, "CAROOT/up", "WSLENV should contain CAROOT/up after running %s", tc.script)
+			t.Logf("WSLENV registry value: %q", wslenvValue)
+
+			// End-to-end: ddev installed and a project starts.
+			testDdevInstallation(t, tc.distro)
+			testBasicDdevFunctionality(t, tc.distro)
+		})
+	}
+}


### PR DESCRIPTION
## The Issue

- Fixes #8439
- Fixes #8468
- Adds tests for the PowerShell install scripts
- Extends the Windows GUI installer to support Debian and Debian-based WSL2 distros (Kali Linux, ~~Parrot OS,~~ eLxr) in addition to Ubuntu variants.

> **Note:** ~~Parrot OS~~ support has been dropped from this PR — its package repositories (deb.parrot.sh) are unreliable and there's no compelling reason to support it. ~~Parrot~~ mentions below are struck through for historical context. The generic Debian-based detection still handles it if anyone uses it; it's just no longer advertised or specifically tested.

## How to Review

This branch is deliberately structured as **two commits** so the user-facing product and the CI/test machinery can be reviewed independently:

1. **`feat(windows): WSL2 installer for Docker CE and Docker Desktop`** — the **core / shipping** change. Review this carefully: the NSIS installer (`winpkg/ddev_windows_installer.nsi`), its helper scripts (`winpkg/scripts/*`), the standalone WSL2 install scripts (`scripts/install_ddev_wsl2_*.ps1`), and the user-facing install docs.
2. **`test(windows): Buildkite Windows installer pipeline and Go installer tests`** — the **CI / test infrastructure**, which does not ship: the dedicated Buildkite pipeline (`.buildkite/*`, `windows-installer.yml`), the Go tests (`winpkg/*_test.go`), runner sanity/setup/diagnostic scripts, Makefile test targets, and runner-provisioning docs.

The split is clean by path (no file appears in both) and the core commit contains no Go changes, so each commit is self-contained. The long iteration history (much of it Docker Desktop WSL2-integration flakiness debugging on the test runners) was squashed away to make review tractable — so the per-commit SHAs referenced below are historical (they now live in the single core commit).

## How This PR Solves The Issue

This PR fixes a series of bugs found during end-to-end testing across multiple distros (developed across many commits, now squashed into the core commit):

**1. CRLF in `DOCKER_DISTRO_FAMILY` breaks curl URL** (`13f7cc759`)
`echo` adds a trailing newline, which WSL-to-Windows capture converts to `\r\n`. When interpolated into a `bash -c` string the `\r` splits the curl URL — curl downloads a directory listing, then bash tries to execute `/gpg` (exit 127). Fixed with `printf`.

**2. Kali Linux not detected** (`bfd336018`)
Kali's registry `Flavor` field is `kali` (from Microsoft's `DistributionInfo.json`), not `debian`. Added `kali` to the Flavor check.

**3. Docker repo suite wrong for Kali** (`433c95b2d`)
Kali's `VERSION_CODENAME=kali-rolling` has no suite in Docker's Debian repo. Added `detect_docker_suite.sh`: looks up the correct Debian stable codename from `/usr/share/distro-info/debian.csv` for distros with non-standard codenames.

**4. ~~Parrot OS support~~ (dropped)** (`6a7519907`)
~~Added `parrot` to the Flavor check. `detect_docker_suite.sh` handles the codename mapping.~~ Parrot support removed in a later commit (unreliable repos).

**5. Future Ubuntu releases broken** (`184cec410`, `660b3eecc`)
`detect_docker_suite.sh` originally hard-coded Ubuntu codenames. Ubuntu 26.04 (`resolute`) wasn't in the list. Fixed by checking `$ID $ID_LIKE` for "ubuntu" and trusting any codename unconditionally (Ubuntu has `ID=ubuntu` but `ID_LIKE=debian`, so checking only `ID_LIKE` missed it).

**6. Silent-mode install missing `detect_docker_suite.sh`** (`f6f91b582`)
The script was only copied in the page-leave function, which `/S` (silent) mode never calls. Added it to the Section block which runs in all modes.

**7. Radio buttons overflow with many distros; all Ubuntu distros get wrong Docker family** (`1455ef94f`, `0ac6a565e`, `7c6e23b3c`)
With 8 distros installed, radio buttons at fixed 24u spacing exceeded the page height — Kali and Debian were created off-screen and not visible. Replaced with a scrollable ListBox. Also fixed `DOCKER_DISTRO_FAMILY` detection: `${ID_LIKE:-$ID}` always resolved to `debian` for Ubuntu (since `ID_LIKE=debian`), causing `docker-ce` to look in the Debian repo instead of Ubuntu's — failed with "no installation candidate".

**8. `DOCKER_DISTRO_FAMILY` inline bash quoting unreliable on Windows** (`263c425ca`)
Replaced the inline bash detection with `detect_docker_family.sh` (same pattern as `detect_docker_suite.sh`) to avoid Windows/NSIS double-quote escaping issues.

**9. eLxr support, systemd, better error surfacing** (`076757bdf`)
- Added `elxr` to the Flavor allowlist; fixed a register-clobber bug (`$R5` was overwritten by StrStr results, making the enumeration loop exit after the first match)
- Added `ensure_systemd_enabled.sh` + `wait_for_systemd.sh`: enables systemd in `/etc/wsl.conf` and restarts the distro before running apt (~~required for Parrot;~~ also makes Docker auto-start via `docker.service` for all distros)
- Replaced direct `apt-get install` calls with `apt_install_with_log.sh` which captures full apt output to `/tmp/ddev_apt_<stage>.log` and surfaces a short tail — NSIS's output buffer was truncating long apt traces, hiding the real error
- Made `pass` package best-effort (not available in eLxr)
- Added `/etc/debian_version` fallback in `detect_docker_suite.sh` ~~for distros like Parrot (`echo` → Debian 13 → `trixie`) and~~ for eLxr (`aria` → Debian 12 → `bookworm`)
- Improved error dialog: debug log path shown at top, error body truncated at 600 chars, OK button opens the log in Notepad

**10. Docker Desktop vs Docker CE on WSL2 distros**
For `/docker-desktop` installs the installer no longer adds the Docker apt repo or installs `docker-ce`/`docker-ce-cli` — Docker Desktop provides the docker CLI through its WSL2 integration, and installing `docker-ce-cli` clobbers `/usr/bin/docker` (Docker Desktop's integration symlink) and breaks docker mid-install. `docker-ce` packages are installed only for the `/docker-ce` (Docker-inside-WSL2) path.

**11. Docs updates** (`85528d297`, `d2d1ba8a9`)
- `ddev-installation.md` and `docker-installation.md`: "Ubuntu distro" → "Debian-based WSL2 distro"; added tip listing supported distros; updated distro picker description

**12. Remove ~~Parrot OS~~ references** (`6df4ef491`)
Dropped all ~~Parrot~~-specific references from the installer, detection scripts, and docs. ~~Parrot~~'s repos are unreliable and it's not worth supporting; generic Debian detection still covers it.

**New files (core commit):**
- `winpkg/scripts/detect_docker_family.sh` — outputs `ubuntu` or `debian` for Docker repo selection
- `winpkg/scripts/detect_docker_suite.sh` — outputs the correct Docker APT suite codename
- `winpkg/scripts/apt_install_with_log.sh` — apt wrapper with retry and full log capture
- `winpkg/scripts/ensure_systemd_enabled.sh` — enables systemd in wsl.conf if not already set
- `winpkg/scripts/wait_for_systemd.sh` — polls until systemd is PID 1
- `winpkg/scripts/check_docker_desktop_wsl2.ps1` — verifies Docker Desktop WSL2 integration

## Manual Testing Instructions

* [Docker installation docs](https://ddev--8464.org.readthedocs.build/en/8464/users/install/docker-installation/#docker-installation-windows)
* [DDEV installation docs](https://ddev--8464.org.readthedocs.build/en/8464/users/install/ddev-installation/#ddev-installation-windows)

- [ ] Ubuntu, Ubuntu 20.04, 22.04, 24.04, 26.04 — Docker CE installs, DDEV runs
- [ ] Debian — installs successfully
- [ ] Kali Linux — `bookworm` suite used correctly
- [ ] ~~Parrot OS — installs successfully (systemd enable required) (download wsl from https://www.parrotsec.org/download/, AMD64 only)~~ (dropped)
- [ ] eLxr — installs successfully, amd64 only, install via `wsl --install eLxr`
- [ ] Multiple distros installed simultaneously — ListBox shows all, scrollable
- [ ] Silent mode (`/S`) — `detect_docker_suite.sh` and `detect_docker_family.sh` available in Section block
- [ ] Verify both Docker CE and Docker Desktop providers on at least some of these
- [ ] Test the PowerShell install scripts

## Automated Testing Overview

Automated coverage is **included in this PR** (the second commit) — it is no longer deferred:

- A dedicated Buildkite pipeline (`.buildkite/windows-installer.yml` + `installer-test.sh`/`.cmd`), decoupled from the main suite, runs one job per matrix case: `traditional`, `ps1-docker-inside`, `ps1-docker-desktop`, and `ddev-test-{ubuntu,debian}-{ce,desktop}`.
- `winpkg/installer_test.go` — `TestWindowsInstallerWSL2` (the GUI installer, per distro × provider) and `TestWindowsInstallerTraditional`.
- `winpkg/wsl2_install_scripts_test.go` — `TestWSL2InstallScripts`, covering the manual `install_ddev_wsl2_docker_{inside,desktop}.ps1` scripts.
- Runner support scripts: `sanetestbot.sh` (checks the runner only — it does not start Docker Desktop), `start-docker-desktop.sh` (Windows Docker Desktop provider startup, run before the docker readiness check), and `restart-docker-desktop.sh` / `dump-docker-desktop-state.sh` / `monitor-docker-desktop.sh` (Docker Desktop WSL2-integration repair + diagnostics).
- `Makefile`: `testwininstaller` and `testwsl2scripts` targets; runner provisioning in `docs/content/developers/buildkite-testmachine-setup.md`.

**Known environmental issue (out of scope):** the Windows test runners use Docker Desktop, whose WSL2 integration is intermittently flaky on older hardware (the harness detects and restart-repairs it). A residual mkcert-CA trust failure in the Windows certificate store (#8485) persists on the slower runner; it is independent of this PR's installer/test changes.

## Release/Deployment Notes

- Windows-only. The GUI installer now supports Debian-based WSL2 distros (Debian, Kali, eLxr) in addition to Ubuntu, for both Docker CE (inside WSL2) and Docker Desktop providers.
- No impact on macOS/Linux or on existing Windows installs.
