### PR TITLE
fix(webserver): restore nonstandard router port in HTTP_HOST for nginx-fpm, fixes #8554

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -113,9 +113,42 @@ RUN sed -i 's#listen = /run/php-fpm.sock#listen = /run/php/php-fpm.sock#' /etc/p
 #     (same for scgi_param and uwsgi_param, matched by \w+_param)
 #   proxy_set_header Host $host;    -> proxy_set_header Host $http_host;
 # If Debian ever drops these lines, the seds are no-ops and nginx's default
-# pass-through of the Host header is correct again.
+# pass-through of the Host header is correct again. Debian's own comment says
+# nginx 1.30.0+ will preserve the port via $host$is_request_port$request_port;
+# once that lands, our "$host;" match no longer fires and we inherit the correct
+# upstream behavior automatically (see ddev/ddev#8555).
+# The last two seds rewrite Debian's now-contradictory "Do not use $http_host"
+# comment so `cat`ing the file in the container is not misleading.
 RUN sed -i 's#^\(\w\+_param\s\+HTTP_HOST\s\+\)$host;#\1$http_host;#' /etc/nginx/fastcgi_params /etc/nginx/scgi_params /etc/nginx/uwsgi_params && \
-    sed -i 's#^\(proxy_set_header\s\+Host\s\+\)$host;#\1$http_host;#' /etc/nginx/proxy_params
+    sed -i 's#^\(proxy_set_header\s\+Host\s\+\)$host;#\1$http_host;#' /etc/nginx/proxy_params && \
+    sed -i 's@^# Do not use HTTP_HOST as "$http_host"\.@# DDEV: the HTTP_HOST line below intentionally uses $http_host to preserve a nonstandard router port (ddev/ddev#8555); Debian set $host as a workaround for bug #1126960, which strips the port.@' /etc/nginx/fastcgi_params /etc/nginx/scgi_params /etc/nginx/uwsgi_params && \
+    sed -i 's@^# Do not set the `Host` header as "$http_host"\.@# DDEV: the Host line below intentionally uses $http_host to preserve a nonstandard router port (ddev/ddev#8555); Debian set $host as a workaround for bug #1126960, which strips the port.@' /etc/nginx/proxy_params
+# Guard: fail the build if the HTTP_HOST/Host rewrite above did not land as
+# $http_host. This deliberately breaks the build in two cases, both of which a
+# maintainer must look at:
+#   - the sed silently failed to match because Debian reformatted its $host
+#     workaround while still stripping the port -> our fix has regressed; or
+#   - Debian shipped the proper fix (nginx 1.30.0+ builds HTTP_HOST from
+#     $host$is_request_port$request_port) -> our workaround is now dead code and
+#     should be removed.
+# Without this guard the second case is invisible: the functional test stays
+# green because the port is preserved upstream, and the dead seds linger. See
+# ddev/ddev#8555.
+RUN <<'EOF'
+set -eu -o pipefail
+for f in /etc/nginx/fastcgi_params /etc/nginx/scgi_params /etc/nginx/uwsgi_params; do
+  if ! grep -Eq '^[a-z]+_param[[:space:]]+HTTP_HOST[[:space:]]+\$http_host;' "$f"; then
+    echo "ERROR: ${f}: HTTP_HOST is not set to \$http_host after the rewrite." >&2
+    echo "Debian's nginx-common line changed (bug #1126960 / ddev/ddev#8555)." >&2
+    echo "If upstream now preserves the port (nginx 1.30.0 \$host\$is_request_port\$request_port), remove this workaround; otherwise fix the seds above." >&2
+    exit 1
+  fi
+done
+if ! grep -Eq '^proxy_set_header[[:space:]]+Host[[:space:]]+\$http_host;' /etc/nginx/proxy_params; then
+  echo "ERROR: /etc/nginx/proxy_params: Host is not set to \$http_host after the rewrite (bug #1126960 / ddev/ddev#8555)." >&2
+  exit 1
+fi
+EOF
 RUN locale-gen
 
 # Composer may need to be updated by composer self-update

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -103,11 +103,19 @@ RUN apt-get -qq autoremove && apt-get -qq clean -y && rm -rf /var/lib/apt/lists/
 COPY ddev-webserver-base-files /
 COPY ddev-webserver-base-scripts /
 RUN sed -i 's#listen = /run/php-fpm.sock#listen = /run/php/php-fpm.sock#' /etc/php/*/fpm/pool.d/www.conf
-# Debian's nginx-common (security workaround for Debian bug #1126960, seen in 1.26.3-3+deb13u7)
-# overrides HTTP_HOST with port-stripped $host in fastcgi_params, which breaks
-# app-generated absolute URLs when router_http(s)_port is not 80/443.
-# Restore the client's Host header (including port) for FastCGI.
-RUN sed -i 's#^\(fastcgi_param\s\+HTTP_HOST\s\+\)$host;#\1$http_host;#' /etc/nginx/fastcgi_params
+# Debian's nginx (since 1.26.3-3+deb13u4, a workaround for Debian bug #1126960)
+# passes the host to backends as the port-stripped $host nginx variable instead of
+# the client's Host header, so PHP sees HTTP_HOST without the port and apps
+# build wrong absolute URLs whenever router_http(s)_port is not 80/443.
+# Rewrite the *_params files to use $http_host (the Host header as sent by the
+# client, port included):
+#   fastcgi_param HTTP_HOST $host;  -> fastcgi_param HTTP_HOST $http_host;
+#     (same for scgi_param and uwsgi_param, matched by \w+_param)
+#   proxy_set_header Host $host;    -> proxy_set_header Host $http_host;
+# If Debian ever drops these lines, the seds are no-ops and nginx's default
+# pass-through of the Host header is correct again.
+RUN sed -i 's#^\(\w\+_param\s\+HTTP_HOST\s\+\)$host;#\1$http_host;#' /etc/nginx/fastcgi_params /etc/nginx/scgi_params /etc/nginx/uwsgi_params && \
+    sed -i 's#^\(proxy_set_header\s\+Host\s\+\)$host;#\1$http_host;#' /etc/nginx/proxy_params
 RUN locale-gen
 
 # Composer may need to be updated by composer self-update

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -103,6 +103,11 @@ RUN apt-get -qq autoremove && apt-get -qq clean -y && rm -rf /var/lib/apt/lists/
 COPY ddev-webserver-base-files /
 COPY ddev-webserver-base-scripts /
 RUN sed -i 's#listen = /run/php-fpm.sock#listen = /run/php/php-fpm.sock#' /etc/php/*/fpm/pool.d/www.conf
+# Debian's nginx-common (security workaround for Debian bug #1126960, seen in 1.26.3-3+deb13u7)
+# overrides HTTP_HOST with port-stripped $host in fastcgi_params, which breaks
+# app-generated absolute URLs when router_http(s)_port is not 80/443.
+# Restore the client's Host header (including port) for FastCGI.
+RUN sed -i 's#^\(fastcgi_param\s\+HTTP_HOST\s\+\)$host;#\1$http_host;#' /etc/nginx/fastcgi_params
 RUN locale-gen
 
 # Composer may need to be updated by composer self-update

--- a/containers/ddev-webserver/ddev-webserver-base-files/var/www/html/test/hosttest.php
+++ b/containers/ddev-webserver/ddev-webserver-base-files/var/www/html/test/hosttest.php
@@ -1,0 +1,9 @@
+<?php
+
+// Reports the request host/port environment that PHP receives.
+// Used by tests to verify that HTTP_HOST preserves a nonstandard port,
+// which apps depend on for building absolute URLs when
+// router_http(s)_port is not 80/443.
+header('Content-Type: text/plain');
+echo "HTTP_HOST=" . ($_SERVER['HTTP_HOST'] ?? '(unset)') . "\n";
+echo "SERVER_PORT=" . ($_SERVER['SERVER_PORT'] ?? '(unset)') . "\n";

--- a/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats
@@ -7,6 +7,20 @@ setup() {
   load setup.sh
 }
 
+@test "HTTP_HOST passed to PHP preserves nonstandard port for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
+  # Debian's nginx-common overrides HTTP_HOST with port-stripped $host in
+  # /etc/nginx/fastcgi_params (Debian bug #1126960 security workaround),
+  # which breaks app-generated absolute URLs when router_http(s)_port
+  # is not 80/443. Make sure the client's Host header, including any
+  # nonstandard port, reaches PHP unchanged.
+  run curl -s --fail -H "Host: hosttest.ddev.site:8443" http://127.0.0.1:$HOST_HTTP_PORT/test/hosttest.php
+  assert_success
+  assert_output --partial "HTTP_HOST=hosttest.ddev.site:8443"
+  run curl -sk --fail -H "Host: hosttest.ddev.site:8443" https://127.0.0.1:$HOST_HTTPS_PORT/test/hosttest.php
+  assert_success
+  assert_output --partial "HTTP_HOST=hosttest.ddev.site:8443"
+}
+
 @test "http and https phpstatus access work inside and outside container for ${WEBSERVER_TYPE} php${PHP_VERSION}" {
   run curl -sSL --fail http://127.0.0.1:$HOST_HTTP_PORT/test/phptest.php
   assert_success

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -4118,6 +4118,17 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 	app.AdditionalHostnames = []string{"sub1", "sub2", "sub3"}
 	app.AdditionalFQDNs = []string{"junker99.example.com"}
 
+	// Probe used to verify that the HTTP_HOST seen by PHP retains the
+	// nonstandard router port; the port has been lost in the past when
+	// Debian's nginx-common overrode HTTP_HOST with the port-stripped
+	// $host in /etc/nginx/fastcgi_params (Debian bug #1126960).
+	hostProbe := filepath.Join(app.AppRoot, app.Docroot, "hosttest-probe.php")
+	err = os.WriteFile(hostProbe, []byte(`<?php echo "HTTP_HOST=" . ($_SERVER['HTTP_HOST'] ?? '(unset)');`), 0644)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Remove(hostProbe)
+	})
+
 	for _, pair := range []testcommon.PortPair{{HTTPPort: "8000", HTTPSPort: "8143"}, {HTTPPort: "8080", HTTPSPort: "8443"}} {
 		testcommon.ClearDockerEnv()
 		app.RouterHTTPPort = pair.HTTPPort
@@ -4168,6 +4179,12 @@ func TestInternalAndExternalAccessToURL(t *testing.T) {
 				// Retry to ride out the occasional M1 EOF on the first hit.
 				testcommon.AssertLocalHTTPContent(t, item+site.Safe200URIWithExpectation.URI, site.Safe200URIWithExpectation.Expect,
 					testcommon.WithMessagef("each external URL should be reachable from the host with expected content"),
+					testcommon.WithMaxAttempts(2),
+				)
+				// PHP must see the full Host header including the nonstandard
+				// router port, or apps will build absolute URLs without it.
+				testcommon.AssertLocalHTTPContent(t, item+"/hosttest-probe.php", "HTTP_HOST="+parts.Host,
+					testcommon.WithMessagef("HTTP_HOST seen by PHP should retain the nonstandard port for %s", item),
 					testcommon.WithMaxAttempts(2),
 				)
 			}

--- a/pkg/testcommon/http.go
+++ b/pkg/testcommon/http.go
@@ -211,7 +211,7 @@ func checkLocalHTTPContent(t *testing.T, fatal bool, rawURL string, wantContent 
 // expected content, not just a working request. Each retry is logged via t.Logf.
 func getLocalHTTPResponse(t *testing.T, rawURL string, cfg requestConfig, contentOK func(body string) bool) (string, *LocalHTTPResponse, error) {
 	t.Helper()
-	address, host, err := localDockerAddress(rawURL)
+	address, hostHeader, serverName, err := localDockerAddress(rawURL)
 	if err != nil {
 		return "", nil, err
 	}
@@ -220,7 +220,7 @@ func getLocalHTTPResponse(t *testing.T, rawURL string, cfg requestConfig, conten
 	var resp *LocalHTTPResponse
 	delay := cfg.tick
 	for attempt := 1; ; attempt++ {
-		body, resp, err = httpGetLocal(address, host, cfg)
+		body, resp, err = httpGetLocal(address, hostHeader, serverName, cfg)
 		success := err == nil && (contentOK == nil || contentOK(body))
 		limit := cfg.maxAttempts
 		// macOS php-fpm sometimes crashes (SIGBUS) and returns a brief 502/503;
@@ -246,20 +246,21 @@ func getLocalHTTPResponse(t *testing.T, rawURL string, cfg requestConfig, conten
 	}
 }
 
-// httpGetLocal makes a single GET to address, sending host as the Host header and
-// TLS server name, and does not follow redirects. A status other than expectStatus
-// is returned as an error, with the body still returned. The response body is read
-// and closed here, so the caller gets a plain string and nothing to close.
-func httpGetLocal(address, host string, cfg requestConfig) (string, *LocalHTTPResponse, error) {
-	// ServerName makes TLS verify the cert for host; ErrUseLastResponse stops the
-	// client from following redirects. Refs:
+// httpGetLocal makes a single GET to address, sending hostHeader as the Host
+// header and serverName as the TLS server name, and does not follow redirects. A
+// status other than expectStatus is returned as an error, with the body still
+// returned. The response body is read and closed here, so the caller gets a plain
+// string and nothing to close.
+func httpGetLocal(address, hostHeader, serverName string, cfg requestConfig) (string, *LocalHTTPResponse, error) {
+	// ServerName makes TLS verify the cert for the hostname; ErrUseLastResponse
+	// stops the client from following redirects. Refs:
 	// https://stackoverflow.com/a/47169975/215713 and
 	// https://stackoverflow.com/a/38150816/215713
 	client := &http.Client{
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
-		Transport: &http.Transport{TLSClientConfig: &tls.Config{ServerName: host}},
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{ServerName: serverName}},
 		Timeout:   cfg.timeout,
 	}
 
@@ -267,7 +268,7 @@ func httpGetLocal(address, host string, cfg requestConfig) (string, *LocalHTTPRe
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create GET request for %s: %w", address, err)
 	}
-	req.Host = host
+	req.Host = hostHeader
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -288,29 +289,38 @@ func httpGetLocal(address, host string, cfg requestConfig) (string, *LocalHTTPRe
 }
 
 // localDockerAddress points rawURL at the local Docker IP but keeps the original
-// hostname for the Host header and TLS server name.
-func localDockerAddress(rawURL string) (address, host string, err error) {
+// hostname for the Host header and TLS server name. Like a real client (browser,
+// curl), the Host header includes the port when it is not the default for the
+// scheme — apps depend on that to build absolute URLs when router_http(s)_port
+// is not 80/443. The TLS server name is always the bare hostname.
+func localDockerAddress(rawURL string) (address, hostHeader, serverName string, err error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to parse URL %s: %w", rawURL, err)
+		return "", "", "", fmt.Errorf("failed to parse URL %s: %w", rawURL, err)
 	}
 	dockerIP, err := dockerutil.GetDockerIP()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get Docker IP: %w", err)
+		return "", "", "", fmt.Errorf("failed to get Docker IP: %w", err)
 	}
-	host = u.Hostname()
+	serverName = u.Hostname()
 	// Read the port before overwriting u.Host, because u.Port() reads it from there.
 	port := u.Port()
+	hostHeader = serverName
+	if port != "" && !(u.Scheme == "http" && port == "80") && !(u.Scheme == "https" && port == "443") {
+		hostHeader = serverName + ":" + port
+	}
 	u.Host = dockerIP
 	if port != "" {
 		u.Host = dockerIP + ":" + port
 	}
-	return u.String(), host, nil
+	return u.String(), hostHeader, serverName, nil
 }
 
-// describeHTTPFailure builds the failure message: a Fail line with the caller's
-// message, then the request, status, headers, body, and the reason(s) it failed
-// (missing substrings and/or a request error).
+// describeHTTPFailure builds the failure message: a "Check failed" line with the
+// caller's message, then the request, status, headers, body, and the reason(s) it
+// failed (missing substrings and/or a request error). The first line deliberately
+// avoids the pattern "Fail:" so searching test output for go's own failure
+// markers doesn't turn up these detail blocks.
 func describeHTTPFailure(rawURL string, resp *LocalHTTPResponse, body string, err error, missing []string, userMsg string) string {
 	status := 0
 	var header http.Header
@@ -332,7 +342,7 @@ func describeHTTPFailure(rawURL string, resp *LocalHTTPResponse, body string, er
 		userMsg = "HTTP request failed"
 	}
 	parts := []string{
-		fmt.Sprintf("Fail: %s", userMsg),
+		fmt.Sprintf("Check failed - %s", userMsg),
 		fmt.Sprintf("GET: %s", rawURL),
 		fmt.Sprintf("Status: %d", status),
 		fmt.Sprintf("Error: %s", strings.Join(reasons, "; ")),

--- a/pkg/testcommon/http_test.go
+++ b/pkg/testcommon/http_test.go
@@ -58,35 +58,47 @@ func TestNewRequestConfig(t *testing.T) {
 }
 
 // TestLocalDockerAddress checks that localDockerAddress points the URL at the
-// Docker IP while keeping the original port and path, and returns the original
-// hostname (used for the Host header and TLS server name).
+// Docker IP while keeping the original port and path, and returns the Host
+// header (with any nonstandard port, as a real client sends it) and the bare
+// hostname for the TLS server name.
 func TestLocalDockerAddress(t *testing.T) {
-	// A URL with a port keeps it.
-	addr, host, err := localDockerAddress("https://example.ddev.site:8142/run")
+	// A URL with a nonstandard port keeps it, in both the address and the Host header.
+	addr, hostHeader, serverName, err := localDockerAddress("https://example.ddev.site:8142/run")
 	require.NoError(t, err)
-	require.Equal(t, "example.ddev.site", host)
+	require.Equal(t, "example.ddev.site:8142", hostHeader, "Host header must include a nonstandard port, like a real client")
+	require.Equal(t, "example.ddev.site", serverName, "TLS server name must never include a port")
 	require.True(t, strings.HasPrefix(addr, "https://"), "scheme must be preserved, got %s", addr)
 	require.Contains(t, addr, ":8142", "port must be preserved, got %s", addr)
 	require.True(t, strings.HasSuffix(addr, "/run"), "path must be preserved, got %s", addr)
 	require.NotContains(t, addr, "example.ddev.site", "host should be replaced by the Docker IP, got %s", addr)
 
 	// A URL without a port must not gain one.
-	addr, host, err = localDockerAddress("http://example.ddev.site/")
+	addr, hostHeader, serverName, err = localDockerAddress("http://example.ddev.site/")
 	require.NoError(t, err)
-	require.Equal(t, "example.ddev.site", host)
+	require.Equal(t, "example.ddev.site", hostHeader)
+	require.Equal(t, "example.ddev.site", serverName)
 	require.True(t, strings.HasPrefix(addr, "http://"), "scheme must be preserved, got %s", addr)
 	require.True(t, strings.HasSuffix(addr, "/"), "path must be preserved, got %s", addr)
 	require.NotContains(t, addr, "example.ddev.site", "host should be replaced by the Docker IP, got %s", addr)
 	u, err := url.Parse(addr)
 	require.NoError(t, err)
 	require.Empty(t, u.Port(), "no port should be added, got %s", addr)
+
+	// A default port for the scheme is omitted from the Host header, like a
+	// real client, but still used to dial.
+	addr, hostHeader, serverName, err = localDockerAddress("https://example.ddev.site:443/")
+	require.NoError(t, err)
+	require.Equal(t, "example.ddev.site", hostHeader, "default port must be omitted from the Host header")
+	require.Equal(t, "example.ddev.site", serverName)
+	require.Contains(t, addr, ":443", "explicit port must still be dialed, got %s", addr)
 }
 
 // TestDescribeHTTPFailure verifies the failure message layout. No Docker needed.
 func TestDescribeHTTPFailure(t *testing.T) {
 	resp := &LocalHTTPResponse{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"text/html"}}}
 	msg := describeHTTPFailure("https://x.ddev.site:8142", resp, "the body", nil, []string{"Recent runs"}, "want a run")
-	require.Contains(t, msg, "Fail: want a run")
+	require.Contains(t, msg, "Check failed - want a run")
+	require.NotContains(t, msg, "Fail:", "failure output must not mimic go's own test-failure markers")
 	require.Contains(t, msg, "GET: https://x.ddev.site:8142")
 	require.Contains(t, msg, "Status: 200")
 	require.Contains(t, msg, `Error: body does not contain ["Recent runs"]`)
@@ -95,7 +107,7 @@ func TestDescribeHTTPFailure(t *testing.T) {
 
 	// A transport error and an empty caller message fall back sensibly.
 	msg = describeHTTPFailure("https://x.ddev.site", nil, "", fmt.Errorf("dial tcp: boom"), nil, "")
-	require.Contains(t, msg, "Fail: HTTP request failed")
+	require.Contains(t, msg, "Check failed - HTTP request failed")
 	require.Contains(t, msg, "Status: 0")
 	require.Contains(t, msg, "Error: dial tcp: boom")
 }

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260703_rfay_traefik_port" // Note that this can be overridden by make
+var WebTag = "v1.25.3" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.25.3" // Note that this can be overridden by make
+var WebTag = "20260703_rfay_traefik_port" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- Fixes #8554

Debian's nginx-common package (security workaround for [Debian bug #1126960](https://bugs.debian.org/1126960), introduced in [`1.26.3-3+deb13u4`, 2026-04-20](https://metadata.ftp-master.debian.org/changelogs/main/n/nginx/stable_changelog)) now overrides `HTTP_HOST`/`Host` with the port-stripped `$host` variable in the `*_params` files. The change entered `ddev-webserver` between the v1.25.2 (`deb13u2`) and v1.25.3 (`deb13u7`) image builds.

As a result, PHP on nginx-fpm projects sees `HTTP_HOST` without the router port whenever `router_http(s)_port` is not 80/443, and apps that build absolute URLs from `HTTP_HOST` (Drupal, TYPO3, essentially all PHP frameworks) generate redirects missing the port, breaking login flows. apache-fpm is unaffected; ddev-router (Traefik) forwards the `Host` header and `X-Forwarded-*` correctly and is not at fault. Full analysis in #8554.

## How This PR Solves The Issue

Seds in `containers/ddev-webserver/Dockerfile` rewrite the Debian overrides back to the client's Host header (including any nonstandard port): `HTTP_HOST $host;` → `HTTP_HOST $http_host;` in `fastcgi_params`/`scgi_params`/`uwsgi_params`, and `proxy_set_header Host $host;` → `$http_host` in `proxy_params` (Debian applied the same workaround there, which would bite user custom configs that `include proxy_params;`). Every DDEV nginx site config does `include fastcgi_params;`, so one image-level change covers all project types as well as user-customized nginx configs. The seds are no-ops if the lines ever disappear from the package, which also restores correct behavior (nginx passes the Host header through automatically when there is no override).

`WebTag` in `pkg/versionconstants/versionconstants.go` is set to the branch image tag.

## Manual Testing Instructions

```bash
ddev config global --router-https-port=8443
mkdir -p ~/tmp/porttest/web && cd ~/tmp/porttest
printf '<?php echo "HTTP_HOST=" . ($_SERVER["HTTP_HOST"] ?? "(unset)") . "\n";' > web/index.php
ddev config --project-type=php --docroot=web
ddev start -y
curl -sk https://porttest.ddev.site:8443/
```

Expect `HTTP_HOST=porttest.ddev.site:8443` (v1.25.3 images show it without the port). On a Drupal project, `curl -sk -D - -o /dev/null "$(ddev drush uli)"` should show a `Location` header that retains `:8443`, with no `reverse_proxy` settings in `settings.php`.

## Automated Testing Overview

- New bats test in `containers/ddev-webserver/tests/ddev-webserver/php_webserver.bats` curls the new `/test/hosttest.php` probe with `Host: hosttest.ddev.site:8443` over http and https and asserts the port reaches PHP unchanged. Runs for every PHP version and both webserver types. Verified passing against the fixed image (nginx-fpm and apache-fpm) and failing against the unfixed v1.25.3 image.
- New assertion in `TestInternalAndExternalAccessToURL`, which already cycles nonstandard router port pairs through the real router: a PHP probe in the test site docroot must report `HTTP_HOST` including the port for every URL. This also guards against any future router-side port stripping.

## Release/Deployment Notes

Requires the `ddev-webserver` image to be pushed with the branch tag before CI can pass. No behavior change for default router ports (80/443); with customized ports, nginx-fpm projects return to the pre-v1.25.3 behavior. No user action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

