### PR TITLE
fix(start): show warnings from log-stderr.sh on start, fixes #8441

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -2045,3 +2045,49 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 		require.Equal(t, expectedWaitTime, int(c.Config.Healthcheck.StartPeriod.Seconds()), "db container healthcheck should have been %v with default_container_timeout set to %v", maxWaitTime, app.DefaultContainerTimeout)
 	}
 }
+
+// TestLogStderrShownOnStart verifies that warnings captured by log-stderr.sh during
+// the image build are shown to the user on `ddev start`, and that the build-hash file
+// is reset to only the signature (no fingerprint) so the next start rebuilds.
+func TestLogStderrShownOnStart(t *testing.T) {
+	origDir, _ := os.Getwd()
+	site := TestSites[0]
+	err := os.Chdir(site.Dir)
+	require.NoError(t, err)
+
+	app, err := ddevapp.NewApp(site.Dir, true)
+	require.NoError(t, err)
+
+	webBuildDir := app.GetConfigPath("web-build")
+	dockerfileFoobar := filepath.Join(webBuildDir, "Dockerfile.foobar")
+
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dockerfileFoobar)
+		_ = app.Stop(true, false)
+		_ = os.Chdir(origDir)
+	})
+
+	// A failing command run through log-stderr.sh produces a build warning.
+	// `|| true` keeps the build itself successful.
+	err = os.MkdirAll(webBuildDir, 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(dockerfileFoobar, []byte("RUN log-stderr.sh foobar || true\n"), 0644)
+	require.NoError(t, err)
+
+	captureErr := util.CaptureUserErr()
+	startErr := app.Start()
+	warnings := captureErr()
+	require.NoError(t, startErr)
+
+	// The warning from the failed `foobar` command must be shown to the user,
+	// along with the trailing "not installed properly" summary.
+	require.Contains(t, warnings, "foobar", "expected the failed 'foobar' command warning")
+	require.Contains(t, warnings, "failed with exit code", "expected the log-stderr.sh failure header")
+	require.Contains(t, warnings, "were not installed properly", "expected the trailing summary warning")
+
+	// When there are build warnings, the build hash is reset to only the
+	// signature (no fingerprint) to trigger a rebuild on the next `ddev start`.
+	hashContent, err := os.ReadFile(app.GetConfigPath(".build-hash"))
+	require.NoError(t, err)
+	require.Equal(t, nodeps.DdevFileSignature, string(hashContent), "build hash should be reset to only the signature when build warnings exist")
+}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1904,6 +1904,14 @@ func (app *DdevApp) Start() error {
 		_, logStderrOutput, logStderrErr := dockerutil.RunSimpleContainer(app.WebImage+"-"+app.Name+"-built", "log-stderr-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "log-stderr.sh --show 2>/dev/null || true"}, []string{}, []string{}, nil, uid, true, false, nil, nil, nil)
 		// If the web image is dirty, try to rebuild it immediately
 		if logStderrErr == nil && strings.TrimSpace(logStderrOutput) != "" && globalconfig.IsInternetActive() {
+			if output.JSONOutput {
+				output.UserOut.Printf("Rebuilding web image without cache...")
+			} else {
+				fmt.Print("Rebuilding web image without cache...")
+				if globalconfig.DdevDebug {
+					output.UserOut.Debugln()
+				}
+			}
 			_, err = app.composeBuild("web", "--no-cache")
 			if err != nil {
 				return err
@@ -2153,9 +2161,8 @@ func (app *DdevApp) Start() error {
 		Cmd: "log-stderr.sh --show 2>/dev/null || true",
 	})
 	logStderr = strings.TrimSpace(logStderr)
+	// Reset the build hash when errors occur
 	if logStderr != "" {
-		util.Warning(logStderr)
-		// Reset the build hash when errors occur
 		_ = os.WriteFile(buildHashFile, []byte(nodeps.DdevFileSignature), 0644)
 	}
 
@@ -2202,11 +2209,12 @@ func (app *DdevApp) Start() error {
 	}
 
 	if logStderr != "" {
-		util.Warning(`Some components of the project %s were not installed properly.
+		util.Warning(`%s
+Some components of the project %s were not installed properly.
 The project is running anyway, but see the warnings above for details.
 If offline, run 'ddev restart' once you are back online.
 If online, check your connection and run 'ddev restart' later.
-If this seems to be a config issue, update it accordingly.`, app.Name)
+If this seems to be a config issue, update it accordingly.`, fmt.Sprintf("%s\n", logStderr), app.Name)
 	}
 
 	return nil

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1901,33 +1901,7 @@ func (app *DdevApp) Start() error {
 			return err
 		}
 
-		// Run log-stderr check and dangling image cleanup concurrently
-		var logStderrOutput string
-		var logStderrErr error
-		var danglingErr error
-		var postBuildWg sync.WaitGroup
-
-		postBuildWg.Go(func() {
-			_, logStderrOutput, logStderrErr = dockerutil.RunSimpleContainer(app.WebImage+"-"+app.Name+"-built", "log-stderr-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "log-stderr.sh --show 2>/dev/null || true"}, []string{}, []string{}, nil, uid, true, false, nil, nil, nil)
-		})
-
-		postBuildWg.Go(func() {
-			util.Debug("Removing dangling images for the project %s", app.GetComposeProjectName())
-			danglingImages, dErr := dockerutil.FindImagesByLabels(map[string]string{"com.ddev.buildhost": "", "com.docker.compose.project": app.GetComposeProjectName()}, true)
-			if dErr != nil {
-				danglingErr = fmt.Errorf("unable to get dangling images for the project %s: %v", app.GetComposeProjectName(), dErr)
-				return
-			}
-			for _, danglingImage := range danglingImages {
-				_ = dockerutil.RemoveImage(danglingImage.ID)
-			}
-		})
-
-		postBuildWg.Wait()
-		if danglingErr != nil {
-			return danglingErr
-		}
-
+		_, logStderrOutput, logStderrErr := dockerutil.RunSimpleContainer(app.WebImage+"-"+app.Name+"-built", "log-stderr-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "log-stderr.sh --show 2>/dev/null || true"}, []string{}, []string{}, nil, uid, true, false, nil, nil, nil)
 		// If the web image is dirty, try to rebuild it immediately
 		if logStderrErr == nil && strings.TrimSpace(logStderrOutput) != "" && globalconfig.IsInternetActive() {
 			_, err = app.composeBuild("web", "--no-cache")
@@ -1941,6 +1915,15 @@ func (app *DdevApp) Start() error {
 
 		buildDuration := util.FormatDuration(buildDurationStart())
 		util.Success("Project images built in %s.", buildDuration)
+
+		util.Debug("Removing dangling images for the project %s", app.GetComposeProjectName())
+		danglingImages, dErr := dockerutil.FindImagesByLabels(map[string]string{"com.ddev.buildhost": "", "com.docker.compose.project": app.GetComposeProjectName()}, true)
+		if dErr != nil {
+			return fmt.Errorf("unable to get dangling images for the project %s: %v", app.GetComposeProjectName(), dErr)
+		}
+		for _, danglingImage := range danglingImages {
+			_ = dockerutil.RemoveImage(danglingImage.ID)
+		}
 	} else {
 		util.Debug("Skipping docker-compose build, build context unchanged and images exist")
 	}
@@ -2142,84 +2125,66 @@ func (app *DdevApp) Start() error {
 		}
 	}
 
-	// Run mount check, log-stderr, PopulateGlobalCustomCommandFiles, and
-	// router start concurrently. These are all independent operations:
-	// - Mount check and log-stderr only need the web container (already healthy)
-	// - PopulateGlobalCustomCommandFiles uses the web container or an anonymous container
-	// - Router start is completely independent
-	var logStderr string
-	type execResult struct {
-		mountErr    error
-		logStderr   string
-		commandsErr error
-		routerErr   error
-		waitErr2    error
+	// Start the router in the background; it's independent of the steps below,
+	// and waiting for it to become ready is the slowest part of startup.
+	var routerWg sync.WaitGroup
+	var routerErr error
+	if !IsRouterDisabled(app) {
+		routerWg.Go(func() {
+			routerErr = StartDdevRouter()
+		})
 	}
-	result := execResult{}
-	var wg sync.WaitGroup
 
-	// Goroutine 1: mount check + log-stderr (sequential, both need web container)
-	wg.Go(func() {
-		util.Debug("Testing to see if /mnt/ddev_config is properly mounted")
-		_, _, result.mountErr = app.Exec(&ExecOpts{
-			Cmd: `ls -l /mnt/ddev_config/nginx_full/nginx-site.conf >/dev/null`,
-		})
+	err = PopulateGlobalCustomCommandFiles()
+	if err != nil {
+		util.Warning("Failed to populate global custom command files: %v", err)
+	}
 
-		util.Debug("Getting stderr output from 'log-stderr.sh --show'")
-		stderr, _, _ := app.Exec(&ExecOpts{
-			Cmd: "log-stderr.sh --show 2>/dev/null || true",
-		})
-		result.logStderr = strings.TrimSpace(stderr)
+	util.Debug("Testing to see if /mnt/ddev_config is properly mounted")
+	_, _, err = app.Exec(&ExecOpts{
+		Cmd: `ls -l /mnt/ddev_config/nginx_full/nginx-site.conf >/dev/null`,
 	})
-
-	// Goroutine 2: PopulateGlobalCustomCommandFiles
-	wg.Go(func() {
-		result.commandsErr = PopulateGlobalCustomCommandFiles()
-	})
-
-	// Goroutine 3: router start + additional containers wait
-	wg.Go(func() {
-		if !IsRouterDisabled(app) {
-			result.routerErr = StartDdevRouter()
-		}
-
-		if result.routerErr != nil {
-			return
-		}
-
-		waitLabels := map[string]string{
-			"com.ddev.site-name":        app.GetName(),
-			"com.docker.compose.oneoff": "False",
-		}
-		containersAwaited, findErr := dockerutil.FindContainersByLabels(waitLabels)
-		if findErr != nil {
-			result.waitErr2 = findErr
-			return
-		}
-		containerNames := dockerutil.GetContainerNames(containersAwaited, []string{GetContainerName(app, "web"), GetContainerName(app, "db")}, "ddev-"+app.Name+"-")
-		if len(containerNames) > 0 {
-			wait := output.StartWait(fmt.Sprintf("Waiting for additional project containers %v to become ready", containerNames))
-			result.waitErr2 = app.WaitByLabels(waitLabels)
-			wait.Complete(result.waitErr2)
-		} else {
-			result.waitErr2 = app.WaitByLabels(waitLabels)
-		}
-	})
-
-	wg.Wait()
-
-	if result.mountErr != nil {
+	if err != nil {
 		util.Warning("Something is wrong with your Docker provider and /mnt/ddev_config is not mounted from the project .ddev folder. Your project cannot normally function successfully with this situation. Is your project in your home directory?")
 	}
-	if result.commandsErr != nil {
-		util.Warning("Failed to populate global custom command files: %v", result.commandsErr)
+
+	util.Debug("Getting stderr output from 'log-stderr.sh --show'")
+	logStderr, _, _ := app.Exec(&ExecOpts{
+		Cmd: "log-stderr.sh --show 2>/dev/null || true",
+	})
+	logStderr = strings.TrimSpace(logStderr)
+	if logStderr != "" {
+		util.Warning(logStderr)
+		// Reset the build hash when errors occur
+		_ = os.WriteFile(buildHashFile, []byte(nodeps.DdevFileSignature), 0644)
 	}
-	logStderr = result.logStderr
-	if result.routerErr != nil {
-		return result.routerErr
+
+	routerWg.Wait()
+	if routerErr != nil {
+		return routerErr
 	}
-	if result.waitErr2 != nil {
-		return result.waitErr2
+
+	waitLabels := map[string]string{
+		"com.ddev.site-name":        app.GetName(),
+		"com.docker.compose.oneoff": "False",
+	}
+	containersAwaited, findErr := dockerutil.FindContainersByLabels(waitLabels)
+	if findErr != nil {
+		return findErr
+	}
+	containerNames := dockerutil.GetContainerNames(containersAwaited, []string{GetContainerName(app, "web"), GetContainerName(app, "db")}, "ddev-"+app.Name+"-")
+	if len(containerNames) > 0 {
+		wait := output.StartWait(fmt.Sprintf("Waiting for additional project containers %v to become ready", containerNames))
+		err = app.WaitByLabels(waitLabels)
+		wait.Complete(err)
+		if err != nil {
+			return err
+		}
+	} else {
+		err = app.WaitByLabels(waitLabels)
+		if err != nil {
+			return err
+		}
 	}
 
 	if _, err = app.CreateSettingsFile(); err != nil {


### PR DESCRIPTION
## The Issue

- Fixes #8441

#8145 stopped `ddev start`/`ddev restart` from showing the warnings captured by `log-stderr.sh --show` (e.g. a failed `n install` for an invalid Node.js version). Its concurrency refactor dropped the call that displays the warning text and the build-hash reset that triggers a rebuild on the next start.

## How This PR Solves The Issue

- Restores the sequential `log-stderr.sh --show` handling that prints the warning via `util.Warning(...)` and resets `.build-hash` to the bare signature so the next `ddev start` rebuilds.
- Replaces the 3-goroutine `execResult` block from #8145 with a single background goroutine for `StartDdevRouter()`, which overlaps the router start (the slowest step) with the independent web-container steps (`PopulateGlobalCustomCommandFiles`, mount check, log-stderr) to keep startup fast without obscuring the warning logic.
- Removes the concurrent dangling-image cleanup, which could race the post-build `log-stderr` check; it now runs sequentially after the build.

## Manual Testing Instructions

```
ddev config --nodejs-version foobar
ddev restart
```

The output must include the `n install` failure warning.

---

After the tests turn green, check for changes in the total duration of the test, this should not change significantly.

## Automated Testing Overview

Adds `TestLogStderrShownOnStart`: builds with a `Dockerfile.foobar` that runs a failing `log-stderr.sh foobar`, asserts the warning is shown on `ddev start`, and that `.build-hash` is reset to only the signature.

## Release/Deployment Notes

No user-facing config or behavior changes beyond restoring the warnings; startup performance is almost unchanged from main.

```bash
# main:

ddev poweroff && ddev delete -Oy && docker builder prune -f
ddev add-on get ddev/ddev-redis
ddev start # 44s
ddev restart # 14s
ddev poweroff && ddev start # 22s

# this PR:

ddev poweroff && ddev delete -Oy && docker builder prune -f
ddev add-on get ddev/ddev-redis
ddev start # 45s
ddev restart # 15s
ddev poweroff && ddev start # 22s
```