### PR TITLE
docs: Remove link to very old processwire thread (#8533) [skip ci]

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2469,8 +2469,6 @@ If you get a warning about "Apache mod_rewrite" during the compatibility check, 
 ddev config --upload-dirs=sites/assets/files && ddev restart
 ```
 
-If you have any questions there is lots of help in the [DDEV thread in the ProcessWire forum](https://processwire.com/talk/topic/27433-using-ddev-for-local-processwire-development-tips-tricks/).
-
 ## Shopware
 
 === "Composer"


### PR DESCRIPTION

## The Issue

The removed link went to a very old thread that doesn't seem useful today.