### PR TITLE
docs: replace newgrp with sg for docker group activation, fixes #8350

### DIFF
--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -131,9 +131,6 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     # Install Docker CE
     sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-    # Install util-linux-extra to ensure newgrp is available (Ubuntu 26.04+/Debian sid)
-    sudo apt-get install -y util-linux-extra 2>/dev/null || true
-
     # Add your user to the docker group (create group if it doesn’t exist)
     sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
 
@@ -141,7 +138,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     sudo systemctl enable --now docker
     ```
 
-    Run `newgrp docker` to open a new subshell with the `docker` group active, then verify with `docker run hello-world`. (A full log out and back in applies the change to your whole session.)
+    Run `sg docker` to open a new subshell with the `docker` group active, then verify with `docker run hello-world`. (A full log out and back in applies the change to your whole session.)
 
     ??? tip "Prefer to run as a script?"
         Create a script file, then run it:
@@ -162,7 +159,6 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
           "$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")" \
           | sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null
         sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-        sudo apt-get install -y util-linux-extra 2>/dev/null || true
         sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
         sudo systemctl enable --now docker
         SCRIPT
@@ -187,7 +183,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     sudo systemctl enable --now docker
     ```
 
-    Run `newgrp docker` to open a new subshell with the `docker` group active, or log out and back in to apply the change to your whole session. See [Post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/) for more details.
+    Run `sg docker` to open a new subshell with the `docker` group active, or log out and back in to apply the change to your whole session. See [Post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/) for more details.
 
     !!!warning "Don’t `sudo` with `docker` or `ddev`"
         Don’t use `sudo` with the `docker` command. If you find yourself needing it, you haven’t finished the installation. You also shouldn’t use `sudo` with `ddev` unless it’s specifically for the [`ddev hostname`](../usage/commands.md#hostname) command.
@@ -286,14 +282,11 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     # Install Docker CE
     sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-    # Install util-linux-extra to ensure newgrp is available (Ubuntu 26.04+/Debian sid)
-    sudo apt-get install -y util-linux-extra 2>/dev/null || true
-
     # Add your user to the docker group (create group if it doesn't exist)
     sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
     ```
 
-    Run `newgrp docker` to open a new subshell with the `docker` group active, or log out and back in to apply the change to your whole session. On WSL2 systems without `systemd`, you may need to start Docker manually with `sudo service docker start`.
+    Run `sg docker` to open a new subshell with the `docker` group active, or log out and back in to apply the change to your whole session. On WSL2 systems without `systemd`, you may need to start Docker manually with `sudo service docker start`.
 
     ??? tip "Prefer to run as a script?"
         Create a script file, then run it:
@@ -313,7 +306,6 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
           "$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")" \
           | sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null
         sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-        sudo apt-get install -y util-linux-extra 2>/dev/null || true
         sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
         SCRIPT
         ```
@@ -373,9 +365,9 @@ A message like this means that your user is not in the `docker` group:
 
 ```bash
 sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
-# newgrp opens a new subshell with the `docker` group active;
+# sg opens a new subshell with the `docker` group active;
 # log out and back in to apply the change to your full session
-newgrp docker
+sg docker
 ```
 
 ---


### PR DESCRIPTION
## The Issue

- Fixes #8350

Ubuntu 26.04 removed `newgrp` from the default install (moved to `util-linux-extra`). The previous fix (#8480) worked around this by installing `util-linux-extra`. This replaces that approach entirely.

## How This PR Solves The Issue

`sg` (from the `passwd` package, Priority: required on all Debian/Ubuntu systems) provides the same behavior as `newgrp`: `sg docker` opens a new subshell with the `docker` group active. Since `passwd` is always installed, no extra package is needed on any Ubuntu or Debian version including 26.04.

- Removes the `sudo apt-get install -y util-linux-extra` lines from all installation instructions and script snippets
- Replaces every `newgrp docker` reference with `sg docker`

