### PR TITLE
perf(router): update network aliases in place instead of recreating on start, for #8132 (#8561) [skip ci]

### DIFF
--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -89,58 +89,23 @@ func StartDdevRouter() error {
 
 	activeApps := GetActiveProjects()
 
-	// Check if router needs to be recreated due to port or hostname changes
-	needsRecreation := false
-	if router != nil && err == nil && router.State == "running" {
-		// Router is running, check if ports or hostnames have changed
-		var portsChanged, hostnamesChanged bool
-
-		// Check ports
-		existingPorts, err := dockerutil.GetBoundHostPorts(router.ID)
-		if err != nil {
-			util.Debug("Error getting bound ports, will recreate router: %v", err)
+	// Port changes require a full recreation (published ports can't change on a
+	// live container); hostname changes only need the network aliases refreshed.
+	needsRecreation := router == nil || err != nil || router.State != "running"
+	hostnamesChanged := false
+	if !needsRecreation {
+		existingPorts, portErr := dockerutil.GetBoundHostPorts(router.ID)
+		existingHostnames, aliasErr := dockerutil.GetRouterNetworkAliases(router.ID)
+		// TraefikMonitorPort is bound by the router but omitted by determineRouterPorts.
+		neededPorts := append(determineRouterPorts(activeApps), globalconfig.DdevGlobalConfig.TraefikMonitorPort)
+		switch {
+		case portErr != nil || aliasErr != nil:
 			needsRecreation = true
-		} else {
-			neededPorts := determineRouterPorts(activeApps)
-			// Add the Traefik monitor port to the needed list for comparison
-			// (it's always bound by the router but not returned by determineRouterPorts
-			// since it's added separately in the static config template)
-			neededPorts = append(neededPorts, globalconfig.DdevGlobalConfig.TraefikMonitorPort)
-			portsChanged = !PortsMatch(existingPorts, neededPorts)
-			util.Debug("Router port comparison: existing=%v needed=%v changed=%v", existingPorts, neededPorts, portsChanged)
+		case !PortsMatch(existingPorts, neededPorts):
+			needsRecreation = true
+		default:
+			hostnamesChanged = !HostnamesMatch(existingHostnames, determineRouterHostnames(activeApps))
 		}
-
-		// Check hostnames (network aliases)
-		if !needsRecreation {
-			existingHostnames, err := dockerutil.GetRouterNetworkAliases(router.ID)
-			if err != nil {
-				util.Debug("Error getting network aliases, will recreate router: %v", err)
-				needsRecreation = true
-			} else {
-				neededHostnames := determineRouterHostnames(activeApps)
-				hostnamesChanged = !HostnamesMatch(existingHostnames, neededHostnames)
-				util.Debug("Router hostname comparison: existing=%v needed=%v changed=%v", existingHostnames, neededHostnames, hostnamesChanged)
-			}
-		}
-
-		// Determine if recreation is needed
-		if !needsRecreation {
-			if portsChanged || hostnamesChanged {
-				if portsChanged && hostnamesChanged {
-					util.Debug("Router ports and hostnames have changed, will recreate router")
-				} else if portsChanged {
-					util.Debug("Router ports have changed, will recreate router")
-				} else {
-					util.Debug("Router hostnames have changed, will recreate router")
-				}
-				needsRecreation = true
-			} else {
-				util.Debug("Router ports and hostnames have not changed, skipping recreation")
-			}
-		}
-	} else {
-		// Router is not running, needs to be started
-		needsRecreation = true
 	}
 
 	if needsRecreation {
@@ -183,6 +148,17 @@ func StartDdevRouter() error {
 		}
 	} else {
 		output.UserOut.Printf("%s already running, pushing new config...", nodeps.RouterContainer)
+
+		// Update network aliases in place rather than recreating the container.
+		// Starting any project with a new hostname changes the router's aliases,
+		// so without this every additional project start would recreate the router.
+		if hostnamesChanged {
+			neededHostnames := determineRouterHostnames(activeApps)
+			util.Debug("Updating router network aliases in place to %v", neededHostnames)
+			if err = dockerutil.UpdateContainerNetworkAliases(router.ID, dockerutil.NetName, neededHostnames); err != nil {
+				return fmt.Errorf("failed to update router network aliases: %v", err)
+			}
+		}
 
 		// Even if we don't recreate, update the Traefik config for the new project
 		err = PushGlobalTraefikConfig(activeApps)

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -940,6 +940,93 @@ func TestRouterNotRebuiltWithExtraPorts(t *testing.T) {
 		"Router ports should be unchanged after starting simple project - router should not have been recreated")
 }
 
+// TestRouterNotRebuiltOnHostnameChange verifies that starting an additional
+// project (which introduces a new network alias/hostname) and restarting a
+// project update the router's network aliases in place rather than recreating
+// the router container.
+func TestRouterNotRebuiltOnHostnameChange(t *testing.T) {
+	// Start clean.
+	ddevapp.PowerOff()
+
+	project1Dir := testcommon.CreateTmpDir(t.Name() + "_project1")
+	project2Dir := testcommon.CreateTmpDir(t.Name() + "_project2")
+
+	app1, err := ddevapp.NewApp(project1Dir, true)
+	require.NoError(t, err)
+	app1.Name = t.Name() + "-project1"
+	app1.Type = nodeps.AppTypePHP
+	require.NoError(t, app1.WriteConfig())
+
+	app2, err := ddevapp.NewApp(project2Dir, true)
+	require.NoError(t, err)
+	app2.Name = t.Name() + "-project2"
+	app2.Type = nodeps.AppTypePHP
+	require.NoError(t, app2.WriteConfig())
+
+	t.Cleanup(func() {
+		_ = app1.Stop(true, false)
+		_ = app2.Stop(true, false)
+		_ = os.RemoveAll(project1Dir)
+		_ = os.RemoveAll(project2Dir)
+		_ = dockerutil.RemoveContainer(nodeps.RouterContainer)
+	})
+
+	// The message the router prints when it reuses the running container versus
+	// the message it prints when it (re)creates the container.
+	reuseMessage := nodeps.RouterContainer + " already running, pushing new config"
+	recreateMessage := "Starting " + nodeps.RouterContainer + ", pushing config"
+
+	// First project start creates the router from scratch.
+	require.NoError(t, app1.Start())
+
+	router, err := ddevapp.FindDdevRouter()
+	require.NoError(t, err)
+	require.NotNil(t, router)
+	originalRouterID := router.ID
+
+	// Starting the second project adds a new hostname (network alias). The router
+	// should be updated in place, not recreated.
+	getOutput := util.CaptureUserOut()
+	err = app2.Start()
+	startOutput := getOutput()
+	require.NoError(t, err)
+
+	require.Contains(t, startOutput, reuseMessage,
+		"second project start should reuse the running router, output: %s", startOutput)
+	require.NotContains(t, startOutput, recreateMessage,
+		"second project start should NOT recreate the router, output: %s", startOutput)
+
+	router, err = ddevapp.FindDdevRouter()
+	require.NoError(t, err)
+	require.Equal(t, originalRouterID, router.ID,
+		"router should not be recreated when a second project adds a new hostname")
+
+	// The router's network aliases should now include both projects' hostnames,
+	// proving the aliases were updated in place.
+	aliases, err := dockerutil.GetRouterNetworkAliases(router.ID)
+	require.NoError(t, err)
+	require.Contains(t, aliases, app1.GetHostname(),
+		"router aliases should include the first project hostname")
+	require.Contains(t, aliases, app2.GetHostname(),
+		"router aliases should include the second project hostname after in-place update")
+
+	// Restarting a project must also reuse the running router.
+	getOutput = util.CaptureUserOut()
+	err = app2.Restart()
+	restartOutput := getOutput()
+	require.NoError(t, err)
+
+	require.Contains(t, restartOutput, reuseMessage,
+		"restart should reuse the running router, output: %s", restartOutput)
+	require.NotContains(t, restartOutput, recreateMessage,
+		"restart should NOT recreate the router, output: %s", restartOutput)
+
+	router, err = ddevapp.FindDdevRouter()
+	require.NoError(t, err)
+	require.Equal(t, originalRouterID, router.ID,
+		"router should not be recreated when a project restarts")
+}
+
 // TestPausedProjectsExcludedFromRouter verifies that when a project is paused,
 // its Traefik configuration is removed from the router when another project starts.
 // This simulates the scenario where Docker restarts and projects end up paused,

--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -986,6 +986,34 @@ func GetRouterNetworkAliases(containerID string) ([]string, error) {
 	return aliases, nil
 }
 
+// UpdateContainerNetworkAliases sets the container's network aliases on the
+// given network. Docker only allows aliases to be set at connect time, so this
+// disconnects and reconnects the container with the new alias set, which avoids
+// recreating the container.
+func UpdateContainerNetworkAliases(containerID, networkName string, aliases []string) error {
+	ctx, apiClient, err := GetDockerClient()
+	if err != nil {
+		return err
+	}
+
+	if _, err = apiClient.NetworkDisconnect(ctx, networkName, client.NetworkDisconnectOptions{
+		Container: containerID,
+	}); err != nil {
+		return fmt.Errorf("failed to disconnect container %s from network %s: %v", containerID, networkName, err)
+	}
+
+	if _, err = apiClient.NetworkConnect(ctx, networkName, client.NetworkConnectOptions{
+		Container: containerID,
+		EndpointConfig: &network.EndpointSettings{
+			Aliases: aliases,
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to reconnect container %s to network %s: %v", containerID, networkName, err)
+	}
+
+	return nil
+}
+
 // Exec does a simple docker exec, no frills, it executes the command
 // with the specified uid (or defaults to root=0 if empty uid)
 // Returns stdout, stderr, error

--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -996,10 +996,22 @@ func UpdateContainerNetworkAliases(containerID, networkName string, aliases []st
 		return err
 	}
 
-	if _, err = apiClient.NetworkDisconnect(ctx, networkName, client.NetworkDisconnectOptions{
-		Container: containerID,
-	}); err != nil {
-		return fmt.Errorf("failed to disconnect container %s from network %s: %v", containerID, networkName, err)
+	// Only disconnect when connected, so an earlier failed reconnect can be repaired.
+	inspectInfo, err := apiClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+	if err != nil {
+		return err
+	}
+	connected := false
+	if inspectInfo.Container.NetworkSettings != nil {
+		_, connected = inspectInfo.Container.NetworkSettings.Networks[networkName]
+	}
+
+	if connected {
+		if _, err = apiClient.NetworkDisconnect(ctx, networkName, client.NetworkDisconnectOptions{
+			Container: containerID,
+		}); err != nil {
+			return fmt.Errorf("failed to disconnect container %s from network %s: %v", containerID, networkName, err)
+		}
 	}
 
 	if _, err = apiClient.NetworkConnect(ctx, networkName, client.NetworkConnectOptions{

--- a/pkg/dockerutil/networks_test.go
+++ b/pkg/dockerutil/networks_test.go
@@ -140,8 +140,7 @@ func TestNetworkAmbiguity(t *testing.T) {
 }
 
 // TestNetworkAliases tests inter-project connectivity using ddev_default network aliases
-// when both projects use the same ports (80/443). This validates the fix for #8110:
-// the router must be recreated when network aliases change even if ports are identical.
+// when both projects use the same ports (80/443). This validates the fix for #8110.
 // See pkg/ddevapp/router_compose_template.yaml
 // This verifies the functionality of https://docs.docker.com/reference/compose-file/services/#aliases
 // Related test: TestInternalAndExternalAccessToURL


### PR DESCRIPTION
## The Issue

- This PR is a follow-up to #8132, which fixed #8110.

PR #8132 made the router recreate itself whenever project hostnames (network aliases) changed so that inter-project HTTP/S communication continued to work correctly. That fixed the correctness issue, but it also meant that starting an additional project (`ddev start`) recreated the router even though its published ports were unchanged. Router recreation is disruptive and slower than necessary for the common case of starting another project.

## How This PR Solves The Issue

This PR preserves the correctness guarantee introduced in #8132 while limiting router recreation to the cases where it is actually required. Hostname-only changes are now handled without recreating the router container.

A new `UpdateContainerNetworkAliases()` function was added to `pkg/dockerutil/containers.go`. Since Docker only allows network aliases to be assigned when a container connects to a network, this function updates the aliases by disconnecting and reconnecting the router to the `ddev_default` network with the new alias set, avoiding container recreation.

The recreation logic in `StartDdevRouter()` (`pkg/ddevapp/router.go`) was also reworked. The router is now recreated only when it is not running, its state cannot be determined, or its published ports have changed, since published ports cannot be modified on a running container. Changes to hostnames alone no longer trigger recreation.

When the router is already running and only the hostname list has changed, its network aliases are updated in place using `UpdateContainerNetworkAliases()` before the Traefik configuration is pushed.

As a result, the correctness guarantee from #8132 is preserved because the aliases are always kept up to date, while the common case of starting an additional project no longer requires a full router recreation.

## Manual Testing Instructions

```bash
# Clean slate
ddev poweroff
mkdir -p ~/tmp/t1 ~/tmp/t2

# First project starts (router is created)
cd ~/tmp/t1 && ddev config --auto && ddev start
printf '<?php\nprint "this is t1\n";' >index.php

# Second project starts: router is NOT recreated, aliases updated in place
cd ~/tmp/t2 && ddev config --auto && ddev start
printf '<?php\nprint "BUT this is t2\n";' >index.php

# Aliases include both projects
docker inspect ddev-router --format '{{json .NetworkSettings.Networks.ddev_default.Aliases}}' | jq
# Should show both t1.ddev.site and t2.ddev.site

# Inter-project communication still works
cd ~/tmp/t1
ddev exec curl -I https://t2.ddev.site

# Router container id stays the same across the second start
# (compare `docker inspect ddev-router --format '{{.Id}}'` before/after)
```

## Automated Testing Overview

New test `TestRouterNotRebuiltOnHostnameChange`.

## Release/Deployment Notes

There are no user-facing configuration changes. Starting additional projects is now faster because the router is no longer recreated when only project hostnames change. The router is still recreated when its published ports change or when it is not running.