### PR TITLE
docs: Ignore winaero.com, cert expired [skip buildkite] (#8537) [skip ci]

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -36,6 +36,8 @@ ignorePatterns:
   - pattern: "https://fixed.docs.upsun.com"
   # codeberg 403
   - pattern: "https://codeberg.org/oerdnj/deb.sury.org"
+  - pattern: "https://winaero.com"
+  
 aliveStatusCodes:
   - 200
   - 206


### PR DESCRIPTION

## The Issue

winaero.com's cert expired.  We probably shouldn't ever use that tool any more, but for now, just ignore the problem with ert.
