### PR TITLE
feat: allow mutagen with use-hardened-images, for #3680

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1525,9 +1525,6 @@ func (app *DdevApp) composeBuild(args ...string) (string, error) {
 // Start initiates docker-compose up
 func (app *DdevApp) Start() error {
 	var err error
-	if app.IsMutagenEnabled() && globalconfig.DdevGlobalConfig.UseHardenedImages {
-		return fmt.Errorf("mutagen is not compatible with use-hardened-images")
-	}
 
 	if _, err := dockerutil.DownloadDockerBuildxIfNeeded(); err != nil {
 		return err

--- a/pkg/ddevapp/hardened_test.go
+++ b/pkg/ddevapp/hardened_test.go
@@ -20,8 +20,8 @@ import (
 
 // TestHardenedStart makes sure we can do a start and basic use with hardened images
 func TestHardenedStart(t *testing.T) {
-	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && (nodeps.IsAppleSilicon() || nodeps.IsWSL2() || dockerutil.IsRancherDesktop()) {
-		t.Skip("Skipping TestHardenedStart because of useless failures to connect on some platforms, no need to test hardened on arm64")
+	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && (nodeps.IsWSL2() || dockerutil.IsRancherDesktop()) {
+		t.Skip("Skipping TestHardenedStart because of useless failures to connect on some platforms")
 	}
 
 	assert := asrt.New(t)

--- a/pkg/ddevapp/hardened_test.go
+++ b/pkg/ddevapp/hardened_test.go
@@ -20,9 +20,6 @@ import (
 
 // TestHardenedStart makes sure we can do a start and basic use with hardened images
 func TestHardenedStart(t *testing.T) {
-	if globalconfig.DdevGlobalConfig.NoBindMounts {
-		t.Skip("Skipping TestHardenedStart because NoBindMounts is true and Mutagen is incompatible with hardened images")
-	}
 	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && (nodeps.IsAppleSilicon() || nodeps.IsWSL2() || dockerutil.IsRancherDesktop()) {
 		t.Skip("Skipping TestHardenedStart because of useless failures to connect on some platforms, no need to test hardened on arm64")
 	}

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -51,8 +51,9 @@ func SetMutagenVolumeOwnership(app *DdevApp) error {
 	// chown's non-zero exit code even with -f.
 	_, _, err := app.Exec(
 		&ExecOpts{
-			Dir: "/tmp",
-			Cmd: fmt.Sprintf("sudo chown -Rf %s:%s /tmp/project_mutagen || true", uidStr, gidStr),
+			Dir:  "/tmp",
+			Cmd:  fmt.Sprintf("chown -Rf %s:%s /tmp/project_mutagen || true", uidStr, gidStr),
+			User: "root",
 		})
 	if err != nil {
 		util.Warning("Failed to chown Mutagen volume: %v", err)


### PR DESCRIPTION
## The Issue

The PR below added a restriction on running Mutagen with use-hardened-images because it didn't work:

- #3680

## How This PR Solves The Issue

Fixes it by running `SetMutagenVolumeOwnership` as `root` without using `sudo`.

## Manual Testing Instructions

v1.19.0-v1.25.2

```
$ ddev config global --performance-mode=mutagen --use-hardened-images
$ ddev start
...
Failed to start demo: mutagen is not compatible with use-hardened-images
```

DDEV HEAD, but without "mutagen is not compatible with use-hardened-images" (manually built binary):

```
$ ddev config global --performance-mode=mutagen --use-hardened-images
$ ddev start
...
Starting Mutagen sync process...
Failed to start demo: failed to CreateOrResumeMutagenSync on Mutagen sync session 'demo'. You may be able to resolve this problem using 'ddev mutagen reForcing synchronization cycle for session sync_XWHQfz9Pp4V5hNEkhAinxaLGY2d5RnUsr
Error: unable to flush session: session is not currently able to synchronize
, err=exit status 1) 
```

This PR:

```
$ ddev config global --performance-mode=mutagen --use-hardened-images
$ ddev start
...
Successfully started demo
...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
