### PR TITLE
fix: add /usr/local/n/bin to sudo secure_path, fixes #8488

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-dev-base-files/etc/sudoers.d/ddev
+++ b/containers/ddev-webserver/ddev-webserver-dev-base-files/etc/sudoers.d/ddev
@@ -1,2 +1,3 @@
 ALL ALL=NOPASSWD: ALL
 Defaults env_keep += "*_proxy *_PROXY DDEV_* IS_DDEV_PROJECT PHP_DEFAULT_VERSION"
+Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/n/bin"

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -80,6 +80,14 @@ func TestNodeJSVersions(t *testing.T) {
 		})
 		assert.NoError(err)
 		assert.True(strings.HasPrefix(out, "v"+v), "Expected node version to start with '%s', but got %s", v, out)
+
+		// Verify node is reachable via sudo (secure_path must include /usr/local/n/bin)
+		out, _, err = app.Exec(&ddevapp.ExecOpts{
+			Cmd:  `sudo -u "$DDEV_USER" node --version`,
+			User: "root",
+		})
+		assert.NoError(err)
+		assert.True(strings.HasPrefix(out, "v"+v), "Expected sudo node version to start with '%s', but got %s", v, out)
 	}
 }
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260610_stasadev_n_install" // Note that this can be overridden by make
+var WebTag = "20260617_stasadev_n_sudoers" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- Fixes #8488

---

Node binaries installed by `n` live in `/usr/local/n/bin`, see:

- #8467

`/usr/local/n/bin` is not included in sudo's compiled-in `secure_path`. This breaks `sudo -u <user> yarn/npm/node` in web-build Dockerfiles.

## How This PR Solves The Issue

Adds a `Defaults secure_path` line to `/etc/sudoers.d/ddev` that includes `/usr/local/n/bin`, so node toolchain binaries are reachable under `sudo`.

## Manual Testing Instructions

```bash
ddev exec -u root 'sudo -u "$DDEV_USER" node --version'
# Should print node version instead of "sudo: node: command not found"
```

## Automated Testing Overview

Extended `TestNodeJSVersions` to also run `sudo -u "$DDEV_USER" node --version` for each tested Node.js version, catching any future regression.

## Release/Deployment Notes

Requires rebuilding the web container image. Fixes a regression introduced when node was moved to `/usr/local/n/bin`.