### PR TITLE
fix(podman): restrict keep-id userns to Linux only, fixes #8223, fixes #8529

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -396,7 +396,7 @@ func TestLaunchCommand(t *testing.T) {
 	}
 }
 
-// TestMysqlCommand tests `ddev mysql“
+// TestMysqlCommand tests `ddev mysql`
 func TestMysqlCommand(t *testing.T) {
 	assert := asrt.New(t)
 
@@ -419,28 +419,52 @@ func TestMysqlCommand(t *testing.T) {
 		assert.NoError(err)
 	})
 
-	err = app.WriteConfig()
-	require.NoError(t, err)
-
 	// This populates the project's
 	// /mnt/ddev-global-cache/global-commands/ which otherwise doesn't get done until ddev start
 	// This matters when --no-bind-mount=true
 	_, err = exec.RunHostCommand("ddev")
 	assert.NoError(err)
 
-	err = app.Start()
-	require.NoError(t, err)
+	dbVersionsToTest := []ddevapp.DatabaseDesc{
+		{Type: nodeps.MariaDB, Version: nodeps.MariaDBDefaultVersion},
+	}
+	if os.Getenv("GOTEST_SHORT") == "" {
+		dbVersionsToTest = append(dbVersionsToTest,
+			ddevapp.DatabaseDesc{Type: nodeps.MySQL, Version: nodeps.MySQL80},
+			ddevapp.DatabaseDesc{Type: nodeps.MySQL, Version: nodeps.MySQL84},
+		)
+	}
 
-	// Test ddev mysql -uroot -proot mysql
-	command := osexec.Command("bash", "-c", "echo 'SHOW TABLES;' | "+DdevBin+" mysql --user=root --password=root --database=mysql")
-	byteOut, err := command.CombinedOutput()
-	assert.NoError(err, "byteOut=%v", string(byteOut))
-	assert.Contains(string(byteOut), `Tables_in_mysql
-column_stats
-columns_priv`)
+	for i, dbDesc := range dbVersionsToTest {
+		desc := fmt.Sprintf("%s:%s", dbDesc.Type, dbDesc.Version)
+		t.Logf("Testing ddev mysql with %s", desc)
+
+		if i > 0 {
+			err = app.Stop(true, false)
+			require.NoError(t, err)
+		}
+		app.Database = dbDesc
+		err = app.WriteConfig()
+		require.NoError(t, err)
+		err = app.Start()
+		require.NoError(t, err, "app.Start() failed for %s", desc)
+
+		// Test ddev mysql with explicit credentials
+		command := osexec.Command("bash", "-c", "echo 'SHOW TABLES;' | "+DdevBin+" mysql --user=root --password=root --database=mysql")
+		byteOut, err := command.CombinedOutput()
+		require.NoError(t, err, "ddev mysql with explicit credentials failed for %s: %s", desc, string(byteOut))
+		assert.Contains(string(byteOut), "columns_priv", "unexpected output for %s: %s", desc, string(byteOut))
+
+		// Test ddev mysql without explicit credentials; relies on ~/.my.cnf being found via HOME.
+		// This is a regression test for https://github.com/ddev/ddev/issues/8529 where
+		// HOME="" on Podman/macOS prevented mysql from reading ~/.my.cnf.
+		command = osexec.Command("bash", "-c", "echo 'SELECT 1;' | "+DdevBin+" mysql")
+		byteOut, err = command.CombinedOutput()
+		require.NoError(t, err, "ddev mysql without credentials failed for %s: %s", desc, string(byteOut))
+	}
 }
 
-// TestPsqlCommand tests `ddev psql“
+// TestPsqlCommand tests `ddev psql"
 func TestPsqlCommand(t *testing.T) {
 	assert := asrt.New(t)
 

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -74,6 +74,7 @@ services:
       {{- if ne (env "DDEV_PAGER") "" }}
       - PAGER=${DDEV_PAGER}
       {{- end }}
+      - HOME=/home/{{ .Username }}
       - TZ={{ .Timezone }}
       - USER={{ .Username }}
     command: ${DDEV_DB_CONTAINER_COMMAND}

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/docker/compose/v5/pkg/api"
@@ -334,8 +333,7 @@ func fixupComposeYaml(project *composeTypes.Project, app *DdevApp) (*composeType
 		}
 
 		if isRootless && service.User == userGroup {
-			if isPodman && nodeps.IsLinux() {
-				// macOS Podman VM lacks subgid mappings for macOS host GIDs (e.g. GID 20/staff)
+			if dockerutil.UseKeepID() {
 				// Podman: set the user namespace mode for the container
 				// https://docs.podman.io/en/v4.6.1/markdown/options/userns.container.html#userns-mode
 				service.UserNSMode = "keep-id"

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/docker/compose/v5/pkg/api"
@@ -333,7 +334,8 @@ func fixupComposeYaml(project *composeTypes.Project, app *DdevApp) (*composeType
 		}
 
 		if isRootless && service.User == userGroup {
-			if isPodman {
+			if isPodman && nodeps.IsLinux() {
+				// macOS Podman VM lacks subgid mappings for macOS host GIDs (e.g. GID 20/staff)
 				// Podman: set the user namespace mode for the container
 				// https://docs.podman.io/en/v4.6.1/markdown/options/userns.container.html#userns-mode
 				service.UserNSMode = "keep-id"

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1260,7 +1260,9 @@ SHELL ["/bin/bash", "-c"]
 
 	if strings.Contains(fullpath, "dbimageBuild") {
 		// bitnami/mysql sets ENV HOME=/, breaking root-based tooling; see https://github.com/bitnami/containers/issues/75578
-		// Setting HOME="" resets it to the default (/root). Must be injected here, not in extraDBContent - that runs after user-defined Dockerfiles.
+		// ENV HOME="" overrides bitnami's HOME=/ during the image build phase (RUN commands).
+		// Runtime HOME is set correctly via the compose environment (HOME=/home/<username>).
+		// Must be injected here, not in extraDBContent - that runs after user-defined Dockerfiles.
 		if app.Database.Type == nodeps.MySQL && (app.Database.Version == nodeps.MySQL80 || app.Database.Version == nodeps.MySQL84) {
 			contents = contents + `
 ENV HOME=""
@@ -1268,7 +1270,7 @@ ENV HOME=""
 		}
 	}
 
-	//  The ENV HOME="" is added for bitnami/mysql habit of overriding ENV HOME=/
+	//  The ENV HOME="" above guards against bitnami/mysql's ENV HOME=/ during image build
 	contents = contents + `
 ARG TARGETPLATFORM
 ARG TARGETARCH

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1758,7 +1758,7 @@ func (app *DdevApp) Start() error {
 	volumeMounts := []string{"ddev-global-cache:/mnt/ddev-global-cache"}
 	chownCmd := fmt.Sprintf("chown -R %s:%s /mnt/ddev-global-cache", uid, gid)
 	labels := map[string]string{}
-	if dockerutil.IsPodmanRootless() {
+	if dockerutil.UseKeepID() {
 		labels["com.ddev.userns"] = "keep-id"
 	}
 

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -272,6 +272,7 @@ func generateRouterCompose(activeApps []*DdevApp) (string, error) {
 		"Hostnames":                  determineRouterHostnames(activeApps),
 		"IsPodman":                   dockerutil.IsPodman(),
 		"IsRootless":                 dockerutil.IsRootless(),
+		"IsLinux":                    nodeps.IsLinux(),
 	}
 
 	t, err := template.New("router_compose_template.yaml").Funcs(getTemplateFuncMap()).ParseFS(bundledAssets, "router_compose_template.yaml")

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -272,7 +272,7 @@ func generateRouterCompose(activeApps []*DdevApp) (string, error) {
 		"Hostnames":                  determineRouterHostnames(activeApps),
 		"IsPodman":                   dockerutil.IsPodman(),
 		"IsRootless":                 dockerutil.IsRootless(),
-		"IsLinux":                    nodeps.IsLinux(),
+		"UseKeepID":                  dockerutil.UseKeepID(),
 	}
 
 	t, err := template.New("router_compose_template.yaml").Funcs(getTemplateFuncMap()).ParseFS(bundledAssets, "router_compose_template.yaml")

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -10,7 +10,7 @@ services:
     init: true
     user: {{ .UID }}:{{ .GID }}
 
-    {{ if and .IsPodman .IsRootless }}
+    {{ if and .IsPodman .IsRootless .IsLinux }}
     userns_mode: keep-id
     {{ end }}
 

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -10,7 +10,7 @@ services:
     init: true
     user: {{ .UID }}:{{ .GID }}
 
-    {{ if and .IsPodman .IsRootless .IsLinux }}
+    {{ if .UseKeepID }}
     userns_mode: keep-id
     {{ end }}
 

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -12,6 +12,7 @@ import (
 	ddevImages "github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/docker/compose/v5/cmd/display"
 	"github.com/docker/compose/v5/pkg/api"
@@ -151,6 +152,7 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 		"GID":              gid,
 		"Timezone":         timezone,
 		"IsPodmanRootless": dockerutil.IsPodmanRootless(),
+		"IsLinux":          nodeps.IsLinux(),
 	}
 	t, err := template.New("ssh_auth_compose_template.yaml").Funcs(getTemplateFuncMap()).ParseFS(bundledAssets, "ssh_auth_compose_template.yaml")
 	if err != nil {

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -12,7 +12,6 @@ import (
 	ddevImages "github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
-	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/docker/compose/v5/cmd/display"
 	"github.com/docker/compose/v5/pkg/api"
@@ -147,12 +146,11 @@ func (app *DdevApp) CreateSSHAuthComposeFile() (string, error) {
 	_ = app.DockerEnv()
 
 	templateVars := map[string]any{
-		"SSHAuthImage":     ddevImages.GetSSHAuthImage(),
-		"UID":              uid,
-		"GID":              gid,
-		"Timezone":         timezone,
-		"IsPodmanRootless": dockerutil.IsPodmanRootless(),
-		"IsLinux":          nodeps.IsLinux(),
+		"SSHAuthImage": ddevImages.GetSSHAuthImage(),
+		"UID":          uid,
+		"GID":          gid,
+		"Timezone":     timezone,
+		"UseKeepID":    dockerutil.UseKeepID(),
 	}
 	t, err := template.New("ssh_auth_compose_template.yaml").Funcs(getTemplateFuncMap()).ParseFS(bundledAssets, "ssh_auth_compose_template.yaml")
 	if err != nil {

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   ddev-ssh-agent:
-    {{ if .IsPodmanRootless .IsLinux }}
+    {{ if and .IsPodmanRootless .IsLinux }}
     userns_mode: keep-id
     {{ end }}
     container_name: ddev-ssh-agent

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   ddev-ssh-agent:
-    {{ if and .IsPodmanRootless .IsLinux }}
+    {{ if .UseKeepID }}
     userns_mode: keep-id
     {{ end }}
     container_name: ddev-ssh-agent

--- a/pkg/ddevapp/ssh_auth_compose_template.yaml
+++ b/pkg/ddevapp/ssh_auth_compose_template.yaml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   ddev-ssh-agent:
-    {{ if .IsPodmanRootless }}
+    {{ if .IsPodmanRootless .IsLinux }}
     userns_mode: keep-id
     {{ end }}
     container_name: ddev-ssh-agent

--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -693,8 +693,8 @@ func RunSimpleContainerExtended(name string, config *container.Config, hostConfi
 			if usernsMode, exists := config.Labels["com.ddev.userns"]; exists {
 				hostConfig.UsernsMode = container.UsernsMode(usernsMode)
 			}
-		} else if nodeps.IsLinux() {
-			// Always use "keep-id" for non-root users on Linux
+		} else if UseKeepID() {
+			// Use "keep-id" for non-root users (Linux rootless Podman only)
 			hostConfig.UsernsMode = "keep-id"
 		}
 	}

--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -693,8 +693,8 @@ func RunSimpleContainerExtended(name string, config *container.Config, hostConfi
 			if usernsMode, exists := config.Labels["com.ddev.userns"]; exists {
 				hostConfig.UsernsMode = container.UsernsMode(usernsMode)
 			}
-		} else {
-			// Always use "keep-id" for non-root users
+		} else if nodeps.IsLinux() {
+			// Always use "keep-id" for non-root users on Linux
 			hostConfig.UsernsMode = "keep-id"
 		}
 	}

--- a/pkg/dockerutil/providers.go
+++ b/pkg/dockerutil/providers.go
@@ -108,6 +108,21 @@ func IsPodmanRootless() bool {
 	return IsRootless() && IsPodman()
 }
 
+// UseKeepID reports whether containers and volume operations should use Podman's
+// "keep-id" user-namespace mode. This is the single source of truth for the
+// decision: every container we create and every volume copy/chown must agree,
+// because they share volumes (notably ddev-global-cache) and a uid written
+// under one userns mapping is unreadable under another.
+//
+// keep-id is correct only on Linux rootless Podman, where it maps the host
+// uid/gid into the container so bind-mounted files have the host's ownership.
+// On macOS/Windows, Podman runs in a Linux VM whose subuid/subgid range cannot
+// map host GIDs (e.g. macOS GID 20/staff), so keep-id must not be used; all
+// containers run under Podman's default rootless userns instead.
+func UseKeepID() bool {
+	return IsPodmanRootless() && nodeps.IsLinux()
+}
+
 // IsDockerRootless detects if Docker is running in rootless mode on Linux
 // It must not be Podman or Lima, which can be rootless as well.
 func IsDockerRootless() bool {

--- a/pkg/dockerutil/volumes.go
+++ b/pkg/dockerutil/volumes.go
@@ -131,7 +131,7 @@ func CopyIntoVolume(sourcePath string, volumeName string, targetSubdir string, u
 	c = c + "mkdir -p " + targetSubdirFullPath + " && sleep infinity "
 
 	labels := map[string]string{}
-	if IsPodmanRootless() {
+	if UseKeepID() {
 		labels["com.ddev.userns"] = "keep-id"
 	}
 	containerID, _, err := RunSimpleContainer(versionconstants.UtilitiesImage, containerName, []string{"bash", "-c", c}, nil, nil, []string{volumeName + ":" + volPath}, "0", false, true, labels, nil, nil)
@@ -243,7 +243,7 @@ func PurgeDirectoryContentsInVolume(volumeName string, subdirs []string, uid str
 	c := fmt.Sprintf("mkdir -p %s && rm -rf %s", strings.Join(mkdirs, " "), strings.Join(rmPaths, " "))
 
 	labels := map[string]string{}
-	if IsPodmanRootless() {
+	if UseKeepID() {
 		labels["com.ddev.userns"] = "keep-id"
 	}
 	_, _, err := RunSimpleContainer(versionconstants.UtilitiesImage, containerName, []string{"bash", "-c", c}, nil, nil, []string{volumeName + ":" + volPath}, "0", true, false, labels, nil, nil)
@@ -272,7 +272,7 @@ func ListFilesInVolume(volumeName string, subdir string) ([]string, error) {
 	c := fmt.Sprintf(`ls -1 "%s" 2>/dev/null || true`, fullPath)
 
 	labels := map[string]string{}
-	if IsPodmanRootless() {
+	if UseKeepID() {
 		labels["com.ddev.userns"] = "keep-id"
 	}
 	_, stdout, err := RunSimpleContainer(versionconstants.UtilitiesImage, containerName, []string{"bash", "-c", c}, nil, nil, []string{volumeName + ":" + volPath}, "0", true, false, labels, nil, nil)
@@ -317,7 +317,7 @@ func RemoveFilesFromVolume(volumeName string, subdir string, files []string) err
 	c := fmt.Sprintf("rm -f %s", strings.Join(rmPaths, " "))
 
 	labels := map[string]string{}
-	if IsPodmanRootless() {
+	if UseKeepID() {
 		labels["com.ddev.userns"] = "keep-id"
 	}
 	_, _, err := RunSimpleContainer(versionconstants.UtilitiesImage, containerName, []string{"bash", "-c", c}, nil, nil, []string{volumeName + ":" + volPath}, "0", true, false, labels, nil, nil)


### PR DESCRIPTION
## The Issue

- Fixes #8223
- Fixes #8529 

Since we were workinig on this and found solution to #8529 went ahead and fixed here.

## How This PR Solves The Issue

Sets `keep-id` only for Podman Linux.

## Manual Testing Instructions

Run Podman on macOS with Mutagen, `ddev start` should work as expected.

Try to do the same with `ddev config global --performance-mode=none` - this one is probably going to break.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
