### PR TITLE
ci(linkspector): remove skip for 429 error, for #7270 (#8570) [skip ci]

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -42,7 +42,5 @@ aliveStatusCodes:
   - 200
   - 206
   - 301
-  # TODO: GitHub changed its limits, now we get 429, remove this workaround when it is resolved
-  # See https://github.com/UmbrellaDocs/action-linkspector/issues/43
-  - 429
+
 #modifiedFilesOnly: true


### PR DESCRIPTION
## The Issue

- For #7270

I wonder if this issue is already solved:

- https://github.com/UmbrellaDocs/action-linkspector/issues/43

## How This PR Solves The Issue

Removes check for 429.

## Manual Testing Instructions

Re-run the docs-check test several times, check for 429 errors.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
