### PR TITLE
fix(webserver): prevent recursion in global web command wrappers, for #6902

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/00-path-setup.bashrc
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/bashrc/00-path-setup.bashrc
@@ -11,6 +11,13 @@ path_append() {
     *) PATH="$PATH:$1" ;;
   esac
 }
+path_remove() {
+  local p result= IFS=:
+  for p in $PATH; do
+    [ "$p" = "$1" ] || result="${result:+$result:}$p"
+  done
+  PATH="$result"
+}
 
 # Add vendor/bin, then user-owned dirs in front of it (prepend order is last-wins)
 path_prepend "${DDEV_COMPOSER_ROOT:-/var/www/html}/vendor/bin"
@@ -23,11 +30,18 @@ path_append "/usr/local/n/bin"
 # Add /var/www/html/bin as the next-to-last item to the $PATH.
 path_append "/var/www/html/bin"
 
-# Add /mnt/ddev-global-cache/global-commands/web as the last item to the $PATH.
-# This allows commands that weren't found elsewhere to be executed. For example, `xdebug on`
-# can be used inside web container
-path_append "/mnt/ddev-global-cache/global-commands/web"
+# Add /mnt/ddev-global-cache/global-commands/web as a fallback for commands like `xdebug on`,
+# but drop it when this shell is running a script from that dir, so a wrapper calling a
+# same-named binary (e.g. yarn -> `yarn "$@"`) doesn't recurse into itself.
+case "$0" in
+  /mnt/ddev-global-cache/global-commands/web/*)
+    path_remove "/mnt/ddev-global-cache/global-commands/web"
+    ;;
+  *)
+    path_append "/mnt/ddev-global-cache/global-commands/web"
+    ;;
+esac
 
-unset -f path_prepend path_append
+unset -f path_prepend path_append path_remove
 
 export PATH

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/asterios
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/asterios
@@ -9,9 +9,6 @@
 ## ExecRaw: true
 ## MutagenSync: true
 
-# Ignore anything we find in the mounted global commands
-PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
-
 if ! command -v asterios >/dev/null; then
   echo "asterios is not available. You may need to 'ddev composer require asterios/core'"
   exit 1

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/drush
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/drush
@@ -9,9 +9,6 @@
 ## ExecRaw: true
 ## MutagenSync: true
 
-# Ignore anything we find in the mounted global commands
-PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
-
 if ! command -v drush >/dev/null; then
   echo "drush is not available. You may need to 'ddev composer require drush/drush'"
   exit 1

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/pint
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/pint
@@ -6,9 +6,6 @@
 ## Example: "ddev pint --dirty" for fixing your current changes lint errors or "ddev pint --test app/Models" for only analyzing your models without autofix.
 ## ProjectTypes: laravel
 
-# Ignore anything we find in the mounted global commands
-PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
-
 if ! command -v pint >/dev/null; then
   echo "pint is not available. You may need to 'ddev composer require laravel/pint'"
   exit 1

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/sake
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/sake
@@ -8,7 +8,4 @@
 ## ExecRaw: true
 ## MutagenSync: true
 
-# Ignore anything we find in the mounted global commands
-PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
-
 sake "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/typo3
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/typo3
@@ -10,7 +10,4 @@
 ## ExecRaw: true
 ## MutagenSync: true
 
-# Ignore anything we find in the mounted global commands
-PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
-
 typo3 "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/wp
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/wp
@@ -7,9 +7,6 @@
 ## ExecRaw: true
 ## MutagenSync: true
 
-# Ignore anything we find in the mounted global commands
-PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
-
 # Add --path if not already set and $DDEV_DOCROOT is defined
 if [[ ! " $* " =~ (--path(=|\s)) ]] && [[ -n "$DDEV_DOCROOT" ]]; then
   # Get the configured path from wp-cli.yml or other config file

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260617_stasadev_n_sudoers" // Note that this can be overridden by make
+var WebTag = "20260619_stasadev_web_recursion" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

@jonaseberle noticed a recursion for `/mnt/ddev-global-cache/global-commands/web`, reported in https://discord.com/channels/664580571770388500/1517512879668989962

I noticed this too when this logic was added in:

- #6902

And we had a workaround for that in some commands, but not everywhere.

## How This PR Solves The Issue

Fixes it by optionally unloading `/mnt/ddev-global-cache/global-commands/web` from PATH when the command from that dir is called.

Removes the previous workaround, which is no longer needed

## Manual Testing Instructions

```bash
ddev exec which -a php
ddev exec sudo rm -f /usr/bin/php
ddev exec which -a php
ddev exec php -v
ddev php -v
ddev exec bash -c 'php -v'
# should still work
ddev exec xdebug on
```

Before:

```
$ ddev exec which -a php
/usr/bin/php
/bin/php
/mnt/ddev-global-cache/global-commands/web/php

$ ddev exec sudo rm -f /usr/bin/php

$ ddev exec which -a php
/mnt/ddev-global-cache/global-commands/web/php

$ ddev exec php -v
bash: warning: shell level (1000) too high, resetting to 1
^C

$ ddev php -v
bash: warning: shell level (1000) too high, resetting to 1
^C

$ ddev exec bash -c 'php -v'
bash: warning: shell level (1000) too high, resetting to 1
^C

$ ddev exec xdebug on
Enabled xdebug
```

After:

```
$ ddev exec which -a php
/usr/bin/php
/bin/php
/mnt/ddev-global-cache/global-commands/web/php

$ ddev exec sudo rm -f /usr/bin/php

$ ddev exec which -a php
/mnt/ddev-global-cache/global-commands/web/php

$ ddev exec php -v
/mnt/ddev-global-cache/global-commands/web/php: line 10: php: command not found
Failed to execute command `php -v`: exit status 127

$ ddev php -v
/mnt/ddev-global-cache/global-commands/web/php: line 10: php: command not found
Failed to execute command `php -v`: exit status 127

$ ddev exec bash -c 'php -v'
/mnt/ddev-global-cache/global-commands/web/php: line 10: php: command not found
Failed to execute command `php -v`: exit status 127

$ ddev exec xdebug on
Enabled xdebug
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
