### PR TITLE
fix(router): stop sharing wildcard SANs across per-project certs, fixes #8562

### DIFF
--- a/containers/ddev-traefik-router/Dockerfile
+++ b/containers/ddev-traefik-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:3.6.13 AS ddev-traefik-router
+FROM traefik:v3 AS ddev-traefik-router
 
 ENV TRAEFIK_MONITOR_PORT=10999
 RUN apk add --no-cache bash curl file htop jq openssl vim yq

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -4512,20 +4512,26 @@ func TestCustomCerts(t *testing.T) {
 	})
 	require.NoError(t, err, "failed to run openssl command '%s' against router, stdout='%s', stderr='%s'", c, stdout, stderr)
 	stdout = strings.Trim(stdout, "\r\n")
-	// This should be our default wildcard cert
-	require.Contains(t, stdout, "*.ddev.site")
+	// The per-project cert now carries only this project's own hostnames; the
+	// shared *.ddev.site wildcard moved to the default cert.
+	// See https://github.com/ddev/ddev/issues/8562
+	require.Contains(t, stdout, app.GetHostname(), "per-project cert should contain the project hostname, stdout='%s'", stdout)
+	require.NotContains(t, stdout, "*.ddev.site", "per-project cert should no longer carry the shared *.ddev.site wildcard, stdout='%s'", stdout)
 
 	// Now stop it so we can install new custom cert.
 	err = app.Stop(true, false)
 	require.NoError(t, err)
 
-	// Generate a certfile/key in .ddev/custom_certs with one DNS name in it
+	// Generate a cert/key in .ddev/custom_certs carrying the project hostname
+	// plus a marker SAN a ddev-generated cert would never have, so we can prove
+	// the custom cert (not the generated one) is served.
 	// mkcert --cert-file d9composer.ddev.site.crt --key-file d9composer.ddev.site.key d9composer.ddev.site
 	// For Traefik generation, it's app.Name,
 	// mkcert --cert-file d9.crt --key-file d9.key d9.ddev.site
 	baseCertName := app.Name
+	customCertMarker := "custom-cert-marker.example.com"
 
-	stdout, err = exec.RunHostCommand("mkcert", "--cert-file", filepath.Join(certDir, baseCertName+".crt"), "--key-file", filepath.Join(certDir, baseCertName+".key"), app.GetHostname())
+	stdout, err = exec.RunHostCommand("mkcert", "--cert-file", filepath.Join(certDir, baseCertName+".crt"), "--key-file", filepath.Join(certDir, baseCertName+".key"), app.GetHostname(), customCertMarker)
 	require.NoError(t, err, "mkcert command failed, stdout=%s", stdout)
 
 	err = app.Start()
@@ -4537,9 +4543,11 @@ func TestCustomCerts(t *testing.T) {
 	})
 	require.NoError(t, err, "openssl command failed, stdout='%s', stderr='%s'", stdout, stderr)
 	stdout = strings.Trim(stdout, "\r\n")
-	// If we had the regular cert, there would be several things here including *.ddev.site
-	// But we should only see the hostname listed.
-	require.Equal(t, app.GetHostname(), stdout, "stdout does not contain hostname, stdout='%s', stderr='%s'", stdout, stderr)
+	// The served cert must be the custom one: it has the marker SAN and lacks
+	// the shared *.ddev.site wildcard.
+	require.Contains(t, stdout, customCertMarker, "served cert should be the custom cert containing the marker SAN, stdout='%s', stderr='%s'", stdout, stderr)
+	require.Contains(t, stdout, app.GetHostname(), "served custom cert should contain the project hostname, stdout='%s', stderr='%s'", stdout, stderr)
+	require.NotContains(t, stdout, "*.ddev.site", "custom cert should not contain the shared *.ddev.site wildcard, stdout='%s', stderr='%s'", stdout, stderr)
 }
 
 // TestEnvironmentVariables tests to make sure that documented environment variables appear

--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -150,8 +151,26 @@ func PushGlobalTraefikConfig(activeApps []*DdevApp) error {
 	// get used instead of Let's Encrypt certs)
 	if !globalconfig.DdevGlobalConfig.UseLetsEncrypt && globalconfig.GetCAROOT() != "" {
 		c := []string{"--cert-file", filepath.Join(globalSourceCertsPath, "default_cert.crt"), "--key-file", filepath.Join(globalSourceCertsPath, "default_key.key"), "127.0.0.1", "localhost", "*.ddev.local", "ddev-router", "ddev-router.ddev", "ddev-router.ddev_default", "*.ddev.site"}
+		// Add a `*.<TLD>` wildcard for every TLD in use (global plus each active
+		// project's). This is the fallback for hosts that no per-project cert
+		// matches.
+		wildcardTLDs := map[string]bool{}
 		if globalconfig.DdevGlobalConfig.ProjectTldGlobal != "" {
-			c = append(c, "*."+globalconfig.DdevGlobalConfig.ProjectTldGlobal)
+			wildcardTLDs[globalconfig.DdevGlobalConfig.ProjectTldGlobal] = true
+		}
+		for _, activeApp := range activeApps {
+			if activeApp.ProjectTLD != "" {
+				wildcardTLDs[activeApp.ProjectTLD] = true
+			}
+		}
+		delete(wildcardTLDs, nodeps.DdevDefaultTLD)
+		sortedTLDs := make([]string, 0, len(wildcardTLDs))
+		for tld := range wildcardTLDs {
+			sortedTLDs = append(sortedTLDs, tld)
+		}
+		sort.Strings(sortedTLDs)
+		for _, tld := range sortedTLDs {
+			c = append(c, "*."+tld)
 		}
 
 		out, err := exec2.RunHostCommand("mkcert", c...)
@@ -496,12 +515,13 @@ func configureTraefikForApp(app *DdevApp) error {
 
 	// Assuming the certs don't exist, or they have #ddev-generated so can be replaced, create them
 	// But not if we don't have mkcert already set up.
-	if sigExists && globalconfig.GetCAROOT() != "" {
-		c := []string{"--cert-file", baseName + ".crt", "--key-file", baseName + ".key", "*.ddev.site", "127.0.0.1", "localhost", "*.ddev.local", "ddev-router", "ddev-router.ddev", "ddev-router.ddev_default"}
+	if sigExists && globalconfig.GetCAROOT() != "" && len(hostnames) > 0 {
+		// Stamp only this project's own hostnames onto its cert; shared
+		// wildcards and internal names live on the default cert. Putting them on
+		// every per-project cert created overlapping SANs that made Traefik
+		// serve the wrong project's cert on a shared TLD.
+		c := []string{"--cert-file", baseName + ".crt", "--key-file", baseName + ".key"}
 		c = append(c, hostnames...)
-		if app.ProjectTLD != nodeps.DdevDefaultTLD {
-			c = append(c, "*."+app.ProjectTLD)
-		}
 		out, err := exec2.RunHostCommand("mkcert", c...)
 		if err != nil {
 			util.Failed("Failed to create certificates for project, check mkcert operation: %v; err=%v", out, err)

--- a/pkg/ddevapp/traefik_test.go
+++ b/pkg/ddevapp/traefik_test.go
@@ -1,6 +1,7 @@
 package ddevapp_test
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -100,6 +101,90 @@ func TestTraefikSimple(t *testing.T) {
 			testcommon.WithMessagef("Traefik should route each project hostname to the static test content"),
 		)
 	}
+}
+
+// TestTraefikSharedTLDCerts verifies that when several projects share one
+// custom (per-project) TLD, each hostname is served its own certificate. It
+// guards the overlapping-SAN regression where every per-project cert carried a
+// shared `*.<TLD>` wildcard, so Traefik 3.7.6+ (which no longer prefers an
+// exact SAN over a wildcard-only match) served one "winner" cert for the whole
+// TLD. See https://github.com/ddev/ddev/issues/8562
+func TestTraefikSharedTLDCerts(t *testing.T) {
+	if globalconfig.GetCAROOT() == "" {
+		t.Skip("Skipping because mkcert/HTTPS is not available (no CAROOT)")
+	}
+	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && (dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop()) {
+		// These providers don't predictably publish 443, which the in-container
+		// openssl below needs.
+		t.Skip("Skipping on Colima/Lima/Rancher because they don't predictably return ports")
+	}
+
+	origDir, _ := os.Getwd()
+
+	ddevapp.PowerOff()
+	origRouter := globalconfig.DdevGlobalConfig.Router
+	globalconfig.DdevGlobalConfig.Router = types.RouterTypeTraefik
+	err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+	require.NoError(t, err)
+
+	// A dotless single-label TLD, so a wrongly-served wildcard cert fails
+	// visibly and this doesn't collide with real .test/.ddev.site projects.
+	const sharedTLD = "ddevt8562"
+
+	// Two projects on the same TLD with distinct names, so a single "winner"
+	// cert would fail one of them.
+	projectNames := []string{"ddevt8562-a", "ddevt8562-b"}
+	var apps []*ddevapp.DdevApp
+	for _, name := range projectNames {
+		dir := testcommon.CreateTmpDir(name)
+		app, err := ddevapp.NewApp(dir, true)
+		require.NoError(t, err)
+		app.Name = name
+		app.Type = nodeps.AppTypePHP
+		app.ProjectTLD = sharedTLD
+		err = os.WriteFile(filepath.Join(dir, "index.php"), []byte("<?php print '"+name+"';"), 0644)
+		require.NoError(t, err)
+		err = app.WriteConfig()
+		require.NoError(t, err)
+		apps = append(apps, app)
+	}
+
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+		for _, app := range apps {
+			_ = app.Stop(true, false)
+			_ = os.RemoveAll(app.AppRoot)
+		}
+		ddevapp.PowerOff()
+		globalconfig.DdevGlobalConfig.Router = origRouter
+		_ = globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
+	})
+
+	for _, app := range apps {
+		err = app.StartAndWait(5)
+		require.NoError(t, err)
+	}
+
+	// For each project, ask the router (via SNI) for its own hostname and
+	// confirm the served cert carries that hostname. openssl runs inside the
+	// project's web container, whose hostname resolves to the router.
+	for _, app := range apps {
+		host := app.GetHostname()
+		httpsPort := app.GetPrimaryRouterHTTPSPort()
+		c := fmt.Sprintf("openssl s_client -connect %s:%s -servername %s </dev/null 2>/dev/null | openssl x509 -noout -text | perl -l -0777 -ne '@names=/\\bDNS:([^\\s,]+)/g; print join(\"\\n\", sort @names);'", host, httpsPort, host)
+		stdout, stderr, err := app.Exec(&ddevapp.ExecOpts{Cmd: c})
+		require.NoError(t, err, "openssl command failed for %s, stdout='%s', stderr='%s'", host, stdout, stderr)
+		stdout = strings.Trim(stdout, "\r\n")
+		require.Contains(t, stdout, host, "SNI %s must be served a certificate carrying its own hostname, got SANs='%s'", host, stdout)
+		// The shared wildcard must no longer live on the per-project cert.
+		require.NotContains(t, stdout, "*."+sharedTLD, "per-project cert must not carry the shared *.%s wildcard, got SANs='%s'", sharedTLD, stdout)
+	}
+
+	// The wildcard fallback now lives on the default cert instead, so it still
+	// covers per-project TLD overrides.
+	defaultCertText, _, err := dockerutil.Exec("ddev-router", "openssl x509 -in /mnt/ddev-global-cache/traefik/certs/default_cert.crt -noout -text", "")
+	require.NoError(t, err)
+	require.Contains(t, defaultCertText, "*."+sharedTLD, "default certificate should carry the *.%s wildcard fallback", sharedTLD)
 }
 
 // TestTraefikVirtualHost tests Traefik with an extra VIRTUAL_HOST

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -32,7 +32,7 @@ var BaseDBTag = "20260628_rfay_mysql_hardened"
 var TraefikRouterImage = "ddev/ddev-traefik-router"
 
 // TraefikRouterTag is traefik router tag
-var TraefikRouterTag = "v1.25.3"
+var TraefikRouterTag = "20260706_stasadev_fix_shared_tld_certs"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"


### PR DESCRIPTION
## The Issue

- Fixes #8562

On a shared TLD, Traefik 3.7.6+ serves one project's certificate for every hostname on that TLD, because each per-project cert carried a shared `*.<TLD>` wildcard SAN. On dotless custom TLDs this breaks HTTPS for all but one project.

## How This PR Solves The Issue

- Per-project certs carry only that project's own hostnames, so each host matches exactly one cert (no shared-wildcard overlap).
- The default cert keeps the `*.<TLD>` wildcard fallback, now for every TLD in use: the global TLD plus each active project's (including per-project `project_tld` overrides).

## Manual Testing Instructions

Run:

```bash
ddev utility download-images
```

Check out http://127.0.0.1:10999/dashboard/#/certificates

```bash
mkdir -p ~/tmp/tld-repro && cd ~/tmp/tld-repro
for i in 1 2; do
  mkdir -p project-$i && echo "<?php echo 'project-$i';" > project-$i/index.php
  (cd project-$i && ddev config --project-name=project-$i --project-type=php --project-tld=myrepro)
done
ddev start project-1 project-2
curl https://project-1.myrepro; echo
curl https://project-2.myrepro; echo
```

Before (using the FIRST commit in this PR, which bumps the traefik image):

```
curl: (60) SSL: no alternative certificate subject name matches target hostname 'project-1.myrepro'
project-2
```

After this PR:

```
project-1
project-2
```

Existing projects need `ddev restart` to regenerate their certs.

## Automated Testing Overview

- New `TestTraefikSharedTLDCerts`: two projects on a shared dotless TLD; asserts each SNI is served its own cert, per-project certs no longer carry `*.<TLD>`, and the default cert does. Fails (reproducing #8562) when only the production fix is reverted.
- `TestCustomCerts` updated for the new minimal per-project SANs.

## Release/Deployment Notes

- Per-project certs are now minimal; existing projects regenerate them on the next `ddev restart`. No config changes required.