### PR TITLE
test: Pause for TestWriteableFilesDirectory on Lima-based tests [skip github]

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2565,7 +2565,7 @@ func TestDdevFullSiteSetup(t *testing.T) {
 // and files created in container are correct user on host.
 func TestWriteableFilesDirectory(t *testing.T) {
 	if dockerutil.IsRancherDesktop() {
-		t.Skip("Skipping on Rancher Desktop, sshfs is too slow")
+		t.Skip("Skipping on Rancher Desktop, it's just too slow")
 	}
 	origDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}
@@ -2645,8 +2645,8 @@ func TestWriteableFilesDirectory(t *testing.T) {
 	err = app.MutagenSyncFlush()
 	require.NoError(t, err)
 
-	// 2024-11-27: It seems that Lima the bind mount isn't exactly synchronous.
-	if dockerutil.IsLima() || dockerutil.IsColima() || dockerutil.IsRancherDesktop() || dockerutil.IsPodmanRootlessmacOS() {
+	// Lima-based docker providers are not completely synchronous on bind mount, wait for them
+	if dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop() {
 		time.Sleep(time.Second * 1)
 	}
 


### PR DESCRIPTION
## The Issue

We had many intermittent failures of TestWriteableFilesDirectory recently on Colima.

* https://buildkite.com/ddev/macos-colima-vz/builds/6838#019f112b-aab1-4ce8-b7c8-1837fc85f8f8/L8423
* https://buildkite.com/ddev/macos-colima-vz/builds/6835

This correlates with rebuilding the Colima instances on the test runners, but we don't know why that would be an issue

However, it's long been known that Lima-based docker providers don't sync instantaneously, and we have workarounds for this in a number of places, including already here

## How This PR Solves The Issue

Pause on Lima-based systems before checking in container.

I was able to demonstrate the problem consistently on my local machine finally with

```
export DDEV_DEBUG=true GOTEST_SHORT=16
make testpkg TESTARGS="-run TestWriteableFiles"
```

And I was able to debug it in VS Code; after failure, was able to manually `ddev ssh` and confirm that by that time the file had appeared.

