### PR TITLE
test(quickstart): pin `@sveltejs/adapter-node@5.5.4`

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -103,5 +103,5 @@ jobs:
           make quickstart-test
 
       - name: Fail on timeout
-        if: cancelled()
+        if: ${{ cancelled() }}
         run: exit 1

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -101,3 +101,7 @@ jobs:
           # Use mutagen by default as it may cause different behaviors
           $(make DDEV_BINARY_FULLPATH) config global --performance-mode=mutagen
           make quickstart-test
+
+      - name: Fail on timeout
+        if: cancelled()
+        run: exit 1

--- a/docs/tests/sveltekit.bats
+++ b/docs/tests/sveltekit.bats
@@ -45,7 +45,8 @@ EOF
   run ddev exec curl -s -OL https://raw.githubusercontent.com/ddev/test-sveltekit/main/vite.config.ts
   assert_success
 
-  run ddev npm install @sveltejs/adapter-node
+  # TODO: see https://github.com/sveltejs/kit/issues/16087
+  run ddev npm install @sveltejs/adapter-node@5.5.4
   assert_success
   run ddev npm install
   assert_success


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/actions/runs/27811705463/job/82329136013

```
ok 42 Sulu quickstart with ddev version 5630dc95b
Error: The operation was canceled.
```

the next test is: 43 sveltekit quickstart

This is an upstream bug:

- https://github.com/sveltejs/kit/issues/16087

## How This PR Solves The Issue

Pins `@sveltejs/adapter-node@5.5.4`, I subscribed to the issue.
Adds `exit 1` on `cancelled()` in GitHub Actions because the "cancelled" status doesn't notify us about the timeout.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
