### PR TITLE
fix(start): do not ask for poweroff with new ddev-ssh-agent, fixes #8520

### DIFF
--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ddev/ddev/pkg/amplitude"
 	"github.com/ddev/ddev/pkg/ddevapp"
+	ddevImages "github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -196,6 +198,12 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 			// Check if any containers are running before prompting for poweroff
 			activeProjects := ddevapp.GetActiveProjects()
 			sshAgent, _ := dockerutil.FindContainerByName("ddev-ssh-agent")
+			// skip check for sshAgent if it's already new
+			if sshAgent != nil &&
+				strings.HasSuffix(sshAgent.Image, ddevImages.GetSSHAuthImage()) &&
+				(sshAgent.State == "running" || sshAgent.State == "starting") {
+				sshAgent = nil
+			}
 			router, _ := dockerutil.FindContainerByName("ddev-router")
 
 			// Only prompt for poweroff if there are active containers


### PR DESCRIPTION
## The Issue

- Fixes #8520

## How This PR Solves The Issue

Adds an extra check inside `checkDdevVersionAndOptInInstrumentation`.

## Manual Testing Instructions

```bash
ddev poweroff
yq -i '.last_started_version = "v1.25.2"' ~/.ddev/global_config.yaml
ddev auth ssh
ddev start
```

DDEV HEAD:

```
$ ddev start
You seem to have a new DDEV version (new=v1.25.2-105-gb45a3f7b2, old=v1.25.2) 
During an upgrade it's important to `ddev poweroff`.
May I do `ddev poweroff` before continuing?
This does no harm and loses no data. [Y/n] (yes): 
```

This PR:

```
$ ddev start
Starting demo...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
