### PR TITLE
fix: warn when CAROOT is set but CA files are inaccessible, fixes #8485 (#8486) [skip ci]

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	osexec "os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -1971,14 +1972,21 @@ func (app *DdevApp) Start() error {
 
 	if !IsRouterDisabled(app) {
 		caRoot := globalconfig.GetCAROOT()
-		if caRoot == "" {
-			if caRootEnv := os.Getenv("CAROOT"); caRootEnv != "" {
-				// CAROOT is explicitly set but mkcert CA files are not accessible.
-				// Warn loudly so operators can diagnose the real cause (broken WSL2
-				// interop, unmounted filesystem, etc.) rather than chasing cryptic TLS errors.
-				util.Warning("CAROOT is set to %q but mkcert CA files (rootCA.pem, rootCA-key.pem) are not readable at that location. DDEV cannot set up trusted HTTPS. On WSL2, check that Windows interop is working (wsl --shutdown, then restart).", caRootEnv)
-			} else {
-				util.Warning("mkcert may not be properly installed, we suggest installing it for trusted https support, `brew install mkcert nss`, `choco install -y mkcert`, etc. and then `mkcert -install`")
+		// Warn loudly so operators can diagnose the real cause (no mkcert installed, broken WSL2
+		// interop, unmounted filesystem, etc.) rather than chasing cryptic TLS errors.
+		if _, err := osexec.LookPath("mkcert"); err != nil {
+			util.Warning("mkcert not found. Install for trusted HTTPS: `brew install mkcert nss`, `choco install -y mkcert`, etc., then run `mkcert -install`.")
+		} else {
+			if !fileutil.FileIsReadable(filepath.Join(caRoot, "rootCA-key.pem")) || !fileutil.FileExists(filepath.Join(caRoot, "rootCA.pem")) {
+				caRootFrom := "`mkcert -CAROOT`"
+				if caRootEnv := os.Getenv("CAROOT"); caRootEnv != "" {
+					caRootFrom = "CAROOT=" + caRootEnv
+				}
+				wsl2Hint := ""
+				if nodeps.IsWSL2() {
+					wsl2Hint = " On WSL2, check Windows interop is working (`wsl --shutdown`, then restart)."
+				}
+				util.Warning("mkcert CA files not readable from %s; run `mkcert -install` for trusted HTTPS.%s", caRootFrom, wsl2Hint)
 			}
 		}
 		router, _ := FindDdevRouter()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	osexec "os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -1971,27 +1970,15 @@ func (app *DdevApp) Start() error {
 	}
 
 	if !IsRouterDisabled(app) {
-		caRoot := globalconfig.GetCAROOT()
-		// Warn loudly so operators can diagnose the real cause (no mkcert installed, broken WSL2
-		// interop, unmounted filesystem, etc.) rather than chasing cryptic TLS errors.
-		if _, err := osexec.LookPath("mkcert"); err != nil {
-			util.Warning("mkcert not found. Install for trusted HTTPS: `brew install mkcert nss`, `choco install -y mkcert`, etc., then run `mkcert -install`.")
-		} else if !fileutil.FileIsReadable(filepath.Join(caRoot, "rootCA-key.pem")) || !fileutil.FileExists(filepath.Join(caRoot, "rootCA.pem")) {
-			caRootFrom := "`mkcert -CAROOT`"
-			if caRootEnv := os.Getenv("CAROOT"); caRootEnv != "" {
-				caRootFrom = "CAROOT=" + caRootEnv
-			}
-			wsl2Hint := ""
-			if nodeps.IsWSL2() {
-				wsl2Hint = " On WSL2, check Windows interop is working (`wsl --shutdown`, then restart)."
-			}
-			util.Warning("mkcert CA files not readable from %s; run `mkcert -install` for trusted HTTPS.%s", caRootFrom, wsl2Hint)
+		if _, caRootErr := globalconfig.ReadCAROOTDetails(); caRootErr != nil {
+			util.Warning("%v", caRootErr)
 		}
 		router, _ := FindDdevRouter()
 
 		// If the router doesn't exist, go ahead and push mkcert root ca certs into the ddev-global-cache/mkcert
 		// This will often be redundant
 		if router == nil {
+			caRoot := globalconfig.GetCAROOT()
 			// Copy ca certs into ddev-global-cache/mkcert
 			if caRoot != "" {
 				uid, _, _ := dockerutil.GetContainerUser()

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1972,7 +1972,14 @@ func (app *DdevApp) Start() error {
 	if !IsRouterDisabled(app) {
 		caRoot := globalconfig.GetCAROOT()
 		if caRoot == "" {
-			util.Warning("mkcert may not be properly installed, we suggest installing it for trusted https support, `brew install mkcert nss`, `choco install -y mkcert`, etc. and then `mkcert -install`")
+			if caRootEnv := os.Getenv("CAROOT"); caRootEnv != "" {
+				// CAROOT is explicitly set but mkcert CA files are not accessible.
+				// Warn loudly so operators can diagnose the real cause (broken WSL2
+				// interop, unmounted filesystem, etc.) rather than chasing cryptic TLS errors.
+				util.Warning("CAROOT is set to %q but mkcert CA files (rootCA.pem, rootCA-key.pem) are not readable at that location. DDEV cannot set up trusted HTTPS. On WSL2, check that Windows interop is working (wsl --shutdown, then restart).", caRootEnv)
+			} else {
+				util.Warning("mkcert may not be properly installed, we suggest installing it for trusted https support, `brew install mkcert nss`, `choco install -y mkcert`, etc. and then `mkcert -install`")
+			}
 		}
 		router, _ := FindDdevRouter()
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1976,18 +1976,16 @@ func (app *DdevApp) Start() error {
 		// interop, unmounted filesystem, etc.) rather than chasing cryptic TLS errors.
 		if _, err := osexec.LookPath("mkcert"); err != nil {
 			util.Warning("mkcert not found. Install for trusted HTTPS: `brew install mkcert nss`, `choco install -y mkcert`, etc., then run `mkcert -install`.")
-		} else {
-			if !fileutil.FileIsReadable(filepath.Join(caRoot, "rootCA-key.pem")) || !fileutil.FileExists(filepath.Join(caRoot, "rootCA.pem")) {
-				caRootFrom := "`mkcert -CAROOT`"
-				if caRootEnv := os.Getenv("CAROOT"); caRootEnv != "" {
-					caRootFrom = "CAROOT=" + caRootEnv
-				}
-				wsl2Hint := ""
-				if nodeps.IsWSL2() {
-					wsl2Hint = " On WSL2, check Windows interop is working (`wsl --shutdown`, then restart)."
-				}
-				util.Warning("mkcert CA files not readable from %s; run `mkcert -install` for trusted HTTPS.%s", caRootFrom, wsl2Hint)
+		} else if !fileutil.FileIsReadable(filepath.Join(caRoot, "rootCA-key.pem")) || !fileutil.FileExists(filepath.Join(caRoot, "rootCA.pem")) {
+			caRootFrom := "`mkcert -CAROOT`"
+			if caRootEnv := os.Getenv("CAROOT"); caRootEnv != "" {
+				caRootFrom = "CAROOT=" + caRootEnv
 			}
+			wsl2Hint := ""
+			if nodeps.IsWSL2() {
+				wsl2Hint = " On WSL2, check Windows interop is working (`wsl --shutdown`, then restart)."
+			}
+			util.Warning("mkcert CA files not readable from %s; run `mkcert -install` for trusted HTTPS.%s", caRootFrom, wsl2Hint)
 		}
 		router, _ := FindDdevRouter()
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -886,7 +886,7 @@ func readCAROOT() string {
 			// CAROOT is explicitly set but CA files are not accessible at the path
 			// mkcert returned. Warn loudly so operators can diagnose the real cause
 			// (broken WSL2 interop, unmounted filesystem, etc.) rather than chasing cryptic TLS errors.
-			output.UserOut.Warnf("CAROOT is set to %q but mkcert CA files (rootCA.pem, rootCA-key.pem) are not readable at that location. DDEV cannot set up trusted HTTPS. On WSL2, check that Windows interop is working (wsl --shutdown, then restart).", root)
+			output.UserErr.Warnf("CAROOT is set to %q but mkcert CA files (rootCA.pem, rootCA-key.pem) are not readable at that location. DDEV cannot set up trusted HTTPS. On WSL2, check that Windows interop is working (wsl --shutdown, then restart).", root)
 		}
 		return ""
 	}

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -882,12 +882,6 @@ func readCAROOT() string {
 	}
 	root := strings.Trim(string(out), "\r\n")
 	if !fileIsReadable(filepath.Join(root, "rootCA-key.pem")) || !fileExists(filepath.Join(root, "rootCA.pem")) {
-		if caRootEnv := os.Getenv("CAROOT"); caRootEnv != "" {
-			// CAROOT is explicitly set but CA files are not accessible at the path
-			// mkcert returned. Warn loudly so operators can diagnose the real cause
-			// (broken WSL2 interop, unmounted filesystem, etc.) rather than chasing cryptic TLS errors.
-			output.UserErr.Warnf("CAROOT is set to %q but mkcert CA files (rootCA.pem, rootCA-key.pem) are not readable at that location. DDEV cannot set up trusted HTTPS. On WSL2, check that Windows interop is working (wsl --shutdown, then restart).", root)
-		}
 		return ""
 	}
 

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -865,27 +865,40 @@ func GetCAROOT() string {
 	return DdevGlobalConfig.MkcertCARoot
 }
 
-// readCAROOT() verifies that the mkcert command is available and its CA keys readable.
+// readCAROOT returns fresh CAROOT without checking for errors
+func readCAROOT() string {
+	caRoot, _ := ReadCAROOTDetails()
+	return caRoot
+}
+
+// ReadCAROOTDetails verifies that the mkcert command is available and its CA keys readable.
 // 1. Find out CAROOT
 // 2. Look there to see if key/crt are readable
 // 3. If not, see if mkcert is even available, return empty
-
-func readCAROOT() string {
+func ReadCAROOTDetails() (string, error) {
 	_, err := exec.LookPath("mkcert")
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("mkcert not found. Install for trusted HTTPS: `brew install mkcert nss`, `choco install -y mkcert`, etc., then run `mkcert -install`")
 	}
-
 	out, err := exec.Command("mkcert", "-CAROOT").Output()
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("error running `mkcert -CAROOT`: %v; troubleshoot with `ddev utility tls-diagnose`", err)
 	}
-	root := strings.Trim(string(out), "\r\n")
-	if !fileIsReadable(filepath.Join(root, "rootCA-key.pem")) || !fileExists(filepath.Join(root, "rootCA.pem")) {
-		return ""
+	caRoot := strings.TrimSpace(string(out))
+	if !fileIsReadable(filepath.Join(caRoot, "rootCA-key.pem")) || !fileExists(filepath.Join(caRoot, "rootCA.pem")) {
+		caRootFrom := `mkcert -CAROOT`
+		if caRootEnv := os.Getenv("CAROOT"); caRootEnv != "" {
+			caRootFrom = fmt.Sprintf("CAROOT=%q", caRootEnv)
+		} else if caRoot != "" {
+			caRootFrom = fmt.Sprintf("`mkcert -CAROOT` output %q", caRoot)
+		}
+		wsl2Hint := ""
+		if nodeps.IsWSL2() {
+			wsl2Hint = ", check Windows interop is working (`wsl --shutdown`, then restart)"
+		}
+		return "", fmt.Errorf("mkcert CA files not readable from %s; run `mkcert -install` for trusted HTTPS%s; troubleshoot with `ddev utility tls-diagnose`", caRootFrom, wsl2Hint)
 	}
-
-	return root
+	return caRoot, nil
 }
 
 // fileIsReadable checks to make sure a file exists and is readable

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -878,11 +878,17 @@ func readCAROOT() string {
 func ReadCAROOTDetails() (string, error) {
 	_, err := exec.LookPath("mkcert")
 	if err != nil {
-		return "", fmt.Errorf("mkcert not found. Install for trusted HTTPS: `brew install mkcert nss`, `choco install -y mkcert`, etc., then run `mkcert -install`")
+		recommendedCommand := "with your OS package manager"
+		if nodeps.IsMacOS() {
+			recommendedCommand = "with `brew install mkcert nss`"
+		} else if nodeps.IsWindows() {
+			recommendedCommand = "with `choco install -y mkcert`"
+		}
+		return "", fmt.Errorf("mkcert not found. Install it %s to trust HTTPS, then run `mkcert -install`", recommendedCommand)
 	}
 	out, err := exec.Command("mkcert", "-CAROOT").Output()
 	if err != nil {
-		return "", fmt.Errorf("error running `mkcert -CAROOT`: %v; troubleshoot with `ddev utility tls-diagnose`", err)
+		return "", fmt.Errorf("error running `mkcert -CAROOT`: %v; use `ddev utility tls-diagnose` for troubleshooting", err)
 	}
 	caRoot := strings.TrimSpace(string(out))
 	if !fileIsReadable(filepath.Join(caRoot, "rootCA-key.pem")) || !fileExists(filepath.Join(caRoot, "rootCA.pem")) {
@@ -890,13 +896,13 @@ func ReadCAROOTDetails() (string, error) {
 		if caRootEnv := os.Getenv("CAROOT"); caRootEnv != "" {
 			caRootFrom = fmt.Sprintf("CAROOT=%q", caRootEnv)
 		} else if caRoot != "" {
-			caRootFrom = fmt.Sprintf("`mkcert -CAROOT` output %q", caRoot)
+			caRootFrom = fmt.Sprintf("`mkcert -CAROOT` at %q", caRoot)
 		}
 		wsl2Hint := ""
 		if nodeps.IsWSL2() {
-			wsl2Hint = ", check Windows interop is working (`wsl --shutdown`, then restart)"
+			wsl2Hint = ", verify Windows interop is working: run `wsl --shutdown`, then restart WSL"
 		}
-		return "", fmt.Errorf("mkcert CA files not readable from %s; run `mkcert -install` for trusted HTTPS%s; troubleshoot with `ddev utility tls-diagnose`", caRootFrom, wsl2Hint)
+		return "", fmt.Errorf("mkcert CA files are not readable from %s; run `mkcert -install` to trust HTTPS%s; use `ddev utility tls-diagnose` for troubleshooting", caRootFrom, wsl2Hint)
 	}
 	return caRoot, nil
 }

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -882,6 +882,12 @@ func readCAROOT() string {
 	}
 	root := strings.Trim(string(out), "\r\n")
 	if !fileIsReadable(filepath.Join(root, "rootCA-key.pem")) || !fileExists(filepath.Join(root, "rootCA.pem")) {
+		if caRootEnv := os.Getenv("CAROOT"); caRootEnv != "" {
+			// CAROOT is explicitly set but CA files are not accessible at the path
+			// mkcert returned. Warn loudly so operators can diagnose the real cause
+			// (broken WSL2 interop, unmounted filesystem, etc.) rather than chasing cryptic TLS errors.
+			output.UserOut.Warnf("CAROOT is set to %q but mkcert CA files (rootCA.pem, rootCA-key.pem) are not readable at that location. DDEV cannot set up trusted HTTPS. On WSL2, check that Windows interop is working (wsl --shutdown, then restart).", root)
+		}
 		return ""
 	}
 


### PR DESCRIPTION
## The Issue

- Fixes #8485

When `CAROOT` is explicitly set but the mkcert CA files are not accessible at
that path, `readCAROOT()` silently returned `""`. DDEV then proceeded with no
CA configured, and all downstream TLS operations failed with cryptic SSL/TLS
errors that appeared unrelated to the real cause.

This was discovered during Windows WSL2 installer testing where `WSLInterop`
gets cleared (e.g. by `apt-get remove docker-ce` removing binfmt_misc entries),
making `.exe` files invocable from WSL2 fail with "Exec format error".

## How This PR Solves The Issue

In `readCAROOT()`, when CA files are not accessible **and** `CAROOT` env var is
explicitly set, emit a clear warning via `output.UserOut.Warnf()` rather than
silently returning `""`. The caller still gets `""` (same behavior), but the
operator sees an actionable message pointing to the real root cause.

## Manual Testing Instructions

1. Set `CAROOT=/some/nonexistent/path` in the environment
2. Run `ddev start` on any project
3. Observe the warning: `CAROOT is set to "/some/nonexistent/path" but mkcert CA files ... are not readable`
4. Without `CAROOT` set, no warning is emitted (unchanged behavior)

## Automated Testing Overview

No new automated tests added — `readCAROOT()` calls `mkcert -CAROOT` which
requires mkcert installed. The change is a one-line conditional warning inside
an existing path; the logic is already covered by the overall TLS test suite.

## Release/Deployment Notes

Purely additive: only emits a warning in a previously-silent failure path.
No behavior change otherwise. Helps WSL2 users and anyone with CAROOT pointing
to temporarily inaccessible paths (network drives, mounted filesystems, etc.)
diagnose TLS issues faster.
