### PR TITLE
fix: restrict XDG_CONFIG_HOME to Linux, add DDEV_XDG_CONFIG_HOME for cross-platform overrides, fixes #8493

### DIFF
--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -226,7 +226,8 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	t.Setenv("USERPROFILE", tmpHomeDir)
 	// Set DOCKER_HOST to the same value as before, otherwise wrong Docker context may be used
 	t.Setenv("DOCKER_HOST", dockerHost)
-	// Set $XDG_CONFIG_HOME to empty string, otherwise it will take precedence over $HOME
+	// Set $DDEV_XDG_CONFIG_HOME to empty string, otherwise it will take precedence over $HOME
+	t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 	t.Setenv("XDG_CONFIG_HOME", "")
 
 	// Make sure that the tmpDir/.ddev and tmpDir/.ddev/.update don't exist before we run ddev.
@@ -302,11 +303,13 @@ func TestCopyGlobalDdevDir(t *testing.T) {
 
 // TestGetGlobalDdevDirLocation checks to make sure that DDEV will use the
 // correct location for its global config. The correct location is:
-// ${XDG_CONFIG_HOME}/ddev if XDG_CONFIG_HOME is set or
+// ${DDEV_XDG_CONFIG_HOME}/ddev if DDEV_XDG_CONFIG_HOME is set (all platforms), or
+// ${XDG_CONFIG_HOME}/ddev if XDG_CONFIG_HOME is set on Linux only, or
 // ~/.ddev if it exists or
-// ~/.config/ddev if it exists
+// ~/.config/ddev if it exists on Linux/WSL2
 func TestGetGlobalDdevDirLocation(t *testing.T) {
-	// Test when $XDG_CONFIG_HOME is not set
+	// Test when neither DDEV_XDG_CONFIG_HOME nor XDG_CONFIG_HOME is set
+	t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 	t.Setenv("XDG_CONFIG_HOME", "")
 	ddevDir := globalconfig.GetGlobalDdevDirLocation()
 	// Original ~/.ddev dir location
@@ -320,12 +323,12 @@ func TestGetGlobalDdevDirLocation(t *testing.T) {
 		}
 	}
 	require.Equal(t, ddevDir, originalGlobalDdevDir)
-	// Test when $XDG_CONFIG_HOME is set
+	// Test when $DDEV_XDG_CONFIG_HOME is set (works on all platforms)
 	tmpDir := testcommon.CreateTmpDir(t.Name())
 	t.Cleanup(func() {
 		_ = os.RemoveAll(tmpDir)
 	})
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	t.Setenv("DDEV_XDG_CONFIG_HOME", tmpDir)
 	// Make sure that the tmpDir/ddev doesn't exist.
 	_, err := os.Stat(filepath.Join(tmpDir, "ddev"))
 	require.Error(t, err)
@@ -333,9 +336,9 @@ func TestGetGlobalDdevDirLocation(t *testing.T) {
 	// Check that we can get the correct location
 	ddevDir = globalconfig.GetGlobalDdevDirLocation()
 	require.Equal(t, ddevDir, filepath.Join(tmpDir, "ddev"))
-	// When $XDG_CONFIG_HOME is not set,
+	// When $DDEV_XDG_CONFIG_HOME is not set,
 	// it should use the default location
-	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 	ddevDir = globalconfig.GetGlobalDdevDirLocation()
 	require.Equal(t, ddevDir, originalGlobalDdevDir)
 }

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -125,7 +125,7 @@ ddev version | grep global-ddev-dir
     mv $HOME/.ddev ${DDEV_XDG_CONFIG_HOME}/ddev
     ```
 
-    On Linux/WSL2, you can also use `$XDG_CONFIG_HOME` from the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) instead of `$DDEV_XDG_CONFIG_HOME`. Or move the directory to `$HOME/.config/ddev` without setting any variable:
+    On Linux/WSL2, you can also use `$XDG_CONFIG_HOME` from the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/) instead of `$DDEV_XDG_CONFIG_HOME`. Or move the directory to `$HOME/.config/ddev` without setting any variable:
 
     ```bash
     mv $HOME/.ddev $HOME/.config/ddev

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -102,12 +102,13 @@ Files beginning with `.` are hidden because they shouldn’t be fiddled with; mo
 
 There’s only one global `.ddev` directory, which normally lives in your home directory: `$HOME/.ddev`, but can be overwritten (first match wins):
 
-1. `$XDG_CONFIG_HOME/ddev` if `$XDG_CONFIG_HOME` is set
-2. `$HOME/.ddev`, which means:
+1. `$DDEV_XDG_CONFIG_HOME/ddev` if `$DDEV_XDG_CONFIG_HOME` is set (all platforms)
+2. `$XDG_CONFIG_HOME/ddev` if `$XDG_CONFIG_HOME` is set on Linux/WSL2 only
+3. `$HOME/.ddev`, which means:
     - `/Users/<username>/.ddev` on macOS
     - `/home/<username>/.ddev` on Linux/WSL2
     - `C:\Users\<username>\.ddev` on Windows
-3. `$HOME/.config/ddev` on Linux/WSL2 only, if `$HOME/.ddev` doesn't exist
+4. `$HOME/.config/ddev` on Linux/WSL2 only, if `$HOME/.ddev` doesn’t exist
 
 To find your actual location, run:
 
@@ -115,20 +116,16 @@ To find your actual location, run:
 ddev version | grep global-ddev-dir
 ```
 
-!!!tip "Using `$XDG_CONFIG_HOME` or `$HOME/.config/ddev`"
-    DDEV can use the `$XDG_CONFIG_HOME` environment variable from [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) to move `$HOME/.ddev` to the `$XDG_CONFIG_HOME/ddev` directory if `$XDG_CONFIG_HOME` is [defined](https://superuser.com/questions/365847/where-should-the-xdg-config-home-variable-be-defined/).
-
-    To use `$HOME/.config/ddev` (or any other directory) instead of `$HOME/.ddev`:
+!!!tip "Moving `$HOME/.ddev` to a custom location"
+    To use a custom directory instead of `$HOME/.ddev`, set `$DDEV_XDG_CONFIG_HOME` to the parent directory. For example, to use `$HOME/.config/ddev`:
 
     ```bash
     ddev poweroff
-    # permanently set environment variable using a directory that works for you
-    export XDG_CONFIG_HOME="$HOME/.config"
-    # restart the terminal and run:
-    mv $HOME/.ddev ${XDG_CONFIG_HOME}/ddev
+    export DDEV_XDG_CONFIG_HOME="$HOME/.config"
+    mv $HOME/.ddev ${DDEV_XDG_CONFIG_HOME}/ddev
     ```
 
-    On Linux/WSL2, you can move the directory to `$HOME/.config/ddev` without setting `$XDG_CONFIG_HOME`:
+    On Linux/WSL2, you can also use `$XDG_CONFIG_HOME` from the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) instead of `$DDEV_XDG_CONFIG_HOME`. Or move the directory to `$HOME/.config/ddev` without setting any variable:
 
     ```bash
     mv $HOME/.ddev $HOME/.config/ddev

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1554,6 +1554,7 @@ func (app *DdevApp) Start() error {
 	if err := globalconfig.CheckForMultipleGlobalDdevDirs(); err != nil {
 		util.WarningOnce("Warning: %v", err)
 	}
+	globalconfig.WarnIfXDGIgnoredOnNonLinux()
 
 	if !globalconfig.IsInternetActive() && globalconfig.DdevDebug {
 		util.WarningOnce("Internet connection not detected, DNS may not work.\nWarning: %v\nSee https://docs.ddev.com/en/stable/users/usage/offline/ for info.", globalconfig.IsInternetActiveErr)

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -169,7 +169,7 @@ func checkMutagenSocketPathLength() {
 		limit = 108
 	}
 	if socketPathLength >= limit {
-		output.UserErr.Warning(fmt.Sprintf("Path to DDEV Mutagen socket is %d characters long.\nMutagen may fail, socket path must contain less than %d characters.\nConsider using a shorter path to DDEV global config with XDG_CONFIG_HOME env.", limit, socketPathLength))
+		output.UserErr.Warning(fmt.Sprintf("Path to DDEV Mutagen socket is %d characters long.\nMutagen may fail, socket path must contain less than %d characters.\nConsider using a shorter path to DDEV global config with DDEV_XDG_CONFIG_HOME env (or XDG_CONFIG_HOME on Linux).", limit, socketPathLength))
 	}
 	checkedMutagenSocketPathLength = true
 }
@@ -650,8 +650,9 @@ func GetGlobalDdevDir() string {
 	return ddevDir
 }
 
-// GetGlobalDdevDirLocation returns the global caching directory location to be used by DDEV:
-// $XDG_CONFIG_HOME/ddev if this $XDG_CONFIG_HOME variable is not empty,
+// GetGlobalDdevDirLocation returns the global config directory location to be used by DDEV:
+// $DDEV_XDG_CONFIG_HOME/ddev if $DDEV_XDG_CONFIG_HOME is set (all platforms),
+// $XDG_CONFIG_HOME/ddev if $XDG_CONFIG_HOME is set on Linux only,
 // ~/.config/ddev if this directory exists on Linux/WSL2 only,
 // ~/.ddev otherwise.
 func GetGlobalDdevDirLocation() string {
@@ -661,16 +662,30 @@ func GetGlobalDdevDirLocation() string {
 	}
 	userHomeDotDdev := filepath.Join(userHome, ".ddev")
 
-	// If $XDG_CONFIG_HOME is set, use $XDG_CONFIG_HOME/ddev,
-	// we create this directory.
-	xdgConfigHomeDir := os.Getenv("XDG_CONFIG_HOME")
-	// Handle ~/xxx without failure; MUTAGEN_DATA_DIRECTORY, for example, can't have it.
-	if strings.HasPrefix(xdgConfigHomeDir, `~`) {
-		xdgConfigHomeDir = userHome + xdgConfigHomeDir[1:]
+	// If $DDEV_XDG_CONFIG_HOME is set, use $DDEV_XDG_CONFIG_HOME/ddev (all platforms).
+	// Handle ~/xxx without failure.
+	ddevXdgConfigHome := os.Getenv("DDEV_XDG_CONFIG_HOME")
+	if strings.HasPrefix(ddevXdgConfigHome, `~`) {
+		ddevXdgConfigHome = userHome + ddevXdgConfigHome[1:]
 	}
-	if xdgConfigHomeDir != "" {
-		return filepath.Join(xdgConfigHomeDir, "ddev")
+	if ddevXdgConfigHome != "" {
+		return filepath.Join(ddevXdgConfigHome, "ddev")
 	}
+
+	// If $XDG_CONFIG_HOME is set and we're on Linux, use $XDG_CONFIG_HOME/ddev.
+	// XDG_CONFIG_HOME is a Linux/freedesktop.org standard. On macOS and Windows it is
+	// not honored, to avoid silent config misplacement for users who have it set globally
+	// for other tools. Use DDEV_XDG_CONFIG_HOME for a cross-platform override.
+	if nodeps.IsLinux() {
+		xdgConfigHomeDir := os.Getenv("XDG_CONFIG_HOME")
+		if strings.HasPrefix(xdgConfigHomeDir, `~`) {
+			xdgConfigHomeDir = userHome + xdgConfigHomeDir[1:]
+		}
+		if xdgConfigHomeDir != "" {
+			return filepath.Join(xdgConfigHomeDir, "ddev")
+		}
+	}
+
 	// If Linux and ~/.ddev doesn't exist and
 	// ~/.config/ddev exists, use it,
 	// we don't create this directory.
@@ -691,6 +706,31 @@ func GetGlobalDdevDirLocation() string {
 	return userHomeDotDdev
 }
 
+// WarnIfXDGIgnoredOnNonLinux emits a one-time warning on macOS/Windows when
+// XDG_CONFIG_HOME is set and $XDG_CONFIG_HOME/ddev exists. DDEV no longer
+// respects XDG_CONFIG_HOME on non-Linux platforms. Use DDEV_XDG_CONFIG_HOME instead.
+func WarnIfXDGIgnoredOnNonLinux() {
+	if nodeps.IsLinux() {
+		return
+	}
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome == "" {
+		return
+	}
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	if strings.HasPrefix(xdgConfigHome, `~`) {
+		xdgConfigHome = userHome + xdgConfigHome[1:]
+	}
+	oldDir := filepath.Join(xdgConfigHome, "ddev")
+	if _, err := os.Stat(oldDir); err != nil {
+		return
+	}
+	output.UserErr.Warningf("XDG_CONFIG_HOME is set but is only respected on Linux. Your previous DDEV config at %s is not being used.\nTo continue using it, set DDEV_XDG_CONFIG_HOME=%s\nOr move it to the default location: mv %s %s", oldDir, xdgConfigHome, oldDir, filepath.Join(userHome, ".ddev"))
+}
+
 // CheckForMultipleGlobalDdevDirs checks for multiple global DDEV directories
 // and returns an error if multiple are found.
 func CheckForMultipleGlobalDdevDirs() error {
@@ -699,8 +739,8 @@ func CheckForMultipleGlobalDdevDirs() error {
 		return err
 	}
 	userHomeDotDdev := filepath.Clean(filepath.Join(userHome, ".ddev"))
-	// On Linux, also check for $HOME/.config/ddev if XDG_CONFIG_HOME is not set
-	if nodeps.IsLinux() && os.Getenv("XDG_CONFIG_HOME") == "" {
+	// On Linux, also check for $HOME/.config/ddev if neither XDG_CONFIG_HOME nor DDEV_XDG_CONFIG_HOME is set
+	if nodeps.IsLinux() && os.Getenv("XDG_CONFIG_HOME") == "" && os.Getenv("DDEV_XDG_CONFIG_HOME") == "" {
 		userConfigDir, err := os.UserConfigDir()
 		if err == nil {
 			linuxDir := filepath.Join(userConfigDir, "ddev")

--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -211,6 +211,7 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		defer os.RemoveAll(tmpHome)
 
 		t.Setenv("HOME", tmpHome)
+		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 		t.Setenv("XDG_CONFIG_HOME", "")
 
 		// Create only XDG directory
@@ -233,6 +234,7 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		defer os.RemoveAll(tmpHome)
 
 		t.Setenv("HOME", tmpHome)
+		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 		t.Setenv("XDG_CONFIG_HOME", "")
 
 		// Create both directories
@@ -250,8 +252,39 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		require.Contains(t, err.Error(), "multiple global DDEV configurations found")
 	})
 
-	// Test 3: XDG_CONFIG_HOME set - should detect conflict
-	t.Run("XDGConfigHomeSet", func(t *testing.T) {
+	// Test 3: DDEV_XDG_CONFIG_HOME set - should detect conflict (all platforms)
+	t.Run("DDEVXDGConfigHomeSet", func(t *testing.T) {
+		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_DDEVXDGHome")
+		defer os.RemoveAll(tmpHome)
+
+		tmpXdg := testcommon.CreateTmpDir("TestCheckMultipleDirs_DDEVXDG")
+		defer os.RemoveAll(tmpXdg)
+
+		t.Setenv("HOME", tmpHome)
+		t.Setenv("DDEV_XDG_CONFIG_HOME", tmpXdg)
+		t.Setenv("XDG_CONFIG_HOME", "")
+
+		// Create both directories
+		defaultDir := tmpHome + "/.ddev"
+		err := os.MkdirAll(defaultDir, 0755)
+		require.NoError(t, err)
+
+		ddevXdgDir := tmpXdg + "/ddev"
+		err = os.MkdirAll(ddevXdgDir, 0755)
+		require.NoError(t, err)
+
+		// Should detect conflict between DDEV_XDG_CONFIG_HOME/ddev and default
+		err = globalconfig.CheckForMultipleGlobalDdevDirs()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "multiple global DDEV configurations found")
+	})
+
+	// Test 4: XDG_CONFIG_HOME set on Linux - should detect conflict
+	t.Run("XDGConfigHomeSetOnLinux", func(t *testing.T) {
+		if !nodeps.IsLinux() {
+			t.Skip("XDG_CONFIG_HOME is only respected on Linux")
+		}
+
 		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_XDGHome")
 		defer os.RemoveAll(tmpHome)
 
@@ -259,6 +292,7 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		defer os.RemoveAll(tmpXdg)
 
 		t.Setenv("HOME", tmpHome)
+		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 		t.Setenv("XDG_CONFIG_HOME", tmpXdg)
 
 		// Create both directories
@@ -270,18 +304,19 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		err = os.MkdirAll(xdgDir, 0755)
 		require.NoError(t, err)
 
-		// Should detect conflict between XDG and default
+		// Should detect conflict between XDG and default on Linux
 		err = globalconfig.CheckForMultipleGlobalDdevDirs()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "multiple global DDEV configurations found")
 	})
 
-	// Test 4: Only default directory exists
+	// Test 5: Only default directory exists
 	t.Run("OnlyDefaultExists", func(t *testing.T) {
 		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_Default")
 		defer os.RemoveAll(tmpHome)
 
 		t.Setenv("HOME", tmpHome)
+		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 		t.Setenv("XDG_CONFIG_HOME", "")
 
 		// Create only default directory

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -238,9 +238,9 @@ func CopyGlobalDdevDir(t *testing.T) string {
 	// Stop the Mutagen daemon running in the ~/.ddev
 	ddevapp.StopMutagenDaemon("")
 	t.Logf("stopped mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory())
-	// Set $XDG_CONFIG_HOME for tests
-	t.Setenv("XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
-	// Make sure that the global config directory is set to $XDG_CONFIG_HOME/ddev
+	// Set $DDEV_XDG_CONFIG_HOME for tests (works on all platforms; XDG_CONFIG_HOME is Linux-only)
+	t.Setenv("DDEV_XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
+	// Make sure that the global config directory is set to $DDEV_XDG_CONFIG_HOME/ddev
 	require.Equal(t, tmpGlobalDdevDir, globalconfig.GetGlobalDdevDir())
 	// And it should be created by now
 	require.DirExists(t, tmpGlobalDdevDir)
@@ -278,9 +278,9 @@ func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
 	// Stop the Mutagen daemon running in the $XDG_CONFIG_HOME/ddev
 	ddevapp.StopMutagenDaemon("")
 	t.Logf("stopped mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory())
-	// After the $XDG_CONFIG_HOME directory is removed,
+	// After the $DDEV_XDG_CONFIG_HOME directory is removed,
 	// globalconfig.GetGlobalDdevDir() should point to ~/.ddev
-	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 	_ = os.RemoveAll(tmpXdgConfigHomeDir)
 	// Make sure that the global config directory is set to ~/.ddev
 	originalGlobalDdevDir := globalconfig.GetGlobalDdevDirLocation()


### PR DESCRIPTION
## The Issue

- Fixes #8493

`XDG_CONFIG_HOME` is a Linux/freedesktop.org standard. DDEV was honoring it on macOS and Windows, silently redirecting the global config dir for users who had it set for other tools. This caused a confusing loop: `~/.ddev` kept getting recreated, the "multiple global DDEV configurations found" warning fired on every run, and users had no idea why (Discord: https://discord.com/channels/664580571770388500/1514302329875071046).

## How This PR Solves The Issue

- `GetGlobalDdevDirLocation()` now gates `XDG_CONFIG_HOME` behind `nodeps.IsLinux()`, so it is ignored on macOS and Windows.
- Adds `DDEV_XDG_CONFIG_HOME` as a DDEV-native cross-platform override (same semantics as `XDG_CONFIG_HOME`: DDEV appends `/ddev` to the value). Takes precedence over `XDG_CONFIG_HOME` on Linux too.
- Adds `WarnIfXDGIgnoredOnNonLinux()`, called from `app.Start()`, which fires once on macOS/Windows when `XDG_CONFIG_HOME` is set and `$XDG_CONFIG_HOME/ddev` exists, guiding the user to migrate.
- Updates `CheckForMultipleGlobalDdevDirs()` to skip the Linux fallback check when `DDEV_XDG_CONFIG_HOME` is set.
- Updates docs and the mutagen socket path hint to mention `DDEV_XDG_CONFIG_HOME`.

New priority order (first match wins):

1. `$DDEV_XDG_CONFIG_HOME/ddev` if `DDEV_XDG_CONFIG_HOME` is set (all platforms)
2. `$XDG_CONFIG_HOME/ddev` if `XDG_CONFIG_HOME` is set — **Linux only**
3. `$HOME/.ddev` (default)
4. `$HOME/.config/ddev` on Linux/WSL2 only, if `$HOME/.ddev` doesn't exist

## Manual Testing Instructions

### Linux / WSL2

```bash
# 1. Default - should use ~/.ddev
env -u DDEV_XDG_CONFIG_HOME -u XDG_CONFIG_HOME ddev version | grep global-ddev-dir
# Expected: /home/<user>/.ddev

# 2. DDEV_XDG_CONFIG_HOME override
DDEV_XDG_CONFIG_HOME=/tmp/custom ddev version | grep global-ddev-dir
# Expected: /tmp/custom/ddev

# 3. XDG_CONFIG_HOME still works on Linux
XDG_CONFIG_HOME=/tmp/xdg ddev version | grep global-ddev-dir
# Expected: /tmp/xdg/ddev

# 4. DDEV_XDG_CONFIG_HOME takes precedence over XDG_CONFIG_HOME
DDEV_XDG_CONFIG_HOME=/tmp/wins XDG_CONFIG_HOME=/tmp/loses ddev version | grep global-ddev-dir
# Expected: /tmp/wins/ddev

# 5. Linux ~/.config/ddev fallback (when ~/.ddev absent)
mkdir -p ~/.config/ddev && mv ~/.ddev ~/.ddev.bak
env -u DDEV_XDG_CONFIG_HOME -u XDG_CONFIG_HOME ddev version | grep global-ddev-dir
# Expected: /home/<user>/.config/ddev
mv ~/.ddev.bak ~/.ddev && rm -rf ~/.config/ddev
```

### macOS

```bash
# 1. Default - should use ~/.ddev (even if XDG_CONFIG_HOME is set in your shell)
env -u DDEV_XDG_CONFIG_HOME -u XDG_CONFIG_HOME ddev version | grep global-ddev-dir
# Expected: /Users/<user>/.ddev

# 2. XDG_CONFIG_HOME is now IGNORED on macOS
XDG_CONFIG_HOME=/tmp/xdg ddev version | grep global-ddev-dir
# Expected: /Users/<user>/.ddev  (not /tmp/xdg/ddev)

# 3. DDEV_XDG_CONFIG_HOME override works on macOS
DDEV_XDG_CONFIG_HOME=/tmp/custom ddev version | grep global-ddev-dir
# Expected: /tmp/custom/ddev

# 4. Migration warning: set XDG_CONFIG_HOME with an existing ddev dir, run ddev start
mkdir -p /tmp/xdg-old/ddev
XDG_CONFIG_HOME=/tmp/xdg-old ddev start
# Expected: one-time warning:
#   "XDG_CONFIG_HOME is set but is only respected on Linux. Your previous DDEV
#    config at /tmp/xdg-old/ddev is not being used. To continue using it, set
#    DDEV_XDG_CONFIG_HOME=/tmp/xdg-old ..."
rm -rf /tmp/xdg-old
```

## Automated Testing Overview

- `TestCheckForMultipleGlobalDdevDirs`: all subtests updated to clear `DDEV_XDG_CONFIG_HOME`; renamed `XDGConfigHomeSet` → `DDEVXDGConfigHomeSet` (cross-platform); added `XDGConfigHomeSetOnLinux` (Linux-only, skipped on macOS/Windows).
- `TestGetGlobalDdevDirLocation`: updated to test `DDEV_XDG_CONFIG_HOME`.
- `testcommon.CopyGlobalDdevDir` / `ResetGlobalDdevDir`: switched from `XDG_CONFIG_HOME` to `DDEV_XDG_CONFIG_HOME` so test isolation works correctly on macOS and Windows CI.

## Release/Deployment Notes

- **Linux**: no behavior change.
- **macOS/Windows**: `XDG_CONFIG_HOME` is no longer honored. Users with an existing `$XDG_CONFIG_HOME/ddev` will see a one-time migration warning on next `ddev start`.
- `DDEV_XDG_CONFIG_HOME` is the new supported cross-platform override for non-default global config locations.
