### PR TITLE
fix(shopware): pin Twig <3.28 to work around admin HTTP 500

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2496,6 +2496,13 @@ ddev config --upload-dirs=sites/assets/files && ddev restart
     # answer `x`, as we're using DDEV for this rather than its recipes.
     ```
 
+    !!!warning "Temporary Twig pin"
+        Twig 3.28.0 changed `include()` to return a `Twig\Markup` object instead of a string, which breaks Shopware 6.7's admin (HTTP 500 on `/admin`). Until [shopware/conflicts#36](https://github.com/shopware/conflicts/pull/36) is released to block Twig 3.28, pin Twig to an earlier version:
+
+        ```bash
+        ddev composer require "twig/twig:<3.28"
+        ```
+
     Run Shopware installation and launch:
 
     ```bash
@@ -2519,6 +2526,9 @@ ddev config --upload-dirs=sites/assets/files && ddev restart
         ddev config --project-type=shopware6 --docroot=public
         ddev start -y
         ddev composer create-project shopware/production
+        # TEMPORARY: pin Twig <3.28 until shopware/conflicts#36 is released;
+        # Twig 3.28 breaks Shopware 6.7's admin with an HTTP 500 on /admin.
+        ddev composer require "twig/twig:<3.28"
         ddev exec console system:install --basic-setup
         ddev launch /admin
         EOF

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2496,13 +2496,6 @@ ddev config --upload-dirs=sites/assets/files && ddev restart
     # answer `x`, as we're using DDEV for this rather than its recipes.
     ```
 
-    !!!warning "Temporary Twig pin"
-        Twig 3.28.0 changed `include()` to return a `Twig\Markup` object instead of a string, which breaks Shopware 6.7's admin (HTTP 500 on `/admin`). Until [shopware/conflicts#36](https://github.com/shopware/conflicts/pull/36) is released to block Twig 3.28, pin Twig to an earlier version:
-
-        ```bash
-        ddev composer require "twig/twig:<3.28"
-        ```
-
     Run Shopware installation and launch:
 
     ```bash
@@ -2526,9 +2519,6 @@ ddev config --upload-dirs=sites/assets/files && ddev restart
         ddev config --project-type=shopware6 --docroot=public
         ddev start -y
         ddev composer create-project shopware/production
-        # TEMPORARY: pin Twig <3.28 until shopware/conflicts#36 is released;
-        # Twig 3.28 breaks Shopware 6.7's admin with an HTTP 500 on /admin.
-        ddev composer require "twig/twig:<3.28"
         ddev exec console system:install --basic-setup
         ddev launch /admin
         EOF

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -32,10 +32,7 @@ teardown() {
   assert_file_not_exist compose.yaml
   assert_file_not_exist compose.override.yaml
 
-  # TEMPORARY WORKAROUND: Twig 3.28.0 made include() return Twig\Markup instead
-  # of string, which breaks Shopware 6.7's TwigFeaturesWithInheritanceExtension
-  # and yields an HTTP 500 on /admin. Remove this pin once shopware/conflicts
-  # blocks Twig 3.28 (https://github.com/shopware/conflicts/pull/36).
+  # TODO: Remove this after upstream makes a new release, see https://github.com/ddev/ddev/pull/8557
   run ddev composer require "twig/twig:<3.28"
   assert_success
 

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -32,6 +32,13 @@ teardown() {
   assert_file_not_exist compose.yaml
   assert_file_not_exist compose.override.yaml
 
+  # TEMPORARY WORKAROUND: Twig 3.28.0 made include() return Twig\Markup instead
+  # of string, which breaks Shopware 6.7's TwigFeaturesWithInheritanceExtension
+  # and yields an HTTP 500 on /admin. Remove this pin once shopware/conflicts
+  # blocks Twig 3.28 (https://github.com/shopware/conflicts/pull/36).
+  run ddev composer require "twig/twig:<3.28"
+  assert_success
+
   run ddev exec console system:install --basic-setup
   assert_success
 


### PR DESCRIPTION
## The Issue

The Shopware 6 quickstart and `docs/tests/shopware.bats` fail with an HTTP 500 on `/admin`.

There is no DDEV issue for this — it is an upstream dependency break, tracked at:

* https://github.com/shopware/conflicts/pull/36 — chore: conflict Twig 3.28 for Shopware 6.7 (open, not yet released)
* https://github.com/twigphp/Twig/pull/4825) — Make the `include()` function return a `Markup` object
* https://github.com/twigphp/Twig/issues/4802

Twig 3.28.0 changed the `include()` function to return a `Twig\Markup` object instead of a `string`. Shopware 6.7's `TwigFeaturesWithInheritanceExtension::include()` still declares a `: string` return type, so rendering `@Administration/administration/index.html.twig` throws:

```
Shopware\Core\Framework\Adapter\Twig\Extension\TwigFeaturesWithInheritanceExtension::include():
Return value must be of type string, Twig\Markup returned
```

and `/admin` returns HTTP 500. The released `shopware/conflicts` (0.6.1) does not yet block Twig 3.28, so `ddev composer create-project shopware/production` pulls the broken version.

## How This PR Solves The Issue

Adds a temporary, clearly-marked `ddev composer require "twig/twig:<3.28"` step after `composer create-project` in both the Shopware quickstart docs and the `shopware.bats` test. This is a stopgap until [shopware/conflicts#36](https://github.com/shopware/conflicts/pull/36) is released, after which Composer resolves Twig `<3.28` on its own and the pin can be removed.

To verify that upstream has fixed, manually run the quickstart tests on upstream/main

## Manual Testing Instructions

Try the quickstart

## Automated Testing Overview

`docs/tests/shopware.bats` exercises the full quickstart and now clears the admin 500. Verified locally that the flow completes through `system:install` and `/admin` renders; before the pin, Twig 3.28.0 produced the 500 and after pinning `twig/twig:<3.28` it does not.

## Release/Deployment Notes

Documentation/test-only change. No binary impact. Revert the Twig pin once `shopware/conflicts` blocks Twig 3.28.
