### PR TITLE
test: fix TestCheckForMultipleGlobalDdevDirs on Windows, for #8531 (#8542) [skip ci]

### DIFF
--- a/pkg/globalconfig/global_config_test.go
+++ b/pkg/globalconfig/global_config_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -212,10 +213,10 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_Default")
 		defer os.RemoveAll(tmpHome)
 
-		t.Setenv("HOME", tmpHome)
+		testcommon.SetTestHome(t, tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 
-		defaultDir := tmpHome + "/.ddev"
+		defaultDir := filepath.Join(tmpHome, ".ddev")
 		err := os.MkdirAll(defaultDir, 0755)
 		require.NoError(t, err)
 
@@ -228,10 +229,10 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_NoConflict")
 		defer os.RemoveAll(tmpHome)
 
-		t.Setenv("HOME", tmpHome)
+		testcommon.SetTestHome(t, tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 
-		xdgDir := tmpHome + "/.config/ddev"
+		xdgDir := filepath.Join(tmpHome, ".config", "ddev")
 		err := os.MkdirAll(xdgDir, 0755)
 		require.NoError(t, err)
 
@@ -249,11 +250,11 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_XDGDefault")
 		defer os.RemoveAll(tmpHome)
 
-		t.Setenv("HOME", tmpHome)
+		testcommon.SetTestHome(t, tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
-		t.Setenv("XDG_CONFIG_HOME", tmpHome+"/.config")
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
 
-		xdgDir := tmpHome + "/.config/ddev"
+		xdgDir := filepath.Join(tmpHome, ".config", "ddev")
 		err := os.MkdirAll(xdgDir, 0755)
 		require.NoError(t, err)
 
@@ -273,11 +274,11 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		tmpXdg := testcommon.CreateTmpDir("TestCheckMultipleDirs_BothXDG")
 		defer os.RemoveAll(tmpXdg)
 
-		t.Setenv("HOME", tmpHome)
+		testcommon.SetTestHome(t, tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", tmpDdevXdg)
 		t.Setenv("XDG_CONFIG_HOME", tmpXdg)
 
-		xdgDir := tmpXdg + "/ddev"
+		xdgDir := filepath.Join(tmpXdg, "ddev")
 		err := os.MkdirAll(xdgDir, 0755)
 		require.NoError(t, err)
 
@@ -294,11 +295,11 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		tmpXdg := testcommon.CreateTmpDir("TestCheckMultipleDirs_XDGNoDdev")
 		defer os.RemoveAll(tmpXdg)
 
-		t.Setenv("HOME", tmpHome)
+		testcommon.SetTestHome(t, tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 		t.Setenv("XDG_CONFIG_HOME", tmpXdg)
 
-		defaultDir := tmpHome + "/.ddev"
+		defaultDir := filepath.Join(tmpHome, ".ddev")
 		err := os.MkdirAll(defaultDir, 0755)
 		require.NoError(t, err)
 
@@ -318,14 +319,14 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		tmpHome := testcommon.CreateTmpDir("TestCheckMultipleDirs_Conflict")
 		defer os.RemoveAll(tmpHome)
 
-		t.Setenv("HOME", tmpHome)
+		testcommon.SetTestHome(t, tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 
-		defaultDir := tmpHome + "/.ddev"
+		defaultDir := filepath.Join(tmpHome, ".ddev")
 		err := os.MkdirAll(defaultDir, 0755)
 		require.NoError(t, err)
 
-		xdgDir := tmpHome + "/.config/ddev"
+		xdgDir := filepath.Join(tmpHome, ".config", "ddev")
 		err = os.MkdirAll(xdgDir, 0755)
 		require.NoError(t, err)
 
@@ -344,14 +345,14 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		tmpXdg := testcommon.CreateTmpDir("TestCheckMultipleDirs_DDEVXDG")
 		defer os.RemoveAll(tmpXdg)
 
-		t.Setenv("HOME", tmpHome)
+		testcommon.SetTestHome(t, tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", tmpXdg)
 
-		defaultDir := tmpHome + "/.ddev"
+		defaultDir := filepath.Join(tmpHome, ".ddev")
 		err := os.MkdirAll(defaultDir, 0755)
 		require.NoError(t, err)
 
-		ddevXdgDir := tmpXdg + "/ddev"
+		ddevXdgDir := filepath.Join(tmpXdg, "ddev")
 		err = os.MkdirAll(ddevXdgDir, 0755)
 		require.NoError(t, err)
 
@@ -370,15 +371,15 @@ func TestCheckForMultipleGlobalDdevDirs(t *testing.T) {
 		tmpXdg := testcommon.CreateTmpDir("TestCheckMultipleDirs_XDG")
 		defer os.RemoveAll(tmpXdg)
 
-		t.Setenv("HOME", tmpHome)
+		testcommon.SetTestHome(t, tmpHome)
 		t.Setenv("DDEV_XDG_CONFIG_HOME", "")
 		t.Setenv("XDG_CONFIG_HOME", tmpXdg)
 
-		defaultDir := tmpHome + "/.ddev"
+		defaultDir := filepath.Join(tmpHome, ".ddev")
 		err := os.MkdirAll(defaultDir, 0755)
 		require.NoError(t, err)
 
-		xdgDir := tmpXdg + "/ddev"
+		xdgDir := filepath.Join(tmpXdg, "ddev")
 		err = os.MkdirAll(xdgDir, 0755)
 		require.NoError(t, err)
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -198,6 +199,17 @@ func OsTempDir() (string, error) {
 	}
 	tmpDir = filepath.Clean(tmpDir)
 	return tmpDir, nil
+}
+
+// SetTestHome sets HOME (and USERPROFILE on Windows) to the given directory.
+// On Windows, os.UserHomeDir() reads USERPROFILE, not HOME, so both must be
+// set for tests that need to isolate the home directory.
+func SetTestHome(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
 }
 
 // CreateTmpDir creates a temporary directory in the homedir


### PR DESCRIPTION


## The Issue

* #8531 

It had trouble with traditional Windows tests (which we don't run until they hit upstream/main, because they are costly, so it wasn't discovered in the PR)

* https://buildkite.com/ddev/ddev-windows-mutagen/builds/6368

## How This PR Solves The Issue

On Windows, os.UserHomeDir() reads USERPROFILE, not HOME. Tests that called t.Setenv("HOME", tmpHome) left USERPROFILE pointing at the real home directory, so CheckForMultipleGlobalDdevDirs found the real ~/.ddev and reported a spurious conflict.

Add testcommon.SetTestHome() which sets both HOME and (on Windows) USERPROFILE. Apply it to all subtests in TestCheckForMultipleGlobalDdevDirs and replace forward-slash string concatenation with filepath.Join for cross-platform path correctness.

## Manual Testing Instructions

I manually ran the buildkite tests, https://buildkite.com/ddev/ddev-windows-mutagen/builds/6370#_

## Automated Testing Overview

That's all it is, minor test update for traditional Windows.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
