### PR TITLE
fix(tui): prevent docker/cli stdin from consuming TUI shortcuts, fixes #8440

### DIFF
--- a/pkg/dockerutil/docker_manager.go
+++ b/pkg/dockerutil/docker_manager.go
@@ -56,9 +56,13 @@ var (
 func getDockerManagerInstance() (*dockerManager, error) {
 	sDockerManagerOnce.Do(func() {
 		sDockerManager = &dockerManager{}
-		// Suppress any output (stdout, stderr) from docker/cli
 		sDockerManager.cli, sDockerManagerErr = command.NewDockerCli(
+			// Suppress any output (stdout, stderr) from docker/cli.
 			command.WithCombinedStreams(io.Discard),
+			// Detach stdin (an empty io.ReadCloser, not os.Stdin) so an in-process
+			// compose exec doesn't compete with the bubbletea TUI for keystrokes;
+			// interactive/piped execs set real stdin via SetExecStdin.
+			command.WithInputStream(io.NopCloser(bytes.NewReader(nil))),
 		)
 		if sDockerManagerErr != nil {
 			return


### PR DESCRIPTION
## The Issue

- Fixes #8440

The singleton Docker CLI defaulted to `os.Stdin` (`NewDockerCli`'s `WithStandardStreams`). Compose `Exec` sets `RunOptions.Interactive`, so its hijack reads `cli.In()` - and the status execs the TUI runs every refresh read fd 0 directly, competing with bubbletea and swallowing keystrokes.

## How This PR Solves The Issue

Detach the singleton from `os.Stdin` with an empty `WithInputStream`. Interactive and piped execs still set the real stdin via `SetExecStdin`, so `ddev exec/ssh` are unaffected.

## Manual Testing Instructions

1. `ddev start`
2. `ddev tui`, open the project view, wait a few seconds.
3. Press shortcuts repeatedly (such as refresh `R`) - they register on first press instead of stalling.

## Automated Testing Overview

No automated test - needs a live TTY.