### PR TITLE
docs: install util-linux-extra in Docker setup, fixes #8350 (#8480) [skip ci]

### DIFF
--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -131,6 +131,9 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     # Install Docker CE
     sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
+    # Install util-linux-extra to ensure newgrp is available (Ubuntu 26.04+/Debian sid)
+    sudo apt-get install -y util-linux-extra 2>/dev/null || true
+
     # Add your user to the docker group (create group if it doesn’t exist)
     sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
 
@@ -159,6 +162,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
           "$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")" \
           | sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null
         sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        sudo apt-get install -y util-linux-extra 2>/dev/null || true
         sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
         sudo systemctl enable --now docker
         SCRIPT
@@ -279,6 +283,9 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     # Install Docker CE
     sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
+    # Install util-linux-extra to ensure newgrp is available (Ubuntu 26.04+/Debian sid)
+    sudo apt-get install -y util-linux-extra 2>/dev/null || true
+
     # Add your user to the docker group (create group if it doesn't exist)
     sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
     ```
@@ -303,6 +310,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
           "$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")" \
           | sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null
         sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        sudo apt-get install -y util-linux-extra 2>/dev/null || true
         sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
         SCRIPT
         ```


### PR DESCRIPTION
## The Issue

- Fixes #8350

`newgrp` was moved from the `login` package into `util-linux-extra` in Ubuntu 26.04 and Debian sid (upstream Debian bug #1111747). Users following the Docker installation instructions would hit `newgrp: command not found` with no explanation.

## How This PR Solves The Issue

Adds `sudo apt-get install -y util-linux-extra 2>/dev/null || true` to all four Debian/Ubuntu Docker install blocks (two main copy-paste blocks and two script tip variants). The `|| true` makes it a silent no-op on older Debian/Ubuntu where the package doesn't exist or isn't needed.

## Manual Testing Instructions

- On Ubuntu 26.04 or Debian sid, follow the Docker installation instructions — `newgrp docker` should work without any extra steps.
- On Ubuntu 22.04/24.04 or Debian 12/13, the extra install line should complete silently with no effect.

## Automated Testing Overview

Documentation-only change; no automated tests apply.

## Release/Deployment Notes

No impact on existing installs. Users on Ubuntu 26.04+ or Debian sid will get `util-linux-extra` installed as part of the Docker setup.
