### PR TITLE
test(php): remove skip for php8.5-solr, for #7697 (#8569) [skip ci]

### DIFF
--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1123,9 +1123,6 @@ func TestPHPConfig(t *testing.T) {
 		phpKeys = util.SubtractSlices(phpKeys, exclusions)
 	}
 
-	// TODO: php8.5: Remove this exclusion when php85 has solr
-	phpKeys = util.SubtractSlices(phpKeys, []string{nodeps.PHP85})
-
 	// Skip any PHP versions embargoed via DDEV_EMBARGO_PHP_VERSIONS (comma-separated, e.g. "8.4,8.3")
 	var embargoedVersions []string
 	for _, v := range phpKeys {


### PR DESCRIPTION
## The Issue

- For #7697

We added some skips when implementing PHP 8.5 support

## How This PR Solves The Issue

Removes the skip for `php8.5-solr`, it's available upstream https://packages.sury.org/php/pool/main/p/php-solr/

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
