### PR TITLE
fix(mysql): bump webserver mysql client to 8.0.46/8.4.10

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
@@ -19,7 +19,7 @@ if [ "${MYSQL_VERSION}" = "5.6" ] || [ "${MYSQL_VERSION}" = "5.5" ]; then
   MYSQL_VERSION="5.7"
 fi
 
-TARBALL_VERSION=v0.2.5
+TARBALL_VERSION=v0.2.6
 TARBALL_URL=https://github.com/ddev/mysql-client-build/releases/download/${TARBALL_VERSION}/mysql-${MYSQL_VERSION}-${ARCH}.tar.gz
 
 # Install the related mysql client if available

--- a/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-files/usr/local/bin/mysql-client-install.sh
@@ -19,7 +19,7 @@ if [ "${MYSQL_VERSION}" = "5.6" ] || [ "${MYSQL_VERSION}" = "5.5" ]; then
   MYSQL_VERSION="5.7"
 fi
 
-TARBALL_VERSION=v0.2.4
+TARBALL_VERSION=v0.2.5
 TARBALL_URL=https://github.com/ddev/mysql-client-build/releases/download/${TARBALL_VERSION}/mysql-${MYSQL_VERSION}-${ARCH}.tar.gz
 
 # Install the related mysql client if available

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "v1.25.3" // Note that this can be overridden by make
+var WebTag = "20260709_mysql_client" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

Follow-up to #8535 (fixes #7962). `@stasadev` pointed out in [a comment on that PR](https://github.com/ddev/ddev/pull/8535#issuecomment-4917549639) that once the mysql 8.0/8.4 server images moved to Docker Hardened Images, the `mysql`/`mysqldump` client binaries baked into `ddev-webserver` were left mismatched with the new server versions:

```
$ ddev exec mysql -V
mysql  Ver 8.0.40 for Linux on x86_64 (Source distribution)

$ ddev exec mysql -V
mysql  Ver 8.4.3 for Linux on x86_64 (Source distribution)
```

`dhi.io/mysql:8.0-dev` and `:8.4-dev` actually serve mysqld 8.0.46/8.4.10, ahead of the previously bundled 8.0.40/8.4.3 client.

## How This PR Solves The Issue

- Bumped the mysql client versions built in [ddev/mysql-client-build](https://github.com/ddev/mysql-client-build) to 8.0.46/8.4.10, released as [v0.2.5](https://github.com/ddev/mysql-client-build/releases/tag/v0.2.5) (ddev/mysql-client-build#1).
- Along the way, found and fixed the arm64 leg of that repo's CI, which was segfaulting mid-compile under QEMU emulation — switched it to a native `ubuntu-24.04-arm` runner (ddev/mysql-client-build#2).
- `mysql-client-install.sh` now points `TARBALL_VERSION` at `v0.2.5`.
- `versionconstants.go`'s `WebTag` is bumped to `20260709_mysql_client` so the rebuilt `ddev-webserver` image (with the new client installer) is pulled.

Filed #8575 to track the general problem: client/server version drift isn't currently detected automatically for mysql, mariadb, or postgres.

## Manual Testing Instructions

1. `ddev config --web-image=ddev/ddev-webserver:20260709_mysql_client` (or check out this branch and `make`).
2. `ddev config --project-type=php --database=mysql:8.0` (and separately `mysql:8.4`) in a test project, then `ddev start`.
3. `ddev exec mysql -V` should report `8.0.46` (or `8.4.10` for the 8.4 project).
4. Exercise `ddev import-db` / `ddev export-db` / `ddev snapshot` to confirm the client works against the new server.

## Automated Testing Overview

- `TestWebserverMariaMySQLDBClient` in `pkg/ddevapp/ddevapp_test.go` starts a project against `mysql:8.0`/`mysql:8.4` and asserts the installed client's version string matches the configured server version (major.minor prefix), then round-trips data through import/export — this exercises the new `v0.2.5` tarballs end-to-end.

