### PR TITLE
docs(docker): add Podman and Docker rootless setup, fixes #8434

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -158,6 +158,7 @@ ReactPHP
 RemainAfterExit
 Remove
 Run
+Runtimes
 SELinux
 SMTP
 SendGrid
@@ -192,6 +193,7 @@ Uz
 VCS
 Vitest
 VM
+VM's
 VNC
 VPN
 VPNs
@@ -608,6 +610,7 @@ rmi
 rsync
 running
 runtime
+runtimes
 rw
 s
 sdk

--- a/docs/content/assets/open-tabs-from-hash.js
+++ b/docs/content/assets/open-tabs-from-hash.js
@@ -7,37 +7,23 @@ const openTabsFromHash = () => {
     let hashElement = document.getElementById(currentHash);
     if (!hashElement) return
 
-    // Detect if element is located in a tab
-    let parentElement = hashElement.closest('.tabbed-block');
-    if (!parentElement) return
+    // Walk up through every enclosing tab (handles tabs nested to any depth)
+    // and activate each one, from the innermost to the outermost.
+    let block = hashElement.closest('.tabbed-block');
+    while (block) {
+        let tabbedSet = block.closest('.tabbed-set');
+        if (!tabbedSet) break;
 
-    // Get all tab labels
-    let allTabs = hashElement.closest('.tabbed-set').querySelector('.tabbed-labels').children;
-    if (!allTabs) return
+        // The labels of this tab set, in the same order as its content blocks.
+        let labels = tabbedSet.querySelector('.tabbed-labels');
+        if (labels) {
+            let index = [...block.parentNode.children].indexOf(block);
+            let label = labels.children[index];
+            if (label) label.click();
+        }
 
-    // get index of tab to click on
-    let index = [...parentElement.parentNode.children].indexOf(parentElement)
-
-    // Simulate mouse click on our tab label
-    allTabs[index].click();
-
-    // If our tab is nested within another tab, open parent tab.
-    if (allTabs[0].getAttribute('for').startsWith('__tabbed_2')) {
-        // Get outer tabs
-        let outerTabs = document.querySelector('.tabbed-labels').children
-
-        // Get outer tab block
-        let outerParent = allTabs[0].closest('.tabbed-block');
-
-        // Get outer tab index
-        let outerIndex = [...outerParent.parentNode.children].indexOf(outerParent)
-
-        // Active outer tab
-        outerTabs[outerIndex].click();
-    }
-
-    if (allTabs[0].getAttribute('for').startsWith('__tabbed_3')) {
-        console.log('While 1 nested tab is debatable 2 should be avoided as it is definitely not user-friendly.')
+        // Continue from the block that encloses this tab set, if any.
+        block = tabbedSet.parentNode ? tabbedSet.parentNode.closest('.tabbed-block') : null;
     }
 
     // scroll to hash

--- a/docs/content/developers/buildkite-testmachine-setup.md
+++ b/docs/content/developers/buildkite-testmachine-setup.md
@@ -2,6 +2,7 @@
 search:
   boost: .2
 ---
+
 # Buildkite Test Agent Setup
 
 We are using [Buildkite](https://buildkite.com/ddev) for Windows and macOS testing. The build machines and `buildkite-agent` must be set up before use.
@@ -318,22 +319,11 @@ Then the Buildkite agent must be configured with tags `lima=true`.
 
 ## Additional Podman Rootless macOS Setup
 
-Podman rootless on macOS runs containers in a lightweight VM managed by `podman machine`. See [Installing Podman on macOS](https://ddev.com/blog/podman-and-docker-rootless/#installing-podman-1) for background.
+Podman rootless on macOS runs containers in a lightweight VM managed by `podman machine`.
 
-1. `brew install podman`
-2. `podman machine init --provider applehv` (uses the Apple Hypervisor Framework; rootless is the default)
-3. `podman machine start`
-4. Create a Docker context pointing at the podman socket (the path varies per machine — read it from `podman machine inspect`):
-
-    ```bash
-    SOCKET=$(podman machine inspect | jq -r '.[0].ConnectionInfo.PodmanSocket.Path')
-    docker context create podman-rootless \
-        --description "Podman (rootless)" \
-        --docker "host=unix://${SOCKET}"
-    ```
-
-5. Verify connectivity: `docker context use podman-rootless && docker ps` should return an empty container list.
-6. Stop the machine when done with initial setup: `podman machine stop`
+1. Follow the instructions for [Podman on macOS](../users/install/docker-installation.md#macos-podman-rootless) to install Podman and set up a rootless Podman machine.
+2. Verify connectivity: `docker context use podman-rootless && docker ps` should return an empty container list.
+3. Stop the machine when done with initial setup: `podman machine stop`
 
 !!!note
     Rootless containers cannot bind to ports below 1024. `test.sh` handles this automatically by setting `DDEV_XDG_CONFIG_HOME` to an isolated config directory and configuring `router-http-port=8080` and `router-https-port=8443` via `ddev config global`.

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -6,217 +6,449 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     ## macOS
 
-    Install one of the supported Docker providers:
+    Choose a container runtime:
 
-    * [OrbStack](#orbstack): Recommended, easiest to install, most performant, commercial, not open-source.
-    * [Lima](#lima): Free, open-source.
-    * [Docker Desktop](#docker-desktop-for-mac): Familiar, popular, not open-source, may require license, may be unstable.
-    * [Rancher Desktop](#rancher-desktop): Free, open-source, simple installation, slower startup.
-    * [Colima](#colima): Free, open-source. Depends on separate Lima installation (managed by Homebrew).
+    * **Docker** (recommended) - The best-tested option. Install OrbStack, Lima, Docker Desktop, Rancher Desktop, or Colima.
+    * **Podman rootless** - Rootless by default; a good fit where Docker is forbidden. Can't use the default ports 80/443, so DDEV must be configured to use unprivileged ports.
 
-    ### OrbStack
+    === "Docker"
 
-    [OrbStack](https://orbstack.dev) is a newer Docker provider that is very popular with DDEV users because it’s fast, lightweight, and easy to install. It’s a good choice for most users. It is *not* open-source, and it is not free for professional use.
-    
-    1. Install OrbStack with `brew install orbstack` or [download it directly](https://orbstack.dev/download).
-    2. Run the OrbStack app (from Applications) to finish setup, choosing "Docker" as the option. Answer any prompts to allow OrbStack access.
+        Install one of the supported Docker providers:
 
-    ### Lima
+        * [OrbStack](#orbstack): Recommended, easiest to install, most performant, commercial, not open-source.
+        * [Lima](#lima): Free, open-source.
+        * [Docker Desktop](#docker-desktop-for-mac): Familiar, popular, not open-source, may require license, may be unstable.
+        * [Rancher Desktop](#rancher-desktop): Free, open-source, simple installation, slower startup.
+        * [Colima](#colima): Free, open-source. Depends on separate Lima installation (managed by Homebrew).
 
-    [Lima](https://github.com/lima-vm/lima) is a free and open-source project supported by the [Cloud Native Computing Foundation](https://cncf.io/).
+        ### OrbStack
 
-    1. Install Lima with `brew install lima`.
-    2. If you don't have the `docker` client (if `docker help` fails) then install it with `brew install docker`.
-    3. Create a 100GB VM in Lima with 4 CPUs, 6GB memory, and Cloudflare DNS. Adjust to your own needs:
-    ```
-    limactl create --name=default --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template:docker
-    docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock"
-    docker context use lima-default
-    ```
-    After the initial run above, you can use `limactl start`.  Run `limactl list` to see configured setup.
+        [OrbStack](https://orbstack.dev) is a newer Docker provider that is very popular with DDEV users because it’s fast, lightweight, and easy to install. It’s a good choice for most users. It is *not* open-source, and it is not free for professional use.
 
-    When your computer restarts, you’ll need to `limactl start` again.
+        1. Install OrbStack with `brew install orbstack` or [download it directly](https://orbstack.dev/download).
+        2. Run the OrbStack app (from Applications) to finish setup, choosing "Docker" as the option. Answer any prompts to allow OrbStack access.
 
-    !!!warning "Docker contexts let the Docker client point at the right Docker server"
-        The Docker provider you're using is selected with `docker context`. You can see the available contexts with `docker context ls` and the currently selected one with `docker context show`. With the setup above you'll want `docker context use lima-default`.
+        ### Lima
 
-    !!!warning "Lima only mounts filesystems in your home directory unless you do further configuration"
-        By default, Lima only works with DDEV projects in your home directory. You must have your projects somewhere in your home directory for DDEV to work unless you do additional configuration. If your project is not in your home directory, you must add additional mounts, as described in [mounts example](https://github.com/lima-vm/lima/blob/e9423da6b7c60083aaa455a0c6ecb5c729edfe1f/examples/docker.yaml#L25-L28).
+        [Lima](https://github.com/lima-vm/lima) is a free and open-source project supported by the [Cloud Native Computing Foundation](https://cncf.io/).
 
-    ### Docker Desktop for Mac
+        1. Install Lima with `brew install lima`.
+        2. If you don't have the `docker` client (if `docker help` fails) then install it with `brew install docker`.
+        3. Create a 100GB VM in Lima with 4 CPUs, 6GB memory, and Cloudflare DNS. Adjust to your own needs:
+        ```
+        limactl create --name=default --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template:docker
+        docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock"
+        docker context use lima-default
+        ```
+        After the initial run above, you can use `limactl start`.  Run `limactl list` to see configured setup.
 
-    Docker Desktop for Mac can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has long been supported by DDEV and has extensive automated testing. It is not open-source, may require a license for many users, and sometimes has stability problems.
+        When your computer restarts, you’ll need to `limactl start` again.
 
-    !!!warning "Ports unavailable?"
-        If you get messages like `Ports are not available... exposing port failed... is vmnetd running?` it means you need to check the "Allow privileged port mapping (requires password)" checkbox in the "Advanced" section of the Docker Desktop configuration. You may have to stop and restart Docker Desktop, and you may have to turn it off, restart Docker Desktop, turn it on again, restart Docker Desktop. (More extensive problem resolution is in [Docker Desktop issue](https://github.com/docker/for-mac/issues/6677).)
+        !!!warning "Docker contexts let the Docker client point at the right Docker server"
+            The Docker provider you're using is selected with `docker context`. You can see the available contexts with `docker context ls` and the currently selected one with `docker context show`. With the setup above you'll want `docker context use lima-default`.
 
-    ### Rancher Desktop
+        !!!warning "Lima only mounts filesystems in your home directory unless you do further configuration"
+            By default, Lima only works with DDEV projects in your home directory. You must have your projects somewhere in your home directory for DDEV to work unless you do additional configuration. If your project is not in your home directory, you must add additional mounts, as described in [mounts example](https://github.com/lima-vm/lima/blob/e9423da6b7c60083aaa455a0c6ecb5c729edfe1f/examples/docker.yaml#L25-L28).
 
-    Rancher Desktop is an easy-to-install free and open-source Docker provider. Install from [Rancher Desktop](https://rancherdesktop.io/). It has automated testing with DDEV. When installing, choose only the Docker option and turn off Kubernetes.
+        ### Docker Desktop for Mac
 
-    ### Colima
+        Docker Desktop for Mac can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). It has long been supported by DDEV and has extensive automated testing. It is not open-source, may require a license for many users, and sometimes has stability problems.
 
-    [Colima](https://github.com/abiosoft/colima) is a free and open-source project which bundles Lima.
+        !!!warning "Ports unavailable?"
+            If you get messages like `Ports are not available... exposing port failed... is vmnetd running?` it means you need to check the "Allow privileged port mapping (requires password)" checkbox in the "Advanced" section of the Docker Desktop configuration. You may have to stop and restart Docker Desktop, and you may have to turn it off, restart Docker Desktop, turn it on again, restart Docker Desktop. (More extensive problem resolution is in [Docker Desktop issue](https://github.com/docker/for-mac/issues/6677).)
 
-    1. Install Colima with `brew install colima`, which also installs Lima and other dependencies.
-    2. If you don't have the `docker` client (if `docker help` fails) then install it with `brew install docker`.
-    3. Start Colima with 4 CPUs, 6GB memory, 100GB storage, and Cloudflare DNS, adjusting as needed:
+        ### Rancher Desktop
+
+        Rancher Desktop is an easy-to-install free and open-source Docker provider. Install from [Rancher Desktop](https://rancherdesktop.io/). It has automated testing with DDEV. When installing, choose only the Docker option and turn off Kubernetes.
+
+        ### Colima
+
+        [Colima](https://github.com/abiosoft/colima) is a free and open-source project which bundles Lima.
+
+        1. Install Colima with `brew install colima`, which also installs Lima and other dependencies.
+        2. If you don't have the `docker` client (if `docker help` fails) then install it with `brew install docker`.
+        3. Start Colima with 4 CPUs, 6GB memory, 100GB storage, and Cloudflare DNS, adjusting as needed:
+
+            ```bash
+            colima start --cpu 4 --memory 6 --disk 100 --vm-type=vz --mount-type=virtiofs --dns=1.1.1.1
+            ```
+
+        After the initial run above, you can use `colima start` or use `colima start -e` to edit the configuration file. Run `colima status` at any time to check Colima’s status.
+
+        !!!warning "Docker contexts let the Docker client point at the right Docker server"
+            Colima activates its own Docker context to prevent conflicts with Docker Desktop. If you run `docker context ls`, you’ll see a list of available contexts where the currently-active one is indicated with a `*`—which will be `colima` after you’ve started it. You can change to the default (Docker Desktop) with `docker context use default` or change back with `docker context use colima`. This means you can run Docker Desktop and Colima at the same time, but be mindful of which context you’re pointing at!
+
+        !!!warning "Colima can only work in your home directory unless you do further configuration"
+            By default, Colima only works with DDEV projects in your home directory. You need to have your projects somewhere in your home directory for DDEV to work unless you do additional configuration. See the `~/.colima/default/colima.yaml` for more information, or notes in [colima.yaml](https://github.com/abiosoft/colima/blob/main/embedded/defaults/colima.yaml#L160-L173).
+
+        ### Migrating Projects Between Docker Providers
+
+        * OrbStack has built-in migration of images and volumes from Docker Desktop.
+        * Move projects between other Docker providers using [How can I migrate from one Docker provider to another?](../usage/faq.md#how-can-i-migrate-from-one-docker-provider-to-another).
+
+    === "Podman rootless"
+
+        Podman on macOS runs containers in a lightweight VM managed by `podman machine`. You can also use [Podman Desktop](https://podman-desktop.io/) for a GUI.
+
+        !!!warning "Podman on macOS can't use ports 80/443"
+            Podman on macOS cannot bind to privileged ports (80/443), so you must configure DDEV to use unprivileged ports. After installing DDEV, run:
+
+            ```bash
+            ddev config global --router-http-port=8080 --router-https-port=8443
+            ```
+
+            Your projects will then be reachable at `https://yourproject.ddev.site:8443` instead of the standard `https://yourproject.ddev.site`.
+
+        ### Install Podman
+
+        Install Podman using Homebrew:
 
         ```bash
-        colima start --cpu 4 --memory 6 --disk 100 --vm-type=vz --mount-type=virtiofs --dns=1.1.1.1
+        brew install podman
         ```
 
-    After the initial run above, you can use `colima start` or use `colima start -e` to edit the configuration file. Run `colima status` at any time to check Colima’s status.
+        Or install [Podman Desktop](https://podman-desktop.io/docs/installation/macos-install) if you prefer a GUI. For more information, see the [official Podman installation guide for macOS](https://podman.io/docs/installation#macos) and the [Podman tutorials](https://github.com/containers/podman/tree/main/docs/tutorials#readme).
 
-    !!!warning "Docker contexts let the Docker client point at the right Docker server"
-        Colima activates its own Docker context to prevent conflicts with Docker Desktop. If you run `docker context ls`, you’ll see a list of available contexts where the currently-active one is indicated with a `*`—which will be `colima` after you’ve started it. You can change to the default (Docker Desktop) with `docker context use default` or change back with `docker context use colima`. This means you can run Docker Desktop and Colima at the same time, but be mindful of which context you’re pointing at!
+        ### Install the Docker CLI
 
-    !!!warning "Colima can only work in your home directory unless you do further configuration"
-        By default, Colima only works with DDEV projects in your home directory. You need to have your projects somewhere in your home directory for DDEV to work unless you do additional configuration. See the `~/.colima/default/colima.yaml` for more information, or notes in [colima.yaml](https://github.com/abiosoft/colima/blob/main/embedded/defaults/colima.yaml#L160-L173).
+        Podman provides a Docker-compatible API, so you can use the Docker CLI as a front-end for Podman. This lets you use familiar `docker` commands, switch between runtimes with Docker contexts, and keep compatibility with tools that expect the `docker` command.
 
-    ### Docker Buildx
+        ```bash
+        brew install docker
+        ```
 
-    DDEV requires the [Docker buildx plugin](https://github.com/docker/buildx). Most Docker providers (OrbStack, Docker Desktop, Rancher Desktop, Colima, Lima) already include it. If `docker buildx version` doesn't work, install it with:
+        ### Initialize and start the Podman machine
 
-    ```bash
-    brew install docker-buildx
-    ```
+        ```bash
+        # check `podman machine init -h` for more options
+        podman machine init --provider applehv
+        podman machine start
+        ```
 
-    More information in [Docker buildx requirement](https://ddev.com/blog/docker-buildx-requirement-v1-25-1/).
+        ### Point the Docker CLI at Podman
 
-    #### Migrating Projects Between Docker Providers
+        ```bash
+        SOCKET=$(podman machine inspect | jq -r '.[0].ConnectionInfo.PodmanSocket.Path')
+        docker context create podman-rootless \
+            --description "Podman (rootless)" \
+            --docker "host=unix://${SOCKET}"
+        docker context use podman-rootless
+        docker ps
+        ```
 
-    * OrbStack has built-in migration of images and volumes from Docker Desktop.
-    * Move projects between other Docker providers using [How can I migrate from one Docker provider to another?](../usage/faq.md#how-can-i-migrate-from-one-docker-provider-to-another).
+        ### Reclaim disk space
+
+        !!!warning "The Podman machine doesn't reclaim its own disk space"
+            The `podman machine` VM grows over time and does not shrink automatically, even after you remove images and containers. Periodically reclaim the freed space by trimming the VM's filesystem:
+
+            ```bash
+            podman machine start
+            podman machine ssh 'sudo fstrim -av'
+            ```
 
 === "Linux"
 
     ## Linux
 
-    * [Docker](#docker-for-linux): Recommended, free, open-source, best performance and stability.
-    * [Docker rootless](#docker-rootless): Experimental support, free, open-source, more complex setup, has limitations.
-    * [Podman](#podman-for-linux): Experimental support, free, open-source, more complex setup, has limitations.
-    * [Docker Desktop](#docker-desktop-for-linux): Not open-source, may require license, may be unstable, doesn't have explicit support from DDEV and doesn't have automated test coverage.
+    Choose a container runtime:
 
-    ### Docker for Linux
+    * **Docker** (recommended) - The best-tested option, with the best performance and stability. Install Docker CE or Docker Desktop.
+    * **Docker rootless** - Runs the Docker daemon without root, which reduces the attack surface. Full Docker compatibility.
+    * **Podman rootless** - Rootless by default; a good fit where Docker is forbidden. More setup and slower than Docker.
 
-    The best way to install Docker on Linux is to use your native package management tool (`apt`, `dnf`, etc.) with the official Docker repository. While many Linux distributions provide Docker packages in their own repositories, these are often outdated and may not include the latest features required for stability in a development environment like DDEV. To ensure you’re using a supported version, install Docker directly from the official Docker repository.
+    === "Docker"
 
-    #### Debian/Ubuntu
+        Install one of the supported Docker providers:
 
-    ```bash
-    # Ensure sudo credentials are cached for copy/paste of this block
-    sudo true
+        * [Docker CE](#docker-for-linux): Recommended, free, open-source, best performance and stability. Install from the official Docker repository.
+        * [Docker Desktop for Linux](#docker-desktop-for-linux): Not explicitly supported by DDEV and has no automated testing.
 
-    # Remove any old/conflicting Docker packages
-    sudo apt-get remove -y docker.io docker-doc docker-compose podman-docker containerd runc 2>/dev/null || true
+        ### Docker for Linux
 
-    # Install prerequisites
-    sudo apt-get update && sudo apt-get install -y ca-certificates curl
-    sudo install -m 0755 -d /etc/apt/keyrings
+        The best way to install Docker on Linux is to use your native package management tool (`apt`, `dnf`, etc.) with the official Docker repository. While many Linux distributions provide Docker packages in their own repositories, these are often outdated and may not include the latest features required for stability in a development environment like DDEV. To ensure you’re using a supported version, install Docker directly from the official Docker repository.
 
-    # Add Docker’s GPG key
-    sudo curl -fsSL https://download.docker.com/linux/$(. /etc/os-release && echo "$ID")/gpg -o /etc/apt/keyrings/docker.asc
-    sudo chmod a+r /etc/apt/keyrings/docker.asc
-
-    # Remove old repository files if present
-    sudo rm -f /etc/apt/keyrings/docker.gpg /etc/apt/sources.list.d/docker.list
-
-    # Add Docker repository in deb822 format
-    printf "Types: deb\nURIs: https://download.docker.com/linux/%s\nSuites: %s\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n" \
-      "$(. /etc/os-release && echo "$ID")" \
-      "$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")" \
-      | sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null
-
-    # Install Docker CE
-    sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-    # Add your user to the docker group (create group if it doesn’t exist)
-    sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
-
-    # Start and enable Docker
-    sudo systemctl enable --now docker
-    ```
-
-    Run `sg docker` to open a new subshell with the `docker` group active, then verify with `docker run hello-world`. (A full log out and back in applies the change to your whole session.)
-
-    ??? tip "Prefer to run as a script?"
-        Create a script file, then run it:
+        #### Debian/Ubuntu
 
         ```bash
-        cat > /tmp/install-docker.sh << 'SCRIPT'
-        #!/usr/bin/env bash
-        set -euo pipefail
+        # Ensure sudo credentials are cached for copy/paste of this block
         sudo true
+
+        # Remove any old/conflicting Docker packages
         sudo apt-get remove -y docker.io docker-doc docker-compose podman-docker containerd runc 2>/dev/null || true
+
+        # Install prerequisites
         sudo apt-get update && sudo apt-get install -y ca-certificates curl
         sudo install -m 0755 -d /etc/apt/keyrings
-        sudo curl -fsSL "https://download.docker.com/linux/$(. /etc/os-release && echo "$ID")/gpg" -o /etc/apt/keyrings/docker.asc
+
+        # Add Docker’s GPG key
+        sudo curl -fsSL https://download.docker.com/linux/$(. /etc/os-release && echo "$ID")/gpg -o /etc/apt/keyrings/docker.asc
         sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+        # Remove old repository files if present
         sudo rm -f /etc/apt/keyrings/docker.gpg /etc/apt/sources.list.d/docker.list
+
+        # Add Docker repository in deb822 format
         printf "Types: deb\nURIs: https://download.docker.com/linux/%s\nSuites: %s\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n" \
           "$(. /etc/os-release && echo "$ID")" \
           "$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")" \
           | sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null
+
+        # Install Docker CE
         sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+        # Add your user to the docker group (create group if it doesn’t exist)
         sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
+
+        # Start and enable Docker
         sudo systemctl enable --now docker
-        SCRIPT
         ```
 
-        Review the script, then run it: `bash /tmp/install-docker.sh`
+        Run `sg docker` to open a new subshell with the `docker` group active, then verify with `docker run hello-world`. (A full log out and back in applies the change to your whole session.)
 
-    See the full [Docker Engine installation docs for Ubuntu](https://docs.docker.com/engine/install/ubuntu/) or [Debian](https://docs.docker.com/engine/install/debian/) for more details.
+        ??? tip "Prefer to run as a script?"
+            Create a script file, then run it:
 
-    #### Other Linux Distributions
+            ```bash
+            cat > /tmp/install-docker.sh << 'SCRIPT'
+            #!/usr/bin/env bash
+            set -euo pipefail
+            sudo true
+            sudo apt-get remove -y docker.io docker-doc docker-compose podman-docker containerd runc 2>/dev/null || true
+            sudo apt-get update && sudo apt-get install -y ca-certificates curl
+            sudo install -m 0755 -d /etc/apt/keyrings
+            sudo curl -fsSL "https://download.docker.com/linux/$(. /etc/os-release && echo "$ID")/gpg" -o /etc/apt/keyrings/docker.asc
+            sudo chmod a+r /etc/apt/keyrings/docker.asc
+            sudo rm -f /etc/apt/keyrings/docker.gpg /etc/apt/sources.list.d/docker.list
+            printf "Types: deb\nURIs: https://download.docker.com/linux/%s\nSuites: %s\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n" \
+              "$(. /etc/os-release && echo "$ID")" \
+              "$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")" \
+              | sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null
+            sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+            sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
+            sudo systemctl enable --now docker
+            SCRIPT
+            ```
 
-    Follow these distribution-specific instructions to set up Docker Engine from the official Docker repository:
+            Review the script, then run it: `bash /tmp/install-docker.sh`
 
-    * [CentOS](https://docs.docker.com/install/linux/docker-ce/centos/)
-    * [Fedora](https://docs.docker.com/install/linux/docker-ce/fedora/)
-    * [binaries](https://docs.docker.com/install/linux/docker-ce/binaries/)
+        See the full [Docker Engine installation docs for Ubuntu](https://docs.docker.com/engine/install/ubuntu/) or [Debian](https://docs.docker.com/engine/install/debian/) for more details.
 
-    After installing Docker, add your user to the `docker` group and enable the Docker daemon to start at boot:
+        #### Other Linux Distributions
 
-    ```bash
-    sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
-    sudo systemctl enable --now docker
-    ```
+        Follow these distribution-specific instructions to set up Docker Engine from the official Docker repository:
 
-    Run `sg docker` to open a new subshell with the `docker` group active, or log out and back in to apply the change to your whole session. See [Post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/) for more details.
+        * [CentOS](https://docs.docker.com/install/linux/docker-ce/centos/)
+        * [Fedora](https://docs.docker.com/install/linux/docker-ce/fedora/)
+        * [binaries](https://docs.docker.com/install/linux/docker-ce/binaries/)
 
-    !!!warning "Don’t `sudo` with `docker` or `ddev`"
-        Don’t use `sudo` with the `docker` command. If you find yourself needing it, you haven’t finished the installation. You also shouldn’t use `sudo` with `ddev` unless it’s specifically for the [`ddev hostname`](../usage/commands.md#hostname) command.
+        After installing Docker, add your user to the `docker` group and enable the Docker daemon to start at boot:
 
-    On systems without `systemd` or its equivalent—mostly if you’re installing inside WSL2—you’ll need to manually start Docker with `service docker start` or the equivalent in your distro. You can add this to your shell profile.
+        ```bash
+        sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
+        sudo systemctl enable --now docker
+        ```
 
-    ### Docker Buildx
+        Run `sg docker` to open a new subshell with the `docker` group active, or log out and back in to apply the change to your whole session. See [Post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/) for more details.
 
-    DDEV requires the [Docker buildx plugin](https://github.com/docker/buildx). Docker CE installed from the official Docker repository includes it. If `docker buildx version` doesn't work, install the `docker-buildx-plugin` package from the Docker repository (e.g. `sudo apt-get install docker-buildx-plugin` on Debian/Ubuntu) or follow any of the installation instructions from [Docker buildx](https://github.com/docker/buildx#installing).
+        !!!warning "Don’t `sudo` with `docker` or `ddev`"
+            Don’t use `sudo` with the `docker` command. If you find yourself needing it, you haven’t finished the installation. You also shouldn’t use `sudo` with `ddev` unless it’s specifically for the [`ddev hostname`](../usage/commands.md#hostname) command.
 
-    More information in [Docker buildx requirement](https://ddev.com/blog/docker-buildx-requirement-v1-25-1/).
+        On systems without `systemd` or its equivalent—mostly if you’re installing inside WSL2—you’ll need to manually start Docker with `service docker start` or the equivalent in your distro. You can add this to your shell profile.
 
-    ### Docker Rootless
+        ### Docker Desktop for Linux
 
-    DDEV has experimental support for Docker rootless mode on Linux. See [Podman and Docker Rootless in DDEV](https://ddev.com/blog/podman-and-docker-rootless/) for details.
+        As an alternative to Docker CE, Docker Desktop for Linux can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). Casual manual testing seems to work, but DDEV does not have explicit support for it and does not have automated testing.
 
-    ### Podman for Linux
+    === "Docker rootless"
 
-    DDEV has experimental support for Podman on Linux. See [Podman and Docker Rootless in DDEV](https://ddev.com/blog/podman-and-docker-rootless/) for details.
+        [Docker rootless mode](https://docs.docker.com/engine/security/rootless/) runs the Docker daemon and containers as a non-root user, which reduces the attack surface (no root daemon, container processes can't touch root-owned files). DDEV supports Docker rootless on Linux and WSL2, with full Docker compatibility.
 
-    ### Docker Desktop for Linux
+        !!!tip "`no_bind_mounts` is no longer required"
+            Earlier DDEV versions (v1.25.0-v1.25.2) required [`no_bind_mounts`](../configuration/config.md#no_bind_mounts) with Docker rootless. That is no longer necessary—Docker rootless now works with bind mounts.
 
-    Docker Desktop for Linux can be downloaded from [docker.com](https://www.docker.com/products/docker-desktop). Casual manual testing seems to work, but DDEV does not have explicit support for it and does not have automated testing.
+        ### Install Docker rootless
+
+        Follow the official [Docker rootless installation guide](https://docs.docker.com/engine/security/rootless/).
+
+        ### Configure the system
+
+        ```bash
+        # Allow privileged port access if needed
+        if [ -f /proc/sys/net/ipv4/ip_unprivileged_port_start ]; then
+          if [ "1024" = "$(cat /proc/sys/net/ipv4/ip_unprivileged_port_start)" ]; then
+            echo 'net.ipv4.ip_unprivileged_port_start=0' | sudo tee -a /etc/sysctl.d/60-rootless.conf
+            sudo sysctl --system
+          fi
+        fi
+        # Allow loopback connections (needed for working Xdebug)
+        # See https://github.com/moby/moby/issues/47684#issuecomment-2166149845
+        mkdir -p ~/.config/systemd/user/docker.service.d
+        cat << 'EOF' > ~/.config/systemd/user/docker.service.d/override.conf
+        [Service]
+        Environment="DOCKERD_ROOTLESS_ROOTLESSKIT_DISABLE_HOST_LOOPBACK=false"
+        EOF
+        ```
+
+        ### Enable the Docker socket
+
+        ```bash
+        systemctl --user enable --now docker.socket
+
+        # You should see `/run/user/1000/docker.sock` (the number may vary):
+        ls $XDG_RUNTIME_DIR/docker.sock
+        ```
+
+        ### Point the Docker CLI at the rootless socket
+
+        ```bash
+        # View existing contexts
+        docker context ls
+
+        # Create the rootless context if it doesn't exist
+        docker context inspect rootless >/dev/null 2>&1 || \
+            docker context create rootless \
+                --description "Rootless runtime socket" \
+                --docker host="unix://$XDG_RUNTIME_DIR/docker.sock"
+
+        # Switch to the context
+        docker context use rootless
+
+        # Verify it works
+        docker ps
+        ```
+
+    === "Podman rootless"
+
+        [Podman](https://podman.io/) is rootless by default, which makes it a good fit for environments that forbid Docker or require rootless operation. Podman is slower than Docker and has more setup, but Podman rootless on Linux is solid.
+
+        !!!warning "Podman versions"
+            Some distributions ship outdated Podman. Ubuntu 24.04, for example, has Podman 4.9.3. DDEV works best with Podman 5.0 or newer; with Podman 4.x you can proceed by ignoring the warning on `ddev start`.
+
+        ### Install Podman
+
+        Install Podman with your distribution's package manager (see the [official Podman installation guide for Linux](https://podman.io/docs/installation#installing-on-linux)):
+
+        ```bash
+        # Ubuntu/Debian
+        sudo apt-get update && sudo apt-get install podman
+        # Fedora
+        sudo dnf install --refresh podman
+        ```
+
+        You can also install [Podman Desktop](https://podman-desktop.io/docs/installation/linux-install) if you prefer a GUI. For more information, see the [Podman tutorials](https://github.com/containers/podman/tree/main/docs/tutorials#readme).
+
+        ### Install the Docker CLI
+
+        Podman provides a Docker-compatible API, so you can use the Docker CLI as a front-end for Podman. This lets you use familiar `docker` commands, switch between runtimes with Docker contexts, and keep compatibility with tools that expect the `docker` command.
+
+        1. [Set up Docker's repository](https://docs.docker.com/engine/install/).
+        2. Install only the CLI (you don't need `docker-ce`, the Docker engine):
+
+            ```bash
+            # Ubuntu/Debian
+            sudo apt-get update && sudo apt-get install docker-ce-cli
+            # Fedora
+            sudo dnf install --refresh docker-ce-cli
+            ```
+
+        ### Configure Podman rootless
+
+        This is the recommended configuration for most users.
+
+        Prepare the system by configuring `subuid`/`subgid` ranges and enabling `userns` options (see the [Arch Linux Wiki](https://wiki.archlinux.org/title/Podman#Rootless_Podman) for details):
+
+        ```bash
+        # Add subuid and subgid ranges if they don't exist for the current user
+        grep "^$(id -un):\|^$(id -u):" /etc/subuid >/dev/null 2>&1 || sudo usermod --add-subuids 100000-165535 $(whoami)
+        grep "^$(id -un):\|^$(id -u):" /etc/subgid >/dev/null 2>&1 || sudo usermod --add-subgids 100000-165535 $(whoami)
+        # Propagate changes to subuid and subgid
+        podman system migrate
+        # Debian requires setting unprivileged_userns_clone
+        if [ -f /proc/sys/kernel/unprivileged_userns_clone ]; then
+          if [ "1" != "$(cat /proc/sys/kernel/unprivileged_userns_clone)" ]; then
+            echo 'kernel.unprivileged_userns_clone=1' | sudo tee -a /etc/sysctl.d/60-rootless.conf
+            sudo sysctl --system
+          fi
+        fi
+        # Fedora requires setting max_user_namespaces
+        if [ -f /proc/sys/user/max_user_namespaces ]; then
+          if [ "0" = "$(cat /proc/sys/user/max_user_namespaces)" ]; then
+            echo 'user.max_user_namespaces=28633' | sudo tee -a /etc/sysctl.d/60-rootless.conf
+            sudo sysctl --system
+          fi
+        fi
+        # Allow privileged port access if needed
+        if [ -f /proc/sys/net/ipv4/ip_unprivileged_port_start ]; then
+          if [ "1024" = "$(cat /proc/sys/net/ipv4/ip_unprivileged_port_start)" ]; then
+            echo 'net.ipv4.ip_unprivileged_port_start=0' | sudo tee -a /etc/sysctl.d/60-rootless.conf
+            sudo sysctl --system
+          fi
+        fi
+        ```
+
+        Enable the Podman socket and verify it's running (see the [Podman socket activation documentation](https://github.com/containers/podman/blob/main/docs/tutorials/socket_activation.md)):
+
+        ```bash
+        systemctl --user enable --now podman.socket
+
+        # You should see `/run/user/1000/podman/podman.sock` (the number may vary):
+        ls $XDG_RUNTIME_DIR/podman/podman.sock
+
+        # You can also check the socket path with:
+        podman info --format '{{.Host.RemoteSocket.Path}}'
+        ```
+
+        Configure the Docker CLI to use Podman (see the [Podman rootless tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md)):
+
+        ```bash
+        # View existing contexts
+        docker context ls
+
+        # Create Podman rootless context
+        docker context create podman-rootless \
+            --description "Podman (rootless)" \
+            --docker host="unix://$XDG_RUNTIME_DIR/podman/podman.sock"
+
+        # Switch to the new context
+        docker context use podman-rootless
+
+        # Verify it works
+        docker ps
+        ```
+
+        ### Podman rootless performance optimization
+
+        Podman rootless is slower than Docker (see [Podman run/build performance issues](https://github.com/containers/podman/issues/13226) and the [Podman performance documentation](https://github.com/containers/podman/blob/main/docs/tutorials/performance.md)). To improve performance, install `fuse-overlayfs` and configure the overlay storage driver:
+
+        ```bash
+        # Ubuntu/Debian
+        sudo apt-get update && sudo apt-get install fuse-overlayfs
+        # Fedora
+        sudo dnf install --refresh fuse-overlayfs
+        ```
+
+        ```bash
+        mkdir -p ~/.config/containers
+        cat << 'EOF' > ~/.config/containers/storage.conf
+        [storage]
+        driver = "overlay"
+        [storage.options.overlay]
+        mount_program = "/usr/bin/fuse-overlayfs"
+        EOF
+        ```
+
+        !!!warning "Existing containers require a reset"
+            If you already have Podman containers, images, or volumes, you'll need to reset Podman for the storage change to take effect: `podman system reset`. This removes all existing containers, images, and volumes (similar to `docker system prune -a`).
 
 === "Windows"
 
     ## Windows
 
-    For DDEV on Windows, choose one of these Docker providers:
+    First [install WSL2](#install-wsl2) below, then [choose a container runtime](#choose-a-container-runtime):
 
-    * **Docker CE inside WSL2** - The most popular, performant, and best-supported way to run DDEV on Windows. The [DDEV installer](ddev-installation.md#windows) installs Docker CE automatically. Requires WSL2.
-    * **Docker Desktop for Windows** - Works with both WSL2 and traditional Windows. Extensive automated testing with DDEV, but has some performance and reliability problems. Not open-source; may require a license for many users.
-    * **Rancher Desktop for Windows** - Free and open-source. Manually tested with DDEV on traditional Windows; no automated testing. Works with both WSL2 and traditional Windows.
+    * **Docker** (recommended) - The best-tested option. Run Docker CE inside WSL2, or use Docker Desktop or Rancher Desktop.
+    * **Docker rootless** - Runs the Docker daemon without root, which reduces the attack surface. Runs inside WSL2 using the same setup as Linux.
+    * **Podman rootless** - Rootless by default; a good fit where Docker is forbidden. Works via Podman Desktop, but is less mature on Windows than on Linux.
 
     ### Install WSL2
 
@@ -250,97 +482,166 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
     * DDEV                   Stopped         2
     ```
 
-    ### Docker CE inside WSL2
+    ### Choose a container runtime
 
-    The [DDEV Windows installer](ddev-installation.md#step-2-install-ddev) automatically installs Docker CE in your WSL2 environment — no manual Docker installation is needed. After installing WSL2 above, proceed to [install DDEV](ddev-installation.md#step-2-install-ddev).
+    === "Docker"
 
-    To install Docker CE manually instead, open your WSL2 terminal (Ubuntu) and run:
+        Install one of the supported Docker providers:
 
-    ```bash
-    # Ensure sudo credentials are cached for copy/paste of this block
-    sudo true
+        * [Docker CE inside WSL2](#docker-ce-inside-wsl2): Recommended, most popular, performant, and best-supported. The [DDEV installer](ddev-installation.md#windows) installs it automatically. Requires WSL2.
+        * [Docker Desktop for Windows](#docker-desktop-for-windows): Works with both WSL2 and traditional Windows. Extensive automated testing, but some performance and reliability problems. Not open-source; may require a license.
+        * [Rancher Desktop for Windows](#rancher-desktop-for-windows): Free, open-source. Manually tested on traditional Windows; no automated testing. Works with both WSL2 and traditional Windows.
 
-    # Remove any old/conflicting Docker packages
-    sudo apt-get remove -y docker.io docker-doc docker-compose podman-docker containerd runc 2>/dev/null || true
+        ### Docker CE inside WSL2
 
-    # Install prerequisites
-    sudo apt-get update && sudo apt-get install -y ca-certificates curl
-    sudo install -m 0755 -d /etc/apt/keyrings
+        The [DDEV Windows installer](ddev-installation.md#step-2-install-ddev) automatically installs Docker CE in your WSL2 environment — no manual Docker installation is needed. After installing WSL2 above, proceed to [install DDEV](ddev-installation.md#step-2-install-ddev).
 
-    # Add Docker's GPG key
-    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-    sudo chmod a+r /etc/apt/keyrings/docker.asc
-
-    # Remove old repository files if present
-    sudo rm -f /etc/apt/keyrings/docker.gpg /etc/apt/sources.list.d/docker.list
-
-    # Add Docker repository in deb822 format
-    printf "Types: deb\nURIs: https://download.docker.com/linux/ubuntu\nSuites: %s\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n" \
-      "$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")" \
-      | sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null
-
-    # Install Docker CE
-    sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-    # Add your user to the docker group (create group if it doesn't exist)
-    sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
-    ```
-
-    Run `sg docker` to open a new subshell with the `docker` group active, or log out and back in to apply the change to your whole session. On WSL2 systems without `systemd`, you may need to start Docker manually with `sudo service docker start`.
-
-    ??? tip "Prefer to run as a script?"
-        Create a script file, then run it:
+        To install Docker CE manually instead, open your WSL2 terminal (Ubuntu) and run:
 
         ```bash
-        cat > /tmp/install-docker.sh << 'SCRIPT'
-        #!/usr/bin/env bash
-        set -euo pipefail
+        # Ensure sudo credentials are cached for copy/paste of this block
         sudo true
+
+        # Remove any old/conflicting Docker packages
         sudo apt-get remove -y docker.io docker-doc docker-compose podman-docker containerd runc 2>/dev/null || true
+
+        # Install prerequisites
         sudo apt-get update && sudo apt-get install -y ca-certificates curl
         sudo install -m 0755 -d /etc/apt/keyrings
+
+        # Add Docker's GPG key
         sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
         sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+        # Remove old repository files if present
         sudo rm -f /etc/apt/keyrings/docker.gpg /etc/apt/sources.list.d/docker.list
+
+        # Add Docker repository in deb822 format
         printf "Types: deb\nURIs: https://download.docker.com/linux/ubuntu\nSuites: %s\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n" \
           "$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")" \
           | sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null
+
+        # Install Docker CE
         sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+        # Add your user to the docker group (create group if it doesn't exist)
         sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
-        SCRIPT
         ```
 
-        Review the script, then run it: `bash /tmp/install-docker.sh`
+        Run `sg docker` to open a new subshell with the `docker` group active, or log out and back in to apply the change to your whole session. On WSL2 systems without `systemd`, you may need to start Docker manually with `sudo service docker start`.
 
-    ### Docker Desktop for Windows
+        ??? tip "Prefer to run as a script?"
+            Create a script file, then run it:
 
-    1. Download and install Docker Desktop from [docker.com](https://www.docker.com/products/docker-desktop).
-    2. During installation, ensure "Use WSL 2 instead of Hyper-V" is selected.
-    3. After installation, open Docker Desktop settings and navigate to **Resources → WSL Integration**.
-    4. Enable integration with your Debian-based WSL2 distro (e.g., Ubuntu-24.04, Debian).
-    5. Apply the changes and restart Docker Desktop if prompted.
-    6. Verify that `docker ps` works in git-bash, PowerShell, or WSL2, wherever you're using it.
+            ```bash
+            cat > /tmp/install-docker.sh << 'SCRIPT'
+            #!/usr/bin/env bash
+            set -euo pipefail
+            sudo true
+            sudo apt-get remove -y docker.io docker-doc docker-compose podman-docker containerd runc 2>/dev/null || true
+            sudo apt-get update && sudo apt-get install -y ca-certificates curl
+            sudo install -m 0755 -d /etc/apt/keyrings
+            sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+            sudo chmod a+r /etc/apt/keyrings/docker.asc
+            sudo rm -f /etc/apt/keyrings/docker.gpg /etc/apt/sources.list.d/docker.list
+            printf "Types: deb\nURIs: https://download.docker.com/linux/ubuntu\nSuites: %s\nComponents: stable\nSigned-By: /etc/apt/keyrings/docker.asc\n" \
+              "$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")" \
+              | sudo tee /etc/apt/sources.list.d/docker.sources >/dev/null
+            sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+            sudo groupadd -f docker && sudo usermod -aG docker ${SUDO_USER:-$USER}
+            SCRIPT
+            ```
 
-    ### Rancher Desktop for Windows
+            Review the script, then run it: `bash /tmp/install-docker.sh`
 
-    1. Download and install [Rancher Desktop](https://rancherdesktop.io/).
-    2. During installation, choose **Docker** as the container runtime and disable Kubernetes.
-    3. After installation, open Rancher Desktop and go to **WSL Integration** in the settings.
-    4. Enable integration with your Debian-based WSL2 distro (e.g., Ubuntu-24.04, Debian).
-    5. Apply the changes and restart Rancher Desktop if needed.
-    6. Verify that `docker ps` works in git-bash, PowerShell, or WSL2, wherever you're using it.
+        ### Docker Desktop for Windows
 
-    ### Docker Buildx
+        1. Download and install Docker Desktop from [docker.com](https://www.docker.com/products/docker-desktop).
+        2. During installation, ensure "Use WSL 2 instead of Hyper-V" is selected.
+        3. After installation, open Docker Desktop settings and navigate to **Resources → WSL Integration**.
+        4. Enable integration with your Debian-based WSL2 distro (e.g., Ubuntu-24.04, Debian).
+        5. Apply the changes and restart Docker Desktop if prompted.
+        6. Verify that `docker ps` works in git-bash, PowerShell, or WSL2, wherever you're using it.
 
-    DDEV requires the [Docker buildx plugin](https://github.com/docker/buildx). Docker CE inside WSL2, Docker Desktop, and Rancher Desktop all include it. If `docker buildx version` doesn't work, install the `docker-buildx-plugin` package inside WSL2 (e.g. `sudo apt-get install docker-buildx-plugin` on Ubuntu).
+        ### Rancher Desktop for Windows
 
-    More information in [Docker buildx requirement](https://ddev.com/blog/docker-buildx-requirement-v1-25-1/).
+        1. Download and install [Rancher Desktop](https://rancherdesktop.io/).
+        2. During installation, choose **Docker** as the container runtime and disable Kubernetes.
+        3. After installation, open Rancher Desktop and go to **WSL Integration** in the settings.
+        4. Enable integration with your Debian-based WSL2 distro (e.g., Ubuntu-24.04, Debian).
+        5. Apply the changes and restart Rancher Desktop if needed.
+        6. Verify that `docker ps` works in git-bash, PowerShell, or WSL2, wherever you're using it.
+
+    === "Docker rootless"
+
+        Docker rootless runs inside WSL2 using the same setup as Linux. In your WSL2 distro, follow the [Docker rootless instructions for Linux](#linux-docker-rootless).
+
+    === "Podman rootless"
+
+        Windows users can run Podman via [Podman Desktop](https://podman-desktop.io/), which manages the WSL2-based VM for you. Podman on Windows works but is less mature than on Linux.
+
+        ### Install Podman
+
+        Install [Podman Desktop](https://podman-desktop.io/docs/installation/windows-install), which includes Podman. Alternatively, install Podman directly following the [official Podman installation guide for Windows](https://podman.io/docs/installation#windows). For more information, see the [Podman tutorials](https://github.com/containers/podman/tree/main/docs/tutorials#readme).
+
+        ### Configure Podman
+
+        Setup and configuration follow the same patterns as the Linux/WSL2 setup, but with Podman Desktop managing the VM for you. Follow the [Podman rootless instructions for Linux](#linux-podman-rootless).
 
 === "Codespaces"
 
     ## GitHub Codespaces
 
     You can set up [GitHub Codespaces](https://github.com/features/codespaces) following the instructions in the [DDEV Installation](ddev-installation.md#github-codespaces) section.
+
+## Docker Buildx
+
+DDEV requires the [Docker buildx plugin](https://github.com/docker/buildx). Most Docker providers (OrbStack, Docker Desktop, Rancher Desktop, Colima, Lima) and Docker CE installed from the official Docker repository already include it. If `docker buildx version` doesn't work, install it:
+
+- **macOS (Homebrew):** `brew install docker-buildx`
+- **Linux/WSL2 (Debian/Ubuntu):** `sudo apt-get install docker-buildx-plugin`
+- **Other:** follow the installation instructions from [Docker buildx](https://github.com/docker/buildx#installing).
+
+More information in [Docker buildx requirement](https://ddev.com/blog/docker-buildx-requirement-v1-25-1/).
+
+## Running Multiple Container Runtimes
+
+You can run Docker and Podman sockets simultaneously and switch between them using Docker contexts.
+
+For example, here's a system with three active Docker contexts:
+
+```bash
+$ docker context ls
+NAME                DESCRIPTION                               DOCKER ENDPOINT
+default             Current DOCKER_HOST based configuration   unix:///var/run/docker.sock
+podman-rootless *   Podman (rootless)                         unix:///run/user/1000/podman/podman.sock
+rootless            Rootless runtime socket                   unix:///run/user/1000/docker.sock
+```
+
+Switch between them with:
+
+```bash
+docker context use "<context-name>"
+```
+
+## Switching Runtimes with DDEV
+
+DDEV automatically detects your active container runtime. To switch:
+
+1. Stop DDEV projects:
+
+   ```bash
+   ddev poweroff
+   ```
+
+2. Switch the Docker context or change the `DOCKER_HOST` environment variable.
+3. Start your project:
+
+   ```bash
+   ddev start
+   ```
+
+For background on the trade-offs between these runtimes, see [Podman and Docker Rootless in DDEV](https://ddev.com/blog/podman-and-docker-rootless/).
 
 <a name="troubleshooting"></a>
 
@@ -385,10 +686,10 @@ These errors indicate Docker context issues:
 - Validate the current context: `docker ps`
 
 !!!warning "Environment variables override Docker context"
-    If you have set `DOCKER_HOST` and/or `DOCKER_CONTEXT` environment variables, they will override the `docker context` settings. This can lead to connection issues if the host is unreachable or the specified context is incorrect. Check your shell profile (`~/.bashrc`, `~/.zshrc`) for these variables.
+If you have set `DOCKER_HOST` and/or `DOCKER_CONTEXT` environment variables, they will override the `docker context` settings. This can lead to connection issues if the host is unreachable or the specified context is incorrect. Check your shell profile (`~/.bashrc`, `~/.zshrc`) for these variables.
 
 !!!tip "Creating a Docker context"
-    You can create a new Docker context using the `docker context create` command. See [Remote Docker Environments](../topics/remote-docker.md) for examples.
+You can create a new Docker context using the `docker context create` command. See [Remote Docker Environments](../topics/remote-docker.md) for examples.
 
 ### Testing Docker Setup
 
@@ -397,7 +698,7 @@ For DDEV to work properly, Docker needs to:
 - Mount your project code directory (typically under your home folder) from host to container
 - Access TCP ports on the host for HTTP/HTTPS (default ports 80 and 443, configurable per project)
 
-Run this command in your *project directory* to verify Docker configuration (use Git Bash if you're on Windows!):
+Run this command in your _project directory_ to verify Docker configuration (use Git Bash if you're on Windows!):
 
 ```bash
 docker run --rm -t -p 80:80 -p 443:443 -v "//$PWD:/tmp/projdir" ddev/ddev-utilities sh -c "echo ---- Project Directory && ls /tmp/projdir"
@@ -434,4 +735,4 @@ Docker daemon isn't running, or no internet connection:
 Stale Docker Hub authentication interfering with public image pulls:
 
 - **Solution:** Run `docker logout` and try again
-- **Note:** Docker authentication is *not* required for normal DDEV operations
+- **Note:** Docker authentication is _not_ required for normal DDEV operations

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -598,13 +598,14 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
 ## Docker Buildx
 
-DDEV requires the [Docker buildx plugin](https://github.com/docker/buildx). Most Docker providers (OrbStack, Docker Desktop, Rancher Desktop, Colima, Lima) and Docker CE installed from the official Docker repository already include it. If `docker buildx version` doesn't work, install it:
+DDEV requires the [Docker buildx plugin](https://github.com/docker/buildx). GUI-based providers (OrbStack, Docker Desktop, Rancher Desktop) bundle it. If `docker buildx version` doesn't work, install it:
 
 - **macOS (Homebrew):** `brew install docker-buildx`
-- **Linux/WSL2 (Debian/Ubuntu):** `sudo apt-get install docker-buildx-plugin`
-- **Other:** follow the installation instructions from [Docker buildx](https://github.com/docker/buildx#installing).
+- **Linux/WSL2 (Debian/Ubuntu):** `sudo apt-get install docker-buildx-plugin` (requires the [official Docker repository](https://docs.docker.com/engine/install/) to be configured)
+- **Other:** see [Docker buildx requirement](https://ddev.com/blog/docker-buildx-requirement-v1-25-1/) for installation instructions across platforms.
 
-More information in [Docker buildx requirement](https://ddev.com/blog/docker-buildx-requirement-v1-25-1/).
+!!!tip "Can't install the plugin?"
+    As a fallback, DDEV can manage its own copy via [`docker_buildx_version`](../configuration/config.md#docker_buildx_version).
 
 ## Running Multiple Container Runtimes
 

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -266,6 +266,8 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
         !!!tip "`no_bind_mounts` is no longer required"
             Earlier DDEV versions (v1.25.0-v1.25.2) required [`no_bind_mounts`](../configuration/config.md#no_bind_mounts) with Docker rootless. That is no longer necessary—Docker rootless now works with bind mounts.
 
+            With bind mounts under Docker rootless, you appear as `root` inside the web container (for example, in [`ddev ssh`](../usage/commands.md#ssh)). This is expected: rootless maps container `root` to your regular host user, so it has no special privileges on the host. If you prefer not to work as `root` in the container, run `ddev config global --no-bind-mounts=true`. This enables [`no_bind_mounts`](../configuration/config.md#no_bind_mounts), which relies on [Mutagen](performance.md#mutagen) to sync files rather than mounting them directly.
+
         ### Install Docker rootless
 
         Follow the official [Docker rootless installation guide](https://docs.docker.com/engine/security/rootless/).


### PR DESCRIPTION
## The Issue

- Fixes #8434

Docker installation docs lacked Podman and Docker rootless setup instructions.

## How This PR Solves The Issue

Reorganizes the Docker installation docs into per-OS tabs with a runtime subtab for each supported container runtime (Docker, Docker rootless, Podman rootless), and fixes nested-tab anchor linking so deep links open the correct tab at any nesting depth.

## Manual Testing Instructions

| New documentation                                                                                                                                                                                                                                                | Existing blog post                                                                                                                                           | Status / Notes                                                                                |
| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
| [https://ddev--8552.org.readthedocs.build/en/8552/users/install/docker-installation/#macos-podman-rootless](https://ddev--8552.org.readthedocs.build/en/8552/users/install/docker-installation/#macos-podman-rootless)                                           | [https://ddev.com/blog/podman-and-docker-rootless/#installing-podman-1](https://ddev.com/blog/podman-and-docker-rootless/#installing-podman-1)                                           | Compare for completeness, correctness, and missing/obsolete steps.                            |
| [https://ddev--8552.org.readthedocs.build/en/8552/users/install/docker-installation/#linux-docker-rootless](https://ddev--8552.org.readthedocs.build/en/8552/users/install/docker-installation/#linux-docker-rootless)                                           | [https://ddev.com/blog/podman-and-docker-rootless/#setting-up-docker-rootless](https://ddev.com/blog/podman-and-docker-rootless/#setting-up-docker-rootless) | Compare for completeness, correctness, and missing/obsolete steps.                            |
| [https://ddev--8552.org.readthedocs.build/en/8552/users/install/docker-installation/#linux-podman-rootless](https://ddev--8552.org.readthedocs.build/en/8552/users/install/docker-installation/#linux-podman-rootless)                                           | [https://ddev.com/blog/podman-and-docker-rootless/#installing-podman](https://ddev.com/blog/podman-and-docker-rootless/#installing-podman)                   | Compare for completeness, correctness, and missing/obsolete steps.                            |
| [https://ddev--8552.org.readthedocs.build/en/8552/users/install/docker-installation/#choose-a-container-runtime-docker-rootless](https://ddev--8552.org.readthedocs.build/en/8552/users/install/docker-installation/#choose-a-container-runtime-docker-rootless) | *(no equivalent section in the blog)*                                                                                                                        | Verify whether this section is complete on its own or if content should be added to the blog. |
| [https://ddev--8552.org.readthedocs.build/en/8552/users/install/docker-installation/#choose-a-container-runtime-podman-rootless](https://ddev--8552.org.readthedocs.build/en/8552/users/install/docker-installation/#choose-a-container-runtime-podman-rootless) | [https://ddev.com/blog/podman-and-docker-rootless/#installing-podman-2](https://ddev.com/blog/podman-and-docker-rootless/#installing-podman-2)               | Compare for completeness, correctness, and missing/obsolete steps.                            |

## Automated Testing Overview

- No automated tests; docs-only change.

## Release/Deployment Notes

- A PR to edit https://ddev.com/blog/podman-and-docker-rootless/ will follow after this goes in.
- Podman rootful setup is intentionally left in the blog only, as it is unusual to use.