### PR TITLE
build: remove pin for Node.js, for #8438

### DIFF
--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -85,8 +85,7 @@ ENV DDEV_PHP_VERSION=$PHP_DEFAULT_VERSION
 ARG PHP_VERSIONS="php8.2 php8.3 php8.4 php8.5"
 ENV PHP_INI=/etc/php/$PHP_DEFAULT_VERSION/fpm/php.ini
 ARG DRUSH_VERSION=8.5.0
-# TODO: remove this Node.js pin once https://github.com/nodejs/node/issues/63487 is resolved
-ARG NODE_VERSION=24.15.0
+ARG NODE_VERSION=24
 ENV PATH=$PATH:/usr/local/n/bin
 # composer normally screams about running as root, we don't need that.
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
 ARG DOCKER_ORG=ddev
-FROM ${DOCKER_ORG}/ddev-php-base:20260610_stasadev_n_install AS ddev-webserver-base
+FROM ${DOCKER_ORG}/ddev-php-base:20260625_stasadev_node_24 AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260619_stasadev_web_recursion" // Note that this can be overridden by make
+var WebTag = "20260625_stasadev_node_24" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/issues/8436#issuecomment-4799484103
- For #8438

> https://nodejs.org/en/blog/release/v24.18.0
> `[3f54c8ba32] - Revert "stream: noop pause/resume on destroyed streams" (Stewart X Addison) #63834`

## How This PR Solves The Issue

Removes the pin.

## Manual Testing Instructions

```
$ ddev exec node -v
v24.18.0
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
