### PR TITLE
fix: skip OS-generated metadata files in custom-config detection and .ddev/.gitignore, fixes #8418 (#8478) [skip ci]

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1683,7 +1683,38 @@ func PrepDdevDirectory(app *DdevApp) error {
 	for _, f := range osGeneratedFiles {
 		ignores = append(ignores, "**/"+f)
 	}
-	ignores = append(ignores, "**/*.example", ".build-hash", ".dbimageBuild", ".ddev-docker-*.yaml", ".*downloads", ".homeadditions", ".importdb*", ".sshimageBuild", ".webimageBuild", "apache/apache-site.conf", "commands/.gitattributes", "config.local.y*ml", "config.*.local.y*ml", "db_snapshots", "mutagen/mutagen.yml", "mutagen/.start-synced", "nginx_full/nginx-site.conf", "postgres/postgresql.conf", "providers/acquia.yaml", "providers/lagoon.yaml", "providers/pantheon.yaml", "providers/platform.yaml", "providers/upsun.yaml", "share-providers/cloudflared.sh", "share-providers/ngrok.sh", fmt.Sprintf("traefik/config/%s.yaml", app.Name), fmt.Sprintf("traefik/certs/%s.crt", app.Name), fmt.Sprintf("traefik/certs/%s.key", app.Name), "xhprof/xhprof_prepend.php", "**/README.*")
+	ignores = append(ignores,
+		"**/*.example",
+		".build-hash",
+		".dbimageBuild",
+		".ddev-docker-*.yaml",
+		".*downloads",
+		".homeadditions",
+		".importdb*",
+		".sshimageBuild",
+		".webimageBuild",
+		"apache/apache-site.conf",
+		"commands/.gitattributes",
+		"config.local.y*ml",
+		"config.*.local.y*ml",
+		"db_snapshots",
+		"mutagen/mutagen.yml",
+		"mutagen/.start-synced",
+		"nginx_full/nginx-site.conf",
+		"postgres/postgresql.conf",
+		"providers/acquia.yaml",
+		"providers/lagoon.yaml",
+		"providers/pantheon.yaml",
+		"providers/platform.yaml",
+		"providers/upsun.yaml",
+		"share-providers/cloudflared.sh",
+		"share-providers/ngrok.sh",
+		fmt.Sprintf("traefik/config/%s.yaml", app.Name),
+		fmt.Sprintf("traefik/certs/%s.crt", app.Name),
+		fmt.Sprintf("traefik/certs/%s.key", app.Name),
+		"xhprof/xhprof_prepend.php",
+		"**/README.*",
+	)
 	err = CreateGitIgnore(dir, ignores...)
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1678,7 +1678,13 @@ func PrepDdevDirectory(app *DdevApp) error {
 
 	// Some of the listed items are wildcards or directories, and if they are, there's an error
 	// opening them and they innately get added to the .gitignore.
-	err = CreateGitIgnore(dir, "**/*.example", ".build-hash", ".dbimageBuild", ".ddev-docker-*.yaml", ".*downloads", ".homeadditions", ".importdb*", ".sshimageBuild", ".webimageBuild", "apache/apache-site.conf", "commands/.gitattributes", "config.local.y*ml", "config.*.local.y*ml", "db_snapshots", "mutagen/mutagen.yml", "mutagen/.start-synced", "nginx_full/nginx-site.conf", "postgres/postgresql.conf", "providers/acquia.yaml", "providers/lagoon.yaml", "providers/pantheon.yaml", "providers/platform.yaml", "providers/upsun.yaml", "share-providers/cloudflared.sh", "share-providers/ngrok.sh", fmt.Sprintf("traefik/config/%s.yaml", app.Name), fmt.Sprintf("traefik/certs/%s.crt", app.Name), fmt.Sprintf("traefik/certs/%s.key", app.Name), "xhprof/xhprof_prepend.php", "**/README.*")
+	// osGeneratedFiles are prefixed with "**/" so they are ignored at any depth inside .ddev/.
+	ignores := make([]string, 0, len(osGeneratedFiles)+30)
+	for _, f := range osGeneratedFiles {
+		ignores = append(ignores, "**/"+f)
+	}
+	ignores = append(ignores, "**/*.example", ".build-hash", ".dbimageBuild", ".ddev-docker-*.yaml", ".*downloads", ".homeadditions", ".importdb*", ".sshimageBuild", ".webimageBuild", "apache/apache-site.conf", "commands/.gitattributes", "config.local.y*ml", "config.*.local.y*ml", "db_snapshots", "mutagen/mutagen.yml", "mutagen/.start-synced", "nginx_full/nginx-site.conf", "postgres/postgresql.conf", "providers/acquia.yaml", "providers/lagoon.yaml", "providers/pantheon.yaml", "providers/platform.yaml", "providers/upsun.yaml", "share-providers/cloudflared.sh", "share-providers/ngrok.sh", fmt.Sprintf("traefik/config/%s.yaml", app.Name), fmt.Sprintf("traefik/certs/%s.crt", app.Name), fmt.Sprintf("traefik/certs/%s.key", app.Name), "xhprof/xhprof_prepend.php", "**/README.*")
+	err = CreateGitIgnore(dir, ignores...)
 	if err != nil {
 		return fmt.Errorf("failed to create gitignore in %s: %v", dir, err)
 	}

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -446,6 +446,10 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 // Files with the #ddev-silent-no-warn marker are excluded unless showAll is true.
 func isCustomConfigFile(filePath string, expectedDdevFiles []string, hasDdevSig, hasSilentNoWarn bool, showAll bool) bool {
 	filename := filepath.Base(filePath)
+	// Ignore OS-generated metadata files (same list used when creating .ddev/.gitignore).
+	if slices.Contains(osGeneratedFiles, filename) {
+		return false
+	}
 	// Exclude example files
 	if strings.HasSuffix(filename, ".example") || filename == "README.txt" {
 		return false

--- a/pkg/ddevapp/config_custom_test.go
+++ b/pkg/ddevapp/config_custom_test.go
@@ -1,0 +1,48 @@
+package ddevapp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestOSGeneratedFilesSkippedInCustomConfig verifies that files in osGeneratedFiles
+// are not reported as custom config, while other files (including hidden dotfiles that
+// are legitimate user customizations) are still reported.
+func TestOSGeneratedFilesSkippedInCustomConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile := func(name, content string) string {
+		path := filepath.Join(tmpDir, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+		return path
+	}
+
+	dsStore := writeFile(".DS_Store", "finder metadata")
+	thumbsDB := writeFile("Thumbs.db", "windows thumbnails")
+	desktopIni := writeFile("desktop.ini", "[.ShellClassInfo]")
+	bashrc := writeFile(".bashrc", "alias ll='ls -la'")
+	gitconfig := writeFile(".gitconfig", "[user]\n\tname = Test")
+	normalScript := writeFile("myscript.sh", "#!/bin/bash")
+
+	files := []string{dsStore, thumbsDB, desktopIni, bashrc, gitconfig, normalScript}
+	customFiles := filterCustomConfigFiles(files, nil, map[string]string{}, false)
+
+	customPaths := make([]string, len(customFiles))
+	for i, f := range customFiles {
+		customPaths[i] = f.path
+	}
+
+	// OS-generated files must not appear.
+	require.NotContains(t, customPaths, dsStore)
+	require.NotContains(t, customPaths, thumbsDB)
+	require.NotContains(t, customPaths, desktopIni)
+
+	// Legitimate hidden dotfiles (e.g., homeadditions) and normal files must appear.
+	require.Contains(t, customPaths, bashrc)
+	require.Contains(t, customPaths, gitconfig)
+	require.Contains(t, customPaths, normalScript)
+}

--- a/pkg/ddevapp/utils.go
+++ b/pkg/ddevapp/utils.go
@@ -194,6 +194,11 @@ func templateCanUse(feature string) bool {
 	return false
 }
 
+// osGeneratedFiles are OS-generated metadata files that should neither be tracked in git
+// nor trigger custom-config warnings. The list is used both when creating .ddev/.gitignore
+// and when detecting custom configuration.
+var osGeneratedFiles = []string{".DS_Store", "Thumbs.db", "desktop.ini"}
+
 // gitIgnoreTemplate will write a .gitignore file.
 // This template expects string slice to be provided, with each string corresponding to
 // a line in the resulting .gitignore.


### PR DESCRIPTION
## The Issue

* Fixes #8418 

macOS `.DS_Store` files (and similar OS-generated metadata files) placed inside
`.ddev/commands/` or `~/.ddev/commands/` were being reported as custom-config
warnings during `ddev start`. These files are never user configuration — they are
written automatically by the OS.

## How This PR Solves The Issue

Introduces `osGeneratedFiles` in `utils.go` as a single shared list of known
OS-generated metadata filenames (`.DS_Store`, `Thumbs.db`, `desktop.ini`).
This list is used in two places so both systems stay in sync:

1. **`.ddev/.gitignore` creation** (`config.go` / `PrepDdevDirectory`): each name
   is prefixed with `**/` and passed to `CreateGitIgnore`, so git ignores them at
   any depth inside `.ddev/`.
2. **Custom-config detection** (`config_custom.go` / `isCustomConfigFile`): the
   basename of each scanned file is checked against the list; matches are not
   reported as custom config.

The fix is intentionally narrow. Legitimate hidden dotfiles that users place in
`homeadditions` or `commands` (`.bashrc`, `.gitconfig`, etc.) are still detected
and reported as custom config.

## Manual Testing Instructions

1. Place a `.DS_Store` file inside `.ddev/commands/` of any project.
2. Run `ddev start` — the file should not appear in the custom-config warning.
3. Place a `.bashrc` in `~/.ddev/homeadditions/` and confirm it IS still reported.
4. Run `ddev config` and verify `.ddev/.gitignore` now includes `/**/.DS_Store`,
   `/**/Thumbs.db`, and `/**/desktop.ini`.

## Automated Testing Overview

`TestOSGeneratedFilesSkippedInCustomConfig` in `pkg/ddevapp/config_custom_test.go`
verifies:
- `.DS_Store`, `Thumbs.db`, and `desktop.ini` are not reported as custom config.
- `.bashrc`, `.gitconfig`, and normal scripts are still reported as custom config.

## Release/Deployment Notes

No configuration changes or migrations required. The `.ddev/.gitignore` will gain
three new entries on the next `ddev config` or `ddev start` for any project.
