### PR TITLE
fix(nodejs): move N_PREFIX to /usr/local/n and make it writable, fixes #8465

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -86,7 +86,8 @@ ARG PHP_VERSIONS="php8.2 php8.3 php8.4 php8.5"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 ARG DRUSH_VERSION=8.5.0
 # TODO: remove this Node.js pin once https://github.com/nodejs/node/issues/63487 is resolved
-ENV NODE_VERSION=24.15.0
+ARG NODE_VERSION=24.15.0
+ENV PATH=/usr/local/n/bin:$PATH
 # composer normally screams about running as root, we don't need that.
 ENV COMPOSER_ALLOW_SUPERUSER=1
 ENV COMPOSER_PROCESS_TIMEOUT=2000
@@ -114,8 +115,7 @@ COPY --from=ddev-keep-root-build /ddev-keep-root.so /usr/local/lib/ddev/ddev-kee
 
 RUN curl -L --fail -o /usr/local/bin/n -sSL https://raw.githubusercontent.com/tj/n/master/bin/n && chmod +x /usr/local/bin/n
 # Install system Node.js, `--cleanup` is important, it removes downloaded files.
-ARG N_PREFIX=/usr/local
-RUN n install --cleanup "${NODE_VERSION}"
+RUN N_PREFIX=/usr/local/n n install --cleanup "${NODE_VERSION}"
 RUN npm install --unsafe-perm=true --global gulp-cli yarn
 
 # Loop through $PHP_VERSIONS, selecting packages for the target architecture.
@@ -170,6 +170,7 @@ RUN chmod 777 /var/lib/php/sessions
 ### There aren't any differences
 FROM scratch AS ddev-php-prod
 ARG XDEBUG_MODE=off
+ENV PATH=/usr/local/n/bin:$PATH
 SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]
 COPY --from=ddev-php-base / /
 EXPOSE 8080 8585

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -87,7 +87,7 @@ ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 ARG DRUSH_VERSION=8.5.0
 # TODO: remove this Node.js pin once https://github.com/nodejs/node/issues/63487 is resolved
 ARG NODE_VERSION=24.15.0
-ENV PATH=/usr/local/n/bin:$PATH
+ENV PATH=$PATH:/usr/local/n/bin
 # composer normally screams about running as root, we don't need that.
 ENV COMPOSER_ALLOW_SUPERUSER=1
 ENV COMPOSER_PROCESS_TIMEOUT=2000
@@ -170,7 +170,7 @@ RUN chmod 777 /var/lib/php/sessions
 ### There aren't any differences
 FROM scratch AS ddev-php-prod
 ARG XDEBUG_MODE=off
-ENV PATH=/usr/local/n/bin:$PATH
+ENV PATH=$PATH:/usr/local/n/bin
 SHELL ["/bin/bash", "-eu","-o", "pipefail",  "-c"]
 COPY --from=ddev-php-base / /
 EXPOSE 8080 8585

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
 ARG DOCKER_ORG=ddev
-FROM ${DOCKER_ORG}/ddev-php-base:20260601_stasadev_n_install AS ddev-webserver-base
+FROM ${DOCKER_ORG}/ddev-php-base:20260610_stasadev_n_install AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -273,7 +273,7 @@ RUN mkdir -p /mnt/ddev-global-cache/mkcert /run/php /run/blackfire /var/run/ngin
 RUN chgrp -R www-data /etc/alternatives /var/lib/dpkg/alternatives && \
     chmod -R g+rwX,o-w /etc/alternatives /var/lib/dpkg/alternatives
 
-RUN chmod -fR ugo+w /etc/nginx /var/cache/nginx /var/lib/nginx /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /usr/local/lib/node_modules /etc/php /etc/apache2 /var/lib/apache2 /mnt/ddev-global-cache/*
+RUN chmod -fR ugo+w /etc/nginx /var/cache/nginx /var/lib/nginx /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/php /etc/apache2 /var/lib/apache2 /mnt/ddev-global-cache/*
 
 RUN mkdir -p /var/xhprof && curl --fail -o /tmp/xhprof.tgz -sSL https://pecl.php.net/get/xhprof && tar -zxf /tmp/xhprof.tgz --strip-components=1 -C /var/xhprof && chmod ugo+rwX /var/xhprof/xhprof_html && rm /tmp/xhprof.tgz
 
@@ -328,6 +328,7 @@ ENV BASH_ENV=/etc/bash.nointeractive.bashrc
 ENV LANG=C.UTF-8
 ENV XHPROF_OUTPUT_DIR=/tmp/xhprof
 ENV PLATFORMSH_CLI_UPDATES_CHECK=0
+ENV PATH=/usr/local/n/bin:$PATH
 
 COPY --from=ddev-webserver-dev-base / /
 HEALTHCHECK --interval=1s --retries=120 --timeout=120s --start-period=120s CMD ["/healthcheck.sh"]
@@ -371,7 +372,7 @@ RUN mkdir -p /mnt/ddev-global-cache/mkcert /run/php /var/run/nginx /var/run/supe
 RUN chgrp -R www-data /etc/alternatives /var/lib/dpkg/alternatives && \
     chmod -R g+rwX,o-w /etc/alternatives /var/lib/dpkg/alternatives
 
-RUN chmod -fR ugo+w /etc/nginx /var/cache/nginx /var/lib/nginx /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /usr/local/lib/node_modules /etc/php /etc/apache2 /var/lib/apache2 /mnt/ddev-global-cache/*
+RUN chmod -fR ugo+w /etc/nginx /var/cache/nginx /var/lib/nginx /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/php /etc/apache2 /var/lib/apache2 /mnt/ddev-global-cache/*
 
 RUN touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log && \
     chmod ugo+rw /var/log/php-fpm.log && \
@@ -412,6 +413,7 @@ ENV LANG=C.UTF-8
 ENV TERM=xterm
 ENV BASH_ENV=/etc/bash.nointeractive.bashrc
 ENV PLATFORMSH_CLI_UPDATES_CHECK=0
+ENV PATH=/usr/local/n/bin:$PATH
 
 COPY --from=ddev-webserver-prod-base / /
 HEALTHCHECK --interval=1s --retries=120 --timeout=120s --start-period=120s CMD ["/healthcheck.sh"]

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -328,7 +328,7 @@ ENV BASH_ENV=/etc/bash.nointeractive.bashrc
 ENV LANG=C.UTF-8
 ENV XHPROF_OUTPUT_DIR=/tmp/xhprof
 ENV PLATFORMSH_CLI_UPDATES_CHECK=0
-ENV PATH=/usr/local/n/bin:$PATH
+ENV PATH=$PATH:/usr/local/n/bin
 
 COPY --from=ddev-webserver-dev-base / /
 HEALTHCHECK --interval=1s --retries=120 --timeout=120s --start-period=120s CMD ["/healthcheck.sh"]
@@ -413,7 +413,7 @@ ENV LANG=C.UTF-8
 ENV TERM=xterm
 ENV BASH_ENV=/etc/bash.nointeractive.bashrc
 ENV PLATFORMSH_CLI_UPDATES_CHECK=0
-ENV PATH=/usr/local/n/bin:$PATH
+ENV PATH=$PATH:/usr/local/n/bin
 
 COPY --from=ddev-webserver-prod-base / /
 HEALTHCHECK --interval=1s --retries=120 --timeout=120s --start-period=120s CMD ["/healthcheck.sh"]

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/00-path-setup.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/00-path-setup.bashrc
@@ -12,13 +12,13 @@ path_append() {
   esac
 }
 
-# If people want to install several Node.js versions, they can use `n install <version>`
-path_prepend "/usr/local/n/bin"
-
 # Add vendor/bin, then user-owned dirs in front of it (prepend order is last-wins)
 path_prepend "${DDEV_COMPOSER_ROOT:-/var/www/html}/vendor/bin"
 path_prepend "$HOME/bin"
 path_prepend "$HOME/.local/bin"
+
+# N_PREFIX for Node.js
+path_append "/usr/local/n/bin"
 
 # Add /var/www/html/bin as the next-to-last item to the $PATH.
 path_append "/var/www/html/bin"

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/00-path-setup.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/00-path-setup.bashrc
@@ -13,7 +13,7 @@ path_append() {
 }
 
 # If people want to install several Node.js versions, they can use `n install <version>`
-path_prepend "$HOME/n/bin"
+path_prepend "/usr/local/n/bin"
 
 # Add vendor/bin, then user-owned dirs in front of it (prepend order is last-wins)
 path_prepend "${DDEV_COMPOSER_ROOT:-/var/www/html}/vendor/bin"

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -103,9 +103,6 @@ sudo mkdir -p ${TERMINUS_CACHE_DIR}
 sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},n_prefix/${HOSTNAME},npm,yarn/classic,yarn/berry,corepack}
 sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
 
-# Remove ~/n/bin so the system Node.js is used by default; run `n install <version>` to switch
-ln -sf "${N_PREFIX}" ~/n && rm -rf ~/n/bin
-
 # The following ensures a persistent and shared "global" cache for
 # yarn classic (frozen v1) and yarn berry (active). In the case of berry, the global cache
 # will only be used if the project is configured to use it through it's own

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -99,9 +99,6 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 
 mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},n_prefix/${HOSTNAME},npm,yarn/classic,yarn/berry,corepack}
 
-# Remove ~/n/bin so the system Node.js is used by default; run `n install <version>` to switch
-ln -sf "${N_PREFIX}" ~/n && rm -rf ~/n/bin
-
 # The following ensures a persistent and shared "global" cache for
 # yarn classic (frozen v1) and yarn berry (active). In the case of berry, the global cache
 # will only be used if the project is configured to use it through it's own

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -34,6 +34,7 @@ setup() {
       "$HOME/.local/bin" \
       "$HOME/bin" \
       "${DDEV_COMPOSER_ROOT:-/var/www/html}/vendor/bin" \
+      "/usr/local/n/bin" \
       "/var/www/html/bin" \
       "/mnt/ddev-global-cache/global-commands/web"; do
       case ":$PATH:" in

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -229,7 +229,8 @@ services:
     - IS_DDEV_PROJECT=true
     - LINES
     - MYSQL_HISTFILE=/mnt/ddev-global-cache/mysqlhistory/${DDEV_SITENAME}-web/mysql_history
-    - N_PREFIX=/mnt/ddev-global-cache/n_prefix/${DDEV_SITENAME}-web
+    - N_PREFIX=/usr/local/n
+    - N_CACHE_PREFIX=/mnt/ddev-global-cache/n_prefix/${DDEV_SITENAME}-web
     - NODE_EXTRA_CA_CERTS=/mnt/ddev-global-cache/mkcert/rootCA.pem
     - npm_config_cache=/mnt/ddev-global-cache/npm
     {{- if ne (env "DDEV_PAGER") "" }}

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1012,23 +1012,23 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 				}
 			}
 			// cd so n resolves auto/engine from the version files copied above
-			extraWebContent = extraWebContent + fmt.Sprintf(`
-### DDEV-injected Node.js install via n (with version files from the project root)
+			extraWebContent = extraWebContent + `
+### DDEV-injected Node.js version files from the project root
 COPY n-version-files/ /tmp/n-version-files/
-ARG N_PREFIX=/usr/local
-RUN cd /tmp/n-version-files && (n install --cleanup "%[1]s" || log-stderr.sh n install --cleanup "%[1]s" || true) && rm -rf /tmp/n-version-files
-`, app.NodeJSVersion)
-		} else {
-			extraWebContent = extraWebContent + fmt.Sprintf(`
-### DDEV-injected Node.js install via n
-ARG N_PREFIX=/usr/local
-RUN n install --cleanup "%[1]s" || log-stderr.sh n install --cleanup "%[1]s" || true
-`, app.NodeJSVersion)
-		}
-		extraWebContent = extraWebContent + `
-### DDEV-injected removal of dangling symlinks left by 'n install'
-RUN find /usr/local/bin -maxdepth 1 -xtype l -delete
 `
+		}
+		extraWebContent = extraWebContent + fmt.Sprintf(`
+### DDEV-injected Node.js install via n
+RUN <<EOF
+set -eu -o pipefail
+cd /tmp/n-version-files || true
+export N_PREFIX=/usr/local/n-new
+if n install --cleanup "%[1]s" || log-stderr.sh n install --cleanup "%[1]s"; then
+  rm -rf /usr/local/n && mv /usr/local/n-new /usr/local/n
+fi
+cd /tmp && rm -rf /tmp/n-version-files
+EOF
+`, app.NodeJSVersion)
 	}
 	if app.CorepackEnable {
 		extraWebContent = extraWebContent + "\nRUN (command -v corepack >/dev/null 2>&1 || log-stderr.sh npm install -g corepack -f || true) && log-stderr.sh corepack enable || true"
@@ -1102,14 +1102,14 @@ RUN <<EOF
 set -eu -o pipefail
 source /etc/os-release || true
 if [ "${VERSION_CODENAME:-}" = "stretch" ] || [ "${VERSION_CODENAME:-}" = "buster" ]; then
-    rm -f /etc/apt/sources.list.d/pgdg.list
-    echo "deb http://archive.debian.org/debian/ ${VERSION_CODENAME} main contrib non-free" >/etc/apt/sources.list
-    echo "deb http://archive.debian.org/debian-security/ ${VERSION_CODENAME}/updates main contrib non-free" >>/etc/apt/sources.list
-    timeout %[1]d apt-get -qq update -o Acquire::AllowInsecureRepositories=true \
-        -o Acquire::AllowDowngradeToInsecureRepositories=true -o APT::Get::AllowUnauthenticated=true || true
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests -o APT::Get::AllowUnauthenticated=true \
-        debian-archive-keyring apt-transport-https ca-certificates
-    echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg-archive main" >/etc/apt/sources.list.d/pgdg.list
+  rm -f /etc/apt/sources.list.d/pgdg.list
+  echo "deb http://archive.debian.org/debian/ ${VERSION_CODENAME} main contrib non-free" >/etc/apt/sources.list
+  echo "deb http://archive.debian.org/debian-security/ ${VERSION_CODENAME}/updates main contrib non-free" >>/etc/apt/sources.list
+  timeout %[1]d apt-get -qq update -o Acquire::AllowInsecureRepositories=true \
+    -o Acquire::AllowDowngradeToInsecureRepositories=true -o APT::Get::AllowUnauthenticated=true || true
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests -o APT::Get::AllowUnauthenticated=true \
+    debian-archive-keyring apt-transport-https ca-certificates
+  echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg-archive main" >/etc/apt/sources.list.d/pgdg.list
 fi
 EOF
 
@@ -1418,8 +1418,8 @@ RUN mkdir -p /run/php /var/run/nginx /var/run/supervisor /var/run/apache2 /var/l
     touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log /var/log/supervisord.log && \
     chmod ugo+rw /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log /var/log/supervisord.log && \
     chmod ugo+rwX /var/log/nginx /var/log/apache2 && \
-    chgrp -R "$gid" /etc/alternatives /var/lib/dpkg/alternatives && \
-    chmod -R g+rwX,o-w /etc/alternatives /var/lib/dpkg/alternatives && \
+    chgrp -R "$gid" /etc/alternatives /var/lib/dpkg/alternatives /usr/local/n && \
+    chmod -R g+rwX,o-w /etc/alternatives /var/lib/dpkg/alternatives /usr/local/n && \
     chmod -f ugo+rx /usr/local/bin /usr/local/bin/* && \
     chgrp "$gid" /usr/local/bin/composer && chmod g+rwx,o-w /usr/local/bin/composer && \
     mkdir -p /tmp/xhprof && chmod -R ugo+w /etc/php /var/lib/php /tmp/xhprof

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -111,7 +111,7 @@ func TestCorepackEnable(t *testing.T) {
 		Cmd: `command -v yarn && ls -l "$(command -v yarn)"`,
 	})
 	require.NoError(t, err)
-	require.Contains(t, out, "/usr/local/bin/yarn")
+	require.Contains(t, out, "/usr/local/n/bin/yarn")
 	require.NotContains(t, out, "corepack")
 	out, _, err = app.Exec(&ddevapp.ExecOpts{
 		Cmd: `yarn --version`,
@@ -126,7 +126,7 @@ func TestCorepackEnable(t *testing.T) {
 		Cmd: `command -v yarn && ls -l "$(command -v yarn)"`,
 	})
 	require.NoError(t, err)
-	require.Contains(t, out, "/usr/local/bin/yarn")
+	require.Contains(t, out, "/usr/local/n/bin/yarn")
 	require.Contains(t, out, "corepack")
 	_, _, err = app.Exec(&ddevapp.ExecOpts{
 		Cmd: `yarn set version stable`,

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260608_stasadev_mariadb_compat" // Note that this can be overridden by make
+var WebTag = "20260610_stasadev_n_install" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- Fixes #8465

Related:

- #8379
- #8443

## How This PR Solves The Issue

- Sets `N_PREFIX=/usr/local/n`
- Sets `N_CACHE_PREFIX=/mnt/ddev-global-cache/n_prefix/${DDEV_SITENAME}-web`
- Adds `/usr/local/n` to `PATH`
- Removes `$HOME/n/bin` from `PATH` as not needed
- Sets file/folder permissions in `/usr/local/n` for the container user

## Manual Testing Instructions

All three should work as expected:

```bash
ddev npm install -g bun@latest
ddev npm install -g npm@latest
ddev exec n install 20 && ddev exec node -v
```

---

v1.25.2: ✅ ❌ ❌

```
$ ddev npm install -g bun@latest

added 5 packages in 6s

$ ddev npm install -g npm@latest
npm error code EACCES
npm error syscall mkdir
npm error path /usr/local/share/man/man7
npm error errno -13
npm error Error: EACCES: permission denied, mkdir '/usr/local/share/man/man7'

$ ddev exec n install 20 && ddev exec node -v
  installing : node-v20.20.2
       mkdir : /usr/local/n/versions/node/20.20.2
mkdir: cannot create directory ‘/usr/local/n/versions/node/20.20.2’: Permission denied
```

---

DDEV HEAD: ❌ ❌ ✅

```
$ ddev npm install -g bun@latest
npm error code EACCES
npm error syscall symlink
npm error path ../lib/node_modules/bun/bin/bunx.exe
npm error dest /usr/local/bin/bunx
npm error errno -13
npm error Error: EACCES: permission denied, symlink '../lib/node_modules/bun/bin/bunx.exe' -> '/usr/local/bin/bunx'

$ ddev npm install -g npm@latest
npm error code EACCES
npm error syscall rename
npm error path /usr/local/bin/npm
npm error dest /usr/local/bin/.npm-uJtxIR1m
npm error errno -13
npm error Error: EACCES: permission denied, rename '/usr/local/bin/npm' -> '/usr/local/bin/.npm-uJtxIR1m'

$ ddev exec n install 20 && ddev exec node -v
  installing : node-v20.20.2
       mkdir : /mnt/ddev-global-cache/n_prefix/demo-web/n/versions/node/20.20.2
       fetch : https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-x64.tar.xz
     copying : node/20.20.2
   installed : v20.20.2 to /mnt/ddev-global-cache/n_prefix/demo-web/bin/node
      active : v20.20.2 at /home/stas/n/bin/node
v20.20.2
```

---

This PR: ✅ ✅ ✅

```
$ ddev npm install -g bun@latest

added 5 packages in 7s

$ ddev npm install -g npm@latest

removed 2 packages, and changed 37 packages in 4s

15 packages are looking for funding
  run `npm fund` for details

$ ddev exec n install 20 && ddev exec node -v
  installing : node-v20.20.2
       mkdir : /mnt/ddev-global-cache/n_prefix/demo-web/n/versions/node/20.20.2
       fetch : https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-x64.tar.xz
     copying : node/20.20.2
   installed : v20.20.2 (with npm 10.8.2)
v20.20.2
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
