### PR TITLE
fix(mysql): guard ENV HOME injection to db context only, fixes #8508

### DIFF
--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1245,10 +1245,12 @@ SHELL ["/bin/bash", "-c"]
 `
 	// bitnami/mysql inappropriately sets ENV HOME=/, see https://github.com/bitnami/containers/issues/75578
 	// Setting HOME="" allows it to have its normal behavior for the added user.
-	if app.Database.Type == nodeps.MySQL && (app.Database.Version == nodeps.MySQL80 || app.Database.Version == nodeps.MySQL84) {
-		contents = contents + `
+	if strings.Contains(fullpath, "dbimageBuild") {
+		if app.Database.Type == nodeps.MySQL && (app.Database.Version == nodeps.MySQL80 || app.Database.Version == nodeps.MySQL84) {
+			contents = contents + `
 ENV HOME=""
 `
+		}
 	}
 
 	//  The ENV HOME="" is added for bitnami/mysql habit of overriding ENV HOME=/

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1243,9 +1243,10 @@ ARG BASE_IMAGE="scratch"
 FROM $BASE_IMAGE
 SHELL ["/bin/bash", "-c"]
 `
-	// bitnami/mysql inappropriately sets ENV HOME=/, see https://github.com/bitnami/containers/issues/75578
-	// Setting HOME="" allows it to have its normal behavior for the added user.
+
 	if strings.Contains(fullpath, "dbimageBuild") {
+		// bitnami/mysql sets ENV HOME=/, breaking root-based tooling; see https://github.com/bitnami/containers/issues/75578
+		// Setting HOME="" resets it to the default (/root). Must be injected here, not in extraDBContent - that runs after user-defined Dockerfiles.
 		if app.Database.Type == nodeps.MySQL && (app.Database.Version == nodeps.MySQL80 || app.Database.Version == nodeps.MySQL84) {
 			contents = contents + `
 ENV HOME=""


### PR DESCRIPTION
## The Issue

- Fixes #8508

## How This PR Solves The Issue

Uses appropriate condition.

## Manual Testing Instructions

I didn't test it.

Using macOS + Podman:

```bash
ddev config --database=mysql:8.0
ddev start # should be no error here
```

The only thing I can confirm: no more `ENV HOME=""` inside:

- `.ddev/.webimageBuild/Dockerfile`
- `$HOME/.ddev/.sshimageBuild/Dockerfile`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
