### PR TITLE
fix(dbeaver): Add flatpak user binary path to search list, fixes #8517

### DIFF
--- a/cmd/ddev/cmd/commands.go
+++ b/cmd/ddev/cmd/commands.go
@@ -252,11 +252,14 @@ func addCustomCommandsFromDir(rootCmd *cobra.Command, app *ddevapp.DdevApp, serv
 
 		// If hostBinaryExists is specified it doesn't exist here, skip
 		if hostBinaryExists != "" {
-			binExists := false
 			bins := strings.Split(hostBinaryExists, ",")
-			if slices.ContainsFunc(bins, fileutil.FileExists) {
-				binExists = true
-			}
+			binExists := slices.ContainsFunc(bins, func(p string) bool {
+				expanded, err := util.ExpandHomedir(strings.TrimSpace(p))
+				if err != nil {
+					expanded = p
+				}
+				return fileutil.FileExists(expanded)
+			})
 			if !binExists {
 				if isCustomCommandInArgs(commandName) {
 					suggestedBinaries, _ := util.ArrayToReadableOutput(bins)

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -5,7 +5,7 @@
 ## Usage: dbeaver
 ## Example: "ddev dbeaver [db] [user]"
 ## OSTypes: darwin,linux,wsl2,windows
-## HostBinaryExists: /Applications/DBeaver.app,/usr/bin/dbeaver,/usr/bin/dbeaver-ce,/usr/bin/dbeaver-le,/usr/bin/dbeaver-ue,/usr/bin/dbeaver-ee,/var/lib/flatpak/exports/bin/io.dbeaver.DBeaverCommunity,/snap/bin/dbeaver-ce,/mnt/c/Program Files/DBeaver/dbeaver.exe,/mnt/c/Program Files/DBeaverLite/dbeaver.exe,/mnt/c/Program Files/DBeaverUltimate/dbeaver.exe,/mnt/c/Program Files/DBeaverEE/dbeaver.exe,C:\Program Files\DBeaver\dbeaver.exe,C:\Program Files\DBeaverLite\dbeaver.exe,C:\Program Files\DBeaverUltimate\dbeaver.exe,C:\Program Files\DBeaverEE\dbeaver.exe
+## HostBinaryExists: /Applications/DBeaver.app,/usr/bin/dbeaver,/usr/bin/dbeaver-ce,/usr/bin/dbeaver-le,/usr/bin/dbeaver-ue,/usr/bin/dbeaver-ee,/var/lib/flatpak/exports/bin/io.dbeaver.DBeaverCommunity,~/.local/share/flatpak/exports/bin/io.dbeaver.DBeaverCommunity,/snap/bin/dbeaver-ce,/mnt/c/Program Files/DBeaver/dbeaver.exe,/mnt/c/Program Files/DBeaverLite/dbeaver.exe,/mnt/c/Program Files/DBeaverUltimate/dbeaver.exe,/mnt/c/Program Files/DBeaverEE/dbeaver.exe,C:\Program Files\DBeaver\dbeaver.exe,C:\Program Files\DBeaverLite\dbeaver.exe,C:\Program Files\DBeaverUltimate\dbeaver.exe,C:\Program Files\DBeaverEE\dbeaver.exe
 
 if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/dbeaver
@@ -37,6 +37,7 @@ case $OSTYPE in
     BINARIES=(
       /usr/bin/dbeaver{,-ce,-le,-ue,-ee}
       /var/lib/flatpak/exports/bin/io.dbeaver.DBeaverCommunity
+      ~/.local/share/flatpak/exports/bin/io.dbeaver.DBeaverCommunity
       /snap/bin/dbeaver-ce
       '/mnt/c/Program Files/DBeaver'{,Lite,Ultimate,EE}'/dbeaver.exe'
     )


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- Fixes #8517

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

- Adds missing `~/.local/share/flatpak/exports/bin/io.dbeaver.DBeaverCommunity` path to the dbeaver command's HostBinaryExists list as well as the binaries that are searched for by the command.

- Modifies the ddev command runner to expand home directories in the paths provided by the command's hostBinaryExist param 
