### PR TITLE
fix(commands): correct case typo in `ddev sequelace`, fixes #8521 (#8522) [skip ci]

### DIFF
--- a/docs/content/users/extend/custom-commands.md
+++ b/docs/content/users/extend/custom-commands.md
@@ -285,7 +285,7 @@ If your host command should only run if a particular file exists, add the `HostB
 
 Usage: `## HostBinaryExists: <path/to/file>`
 
-Example: `## HostBinaryExists: /Applications/Sequel ace.app`
+Example: `## HostBinaryExists: /Applications/Sequel Ace.app`
 
 ### `DBTypes` Annotation
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1255,7 +1255,7 @@ curl -fsSL https://ddev.com/install.sh | bash
 
 ## `sequelace`
 
-Open [SequelAce](https://sequel-ace.com/) with the current project’s database (global shell host container command). This command is only available if `Sequel Ace.app` is installed as `/Applications/Sequel ace.app`, and only for projects with `mysql` or `mariadb` databases.
+Open [SequelAce](https://sequel-ace.com/) with the current project’s database (global shell host container command). This command is only available if `Sequel Ace.app` is installed as `/Applications/Sequel Ace.app`, and only for projects with `mysql` or `mariadb` databases.
 
 Example:
 

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/sequelace
@@ -5,7 +5,7 @@
 ## Usage: sequelace
 ## Example: "ddev sequelace" or "ddev sequelace database2" to open a database named "database2".
 ## OSTypes: darwin
-## HostBinaryExists: /Applications/Sequel ace.app
+## HostBinaryExists: /Applications/Sequel Ace.app
 ## DBTypes: mysql,mariadb
 
 DATABASE="${1:-db}"


### PR DESCRIPTION
## The Issue

ddev does not detect the presence of the `Sequel Ace.app` properly since the `HostBinaryExists` in the configuration wrongly uses a lowercase `app` in the binary name. This is ignored on case-agnostic macs but will fail on case-sensitive ones.

- Fixes #8521

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Fix a case typo in the `ddev sequelace` command that prevented the detection of sqel ace on case sensitive macs 

`Sequel ace.app` -> `Sequel Ace.app`

## Manual Testing Instructions

Try to start `ddev sequelace` on a case-sensitive vs a case agnostic mac. Since this is not that easy to reproduce and the issue is a clear typo it might suffice to verify that `ddev sequelace` will still work on default case-agnostic macs afterwards.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

The `ddev squelace` command now detects Sequel Ace on case-sensitive Macs.