### PR TITLE
feat(drupal): Support new dr command built into drupal11.4+, fixes #8500

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -234,7 +234,7 @@ func TestCustomCommands(t *testing.T) {
 	}
 
 	// New Drupal commands in drupal11/12+
-	for _, drupalType := range []string{nodeps.AppTypeDrupal11, nodeps.AppTypeDrupal12} {
+	for _, drupalType := range []string{nodeps.AppTypeDrupal, nodeps.AppTypeDrupal12, nodeps.AppTypeDrupal11} {
 		app.Type = drupalType
 		_ = app.WriteConfig()
 		_, _ = exec.RunHostCommand(DdevBin)

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -191,7 +191,7 @@ func TestCustomCommands(t *testing.T) {
 		assert.NoError(err, "Failed to run ddev %s --version", c)
 	}
 	// The various CMS commands should not be available here
-	for _, c := range []string{"artisan", "art", "cake", "drush", "magento", "typo3", "wp"} {
+	for _, c := range []string{"artisan", "art", "cake", "dr", "drush", "magento", "typo3", "wp"} {
 		_, err = exec.RunHostCommand(DdevBin, c, "-h")
 		assert.Error(err, "found command %s when it should not have been there (no error) app.Type=%s", c, app.Type)
 	}
@@ -228,6 +228,20 @@ func TestCustomCommands(t *testing.T) {
 		assert.NoError(err)
 
 		for _, c := range []string{"drush"} {
+			_, err = exec.RunHostCommand(DdevBin, "help", c)
+			assert.NoError(err)
+		}
+	}
+
+	// New Drupal commands in drupal11/12+
+	for _, drupalType := range []string{nodeps.AppTypeDrupal11, nodeps.AppTypeDrupal12} {
+		app.Type = drupalType
+		_ = app.WriteConfig()
+		_, _ = exec.RunHostCommand(DdevBin)
+		err = app.MutagenSyncFlush()
+		assert.NoError(err)
+
+		for _, c := range []string{"dr"} {
 			_, err = exec.RunHostCommand(DdevBin, "help", c)
 			assert.NoError(err)
 		}

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -59,6 +59,7 @@ The dashboard automatically detects your terminal's color capabilities and adapt
 * [`ddev xdebug`](../usage/commands.md#xdebug) enables Xdebug, `ddev xdebug off` disables it, and `ddev xdebug status` shows status. You can toggle Xdebug on and off easily using `ddev xdebug toggle`.
 * [`ddev xhprof`](../usage/commands.md#xhprof) enables xhprof, `ddev xhprof off` disables it, and `ddev xhprof status` shows status.
 * [`ddev xhgui`](../usage/commands.md#xhgui) enables XHGui, `ddev xhgui off` disables it, and `ddev xhgui status` shows status.
+* [`ddev dr`](../usage/commands.md#dr) (Drupal 11.4+ only) gives direct access to the `dr` CLI, the next-generation Drupal CLI available in Drupal 11.4+.
 * [`ddev drush`](../usage/commands.md#drush) (Drupal and Backdrop only) gives direct access to the `drush` CLI.
 * [`ddev artisan`](../usage/commands.md#artisan) (Laravel only) gives direct access to the Laravel `artisan` CLI.
 * [`ddev asterios`](../usage/commands.md#asterios) (Asterios only) gives direct access to the Asterios `asterios` CLI.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -621,11 +621,18 @@ ddev dotenv set .ddev/.env --extra value --another-key "extra value"
 ddev dotenv set .ddev/.env.redis --redis-tag 7-bookworm
 ```
 
+## `dr`
+
+Run the Drupal `dr` CLI; available only in projects of type `drupal11` and `drupal12`, and only if `dr` is available in the project (Drupal 11.4+).
+
+```shell
+# Show dr status
+ddev dr system:status
+```
+
 ## `drush`
 
-*Alias: `dr`.*
-
-Run the `drush` command; available only in projects of type `drupal*`, and only available if `drush` is in the project. On projects of type `drupal`, `drush` should be installed in the project itself, (`ddev composer require drush/drush`). On projects of type `drupal7` `drush` 8 is provided by DDEV.
+Run the `drush` command; available only in projects of type `drupal*` and `backdrop`, and only available if `drush` is in the project. On projects of type `drupal`, `drush` should be installed in the project itself, (`ddev composer require drush/drush`). On projects of type `drupal7` `drush` 8 is provided by DDEV.
 
 ```shell
 # Show drush status/configuration

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/dr
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/dr
@@ -4,12 +4,9 @@
 ## Description: Run dr CLI (Drupal 11.4+) inside the web container
 ## Usage: dr [flags] [args]
 ## Example: "ddev dr cr" or "ddev dr list" or "ddev dr system:status"
-## ProjectTypes: drupal11,drupal12
+## ProjectTypes: drupal,drupal11,drupal12
 ## ExecRaw: true
 ## MutagenSync: true
-
-# Ignore anything we find in the mounted global commands
-PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
 
 if ! command -v dr >/dev/null; then
   echo "dr is not available. It should be available in composer-installed Drupal 11.4+ projects."

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/dr
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/dr
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run dr CLI (Drupal 11.4+) inside the web container
+## Usage: dr [flags] [args]
+## Example: "ddev dr cr" or "ddev dr list" or "ddev dr system:status"
+## ProjectTypes: drupal11,drupal12
+## ExecRaw: true
+## MutagenSync: true
+
+# Ignore anything we find in the mounted global commands
+PATH=${PATH//\/mnt\/ddev-global-cache\/global-commands\/web/}
+
+if ! command -v dr >/dev/null; then
+  echo "dr is not available. It should be available in composer-installed Drupal 11.4+ projects."
+  exit 1
+fi
+dr "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/drush
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/drush
@@ -4,7 +4,6 @@
 ## Description: Run drush CLI inside the web container
 ## Usage: drush [flags] [args]
 ## Example: "ddev drush uli" or "ddev drush sql-cli" or "ddev drush --version"
-## Aliases: dr
 ## ProjectTypes: drupal,drupal12,drupal11,drupal10,drupal9,drupal8,drupal7,backdrop
 ## ExecRaw: true
 ## MutagenSync: true


### PR DESCRIPTION

## The Issue

* #8500 

Where available, the new Drupal 11.4+ core command `dr` is supported.

## How This PR Solves The Issue

* Add `dr`
* Remove the `dr` alias from `ddev drush`
* Add to docs

## Manual Testing Instructions

Drupal 11.4 isn't out yet, but you can composer-install the HEAD version of drupal11 with

```
ddev composer create-project "drupal/recommended-project:11.x-dev@dev"
```

For drupal12, use the drupal12 quickstart

1. Set up a Drupal 11.4+ project: 
	```
	ddev config --project-type=drupal11 --docroot=web && ddev start
    ```
3. Install Drupal with web UI or otherwise. To do it with `dr`:
	```
	rm -r web/sites/default/files/* web/sites/default/settings.php
	ddev dr install demo_umami
	```
4. Run ddev dr system:status — should execute the dr command inside the web container
5. Run ddev dr in a non-drupal11/12 project type — command should not be available
6. Run ddev drush — should still work as before, no longer has a dr alias
7. Run ddev dr in a drupal11 project without dr installed (11.3)— should print a helpful error message

## Automated Testing Overview

* `dr` test was added to TestCustomCommands

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
