### PR TITLE
test(auth-ssh): harden ddevauthssh.expect against passphrase prompt race

### DIFF
--- a/cmd/ddev/cmd/testdata/TestCmdAuthSSH/ddevauthssh.expect
+++ b/cmd/ddev/cmd/testdata/TestCmdAuthSSH/ddevauthssh.expect
@@ -4,8 +4,16 @@ set ddevpath [lindex $argv 0];
 set keypath [lindex $argv 1];
 set passphrase [lindex $argv 2];
 
+# ssh-add reads the passphrase with readpassphrase(), which flushes pending
+# input (TCSAFLUSH) before reading. Sending too early loses the passphrase
+# under high pty I/O latency (e.g. WSL2 mirrored), so sleep first. exp_continue
+# re-answers any re-prompt; timeout/eof handlers fail loudly.
+set timeout 30
 spawn "$ddevpath" auth ssh -d "$keypath"
-expect "Enter passphrase"
-send "$passphrase\n";
-expect "Identity added"
-interact
+expect {
+    "Identity added"   { }
+    "Enter passphrase" { sleep 0.3; send -- "$passphrase\n"; exp_continue }
+    timeout            { puts "FAIL: timed out waiting for 'Identity added'"; exit 2 }
+    eof                { puts "FAIL: eof before 'Identity added'"; exit 3 }
+}
+expect eof

--- a/pkg/ddevapp/testdata/TestAcquiaPull/ddevauthssh.expect
+++ b/pkg/ddevapp/testdata/TestAcquiaPull/ddevauthssh.expect
@@ -3,6 +3,13 @@
 set ddevpath [lindex $argv 0];
 set keypath [lindex $argv 1];
 
+# Key has no passphrase, so this adds it without prompting.
+set timeout 30
 spawn "$ddevpath" auth ssh -d "$keypath"
-expect "Identity added"
-interact
+expect {
+    "Identity added"   { }
+    "Enter passphrase" { puts "FAIL: unexpected passphrase prompt"; exit 4 }
+    timeout            { puts "FAIL: timed out waiting for 'Identity added'"; exit 2 }
+    eof                { puts "FAIL: eof before 'Identity added'"; exit 3 }
+}
+expect eof

--- a/pkg/ddevapp/testdata/TestAcquiaPush/ddevauthssh.expect
+++ b/pkg/ddevapp/testdata/TestAcquiaPush/ddevauthssh.expect
@@ -3,6 +3,13 @@
 set ddevpath [lindex $argv 0];
 set keypath [lindex $argv 1];
 
+# Key has no passphrase, so this adds it without prompting.
+set timeout 30
 spawn "$ddevpath" auth ssh -d "$keypath"
-expect "Identity added"
-interact
+expect {
+    "Identity added"   { }
+    "Enter passphrase" { puts "FAIL: unexpected passphrase prompt"; exit 4 }
+    timeout            { puts "FAIL: timed out waiting for 'Identity added'"; exit 2 }
+    eof                { puts "FAIL: eof before 'Identity added'"; exit 3 }
+}
+expect eof

--- a/pkg/ddevapp/testdata/TestLagoonPull/ddevauthssh.expect
+++ b/pkg/ddevapp/testdata/TestLagoonPull/ddevauthssh.expect
@@ -3,6 +3,13 @@
 set ddevpath [lindex $argv 0];
 set keypath [lindex $argv 1];
 
+# Key has no passphrase, so this adds it without prompting.
+set timeout 30
 spawn "$ddevpath" auth ssh -d "$keypath"
-expect "Identity added"
-interact
+expect {
+    "Identity added"   { }
+    "Enter passphrase" { puts "FAIL: unexpected passphrase prompt"; exit 4 }
+    timeout            { puts "FAIL: timed out waiting for 'Identity added'"; exit 2 }
+    eof                { puts "FAIL: eof before 'Identity added'"; exit 3 }
+}
+expect eof

--- a/pkg/ddevapp/testdata/TestLagoonPush/ddevauthssh.expect
+++ b/pkg/ddevapp/testdata/TestLagoonPush/ddevauthssh.expect
@@ -3,6 +3,13 @@
 set ddevpath [lindex $argv 0];
 set keypath [lindex $argv 1];
 
+# Key has no passphrase, so this adds it without prompting.
+set timeout 30
 spawn "$ddevpath" auth ssh -d "$keypath"
-expect "Identity added"
-interact
+expect {
+    "Identity added"   { }
+    "Enter passphrase" { puts "FAIL: unexpected passphrase prompt"; exit 4 }
+    timeout            { puts "FAIL: timed out waiting for 'Identity added'"; exit 2 }
+    eof                { puts "FAIL: eof before 'Identity added'"; exit 3 }
+}
+expect eof

--- a/pkg/ddevapp/testdata/TestPantheonPull/ddevauthssh.expect
+++ b/pkg/ddevapp/testdata/TestPantheonPull/ddevauthssh.expect
@@ -3,6 +3,13 @@
 set ddevpath [lindex $argv 0];
 set keypath [lindex $argv 1];
 
+# Key has no passphrase, so this adds it without prompting.
+set timeout 30
 spawn "$ddevpath" auth ssh -d "$keypath"
-expect "Identity added"
-interact
+expect {
+    "Identity added"   { }
+    "Enter passphrase" { puts "FAIL: unexpected passphrase prompt"; exit 4 }
+    timeout            { puts "FAIL: timed out waiting for 'Identity added'"; exit 2 }
+    eof                { puts "FAIL: eof before 'Identity added'"; exit 3 }
+}
+expect eof

--- a/pkg/ddevapp/testdata/TestPantheonPush/ddevauthssh.expect
+++ b/pkg/ddevapp/testdata/TestPantheonPush/ddevauthssh.expect
@@ -3,6 +3,13 @@
 set ddevpath [lindex $argv 0];
 set keypath [lindex $argv 1];
 
+# Key has no passphrase, so this adds it without prompting.
+set timeout 30
 spawn "$ddevpath" auth ssh -d "$keypath"
-expect "Identity added"
-interact
+expect {
+    "Identity added"   { }
+    "Enter passphrase" { puts "FAIL: unexpected passphrase prompt"; exit 4 }
+    timeout            { puts "FAIL: timed out waiting for 'Identity added'"; exit 2 }
+    eof                { puts "FAIL: eof before 'Identity added'"; exit 3 }
+}
+expect eof


### PR DESCRIPTION
## The Issue

- `TestCmdAuthSSH` fails intermittently on the wsl2-mirrored runner with "does not contain 'Identity added:'".

https://buildkite.com/ddev/wsl2-mirrored/builds/1090

```
RUN TestCmdAuthSSH
PERF: enter ddevapp.NewApp(, includeOverrides=false) at 10:47:55.311690075
PERF: exit ddevapp.NewApp(, includeOverrides=false) at 10:47:55.336495515 after 24ms
Command  Result=All identities removed.
Command  Result=80748c8bdc9d1b7da799e0cb42e4fdf7e2545be28ac01b5a872a86500091df8c
Command  Result='172.18.0.6'
PERF: enter app.Exec &{web  ssh -o BatchMode=yes root@172.18.0.6 pwd [] false false <nil> <nil> false []  false} at 10:47:56.216905356
PERF: exit app.Exec &{web  ssh -o BatchMode=yes root@172.18.0.6 pwd [] false false <nil> <nil> false []  false} at 10:47:56.396439149 after 179ms
Command  Result=spawn /var/lib/buildkite-agent/builds/tb-wsl-12-1/ddev/wsl2-mirrored/.gotmp/bin/linux_amd64/ddev auth ssh -d /var/lib/buildkite-agent/builds/tb-wsl-12-1/ddev/wsl2-mirrored/cmd/ddev/cmd/testdata/TestCmdAuthSSH/.ssh
2026-06-26T10:47:56.536 Found 2 file paths to process
2026-06-26T10:47:56.537 Added SSH private key: /var/lib/buildkite-agent/builds/tb-wsl-12-1/ddev/wsl2-mirrored/cmd/ddev/cmd/testdata/TestCmdAuthSSH/.ssh/id_rsa
2026-06-26T10:47:56.602 Ensuring ddev-ssh-agent container is running with the current image
2026-06-26T10:47:56.611 ddev-ssh-agent is running
Adding 1 SSH private key(s)...
2026-06-26T10:47:56.611 Binding SSH private key /var/lib/buildkite-agent/builds/tb-wsl-12-1/ddev/wsl2-mirrored/cmd/ddev/cmd/testdata/TestCmdAuthSSH/.ssh/id_rsa into container as /tmp/sshtmp/id_rsa
testkey
testkey
Adding key id_rsa
Enter passphrase for id_rsa:
    auth-ssh_test.go:75:
        	Error Trace:	/var/lib/buildkite-agent/builds/tb-wsl-12-1/ddev/wsl2-mirrored/cmd/ddev/cmd/auth-ssh_test.go:75
        	Error:      	"spawn /var/lib/buildkite-agent/builds/tb-wsl-12-1/ddev/wsl2-mirrored/.gotmp/bin/linux_amd64/ddev auth ssh -d /var/lib/buildkite-agent/builds/tb-wsl-12-1/ddev/wsl2-mirrored/cmd/ddev/cmd/testdata/TestCmdAuthSSH/.ssh\r\n2026-06-26T10:47:56.536 Found 2 file paths to process\r\n2026-06-26T10:47:56.537 Added SSH private key: /var/lib/buildkite-agent/builds/tb-wsl-12-1/ddev/wsl2-mirrored/cmd/ddev/cmd/testdata/TestCmdAuthSSH/.ssh/id_rsa\r\n2026-06-26T10:47:56.602 Ensuring ddev-ssh-agent container is running with the current image\r\n2026-06-26T10:47:56.611 ddev-ssh-agent is running\r\nAdding 1 SSH private key(s)...\r\n2026-06-26T10:47:56.611 Binding SSH private key /var/lib/buildkite-agent/builds/tb-wsl-12-1/ddev/wsl2-mirrored/cmd/ddev/cmd/testdata/TestCmdAuthSSH/.ssh/id_rsa into container as /tmp/sshtmp/id_rsa\r\ntestkey\r\ntestkey\r\nAdding key id_rsa\r\nEnter passphrase for id_rsa: " does not contain "Identity added:"
        	Test:       	TestCmdAuthSSH
2026-06-26T10:48:16.361 Removing merged config for project with command 'rm -rf /mnt/ddev-global-cache/traefik/config/TestCmdWordpress_merged.yaml'
2026-06-26T10:48:17.425 Cleaning ddev-global-cache with command 'rm -rf /mnt/ddev-global-cache/*/TestCmdWordpress-{web,db} /mnt/ddev-global-cache/traefik/*/TestCmdWordpress.{crt,key} /mnt/ddev-global-cache/traefik/config/TestCmdWordpress_merged.yaml'
 Container ddev-TestCmdWordpress-db Stopping
 Container ddev-TestCmdWordpress-web Stopping
 Container ddev-TestCmdWordpress-web Stopped
 Container ddev-TestCmdWordpress-db Stopped
 Container ddev-TestCmdWordpress-web Stopping
 Container ddev-TestCmdWordpress-db Stopping
 Container ddev-TestCmdWordpress-web Stopped
 Container ddev-TestCmdWordpress-web Removing
 Container ddev-TestCmdWordpress-db Stopped
 Container ddev-TestCmdWordpress-db Removing
 Container ddev-TestCmdWordpress-web Removed
 Container ddev-TestCmdWordpress-db Removed
 Network ddev-testcmdwordpress_default Removing
 Network ddev-testcmdwordpress_default Removed
Not trying to remove hostnames from hosts file because DDEV_NONINTERACTIVE=true
Volume TestCmdWordpress-mariadb for project TestCmdWordpress was deleted
2026-06-26T10:48:21.480 Deleted Docker image sha256:24a69c612842cb95549635d49fd010456e00052f2333cc4709ffbfbb829cc917
Image ddev/ddev-webserver:20260625_stasadev_node_24-TestCmdWordpress-built for project TestCmdWordpress was deleted
2026-06-26T10:48:21.738 Deleted Docker image sha256:6c9bbcf92c54ff15e0b59b2752065ca207b9988e2ba1d9af3e404c619e20cdfe
Image ddev/ddev-dbserver-mariadb-11.8:20260608_stasadev_mariadb_compat-TestCmdWordpress-built for project TestCmdWordpress was deleted
Project TestCmdWordpress was deleted. Your code and configuration are unchanged.
FAIL: TestCmdAuthSSH (24.63s)
```

`ssh-add` reads the passphrase with `readpassphrase()`, which flushes pending input (`TCSAFLUSH`) before reading. The old script sent the passphrase the instant the prompt appeared; under high pty I/O latency (WSL2 mirrored networking adds jitter to the docker-attach forwarding) the bytes can land before that flush and be discarded. expect then hit its default timeout, fell through to `interact`, and exited 0 — so only the `Contains` assertion failed, hiding the cause.

## How This PR Solves The Issue

- `sleep 0.3` before sending closes the `TCSAFLUSH` window.
- `exp_continue` re-answers if `ssh-add` re-prompts.
- `set timeout 30` plus `timeout`/`eof` handlers make real failures exit non-zero instead of falling through to `interact`.

The six provider scripts (Acquia/Lagoon/Pantheon push+pull) use unencrypted keys, so they get the same loud-failure handling without the resend loop.

## Manual Testing Instructions

- `make testcmd TESTARGS="-run TestCmdAuthSSH"`

## Automated Testing Overview

- No test logic changed, only the expect driver scripts.

## Release/Deployment Notes

- Test-only change. No user-facing or runtime impact.