### PR TITLE
fix(docker): do not cache build on start, fixes #8433

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -715,6 +715,18 @@ func (app *DdevApp) FixObsolete() {
 		}
 	}
 
+	// Remove old .build-hash file which is no longer used
+	for _, file := range []string{".build-hash"} {
+		filePath := app.GetConfigPath(file)
+		signatureFound, err := fileutil.FgrepStringInFile(filePath, nodeps.DdevFileSignature)
+		if err == nil && signatureFound {
+			err = os.Remove(filePath)
+			if err != nil {
+				util.Warning("attempted to remove %s but failed, you may want to remove it manually: %v", filePath, err)
+			}
+		}
+	}
+
 	// Remove old global commands
 	for _, command := range []string{"host/sequelpro", "host/yarn", "host/xhgui", "web/nvm", "web/autocomplete/nvm", "web/python", "web/typo3cms"} {
 		cmdPath := filepath.Join(globalconfig.GetGlobalDdevDir(), "commands/", command)
@@ -1697,7 +1709,6 @@ func PrepDdevDirectory(app *DdevApp) error {
 	}
 	ignores = append(ignores,
 		"**/*.example",
-		".build-hash",
 		".dbimageBuild",
 		".ddev-docker-*.yaml",
 		".*downloads",

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -2085,10 +2085,4 @@ func TestLogStderrShownOnStart(t *testing.T) {
 	require.Contains(t, warnings, "foobar", "expected the failed 'foobar' command warning")
 	require.Contains(t, warnings, "failed with exit code", "expected the log-stderr.sh failure header")
 	require.Contains(t, warnings, "were not installed properly", "expected the trailing summary warning")
-
-	// When there are build warnings, the build hash is reset to only the
-	// signature (no fingerprint) to trigger a rebuild on the next `ddev start`.
-	hashContent, err := os.ReadFile(app.GetConfigPath(".build-hash"))
-	require.NoError(t, err)
-	require.Equal(t, nodeps.DdevFileSignature, string(hashContent), "build hash should be reset to only the signature when build warnings exist")
 }

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -2048,8 +2048,7 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 }
 
 // TestLogStderrShownOnStart verifies that warnings captured by log-stderr.sh during
-// the image build are shown to the user on `ddev start`, and that the build-hash file
-// is reset to only the signature (no fingerprint) so the next start rebuilds.
+// the image build are shown to the user on `ddev start`
 func TestLogStderrShownOnStart(t *testing.T) {
 	origDir, _ := os.Getwd()
 	site := TestSites[0]

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1522,24 +1522,6 @@ func (app *DdevApp) composeBuild(args ...string) (string, error) {
 	return out, fmt.Errorf("docker-compose build failed after %d attempts: %v, output='%s', stderr='%s'", composeBuildMaxRetries, lastErr, out, stderr)
 }
 
-// buildContextFingerprint returns an SHA-256 hash of the build context directories
-// (.webimageBuild, .dbimageBuild) and base image IDs. This is used to detect
-// when docker-compose build can be skipped because nothing has changed.
-// Image IDs (sha256 digests) are used instead of tag names so that
-// rebuilt images with the same tag are still detected as changed.
-func (app *DdevApp) buildContextFingerprint() string {
-	dirs := []string{
-		app.GetConfigPath(".webimageBuild"),
-		app.GetConfigPath(".dbimageBuild"),
-	}
-	hash, err := fileutil.HashDirs(dirs, dockerutil.ImageID(app.WebImage), dockerutil.ImageID(app.GetDBImage()))
-	if err != nil {
-		util.Warning("unable to hash build context directories: %v", err)
-		return ""
-	}
-	return hash
-}
-
 // Start initiates docker-compose up
 func (app *DdevApp) Start() error {
 	var err error
@@ -1852,27 +1834,6 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
-	// Build extra layers on web and db images if necessary.
-	// Skip the build entirely if the build context hasn't changed and built images exist.
-	buildHashFile := app.GetConfigPath(".build-hash")
-	currentBuildHash := nodeps.DdevFileSignature + "\n" + app.buildContextFingerprint()
-	savedBuildHash, _ := os.ReadFile(buildHashFile)
-	buildNeeded := app.NoCache || currentBuildHash != string(savedBuildHash)
-
-	if !buildNeeded {
-		// Verify the built images still exist locally
-		webBuilt := app.WebImage + "-" + app.Name + "-built"
-		dbBuilt := app.GetDBImage() + "-" + app.Name + "-built"
-		webExists, _ := dockerutil.ImageExistsLocally(webBuilt)
-		dbExists := true
-		if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
-			dbExists, _ = dockerutil.ImageExistsLocally(dbBuilt)
-		}
-		if !webExists || !dbExists {
-			buildNeeded = true
-		}
-	}
-
 	// Wait for background chown to finish before proceeding.
 	// SSH agent runs after chown (needs volumes ready) and after WriteDockerComposeYAML
 	// (reads app.ComposeYaml) — so it runs sequentially here to avoid a data race.
@@ -1886,55 +1847,52 @@ func (app *DdevApp) Start() error {
 		}
 	}
 
-	if buildNeeded {
+	if output.JSONOutput {
+		output.UserOut.Printf("Building project images...")
+	} else {
+		// Using fmt.Print to avoid a newline, as output.UserOut.Printf adds one by default.
+		// See https://github.com/sirupsen/logrus/issues/167
+		// We want the progress dots to appear on the same line.
+		fmt.Print("Building project images...")
+		// Print a newline before util.Debug below
+		if globalconfig.DdevDebug {
+			output.UserOut.Debugln()
+		}
+	}
+	buildDurationStart := util.ElapsedDuration(time.Now())
+
+	_, err = app.composeBuild()
+	if err != nil {
+		return err
+	}
+
+	_, logStderrOutput, logStderrErr := dockerutil.RunSimpleContainer(app.WebImage+"-"+app.Name+"-built", "log-stderr-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "log-stderr.sh --show 2>/dev/null || true"}, []string{}, []string{}, nil, uid, true, false, nil, nil, nil)
+	// If the web image is dirty, try to rebuild it immediately
+	if logStderrErr == nil && strings.TrimSpace(logStderrOutput) != "" && globalconfig.IsInternetActive() {
 		if output.JSONOutput {
-			output.UserOut.Printf("Building project images...")
+			output.UserOut.Printf("Rebuilding web image without cache...")
 		} else {
-			fmt.Print("Building project images...")
+			fmt.Print("Rebuilding web image without cache...")
 			if globalconfig.DdevDebug {
 				output.UserOut.Debugln()
 			}
 		}
-		buildDurationStart := util.ElapsedDuration(time.Now())
-
-		_, err = app.composeBuild()
+		_, err = app.composeBuild("web", "--no-cache")
 		if err != nil {
 			return err
 		}
+	}
 
-		_, logStderrOutput, logStderrErr := dockerutil.RunSimpleContainer(app.WebImage+"-"+app.Name+"-built", "log-stderr-"+app.Name+"-"+util.RandString(6), []string{"sh", "-c", "log-stderr.sh --show 2>/dev/null || true"}, []string{}, []string{}, nil, uid, true, false, nil, nil, nil)
-		// If the web image is dirty, try to rebuild it immediately
-		if logStderrErr == nil && strings.TrimSpace(logStderrOutput) != "" && globalconfig.IsInternetActive() {
-			if output.JSONOutput {
-				output.UserOut.Printf("Rebuilding web image without cache...")
-			} else {
-				fmt.Print("Rebuilding web image without cache...")
-				if globalconfig.DdevDebug {
-					output.UserOut.Debugln()
-				}
-			}
-			_, err = app.composeBuild("web", "--no-cache")
-			if err != nil {
-				return err
-			}
-		}
+	buildDuration := util.FormatDuration(buildDurationStart())
+	util.Success("Project images built in %s.", buildDuration)
 
-		// Save build hash on successful build
-		_ = os.WriteFile(buildHashFile, []byte(currentBuildHash), 0644)
-
-		buildDuration := util.FormatDuration(buildDurationStart())
-		util.Success("Project images built in %s.", buildDuration)
-
-		util.Debug("Removing dangling images for the project %s", app.GetComposeProjectName())
-		danglingImages, dErr := dockerutil.FindImagesByLabels(map[string]string{"com.ddev.buildhost": "", "com.docker.compose.project": app.GetComposeProjectName()}, true)
-		if dErr != nil {
-			return fmt.Errorf("unable to get dangling images for the project %s: %v", app.GetComposeProjectName(), dErr)
-		}
-		for _, danglingImage := range danglingImages {
-			_ = dockerutil.RemoveImage(danglingImage.ID)
-		}
-	} else {
-		util.Debug("Skipping docker-compose build, build context unchanged and images exist")
+	util.Debug("Removing dangling images for the project %s", app.GetComposeProjectName())
+	danglingImages, dErr := dockerutil.FindImagesByLabels(map[string]string{"com.ddev.buildhost": "", "com.docker.compose.project": app.GetComposeProjectName()}, true)
+	if dErr != nil {
+		return fmt.Errorf("unable to get dangling images for the project %s: %v", app.GetComposeProjectName(), dErr)
+	}
+	for _, danglingImage := range danglingImages {
+		_ = dockerutil.RemoveImage(danglingImage.ID)
 	}
 
 	util.Debug("Executing docker-compose -f %s up -d", app.DockerComposeFullRenderedYAMLPath())
@@ -2067,6 +2025,7 @@ func (app *DdevApp) Start() error {
 	if err != nil {
 		util.Warning("Unable to run /start.sh, stdout=%s, stderr=%s: %v", stdout, stderr, err)
 	}
+
 	// With NoBindMounts we have to symlink the copied xhprof_prepend.php into /usr/local/bin
 	// When in prepend mode, which will soon become fairly obsolete.
 	// Normally it's bind-mounted into there in prepend mode.
@@ -2162,10 +2121,6 @@ func (app *DdevApp) Start() error {
 		Cmd: "log-stderr.sh --show 2>/dev/null || true",
 	})
 	logStderr = strings.TrimSpace(logStderr)
-	// Reset the build hash when errors occur
-	if logStderr != "" {
-		_ = os.WriteFile(buildHashFile, []byte(nodeps.DdevFileSignature), 0644)
-	}
 
 	routerWg.Wait()
 	if routerErr != nil {

--- a/pkg/dockerutil/images.go
+++ b/pkg/dockerutil/images.go
@@ -57,20 +57,6 @@ func FindImagesByLabels(labels map[string]string, danglingOnly bool) ([]image.Su
 	return images.Items, nil
 }
 
-// ImageID returns the content-addressable ID (sha256:...) of a local image,
-// falling back to the tag name on any error.
-func ImageID(imageName string) string {
-	ctx, apiClient, err := GetDockerClient()
-	if err != nil {
-		return imageName
-	}
-	info, err := apiClient.ImageInspect(ctx, imageName)
-	if err != nil {
-		return imageName
-	}
-	return info.ID
-}
-
 // RemoveImage removes an image with force
 func RemoveImage(tag string) error {
 	ctx, apiClient, err := GetDockerClient()

--- a/pkg/fileutil/hash_dir.go
+++ b/pkg/fileutil/hash_dir.go
@@ -54,29 +54,3 @@ func HashDir(dir string) (string, error) {
 
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
-
-// HashDirs returns a SHA-256 hash of multiple directories' contents combined.
-// Additional strings (e.g., image names) can be included via extraStrings
-// to ensure changes to those values also produce a different hash.
-func HashDirs(dirs []string, extraStrings ...string) (string, error) {
-	h := sha256.New()
-
-	for _, s := range extraStrings {
-		_, _ = io.WriteString(h, s)
-	}
-
-	for _, dir := range dirs {
-		// Skip non-existent directories with an empty marker
-		if _, statErr := os.Stat(dir); os.IsNotExist(statErr) {
-			_, _ = io.WriteString(h, dir+":empty")
-			continue
-		}
-		dirHash, err := HashDir(dir)
-		if err != nil {
-			return "", err
-		}
-		_, _ = io.WriteString(h, dirHash)
-	}
-
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
-}

--- a/pkg/fileutil/hash_dir_test.go
+++ b/pkg/fileutil/hash_dir_test.go
@@ -36,25 +36,3 @@ func TestHashDir(t *testing.T) {
 	_, err = fileutil.HashDir(filepath.Join(dir, "nonexistent"))
 	require.Error(t, err)
 }
-
-func TestHashDirs(t *testing.T) {
-	dir1 := t.TempDir()
-	dir2 := t.TempDir()
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir1, "a.txt"), []byte("aaa"), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(dir2, "b.txt"), []byte("bbb"), 0644))
-
-	hash1, err := fileutil.HashDirs([]string{dir1, dir2})
-	require.NoError(t, err)
-	require.NotEmpty(t, hash1)
-
-	// Changing extraStrings should change the hash
-	hash2, err := fileutil.HashDirs([]string{dir1, dir2}, "image:v1")
-	require.NoError(t, err)
-	require.NotEqual(t, hash1, hash2)
-
-	// Non-existent directory should be handled gracefully
-	hash3, err := fileutil.HashDirs([]string{dir1, filepath.Join(dir1, "missing")})
-	require.NoError(t, err)
-	require.NotEmpty(t, hash3)
-}


### PR DESCRIPTION
## The Issue

- Fixes #8433

The main reason I'm going to remove `.ddev/.build-hash` is that `docker-compose.yaml` can define build contexts for any service:

- https://docs.docker.com/reference/compose-file/build/#context
- https://docs.docker.com/reference/compose-file/build/#additional_contexts (I didn't even know about this one.)

And here's the logic we currently have:

https://github.com/ddev/ddev/blob/829012792d178b1197d103c1f3aa18c8831b6b89/pkg/ddevapp/ddevapp.go#L1530-L1541

That code only handles `context` for `web` and `db`.

Any additional service or add-on that uses `context` or `additional_contexts` will not trigger a rebuild.

I also found that when `dockerfile_inline` is used, the build context defaults to `.`, which means the `.ddev` directory. In that case, DDEV computes `.ddev/.build-hash` from the entire directory, including `.ddev/.build-hash` itself, `.ddev/.db_snapshots` (which can be huge), and any other files users happen to place in `.ddev`.

Claude's response was: "That's easy - just don't compute the hash when the context is `.ddev`; only do it for contexts in subdirectories such as `.ddev/.webimageBuild`."

But that's not correct. If a user has `COPY` or `ADD` instructions in their `Dockerfile` or `dockerfile_inline`, and the build context is `.ddev`, then changes within `.ddev` absolutely must be taken into account.

## How This PR Solves The Issue

- Reverts changes from #8145 related to build.
- Removes `.ddev/.build-hash` on `ddev start`.

## Manual Testing Instructions

Run `ddev start && ddev restart`, see `Building project images...` from both commands.

## Automated Testing Overview

I expect all the tests to run slower, but it's better to be safe than sorry.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
