### PR TITLE
ci: comment on PRs included in a release (#8558) [skip ci]

### DIFF
--- a/.github/workflows/release-commenter.yml
+++ b/.github/workflows/release-commenter.yml
@@ -1,0 +1,37 @@
+name: Comment on release
+
+# Comments on PRs that are included in a release, letting contributors know
+# their change has shipped. Parses PR references out of the release notes
+# body sequentially (with a small delay between requests), which avoids the
+# GitHub secondary rate limits that a commit-diffing/GraphQL approach hits on
+# releases with many merged PRs.
+# Only runs on real (non-prerelease) releases; edge/prerelease tags are skipped.
+#
+# A few numbers referenced inline in PR titles (e.g. "fixes #1234") are plain
+# issues rather than PRs, so they 404 and get counted as "failed comments" by
+# the action even though the real PR comments succeed; continue-on-error
+# avoids a spurious red X for that.
+on:
+  release:
+    types: [released]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+env:
+  # nflaig/release-comment-on-pr's action.yml declares node20; force node24
+  # ahead of Node 20's removal from runners, see
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  release-commenter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nflaig/release-comment-on-pr@v1
+        continue-on-error: true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            🎉 This PR is included in the [${releaseTag}](${releaseUrl}) release.

--- a/.github/workflows/release-commenter.yml
+++ b/.github/workflows/release-commenter.yml
@@ -1,15 +1,17 @@
 name: Comment on release
 
 # Lets contributors know their change has shipped, without emailing every
-# repo watcher for every PR in the release. GitHub's release-notes generator
-# emits one unambiguous line per PR in the "## What's Changed" section:
+# repo watcher for every PR (and issue) in the release. GitHub's release-notes
+# generator emits one unambiguous line per PR in the "## What's Changed"
+# section:
 #   * <title> by @<username> in https://github.com/<owner>/<repo>/pull/<number>
 # We parse only that block, so unlike a generic "#1234" scan we never trip
-# over inline "fixes #1234" issue references in the hand-written sections
-# above it (those aren't PRs and would otherwise 404).
+# over inline "fixes #1234" issue references as if they were PRs. Those
+# inline references are exactly what we use to also notify the issues a PR
+# closes, since the PR title text is already right there.
 #
-# Team/collaborator-authored PRs get a silent 🚀 reaction instead of a
-# comment -- they already know their PR shipped, since they cut the
+# Team/collaborator-authored PRs and issues get a silent 🚀 reaction instead
+# of a comment -- they already know their PR shipped, since they cut the
 # release, and reactions never trigger email notifications. Only outside
 # contributors, who are unlikely to be watching the repo, get the actual
 # comment. See the PR description for the numbers behind this split.
@@ -32,59 +34,75 @@ jobs:
           script: |
             const INTERNAL_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
             const release = context.payload.release;
-            const message = `🎉 This PR is included in the [${release.tag_name}](${release.html_url}) release.`;
+            const prMessage = `🎉 This PR is included in the [${release.tag_name}](${release.html_url}) release.`;
+            const issueMessage = `🎉 This issue was fixed in the [${release.tag_name}](${release.html_url}) release.`;
 
             /**
-             * Extract {number -> username} for every PR referenced in the
-             * auto-generated "## What's Changed" block of the release body.
+             * Extract every PR referenced in the auto-generated "## What's
+             * Changed" block of the release body, plus every issue closed
+             * by one of those PRs (from "fixes #123"-style keywords already
+             * in the PR title text, minus anything that's a PR itself).
              */
-            function extractReferencedPRs(body) {
+            function extractReferenced(body) {
               const afterHeading = body.split(/^## What's Changed$/m)[1];
               const section = (afterHeading ?? body).split(/^## /m)[0];
-              const pattern = /^\*.*\bby @(\S+) in https:\/\/github\.com\/\S+\/pull\/(\d+)\s*$/gm;
-              const referenced = new Map();
+              const linePattern = /^\*(.*)\bby @(\S+) in https:\/\/github\.com\/\S+\/pull\/(\d+)\s*$/gm;
+              const closeKeywords = /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)/gi;
+
+              const prs = new Map();
+              const issues = new Set();
               let match;
-              while ((match = pattern.exec(section)) !== null) {
-                referenced.set(Number(match[2]), match[1]);
+              while ((match = linePattern.exec(section)) !== null) {
+                const [, title, username, prNumberStr] = match;
+                prs.set(Number(prNumberStr), username);
+                let issueMatch;
+                while ((issueMatch = closeKeywords.exec(title)) !== null) {
+                  issues.add(Number(issueMatch[1]));
+                }
               }
-              return referenced;
+              for (const prNumber of prs.keys()) {
+                issues.delete(prNumber);
+              }
+              return { prs, issues };
             }
 
-            const referenced = extractReferencedPRs(release.body || '');
-            core.info(`Found ${referenced.size} PR(s) referenced in the release notes`);
+            const { prs, issues } = extractReferenced(release.body || '');
+            core.info(`Found ${prs.size} PR(s) and ${issues.size} issue(s) referenced in the release notes`);
 
             let commented = 0;
             let reacted = 0;
             let skipped = 0;
 
-            for (const [prNumber, username] of referenced) {
+            for (const number of [...prs.keys(), ...issues]) {
               // let's be a bit more friendly to the GitHub API
               await new Promise((resolve) => setTimeout(resolve, 300));
 
-              if (username.endsWith('[bot]')) {
-                skipped++;
-                continue;
-              }
-
-              let pullRequest;
+              let target;
               try {
-                ({ data: pullRequest } = await github.rest.pulls.get({
+                ({ data: target } = await github.rest.issues.get({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  pull_number: prNumber,
+                  issue_number: number,
                 }));
               } catch (error) {
-                core.warning(`Skipping #${prNumber}: ${error.message}`);
+                core.warning(`Skipping #${number}: ${error.message}`);
                 skipped++;
                 continue;
               }
 
+              if (target.user?.login.endsWith('[bot]')) {
+                skipped++;
+                continue;
+              }
+
+              const message = target.pull_request ? prMessage : issueMessage;
+
               try {
-                if (INTERNAL_ASSOCIATIONS.has(pullRequest.author_association)) {
+                if (INTERNAL_ASSOCIATIONS.has(target.author_association)) {
                   await github.rest.reactions.createForIssue({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    issue_number: prNumber,
+                    issue_number: number,
                     content: 'rocket',
                   });
                   reacted++;
@@ -92,15 +110,15 @@ jobs:
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    issue_number: prNumber,
+                    issue_number: number,
                     body: message,
                   });
                   commented++;
                 }
               } catch (error) {
-                core.warning(`Failed to notify #${prNumber}: ${error.message}`);
+                core.warning(`Failed to notify #${number}: ${error.message}`);
                 skipped++;
               }
             }
 
-            core.info(`Commented on ${commented}, reacted to ${reacted}, skipped ${skipped} PR(s).`);
+            core.info(`Commented on ${commented}, reacted to ${reacted}, skipped ${skipped} item(s).`);

--- a/.github/workflows/release-commenter.yml
+++ b/.github/workflows/release-commenter.yml
@@ -1,16 +1,20 @@
 name: Comment on release
 
-# Comments on PRs that are included in a release, letting contributors know
-# their change has shipped. Parses PR references out of the release notes
-# body sequentially (with a small delay between requests), which avoids the
-# GitHub secondary rate limits that a commit-diffing/GraphQL approach hits on
-# releases with many merged PRs.
-# Only runs on real (non-prerelease) releases; edge/prerelease tags are skipped.
+# Lets contributors know their change has shipped, without emailing every
+# repo watcher for every PR in the release. GitHub's release-notes generator
+# emits one unambiguous line per PR in the "## What's Changed" section:
+#   * <title> by @<username> in https://github.com/<owner>/<repo>/pull/<number>
+# We parse only that block, so unlike a generic "#1234" scan we never trip
+# over inline "fixes #1234" issue references in the hand-written sections
+# above it (those aren't PRs and would otherwise 404).
 #
-# A few numbers referenced inline in PR titles (e.g. "fixes #1234") are plain
-# issues rather than PRs, so they 404 and get counted as "failed comments" by
-# the action even though the real PR comments succeed; continue-on-error
-# avoids a spurious red X for that.
+# Team/collaborator-authored PRs get a silent 🚀 reaction instead of a
+# comment -- they already know their PR shipped, since they cut the
+# release, and reactions never trigger email notifications. Only outside
+# contributors, who are unlikely to be watching the repo, get the actual
+# comment. See the PR description for the numbers behind this split.
+#
+# Only runs on real (non-prerelease) releases; edge/prerelease tags are skipped.
 on:
   release:
     types: [released]
@@ -19,19 +23,84 @@ permissions:
   issues: write
   pull-requests: write
 
-env:
-  # nflaig/release-comment-on-pr's action.yml declares node20; force node24
-  # ahead of Node 20's removal from runners, see
-  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   release-commenter:
     runs-on: ubuntu-latest
     steps:
-      - uses: nflaig/release-comment-on-pr@v1
-        continue-on-error: true
+      - uses: actions/github-script@v9
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          message: |
-            🎉 This PR is included in the [${releaseTag}](${releaseUrl}) release.
+          script: |
+            const INTERNAL_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            const release = context.payload.release;
+            const message = `🎉 This PR is included in the [${release.tag_name}](${release.html_url}) release.`;
+
+            /**
+             * Extract {number -> username} for every PR referenced in the
+             * auto-generated "## What's Changed" block of the release body.
+             */
+            function extractReferencedPRs(body) {
+              const afterHeading = body.split(/^## What's Changed$/m)[1];
+              const section = (afterHeading ?? body).split(/^## /m)[0];
+              const pattern = /^\*.*\bby @(\S+) in https:\/\/github\.com\/\S+\/pull\/(\d+)\s*$/gm;
+              const referenced = new Map();
+              let match;
+              while ((match = pattern.exec(section)) !== null) {
+                referenced.set(Number(match[2]), match[1]);
+              }
+              return referenced;
+            }
+
+            const referenced = extractReferencedPRs(release.body || '');
+            core.info(`Found ${referenced.size} PR(s) referenced in the release notes`);
+
+            let commented = 0;
+            let reacted = 0;
+            let skipped = 0;
+
+            for (const [prNumber, username] of referenced) {
+              // let's be a bit more friendly to the GitHub API
+              await new Promise((resolve) => setTimeout(resolve, 300));
+
+              if (username.endsWith('[bot]')) {
+                skipped++;
+                continue;
+              }
+
+              let pullRequest;
+              try {
+                ({ data: pullRequest } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                }));
+              } catch (error) {
+                core.warning(`Skipping #${prNumber}: ${error.message}`);
+                skipped++;
+                continue;
+              }
+
+              try {
+                if (INTERNAL_ASSOCIATIONS.has(pullRequest.author_association)) {
+                  await github.rest.reactions.createForIssue({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    content: 'rocket',
+                  });
+                  reacted++;
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body: message,
+                  });
+                  commented++;
+                }
+              } catch (error) {
+                core.warning(`Failed to notify #${prNumber}: ${error.message}`);
+                skipped++;
+              }
+            }
+
+            core.info(`Commented on ${commented}, reacted to ${reacted}, skipped ${skipped} PR(s).`);


### PR DESCRIPTION
## Short Summary (TL;DR)

Replaces both third-party release-comment actions with an in-repo script that reacts (🚀, no email) instead of commenting on team/collaborator-authored PRs and issues, and only posts the actual notifying comment for outside contributors — cutting notification-triggering comments by ~89% on a real release sample while still telling every contributor who benefits that their change shipped.

## The Issue

People (and maintainers) often wonder what release a PR went into

## How This PR Solves The Issue

Adds `.github/workflows/release-commenter.yml`, which runs on real (non-prerelease) `release` events and notifies every PR mentioned in the release, linking to the release.

Two third-party actions were evaluated:

* **[apexskier/github-release-commenter](https://github.com/apexskier/github-release-commenter)** was tried first. It diffs commits between the two most recent releases and fires one concurrent GitHub GraphQL request *per commit* with no throttling. Real `ddev/ddev` release gaps regularly span 40-170+ merged PRs (e.g. 167 commits between `v1.24.10` and `v1.25.0`), which blows past GitHub's ~100-concurrent-request secondary rate limit. It failed with `HttpError: You have exceeded a secondary rate limit` on a test release in `ddev-test/ddev` ([run](https://github.com/ddev-test/ddev/actions/runs/28708443472)). A stronger token doesn't help — that limit applies per-requester regardless of token type. It's also not idempotent (no de-dup/upsert check), so a retry risks double-commenting.
* **[nflaig/release-comment-on-pr](https://github.com/nflaig/release-comment-on-pr)** was tried second. It parses PR references out of the release notes body and posts comments sequentially with a small delay between each request, avoiding the concurrency problem entirely.

Both post an actual comment on every referenced PR, unconditionally. @stasadev flagged that this causes an avalanche of email at release time: `ddev/ddev` has 55 people watching the repo (`gh api repos/ddev/ddev --jq .subscribers_count`) with GitHub's default "All Activity" notifications, and a release with 100+ merged PRs means each of them gets 100+ emails within about a minute. Sampling the real `v1.25.2` release, ~75-85% of referenced PRs are authored by the team itself (32-77 of ~90-100 depending on extraction method, see below) — people who already know their PR shipped, since they cut the release.

So this PR no longer uses either third-party action. Instead `.github/workflows/release-commenter.yml` runs an inline `actions/github-script` step (matching the pattern already used in `pr-artifacts-comment.yml`) that: parses PR numbers directly out of the auto-generated `## What's Changed` block in the release body (GitHub itself emits one unambiguous `* <title> by @<user> in <pull-url>` line per PR there, so there's no need to guess at bare `#1234` references, which is what caused the 3 false-positive 404s in the previous approach); looks up each PR's `author_association`; and either adds a silent 🚀 reaction (for `OWNER`/`MEMBER`/`COLLABORATOR` authors — no email is ever sent for a reaction) or posts the actual congratulatory comment (for outside contributors, who are the ones who actually benefit from the heads-up and are unlikely to be watching the repo). Bot-authored PRs (dependabot, etc.) are skipped entirely.

Verified against the real `v1.25.2` release notes: the new `## What's Changed`-scoped parser extracted 96 referenced PR numbers with zero false positives (vs. 98 of 101 with the old bare-`#1234` scan, which mis-fired on 3 inline `fixes #1234` issue references). Cross-checking `author_association` for all 96 via the GitHub GraphQL API: 78 are `MEMBER`/`COLLABORATOR` (would get a reaction, no email), 11 are `CONTRIBUTOR` (would get the actual comment), 7 are bot-authored (skipped). That's an ~89% reduction in notification-triggering comments for this sample release, concentrated on the contributors who actually benefit.

The workflow also notifies the issues a released PR closes, not just the PR itself, since the person who filed a bug report is often exactly the outside contributor who benefits most from knowing it shipped. `fixes`/`closes`/`resolves #NNNN`-style keywords are already sitting in the PR title text this workflow parses, so this reuses the same text instead of an extra API traversal, then dedupes against the PR set and routes each issue through the identical `author_association` react-or-comment logic (via `issues.get`, which returns pull requests too — keyed off its `pull_request` field — so PRs and issues now share one lookup/notify path). Verified against `v1.25.2`: 23 issue references extracted, all 23 resolved cleanly via GraphQL — 15 were filed and fixed by the same team member (reaction only) and 8 were filed by real outside reporters (would get the comment).

## Manual Testing Instructions

This only runs on real (non-prerelease) `release` events, so it can't be exercised on a PR build.

The comment-posting mechanism itself (still used unchanged for the outside-contributor path) was originally tested end-to-end on the `ddev-test/ddev` sandbox against the third-party-action version:

* Experimental PR: [ddev-test/ddev#28](https://github.com/ddev-test/ddev/pull/28)
* Experimental release: [ddev-test/ddev v1.102.1](https://github.com/ddev-test/ddev/releases/tag/v1.102.1)
* Resulting comment: <https://github.com/ddev-test/ddev/pull/28#issuecomment-4882521926>

The new pieces added in this update — the `## What's Changed`-scoped PR extraction, and branching on `author_association` to react instead of comment on team/collaborator PRs — were first validated against real data: the extraction regex was run against the actual bodies of `v1.25.2`, `v1.25.1`, `v1.25.3`, and `v1.24.9` to confirm the heading format is consistent and the parse is exact (0 false positives on `v1.25.2` vs. 3 previously); `author_association` for all 96 PRs referenced in `v1.25.2` was cross-checked via the GraphQL API and 100% resolved to a real PR with a sensible association.

Then run live end-to-end on the current version of this workflow, pushed to `ddev-test/ddev`'s default branch:

* Merged [ddev-test/ddev#47](https://github.com/ddev-test/ddev/pull/47) (author `ddltest`, `FIRST_TIME_CONTRIBUTOR`) and [ddev-test/ddev#49](https://github.com/ddev-test/ddev/pull/49) (author `rfay`, `MEMBER`) into `main`.
* Cut [ddev-test/ddev v1.106.2](https://github.com/ddev-test/ddev/releases/tag/v1.106.2), whose auto-generated notes referenced both PRs.
* The triggered [workflow run](https://github.com/ddev-test/ddev/actions/runs/32780691139) logged `Found 2 PR(s) referenced in the release notes` / `Commented on 1, reacted to 1, skipped 0 PR(s).`
* Confirmed on GitHub: #47 (outside contributor) got [the actual comment](https://github.com/ddev-test/ddev/pull/47#issuecomment-5401719147), which arrived as a real email notification; #49 (team member) got only a silent 🚀 reaction and no comment, and generated no email.

The issue-closing addition was verified the same way. [Issue #50](https://github.com/ddev-test/ddev/issues/50) and [PR #51](https://github.com/ddev-test/ddev/pull/51) (titled `... fixes #50`, both authored by `rfay`/`MEMBER`) were created, PR #51 was merged, and [ddev-test/ddev v1.106.3](https://github.com/ddev-test/ddev/releases/tag/v1.106.3) was cut referencing it. The triggered [workflow run](https://github.com/ddev-test/ddev/actions/runs/32781985803) logged `Found 1 PR(s) and 1 issue(s) referenced in the release notes` / `Commented on 0, reacted to 2, skipped 0 item(s).`, and both #50 and #51 show only a 🚀 reaction with no comment, confirming the issue-extraction, dedup, and shared `issues.get` lookup path all work as intended. The comment path for an issue filed by a genuine outside reporter wasn't re-verified live (no second non-member account available in the sandbox), but it's the identical `createComment`/association logic already proven live for PRs, plus the real-data check above.

## Automated Testing Overview

None — this is a release-time-only GitHub Actions workflow with no unit-testable logic of its own. Correctness was verified against real release data (as described above) and confirmed with a live `release: released` run in the `ddev-test/ddev` sandbox, described in Manual Testing Instructions.

## Release/Deployment Notes

No deployment steps. The visible behavior change for maintainers: your own merged PRs (and issues you filed and fixed yourself) get a 🚀 reaction on release instead of a comment, so you'll stop seeing/being emailed about those; outside contributors still get the same congratulatory comment as before, now also on issues they filed that a released PR closes.


