### PR TITLE
fix: continue when `#ddev-generated` is missing in generate config functions, for #2305

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2457,9 +2457,9 @@ func (app *DdevApp) GenerateWebserverConfig() error {
 			if err != nil {
 				return err
 			}
-			// If the signature doesn't exist, they have taken over the file, so return
+			// If the signature doesn't exist, they have taken over the file, so skip it
 			if !sigExists {
-				return nil
+				continue
 			}
 		}
 
@@ -2510,9 +2510,9 @@ func (app *DdevApp) GeneratePostgresConfig() error {
 			if err != nil {
 				return err
 			}
-			// If the signature doesn't exist, they have taken over the file, so return
+			// If the signature doesn't exist, they have taken over the file, so skip it
 			if !sigExists {
-				return nil
+				continue
 			}
 		}
 


### PR DESCRIPTION
## The Issue

- For #2305

From Discord https://discord.com/channels/664580571770388500/1520077061165813941

If you have `.ddev/nginx_full/nginx-site.conf` without `#ddev-generated`, then `.ddev/apache/apache-site.conf` is not recreated:

```bash
ddev config --webserver-type=apache-fpm
ddev start
sed -i 's/#ddev-generated//' .ddev/nginx_full/nginx-site.conf
rm -f .ddev/apache/apache-site.conf
ddev restart # timeout error
ls -l .ddev/apache/apache-site.conf # no file here
```

## How This PR Solves The Issue

Fixes early return in `app.GenerateWebserverConfig()` and `app.GeneratePostgresConfig()`.

PostgreSQL isn't really broken because there is only one file in the loop, but the early return is wrong.

## Manual Testing Instructions

```bash
ddev config --webserver-type=apache-fpm
ddev start
sed -i 's/#ddev-generated//' .ddev/nginx_full/nginx-site.conf
rm -f .ddev/apache/apache-site.conf
ddev restart
ls -l .ddev/apache/apache-site.conf
```

## Automated Testing Overview

I thought about adding a test for this, but it's too fragile and can't cover every case. For example, if I add `nginx-site.conf` without `#ddev-generated` and check `apache-site.conf`, the test will pass. But if I change the order of the files in `app.GenerateWebserverConfig()`, the test will not catch the change.

In the end, I decided that fixing the logic is enough. Otherwise, I'd just be adding a lot of test code that provides little value and becomes maintenance overhead.

## Release/Deployment Notes

Affected DDEV versions:

- v1.15-alpha5 - v1.25.2