### PR TITLE
fix(mutagen): detect missing docker CLI early, fixes #8457

### DIFF
--- a/cmd/ddev/cmd/utility-mutagen-diagnose.go
+++ b/cmd/ddev/cmd/utility-mutagen-diagnose.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/version"
@@ -32,6 +33,10 @@ ddev utility mutagen-diagnose --all  # Show all Mutagen volumes`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 0 {
 			util.Failed("This command takes no additional arguments")
+		}
+
+		if err := dockerutil.CheckDockerCLI(); err != nil {
+			util.Failed("docker CLI is not available: %v\nMutagen requires a working docker CLI to connect to containers.", err)
 		}
 
 		showAll, _ := cmd.Flags().GetBool("all")

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2000,6 +2000,9 @@ func (app *DdevApp) Start() error {
 	}
 
 	if app.IsMutagenEnabled() {
+		if cliErr := dockerutil.CheckDockerCLI(); cliErr != nil {
+			return fmt.Errorf("mutagen requires a working docker CLI to connect to containers, but: %v\nInstall docker CLI and ensure it is in PATH, then retry", cliErr)
+		}
 		app.checkMutagenUploadDirs()
 
 		mounted, err := IsMutagenVolumeMounted(app)

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -217,6 +217,11 @@ func CreateOrResumeMutagenSync(app *DdevApp) error {
 		if len(container.Names) > 0 {
 			containerRef = container.Names[0]
 		}
+		// Mutagen uses the docker CLI (not the API) to connect to containers, so
+		// verify it's available before attempting the sync create.
+		if cliErr := dockerutil.CheckDockerCLI(); cliErr != nil {
+			return fmt.Errorf("mutagen requires a working docker CLI to connect to containers, but: %v\nInstall docker CLI and ensure it is in PATH, then retry", cliErr)
+		}
 		// TODO: Consider using a function to specify the Docker beta
 		args := []string{"sync", "create", app.AppRoot, fmt.Sprintf("docker:/%s/var/www/html", containerRef), "--no-global-configuration", "--name", syncName, "--label", mutagenSignatureLabelName + "=" + vLabel, "--label", mutagenConfigFileHashLabelName + "=" + hLabel}
 		if configFile != "" {

--- a/pkg/dockerutil/requirements.go
+++ b/pkg/dockerutil/requirements.go
@@ -105,6 +105,42 @@ func CheckAvailableSpace() error {
 	return nil
 }
 
+// CheckDockerCLI verifies that the docker CLI binary exists and can run basic
+// commands. Some tools (e.g. Mutagen) shell out to the docker CLI rather than
+// using the Docker API, so a working daemon alone is not sufficient.
+//
+// The lookup order mirrors Mutagen's own docker binary resolution
+// (pkg/docker/docker.go): MUTAGEN_DOCKER_PATH env var takes priority over PATH.
+func CheckDockerCLI() error {
+	dockerPath, err := findDockerCLI()
+	if err != nil {
+		return err
+	}
+	cmd := osexec.Command(dockerPath, "ps")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker CLI found at %s but 'docker ps' failed: %v (output: %s)", dockerPath, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// findDockerCLI resolves the docker binary path using the same priority order
+// as Mutagen: MUTAGEN_DOCKER_PATH env var first, then PATH.
+func findDockerCLI() (string, error) {
+	if searchPath := os.Getenv("MUTAGEN_DOCKER_PATH"); searchPath != "" {
+		p := filepath.Join(searchPath, "docker")
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+		return "", fmt.Errorf("MUTAGEN_DOCKER_PATH is set to %q but no docker binary found there", searchPath)
+	}
+	p, err := osexec.LookPath("docker")
+	if err != nil {
+		return "", fmt.Errorf("docker CLI not found in PATH: %v", err)
+	}
+	return p, nil
+}
+
 // CheckDockerAuth checks if Docker authentication is properly configured
 func CheckDockerAuth() error {
 	homeDir, err := os.UserHomeDir()


### PR DESCRIPTION
## The Issue

- Fixes #8457

When the `docker` CLI binary is missing or unlinked, `ddev start` with mutagen enabled fails with a cryptic error buried deep in mutagen output:

```
unable to identify 'docker' command: unable to locate command
```

Mutagen shells out to the `docker` CLI binary directly (using the `docker://` transport) rather than using the Docker API. A reachable Docker daemon is not sufficient — the CLI binary must also be present and functional.

## How This PR Solves The Issue

Adds `CheckDockerCLI()` in `pkg/dockerutil/requirements.go` which:
- Resolves the docker binary using the same priority order as Mutagen itself: `MUTAGEN_DOCKER_PATH` env var first, then `PATH`
- Runs `docker ps` to confirm the binary is functional (not just present)

Calls `CheckDockerCLI()` in three places:
- **Early in `app.Start()`** for any mutagen-enabled project, before container work begins — so `ddev start` fails fast with a clear message instead of grinding through container startup first
- **In `CreateOrResumeMutagenSync()`** as a secondary guard for any caller that bypasses `Start()`
- **At the top of `ddev utility mutagen-diagnose`**, since that command also requires the docker CLI

## Manual Testing Instructions

1. Rename or remove the `docker` binary from your PATH (e.g. `sudo mv /usr/local/bin/docker /usr/local/bin/docker.bak`)
2. In a project with mutagen enabled, run `ddev start`
3. Expect a clear error: `mutagen requires a working docker CLI to connect to containers, but: docker CLI not found in PATH`
4. Run `ddev utility mutagen-diagnose`
5. Expect a clear error: `docker CLI is not available: docker CLI not found in PATH`
6. Restore the binary and confirm `ddev start` works normally

## Automated Testing Overview

No new automated tests — the failure mode requires manipulating the host PATH in a way that's awkward to do reliably in CI. The change is straightforward: if `docker ps` exits non-zero or the binary isn't found, we return an error with an actionable message.

## Release/Deployment Notes

Users who have a functioning docker CLI (the normal case) are unaffected — `CheckDockerCLI()` adds one `docker ps` call per `ddev start` for mutagen projects. Users missing the CLI get a clear error instead of a confusing mutagen failure.
