### PR TITLE
docs: add TYPO3 special handling for `ddev share`, fixes #7799

### DIFF
--- a/docs/content/users/topics/sharing.md
+++ b/docs/content/users/topics/sharing.md
@@ -143,6 +143,42 @@ If you have a domain managed by Cloudflare, you can use a named tunnel for a sta
 
 Some CMSes like WordPress and Magento require special handling because they don't automatically handle the URL routed to them. For more extensive instructions and possibilities, read the [DDEV Share Blog](https://ddev.com/blog/share-providers/).
 
+### TYPO3 special handling: Strip the host from `base`
+
+TYPO3's site configuration (`config/sites/<identifier>/config.yaml`) stores an absolute `base` URL for each site, for example:
+
+```yaml
+base: 'https://typo3.ddev.site/'
+```
+
+TYPO3 only routes requests whose Host header exactly matches `base`, so an ngrok or cloudflared tunnel hostname will 404 until `base` is adjusted.
+
+**Simplest fix (permanent):** Set `base: /` (or `/your-path/` if the site normally lives under a subpath) by hand, then run `ddev typo3 cache:flush` to clear the derived routing caches. This works indefinitely for local development and needs no further changes.
+
+**Automatic fix (reversible, multi-site-safe):** Use `pre-share`/`post-share` hooks to strip only the scheme and host from `base`, preserving any existing path. This matters for multi-site projects — commenting out or blanking every `base` collapses all sites to the same host-less `/` route and only one wins; stripping just the host keeps each site's own path distinct:
+
+```yaml
+hooks:
+  pre-share:
+    - exec: |
+        for f in config/sites/*/config.yaml; do
+          cp "$f" "$f.pre-share-backup"
+          newbase=$(yq '.base' "$f" | sed -E 's#^https?://[^/]+##')
+          [ -z "$newbase" ] && newbase="/"
+          yq -i ".base = \"$newbase\"" "$f"
+        done
+        vendor/bin/typo3 cache:flush
+  post-share:
+    - exec: |
+        for f in config/sites/*/config.yaml.pre-share-backup; do
+          mv "$f" "${f%.pre-share-backup}"
+        done
+        vendor/bin/typo3 cache:flush
+        ddev mutagen sync
+```
+
+This doesn't handle `baseVariants` entries or per-language `base` overrides, which are more advanced, less common setups. (See the [DDEV Share Blog](https://ddev.com/blog/share-providers/) for more on writing `pre-share`/`post-share` hooks.)
+
 ### WordPress special handling: Change the URL using `wp search-replace`
 
 WordPress only has the one base URL, but the `wp` command is built into DDEV’s web container.

--- a/docs/content/users/topics/sharing.md
+++ b/docs/content/users/topics/sharing.md
@@ -167,14 +167,13 @@ hooks:
           [ -z "$newbase" ] && newbase="/"
           yq -i ".base = \"$newbase\"" "$f"
         done
-        vendor/bin/typo3 cache:flush
+        typo3 cache:flush
   post-share:
     - exec: |
         for f in config/sites/*/config.yaml.pre-share-backup; do
           mv "$f" "${f%.pre-share-backup}"
         done
-        vendor/bin/typo3 cache:flush
-        ddev mutagen sync
+        typo3 cache:flush
 ```
 
 This doesn't handle `baseVariants` entries or per-language `base` overrides, which are more advanced, less common setups. (See the [DDEV Share Blog](https://ddev.com/blog/share-providers/) for more on writing `pre-share`/`post-share` hooks.)


### PR DESCRIPTION
## The Issue

* Fixes #7799 

TYPO3 sites 404 when accessed through `ddev share` (or other tunnel/alternate-hostname setups). TYPO3's site configuration (`config/sites/<identifier>/config.yaml`) stores an absolute `base` URL per site, and TYPO3 only routes requests whose Host header exactly matches that `base`. A tunnel's hostname never matches, so the request 404s. This is the same class of problem already documented for WordPress and Magento 2, but wasn't yet covered for TYPO3.

## How This PR Solves The Issue

Adds a new "TYPO3 special handling" section to [Sharing Your Project](https://docs.ddev.com/en/stable/users/topics/sharing/), placed first in the "Special Handling for Complex CMSes" section:

- Explains the root cause (absolute `base` requires an exact Host match).
- Documents a simple, permanent fix: set `base: /` (or a path) by hand and flush TYPO3's cache.
- Documents an automatic, reversible `pre-share`/`post-share` hook pair that strips only the scheme+host from `base` (via `yq`), preserving any existing path. This is multi-site-safe, unlike blanking `base` entirely, which would collapse all sites to the same host-less route and break all but one of them.

## Manual Testing Instructions

Rendered for review at https://ddev--8556.org.readthedocs.build/en/8556/users/topics/sharing/#special-handling-for-complex-cmses

Consider trying it out.

Sample TYPO3 example in https://github.com/rfay/typo3demo, or use the DDEV quickstart at https://docs.ddev.com/en/latest/users/quickstart/#typo3

The older quickstart (current stable) requires the hooks, https://docs.ddev.com/en/stable/users/quickstart/#typo3

## Automated Testing Overview

Documentation-only change; no automated tests added.

