### PR TITLE
ci(macos): untap pre-installed aws/tap before brew install

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -163,6 +163,9 @@ jobs:
 
       - name: "setup macOS"
         run: |
+          # The macos-latest runner image pre-taps aws/tap, which Homebrew 6.0+
+          # flags as untrusted on every invocation. We don't use it, so remove it.
+          brew untap aws/tap || true
           brew install coreutils gnu-getopt jq
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## The Issue

The `notarize-macos` job in `Main branch build/release (signed)` produces a noisy warning annotation:

```
The following taps are not trusted:
  aws/tap

Homebrew is currently ignoring formulae, casks and commands from these taps because tap trust is required.
```

This comes from Homebrew 6.0+'s new tap-trust check flagging `aws/tap`, a tap that's pre-installed on GitHub's `macos-latest` runner image (unrelated to our build). We don't use that tap.

Demonstrated in the test release build here (see the `Sign and Notarize ddev on macOS` job annotations): https://github.com/ddev-test/ddev/releases#release-v1.102.1
Problem build output: https://github.com/ddev-test/ddev/actions/runs/28709781791/job/85141634433

## How This PR Solves The Issue

Untaps `aws/tap` in the "setup macOS" step of `notarize-macos` before installing our own deps (`coreutils`, `gnu-getopt`, `jq`), so Homebrew's tap-trust check has nothing untrusted to complain about.

Verified fixed in this test release: https://github.com/ddev-test/ddev/releases/tag/v1.102.2
Fixed build output (no tap-trust annotation): https://github.com/ddev-test/ddev/actions/runs/28710492328/job/85143469030

## Manual Testing Instructions

I experimented with this in ddev-test/ddev as shown above, I think it should work and does no harm.

