### PR TITLE
fix: stop honoring XDG_CONFIG_HOME on Linux too, use DDEV_XDG_CONFIG_HOME, fixes #8493

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 
     // A set of name-value pairs that sets or overrides environment variables for the container.
     "containerEnv": {
-        "XDG_CONFIG_HOME": "/workspaces/.config",
+        "DDEV_XDG_CONFIG_HOME": "/workspaces/.config",
         "IN_DEVCONTAINER": "true"
     },
 

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -95,9 +95,7 @@ jobs:
           DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           brew unlink ddev || true
-          rm -f ~/.config/ddev
           make
-          unset XDG_CONFIG_HOME
           # Use mutagen by default as it may cause different behaviors
           $(make DDEV_BINARY_FULLPATH) config global --performance-mode=mutagen
           make quickstart-test

--- a/cmd/ddev/cmd/cmd_version.go
+++ b/cmd/ddev/cmd/cmd_version.go
@@ -59,6 +59,8 @@ var versionCmd = &cobra.Command{
 		}
 		t.Render()
 		output.UserOut.WithField("raw", v).Println(out.String())
+
+		util.WarnAboutMultipleGlobalDdevDirs()
 		amplitude.CheckSetUp()
 
 		if dockerErr != nil {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -953,7 +953,6 @@ func TestHasConfigNameOverride(t *testing.T) {
 func TestOmitProjectNameByDefault(t *testing.T) {
 	origDir, _ := os.Getwd()
 
-	// Create temporary XDG_CONFIG_HOME for isolated testing
 	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {
@@ -1081,7 +1080,6 @@ func TestOmitProjectNameReconfig(t *testing.T) {
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
 
-	// Create temporary XDG_CONFIG_HOME for isolated testing
 	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {
@@ -1142,7 +1140,6 @@ func TestOmitProjectNameWithConfigOverride(t *testing.T) {
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
 
-	// Create temporary XDG_CONFIG_HOME for isolated testing
 	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {
@@ -1203,7 +1200,6 @@ func TestOmitProjectNameWithConfigOverride(t *testing.T) {
 func TestGlobalConfigOmitProjectNameDefault(t *testing.T) {
 	assert := asrt.New(t)
 
-	// Create temporary XDG_CONFIG_HOME for isolated testing
 	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {

--- a/cmd/ddev/cmd/delete_test.go
+++ b/cmd/ddev/cmd/delete_test.go
@@ -89,7 +89,6 @@ func TestOmitSnapshotOnDeleteGlobal(t *testing.T) {
 	require.NoError(t, err)
 	t.Setenv("NO_COLOR", "true")
 
-	// Create temporary XDG_CONFIG_HOME for isolated global config testing
 	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {

--- a/cmd/ddev/cmd/list_test.go
+++ b/cmd/ddev/cmd/list_test.go
@@ -23,7 +23,6 @@ func TestCmdList(t *testing.T) {
 	origDir, _ := os.Getwd()
 	t.Setenv("DDEV_DEBUG", "")
 
-	// Create temporary XDG_CONFIG_HOME for isolated testing
 	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 
 	t.Cleanup(func() {

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -242,7 +242,6 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 	t.Setenv("DOCKER_HOST", dockerHost)
 	// Set $DDEV_XDG_CONFIG_HOME to empty string, otherwise it will take precedence over $HOME
 	t.Setenv("DDEV_XDG_CONFIG_HOME", "")
-	t.Setenv("XDG_CONFIG_HOME", "")
 
 	// Make sure that the tmpDir/.ddev and tmpDir/.ddev/.update don't exist before we run ddev.
 	_, err = os.Stat(filepath.Join(tmpHomeDir, ".ddev"))
@@ -275,7 +274,7 @@ func TestCreateGlobalDdevDir(t *testing.T) {
 }
 
 // TestCopyGlobalDdevDir checks to make sure that DDEV will use
-// ddev folder in user's custom dir $XDG_CONFIG_HOME/ddev instead of ~/.ddev
+// ddev folder in user's custom dir $DDEV_XDG_CONFIG_HOME/ddev instead of ~/.ddev
 func TestCopyGlobalDdevDir(t *testing.T) {
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
@@ -301,7 +300,7 @@ func TestCopyGlobalDdevDir(t *testing.T) {
 	out, err := exec.RunHostCommand(DdevBin, "config", "--auto")
 	require.NoError(t, err, "failed to ddev config --auto, out=%v, err=%v", out, err)
 
-	// Make sure that $XDG_CONFIG_HOME/ddev/.update don't exist before we run ddev start
+	// Make sure that $DDEV_XDG_CONFIG_HOME/ddev/.update don't exist before we run ddev start
 	tmpUpdateFilePath := filepath.Join(globalconfig.GetGlobalDdevDir(), ".update")
 	_, err = os.Stat(tmpUpdateFilePath)
 	require.Error(t, err)
@@ -318,13 +317,11 @@ func TestCopyGlobalDdevDir(t *testing.T) {
 // TestGetGlobalDdevDirLocation checks to make sure that DDEV will use the
 // correct location for its global config. The correct location is:
 // ${DDEV_XDG_CONFIG_HOME}/ddev if DDEV_XDG_CONFIG_HOME is set (all platforms), or
-// ${XDG_CONFIG_HOME}/ddev if XDG_CONFIG_HOME is set on Linux only, or
 // ~/.ddev if it exists or
 // ~/.config/ddev if it exists on Linux/WSL2
 func TestGetGlobalDdevDirLocation(t *testing.T) {
-	// Test when neither DDEV_XDG_CONFIG_HOME nor XDG_CONFIG_HOME is set
+	// Test when DDEV_XDG_CONFIG_HOME is not set
 	t.Setenv("DDEV_XDG_CONFIG_HOME", "")
-	t.Setenv("XDG_CONFIG_HOME", "")
 	ddevDir := globalconfig.GetGlobalDdevDirLocation()
 	// Original ~/.ddev dir location
 	originalGlobalDdevDir := filepath.Join(util.GetHomeDir(), ".ddev")

--- a/cmd/ddev/cmd/scripts/test_ddev.sh
+++ b/cmd/ddev/cmd/scripts/test_ddev.sh
@@ -95,8 +95,8 @@ header "project configuration via ddev utility configyaml"
 ddev utility configyaml --full-yaml --omit-keys=web_environment 2>/dev/null || { ddev utility configyaml | (grep -v "^web_environment" || true); }
 
 header "DDEV Global Information"
-if [ "$XDG_CONFIG_HOME" != "" ]; then
-  echo "XDG_CONFIG_HOME is set to non-default value: '${XDG_CONFIG_HOME}'"
+if [ "$DDEV_XDG_CONFIG_HOME" != "" ]; then
+  echo "DDEV_XDG_CONFIG_HOME is set to non-default value: '${DDEV_XDG_CONFIG_HOME}'"
 fi
 echo "Global DDEV dir is $(get_global_ddev_dir)"
 echo ""

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -157,6 +157,7 @@ ddev start --all`,
 			util.Success("Successfully started %s", project.GetName())
 			emitReachProjectMessage(project)
 		}
+		util.WarnAboutMultipleGlobalDdevDirs()
 		amplitude.CheckSetUp()
 	},
 }

--- a/cmd/ddev/cmd/start_test.go
+++ b/cmd/ddev/cmd/start_test.go
@@ -168,7 +168,6 @@ func TestCmdStartShowsMessages(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, []string{"stop", site.Name})
 	require.NoError(t, err)
 
-	// Create temporary XDG_CONFIG_HOME for isolated testing
 	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 	tmpGlobalDdevDir := globalconfig.GetGlobalDdevDir()
 
@@ -244,7 +243,6 @@ func TestCmdStartShowsSponsorshipData(t *testing.T) {
 	_, err = exec.RunCommand(DdevBin, []string{"stop", site.Name})
 	require.NoError(t, err)
 
-	// Create temporary XDG_CONFIG_HOME for isolated testing
 	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
 	tmpGlobalDdevDir := globalconfig.GetGlobalDdevDir()
 

--- a/containers/devcontainers/install-ddev/README.md
+++ b/containers/devcontainers/install-ddev/README.md
@@ -20,7 +20,7 @@ Add the feature to your `.devcontainer/devcontainer.json`:
 
 The feature automatically:
 - Installs DDEV from the apt repository
-- Configures environment variables (`XDG_CONFIG_HOME`, `IN_DEVCONTAINER`)
+- Configures environment variables (`DDEV_XDG_CONFIG_HOME`, `IN_DEVCONTAINER`)
 - Installs mkcert binary (DDEV will generate certificates as needed)
 - Fixes `/workspaces` permissions for config storage
 - Verifies installation with `ddev version`

--- a/containers/devcontainers/install-ddev/devcontainer-feature.json
+++ b/containers/devcontainers/install-ddev/devcontainer-feature.json
@@ -8,7 +8,7 @@
         "ghcr.io/devcontainers/features/docker-in-docker"
     ],
     "containerEnv": {
-        "XDG_CONFIG_HOME": "/workspaces/.config",
+        "DDEV_XDG_CONFIG_HOME": "/workspaces/.config",
         "IN_DEVCONTAINER": "true"
     },
     "postCreateCommand": "/usr/local/bin/ddev-post-create.sh"

--- a/docs/content/users/extend/in-container-configuration.md
+++ b/docs/content/users/extend/in-container-configuration.md
@@ -5,7 +5,7 @@ Custom shell configuration (Bash or your preferred shell), your usual Git config
 ## Using `homeadditions` to Customize In-Container Home Directory
 
 !!!tip "Finding Your Global DDEV Directory"
-    The examples below automatically detect the correct global DDEV directory (including when `$XDG_CONFIG_HOME` is set) using the `DDEV_DIR` variable. See [global configuration directory](../usage/architecture.md#global-files) for details.
+    The examples below automatically detect the correct global DDEV directory (including when `$DDEV_XDG_CONFIG_HOME` is set) using the `DDEV_DIR` variable. See [global configuration directory](../usage/architecture.md#global-files) for details.
 
 Place all your dotfiles in your global `homeadditions` directory or your project's `.ddev/homeadditions` directory and DDEV will use these in your project's `web` containers.
 

--- a/docs/content/users/usage/architecture.md
+++ b/docs/content/users/usage/architecture.md
@@ -103,12 +103,11 @@ Files beginning with `.` are hidden because they shouldn’t be fiddled with; mo
 There’s only one global `.ddev` directory, which normally lives in your home directory: `$HOME/.ddev`, but can be overwritten (first match wins):
 
 1. `$DDEV_XDG_CONFIG_HOME/ddev` if `$DDEV_XDG_CONFIG_HOME` is set (all platforms)
-2. `$XDG_CONFIG_HOME/ddev` if `$XDG_CONFIG_HOME` is set on Linux/WSL2 only
-3. `$HOME/.ddev`, which means:
+2. `$HOME/.ddev`, which means:
     - `/Users/<username>/.ddev` on macOS
     - `/home/<username>/.ddev` on Linux/WSL2
     - `C:\Users\<username>\.ddev` on Windows
-4. `$HOME/.config/ddev` on Linux/WSL2 only, if `$HOME/.ddev` doesn’t exist
+3. `$HOME/.config/ddev` on Linux/WSL2 only, if `$HOME/.ddev` doesn’t exist
 
 To find your actual location, run:
 
@@ -125,7 +124,7 @@ ddev version | grep global-ddev-dir
     mv $HOME/.ddev ${DDEV_XDG_CONFIG_HOME}/ddev
     ```
 
-    On Linux/WSL2, you can also use `$XDG_CONFIG_HOME` from the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/) instead of `$DDEV_XDG_CONFIG_HOME`. Or move the directory to `$HOME/.config/ddev` without setting any variable:
+    On Linux/WSL2, you can also move the directory to `$HOME/.config/ddev` without setting the variable:
 
     ```bash
     mv $HOME/.ddev $HOME/.config/ddev

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1530,11 +1530,6 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
-	if err := globalconfig.CheckForMultipleGlobalDdevDirs(); err != nil {
-		util.WarningOnce("Warning: %v", err)
-	}
-	globalconfig.WarnIfXDGIgnoredOnNonLinux()
-
 	if !globalconfig.IsInternetActive() && globalconfig.DdevDebug {
 		util.WarningOnce("Internet connection not detected, DNS may not work.\nWarning: %v\nSee https://docs.ddev.com/en/stable/users/usage/offline/ for info.", globalconfig.IsInternetActiveErr)
 	}

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -706,15 +706,14 @@ func CheckForMultipleGlobalDdevDirs() error {
 	userHomeDotDdev := filepath.Join(userHome, ".ddev")
 	linuxConfigDdevDir := filepath.Clean(filepath.Join(userHome, ".config", "ddev"))
 
-	// $XDG_CONFIG_HOME/ddev is no longer honored, except on Linux where it coincides
-	// with the ~/.config/ddev fallback (handled below). DDEV_XDG_CONFIG_HOME takes
-	// precedence, so skip this when it is set.
+	// Show a warning about leftover config at $XDG_CONFIG_HOME/ddev if DDEV_XDG_CONFIG_HOME is not set
 	if os.Getenv("DDEV_XDG_CONFIG_HOME") == "" {
 		if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
 			if strings.HasPrefix(xdgConfigHome, `~`) {
 				xdgConfigHome = userHome + xdgConfigHome[1:]
 			}
 			xdgDdevDir := filepath.Clean(filepath.Join(xdgConfigHome, "ddev"))
+			// On Linux, we don't want to warn about existing ~/.config/ddev
 			recognizedOnLinux := nodeps.IsLinux() && xdgDdevDir == linuxConfigDdevDir
 			if xdgDdevDir != actualDdevDir && !recognizedOnLinux {
 				if _, err := os.Stat(xdgDdevDir); err == nil {

--- a/pkg/globalconfig/global_config.go
+++ b/pkg/globalconfig/global_config.go
@@ -169,7 +169,7 @@ func checkMutagenSocketPathLength() {
 		limit = 108
 	}
 	if socketPathLength >= limit {
-		output.UserErr.Warning(fmt.Sprintf("Path to DDEV Mutagen socket is %d characters long.\nMutagen may fail, socket path must contain less than %d characters.\nConsider using a shorter path to DDEV global config with DDEV_XDG_CONFIG_HOME env (or XDG_CONFIG_HOME on Linux).", limit, socketPathLength))
+		output.UserErr.Warning(fmt.Sprintf("Path to DDEV Mutagen socket is %d characters long.\nMutagen may fail, socket path must contain less than %d characters.", limit, socketPathLength))
 	}
 	checkedMutagenSocketPathLength = true
 }
@@ -652,7 +652,6 @@ func GetGlobalDdevDir() string {
 
 // GetGlobalDdevDirLocation returns the global config directory location to be used by DDEV:
 // $DDEV_XDG_CONFIG_HOME/ddev if $DDEV_XDG_CONFIG_HOME is set (all platforms),
-// $XDG_CONFIG_HOME/ddev if $XDG_CONFIG_HOME is set on Linux only,
 // ~/.config/ddev if this directory exists on Linux/WSL2 only,
 // ~/.ddev otherwise.
 func GetGlobalDdevDirLocation() string {
@@ -672,32 +671,18 @@ func GetGlobalDdevDirLocation() string {
 		return filepath.Join(ddevXdgConfigHome, "ddev")
 	}
 
-	// If $XDG_CONFIG_HOME is set and we're on Linux, use $XDG_CONFIG_HOME/ddev.
-	// XDG_CONFIG_HOME is a Linux/freedesktop.org standard. On macOS and Windows it is
-	// not honored, to avoid silent config misplacement for users who have it set globally
-	// for other tools. Use DDEV_XDG_CONFIG_HOME for a cross-platform override.
-	if nodeps.IsLinux() {
-		xdgConfigHomeDir := os.Getenv("XDG_CONFIG_HOME")
-		if strings.HasPrefix(xdgConfigHomeDir, `~`) {
-			xdgConfigHomeDir = userHome + xdgConfigHomeDir[1:]
-		}
-		if xdgConfigHomeDir != "" {
-			return filepath.Join(xdgConfigHomeDir, "ddev")
-		}
-	}
-
 	// If Linux and ~/.ddev doesn't exist and
 	// ~/.config/ddev exists, use it,
 	// we don't create this directory.
 	stat, userHomeDotDdevErr := os.Stat(userHomeDotDdev)
 	userHomeDotDdevIsDir := userHomeDotDdevErr == nil && stat.IsDir()
 	if nodeps.IsLinux() && !userHomeDotDdevIsDir {
-		userConfigDir, err := os.UserConfigDir()
-		if err == nil {
-			linuxDir := filepath.Join(userConfigDir, "ddev")
-			if _, err := os.Stat(linuxDir); err == nil {
-				return linuxDir
-			}
+		// Use the standard ~/.config/ddev location on Linux/WSL2.
+		// We intentionally use ~/.config rather than using os.UserConfigDir(),
+		// which would honor $XDG_CONFIG_HOME. Use DDEV_XDG_CONFIG_HOME to relocate.
+		linuxDir := filepath.Join(userHome, ".config", "ddev")
+		if _, err := os.Stat(linuxDir); err == nil {
+			return linuxDir
 		}
 	}
 	// Otherwise, use ~/.ddev
@@ -706,56 +691,59 @@ func GetGlobalDdevDirLocation() string {
 	return userHomeDotDdev
 }
 
-// WarnIfXDGIgnoredOnNonLinux emits a one-time warning on macOS/Windows when
-// XDG_CONFIG_HOME is set and $XDG_CONFIG_HOME/ddev exists. DDEV no longer
-// respects XDG_CONFIG_HOME on non-Linux platforms. Use DDEV_XDG_CONFIG_HOME instead.
-func WarnIfXDGIgnoredOnNonLinux() {
-	if nodeps.IsLinux() {
-		return
-	}
-	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
-	if xdgConfigHome == "" {
-		return
-	}
-	userHome, err := os.UserHomeDir()
-	if err != nil {
-		return
-	}
-	if strings.HasPrefix(xdgConfigHome, `~`) {
-		xdgConfigHome = userHome + xdgConfigHome[1:]
-	}
-	oldDir := filepath.Join(xdgConfigHome, "ddev")
-	if _, err := os.Stat(oldDir); err != nil {
-		return
-	}
-	output.UserErr.Warningf("XDG_CONFIG_HOME is set but is only respected on Linux. Your previous DDEV config at %s is not being used.\nTo continue using it, set DDEV_XDG_CONFIG_HOME=%s\nOr move it to the default location: mv %s %s", oldDir, xdgConfigHome, oldDir, filepath.Join(userHome, ".ddev"))
-}
-
-// CheckForMultipleGlobalDdevDirs checks for multiple global DDEV directories
-// and returns an error if multiple are found.
+// CheckForMultipleGlobalDdevDirs returns an error if a global DDEV config exists in a
+// location other than the one DDEV uses, so the user can remove or relocate it.
+// Leftover config at a no-longer-honored $XDG_CONFIG_HOME/ddev is reported with
+// instructions to set DDEV_XDG_CONFIG_HOME or remove it. A stale ~/.ddev or, on Linux,
+// ~/.config/ddev is also reported; when both Linux standard locations exist, ~/.ddev
+// wins by precedence but either is valid.
 func CheckForMultipleGlobalDdevDirs() error {
 	userHome, err := os.UserHomeDir()
 	if err != nil {
 		return err
 	}
-	userHomeDotDdev := filepath.Clean(filepath.Join(userHome, ".ddev"))
-	// On Linux, also check for $HOME/.config/ddev if neither XDG_CONFIG_HOME nor DDEV_XDG_CONFIG_HOME is set
-	if nodeps.IsLinux() && os.Getenv("XDG_CONFIG_HOME") == "" && os.Getenv("DDEV_XDG_CONFIG_HOME") == "" {
-		userConfigDir, err := os.UserConfigDir()
-		if err == nil {
-			linuxDir := filepath.Join(userConfigDir, "ddev")
-			if _, err := os.Stat(linuxDir); err == nil {
-				userHomeDotDdev = filepath.Clean(linuxDir)
+	actualDdevDir := filepath.Clean(GetGlobalDdevDirLocation())
+	userHomeDotDdev := filepath.Join(userHome, ".ddev")
+	linuxConfigDdevDir := filepath.Clean(filepath.Join(userHome, ".config", "ddev"))
+
+	// $XDG_CONFIG_HOME/ddev is no longer honored, except on Linux where it coincides
+	// with the ~/.config/ddev fallback (handled below). DDEV_XDG_CONFIG_HOME takes
+	// precedence, so skip this when it is set.
+	if os.Getenv("DDEV_XDG_CONFIG_HOME") == "" {
+		if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+			if strings.HasPrefix(xdgConfigHome, `~`) {
+				xdgConfigHome = userHome + xdgConfigHome[1:]
+			}
+			xdgDdevDir := filepath.Clean(filepath.Join(xdgConfigHome, "ddev"))
+			recognizedOnLinux := nodeps.IsLinux() && xdgDdevDir == linuxConfigDdevDir
+			if xdgDdevDir != actualDdevDir && !recognizedOnLinux {
+				if _, err := os.Stat(xdgDdevDir); err == nil {
+					return fmt.Errorf("found a leftover DDEV global config at %q; DDEV no longer honors XDG_CONFIG_HOME, so it is not being used. To keep using it, set DDEV_XDG_CONFIG_HOME=%q; otherwise remove %q", xdgDdevDir, xdgConfigHome, xdgDdevDir)
+				}
 			}
 		}
 	}
-	actualDdevDir := filepath.Clean(GetGlobalDdevDirLocation())
-	// If the actual location is not the default $HOME/.ddev (or $HOME/.config/ddev on Linux),
-	// and the default location exists, warn the user
-	if actualDdevDir != userHomeDotDdev {
-		if _, err := os.Stat(userHomeDotDdev); err == nil {
-			return fmt.Errorf("multiple global DDEV configurations found, %s is used, %s is not used, delete one of them to avoid confusion", actualDdevDir, userHomeDotDdev)
+
+	// ~/.ddev and, on Linux, ~/.config/ddev are both recognized locations. If a
+	// recognized location other than the active one holds config, point it out.
+	cleanUserHomeDotDdev := filepath.Clean(userHomeDotDdev)
+	candidates := []string{cleanUserHomeDotDdev}
+	if nodeps.IsLinux() {
+		candidates = append(candidates, linuxConfigDdevDir)
+	}
+	for _, candidate := range candidates {
+		if candidate == actualDdevDir {
+			continue
 		}
+		if _, err := os.Stat(candidate); err != nil {
+			continue
+		}
+		// On Linux both locations are standard, so explain that either can be
+		// removed rather than naming only one.
+		if actualDdevDir == cleanUserHomeDotDdev && candidate == linuxConfigDdevDir {
+			return fmt.Errorf("multiple global DDEV configurations found, both %q and %q exist; %q is in use because it takes precedence. To use %q instead, remove %q; otherwise remove %q to avoid confusion", actualDdevDir, candidate, actualDdevDir, candidate, actualDdevDir, candidate)
+		}
+		return fmt.Errorf("multiple global DDEV configurations found, %q is in use; %q is not used and can be removed to avoid confusion", actualDdevDir, candidate)
 	}
 
 	return nil

--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -214,7 +214,6 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 
 		t.Setenv("HOME", tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
-		t.Setenv("XDG_CONFIG_HOME", "")
 
 		defaultDir := tmpHome + "/.ddev"
 		err := os.MkdirAll(defaultDir, 0755)
@@ -231,7 +230,6 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 
 		t.Setenv("HOME", tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
-		t.Setenv("XDG_CONFIG_HOME", "")
 
 		xdgDir := tmpHome + "/.config/ddev"
 		err := os.MkdirAll(xdgDir, 0755)
@@ -241,8 +239,8 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	// XDG_CONFIG_HOME pointing at the conventional ~/.config on Linux is the
-	// recognized fallback, not a leftover, so it must stay silent.
+	// XDG_CONFIG_HOME pointing at ~/.config on Linux
+	// doesn't trigger a warning because we recognize ~/.config/ddev
 	t.Run("XDGConfigHomeIsConventionalDefault", func(t *testing.T) {
 		if !nodeps.IsLinux() {
 			t.Skip("~/.config/ddev fallback only applies on Linux")
@@ -322,7 +320,6 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 
 		t.Setenv("HOME", tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
-		t.Setenv("XDG_CONFIG_HOME", "")
 
 		defaultDir := tmpHome + "/.ddev"
 		err := os.MkdirAll(defaultDir, 0755)
@@ -349,7 +346,6 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 
 		t.Setenv("HOME", tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", tmpXdg)
-		t.Setenv("XDG_CONFIG_HOME", "")
 
 		defaultDir := tmpHome + "/.ddev"
 		err := os.MkdirAll(defaultDir, 0755)

--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -205,8 +205,27 @@ func TestIsInternetActive(t *testing.T) {
 
 // TestCheckForMultipleGlobalDdevDirs tests CheckForMultipleGlobalDdevDirs behavior
 func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
-	// Test 1: No conflict - only one directory exists
-	t.Run("NoConflict", func(t *testing.T) {
+	// ===== Happy path: a single recognized location is in use, no warning =====
+
+	// Only the default ~/.ddev exists.
+	t.Run("OnlyDefaultExists", func(t *testing.T) {
+		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_Default")
+		defer os.RemoveAll(tmpHome)
+
+		t.Setenv("HOME", tmpHome)
+		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
+		t.Setenv("XDG_CONFIG_HOME", "")
+
+		defaultDir := tmpHome + "/.ddev"
+		err := os.MkdirAll(defaultDir, 0755)
+		require.NoError(t, err)
+
+		err = globalconfig.CheckForMultipleGlobalDdevDirs()
+		require.NoError(t, err)
+	})
+
+	// Only ~/.config/ddev exists (the Linux fallback), ~/.ddev does not.
+	t.Run("OnlyConfigDdevExists", func(t *testing.T) {
 		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_NoConflict")
 		defer os.RemoveAll(tmpHome)
 
@@ -214,17 +233,85 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 		t.Setenv("XDG_CONFIG_HOME", "")
 
-		// Create only XDG directory
 		xdgDir := tmpHome + "/.config/ddev"
 		err := os.MkdirAll(xdgDir, 0755)
 		require.NoError(t, err)
 
-		// Should not return error as ~/.ddev doesn't exist
 		err = globalconfig.CheckForMultipleGlobalDdevDirs()
 		require.NoError(t, err)
 	})
 
-	// Test 2: Conflict - both directories exist (Linux only)
+	// XDG_CONFIG_HOME pointing at the conventional ~/.config on Linux is the
+	// recognized fallback, not a leftover, so it must stay silent.
+	t.Run("XDGConfigHomeIsConventionalDefault", func(t *testing.T) {
+		if !nodeps.IsLinux() {
+			t.Skip("~/.config/ddev fallback only applies on Linux")
+		}
+
+		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_XDGDefault")
+		defer os.RemoveAll(tmpHome)
+
+		t.Setenv("HOME", tmpHome)
+		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
+		t.Setenv("XDG_CONFIG_HOME", tmpHome+"/.config")
+
+		xdgDir := tmpHome + "/.config/ddev"
+		err := os.MkdirAll(xdgDir, 0755)
+		require.NoError(t, err)
+
+		err = globalconfig.CheckForMultipleGlobalDdevDirs()
+		require.NoError(t, err)
+	})
+
+	// DDEV_XDG_CONFIG_HOME takes precedence over XDG_CONFIG_HOME, so a leftover
+	// XDG_CONFIG_HOME/ddev must not be reported when both are set.
+	t.Run("DDEVXDGConfigHomeSuppressesXDGLeftover", func(t *testing.T) {
+		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_BothHome")
+		defer os.RemoveAll(tmpHome)
+
+		tmpDdevXdg := testcommon.CreateTmpDir("TestCheckMultipleDirs_BothDDEVXDG")
+		defer os.RemoveAll(tmpDdevXdg)
+
+		tmpXdg := testcommon.CreateTmpDir("TestCheckMultipleDirs_BothXDG")
+		defer os.RemoveAll(tmpXdg)
+
+		t.Setenv("HOME", tmpHome)
+		t.Setenv("DDEV_XDG_CONFIG_HOME", tmpDdevXdg)
+		t.Setenv("XDG_CONFIG_HOME", tmpXdg)
+
+		xdgDir := tmpXdg + "/ddev"
+		err := os.MkdirAll(xdgDir, 0755)
+		require.NoError(t, err)
+
+		err = globalconfig.CheckForMultipleGlobalDdevDirs()
+		require.NoError(t, err)
+	})
+
+	// XDG_CONFIG_HOME is set but has no ddev directory under it, so there is
+	// nothing to recover and no warning.
+	t.Run("XDGConfigHomeWithoutDdevDir", func(t *testing.T) {
+		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_XDGEmpty")
+		defer os.RemoveAll(tmpHome)
+
+		tmpXdg := testcommon.CreateTmpDir("TestCheckMultipleDirs_XDGNoDdev")
+		defer os.RemoveAll(tmpXdg)
+
+		t.Setenv("HOME", tmpHome)
+		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
+		t.Setenv("XDG_CONFIG_HOME", tmpXdg)
+
+		defaultDir := tmpHome + "/.ddev"
+		err := os.MkdirAll(defaultDir, 0755)
+		require.NoError(t, err)
+
+		err = globalconfig.CheckForMultipleGlobalDdevDirs()
+		require.NoError(t, err)
+	})
+
+	// ===== Error path: config exists in a location other than the one in use =====
+
+	// Both Linux standard locations exist; ~/.ddev wins by precedence and the
+	// message must explain that either can be removed, not name only one.
 	t.Run("ConflictBothExist", func(t *testing.T) {
 		if !nodeps.IsLinux() {
 			t.Skip("This test only runs on Linux")
@@ -237,7 +324,6 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 		t.Setenv("XDG_CONFIG_HOME", "")
 
-		// Create both directories
 		defaultDir := tmpHome + "/.ddev"
 		err := os.MkdirAll(defaultDir, 0755)
 		require.NoError(t, err)
@@ -246,13 +332,14 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		err = os.MkdirAll(xdgDir, 0755)
 		require.NoError(t, err)
 
-		// Should detect conflict
 		err = globalconfig.CheckForMultipleGlobalDdevDirs()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "multiple global DDEV configurations found")
+		require.Contains(t, err.Error(), "takes precedence")
+		require.Contains(t, err.Error(), "To use "+strconv.Quote(xdgDir)+" instead, remove "+strconv.Quote(defaultDir))
 	})
 
-	// Test 3: DDEV_XDG_CONFIG_HOME set - should detect conflict (all platforms)
+	// DDEV_XDG_CONFIG_HOME is in use while a stale ~/.ddev exists (all platforms).
 	t.Run("DDEVXDGConfigHomeSet", func(t *testing.T) {
 		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_DDEVXDGHome")
 		defer os.RemoveAll(tmpHome)
@@ -264,7 +351,6 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		t.Setenv("DDEV_XDG_CONFIG_HOME", tmpXdg)
 		t.Setenv("XDG_CONFIG_HOME", "")
 
-		// Create both directories
 		defaultDir := tmpHome + "/.ddev"
 		err := os.MkdirAll(defaultDir, 0755)
 		require.NoError(t, err)
@@ -273,18 +359,15 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		err = os.MkdirAll(ddevXdgDir, 0755)
 		require.NoError(t, err)
 
-		// Should detect conflict between DDEV_XDG_CONFIG_HOME/ddev and default
 		err = globalconfig.CheckForMultipleGlobalDdevDirs()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "multiple global DDEV configurations found")
 	})
 
-	// Test 4: XDG_CONFIG_HOME set on Linux - should detect conflict
-	t.Run("XDGConfigHomeSetOnLinux", func(t *testing.T) {
-		if !nodeps.IsLinux() {
-			t.Skip("XDG_CONFIG_HOME is only respected on Linux")
-		}
-
+	// Leftover XDG_CONFIG_HOME/ddev that DDEV no longer honors (any platform, when
+	// it is not the ~/.config/ddev fallback on Linux). The warning must tell the
+	// user to set DDEV_XDG_CONFIG_HOME or remove it.
+	t.Run("XDGConfigHomeLeftover", func(t *testing.T) {
 		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_XDGHome")
 		defer os.RemoveAll(tmpHome)
 
@@ -295,7 +378,6 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 		t.Setenv("XDG_CONFIG_HOME", tmpXdg)
 
-		// Create both directories
 		defaultDir := tmpHome + "/.ddev"
 		err := os.MkdirAll(defaultDir, 0755)
 		require.NoError(t, err)
@@ -304,28 +386,9 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		err = os.MkdirAll(xdgDir, 0755)
 		require.NoError(t, err)
 
-		// Should detect conflict between XDG and default on Linux
 		err = globalconfig.CheckForMultipleGlobalDdevDirs()
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "multiple global DDEV configurations found")
-	})
-
-	// Test 5: Only default directory exists
-	t.Run("OnlyDefaultExists", func(t *testing.T) {
-		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_Default")
-		defer os.RemoveAll(tmpHome)
-
-		t.Setenv("HOME", tmpHome)
-		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
-		t.Setenv("XDG_CONFIG_HOME", "")
-
-		// Create only default directory
-		defaultDir := tmpHome + "/.ddev"
-		err := os.MkdirAll(defaultDir, 0755)
-		require.NoError(t, err)
-
-		// Should not return error
-		err = globalconfig.CheckForMultipleGlobalDdevDirs()
-		require.NoError(t, err)
+		require.Contains(t, err.Error(), "DDEV no longer honors XDG_CONFIG_HOME")
+		require.Contains(t, err.Error(), "DDEV_XDG_CONFIG_HOME="+strconv.Quote(tmpXdg))
 	})
 }

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -216,11 +216,11 @@ func CreateTmpDir(prefix string) string {
 }
 
 // CopyGlobalDdevDir creates a temporary global config directory for DDEV
-// using a temporary directory which is set to $XDG_CONFIG_HOME/ddev
+// using a temporary directory which is set to $DDEV_XDG_CONFIG_HOME/ddev
 // Don't forget to run ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 // in the test's cleanup function.
 func CopyGlobalDdevDir(t *testing.T) string {
-	// Create $XDG_CONFIG_HOME
+	// Create $DDEV_XDG_CONFIG_HOME
 	tmpXdgConfigHomeDir := CreateTmpDir("Home_" + util.RandString(5))
 	// Global DDEV config directory should be named "ddev"
 	tmpGlobalDdevDir := filepath.Join(tmpXdgConfigHomeDir, "ddev")
@@ -244,9 +244,9 @@ func CopyGlobalDdevDir(t *testing.T) string {
 	require.Equal(t, tmpGlobalDdevDir, globalconfig.GetGlobalDdevDir())
 	// And it should be created by now
 	require.DirExists(t, tmpGlobalDdevDir)
-	// Create the global config in $XDG_CONFIG_HOME/ddev
+	// Create the global config in $DDEV_XDG_CONFIG_HOME/ddev
 	globalconfig.EnsureGlobalConfig()
-	// Copy some settings from ~/.ddev to $XDG_CONFIG_HOME/ddev
+	// Copy some settings from ~/.ddev to $DDEV_XDG_CONFIG_HOME/ddev
 	globalconfig.DdevGlobalConfig.PerformanceMode = originalGlobalConfig.PerformanceMode
 	globalconfig.DdevGlobalConfig.NoBindMounts = originalGlobalConfig.NoBindMounts
 	globalconfig.DdevGlobalConfig.LastStartedVersion = originalGlobalConfig.LastStartedVersion
@@ -263,7 +263,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 	sourceBinDir := filepath.Join(originalGlobalDdevDir, "bin")
 	_, err = os.Stat(sourceBinDir)
 	if !os.IsNotExist(err) {
-		// Copy ~/.ddev/bin to $XDG_CONFIG_HOME/ddev/bin
+		// Copy ~/.ddev/bin to $DDEV_XDG_CONFIG_HOME/ddev/bin
 		err = copy2.Copy(sourceBinDir, filepath.Join(tmpGlobalDdevDir, "bin"))
 		require.NoError(t, err)
 	}
@@ -280,9 +280,9 @@ func CopyGlobalDdevDir(t *testing.T) string {
 	return tmpXdgConfigHomeDir
 }
 
-// ResetGlobalDdevDir removes temporary $XDG_CONFIG_HOME directory
+// ResetGlobalDdevDir removes temporary $DDEV_XDG_CONFIG_HOME directory
 func ResetGlobalDdevDir(t *testing.T, tmpXdgConfigHomeDir string) {
-	// Stop the Mutagen daemon running in the $XDG_CONFIG_HOME/ddev
+	// Stop the Mutagen daemon running
 	ddevapp.StopMutagenDaemon("")
 	t.Logf("stopped mutagen daemon '%s' with MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory())
 	// After the $DDEV_XDG_CONFIG_HOME directory is removed,

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -238,7 +238,7 @@ func CopyGlobalDdevDir(t *testing.T) string {
 	// Stop the Mutagen daemon running in the ~/.ddev
 	ddevapp.StopMutagenDaemon("")
 	t.Logf("stopped mutagen daemon %s in MUTAGEN_DATA_DIRECTORY=%s", globalconfig.GetMutagenPath(), globalconfig.GetMutagenDataDirectory())
-	// Set $DDEV_XDG_CONFIG_HOME for tests (works on all platforms; XDG_CONFIG_HOME is Linux-only)
+	// Set $DDEV_XDG_CONFIG_HOME for tests (works on all platforms)
 	t.Setenv("DDEV_XDG_CONFIG_HOME", tmpXdgConfigHomeDir)
 	// Make sure that the global config directory is set to $DDEV_XDG_CONFIG_HOME/ddev
 	require.Equal(t, tmpGlobalDdevDir, globalconfig.GetGlobalDdevDir())

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -637,3 +637,13 @@ func IsPHPVersionEmbargoed(phpVersion string) bool {
 	}
 	return false
 }
+
+// WarnAboutMultipleGlobalDdevDirs warns once if a global DDEV config exists in a
+// location other than the one DDEV actually uses. It is a no-op in JSON output mode.
+func WarnAboutMultipleGlobalDdevDirs() {
+	if !output.JSONOutput {
+		if err := globalconfig.CheckForMultipleGlobalDdevDirs(); err != nil {
+			WarningWithColor("magenta", "Warning: %v", err)
+		}
+	}
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -643,7 +643,7 @@ func IsPHPVersionEmbargoed(phpVersion string) bool {
 func WarnAboutMultipleGlobalDdevDirs() {
 	if !output.JSONOutput {
 		if err := globalconfig.CheckForMultipleGlobalDdevDirs(); err != nil {
-			WarningWithColor("magenta", "Warning: %v", err)
+			WarningWithColor("magenta", "Warning: %v.", err)
 		}
 	}
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -638,7 +638,7 @@ func IsPHPVersionEmbargoed(phpVersion string) bool {
 	return false
 }
 
-// WarnAboutMultipleGlobalDdevDirs warns once if a global DDEV config exists in a
+// WarnAboutMultipleGlobalDdevDirs warns if a global DDEV config exists in a
 // location other than the one DDEV actually uses. It is a no-op in JSON output mode.
 func WarnAboutMultipleGlobalDdevDirs() {
 	if !output.JSONOutput {


### PR DESCRIPTION
## The Issue

- Follow-up to #8494, completing #8493 for Linux

#8494 stopped DDEV from honoring `XDG_CONFIG_HOME` on macOS and Windows but kept it on Linux. On Linux it still silently relocates the global config dir for users who set `XDG_CONFIG_HOME` for other tools, the same confusion the original issue described. DDEV now ignores `XDG_CONFIG_HOME` on every platform.

## How This PR Solves The Issue

- `GetGlobalDdevDirLocation()` no longer reads `XDG_CONFIG_HOME`. The Linux/WSL2 `~/.config/ddev` fallback now resolves `$HOME/.config/ddev` directly instead of `os.UserConfigDir()`, which honors `XDG_CONFIG_HOME`.
- `DDEV_XDG_CONFIG_HOME` (all platforms) and the Linux/WSL2 `~/.config/ddev` fallback are the only ways to relocate the global config.
- `CheckForMultipleGlobalDdevDirs()` now reports a leftover `$XDG_CONFIG_HOME/ddev` (no longer honored) with migration instructions, plus a stale `~/.ddev` or `~/.config/ddev`. Replaces the removed `WarnIfXDGIgnoredOnNonLinux()`.
- The warning is emitted from `ddev version` and `ddev start` via `util.WarnAboutMultipleGlobalDdevDirs()`, no longer from `app.Start()`.
- Test helpers, devcontainer config/feature, docs, and the quickstart workflow switch from `XDG_CONFIG_HOME` to `DDEV_XDG_CONFIG_HOME`.

New priority order (first match wins):

1. `$DDEV_XDG_CONFIG_HOME/ddev` if set (all platforms)
2. `$HOME/.ddev`
3. `$HOME/.config/ddev` on Linux/WSL2 only, if `$HOME/.ddev` doesn't exist

https://ddev--8531.org.readthedocs.build/en/8531/users/usage/architecture/#global-files

## Manual Testing Instructions

## Manual Testing Instructions

---

### 1. Default configuration (`~/.ddev`)

```bash
rm -rf ~/.ddev ~/.config/ddev ~/tmp/ddev ~/xdg/ddev

ddev version | grep global-ddev-dir
```

Expected:

```text
global-ddev-dir   /home/$USER/.ddev
```

No warning in `ddev version` / `ddev start`.

---

### 2. Linux fallback (`~/.config/ddev`)

```bash
rm -rf ~/.ddev ~/.config/ddev ~/tmp/ddev ~/xdg/ddev
mkdir -p ~/.config/ddev

ddev version | grep global-ddev-dir
```

Expected:

```text
global-ddev-dir   /home/$USER/.config/ddev
```

No warning in `ddev version` / `ddev start`.

---

### 3. Linux: `XDG_CONFIG_HOME=~/.config`

DDEV doesn't warn about `XDG_CONFIG_HOME`, because it's Linux fallback (`~/.config/ddev`)

```bash
rm -rf ~/.ddev ~/.config/ddev ~/tmp/ddev ~/xdg/ddev
mkdir -p ~/.config/ddev
XDG_CONFIG_HOME=~/.config ddev version | grep global-ddev-dir
```

Expected:

```text
global-ddev-dir   /home/$USER/.config/ddev
```

No warning in `ddev version` / `ddev start`.

---

### 4. When `DDEV_XDG_CONFIG_HOME` is set, we don't show any warnings about existing `XDG_CONFIG_HOME`

```bash
rm -rf ~/.ddev ~/.config/ddev ~/tmp/ddev ~/xdg/ddev
mkdir -p ~/tmp/ddev ~/xdg/ddev

DDEV_XDG_CONFIG_HOME=~/tmp XDG_CONFIG_HOME=~/xdg ddev version | grep global-ddev-dir
```

Expected:

```text
global-ddev-dir   /home/$USER/tmp/ddev
```

No warning in `ddev version` / `ddev start`.

---

### 5. `XDG_CONFIG_HOME` is set, but no `ddev` directory exists there

```bash
rm -rf ~/.ddev ~/.config/ddev ~/tmp/ddev ~/xdg/ddev

XDG_CONFIG_HOME=~/xdg ddev version | grep global-ddev-dir
```

Expected:

```text
global-ddev-dir   /home/$USER/.ddev
```

No warning in `ddev version` / `ddev start`.

---

### 6. Both Linux locations exist

```bash
rm -rf ~/.ddev ~/.config/ddev ~/tmp/ddev ~/xdg/ddev
mkdir -p ~/.ddev ~/.config/ddev

ddev version | grep global-ddev-dir
```

Expected warning in `ddev version` / `ddev start`:

```text
Warning: multiple global DDEV configurations found ...
```

Expected:

```text
global-ddev-dir   /home/$USER/.ddev
```

---

### 7. `DDEV_XDG_CONFIG_HOME` with stale `~/.ddev`

```bash
rm -rf ~/.ddev ~/.config/ddev ~/tmp/ddev ~/xdg/ddev
mkdir -p ~/tmp/ddev ~/.ddev

DDEV_XDG_CONFIG_HOME=~/tmp ddev version | grep global-ddev-dir
```

Expected warning in `ddev version` / `ddev start`:

```text
Warning: multiple global DDEV configurations found ...
```

Expected:

```text
global-ddev-dir   /home/$USER/tmp/ddev
```

---

### 8. Leftover `XDG_CONFIG_HOME` location is no longer honored

```bash
rm -rf ~/.ddev ~/.config/ddev ~/tmp/ddev ~/xdg/ddev
mkdir -p ~/.ddev ~/xdg/ddev

XDG_CONFIG_HOME=~/xdg ddev version | grep global-ddev-dir
```

Expected warning in `ddev version` / `ddev start`:

```text
Warning: found a leftover DDEV global config at "/home/$USER/xdg/ddev"; DDEV no longer honors XDG_CONFIG_HOME, so it is not being used. To keep using it, set DDEV_XDG_CONFIG_HOME="/home/$USER/xdg"; otherwise remove "/home/$USER/xdg/ddev".

global-ddev-dir   /home/$USER/.ddev
```

---

## Automated Testing Overview

- `TestCheckForMultipleGlobalDdevDirs`: reordered into happy-path cases (no warning) first, then error-path cases (warning), covering all eight scenarios in the table.
- `TestGetGlobalDdevDirLocation` and `TestCreateGlobalDdevDir`: drop `XDG_CONFIG_HOME` handling.
- `testcommon.CopyGlobalDdevDir` / `ResetGlobalDdevDir`: already use `DDEV_XDG_CONFIG_HOME`; comments updated.

## Release/Deployment Notes

- **Linux/WSL2**: `XDG_CONFIG_HOME` is no longer honored. Users relying on it for the DDEV global config get a one-time warning on `ddev version` / `ddev start` telling them to set `DDEV_XDG_CONFIG_HOME` or move the config to `~/.config/ddev`.
- **macOS/Windows**: no change from #8494.
- `DDEV_XDG_CONFIG_HOME` is the supported cross-platform override.