### PR TITLE
ci(github): update dependabot.yml (#8565) [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Basic dependabot.yml file
-# REF: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
+# REF: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions
 
 version: 2
 updates:
@@ -12,4 +12,4 @@ updates:
       interval: "weekly"
     # Don't respond to updates right away
     cooldown:
-      - default-days: 30
+      default-days: 30

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Basic dependabot.yml file
-# REF: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions
+# REF: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
@@ -10,6 +10,17 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
-    # Don't respond to updates right away
+    # Let new releases settle before opening a PR
     cooldown:
-      default-days: 30
+      default-days: 14
+    # Open a single combined PR for all action updates
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    # Floating major tags (@v4) auto-track minor/patch, so bump only on major.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,14 @@ updates:
     # Let new releases settle before opening a PR
     cooldown:
       default-days: 14
-    # Open a single combined PR for all action updates
+    # Group updates by vendor; any action not matched gets its own PR.
     groups:
-      github-actions:
+      actions:
         patterns:
-          - "*"
+          - "actions/*"
+      docker:
+        patterns:
+          - "docker/*"
     # Floating major tags (@v4) auto-track minor/patch, so bump only on major.
     ignore:
       - dependency-name: "*"


### PR DESCRIPTION
## The Issue

I tried to add `.github/dependabot.yml` to a different project, and it showed an error:

https://github.com/ddev/ddev-gitlab-ci/pull/33/checks?check_run_id=85619295043

```
The property '#/updates/0/cooldown' of type array did not match the following type: object
```

## How This PR Solves The Issue

Updates dependabot.yml accordingly.
Adds grouping for dependabot PRs.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
