### PR TITLE
ci(buildkite): trim podman machine and run maintenance post-test (#8551) [skip ci]

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -81,6 +81,12 @@ function try_cleanup_containers_native {
 # In cleanup, stop everything we know of but leave either Orbstack or Docker Desktop running
 if [ "${os:-}" = "darwin" ]; then
   function cleanup {
+    # Post-test maintenance, while the provider is still up and before we stop it.
+    # Guarded so it doesn't run on the initial cleanup call at startup.
+    if [ "${RAN_TESTS:-false}" = "true" ]; then
+      echo "--- running testbot_maintenance.sh (post-test)"
+      ${TIMEOUT} 10m bash "$(dirname "$0")/testbot_maintenance.sh" || true
+    fi
     command -v orb 2>/dev/null && echo "Stopping orbstack" && (nohup orb stop &)
     sleep 3 # Since we backgrounded orb stop, make sure it completes
     if [ -f /Applications/Docker.app ]; then echo "Stopping Docker Desktop" && (killall com.docker.backend || true); fi
@@ -197,11 +203,12 @@ if [ "${os:-}" = "darwin" ]; then
       # router port override is applied after testbot_maintenance.sh runs, because
       # that script deletes ~/.ddev/global_config.yaml (see below, before tests).
 
-      if ! try_cleanup_containers_native; then
+      if ! try_cleanup_containers_via_ssh podman machine ssh; then
         echo "ERROR: Containers remain after podman machine start; aborting" >&2
         docker ps -a >&2 || true
         exit 1
       fi
+      podman machine ssh 'sudo fstrim -av'
       ;;
 
     *)
@@ -373,6 +380,8 @@ echo "--- Running tests..."
 # .buildkite/windows-installer.yml), decoupled from this suite so they can fan
 # out across runners.
 
+# From here on, cleanup (the EXIT trap) runs testbot_maintenance.sh post-test.
+RAN_TESTS=true
 make ${MAKE_TARGET:-test} TESTARGS="${TESTARGS:-}" TESTPKG="${TESTPKG:-}" TESTFILE="${TESTFILE:-}" | sed -u 's/^--- FAIL:/+++ FAIL:/; /\//!s/^=== RUN /--- RUN /'
 RV=$?
 echo "test.sh completed with status=$RV"

--- a/.buildkite/testbot_maintenance.sh
+++ b/.buildkite/testbot_maintenance.sh
@@ -67,6 +67,10 @@ fi
 docker system prune --volumes --force || true
 docker volume prune -a -f || true
 
+if [ "${DOCKER_TYPE:-}" = "podman-rootless" ] && command -v podman >/dev/null; then
+    podman machine ssh 'sudo fstrim -av' || true
+fi
+
 # Update all images that could have changed
 ( docker images | awk '/ddev|traefik|postgres/ {print $1":"$2 }' | xargs -L1 docker pull ) || true
 


### PR DESCRIPTION
## The Issue

The podman-rootless testbot runs on `main` only but shares a macOS runner with other providers. The podman VM's sparse disk image never shrinks on its own (grew to ~53G), filling the host disk and failing other providers' builds.

https://buildkite.com/ddev/macos-rancher-desktop/builds/2557
```
Disk usage is 95% on tb-macos-arm64-6, not usable
```

```
testbot@tb-macos-arm64-6 ~ % orb stop

testbot@tb-macos-arm64-6 ~ % docker context use podman-rootless

testbot@tb-macos-arm64-6 ~ % podman machine start

testbot@tb-macos-arm64-6 ~ % du -sh ~/.local/share/containers/podman/machine/
 53G	/Users/testbot/.local/share/containers/podman/machine/

testbot@tb-macos-arm64-6 ~ % podman system df
TYPE           TOTAL       ACTIVE      SIZE        RECLAIMABLE
Images         0           0           0B          0B (0%)
Containers     0           0           0B          0B (0%)
Local Volumes  0           0           0B          0B (0%)

testbot@tb-macos-arm64-6 ~ % podman machine ssh 'sudo fstrim -av'
/: 99.5 GiB (106836242432 bytes) trimmed on /dev/vda4

testbot@tb-macos-arm64-6 ~ % du -sh ~/.local/share/containers/podman/machine/
2.7G	/Users/testbot/.local/share/containers/podman/machine/
```

## How This PR Solves The Issue

- `fstrim` the podman machine so freed blocks return to the host.
- Run `testbot_maintenance.sh` post-test via the `cleanup` EXIT trap, so the reclaim happens before another provider reuses the runner and on both pass and fail.
- Use the ssh-based container cleanup for podman.

## Manual Testing Instructions

Run the podman-rootless Buildkite job and confirm `~/.local/share/containers/podman/machine/` shrinks after the run.

## Automated Testing Overview

No new tests; the CI shell changes are exercised by the Buildkite pipeline.

## Release/Deployment Notes

CI-only, no user-facing impact.