### PR TITLE
fix(router): temp pin for traefik:3.6.13, for #8562

### DIFF
--- a/containers/ddev-traefik-router/Dockerfile
+++ b/containers/ddev-traefik-router/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:3 AS ddev-traefik-router
+FROM traefik:3.6.13 AS ddev-traefik-router
 
 ENV TRAEFIK_MONITOR_PORT=10999
 RUN apk add --no-cache bash curl file htop jq openssl vim yq


### PR DESCRIPTION
## The Issue

- For #8562

We need to release v1.25.3, but a change in this PR is hard to review and pull at the last minute:

- #8563

## How This PR Solves The Issue

Pins Traefik to 3.6.13. This is what we used to have in v1.25.2. So I simply moved the tag:

```bash
docker buildx imagetools create -t ddev/ddev-traefik-router:latest ddev/ddev-traefik-router:v1.25.2
docker buildx imagetools create -t ddev/ddev-traefik-router:v1.25.3 ddev/ddev-traefik-router:v1.25.2
```

## Manual Testing Instructions

Run `ddev utility download-images`.

And:

```bash
mkdir -p ~/tmp/tld-repro && cd ~/tmp/tld-repro
for i in 1 2; do
  mkdir -p project-$i && echo "<?php echo 'project-$i';" > project-$i/index.php
  (cd project-$i && ddev config --project-name=project-$i --project-type=php --project-tld=myrepro)
done
ddev start project-1 project-2
curl https://project-1.myrepro; echo
curl https://project-2.myrepro; echo
```

Before this PR (DDEV HEAD using older v1.25.3 traefik image):

```
curl: (60) SSL: no alternative certificate subject name matches target hostname 'project-1.myrepro'
project-2
```

After this PR:

```
project-1
project-2
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
