### PR TITLE
build(gnupg): Remove references to obsolete gnupg2

### DIFF
--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -45,7 +45,7 @@ RUN mkdir -p /var/lib/apt/lists/partial
 RUN <<EOF
     set -eu -o pipefail
     apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" bzip2 curl gnupg2 gpgv less lsb-release pv tzdata vim-tiny wget
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" bzip2 curl gnupg gpgv less lsb-release pv tzdata vim-tiny wget
     update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 10
 
     # Install tzdata-legacy to avoid issues with deprecated timezones

--- a/containers/ddev-php-base/ddev-php-files/extract-php-configs.sh
+++ b/containers/ddev-php-base/ddev-php-files/extract-php-configs.sh
@@ -78,7 +78,7 @@ extract_php_configs() {
 
         # Install prerequisites
         apt-get update -qq
-        apt-get install -y -qq lsb-release ca-certificates curl wget gnupg2
+        apt-get install -y -qq lsb-release ca-certificates curl wget gnupg
 
         # Add deb.sury.org repository
         curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb


### PR DESCRIPTION

## The Issue

gnupg2 package is not really useful anywhere in recent years.

Just use gnupg

I'm not even going to build a new ddev-php-base image for this unless requested, the container tests should be enough.

Discovered this while working on the Windows installer for Debian-based distros. One of the distros didn't have gnupg2, just gnupg.