### PR TITLE
feat: add x-ddev.omit-ddev-labels to skip com.ddev.* label injection, fixes #8389

### DIFF
--- a/docs/content/users/extend/creating-add-ons.md
+++ b/docs/content/users/extend/creating-add-ons.md
@@ -313,7 +313,7 @@ services:
       describe-info: "API key: ${MYSERVICE_API_KEY}"
 ```
 
-See [Customizing ddev describe output](custom-docker-services.md#customizing-ddev-describe-output) for full details.
+See [Customizing ddev describe output](custom-docker-services.md#customizing-ddev-describe-output) for full details, and the [`x-ddev` Extension](custom-docker-services.md#x-ddev-extension) for all supported keys.
 
 ### Minor Docker Image Customization
 

--- a/docs/content/users/extend/custom-docker-services.md
+++ b/docs/content/users/extend/custom-docker-services.md
@@ -120,6 +120,17 @@ volumes:
   - "../:/var/www/html:cached"
 ```
 
+## `x-ddev` Extension
+
+The `x-ddev` extension field lets you customize DDEV behavior per service in your `.ddev/docker-compose.*.yaml` files.
+
+| Key | Description |
+|-----|-------------|
+| [`describe-url-port`](#customizing-ddev-describe-output) | Text shown in the `URL/PORT` column of `ddev describe` |
+| [`describe-info`](#customizing-ddev-describe-output) | Text shown in the `INFO` column of `ddev describe` |
+| [`ssh-shell`](../extend/in-container-configuration.md#changing-ddev-ssh-shell) | Shell used by `ddev ssh` for this service |
+| [`omit-ddev-labels`](#omitting-comddev-labels-from-a-service) | Skip injecting `com.ddev.*` labels onto this service |
+
 ### Customizing `ddev describe` Output
 
 You can use the `x-ddev` extension field in your `.ddev/docker-compose.*.yaml` configuration to customize the output of [`ddev describe`](../usage/commands.md#describe).
@@ -158,6 +169,38 @@ services:
 
 !!!tip
     See related `x-ddev.ssh-shell` configuration for [Changing `ddev ssh` Shell](../extend/in-container-configuration.md#changing-ddev-ssh-shell).
+
+### Omitting `com.ddev.*` Labels from a Service
+
+Setting `x-ddev.omit-ddev-labels: true` stops DDEV from injecting `com.ddev.*` labels onto a service.
+
+DDEV normally stamps these labels (like `com.ddev.site-name`) on every service and has `ddev start` wait for the matching containers. That makes `ddev start` fail when a one-shot container exits before the wait completes. Omitting the labels drops the service from that wait, while leaving it in the compose file so `ddev stop`, `ddev poweroff`, and `ddev delete` still tear it down.
+
+```yaml
+services:
+  # One-shot container: prepares the shared volume, then exits
+  init:
+    container_name: "ddev-${DDEV_SITENAME}-init"
+    image: busybox:stable
+    command:
+      - sh
+      - -c
+      - |
+        mkdir -p /assets/cache &&
+        chown -R ${DDEV_UID}:${DDEV_GID} /assets
+    volumes:
+      - "assets:/assets"
+    x-ddev:
+      omit-ddev-labels: true
+
+  # web mounts the same volume
+  web:
+    volumes:
+      - "assets:/mnt/assets"
+
+volumes:
+  assets:
+```
 
 ## Advanced Service Examples
 

--- a/docs/content/users/extend/custom-docker-services.md
+++ b/docs/content/users/extend/custom-docker-services.md
@@ -186,10 +186,10 @@ services:
       - sh
       - -c
       - |
-        mkdir -p /assets/cache &&
-        chown -R ${DDEV_UID}:${DDEV_GID} /assets
+        mkdir -p /mnt/assets/cache &&
+        chown -R ${DDEV_UID}:${DDEV_GID} /mnt/assets
     volumes:
-      - "assets:/assets"
+      - "assets:/mnt/assets"
     x-ddev:
       omit-ddev-labels: true
 
@@ -197,6 +197,9 @@ services:
   web:
     volumes:
       - "assets:/mnt/assets"
+    depends_on:
+      init:
+        condition: service_completed_successfully
 
 volumes:
   assets:

--- a/docs/content/users/extend/custom-docker-services.md
+++ b/docs/content/users/extend/custom-docker-services.md
@@ -128,7 +128,7 @@ The `x-ddev` extension field lets you customize DDEV behavior per service in you
 |-----|-------------|
 | [`describe-url-port`](#customizing-ddev-describe-output) | Text shown in the `URL/PORT` column of `ddev describe` |
 | [`describe-info`](#customizing-ddev-describe-output) | Text shown in the `INFO` column of `ddev describe` |
-| [`ssh-shell`](../extend/in-container-configuration.md#changing-ddev-ssh-shell) | Shell used by `ddev ssh` for this service |
+| [`ssh-shell`](../extend/in-container-configuration.md#changing-ddev-ssh-shell) | Shell used by `ddev ssh -s <service>` for this service |
 | [`omit-ddev-labels`](#omitting-comddev-labels-from-a-service) | Skip injecting `com.ddev.*` labels onto this service |
 
 ### Customizing `ddev describe` Output

--- a/docs/content/users/extend/in-container-configuration.md
+++ b/docs/content/users/extend/in-container-configuration.md
@@ -149,7 +149,7 @@ services:
 To change the shell for a custom service, add the `x-ddev.ssh-shell` field to that service's configuration and ensure the desired shell is [installed in the image](./customizing-images.md).
 
 !!!tip
-    See related `x-ddev.describe-*` configuration for [Customizing `ddev describe` Output](../extend/custom-docker-services.md#customizing-ddev-describe-output).
+    See the [`x-ddev` Extension](../extend/custom-docker-services.md#x-ddev-extension) for all supported keys, including `describe-*` and `omit-ddev-labels`.
 
 ## Using `NO_COLOR` Inside Containers
 

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -141,6 +141,7 @@ type XDdevExtension struct {
 	DescribeURLPort string `mapstructure:"describe-url-port"`
 	DescribeInfo    string `mapstructure:"describe-info"`
 	SSHShell        string `mapstructure:"ssh-shell"`
+	OmitDdevLabels  bool   `mapstructure:"omit-ddev-labels"`
 }
 
 // GetXDdevExtension retrieves the x-ddev extension for a given service from the ComposeYaml
@@ -200,6 +201,10 @@ func GetDdevLabels(app *DdevApp) map[string]string {
 func injectDdevLabels(project *composeTypes.Project, app *DdevApp) {
 	labels := GetDdevLabels(app)
 	for name, service := range project.Services {
+		var x XDdevExtension
+		if found, err := service.Extensions.Get("x-ddev", &x); err == nil && found && x.OmitDdevLabels {
+			continue // user opted this service out of DDEV labels
+		}
 		if service.Labels == nil {
 			service.Labels = composeTypes.Labels{}
 		}

--- a/pkg/ddevapp/compose_yaml_test.go
+++ b/pkg/ddevapp/compose_yaml_test.go
@@ -41,12 +41,20 @@ services:
     image: ddev/ddev-utilities
     x-ddev:
       ssh-shell: fish
-  noshell:
+  no-shell:
     image: ddev/ddev-utilities
     x-ddev:
       describe-info: "has info but no shell"
-  noextension:
+  no-extension:
     image: ddev/ddev-utilities
+  omit-ddev-labels:
+    image: ddev/ddev-utilities
+    x-ddev:
+      omit-ddev-labels: true
+  with-others:
+    image: ddev/ddev-utilities
+    x-ddev:
+      describe-info: "has other fields"
 `
 
 	project, err := dockerutil.CreateComposeProject(composeYAML)
@@ -79,7 +87,7 @@ services:
 
 	// Test service with no shell - should default to sh
 	t.Run("service without shell defaults to sh", func(t *testing.T) {
-		xDdev := app.GetXDdevExtension("noshell")
+		xDdev := app.GetXDdevExtension("no-shell")
 		assert.Equal("has info but no shell", xDdev.DescribeInfo)
 		assert.Equal("", xDdev.DescribeURLPort)
 		assert.Equal("sh", xDdev.SSHShell)
@@ -87,10 +95,23 @@ services:
 
 	// Test service with no x-ddev extension - should default to sh
 	t.Run("service without x-ddev extension", func(t *testing.T) {
-		xDdev := app.GetXDdevExtension("noextension")
+		xDdev := app.GetXDdevExtension("no-extension")
 		assert.Equal("", xDdev.DescribeInfo)
 		assert.Equal("", xDdev.DescribeURLPort)
 		assert.Equal("sh", xDdev.SSHShell)
+		assert.False(xDdev.OmitDdevLabels)
+	})
+
+	// Test service with omit-ddev-labels: true
+	t.Run("service with omit-ddev-labels true", func(t *testing.T) {
+		xDdev := app.GetXDdevExtension("omit-ddev-labels")
+		assert.True(xDdev.OmitDdevLabels)
+	})
+
+	// Test service with other x-ddev fields but no omit-ddev-labels
+	t.Run("service without omit-ddev-labels defaults to false", func(t *testing.T) {
+		xDdev := app.GetXDdevExtension("with-others")
+		assert.False(xDdev.OmitDdevLabels)
 	})
 
 	// Test non-existent service
@@ -229,7 +250,7 @@ func TestFixupComposeYaml(t *testing.T) {
 	require.NotEmpty(t, app.ComposeYaml)
 	require.NotEmpty(t, app.ComposeYaml.Services)
 
-	expectedServices := []string{"web", "db", "dummy1", "dummy2"}
+	expectedServices := []string{"web", "db", "dummy1", "dummy2", "dummy3"}
 	for _, serviceName := range expectedServices {
 		_, ok := app.ComposeYaml.Services[serviceName]
 		require.True(t, ok, "%s service not found in app.ComposeYaml.Services", serviceName)
@@ -265,6 +286,7 @@ func TestFixupComposeYaml(t *testing.T) {
 
 	totalPortsChecked := 0
 	buildServicesChecked := 0
+	omitLabelServicesChecked := 0
 	for serviceName, service := range app.ComposeYaml.Services {
 		t.Run("service_"+serviceName, func(t *testing.T) {
 			require.Contains(t, service.Networks, "ddev_default", "service %s missing ddev_default network", serviceName)
@@ -284,6 +306,19 @@ func TestFixupComposeYaml(t *testing.T) {
 				require.Equal(t, "127.0.0.1", port.HostIP, "service %s port %d should have HostIP set to 127.0.0.1", serviceName, portIndex)
 			}
 
+			if serviceName == "dummy3" {
+				omitLabelServicesChecked++
+				for k := range ddevapp.GetDdevLabels(app) {
+					require.NotContains(t, service.Labels, k, "service %s should not have label %s", serviceName, k)
+				}
+				if service.Build != nil {
+					for k := range ddevapp.GetDdevLabels(app) {
+						require.NotContains(t, service.Build.Labels, k, "service %s build should not have label %s", serviceName, k)
+					}
+				}
+				return
+			}
+
 			for k, v := range ddevapp.GetDdevLabels(app) {
 				require.Contains(t, service.Labels, k, "service %s missing label %s", serviceName, k)
 				require.Equal(t, v, service.Labels[k], "service %s label %s value incorrect", serviceName, k)
@@ -300,6 +335,7 @@ func TestFixupComposeYaml(t *testing.T) {
 	}
 	require.Positive(t, buildServicesChecked, "build label check never ran")
 	require.Positive(t, totalPortsChecked, "port HostIP check never ran")
+	require.Positive(t, omitLabelServicesChecked, "omit-ddev-labels check never ran")
 
 	hasPort12345 := false
 	for _, port := range webService.Ports {

--- a/pkg/ddevapp/testdata/TestFixupComposeYaml/.ddev/docker-compose.dummy3.yaml
+++ b/pkg/ddevapp/testdata/TestFixupComposeYaml/.ddev/docker-compose.dummy3.yaml
@@ -1,0 +1,6 @@
+services:
+  dummy3:
+    build:
+      context: .
+    x-ddev:
+      omit-ddev-labels: true


### PR DESCRIPTION
## The Issue

- Fixes #8389

One-shot or init containers that exit before `ddev start` completes its wait cause the start to fail, because DDEV waits for all containers bearing `com.ddev.*` labels.

## How This PR Solves The Issue

Add `x-ddev.omit-ddev-labels: true` support to `injectDdevLabels`. When set, DDEV skips stamping `com.ddev.*` labels onto that service, dropping it from the startup wait while keeping it in the compose file so `ddev stop`, `ddev poweroff`, and `ddev delete` still tear it down.

Also adds an `x-ddev` reference table to the custom-docker-services docs, renames it as a dedicated section, and updates cross-links in creating-add-ons.md and in-container-configuration.md.

https://ddev--8540.org.readthedocs.build/en/8540/users/extend/custom-docker-services/#x-ddev-extension

## Manual Testing Instructions

Using the example from https://ddev--8540.org.readthedocs.build/en/8540/users/extend/custom-docker-services/#omitting-comddev-labels-from-a-service, create a `.ddev/docker-compose.init.yaml` file.

1. Run `ddev start` - confirm no issues.
2. Remove `omit-ddev-labels: true` or set it to `false`, and run `ddev restart` - failed to restart because the container had already stopped.

## Automated Testing Overview

- Extended `TestGetXDdevExtension` with cases for `omit-ddev-labels: true` and the false default.
- Extended `TestFixupComposeYaml` with a `dummy3` service that asserts no `com.ddev.*` labels are injected when the flag is set.

## Release/Deployment Notes

No breaking changes. Services without `x-ddev.omit-ddev-labels` are unaffected.