### PR TITLE
test(quickstart): update shopware6

### DIFF
--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -27,6 +27,7 @@ teardown() {
   #    [x] No permanently, never ask again for this project
   run bats_pipe printf "y\nx\n" \| ddev composer create-project shopware/production
   assert_success
+  assert_output --partial "execute code and wish to enable it now?"
   assert_output --partial "Do you want to include Docker configuration from recipes?"
   assert_file_not_exist compose.yaml
   assert_file_not_exist compose.override.yaml

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -21,9 +21,11 @@ teardown() {
   run ddev start -y
   assert_success
 
-  # Do you want to include Docker configuration from recipes?
-  # [x] No permanently, never ask again for this project
-  run bats_pipe echo x \| ddev composer create-project shopware/production
+  # 1. Do you trust "php-http/discovery" to execute code and wish to enable it now?
+  #    (writes "allow-plugins" to composer.json) [y,n,d,?]
+  # 2. Do you want to include Docker configuration from recipes?
+  #    [x] No permanently, never ask again for this project
+  run bats_pipe printf "y\nx\n" \| ddev composer create-project shopware/production
   assert_success
   assert_output --partial "Do you want to include Docker configuration from recipes?"
   assert_file_not_exist compose.yaml


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/actions/runs/27624422933/job/81681979816?pr=8481#step:9:381

```
not ok 37 Shopware Composer based quickstart with ddev version a45357b0f
# (from function `assert_output' in file /home/linuxbrew/.linuxbrew/lib/bats-assert/src/assert_output.bash, line 186,
#  in test file docs/tests/shopware.bats, line 28)
#   `assert_output --partial "Do you want to include Docker configuration from recipes?"' failed
# Not trying to remove hostnames from hosts file because DDEV_NONINTERACTIVE=true
#
# -- output does not contain substring --
# substring (1 lines):
#   Do you want to include Docker configuration from recipes?
# output (287 lines):
#   Executing Composer command: [composer create-project --no-plugins --no-scripts --no-install shopware/production /tmp/TEpUtY]
#
#   Creating a "shopware/production" project at "/tmp/TEpUtY"
#   Installing shopware/production (v6.7.11.0)
#   Plugins have been disabled.
#     - Downloading shopware/production (v6.7.11.0)
#     - Installing shopware/production (v6.7.11.0): Extracting archive
#   Created project in /tmp/TEpUtY
#
#   Moving install to Composer root
#   Updating /home/runner/tmp/my-shopware-site.OoIdUs/my-shopware-site/.env.local with map[APP_ENV:dev APP_URL:https://my-shopware-site.ddev.site DATABASE_URL:***db:3306/db MAILER_DSN:smtp://127.0.0.1:1025?encryption=&auth_mode=]
#   Executing Composer command: [script -q -c composer install /dev/null]
#
#   x
#   No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See https://getcomposer.org/install for more information.
#   Loading composer repositories with package information
#   Updating dependencies
#   Lock file operations: 164 installs, 0 updates, 0 removals
#     - Locking async-aws/core (1.29.0)
#     - Locking brick/math (0.14.8)
#     - Locking cocur/slugify (v4.7.1)
#     - Locking composer/ca-bundle (1.5.12)
#     - Locking composer/class-map-generator (1.7.3)
#     - Locking composer/composer (2.10.1)
#     - Locking composer/metadata-minifier (1.0.0)
#     - Locking composer/pcre (3.4.0)
#     - Locking composer/semver (3.4.4)
#     - Locking composer/spdx-licenses (1.6.0)
#     - Locking composer/xdebug-handler (3.0.5)
#     - Locking defuse/php-encryption (v2.4.0)
#     - Locking doctrine/dbal (4.4.3)
#     - Locking doctrine/deprecations (1.1.6)
#     - Locking doctrine/inflector (2.1.0)
#     - Locking doctrine/instantiator (2.1.0)
#     - Locking doctrine/lexer (3.0.1)
#     - Locking dompdf/dompdf (v3.1.4)
#     - Locking dompdf/php-font-lib (1.0.2)
#     - Locking dompdf/php-svg-lib (1.0.2)
#     - Locking dragonmantank/cron-expression (v3.6.0)
#     - Locking egulias/email-validator (4.0.4)
#     - Locking ezimuel/guzzlestreams (4.1.0)
#     - Locking ezimuel/ringphp (1.4.1)
#     - Locking ezyang/htmlpurifier (v4.19.0)
#     - Locking friendsofphp/proxy-manager-lts (v1.0.19)
#     - Locking goetas-webservices/xsd2php-runtime (0.2.18)
#     - Locking guzzlehttp/guzzle (7.11.2)
#     - Locking guzzlehttp/promises (2.5.0)
#     - Locking guzzlehttp/psr7 (2.11.1)
#     - Locking horstoeko/mimedb (v1.0.8)
#     - Locking horstoeko/stringmanagement (v1.0.12)
#     - Locking horstoeko/zugferd (v1.0.123)
#     - Locking jms/metadata (2.9.0)
#     - Locking jms/serializer (3.32.7)
#     - Locking justinrainbow/json-schema (6.9.0)
#     - Locking laminas/laminas-code (4.17.0)
#     - Locking lcobucci/clock (3.6.0)
#     - Locking lcobucci/jwt (5.6.0)
#     - Locking league/event (3.0.3)
#     - Locking league/flysystem (3.34.0)
#     - Locking league/flysystem-local (3.31.0)
#     - Locking league/flysystem-memory (3.31.0)
#     - Locking league/mime-type-detection (1.16.0)
#     - Locking league/oauth2-server (9.4.0)
#     - Locking league/uri (7.8.1)
#     - Locking league/uri-interfaces (7.8.1)
#     - Locking marc-mabe/php-enum (v4.7.2)
#     - Locking masterminds/html5 (2.10.0)
#     - Locking mcp/sdk (v0.5.0)
#     - Locking meyfa/php-svg (v0.16.1)
#     - Locking monolog/monolog (3.10.0)
#     - Locking nyholm/psr7 (1.8.2)
#     - Locking opensearch-project/opensearch-php (2.6.0)
#     - Locking opis/json-schema (2.6.0)
#     - Locking opis/string (2.1.0)
#     - Locking opis/uri (1.1.0)
#     - Locking paragonie/constant_time_encoding (v3.1.3)
#     - Locking pentatrion/vite-bundle (v8.2.4)
#     - Locking php-http/discovery (1.20.0)
#     - Locking phpdocumentor/reflection-common (2.2.0)
#     - Locking phpdocumentor/reflection-docblock (6.0.3)
#     - Locking phpdocumentor/type-resolver (2.0.0)
#     - Locking phpseclib/phpseclib (3.0.55)
#     - Locking phpstan/phpdoc-parser (2.3.2)
#     - Locking psr/cache (3.0.0)
#     - Locking psr/clock (1.0.0)
#     - Locking psr/container (2.0.2)
#     - Locking psr/event-dispatcher (1.0.0)
#     - Locking psr/http-client (1.0.3)
#     - Locking psr/http-factory (1.1.0)
#     - Locking psr/http-message (2.0)
#     - Locking psr/http-server-handler (1.0.2)
#     - Locking psr/http-server-middleware (1.0.2)
#     - Locking psr/log (3.0.2)
#     - Locking psr/simple-cache (3.0.0)
#     - Locking ralouphie/getallheaders (3.0.3)
#     - Locking ramsey/collection (2.1.1)
#     - Locking ramsey/uuid (4.9.2)
#     - Locking react/promise (v3.3.0)
#     - Locking sabberworm/php-css-parser (v9.3.0)
#     - Locking scssphp/scssphp (v1.12.0)
#     - Locking seld/jsonlint (1.12.1)
#     - Locking seld/phar-utils (1.2.1)
#     - Locking seld/signal-handler (2.0.2)
#     - Locking setasign/fpdf (1.9.0)
#     - Locking setasign/fpdi (v2.6.8)
#     - Locking setasign/tfpdf (v1.33)
#     - Locking shopware/administration (v6.7.11.0)
#     - Locking shopware/conflicts (0.6.1)
#     - Locking shopware/core (v6.7.11.0)
#     - Locking shopware/elasticsearch (v6.7.11.0)
#     - Locking shopware/storefront (v6.7.11.0)
#     - Locking shyim/opensearch-php-dsl (1.1.5)
#     - Locking smalot/pdfparser (v2.12.5)
#     - Locking squirrelphp/twig-php-syntax (v1.13)
#     - Locking symfony/asset (v7.4.8)
#     - Locking symfony/cache (v7.4.13)
#     - Locking symfony/cache-contracts (v3.6.0)
#     - Locking symfony/clock (v7.4.8)
#     - Locking symfony/config (v7.4.10)
#     - Locking symfony/console (v7.4.13)
#     - Locking symfony/debug-bundle (v7.4.8)
#     - Locking symfony/dependency-injection (v7.4.13)
#     - Locking symfony/deprecation-contracts (v3.6.0)
#     - Locking symfony/doctrine-messenger (v7.4.6)
#     - Locking symfony/dotenv (v7.4.11)
#     - Locking symfony/error-handler (v7.4.8)
#     - Locking symfony/event-dispatcher (v7.4.9)
#     - Locking symfony/event-dispatcher-contracts (v3.6.0)
#     - Locking symfony/filesystem (v7.4.11)
#     - Locking symfony/finder (v7.4.8)
#     - Locking symfony/flex (v2.11.0)
#     - Locking symfony/framework-bundle (v7.4.13)
#     - Locking symfony/http-client (v7.4.13)
#     - Locking symfony/http-client-contracts (v3.6.0)
#     - Locking symfony/http-foundation (v7.4.13)
#     - Locking symfony/http-kernel (v7.4.13)
#     - Locking symfony/intl (v7.4.8)
#     - Locking symfony/lock (v7.4.9)
#     - Locking symfony/mailer (v7.4.12)
#     - Locking symfony/mcp-bundle (v0.9.0)
#     - Locking symfony/messenger (v7.4.12)
#     - Locking symfony/mime (v7.4.13)
#     - Locking symfony/monolog-bridge (v7.4.12)
#     - Locking symfony/monolog-bundle (v3.11.2)
#     - Locking symfony/options-resolver (v7.4.8)
#     - Locking symfony/password-hasher (v8.1.0)
#     - Locking symfony/polyfill-php83 (v1.38.2)
#     - Locking symfony/polyfill-php84 (v1.38.1)
#     - Locking symfony/polyfill-php85 (v1.38.1)
#     - Locking symfony/polyfill-php86 (v1.38.0)
#     - Locking symfony/polyfill-uuid (v1.37.0)
#     - Locking symfony/process (v7.4.13)
#     - Locking symfony/property-access (v7.4.8)
#     - Locking symfony/property-info (v7.4.8)
#     - Locking symfony/proxy-manager-bridge (v6.4.28)
#     - Locking symfony/psr-http-message-bridge (v7.4.8)
#     - Locking symfony/rate-limiter (v7.4.13)
#     - Locking symfony/routing (v7.4.13)
#     - Locking symfony/runtime (v7.4.13)
#     - Locking symfony/scheduler (v7.4.13)
#     - Locking symfony/security-core (v7.4.13)
#     - Locking symfony/serializer (v7.4.10)
#     - Locking symfony/service-contracts (v3.6.1)
#     - Locking symfony/stopwatch (v7.4.8)
#     - Locking symfony/string (v7.4.13)
#     - Locking symfony/translation (v7.4.10)
#     - Locking symfony/translation-contracts (v3.6.1)
#     - Locking symfony/twig-bridge (v7.4.12)
#     - Locking symfony/twig-bundle (v7.4.8)
#     - Locking symfony/type-info (v8.1.0)
#     - Locking symfony/uid (v8.1.0)
#     - Locking symfony/ux-twig-component (v2.35.0)
#     - Locking symfony/validator (v7.4.10)
#     - Locking symfony/var-dumper (v8.1.0)
#     - Locking symfony/var-exporter (v7.4.9)
#     - Locking symfony/yaml (v7.4.13)
#     - Locking thecodingmachine/safe (v3.4.0)
#     - Locking twig/intl-extra (v3.26.0)
#     - Locking twig/string-extra (v3.24.0)
#     - Locking twig/twig (v3.27.1)
#     - Locking webmozart/assert (2.4.1)
#     - Locking zircote/swagger-php (4.11.1)
#   Writing lock file
#   Installing dependencies from lock file (including require-dev)
#   Package operations: 164 installs, 0 updates, 0 removals
#     - Downloading symfony/runtime (v7.4.13)
#     - Downloading symfony/flex (v2.11.0)
#     - Downloading shopware/core (v6.7.11.0)
#     - Downloading zircote/swagger-php (4.11.1)
#     - Downloading symfony/string (v7.4.13)
#     - Downloading symfony/type-info (v8.1.0)
#     - Downloading symfony/dependency-injection (v7.4.13)
#     - Downloading symfony/password-hasher (v8.1.0)
#     - Downloading symfony/security-core (v7.4.13)
#     - Downloading symfony/scheduler (v7.4.13)
#     - Downloading symfony/rate-limiter (v7.4.13)
#     - Downloading symfony/psr-http-message-bridge (v7.4.8)
#     - Downloading symfony/proxy-manager-bridge (v6.4.28)
#     - Downloading symfony/cache-contracts (v3.6.0)
#     - Downloading symfony/cache (v7.4.13)
#     - Downloading symfony/framework-bundle (v7.4.13)
#     - Downloading webmozart/assert (2.4.1)
#     - Downloading phpdocumentor/type-resolver (2.0.0)
#     - Downloading phpdocumentor/reflection-docblock (6.0.3)
#     - Downloading opis/string (2.1.0)
#     - Downloading opis/uri (1.1.0)
#     - Downloading opis/json-schema (2.6.0)
#     - Downloading mcp/sdk (v0.5.0)
#     - Downloading symfony/mcp-bundle (v0.9.0)
#     - Downloading symfony/http-client (v7.4.13)
#     - Downloading doctrine/dbal (4.4.3)
#     - Downloading symfony/debug-bundle (v7.4.8)
#     - Downloading squirrelphp/twig-php-syntax (v1.13)
#     - Downloading setasign/tfpdf (v1.33)
#     - Downloading setasign/fpdi (v2.6.8)
#     - Downloading league/event (3.0.3)
#     - Downloading lcobucci/clock (3.6.0)
#     - Downloading defuse/php-encryption (v2.4.0)
#     - Downloading league/oauth2-server (9.4.0)
#     - Downloading league/flysystem-memory (3.31.0)
#     - Downloading smalot/pdfparser (v2.12.5)
#     - Downloading setasign/fpdf (1.9.0)
#     - Downloading jms/metadata (2.9.0)
#     - Downloading jms/serializer (3.32.7)
#     - Downloading horstoeko/stringmanagement (v1.0.12)
#     - Downloading horstoeko/mimedb (v1.0.8)
#     - Downloading goetas-webservices/xsd2php-runtime (0.2.18)
#     - Downloading horstoeko/zugferd (v1.0.123)
#     - Downloading dompdf/php-svg-lib (1.0.2)
#     - Downloading dompdf/php-font-lib (1.0.2)
#     - Downloading dompdf/dompdf (v3.1.4)
#     - Downloading cocur/slugify (v4.7.1)
#     - Downloading ezimuel/guzzlestreams (4.1.0)
#     - Downloading ezimuel/ringphp (1.4.1)
#     - Downloading pentatrion/vite-bundle (v8.2.4)
#     - Downloading shopware/administration (v6.7.11.0)
#     - Downloading shyim/opensearch-php-dsl (1.1.5)
#     - Downloading opensearch-project/opensearch-php (2.6.0)
#     - Downloading async-aws/core (1.29.0)
#     - Downloading shopware/elasticsearch (v6.7.11.0)
#     - Downloading scssphp/scssphp (v1.12.0)
#     - Downloading meyfa/php-svg (v0.16.1)
#     - Downloading shopware/storefront (v6.7.11.0)
#     0/58 [>---------------------------]   0% 15/58 [=======>--------------------]  25% 32/58 [===============>------------]  55% 45/58 [=====================>------]  77% 52/58 [=========================>--]  89% 54/58 [==========================>-]  93% 57/58 [===========================>]  98% 58/58 [============================] 100%  - Installing symfony/runtime (v7.4.13): Extracting archive
#   php-http/discovery contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
#   Do you trust "php-http/discovery" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y - add package to allow-plugins in composer.json and let it run immediately
#   n - add package (as disallowed) to allow-plugins in composer.json to suppress further prompts
#   d - discard this, do not change composer.json and do not allow the plugin to run
#   ? - print help
#   Do you trust "php-http/discovery" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y - add package to allow-plugins in composer.json and let it run immediately
#   n - add package (as disallowed) to allow-plugins in composer.json to suppress further prompts
#   d - discard this, do not change composer.json and do not allow the plugin to run
#   ? - print help
#   y - add package to allow-plugins in composer.json and let it run immediately
#   n - add package (as disallowed) to allow-plugins in composer.json to suppress further prompts
#   d - discard this, do not change composer.json and do not allow the plugin to run
#   ? - print help
#   y - add package to allow-plugins in composer.json and let it run immediately
#   n - add package (as disallowed) to allow-plugins in composer.json to suppress further prompts
#   d - discard this, do not change composer.json and do not allow the plugin to run
#   ? - print help
#   y - add package to allow-plugins in composer.json and let it run immediately
#   n - add package (as disallowed) to allow-plugins in composer.json to suppress further prompts
#   d - discard this, do not change composer.json and do not allow the plugin to run
#   ? - print help
#   y - add package to allow-plugins in composer.json and let it run immediately
#   n - add package (as disallowed) to allow-plugins in composer.json to suppress further prompts
#   d - discard this, do not change composer.json and do not allow the plugin to run
#   ? - print help
#   Too many failed prompts, aborting.
#
#   In PluginManager.php line 821:
#
#     php-http/discovery contains a Composer plugin which is blocked by your allo
#     w-plugins config. You may add it to the list if you consider it safe.
#     You can run "composer config --no-plugins allow-plugins.php-http/discovery
#     [true|false]" to enable it (true) or disable it explicitly and suppress thi
#     s exception (false)
#     See https://getcomposer.org/allow-plugins
#
#
#   install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--download-only] [--dev] [--no-suggest] [--no-dev] [--no-security-blocking] [--no-blocking] [--no-autoloader] [--no-progress] [--no-install] [--audit] [--audit-format AUDIT-FORMAT] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--strict-psr-autoloader] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>...]
#
#
#   Updating /home/runner/tmp/my-shopware-site.OoIdUs/my-shopware-site/.env.local with map[APP_ENV:dev APP_URL:https://my-shopware-site.ddev.site DATABASE_URL:***db:3306/db MAILER_DSN:smtp://127.0.0.1:1025?encryption=&auth_mode=]
#   
#   ddev composer create-project was successful.
# --
#
#  Container ddev-my-shopware-site-db Stopping
#  Container ddev-my-shopware-site-web Stopping
#  Container ddev-my-shopware-site-db Stopped
#  Container ddev-my-shopware-site-web Stopped
#  Container ddev-my-shopware-site-db Stopping
#  Container ddev-my-shopware-site-web Stopping
#  Container ddev-my-shopware-site-web Stopped
#  Container ddev-my-shopware-site-web Removing
#  Container ddev-my-shopware-site-db Stopped
#  Container ddev-my-shopware-site-db Removing
#  Container ddev-my-shopware-site-db Removed
#  Container ddev-my-shopware-site-web Removed
#  Network ddev-my-shopware-site_default Removing
#  Network ddev-my-shopware-site_default Removed
# Not trying to remove hostnames from hosts file because DDEV_NONINTERACTIVE=true
```

## How This PR Solves The Issue

Fixes the Shopware 6 quickstart test.
Shopware 6 was updated today https://www.shopware.com/en/changelog/

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
