### PR TITLE
feat(docker): respect docker-buildx from snap on linux, fixes #8515

### DIFF
--- a/pkg/dockerutil/docker_manager.go
+++ b/pkg/dockerutil/docker_manager.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"os/exec"
 	"path/filepath"
 	"sync"
 
 	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/docker/cli/cli-plugins/manager"
@@ -80,12 +82,8 @@ func getDockerManagerInstance() (*dockerManager, error) {
 			return
 		}
 		sDockerManager.cliPluginsExtraDirsDefault = sDockerManager.cli.ConfigFile().CLIPluginsExtraDirs
-		if globalconfig.GetRequiredDockerBuildxVersion() != "" {
-			// Prepend global ddev bin directory to CLI plugin search path so it takes
-			// priority over any user-configured extra dirs and ~/.docker/cli-plugins.
-			// Must be done after Initialize(), which reloads configFile from disk.
-			sDockerManager.cli.ConfigFile().CLIPluginsExtraDirs = append([]string{filepath.Join(globalconfig.GetGlobalDdevDir(), "bin")}, sDockerManager.cliPluginsExtraDirsDefault...)
-		}
+		// Must be done after Initialize(), which reloads configFile from disk.
+		sDockerManager.updateCLIPluginsExtraDirs()
 		sDockerManager.dockerContextName = sDockerManager.cli.CurrentContext()
 		sDockerManager.host = sDockerManager.cli.DockerEndpoint().Host
 		util.Verbose("getDockerManagerInstance(): dockerContextName=%s, host=%s", sDockerManager.dockerContextName, sDockerManager.host)
@@ -232,16 +230,33 @@ func ResetDockerHost(host string) error {
 	return nil
 }
 
+// updateCLIPluginsExtraDirs updates CLIPluginsExtraDirs by prepending any
+// platform-specific plugin directories ahead of the saved defaults.
+// DDEV's global bin dir takes highest priority (prepended last), so its
+// buildx overrides both the snap path and any user-configured dirs.
+func (dm *dockerManager) updateCLIPluginsExtraDirs() {
+	dirs := dm.cliPluginsExtraDirsDefault
+	if nodeps.IsLinux() {
+		// Respect docker-buildx bundled with Docker snap on Linux https://snapcraft.io/docker
+		if dockerPath, err := exec.LookPath("docker"); err == nil && dockerPath == "/snap/bin/docker" {
+			dirs = append([]string{"/snap/docker/current/usr/libexec/docker/cli-plugins"}, dirs...)
+		}
+	}
+	if globalconfig.GetRequiredDockerBuildxVersion() != "" {
+		// Prepend global ddev bin directory so it takes priority over snap and
+		// any user-configured extra dirs and ~/.docker/cli-plugins.
+		dirs = append([]string{filepath.Join(globalconfig.GetGlobalDdevDir(), "bin")}, dirs...)
+	}
+	dm.cli.ConfigFile().CLIPluginsExtraDirs = dirs
+}
+
 // ResetCLIPlugins resets the cached list of Docker CLI plugins in the singleton.
 func ResetCLIPlugins() error {
 	dm, err := getDockerManagerInstance()
 	if err != nil {
 		return err
 	}
-	if globalconfig.GetRequiredDockerBuildxVersion() != "" {
-		// Reset CLIPluginsExtraDirs, because globalconfig.GetGlobalDdevDir() may have been modified by tests
-		dm.cli.ConfigFile().CLIPluginsExtraDirs = append([]string{filepath.Join(globalconfig.GetGlobalDdevDir(), "bin")}, dm.cliPluginsExtraDirsDefault...)
-	}
+	dm.updateCLIPluginsExtraDirs()
 	dm.cliPlugins, dm.cliPluginsErr = manager.ListPlugins(dm.cli, &cobra.Command{})
 	return dm.cliPluginsErr
 }


### PR DESCRIPTION
## The Issue

- Fixes #8515

## How This PR Solves The Issue

Adds `/snap/docker/current/usr/libexec/docker/cli-plugins` to `CLIPluginsExtraDirs`.

## Manual Testing Instructions

Using Ubuntu:

```bash
sudo snap install docker
```

Then install DDEV and run:

```bash
# no error for buildx here
ddev version

# should show `/snap/docker/current/usr/libexec/docker/cli-plugins/docker-buildx` for Buildx
ddev utility dockercheck
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
