### PR TITLE
docs: skip codeberg, use stable link for docs in github workflows (#8528) [skip ci]

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -37,7 +37,7 @@ labels:
 
 checks:
   - context: "Semantic Pull Request"
-    url: "https://docs.ddev.com/en/latest/developers/building-contributing/#pull-request-title-guidelines"
+    url: "https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines"
     description:
       success: Ready for review.
       failure: Missing semantic label.

--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -144,7 +144,7 @@ jobs:
               return acc;
             }, 'Download the artifacts for this pull request:\n');
 
-            body += `\n\nSee [Testing a PR](https://docs.ddev.com/en/latest/developers/building-contributing/#testing-a-pr).`;
+            body += `\n\nSee [Testing a PR](https://docs.ddev.com/en/stable/developers/building-contributing/#testing-a-pr).`;
             const codespacesLink = prRef && prRepoId
               ? `https://github.com/codespaces/new?ref=${prRef}&repo=${prRepoId}`
               : `https://github.com/codespaces/new/${context.repo.owner}/${context.repo.repo}`;

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
           pattern: '^(build|chore|ci|docs|feat|fix|perf|refactor|style|test)(\([a-z][a-z0-9-]*\))?!?:\s(?!.*  )[A-Za-z''"`].*[A-Za-z0-9\]\)''"`](?:, (?:fixes|for) #\d+)*$'
           flags: ''
           excludeDescription: true
-          error: 'Title does not follow our conventions see https://docs.ddev.com/en/latest/developers/building-contributing/#pull-request-title-guidelines'
+          error: 'Title does not follow our conventions see https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines'
 
   assign_labels:
     name: Assign Labels

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -34,6 +34,8 @@ ignorePatterns:
   - pattern: "https://mailpit.axllent.org"
   # fixed.docs.upsun.com resets the connection to linkspector's headless browser
   - pattern: "https://fixed.docs.upsun.com"
+  # codeberg 403
+  - pattern: "https://codeberg.org/oerdnj/deb.sury.org"
 aliveStatusCodes:
   - 200
   - 206


### PR DESCRIPTION
## The Issue

This is annoying:

https://github.com/ddev/ddev/actions/runs/28126644600/job/83444368758

```
Running linkspector with reviewdog 🐶 ...
message:"Cannot reach https://codeberg.org/oerdnj/deb.sury.org Status: 403"  location:{path:"docs/content/developers/maintainers.md"  range:{start:{line:89  column:38}  end:{line:89  column:103}}}  severity:ERROR  source:{name:"linkspector"  url:"https://github.com/UmbrellaDocs/linkspector"}
reviewdog: found at least one issue with severity greater than or equal to the given level: any
Error: [Linkspector] reported by reviewdog 🐶
Cannot reach https://codeberg.org/oerdnj/deb.sury.org Status: 403
```

## How This PR Solves The Issue

- Excludes https://codeberg.org/oerdnj/deb.sury.org from linkspector.
- Uses `/en/stable` instead of `/en/latest` links as we can update `stable` at any time  #8408

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
