### PR TITLE
fix(nodejs): always install gulp-cli and yarn, fixes #8496 (#8498) [skip ci]

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1029,8 +1029,8 @@ n install --cleanup "%[1]s" || log-stderr.sh n install --cleanup "%[1]s" || true
 NODE_VERSION=$(node -v)
 IFS=. read -r NODE_MAJOR NODE_MINOR _ <<< "${NODE_VERSION#v}"
 INSTALL_PKGS=""
-if [ "$NODE_MAJOR" -lt 10 ] || { [ "$NODE_MAJOR" -eq 10 ] && [ "$NODE_MINOR" -lt 10 ]; }; then
-  INSTALL_PKGS="$INSTALL_PKGS gulp-cli@2" # for Node.js <10.10
+if [ "$NODE_MAJOR" -lt 10 ] || { [ "$NODE_MAJOR" -eq 10 ] && [ "$NODE_MINOR" -lt 13 ]; }; then
+  INSTALL_PKGS="$INSTALL_PKGS gulp-cli@2" # for Node.js <10.13
 fi
 if [ "$NODE_MAJOR" -lt 6 ]; then
   INSTALL_PKGS="$INSTALL_PKGS yarn@1.11.1" # for Node.js <6

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1024,20 +1024,19 @@ COPY n-version-files/ /tmp/n-version-files/
 RUN <<EOF
 set -eu -o pipefail
 cd /tmp/n-version-files || true
-export N_PREFIX=/usr/local/n-new
-if n install --cleanup "%[1]s" || log-stderr.sh n install --cleanup "%[1]s"; then
-  rm -rf /usr/local/n && mv /usr/local/n-new /usr/local/n
-  NODE_VERSION=$(node -v)
-  IFS=. read -r NODE_MAJOR NODE_MINOR _ <<< "${NODE_VERSION#v}"
-  GULP_CLI_TAG=latest
-  if [ "$NODE_MAJOR" -lt 10 ] || { [ "$NODE_MAJOR" -eq 10 ] && [ "$NODE_MINOR" -lt 10 ]; }; then
-    GULP_CLI_TAG=2 # for Node.js <10.10
-  fi
-  YARN_TAG=latest
-  if [ "$NODE_MAJOR" -lt 6 ]; then
-    YARN_TAG=1.11.1 # for Node.js <6
-  fi
-  log-stderr.sh npm install --unsafe-perm=true --global gulp-cli@$GULP_CLI_TAG yarn@$YARN_TAG || true
+export N_PREFIX=/usr/local/n
+n install --cleanup "%[1]s" || log-stderr.sh n install --cleanup "%[1]s" || true
+NODE_VERSION=$(node -v)
+IFS=. read -r NODE_MAJOR NODE_MINOR _ <<< "${NODE_VERSION#v}"
+INSTALL_PKGS=""
+if [ "$NODE_MAJOR" -lt 10 ] || { [ "$NODE_MAJOR" -eq 10 ] && [ "$NODE_MINOR" -lt 10 ]; }; then
+  INSTALL_PKGS="$INSTALL_PKGS gulp-cli@2" # for Node.js <10.10
+fi
+if [ "$NODE_MAJOR" -lt 6 ]; then
+  INSTALL_PKGS="$INSTALL_PKGS yarn@1.11.1" # for Node.js <6
+fi
+if [ -n "$INSTALL_PKGS" ]; then
+  log-stderr.sh npm install --unsafe-perm=true --global $INSTALL_PKGS -f || true
 fi
 cd /tmp && rm -rf /tmp/n-version-files
 EOF

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1027,6 +1027,17 @@ cd /tmp/n-version-files || true
 export N_PREFIX=/usr/local/n-new
 if n install --cleanup "%[1]s" || log-stderr.sh n install --cleanup "%[1]s"; then
   rm -rf /usr/local/n && mv /usr/local/n-new /usr/local/n
+  NODE_VERSION=$(node -v)
+  IFS=. read -r NODE_MAJOR NODE_MINOR _ <<< "${NODE_VERSION#v}"
+  GULP_CLI_TAG=latest
+  if [ "$NODE_MAJOR" -lt 10 ] || { [ "$NODE_MAJOR" -eq 10 ] && [ "$NODE_MINOR" -lt 10 ]; }; then
+    GULP_CLI_TAG=2 # for Node.js <10.10
+  fi
+  YARN_TAG=latest
+  if [ "$NODE_MAJOR" -lt 6 ]; then
+    YARN_TAG=1.11.1 # for Node.js <6
+  fi
+  log-stderr.sh npm install --unsafe-perm=true --global gulp-cli@$GULP_CLI_TAG yarn@$YARN_TAG || true
 fi
 cd /tmp && rm -rf /tmp/n-version-files
 EOF

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -88,6 +88,12 @@ func TestNodeJSVersions(t *testing.T) {
 		})
 		assert.NoError(err)
 		assert.True(strings.HasPrefix(out, "v"+v), "Expected sudo node version to start with '%s', but got %s", v, out)
+
+		// Verify that globally installed npm packages are present and working
+		out, _, err = app.Exec(&ddevapp.ExecOpts{
+			Cmd: `gulp --version && yarn --version`,
+		})
+		assert.NoError(err)
 	}
 }
 

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -90,7 +90,7 @@ func TestNodeJSVersions(t *testing.T) {
 		assert.True(strings.HasPrefix(out, "v"+v), "Expected sudo node version to start with '%s', but got %s", v, out)
 
 		// Verify that globally installed npm packages are present and working
-		out, _, err = app.Exec(&ddevapp.ExecOpts{
+		_, _, err = app.Exec(&ddevapp.ExecOpts{
 			Cmd: `gulp --version && yarn --version`,
 		})
 		assert.NoError(err)


### PR DESCRIPTION
## The Issue

- Fixes #8496

Caused by fresh installation for Node.js added in:

- #8467

## How This PR Solves The Issue

Adds extra installation for `gulp-cli` and `yarn` when you switch the Node.js version.

I also checked that the packages are compatible with all Node.js versions and added conditions similar to:

- https://github.com/ddev/ddev-pnpm/pull/15

## Manual Testing Instructions

```bash
ddev config --nodejs-version=6
ddev restart
ddev yarn -v
ddev exec gulp -v
```

## Automated Testing Overview

Added missing checks for `gulp-cli` and `yarn`.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
