### PR TITLE
test(docs): Ignore link check URLs [skip ci]

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -30,6 +30,10 @@ ignorePatterns:
   - pattern: "https://specifications.freedesktop.org"
   - pattern: "https://mutagen.io"
   - pattern: "https://www.npmjs.com"
+  # mailpit.axllent.org blocks linkspector's headless browser with a 403 (spam check, blocking IP)
+  - pattern: "https://mailpit.axllent.org"
+  # fixed.docs.upsun.com resets the connection to linkspector's headless browser
+  - pattern: "https://fixed.docs.upsun.com"
 aliveStatusCodes:
   - 200
   - 206


### PR DESCRIPTION

## The Issue

We're having trouble doing link check on two valid URLs, probably spam/IP blocks in these two locations.

https://github.com/ddev/ddev/actions/runs/27838410004/job/82399231318

Ignore them in .linkspector.yml