### PR TITLE
docs(wsl2): use Ubuntu-26.04 instead of Ubuntu-24.04, for #8326, for #8408

### DIFF
--- a/docs/content/users/install/ddev-installation.md
+++ b/docs/content/users/install/ddev-installation.md
@@ -224,7 +224,7 @@ Once you’ve [installed a Docker provider](docker-installation.md), you’re re
 
     ```powershell
     # You'll be asked to set a username and password for the distro:
-    wsl --install Ubuntu-24.04 --name DDEV
+    wsl --install Ubuntu-26.04 --name DDEV
     ```
 
     !!!tip "\"DDEV\" is just a suggested name — use any name you like."

--- a/docs/content/users/install/docker-installation.md
+++ b/docs/content/users/install/docker-installation.md
@@ -468,7 +468,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
 
     ```powershell
     # You'll be asked to set a username and password for the distro:
-    wsl --install Ubuntu-24.04 --name DDEV
+    wsl --install Ubuntu-26.04 --name DDEV
     ```
 
     !!!tip "\"DDEV\" is just a suggested name — use any name you like."
@@ -561,7 +561,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
         1. Download and install Docker Desktop from [docker.com](https://www.docker.com/products/docker-desktop).
         2. During installation, ensure "Use WSL 2 instead of Hyper-V" is selected.
         3. After installation, open Docker Desktop settings and navigate to **Resources → WSL Integration**.
-        4. Enable integration with your Debian-based WSL2 distro (e.g., Ubuntu-24.04, Debian).
+        4. Enable integration with your Debian-based WSL2 distro (e.g., Ubuntu-26.04, Debian).
         5. Apply the changes and restart Docker Desktop if prompted.
         6. Verify that `docker ps` works in git-bash, PowerShell, or WSL2, wherever you're using it.
 
@@ -570,7 +570,7 @@ You’ll need a Docker provider on your system before you can [install DDEV](dde
         1. Download and install [Rancher Desktop](https://rancherdesktop.io/).
         2. During installation, choose **Docker** as the container runtime and disable Kubernetes.
         3. After installation, open Rancher Desktop and go to **WSL Integration** in the settings.
-        4. Enable integration with your Debian-based WSL2 distro (e.g., Ubuntu-24.04, Debian).
+        4. Enable integration with your Debian-based WSL2 distro (e.g., Ubuntu-26.04, Debian).
         5. Apply the changes and restart Rancher Desktop if needed.
         6. Verify that `docker ps` works in git-bash, PowerShell, or WSL2, wherever you're using it.
 

--- a/winpkg/ddev_windows_installer.nsi
+++ b/winpkg/ddev_windows_installer.nsi
@@ -2204,7 +2204,7 @@ Function ParseCommandLine
             /help or /?                  - Show this help message$\n$\n\
             Examples:$\n\
             installer.exe /docker-ce /distro=Ubuntu$\n\
-            installer.exe /docker-desktop /distro=Ubuntu-24.04$\n\
+            installer.exe /docker-desktop /distro=Ubuntu-26.04$\n\
             installer.exe /traditional$\n\
             installer.exe /traditional /S"
         Abort
@@ -2222,7 +2222,7 @@ Function ParseCommandLine
             /help or /?                  - Show this help message$\n$\n\
             Examples:$\n\
             installer.exe /docker-ce /distro=Ubuntu$\n\
-            installer.exe /docker-desktop /distro=Ubuntu-24.04$\n\
+            installer.exe /docker-desktop /distro=Ubuntu-26.04$\n\
             installer.exe /traditional$\n\
             installer.exe /traditional /S"
         Abort

--- a/winpkg/installer_test.go
+++ b/winpkg/installer_test.go
@@ -210,7 +210,7 @@ func TestWindowsInstallerWSL2(t *testing.T) {
 		baseDistro string // WSL catalog distro the instance is provisioned from
 		provider   string // "docker-ce" or "docker-desktop"
 	}{
-		// "Ubuntu" in the WSL catalog installs the current LTS (Ubuntu 26.04 as of 2026).
+		// "Ubuntu" in the WSL catalog installs the current LTS (Ubuntu-26.04 as of 2026).
 		{instance: "ddev-test-ubuntu-ce", baseDistro: "Ubuntu", provider: "docker-ce"},
 		{instance: "ddev-test-ubuntu-desktop", baseDistro: "Ubuntu", provider: "docker-desktop"},
 		// {instance: "ddev-test-ubuntu2404-ce", baseDistro: "Ubuntu-24.04", provider: "docker-ce"},


### PR DESCRIPTION
## The Issue

- For #8326
- For #8408

We don't need to recommend `Ubuntu-24.04` anymore.

## How This PR Solves The Issue

Uses `Ubuntu-26.04`. I could switch back to `Ubuntu`, but `Ubuntu-28.04` might break things again. It's better to be explicit, and we can update it every two years.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
