### PR TITLE
ci(github): add brew sandbox setup, remove obsolete env, for #8469

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -33,11 +33,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   DDEV_IGNORE_EXPIRING_KEYS: ${{ vars.DDEV_IGNORE_EXPIRING_KEYS || 'true' }}
   DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION: ${{ vars.DDEV_MAX_DAYS_BEFORE_CERT_EXPIRATION || '90' }}
-  HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  HOMEBREW_NO_SANDBOX_LINUX: 1
 
 permissions:
   contents: read
@@ -58,6 +55,9 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
+        with:
+          brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
+          setup-sandbox: true
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -29,12 +29,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  HOMEBREW_NO_SANDBOX_LINUX: 1
-
 permissions:
   actions: write
 
@@ -47,10 +41,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Spellcheck
         uses: rojopolis/spellcheck-github-actions@v0
@@ -70,7 +60,7 @@ jobs:
         with:
           limit-access-to-actor: true
       - name: Run linkspector to check external links
-        uses: umbrelladocs/action-linkspector@v1.4.0
+        uses: umbrelladocs/action-linkspector@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,9 +21,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 permissions:
   contents: read
 
@@ -43,9 +40,6 @@ jobs:
         with:
           go-version: '>=1.23'
           check-latest: true
-
-      - name: Add Homebrew to PATH
-        run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
 
       - name: Lint Go Files
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -231,6 +231,8 @@ echo "capath=/etc/ssl/certs/" >>~/.curlrc
 
 source ~/.bashrc
 
+brew trust bats-core/bats-core
+
 for item in bats-core bats-core/bats-core/bats-assert bats-core/bats-core/bats-file bats-core/bats-core/bats-support ddev/ddev/ddev golangci-lint; do
   brew install $item >/dev/null || brew upgrade -y $item >/dev/null
 done

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -24,7 +24,6 @@ on:
 #  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   AmplitudeAPIKey: ${{ secrets.AMPLITUDE_API_KEY }}
   BUILDKIT_PROGRESS: plain
   DOCKER_CLI_EXPERIMENTAL: enabled
@@ -34,7 +33,6 @@ env:
   HOMEBREW_STABLE_REPOSITORY: ${{ vars.HOMEBREW_STABLE_REPOSITORY }}
   REPOSITORY_OWNER: ${{ github.repository_owner }}
   DOCKER_ORG: ${{ vars.DOCKER_ORG }}
-  HOMEBREW_NO_SANDBOX_LINUX: 1
 
 permissions:
   packages: write
@@ -53,6 +51,9 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
+        with:
+          brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
+          setup-sandbox: true
 
       - name: Install Docker and deps
         run: ./.github/workflows/linux-setup.sh

--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -3,8 +3,6 @@ on:
   workflow_run:
     workflows: ['PR Build']
     types: [completed]
-env:
-  HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
   actions: write

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,13 +23,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   BUILDKIT_PROGRESS: plain
   DOCKER_CLI_EXPERIMENTAL: enabled
   DDEV_DEBUG: true
-  HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  HOMEBREW_NO_SANDBOX_LINUX: 1
-
 
 permissions:
   contents: read
@@ -46,9 +42,6 @@ jobs:
           # We need to get all branches and tags for git describe to work properly
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Install build tools
         run: ./.github/workflows/linux-build-setup.sh

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -27,11 +27,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  HOMEBREW_NO_SANDBOX_LINUX: 1
-
 permissions:
   actions: write
 
@@ -60,6 +55,9 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
+        with:
+          brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
+          setup-sandbox: true
 
       - name: Remove unnecessary items on disk
         uses: jlumbroso/free-disk-space@main
@@ -93,6 +91,8 @@ jobs:
           limit-access-to-actor: true
 
       - name: Run quickstart test
+        env:
+          DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           brew unlink ddev || true
           rm -f ~/.config/ddev

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -121,12 +121,10 @@ jobs:
     runs-on: ${{ inputs.runner }}
 
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
       BUILDKIT_PROGRESS: plain
       DOCKER_CLI_EXPERIMENTAL: enabled
       DDEV_DEBUG: true
       DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CGO_ENABLED: ${{ inputs.cgo_enabled }}
       DDEV_NONINTERACTIVE: "true"
       DDEV_SKIP_NODEJS_TEST: ${{ inputs.ddev_skip_nodejs_test }}
@@ -141,7 +139,6 @@ jobs:
       DDEV_TEST_PODMAN_ROOTLESS: ${{ inputs.ddev_test_podman_rootless }}
       DDEV_TEST_PODMAN_ROOT: ${{ inputs.ddev_test_podman_root }}
       DDEV_TEST_DOCKER_ROOTLESS: ${{ inputs.ddev_test_docker_rootless }}
-      HOMEBREW_NO_SANDBOX_LINUX: 1
 
     steps:
       - uses: actions/checkout@v7
@@ -187,6 +184,9 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
+        with:
+          brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
+          setup-sandbox: true
 
       - name: Remove unnecessary items on disk
         uses: jlumbroso/free-disk-space@main

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -29,7 +29,7 @@ To disable the dashboard and show the classic help text instead, set [`no_tui: t
 
 The dashboard automatically detects your terminal's color capabilities and adapts its output. If colors or styling don't render correctly in your terminal, you have several options:
 
-* **Disable colors**: Run `NO_COLOR=1 ddev` or `export NO_COLOR=1` in your shell. This follows the [NO_COLOR](https://no-color.org/) standard and disables all color output while keeping the dashboard functional.
+* **Disable colors**: Run `NO_COLOR=1 ddev` or `export NO_COLOR=1` in your shell to disable all color output while keeping the dashboard functional.
 * **Use simple formatting globally**: Run `ddev config global --simple-formatting=true` to disable colors and table formatting across all DDEV commands, including the dashboard. See [`simple_formatting`](../configuration/config.md#simple_formatting).
 * **Set `TERM` appropriately**: If your terminal supports color but DDEV doesn't detect it, make sure your `TERM` environment variable is set correctly (e.g., `xterm-256color`). Some SSH clients or multiplexers like `tmux` or `screen` may need explicit configuration.
 * **Disable the dashboard entirely**: If the interactive dashboard doesn't work well in your environment (e.g., a very limited terminal or CI), use `DDEV_NO_TUI=true` or set [`no_tui: true`](../configuration/config.md#no_tui) in `$HOME/.ddev/global_config.yaml` to fall back to the classic help output.


### PR DESCRIPTION
## The Issue

- For #8469

## How This PR Solves The Issue

- Replaces `HOMEBREW_NO_SANDBOX_LINUX=1` with `setup-sandbox: true`
- Replaces `HOMEBREW_GITHUB_API_TOKEN` with `brew-gh-api-token`
- Bumps `umbrelladocs/action-linkspector@v1.4.0` to use `v1` (`v1.4.0` used Node.js v20)
- Removes `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`
- Removes `Homebrew/actions/setup-homebrew@main` from workflows where it's in use
- Removes link to https://no-color.org/ from the docs, the website is down, and I don't see any recent activity in https://github.com/jcs/no_color

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
