### PR TITLE
ci(podman): update workflow for Podman 6

### DIFF
--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -77,6 +77,10 @@ ExecStart=/home/linuxbrew/.linuxbrew/bin/podman $LOGGING system service
 [Install]
 WantedBy=default.target
 EOF
+  # Fix for Podman 6: "registries.conf must be in v2 format but is in v1"
+  sudo tee /etc/containers/registries.conf > /dev/null <<EOF
+unqualified-search-registries = ["docker.io"]
+EOF
   # Reload systemd
   systemctl --user daemon-reload
   # Set DNS
@@ -159,6 +163,10 @@ EOF
 SocketMode=0660
 SocketUser=root
 SocketGroup=docker
+EOF
+  # Fix for Podman 6: "registries.conf must be in v2 format but is in v1"
+  sudo tee /etc/containers/registries.conf > /dev/null <<EOF
+unqualified-search-registries = ["docker.io"]
 EOF
   # Reload systemd
   sudo systemctl daemon-reload


### PR DESCRIPTION
## The Issue

https://github.com/ddev/ddev/actions/runs/28155402216/job/83382643783#step:9:310

```
+ podman info --format '{{.Host.RemoteSocket.Path}}'
Error: getting registries: loading registries configuration "/etc/containers/registries.conf": registries.conf must be in v2 format but is in v1
+ true
```

https://github.com/podman-container-tools/podman/releases/tag/v6.0.0

## How This PR Solves The Issue

Updates the file, v1 looked like this:

```
$ cat /etc/containers/registries.conf
[registries.search]
registries = ['docker.io', 'quay.io']
```

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
