### PR TITLE
docs(typo3): require Camino theme, drop empty distribution prompt (#8548) [skip ci]

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -14,6 +14,7 @@ Bash
 Bluesky
 CakePHP
 Callgraph
+Camino
 CER
 CGroups
 CI

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2910,13 +2910,18 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev composer create-project "typo3/cms-base-distribution:^14"
     ```
 
+    Install the Camino default site theme, as [recommended by the TYPO3 documentation](https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/Install.html):
+
+    ```bash
+    ddev composer req typo3/theme-camino
+    ```
+
     Run the TYPO3 setup:
 
     ```bash
     ddev typo3 setup \
         --admin-user-password="Demo123*" \
         --driver=mysqli \
-        --create-site=https://${PROJECT_NAME}.ddev.site \
         --server-type=other \
         --dbname=db \
         --username=db \
@@ -2947,10 +2952,10 @@ DDEV automatically updates or creates the `.env.local` file with the database in
         ddev config --project-type=typo3 --docroot=public
         ddev start -y
         ddev composer create-project "typo3/cms-base-distribution:^14"
+        ddev composer req typo3/theme-camino
         ddev typo3 setup \
             --admin-user-password="Demo123*" \
             --driver=mysqli \
-            --create-site=https://${PROJECT_NAME}.ddev.site \
             --server-type=other \
             --dbname=db \
             --username=db \

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2910,7 +2910,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev composer create-project "typo3/cms-base-distribution:^14"
     ```
 
-    Install the Camino default site theme, as [recommended by the TYPO3 documentation](https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/Install.html):
+    Install the Camino default theme [recommended for TYPO3 Core](https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/Install.html):
 
     ```bash
     ddev composer req typo3/theme-camino

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2913,7 +2913,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     Install the Camino default theme [recommended for TYPO3 Core](https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/Install.html):
 
     ```bash
-    ddev composer req typo3/theme-camino
+    ddev composer require typo3/theme-camino
     ```
 
     Run the TYPO3 setup:
@@ -2952,7 +2952,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
         ddev config --project-type=typo3 --docroot=public
         ddev start -y
         ddev composer create-project "typo3/cms-base-distribution:^14"
-        ddev composer req typo3/theme-camino
+        ddev composer require typo3/theme-camino
         ddev typo3 setup \
             --admin-user-password="Demo123*" \
             --driver=mysqli \

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2933,8 +2933,13 @@ DDEV automatically updates or creates the `.env.local` file with the database in
         --project-name="My TYPO3 site" \
         --force
     ```
+    Launch the site content:
 
-    Launch the site:
+    ```bash
+    ddev launch /camino
+    ```
+
+    Launch the backend:
 
     ```bash
     ddev launch /typo3/
@@ -2966,6 +2971,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
             --admin-email=admin@example.com \
             --project-name="My TYPO3 site" \
             --force
+        ddev launch /camino
         ddev launch /typo3/
         EOF
         chmod +x setup-typo3.sh

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -21,11 +21,12 @@ teardown() {
   assert_success
   run ddev composer create-project "typo3/cms-base-distribution:^14" >/dev/null
   assert_success
+  run ddev composer req typo3/theme-camino >/dev/null
+  assert_success
 
   run ddev typo3 setup \
     --admin-user-password="Demo123*" \
     --driver=mysqli \
-    --create-site=https://${PROJNAME}.ddev.site \
     --server-type=other \
     --dbname=db \
     --username=db \
@@ -42,11 +43,11 @@ teardown() {
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
   assert_success
 
-  run curl -sfIv "https://${PROJNAME}.ddev.site/"
+  run curl -sfIv "https://${PROJNAME}.ddev.site/camino/"
   assert_output --partial "HTTP/2 200"
   assert_success
-  run curl -sfLv "https://${PROJNAME}.ddev.site/"
-  assert_output --partial "Welcome to your default website"
+  run curl -sfLv "https://${PROJNAME}.ddev.site/camino/"
+  assert_output --partial "Camino de Compostela"
   assert_success
   run curl -sfLv "https://${PROJNAME}.ddev.site/typo3/"
   assert_output --partial "TYPO3 CMS Login:"

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -21,7 +21,7 @@ teardown() {
   assert_success
   run ddev composer create-project "typo3/cms-base-distribution:^14" >/dev/null
   assert_success
-  run ddev composer req typo3/theme-camino >/dev/null
+  run ddev composer require typo3/theme-camino >/dev/null
   assert_success
 
   run ddev typo3 setup \


### PR DESCRIPTION
## The Issue

The TYPO3 quickstart in `docs/content/users/quickstart.md` had two problems:

1. It didn't follow the TYPO3 documentation's recommendation to install the [Camino](https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/Installation/Install.html) default site theme.
2. `ddev typo3 setup` printed `Select a distribution to import [default: none]` with no real distribution installed to select, and the `--create-site` flag was passed even though it has no effect once a distribution package is active — producing a confusing, empty prompt/warning during an otherwise non-interactive setup.

## How This PR Solves The Issue

- Adds `ddev composer req typo3/theme-camino` after `ddev composer create-project` in both the visible instructions and the "run as a script" version, matching TYPO3's own recommended install flow.
- Removes the now-redundant `--create-site=...` flag from `ddev typo3 setup`, since it's ignored (with a warning) once a distribution package is active. With Camino required first, `--force` auto-selects it as the sole available distribution and completes without any warning or prompt.
- Updates `docs/tests/typo3.bats` (TYPO3 v14 test) to require the theme and to check the front end at `/camino/` (where the Camino distribution places its site) instead of `/`, asserting on stable Camino demo content instead of the old default-site text.

## Manual Testing Instructions

Rendered at https://ddev--8548.org.readthedocs.build/en/8548/users/quickstart/#typo3


Follow the quickstart instructions. Verify that /typo3 (backend) and /camino (front-end) both work

## Automated Testing Overview

Updated the TYPO3 v14 test in `docs/tests/typo3.bats` to require the theme and assert against the new `/camino/` front-end URL and content. Ran the full `docs/tests/typo3.bats` suite locally (v14, v13, v12, v11, git-clone, XHGui) — all 6 tests pass.

## Release/Deployment Notes

Documentation and test-only change; no code changes. TYPO3 quickstart users following the doc will get the Camino theme with demo content at `/camino/` instead of a bare TYPO3 installation.
