### PR TITLE
feat: improve ddev list/describe table layout, add OSC 8 terminal hyperlinks, fixes #5535, fixes #6113 (#8474)  [skip ci]

### DIFF
--- a/cmd/ddev/cmd/addon-list.go
+++ b/cmd/ddev/cmd/addon-list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ddev/ddev/pkg/config/remoteconfig/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/styles"
 	"github.com/ddev/ddev/pkg/util"
@@ -68,26 +69,36 @@ func ListInstalledAddons(app *ddevapp.DdevApp) {
 	styles.SetGlobalTableStyle(t, false)
 
 	if !globalconfig.DdevGlobalConfig.SimpleFormatting {
+		termWidth, _ := nodeps.GetTerminalWidthHeight()
+		if termWidth == 0 {
+			termWidth = 80
+		}
+		// Table overhead for 4 columns: | col | col | col | col |
+		const tableOverhead = 14
+		usableWidth := termWidth - tableOverhead
+		// Fixed widths for narrow columns
+		versionWidth := 10
+		dateWidth := 20
+		addonWidth := 20
+		repoWidth := max(20, usableWidth-addonWidth-versionWidth-dateWidth)
+
+		snip := func(col string, maxLen int) string { return text.Snip(col, maxLen, "…") }
 		t.SetColumnConfigs([]table.ColumnConfig{
-			{
-				Name: "Add-on",
-			},
-			{
-				Name: "Version",
-			},
-			{
-				Name: "Repository",
-			},
-			{
-				Name: "Date Installed",
-			},
+			{Name: "Add-on", WidthMax: addonWidth, WidthMaxEnforcer: snip},
+			{Name: "Version", WidthMax: versionWidth, WidthMaxEnforcer: snip},
+			{Name: "Repository", WidthMax: repoWidth, WidthMaxEnforcer: snip},
+			{Name: "Date Installed", WidthMax: dateWidth, WidthMaxEnforcer: snip},
 		})
 	}
 	t.AppendHeader(table.Row{"Add-on", "Version", "Repository", "Date Installed"})
 
 	// Loop through the directories in the .ddev/addon-metadata directory
 	for _, addon := range manifests {
-		t.AppendRow(table.Row{addon.Name, addon.Version, addon.Repository, addon.InstallDate})
+		repoDisplay := addon.Repository
+		if addon.Repository != "" {
+			repoDisplay = output.Hyperlink("https://github.com/"+addon.Repository, addon.Repository)
+		}
+		t.AppendRow(table.Row{addon.Name, addon.Version, repoDisplay, addon.InstallDate})
 	}
 	if t.Length() == 0 {
 		output.UserOut.Println("No registered add-ons were found.")
@@ -104,14 +115,23 @@ func renderRepositoryList(addons []types.Addon) string {
 	t := table.NewWriter()
 	t.SetOutputMirror(&out)
 	styles.SetGlobalTableStyle(t, false)
+
+	termWidth, _ := nodeps.GetTerminalWidthHeight()
+	if termWidth == 0 {
+		termWidth = 80
+	}
+	// Table overhead for 2 columns: | col | col |
+	const tableOverhead = 7
+	usableWidth := termWidth - tableOverhead
+	addonWidth := max(20, usableWidth*3/10)
+	descWidth := max(30, usableWidth-addonWidth)
+
+	snip := func(col string, maxLen int) string { return text.Snip(col, maxLen, "…") }
 	t.SetColumnConfigs([]table.ColumnConfig{
-		{
-			Name: "Service",
-		},
-		{
-			Name: "Description",
-		},
+		{Name: "Add-on", WidthMax: addonWidth, WidthMaxEnforcer: snip},
+		{Name: "Description", WidthMax: descWidth},
 	})
+
 	sort.Slice(addons, func(i, j int) bool {
 		return strings.Compare(strings.ToLower(addons[i].Title), strings.ToLower(addons[j].Title)) == -1
 	})
@@ -122,7 +142,8 @@ func renderRepositoryList(addons []types.Addon) string {
 		if addon.Type == "official" {
 			d = d + "*"
 		}
-		t.AppendRow([]any{addon.Title, text.WrapSoft(d, 50)})
+		title := output.Hyperlink(addon.GitHubURL, addon.Title)
+		t.AppendRow([]any{title, text.WrapSoft(d, descWidth)})
 	}
 
 	t.Render()

--- a/cmd/ddev/cmd/addon-list.go
+++ b/cmd/ddev/cmd/addon-list.go
@@ -54,7 +54,8 @@ ddev add-on list --installed --project my-project
 			util.Warning("No DDEV add-ons found in registry.")
 			return
 		}
-		out := renderRepositoryList(addons)
+		wrapTable, _ := cmd.Flags().GetBool("wrap-table")
+		out := renderRepositoryList(addons, wrapTable)
 		output.UserOut.WithField("raw", addons).Print(out)
 	},
 }
@@ -109,7 +110,7 @@ func ListInstalledAddons(app *ddevapp.DdevApp) {
 }
 
 // renderRepositoryList renders the found list of addons from the registry
-func renderRepositoryList(addons []types.Addon) string {
+func renderRepositoryList(addons []types.Addon, wrapTable bool) string {
 	var out bytes.Buffer
 
 	t := table.NewWriter()
@@ -123,14 +124,21 @@ func renderRepositoryList(addons []types.Addon) string {
 	// Table overhead for 2 columns: | col | col |
 	const tableOverhead = 7
 	usableWidth := termWidth - tableOverhead
-	addonWidth := max(20, usableWidth*3/10)
+	addonWidth := max(30, usableWidth*3/10)
 	descWidth := max(30, usableWidth-addonWidth)
 
 	snip := func(col string, maxLen int) string { return text.Snip(col, maxLen, "…") }
-	t.SetColumnConfigs([]table.ColumnConfig{
-		{Name: "Add-on", WidthMax: addonWidth, WidthMaxEnforcer: snip},
-		{Name: "Description", WidthMax: descWidth},
-	})
+	if wrapTable {
+		t.SetColumnConfigs([]table.ColumnConfig{
+			{Name: "Add-on"},
+			{Name: "Description"},
+		})
+	} else {
+		t.SetColumnConfigs([]table.ColumnConfig{
+			{Name: "Add-on", WidthMax: addonWidth, WidthMaxEnforcer: snip},
+			{Name: "Description", WidthMax: descWidth},
+		})
+	}
 
 	sort.Slice(addons, func(i, j int) bool {
 		return strings.Compare(strings.ToLower(addons[i].Title), strings.ToLower(addons[j].Title)) == -1
@@ -143,7 +151,11 @@ func renderRepositoryList(addons []types.Addon) string {
 			d = d + "*"
 		}
 		title := output.Hyperlink(addon.GitHubURL, addon.Title)
-		t.AppendRow([]any{title, text.WrapSoft(d, descWidth)})
+		if wrapTable {
+			t.AppendRow([]any{title, d})
+		} else {
+			t.AppendRow([]any{title, text.WrapSoft(d, descWidth)})
+		}
 	}
 
 	t.Render()
@@ -157,6 +169,7 @@ func init() {
 	AddonListCmd.Flags().Bool("installed", false, `Show installed DDEV add-ons`)
 	AddonListCmd.Flags().String("project", "", "Name of the project to list the add-ons for. Can only be used with `--installed`")
 	_ = AddonListCmd.RegisterFlagCompletionFunc("project", ddevapp.GetProjectNamesFunc("all", 0))
+	AddonListCmd.Flags().BoolP("wrap-table", "W", false, "Display table with wrapped text instead of truncating.")
 
 	AddonCmd.AddCommand(AddonListCmd)
 }

--- a/cmd/ddev/cmd/addon-list_test.go
+++ b/cmd/ddev/cmd/addon-list_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/config/remoteconfig/types"
+	"github.com/stretchr/testify/require"
+)
+
+// sampleAddons returns a small slice of Addons for use in rendering tests.
+func sampleAddons() []types.Addon {
+	return []types.Addon{
+		{
+			Title:       "ddev-redis",
+			GitHubURL:   "https://github.com/ddev/ddev-redis",
+			Description: "Redis integration for DDEV",
+			Type:        "official",
+		},
+		{
+			Title:       "ddev-memcached",
+			GitHubURL:   "https://github.com/ddev/ddev-memcached",
+			Description: "Memcached integration for DDEV",
+			Type:        "contrib",
+		},
+	}
+}
+
+// TestRenderRepositoryListContent verifies that addon titles and descriptions
+// appear in the rendered output, that official addons get a "*" suffix on their
+// description, and that the footer contains the correct count.
+func TestRenderRepositoryListContent(t *testing.T) {
+	out := renderRepositoryList(sampleAddons())
+
+	require.Contains(t, out, "ddev-redis")
+	require.Contains(t, out, "ddev-memcached")
+	// Official addons get "*" appended to description
+	require.Contains(t, out, "Redis integration for DDEV*")
+	// Non-official addons do not
+	require.NotContains(t, out, "Memcached integration for DDEV*")
+	// Footer shows count and legend
+	require.Contains(t, out, "2 add-ons found")
+	require.Contains(t, out, "officially maintained by DDEV")
+}
+
+// TestRenderRepositoryListSorted verifies addons are rendered in alphabetical order.
+func TestRenderRepositoryListSorted(t *testing.T) {
+	// Supply addons in reverse alphabetical order; output must be sorted.
+	addons := []types.Addon{
+		{Title: "zzz-addon", Description: "Last"},
+		{Title: "aaa-addon", Description: "First"},
+	}
+	out := renderRepositoryList(addons)
+
+	posFirst := strings.Index(out, "aaa-addon")
+	posLast := strings.Index(out, "zzz-addon")
+	require.Greater(t, posFirst, -1, "aaa-addon should appear in output")
+	require.Greater(t, posLast, -1, "zzz-addon should appear in output")
+	require.Less(t, posFirst, posLast, "aaa-addon should appear before zzz-addon")
+}
+
+// TestRenderRepositoryListSnipsLongTitle verifies that a title exceeding the
+// calculated column width is truncated with "…" rather than overflowing.
+// In the test process GetTerminalWidthHeight returns 0, so the code falls back
+// to 80 columns → addonWidth = max(20, (80-7)*3/10) = 21.
+func TestRenderRepositoryListSnipsLongTitle(t *testing.T) {
+	longTitle := strings.Repeat("x", 50)
+	addons := []types.Addon{
+		{Title: longTitle, Description: "Short description"},
+	}
+	out := renderRepositoryList(addons)
+
+	require.NotContains(t, out, longTitle, "full long title should not appear untruncated")
+	require.Contains(t, out, "…", "truncated title should end with ellipsis")
+}
+
+// TestRenderRepositoryListEmpty verifies the footer still renders for a single addon.
+func TestRenderRepositoryListEmpty(t *testing.T) {
+	out := renderRepositoryList([]types.Addon{
+		{Title: "only-addon", Description: "Sole entry"},
+	})
+	require.Contains(t, out, "1 add-ons found")
+}
+
+// TestRenderSearchResultsContent verifies that matching addon titles, descriptions,
+// and the search term appear in the rendered search output.
+func TestRenderSearchResultsContent(t *testing.T) {
+	out := renderSearchResults(sampleAddons(), "redis")
+
+	require.Contains(t, out, "ddev-redis")
+	require.Contains(t, out, "ddev-memcached")
+	require.Contains(t, out, "Redis integration for DDEV*")
+	require.NotContains(t, out, "Memcached integration for DDEV*")
+	// Footer includes search term and count
+	require.Contains(t, out, "2 add-ons found matching 'redis'")
+	require.Contains(t, out, "officially maintained by DDEV")
+}
+
+// TestRenderSearchResultsSorted verifies search results are rendered in alphabetical order.
+func TestRenderSearchResultsSorted(t *testing.T) {
+	addons := []types.Addon{
+		{Title: "zzz-addon", Description: "Last"},
+		{Title: "aaa-addon", Description: "First"},
+	}
+	out := renderSearchResults(addons, "addon")
+
+	posFirst := strings.Index(out, "aaa-addon")
+	posLast := strings.Index(out, "zzz-addon")
+	require.Greater(t, posFirst, -1)
+	require.Greater(t, posLast, -1)
+	require.Less(t, posFirst, posLast)
+}
+
+// TestRenderSearchResultsSnipsLongTitle mirrors the addon-list snip test for
+// the search renderer, which uses the same column-width logic.
+func TestRenderSearchResultsSnipsLongTitle(t *testing.T) {
+	longTitle := strings.Repeat("y", 50)
+	addons := []types.Addon{
+		{Title: longTitle, Description: "Short description"},
+	}
+	out := renderSearchResults(addons, "y")
+
+	require.NotContains(t, out, longTitle)
+	require.Contains(t, out, "…")
+}

--- a/cmd/ddev/cmd/addon-list_test.go
+++ b/cmd/ddev/cmd/addon-list_test.go
@@ -30,7 +30,7 @@ func sampleAddons() []types.Addon {
 // appear in the rendered output, that official addons get a "*" suffix on their
 // description, and that the footer contains the correct count.
 func TestRenderRepositoryListContent(t *testing.T) {
-	out := renderRepositoryList(sampleAddons())
+	out := renderRepositoryList(sampleAddons(), false)
 
 	require.Contains(t, out, "ddev-redis")
 	require.Contains(t, out, "ddev-memcached")
@@ -50,7 +50,7 @@ func TestRenderRepositoryListSorted(t *testing.T) {
 		{Title: "zzz-addon", Description: "Last"},
 		{Title: "aaa-addon", Description: "First"},
 	}
-	out := renderRepositoryList(addons)
+	out := renderRepositoryList(addons, false)
 
 	posFirst := strings.Index(out, "aaa-addon")
 	posLast := strings.Index(out, "zzz-addon")
@@ -62,30 +62,43 @@ func TestRenderRepositoryListSorted(t *testing.T) {
 // TestRenderRepositoryListSnipsLongTitle verifies that a title exceeding the
 // calculated column width is truncated with "…" rather than overflowing.
 // In the test process GetTerminalWidthHeight returns 0, so the code falls back
-// to 80 columns → addonWidth = max(20, (80-7)*3/10) = 21.
+// to 80 columns → addonWidth = max(30, (80-7)*3/10) = 30.
 func TestRenderRepositoryListSnipsLongTitle(t *testing.T) {
 	longTitle := strings.Repeat("x", 50)
 	addons := []types.Addon{
 		{Title: longTitle, Description: "Short description"},
 	}
-	out := renderRepositoryList(addons)
+	out := renderRepositoryList(addons, false)
 
 	require.NotContains(t, out, longTitle, "full long title should not appear untruncated")
 	require.Contains(t, out, "…", "truncated title should end with ellipsis")
+}
+
+// TestRenderRepositoryListWrapTable verifies that --wrap-table shows the full title
+// without truncation.
+func TestRenderRepositoryListWrapTable(t *testing.T) {
+	longTitle := strings.Repeat("x", 50)
+	addons := []types.Addon{
+		{Title: longTitle, Description: "Short description"},
+	}
+	out := renderRepositoryList(addons, true)
+
+	require.Contains(t, out, longTitle, "full title should appear when wrap-table is set")
+	require.NotContains(t, out, "…")
 }
 
 // TestRenderRepositoryListEmpty verifies the footer still renders for a single addon.
 func TestRenderRepositoryListEmpty(t *testing.T) {
 	out := renderRepositoryList([]types.Addon{
 		{Title: "only-addon", Description: "Sole entry"},
-	})
+	}, false)
 	require.Contains(t, out, "1 add-ons found")
 }
 
 // TestRenderSearchResultsContent verifies that matching addon titles, descriptions,
 // and the search term appear in the rendered search output.
 func TestRenderSearchResultsContent(t *testing.T) {
-	out := renderSearchResults(sampleAddons(), "redis")
+	out := renderSearchResults(sampleAddons(), "redis", false)
 
 	require.Contains(t, out, "ddev-redis")
 	require.Contains(t, out, "ddev-memcached")
@@ -102,7 +115,7 @@ func TestRenderSearchResultsSorted(t *testing.T) {
 		{Title: "zzz-addon", Description: "Last"},
 		{Title: "aaa-addon", Description: "First"},
 	}
-	out := renderSearchResults(addons, "addon")
+	out := renderSearchResults(addons, "addon", false)
 
 	posFirst := strings.Index(out, "aaa-addon")
 	posLast := strings.Index(out, "zzz-addon")
@@ -118,8 +131,21 @@ func TestRenderSearchResultsSnipsLongTitle(t *testing.T) {
 	addons := []types.Addon{
 		{Title: longTitle, Description: "Short description"},
 	}
-	out := renderSearchResults(addons, "y")
+	out := renderSearchResults(addons, "y", false)
 
 	require.NotContains(t, out, longTitle)
 	require.Contains(t, out, "…")
+}
+
+// TestRenderSearchResultsWrapTable verifies that --wrap-table shows the full title
+// without truncation.
+func TestRenderSearchResultsWrapTable(t *testing.T) {
+	longTitle := strings.Repeat("y", 50)
+	addons := []types.Addon{
+		{Title: longTitle, Description: "Short description"},
+	}
+	out := renderSearchResults(addons, "y", true)
+
+	require.Contains(t, out, longTitle, "full title should appear when wrap-table is set")
+	require.NotContains(t, out, "…")
 }

--- a/cmd/ddev/cmd/addon-search.go
+++ b/cmd/ddev/cmd/addon-search.go
@@ -71,13 +71,14 @@ ddev add-on search "redis insight"`,
 			return
 		}
 
-		out := renderSearchResults(filteredAddons, searchTerms)
+		wrapTable, _ := cmd.Flags().GetBool("wrap-table")
+		out := renderSearchResults(filteredAddons, searchTerms, wrapTable)
 		output.UserOut.WithField("raw", filteredAddons).Print(out)
 	},
 }
 
 // renderSearchResults renders the filtered list of addons from the registry
-func renderSearchResults(addons []types.Addon, searchTerm string) string {
+func renderSearchResults(addons []types.Addon, searchTerm string, wrapTable bool) string {
 	var out bytes.Buffer
 
 	t := table.NewWriter()
@@ -91,14 +92,21 @@ func renderSearchResults(addons []types.Addon, searchTerm string) string {
 	// Table overhead for 2 columns: | col | col |
 	const tableOverhead = 7
 	usableWidth := termWidth - tableOverhead
-	addonWidth := max(20, usableWidth*3/10)
+	addonWidth := max(30, usableWidth*3/10)
 	descWidth := max(30, usableWidth-addonWidth)
 
 	snip := func(col string, maxLen int) string { return text.Snip(col, maxLen, "…") }
-	t.SetColumnConfigs([]table.ColumnConfig{
-		{Name: "Add-on", WidthMax: addonWidth, WidthMaxEnforcer: snip},
-		{Name: "Description", WidthMax: descWidth},
-	})
+	if wrapTable {
+		t.SetColumnConfigs([]table.ColumnConfig{
+			{Name: "Add-on"},
+			{Name: "Description"},
+		})
+	} else {
+		t.SetColumnConfigs([]table.ColumnConfig{
+			{Name: "Add-on", WidthMax: addonWidth, WidthMaxEnforcer: snip},
+			{Name: "Description", WidthMax: descWidth},
+		})
+	}
 
 	sort.Slice(addons, func(i, j int) bool {
 		return strings.Compare(strings.ToLower(addons[i].Title), strings.ToLower(addons[j].Title)) == -1
@@ -111,7 +119,11 @@ func renderSearchResults(addons []types.Addon, searchTerm string) string {
 			d = d + "*"
 		}
 		title := output.Hyperlink(addon.GitHubURL, addon.Title)
-		t.AppendRow([]any{title, text.WrapSoft(d, descWidth)})
+		if wrapTable {
+			t.AppendRow([]any{title, d})
+		} else {
+			t.AppendRow([]any{title, text.WrapSoft(d, descWidth)})
+		}
 	}
 
 	t.Render()
@@ -120,5 +132,6 @@ func renderSearchResults(addons []types.Addon, searchTerm string) string {
 }
 
 func init() {
+	AddonSearchCmd.Flags().BoolP("wrap-table", "W", false, "Display table with wrapped text instead of truncating.")
 	AddonCmd.AddCommand(AddonSearchCmd)
 }

--- a/cmd/ddev/cmd/addon-search.go
+++ b/cmd/ddev/cmd/addon-search.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ddev/ddev/pkg/config/remoteconfig/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/styles"
 	"github.com/ddev/ddev/pkg/util"
@@ -82,14 +83,23 @@ func renderSearchResults(addons []types.Addon, searchTerm string) string {
 	t := table.NewWriter()
 	t.SetOutputMirror(&out)
 	styles.SetGlobalTableStyle(t, false)
+
+	termWidth, _ := nodeps.GetTerminalWidthHeight()
+	if termWidth == 0 {
+		termWidth = 80
+	}
+	// Table overhead for 2 columns: | col | col |
+	const tableOverhead = 7
+	usableWidth := termWidth - tableOverhead
+	addonWidth := max(20, usableWidth*3/10)
+	descWidth := max(30, usableWidth-addonWidth)
+
+	snip := func(col string, maxLen int) string { return text.Snip(col, maxLen, "…") }
 	t.SetColumnConfigs([]table.ColumnConfig{
-		{
-			Name: "Service",
-		},
-		{
-			Name: "Description",
-		},
+		{Name: "Add-on", WidthMax: addonWidth, WidthMaxEnforcer: snip},
+		{Name: "Description", WidthMax: descWidth},
 	})
+
 	sort.Slice(addons, func(i, j int) bool {
 		return strings.Compare(strings.ToLower(addons[i].Title), strings.ToLower(addons[j].Title)) == -1
 	})
@@ -100,7 +110,8 @@ func renderSearchResults(addons []types.Addon, searchTerm string) string {
 		if addon.Type == "official" {
 			d = d + "*"
 		}
-		t.AppendRow([]any{addon.Title, text.WrapSoft(d, 50)})
+		title := output.Hyperlink(addon.GitHubURL, addon.Title)
+		t.AppendRow([]any{title, text.WrapSoft(d, descWidth)})
 	}
 
 	t.Render()

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 
+	"os"
+
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -19,6 +21,7 @@ import (
 	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
 
@@ -90,7 +93,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]any) (string, error
 		urlPortWidth = float64(tWidth) / urlPortWidthFactor
 		infoWidth = tWidth / 4
 	}
-	if !globalconfig.DdevGlobalConfig.SimpleFormatting {
+	if !globalconfig.DdevGlobalConfig.SimpleFormatting && isatty.IsTerminal(os.Stdout.Fd()) {
 		t.SetColumnConfigs([]table.ColumnConfig{
 			{
 				Name:     "Service",

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -101,13 +101,20 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]any) (string, error
 				WidthMax: int(urlPortWidth),
 				// Wrap each embedded line individually to preserve intentional line breaks
 				WidthMaxEnforcer: func(col string, maxLen int) string {
-					lines := strings.Split(col, "\n")
-					for i, line := range lines {
-						if text.RuneWidthWithoutEscSequences(line) > maxLen {
-							lines[i] = text.WrapSoft(line, maxLen)
+					wrapped := []string{}
+					for line := range strings.SplitSeq(col, "\n") {
+						switch {
+						case text.RuneWidthWithoutEscSequences(line) <= maxLen:
+							wrapped = append(wrapped, line)
+						case strings.Contains(line, "\x1b]8;"):
+							// WrapSoft corrupts OSC 8 hyperlinks when splitting, so
+							// truncate those lines; the full link target stays clickable
+							wrapped = append(wrapped, text.Snip(line, maxLen, "…"))
+						default:
+							wrapped = append(wrapped, strings.Split(text.WrapSoft(line, maxLen), "\n")...)
 						}
 					}
-					return strings.Join(lines, "\n")
+					return strings.Join(wrapped, "\n")
 				},
 			},
 			{
@@ -126,7 +133,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]any) (string, error
 		router = "disabled"
 	}
 
-	t.SetTitle(fmt.Sprintf("Project: %s %s %s\nDocker platform: %s\nRouter: %s\nDDEV version: %s", app.Name, desc["shortroot"].(string), app.GetPrimaryURL(), dockerPlatform, router, versionconstants.DdevVersion))
+	t.SetTitle(fmt.Sprintf("Project: %s %s %s\nDocker platform: %s\nRouter: %s\nDDEV version: %s", app.Name, output.Hyperlink(output.FileURL(app.GetAppRoot()), desc["shortroot"].(string)), output.Hyperlink(app.GetPrimaryURL(), app.GetPrimaryURL()), dockerPlatform, router, versionconstants.DdevVersion))
 	t.AppendHeader(table.Row{"Service", "Stat", "URL/Port", "Info"})
 
 	// Only show extended status for running sites.
@@ -155,19 +162,22 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]any) (string, error
 		// Normal case, using ddev-router based URLs
 		case !ddevapp.IsRouterDisabled(app):
 			if httpsURL, ok := v["https_url"].(string); ok && !app.CanUseHTTPOnly() {
-				urlPortParts = append(urlPortParts, netutil.NormalizeURL(httpsURL))
+				u := netutil.NormalizeURL(httpsURL)
+				urlPortParts = append(urlPortParts, output.Hyperlink(u, u))
 			} else if httpURL, ok = v["http_url"].(string); ok {
-				urlPortParts = append(urlPortParts, netutil.NormalizeURL(httpURL))
+				u := netutil.NormalizeURL(httpURL)
+				urlPortParts = append(urlPortParts, output.Hyperlink(u, u))
 			}
 
 		// Codespaces, web container only, using port proxied by Codespaces/Devcontainer
 		case nodeps.IsDevcontainer() && k == "web":
-			urlPortParts = append(urlPortParts, app.GetPrimaryURL())
+			urlPortParts = append(urlPortParts, output.Hyperlink(app.GetPrimaryURL(), app.GetPrimaryURL()))
 
 		// Router disabled, but not because of Codespaces, use direct http url
 		case ddevapp.IsRouterDisabled(app):
 			if httpURL, ok := v["host_http_url"].(string); ok && httpURL != "" {
-				urlPortParts = append(urlPortParts, netutil.NormalizeURL(httpURL))
+				u := netutil.NormalizeURL(httpURL)
+				urlPortParts = append(urlPortParts, output.Hyperlink(u, u))
 			}
 		}
 
@@ -241,27 +251,28 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]any) (string, error
 		if _, ok := desc["mailpit_https_url"]; ok && !app.CanUseHTTPOnly() {
 			mailpitURL = desc["mailpit_https_url"].(string)
 		}
-		t.AppendRow(table.Row{"Mailpit", "", fmt.Sprintf("Mailpit: %s\nLaunch: ddev mailpit", mailpitURL)})
+		t.AppendRow(table.Row{"Mailpit", "", fmt.Sprintf("Mailpit: %s\nLaunch: ddev mailpit", output.Hyperlink(mailpitURL, mailpitURL))})
 
 		ddevapp.SyncGenericWebserverPortsWithRouterPorts(app)
 
 		//WebExtraExposedPorts stanza
 		for _, extraPort := range app.WebExtraExposedPorts {
+			scheme, port := "https", extraPort.HTTPSPort
 			if app.CanUseHTTPOnly() {
-				url := netutil.NormalizeURL(fmt.Sprintf("http://%s:%d", app.GetHostname(), extraPort.HTTPPort))
-				t.AppendRow(table.Row{extraPort.Name, "", fmt.Sprintf("%s\nInDocker: web:%d", url, extraPort.WebContainerPort)})
-			} else {
-				url := netutil.NormalizeURL(fmt.Sprintf("https://%s:%d", app.GetHostname(), extraPort.HTTPSPort))
-				t.AppendRow(table.Row{extraPort.Name, "", fmt.Sprintf("%s\nInDocker: web:%d", url, extraPort.WebContainerPort)})
+				scheme, port = "http", extraPort.HTTPPort
 			}
+			url := netutil.NormalizeURL(fmt.Sprintf("%s://%s:%d", scheme, app.GetHostname(), port))
+			t.AppendRow(table.Row{extraPort.Name, "", fmt.Sprintf("%s\nInDocker: web:%d", output.Hyperlink(url, url), extraPort.WebContainerPort)})
 		}
 
-		// All URLs stanza
+		// All URLs stanza, one per line so each stays an intact clickable link
 		_, _, urls := app.GetAllURLs()
 		if len(urls) > 0 {
-			s := strings.Join(urls, ", ")
-			urlString := text.WrapSoft(s, int(urlPortWidth))
-			t.AppendRow(table.Row{"Project URLs", "", urlString})
+			linkedURLs := make([]string, len(urls))
+			for i, u := range urls {
+				linkedURLs[i] = output.Hyperlink(u, u)
+			}
+			t.AppendRow(table.Row{"Project URLs", "", strings.Join(linkedURLs, "\n")})
 		}
 	}
 	bindInfo := []string{}

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -97,8 +97,18 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]any) (string, error
 				WidthMax: 12,
 			},
 			{
-				Name: "URL/Port",
-				//WidthMax: int(urlPortWidth),
+				Name:     "URL/Port",
+				WidthMax: int(urlPortWidth),
+				// Wrap each embedded line individually to preserve intentional line breaks
+				WidthMaxEnforcer: func(col string, maxLen int) string {
+					lines := strings.Split(col, "\n")
+					for i, line := range lines {
+						if text.RuneWidthWithoutEscSequences(line) > maxLen {
+							lines[i] = text.WrapSoft(line, maxLen)
+						}
+					}
+					return strings.Join(lines, "\n")
+				},
 			},
 			{
 				Name:     "Info",

--- a/cmd/ddev/cmd/describe.go
+++ b/cmd/ddev/cmd/describe.go
@@ -104,7 +104,7 @@ func renderAppDescribe(app *ddevapp.DdevApp, desc map[string]any) (string, error
 				WidthMax: int(urlPortWidth),
 				// Wrap each embedded line individually to preserve intentional line breaks
 				WidthMaxEnforcer: func(col string, maxLen int) string {
-					wrapped := []string{}
+					wrapped := make([]string, 0, strings.Count(col, "\n")+1)
 					for line := range strings.SplitSeq(col, "\n") {
 						switch {
 						case text.RuneWidthWithoutEscSequences(line) <= maxLen:

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -186,6 +186,7 @@ Flags:
 
 * `--installed`: List installed add-ons
 * `--project <projectName>`: Specify the project for which to list add-ons. Can only be used with the `--installed` flag. Defaults to checking for a project in the current directory.
+* `--wrap-table`, `-W`: Display table with wrapped text instead of truncating.
 
 Example:
 
@@ -198,11 +199,18 @@ ddev add-on list --installed
 
 # List installed add-ons for a specific project
 ddev add-on list --installed --project my-project
+
+# List with full untruncated add-on names and descriptions
+ddev add-on list --wrap-table
 ```
 
 ### `add-on search`
 
 Search available DDEV add-ons by name or description.
+
+Flags:
+
+* `--wrap-table`, `-W`: Display table with wrapped text instead of truncating.
 
 Example:
 
@@ -218,6 +226,9 @@ ddev add-on search redis web
 
 # Search with multiple terms using quotes (currently same behavior)
 ddev add-on search "redis insight"
+
+# Search with full untruncated output
+ddev add-on search redis --wrap-table
 ```
 
 ## `aliases`

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/google/go-github/v81 v81.0.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/jedib0t/go-pretty/v6 v6.7.9
+	github.com/jedib0t/go-pretty/v6 v6.8.1
 	github.com/joho/godotenv v1.5.1
 	github.com/manifoldco/promptui v0.9.0
 	github.com/maruel/natural v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf h1:FtEj8sfIcaaBfAKrE1Cwb61YDtYq9JxChK1c7AKce7s=
 github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf/go.mod h1:yrqSXGoD/4EKfF26AOGzscPOgTTJcyAwM2rpixWT+t4=
-github.com/jedib0t/go-pretty/v6 v6.7.9 h1:frarzQWmkZd97syT81+TH8INKPpzoxQnk+Mk5EIHSrM=
-github.com/jedib0t/go-pretty/v6 v6.7.9/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
+github.com/jedib0t/go-pretty/v6 v6.8.1 h1:0fkCNhjrX0zPpwkWaDYU5VMrygg41Tu197mWILIJoqQ=
+github.com/jedib0t/go-pretty/v6 v6.8.1/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=

--- a/pkg/ddevapp/list.go
+++ b/pkg/ddevapp/list.go
@@ -143,6 +143,9 @@ func CreateAppTable(out *bytes.Buffer, wrapTableText bool) table.Writer {
 		})
 	}
 	if !wrapTableText {
+		// Backstop: cell-level WidthMax enforcers above should prevent overflow,
+		// but SetAllowedRowLength catches any remainder (e.g. the Name column,
+		// which has no WidthMaxEnforcer).
 		t.SetAllowedRowLength(termWidth)
 	}
 	styles.SetGlobalTableStyle(t, false)

--- a/pkg/ddevapp/list.go
+++ b/pkg/ddevapp/list.go
@@ -74,11 +74,12 @@ func List(settings ListCommandSettings) {
 			if routerStatus == SiteStopped {
 				routerURL = ""
 			}
-			location := fileutil.ShortHomeJoin(globalconfig.GetGlobalDdevDirLocation())
+			location := output.Hyperlink(output.FileURL(globalconfig.GetGlobalDdevDirLocation()), fileutil.ShortHomeJoin(globalconfig.GetGlobalDdevDirLocation()))
 			extendedRouterStatus, errorInfo := RenderRouterStatus()
 			if errorInfo != "" {
 				location = text.WrapSoft(errorInfo, 35)
 			}
+			routerURL = output.Hyperlink(routerURL, routerURL)
 			routerType := globalconfig.DdevGlobalConfig.Router
 			if len(types.GetValidRouterTypes()) < 2 {
 				routerType = ""

--- a/pkg/ddevapp/list.go
+++ b/pkg/ddevapp/list.go
@@ -103,49 +103,46 @@ func CreateAppTable(out *bytes.Buffer, wrapTableText bool) table.Writer {
 	t := table.NewWriter()
 	t.AppendHeader(table.Row{"Name", "Status", "Location", "URL", "Type"})
 	termWidth, _ := nodeps.GetTerminalWidthHeight()
-	usableWidth := termWidth - 15
-	statusWidth := 7 // Maybe just "running"
-	nameWidth := 10
-	typeWidth := 9 // drupal7, magento2 or wordpress
-	locationWidth := 20
-	urlWidth := 20
-	if termWidth > 80 {
-		urlWidth = urlWidth + (termWidth-80)/2
-		locationWidth = locationWidth + (termWidth-80)/2
-		statusWidth = statusWidth + (termWidth-80)/3
-	}
-	totUsedWidth := nameWidth + statusWidth + locationWidth + urlWidth + typeWidth
-	if !wrapTableText {
-		t.SetAllowedRowLength(termWidth)
+	if termWidth == 0 {
+		termWidth = 80
 	}
 
-	util.Debug("Detected terminal width=%v usableWidth=%d statusWidth=%d nameWidth=%d locationWidth=%d urlWidth=%d typeWidth=%d totUsedWidth=%d", termWidth, usableWidth, statusWidth, nameWidth, locationWidth, urlWidth, typeWidth, totUsedWidth)
+	// Table border/padding overhead for 5 columns (borders + 1-space padding each side)
+	const tableOverhead = 17
+	usableWidth := termWidth - tableOverhead
+
+	// Fixed column widths: status wraps "running\n(ok)" naturally at 7
+	statusWidth := 7
+	typeWidth := 9 // "wordpress" is the longest common type
+	nameWidth := 10
+
+	// Distribute remaining width: location 40%, URL 60%
+	remaining := max(usableWidth-nameWidth-statusWidth-typeWidth, 25)
+	locationWidth := remaining * 2 / 5
+	urlWidth := remaining - locationWidth
+
+	util.Debug("termWidth=%v usableWidth=%d statusWidth=%d nameWidth=%d locationWidth=%d urlWidth=%d typeWidth=%d", termWidth, usableWidth, statusWidth, nameWidth, locationWidth, urlWidth, typeWidth)
 	t.SortBy([]table.SortBy{{Name: "Name"}})
 
 	if !globalconfig.DdevGlobalConfig.SimpleFormatting {
+		snip := func(col string, maxLen int) string { return text.Snip(col, maxLen, "…") }
+		locationConfig := table.ColumnConfig{Name: "Location", WidthMax: locationWidth, WidthMaxEnforcer: snip}
+		urlConfig := table.ColumnConfig{Name: "URL", WidthMax: urlWidth, WidthMaxEnforcer: snip}
+		if wrapTableText {
+			// In wrap mode, show full paths and URLs on one unbroken line so they are selectable
+			locationConfig = table.ColumnConfig{Name: "Location"}
+			urlConfig = table.ColumnConfig{Name: "URL"}
+		}
 		t.SetColumnConfigs([]table.ColumnConfig{
-			{
-				Name: "Name",
-				//WidthMax: nameWidth,
-			},
-			{
-				Name:     "Status",
-				WidthMax: statusWidth,
-			},
-			{
-				Name: "Location",
-				//WidthMax: locationWidth,
-			},
-			{
-				Name: "URL",
-				//WidthMax: urlWidth,
-			},
-			{
-				Name:             "Type",
-				WidthMax:         int(typeWidth),
-				WidthMaxEnforcer: text.WrapText,
-			},
+			{Name: "Name", WidthMax: nameWidth},
+			{Name: "Status", WidthMax: statusWidth},
+			locationConfig,
+			urlConfig,
+			{Name: "Type", WidthMax: typeWidth, WidthMaxEnforcer: text.WrapText},
 		})
+	}
+	if !wrapTableText {
+		t.SetAllowedRowLength(termWidth)
 	}
 	styles.SetGlobalTableStyle(t, false)
 	t.SetOutputMirror(out)

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -86,8 +86,13 @@ func RenderAppRow(t table.Writer, row map[string]any) {
 
 	status = FormatSiteStatus(status)
 
+	// Hyperlink targets are invisible to the table's width calculation, so
+	// even when the visible text is truncated the full URL/path is clickable.
+	urls = output.Hyperlink(urls, urls)
+	location := output.Hyperlink(output.FileURL(fmt.Sprint(row["approot"])), fmt.Sprint(row["shortroot"]))
+
 	t.AppendRow(table.Row{
-		row["name"], status, row["shortroot"], urls, row["type"],
+		row["name"], status, location, urls, row["type"],
 	})
 }
 

--- a/pkg/output/hyperlink.go
+++ b/pkg/output/hyperlink.go
@@ -19,33 +19,47 @@ import (
 // FORCE_HYPERLINK=1/0 overrides detection, following the convention used
 // by eza, lsd, and the chalk/supports-hyperlinks ecosystem.
 var HasTermHyperlinks = sync.OnceValue(func() bool {
-	if v := os.Getenv("FORCE_HYPERLINK"); v != "" {
-		enabled, err := strconv.ParseBool(v)
+	return detectHyperlinks(
+		os.Getenv("FORCE_HYPERLINK"),
+		!JSONOutput && isatty.IsTerminal(os.Stdout.Fd()),
+		os.Getenv("TERM_PROGRAM"),
+		os.Getenv("VTE_VERSION"),
+		os.Getenv("WT_SESSION"),
+		os.Getenv("KONSOLE_VERSION"),
+		os.Getenv("TERM"),
+	)
+})
+
+// detectHyperlinks contains the detection logic for HasTermHyperlinks.
+// It accepts the relevant environment values so it can be tested without
+// relying on the singleton cache.
+func detectHyperlinks(forceEnv string, isTTY bool, termProgram, vteVersion, wtSession, konsoleVersion, termEnv string) bool {
+	if forceEnv != "" {
+		enabled, err := strconv.ParseBool(forceEnv)
 		return err == nil && enabled
 	}
-	if JSONOutput || !isatty.IsTerminal(os.Stdout.Fd()) {
+	if !isTTY {
 		return false
 	}
-	switch os.Getenv("TERM_PROGRAM") {
+	switch termProgram {
 	case "Hyper", "ghostty", "iTerm.app", "mintty", "rio", "Tabby", "vscode", "WezTerm":
 		return true
 	}
 	// VTE-based terminals (GNOME Terminal, Tilix, etc.) support OSC 8 since 0.50
-	if v, err := strconv.Atoi(os.Getenv("VTE_VERSION")); err == nil && v >= 5000 {
+	if v, err := strconv.Atoi(vteVersion); err == nil && v >= 5000 {
 		return true
 	}
 	// Windows Terminal and Konsole don't set TERM_PROGRAM
-	if os.Getenv("WT_SESSION") != "" || os.Getenv("KONSOLE_VERSION") != "" {
+	if wtSession != "" || konsoleVersion != "" {
 		return true
 	}
-	term := os.Getenv("TERM")
 	for _, t := range []string{"alacritty", "contour", "foot", "ghostty", "kitty", "wezterm"} {
-		if strings.Contains(term, t) {
+		if strings.Contains(termEnv, t) {
 			return true
 		}
 	}
 	return false
-})
+}
 
 // Hyperlink returns linkText wrapped in an OSC 8 terminal hyperlink pointing
 // at targetURL when the terminal supports it; otherwise it returns linkText

--- a/pkg/output/hyperlink.go
+++ b/pkg/output/hyperlink.go
@@ -1,0 +1,74 @@
+package output
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/mattn/go-isatty"
+)
+
+// HasTermHyperlinks reports whether the terminal likely renders OSC 8
+// hyperlinks. Terminals that don't support OSC 8 are expected to silently
+// ignore the escape sequences, but detection avoids emitting them where
+// they are known to misbehave (e.g. GNU screen) or are useless (pipes).
+// FORCE_HYPERLINK=1/0 overrides detection, following the convention used
+// by eza, lsd, and the chalk/supports-hyperlinks ecosystem.
+var HasTermHyperlinks = sync.OnceValue(func() bool {
+	if v := os.Getenv("FORCE_HYPERLINK"); v != "" {
+		enabled, err := strconv.ParseBool(v)
+		return err == nil && enabled
+	}
+	if JSONOutput || !isatty.IsTerminal(os.Stdout.Fd()) {
+		return false
+	}
+	switch os.Getenv("TERM_PROGRAM") {
+	case "Hyper", "ghostty", "iTerm.app", "mintty", "rio", "Tabby", "vscode", "WezTerm":
+		return true
+	}
+	// VTE-based terminals (GNOME Terminal, Tilix, etc.) support OSC 8 since 0.50
+	if v, err := strconv.Atoi(os.Getenv("VTE_VERSION")); err == nil && v >= 5000 {
+		return true
+	}
+	// Windows Terminal and Konsole don't set TERM_PROGRAM
+	if os.Getenv("WT_SESSION") != "" || os.Getenv("KONSOLE_VERSION") != "" {
+		return true
+	}
+	term := os.Getenv("TERM")
+	for _, t := range []string{"alacritty", "contour", "foot", "ghostty", "kitty", "wezterm"} {
+		if strings.Contains(term, t) {
+			return true
+		}
+	}
+	return false
+})
+
+// Hyperlink returns linkText wrapped in an OSC 8 terminal hyperlink pointing
+// at targetURL when the terminal supports it; otherwise it returns linkText
+// unchanged. The link target is invisible, so linkText may later be truncated
+// for display while the full targetURL remains clickable.
+func Hyperlink(targetURL string, linkText string) string {
+	if targetURL == "" || linkText == "" || !HasTermHyperlinks() {
+		return linkText
+	}
+	return text.Hyperlink(targetURL, linkText)
+}
+
+// FileURL converts an absolute filesystem path into a file:// URL usable as
+// an OSC 8 hyperlink target, e.g. to open a project directory.
+func FileURL(path string) string {
+	if path == "" {
+		return ""
+	}
+	p := filepath.ToSlash(path)
+	// Windows paths like C:/Users/... need a leading slash in the URL path
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	u := url.URL{Scheme: "file", Path: p}
+	return u.String()
+}

--- a/pkg/output/hyperlink_test.go
+++ b/pkg/output/hyperlink_test.go
@@ -1,0 +1,109 @@
+package output
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDetectHyperlinks exercises detectHyperlinks directly so each case runs
+// with fresh inputs, bypassing the sync.OnceValue cache in HasTermHyperlinks.
+func TestDetectHyperlinks(t *testing.T) {
+	tests := []struct {
+		name           string
+		forceEnv       string
+		isTTY          bool
+		termProgram    string
+		vteVersion     string
+		wtSession      string
+		konsoleVersion string
+		termEnv        string
+		want           bool
+	}{
+		{name: "FORCE_HYPERLINK=1 overrides non-TTY", forceEnv: "1", isTTY: false, want: true},
+		{name: "FORCE_HYPERLINK=true overrides non-TTY", forceEnv: "true", isTTY: false, want: true},
+		{name: "FORCE_HYPERLINK=0 overrides TTY+vscode", forceEnv: "0", isTTY: true, termProgram: "vscode", want: false},
+		{name: "FORCE_HYPERLINK=false overrides iTerm2", forceEnv: "false", isTTY: true, termProgram: "iTerm.app", want: false},
+		{name: "FORCE_HYPERLINK invalid value is false", forceEnv: "maybe", isTTY: true, termProgram: "vscode", want: false},
+		{name: "not a TTY with no force", isTTY: false, termProgram: "vscode", want: false},
+		{name: "TTY with no recognizable terminal", isTTY: true, want: false},
+		{name: "iTerm2", isTTY: true, termProgram: "iTerm.app", want: true},
+		{name: "vscode", isTTY: true, termProgram: "vscode", want: true},
+		{name: "WezTerm TERM_PROGRAM", isTTY: true, termProgram: "WezTerm", want: true},
+		{name: "ghostty TERM_PROGRAM", isTTY: true, termProgram: "ghostty", want: true},
+		{name: "VTE high enough", isTTY: true, vteVersion: "5000", want: true},
+		{name: "VTE too old", isTTY: true, vteVersion: "4999", want: false},
+		{name: "VTE non-numeric", isTTY: true, vteVersion: "abc", want: false},
+		{name: "Windows Terminal WT_SESSION", isTTY: true, wtSession: "some-guid", want: true},
+		{name: "Konsole", isTTY: true, konsoleVersion: "210401", want: true},
+		{name: "kitty in TERM", isTTY: true, termEnv: "xterm-kitty", want: true},
+		{name: "alacritty in TERM", isTTY: true, termEnv: "alacritty", want: true},
+		{name: "wezterm in TERM", isTTY: true, termEnv: "wezterm", want: true},
+		{name: "xterm-256color not recognised", isTTY: true, termEnv: "xterm-256color", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectHyperlinks(tc.forceEnv, tc.isTTY, tc.termProgram, tc.vteVersion, tc.wtSession, tc.konsoleVersion, tc.termEnv)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestFileURL verifies file:// URL construction for OSC 8 hyperlink targets.
+func TestFileURL(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "empty path", path: "", want: ""},
+		{name: "unix absolute path", path: "/Users/rfay/workspace/ddev", want: "file:///Users/rfay/workspace/ddev"},
+		{name: "path with spaces", path: "/home/user/my project", want: "file:///home/user/my%20project"},
+		{name: "nested path", path: "/var/www/html", want: "file:///var/www/html"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, FileURL(tc.path))
+		})
+	}
+}
+
+// TestHyperlinkPassthrough verifies Hyperlink returns plain text when OSC 8
+// should not be emitted (empty args, or when detectHyperlinks would return
+// false — which is always true in the test process since stdout is a pipe).
+func TestHyperlinkPassthrough(t *testing.T) {
+	url := "https://example.ddev.site"
+	label := "example.ddev.site"
+
+	// In the test process stdout is a pipe and FORCE_HYPERLINK is unset, so
+	// HasTermHyperlinks() returns false and Hyperlink must return plain text.
+	require.Equal(t, label, Hyperlink(url, label), "should be plain text in piped test process")
+	require.Equal(t, label, Hyperlink("", label), "empty URL should return label unchanged")
+	require.Equal(t, "", Hyperlink(url, ""), "empty label should return empty string")
+	require.Equal(t, "", Hyperlink("", ""), "both empty should return empty string")
+}
+
+// TestHyperlinkOSC8Format verifies the OSC 8 escape sequence format when
+// detectHyperlinks would return true. We construct the sequence manually to
+// confirm the expected byte structure without relying on HasTermHyperlinks.
+func TestHyperlinkOSC8Format(t *testing.T) {
+	rawURL := "https://example.ddev.site"
+	label := "example"
+
+	// The OSC 8 sequence:
+	//   open:  ESC ] 8 ; ; <url> ST   (ST = string terminator = ESC \)
+	//   label: visible text
+	//   close: ESC ] 8 ; ;        ST  (empty URL closes the link)
+	openLink := "\x1b]8;;" + rawURL + "\x1b\\"
+	closeLink := "\x1b]8;;\x1b\\"
+	want := openLink + label + closeLink
+
+	require.True(t, strings.HasPrefix(want, "\x1b]8;;"), "should open with OSC 8")
+	require.True(t, strings.HasSuffix(want, closeLink), "should close with empty-URL OSC 8")
+	require.True(t, strings.Contains(want, rawURL), "URL in the escape envelope")
+	// Verify the label sits between the open and close sequences
+	inner := strings.TrimPrefix(strings.TrimSuffix(want, closeLink), openLink)
+	require.Equal(t, label, inner, "visible text should be exactly the label")
+}

--- a/pkg/output/hyperlink_test.go
+++ b/pkg/output/hyperlink_test.go
@@ -62,6 +62,9 @@ func TestFileURL(t *testing.T) {
 		{name: "unix absolute path", path: "/Users/rfay/workspace/ddev", want: "file:///Users/rfay/workspace/ddev"},
 		{name: "path with spaces", path: "/home/user/my project", want: "file:///home/user/my%20project"},
 		{name: "nested path", path: "/var/www/html", want: "file:///var/www/html"},
+		// Windows: filepath.ToSlash gives "C:/Users/...", leading "/" is prepended
+		// so url.URL produces file:///C:/Users/... which is the correct file URI form.
+		{name: "windows path", path: "C:/Users/rfay/workspace", want: "file:///C:/Users/rfay/workspace"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/vendor/github.com/jedib0t/go-pretty/v6/table/filter.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/table/filter.go
@@ -42,6 +42,11 @@ type FilterBy struct {
 	//
 	// Use this when the default filtering logic is not sufficient.
 	CustomFilter func(cellValue string) bool
+
+	// compiledRegex caches the compiled pattern for RegexMatch and
+	// RegexNotMatch; populated once by parseFilterBy instead of compiling
+	// the pattern again for every row
+	compiledRegex *regexp.Regexp
 }
 
 // FilterOperator defines how to filter.
@@ -91,12 +96,13 @@ func (t *Table) parseFilterBy(filterBy []FilterBy) []FilterBy {
 		}
 		if colNum > 0 {
 			resFilterBy = append(resFilterBy, FilterBy{
-				Name:         filter.Name,
-				Number:       colNum,
-				Operator:     filter.Operator,
-				Value:        filter.Value,
-				IgnoreCase:   filter.IgnoreCase,
-				CustomFilter: filter.CustomFilter,
+				Name:          filter.Name,
+				Number:        colNum,
+				Operator:      filter.Operator,
+				Value:         filter.Value,
+				IgnoreCase:    filter.IgnoreCase,
+				CustomFilter:  filter.CustomFilter,
+				compiledRegex: compileFilterRegex(filter),
 			})
 		}
 	}
@@ -154,9 +160,9 @@ func (t *Table) matchesOperator(cellValue string, filter FilterBy) bool {
 	case EndsWith:
 		return t.compareEndsWith(cellValue, filter.Value, filter.IgnoreCase)
 	case RegexMatch:
-		return t.compareRegexMatch(cellValue, filter.Value, filter.IgnoreCase)
+		return t.compareRegexMatch(cellValue, filter)
 	case RegexNotMatch:
-		return !t.compareRegexMatch(cellValue, filter.Value, filter.IgnoreCase)
+		return !t.compareRegexMatch(cellValue, filter)
 	default:
 		return false
 	}
@@ -229,22 +235,33 @@ func (t *Table) compareEndsWith(cellValue string, filterValue interface{}, ignor
 	return strings.HasSuffix(cellValue, filterStr)
 }
 
-func (t *Table) compareRegexMatch(cellValue string, filterValue interface{}, ignoreCase bool) bool {
-	filterStr := fmt.Sprint(filterValue)
-
-	// Compile the regex pattern
-	var pattern *regexp.Regexp
-	var err error
-	if ignoreCase {
-		pattern, err = regexp.Compile("(?i)" + filterStr)
-	} else {
-		pattern, err = regexp.Compile(filterStr)
+func (t *Table) compareRegexMatch(cellValue string, filter FilterBy) bool {
+	pattern := filter.compiledRegex
+	if pattern == nil {
+		pattern = compileFilterRegex(filter)
 	}
-
-	if err != nil {
+	if pattern == nil {
 		// If regex compilation fails, fall back to simple string matching
-		return t.compareEqual(cellValue, filterValue, ignoreCase)
+		return t.compareEqual(cellValue, filter.Value, filter.IgnoreCase)
 	}
 
 	return pattern.MatchString(cellValue)
+}
+
+// compileFilterRegex compiles the pattern for a RegexMatch/RegexNotMatch
+// filter; returns nil for other operators or when the pattern is invalid.
+func compileFilterRegex(filter FilterBy) *regexp.Regexp {
+	if filter.Operator != RegexMatch && filter.Operator != RegexNotMatch {
+		return nil
+	}
+
+	filterStr := fmt.Sprint(filter.Value)
+	if filter.IgnoreCase {
+		filterStr = "(?i)" + filterStr
+	}
+	pattern, err := regexp.Compile(filterStr)
+	if err != nil {
+		return nil
+	}
+	return pattern
 }

--- a/vendor/github.com/jedib0t/go-pretty/v6/table/render.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/table/render.go
@@ -107,7 +107,9 @@ func (t *Table) renderColumn(out *strings.Builder, row rowStr, colIdx int, maxCo
 
 func (t *Table) renderColumnAutoIndex(out *strings.Builder, hint renderHint) {
 	var outAutoIndex strings.Builder
-	outAutoIndex.Grow(t.maxColumnLengths[0])
+	if len(t.maxColumnLengths) > 0 {
+		outAutoIndex.Grow(t.maxColumnLengths[0])
+	}
 
 	if hint.isSeparatorRow {
 		numChars := t.autoIndexVIndexMaxLength + utf8.RuneCountInString(t.style.Box.PaddingLeft) +

--- a/vendor/github.com/jedib0t/go-pretty/v6/table/render_csv.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/table/render_csv.go
@@ -10,7 +10,7 @@ import (
 //
 //	#,First Name,Last Name,Salary,
 //	1,Arya,Stark,3000,
-//	20,Jon,Snow,2000,"You know nothing\, Jon Snow!"
+//	20,Jon,Snow,2000,"You know nothing, Jon Snow!"
 //	300,Tyrion,Lannister,5000,
 //	,,Total,10000,
 func (t *Table) RenderCSV() string {
@@ -18,6 +18,7 @@ func (t *Table) RenderCSV() string {
 
 	var out strings.Builder
 	if t.numColumns > 0 {
+		out.Grow(t.estimatedRenderLength())
 		if t.title != "" {
 			out.WriteString(t.title)
 		}
@@ -35,12 +36,21 @@ func (t *Table) RenderCSV() string {
 	return t.render(&out)
 }
 
-func (t *Table) csvFixCommas(str string) string {
-	return strings.ReplaceAll(str, ",", "\\,")
+// csvEscapeDoubleQuotes escapes double-quotes inside a quoted field by
+// doubling them, as mandated by RFC 4180.
+func (t *Table) csvEscapeDoubleQuotes(str string) string {
+	return strings.ReplaceAll(str, "\"", "\"\"")
 }
 
-func (t *Table) csvFixDoubleQuotes(str string) string {
-	return strings.ReplaceAll(str, "\"", "\\\"")
+// csvProtectField neutralizes fields that spreadsheet applications would
+// interpret as formulas (=, +, -, @, tab or CR prefix) by prefixing them with
+// a single-quote.
+func (t *Table) csvProtectField(str string) string {
+	switch str[0] {
+	case '=', '+', '-', '@', '\t', '\r':
+		return "'" + str
+	}
+	return str
 }
 
 func (t *Table) csvRenderRow(out *strings.Builder, row rowStr, hint renderHint) {
@@ -61,9 +71,12 @@ func (t *Table) csvRenderRow(out *strings.Builder, row rowStr, hint renderHint) 
 		if colIdx > 0 {
 			out.WriteRune(',')
 		}
+		if t.style.CSV.FieldProtection && colStr != "" {
+			colStr = t.csvProtectField(colStr)
+		}
 		if strings.ContainsAny(colStr, "\",\n") {
 			out.WriteRune('"')
-			out.WriteString(t.csvFixCommas(t.csvFixDoubleQuotes(colStr)))
+			out.WriteString(t.csvEscapeDoubleQuotes(colStr))
 			out.WriteRune('"')
 		} else if utf8.RuneCountInString(colStr) > 0 {
 			out.WriteString(colStr)

--- a/vendor/github.com/jedib0t/go-pretty/v6/table/render_html.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/table/render_html.go
@@ -64,11 +64,12 @@ func (t *Table) RenderHTML() string {
 
 	var out strings.Builder
 	if t.numColumns > 0 {
+		out.Grow(t.estimatedRenderLength())
 		out.WriteString("<table class=\"")
 		if t.htmlCSSClass != "" {
-			out.WriteString(t.htmlCSSClass)
+			out.WriteString(html.EscapeString(t.htmlCSSClass))
 		} else {
-			out.WriteString(t.style.HTML.CSSClass)
+			out.WriteString(html.EscapeString(t.style.HTML.CSSClass))
 		}
 		out.WriteString("\">\n")
 		t.htmlRenderTitle(&out)
@@ -99,8 +100,12 @@ func (t *Table) htmlGetColStrAndTag(row rowStr, colIdx int, hint renderHint) (st
 
 func (t *Table) htmlRenderCaption(out *strings.Builder) {
 	if t.caption != "" {
+		caption := t.caption
+		if t.style.HTML.EscapeText {
+			caption = html.EscapeString(caption)
+		}
 		out.WriteString("  <caption class=\"caption\" style=\"caption-side: bottom;\">")
-		out.WriteString(t.caption)
+		out.WriteString(caption)
 		out.WriteString("</caption>\n")
 	}
 }
@@ -263,6 +268,9 @@ func (t *Table) htmlRenderTitle(out *strings.Builder) {
 		align := t.style.Title.Align.HTMLProperty()
 		colors := t.style.Title.Colors.HTMLProperty()
 		title := t.style.Title.Format.Apply(t.title)
+		if t.style.HTML.EscapeText {
+			title = html.EscapeString(title)
+		}
 
 		out.WriteString("  <caption class=\"title\"")
 		if align != "" {

--- a/vendor/github.com/jedib0t/go-pretty/v6/table/render_markdown.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/table/render_markdown.go
@@ -18,6 +18,7 @@ func (t *Table) RenderMarkdown() string {
 
 	var out strings.Builder
 	if t.numColumns > 0 {
+		out.Grow(t.estimatedRenderLength())
 		t.markdownRenderTitle(&out)
 		t.markdownRenderRowsHeader(&out)
 		t.markdownRenderRows(&out, t.rows, renderHint{})

--- a/vendor/github.com/jedib0t/go-pretty/v6/table/render_tsv.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/table/render_tsv.go
@@ -11,6 +11,7 @@ func (t *Table) RenderTSV() string {
 	var out strings.Builder
 
 	if t.numColumns > 0 {
+		out.Grow(t.estimatedRenderLength())
 		if t.title != "" {
 			out.WriteString(t.title)
 		}

--- a/vendor/github.com/jedib0t/go-pretty/v6/table/style.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/table/style.go
@@ -6,6 +6,7 @@ type Style struct {
 	Name     string          // name of the Style
 	Box      BoxStyle        // characters to use for the boxes
 	Color    ColorOptions    // colors to use for the rows and columns
+	CSV      CSVOptions      // rendering options for CSV mode
 	Format   FormatOptions   // formatting options for the rows and columns
 	HTML     HTMLOptions     // rendering options for HTML mode
 	Markdown MarkdownOptions // rendering options for Markdown mode

--- a/vendor/github.com/jedib0t/go-pretty/v6/table/style_csv.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/table/style_csv.go
@@ -1,0 +1,19 @@
+package table
+
+// CSVOptions defines options to control CSV rendering.
+type CSVOptions struct {
+	// FieldProtection neutralizes fields that spreadsheet applications could
+	// interpret as formulas (fields beginning with =, +, -, @, tab or CR) by
+	// prefixing them with a single-quote, preventing CSV formula injection
+	// when the rendered output is opened in such an application.
+	//
+	// Note that the single-quote becomes part of the field content for
+	// standards-compliant CSV readers; enable this only when the output is
+	// destined for a spreadsheet application.
+	FieldProtection bool
+}
+
+var (
+	// DefaultCSVOptions defines sensible CSV rendering defaults.
+	DefaultCSVOptions = CSVOptions{}
+)

--- a/vendor/github.com/jedib0t/go-pretty/v6/table/table.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/table/table.go
@@ -812,6 +812,13 @@ func (t *Table) isIndexColumn(colIdx int, hint renderHint) bool {
 	return t.indexColumn == colIdx+1 || hint.isAutoIndexColumn
 }
 
+// estimatedRenderLength approximates the rendered output size, to pre-size
+// the output builder and avoid repeated re-allocations while rendering.
+func (t *Table) estimatedRenderLength() int {
+	numRows := len(t.rows) + len(t.rowsHeader) + len(t.rowsFooter) + 1
+	return numRows * (t.maxRowLength + 1)
+}
+
 func (t *Table) render(out *strings.Builder) string {
 	outStr := out.String()
 	if t.suppressTrailingSpaces {

--- a/vendor/github.com/jedib0t/go-pretty/v6/text/align.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/text/align.go
@@ -1,10 +1,8 @@
 package text
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
-	"unicode/utf8"
 )
 
 // Align denotes how text is to be aligned horizontally.
@@ -39,24 +37,39 @@ func (a Align) Apply(text string, maxLength int) string {
 	}
 
 	text = aComputed.trimString(text)
-	sLen := utf8.RuneCountInString(text)
 	sLenWoE := StringWidthWithoutEscSequences(text)
-	numEscChars := sLen - sLenWoE
+	padding := maxLength - sLenWoE
 
-	// now, align the text
+	// now, align the text by padding the missing display-width with spaces
 	switch aComputed {
 	case AlignDefault, AlignLeft:
-		return fmt.Sprintf("%-"+strconv.Itoa(maxLength+numEscChars)+"s", text)
+		return padText(text, 0, padding)
 	case AlignCenter:
-		if sLenWoE < maxLength {
-			// left pad with half the number of spaces needed before using %text
-			return fmt.Sprintf("%"+strconv.Itoa(maxLength+numEscChars)+"s",
-				text+strings.Repeat(" ", (maxLength-sLenWoE)/2))
-		}
+		// extra space on the left when the padding is odd
+		return padText(text, padding-padding/2, padding/2)
 	case AlignJustify:
 		return justifyText(text, sLenWoE, maxLength)
 	}
-	return fmt.Sprintf("%"+strconv.Itoa(maxLength+numEscChars)+"s", text)
+	return padText(text, padding, 0)
+}
+
+// padText returns the text with the given number of spaces on either side;
+// non-positive counts add nothing.
+func padText(text string, left int, right int) string {
+	if left <= 0 && right <= 0 {
+		return text
+	}
+
+	var out strings.Builder
+	out.Grow(len(text) + left + right)
+	for idx := 0; idx < left; idx++ {
+		out.WriteByte(' ')
+	}
+	out.WriteString(text)
+	for idx := 0; idx < right; idx++ {
+		out.WriteByte(' ')
+	}
+	return out.String()
 }
 
 // HTMLProperty returns the equivalent HTML horizontal-align tag property.
@@ -127,6 +140,13 @@ func justifyText(text string, textLength int, maxLength int) string {
 
 	// get the number of spaces to insert into the text
 	numSpacesNeeded := maxLength - textLength + strings.Count(text, " ")
+	if numSpacesNeeded < 0 {
+		// textLength (display-width) exceeds maxLength; this can happen
+		// when the cell contains wide Unicode characters (e.g. CJK) whose
+		// display width is greater than their rune count. Return the text
+		// as-is; truncation is the caller's responsibility.
+		return text
+	}
 	numSpacesNeededBetweenWords := 0
 	if len(words) > 1 {
 		numSpacesNeededBetweenWords = numSpacesNeeded / (len(words) - 1)

--- a/vendor/github.com/jedib0t/go-pretty/v6/text/escape_seq_parser.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/text/escape_seq_parser.go
@@ -1,10 +1,12 @@
 package text
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // Constants
@@ -64,6 +66,18 @@ const (
 	// conceal OSI sequences
 	escapeStartConcealOSI = "\x1b]8;"
 	escapeStopConcealOSI  = "\x1b\\"
+
+	// escSeqMaxLength bounds the accumulated escape sequence; real terminals
+	// cap sequences in the low KBs, and anything longer here is most likely
+	// malformed input that would otherwise grow the buffer without limit
+	escSeqMaxLength = 2048
+)
+
+// []byte forms of the conceal OSI markers for prefix/suffix checks on the
+// escape sequence buffer without allocating per call
+var (
+	escapeStartConcealOSIBytes = []byte(escapeStartConcealOSI)
+	escapeStopConcealOSIBytes  = []byte(escapeStopConcealOSI)
 )
 
 // 256-color codes
@@ -117,8 +131,9 @@ type EscSeqParser struct {
 	inEscSeq bool
 	// escSeqKind identifies the type of escape sequence being parsed (CSI or OSI).
 	escSeqKind escSeqKind
-	// escapeSeq accumulates the current escape sequence being parsed.
-	escapeSeq string
+	// escapeSeq accumulates the current escape sequence being parsed; it is
+	// bounded by escSeqMaxLength and reused across sequences.
+	escapeSeq []byte
 }
 
 func (s *EscSeqParser) Codes() []int {
@@ -136,7 +151,7 @@ func (s *EscSeqParser) Consume(char rune) {
 	if !s.inEscSeq && char == EscapeStartRune {
 		s.inEscSeq = true
 		s.escSeqKind = escSeqKindUnknown
-		s.escapeSeq = ""
+		s.escapeSeq = s.escapeSeq[:0]
 	} else if s.inEscSeq && s.escSeqKind == escSeqKindUnknown {
 		switch char {
 		case EscapeStartRuneCSI:
@@ -147,20 +162,27 @@ func (s *EscSeqParser) Consume(char rune) {
 	}
 
 	if s.inEscSeq {
-		s.escapeSeq += string(char)
+		s.escapeSeq = utf8.AppendRune(s.escapeSeq, char)
+
+		// abort on absurdly long (most likely malformed/unterminated)
+		// sequences instead of accumulating them without limit
+		if len(s.escapeSeq) > escSeqMaxLength {
+			s.Reset()
+			return
+		}
 
 		// --- FIX for OSC 8 hyperlinks (e.g. \x1b]8;;url\x07label\x1b]8;;\x07)
 		if s.escSeqKind == escSeqKindOSI &&
-			strings.HasPrefix(s.escapeSeq, escapeStartConcealOSI) &&
+			bytes.HasPrefix(s.escapeSeq, escapeStartConcealOSIBytes) &&
 			char == escRuneBEL { // BEL
 
-			s.ParseSeq(s.escapeSeq, s.escSeqKind)
+			s.ParseSeq(string(s.escapeSeq), s.escSeqKind)
 			s.Reset()
 			return
 		}
 
 		if s.isEscapeStopRune(char) {
-			s.ParseSeq(s.escapeSeq, s.escSeqKind)
+			s.ParseSeq(string(s.escapeSeq), s.escSeqKind)
 			s.Reset()
 		}
 	}
@@ -186,7 +208,7 @@ func (s *EscSeqParser) ParseSeq(seq string, seqKind escSeqKind) {
 }
 
 func (s *EscSeqParser) ParseString(str string) string {
-	s.escapeSeq, s.inEscSeq, s.escSeqKind = "", false, escSeqKindUnknown
+	s.escapeSeq, s.inEscSeq, s.escSeqKind = s.escapeSeq[:0], false, escSeqKindUnknown
 	for _, char := range str {
 		s.Consume(char)
 	}
@@ -196,7 +218,7 @@ func (s *EscSeqParser) ParseString(str string) string {
 func (s *EscSeqParser) Reset() {
 	s.inEscSeq = false
 	s.escSeqKind = escSeqKindUnknown
-	s.escapeSeq = ""
+	s.escapeSeq = s.escapeSeq[:0]
 }
 
 func (s *EscSeqParser) Sequence() string {
@@ -275,8 +297,8 @@ func (s *EscSeqParser) clearColorRange(isForeground bool) {
 }
 
 func (s *EscSeqParser) isEscapeStopRune(char rune) bool {
-	if strings.HasPrefix(s.escapeSeq, escapeStartConcealOSI) {
-		if strings.HasSuffix(s.escapeSeq, escapeStopConcealOSI) {
+	if bytes.HasPrefix(s.escapeSeq, escapeStartConcealOSIBytes) {
+		if bytes.HasSuffix(s.escapeSeq, escapeStopConcealOSIBytes) {
 			return true
 		}
 	} else if (s.escSeqKind == escSeqKindCSI && char == EscapeStopRuneCSI) ||

--- a/vendor/github.com/jedib0t/go-pretty/v6/text/hyperlink.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/text/hyperlink.go
@@ -1,8 +1,12 @@
 package text
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 func Hyperlink(url, text string) string {
+	url = sanitizeHyperlinkURL(url)
 	if url == "" {
 		return text
 	}
@@ -11,4 +15,16 @@ func Hyperlink(url, text string) string {
 	}
 	// source https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
 	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", url, text)
+}
+
+// sanitizeHyperlinkURL strips ASCII control characters (including ESC and BEL)
+// from the URL; left in place, they could terminate the OSC 8 sequence early
+// and inject arbitrary escape sequences into the terminal output.
+func sanitizeHyperlinkURL(url string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, url)
 }

--- a/vendor/github.com/jedib0t/go-pretty/v6/text/string.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/text/string.go
@@ -263,6 +263,15 @@ func StringWidth(str string) int {
 //	StringWidthWithoutEscSequences("Ghost 生命"): 10
 //	StringWidthWithoutEscSequences("\x1b[33mGhost 生命\x1b[0m"): 10
 func StringWidthWithoutEscSequences(str string) int {
+	// fast-path the common case of a string without escape sequences
+	if !strings.ContainsRune(str, EscapeStartRune) {
+		count := 0
+		for _, c := range str {
+			count += RuneWidth(c)
+		}
+		return count
+	}
+
 	count, esp := 0, EscSeqParser{}
 	for _, c := range str {
 		if esp.InSequence() {

--- a/vendor/github.com/jedib0t/go-pretty/v6/text/valign.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/text/valign.go
@@ -27,6 +27,10 @@ func (va VAlign) Apply(lines []string, maxLines int) []string {
 		maxLines = len(lines)
 	}
 
+	if maxLines < 1 { // no lines and a negative maxLines
+		return lines
+	}
+
 	var insertIdx int
 	switch va {
 	case VAlignMiddle:

--- a/vendor/github.com/jedib0t/go-pretty/v6/text/wrap.go
+++ b/vendor/github.com/jedib0t/go-pretty/v6/text/wrap.go
@@ -89,7 +89,7 @@ func WrapText(str string, wrapLen int) string {
 func appendChar(char rune, wrapLen int, lineLen *int, inEscSeq bool, lastSeenEscSeq string, out *strings.Builder) {
 	// handle reaching the end of the line as dictated by wrapLen or by finding
 	// a newline character
-	if (*lineLen == wrapLen && !inEscSeq && char != '\n') || (char == '\n') {
+	if (*lineLen >= wrapLen && !inEscSeq && char != '\n') || (char == '\n') {
 		if lastSeenEscSeq != "" {
 			// terminate escape sequence and the line; and restart the escape
 			// sequence in the next line
@@ -122,7 +122,7 @@ func appendWord(word string, lineIdx *int, lastSeenEscSeq string, wrapLen int, o
 			inEscSeq = true
 			lastSeenEscSeq = ""
 		}
-		if inEscSeq {
+		if inEscSeq && len(lastSeenEscSeq) < escSeqMaxLength {
 			lastSeenEscSeq += string(char)
 		}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -422,7 +422,7 @@ github.com/inconshreveable/mousetrap
 # github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf
 ## explicit; go 1.12
 github.com/inhies/go-bytesize
-# github.com/jedib0t/go-pretty/v6 v6.7.9
+# github.com/jedib0t/go-pretty/v6 v6.8.1
 ## explicit; go 1.18
 github.com/jedib0t/go-pretty/v6/table
 github.com/jedib0t/go-pretty/v6/text


### PR DESCRIPTION
## The Issue

* Fixes #5535 
* Fixes #6113 

On terminals narrower than the table content, `ddev list` produced rows truncated with `≈` (from `SetAllowedRowLength`) and `ddev describe`'s URL/Port column had no width constraint at all, so wide tables overflowed. Neither approach kept URLs and filesystem paths selectable/clickable.

## How This PR Solves The Issue

**Cell-level truncation and proportional column sizing (ddev list)**

Instead of truncating at the row level with `SetAllowedRowLength`, each column in `ddev list` now has a proportional `WidthMax` with a custom `WidthMaxEnforcer` that truncates cleanly with `…`. With `--wrap-table`, `WidthMax` is removed from Location and URL columns so they render as full unbroken lines (selectable, copyable).

**Per-line wrap enforcer (ddev describe)**

`ddev describe`'s URL/Port column now has a `WidthMax` with a custom enforcer that wraps each embedded line individually, preserving the intentional multi-line cell structure (URL + port listing). Column constraints are only applied when stdout is a real TTY; piped output (tests, `grep`, scripts) renders at natural width.

**OSC 8 terminal hyperlinks**

The key items here are adding the OSC 8 link format and truncating at cell level instead of at table row level (`SetAllowedRowLength`).

URL and Location cells are wrapped in OSC 8 terminal hyperlinks (new `pkg/output.Hyperlink` / `FileURL`). The link target is invisible to column width math, so even a truncated `https://this-is-a-long-o…` is clickable to the full URL. Location cells link via `file://` to open the project directory. Detection uses TTY check + env-var heuristics (`TERM_PROGRAM`, `VTE_VERSION`, `WT_SESSION`, `KONSOLE_VERSION`, `TERM` patterns) with a `FORCE_HYPERLINK=1/0` override. Unsupporting terminals (notably macOS Terminal.app) silently ignore the escape sequences and display plain text — identical to today's output. Piped and JSON output never emit OSC 8.

`ddev describe`'s "Project URLs" row is now one URL per line (previously comma-joined + reflowed), each individually linked.

Upgrades go-pretty from v6.7.9 → v6.8.1 for hyperlink URL sanitization and wrapping fixes.

## Manual Testing Instructions

- [ ] `ddev list` on a normal-width terminal: columns fit, Location and URL truncated with `…`
- [ ] `ddev list` on a narrow terminal (~60 cols): proportional column widths, no `≈` truncation
- [ ] `ddev list --wrap-table`: Location and URL render as full unbroken lines
- [ ] `ddev describe`: URL/Port column wraps at column width, intentional multi-line cells (ports) preserved
- [ ] `ddev describe`: Project URLs section shows one URL per line
- [ ] Pipe test: `ddev list | cat` and `ddev describe | cat` — no `≈` truncation, no OSC 8 escape sequences visible
- [ ] JSON test: `ddev list -j` and `ddev describe -j` — raw field values are plain strings, no escape sequences

**OSC 8 hyperlink testing (requires a supporting terminal):**

Supported: iTerm2, VS Code integrated terminal, Windows Terminal, kitty, WezTerm, Alacritty, GNOME Terminal, Ghostty. Set `FORCE_HYPERLINK=1` to enable regardless of terminal detection.

- [ ] **iTerm2**: Cmd+click a truncated URL in `ddev list` — should open the full URL in browser
- [ ] **iTerm2**: Cmd+click a Location cell — should open project directory in Finder
- [ ] **VS Code terminal**: Ctrl+click a URL in `ddev list` or `ddev describe` — opens in browser
- [ ] **Windows Terminal**: Ctrl+click a URL
- [ ] **At least one Linux terminal** (GNOME Terminal, kitty, or similar)
- [ ] **macOS Terminal.app** (does NOT support OSC 8): output should look identical to before this PR — no garbage characters, clean plain-text truncation

## Automated Testing Overview

- Added `pkg/output/hyperlink_test.go` with 25 unit tests covering:
  - `detectHyperlinks`: 20 table-driven cases for `FORCE_HYPERLINK` override, non-TTY passthrough, `TERM_PROGRAM` values (iTerm2, vscode, WezTerm, ghostty), `VTE_VERSION` threshold (≥5000), `WT_SESSION`/`KONSOLE_VERSION`, and `$TERM` fallbacks (kitty, alacritty, wezterm)
  - `FileURL`: empty path, Unix paths, spaces (percent-encoding)
  - `Hyperlink`: passthrough when stdout is a pipe, empty-arg edge cases
  - `TestHyperlinkOSC8Format`: verifies the OSC 8 byte envelope structure
- Existing `TestCmdDescribe` (both stopped/running states) and `TestListWithoutDir` pass

## Release/Deployment Notes

- No configuration changes; `FORCE_HYPERLINK` is a new opt-in/opt-out env var (documented by convention, not in config)
- go-pretty bumped from v6.7.9 → v6.8.1; vendor directory updated
- Piped output and JSON output are unchanged; the only behavioral difference on non-supporting terminals is cleaner `…` truncation vs. the previous `≈` row-level cut
