### PR TITLE
fix(build): honor service platform override when building images, fixes #8578

### DIFF
--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -388,6 +388,19 @@ func fixupComposeYaml(project *composeTypes.Project, app *DdevApp) (*composeType
 			}
 		}
 
+		// Propagate the service's `platform` into `build.platforms` so a built
+		// image matches the requested architecture. The compose-go library
+		// doesn't derive `build.platforms` from the service-level `platform`,
+		// so without this a build would target the host platform, which then
+		// fails the platform match at `up` time when a project overrides
+		// `platform:` (e.g. linux/amd64 on an arm64 host). Fixed up here,
+		// rather than only where DDEV explicitly builds, so every build
+		// triggered from the rendered compose file picks it up.
+		// See https://github.com/ddev/ddev/issues/8578.
+		if service.Build != nil && service.Platform != "" && len(service.Build.Platforms) == 0 {
+			service.Build.Platforms = []string{service.Platform}
+		}
+
 		// Add SELinux labels to bind mounts when SELinux is enabled
 		if isSELinux {
 			for i, vol := range service.Volumes {

--- a/pkg/ddevapp/compose_yaml.go
+++ b/pkg/ddevapp/compose_yaml.go
@@ -388,17 +388,11 @@ func fixupComposeYaml(project *composeTypes.Project, app *DdevApp) (*composeType
 			}
 		}
 
-		// Propagate the service's `platform` into `build.platforms` so a built
-		// image matches the requested architecture. The compose-go library
-		// doesn't derive `build.platforms` from the service-level `platform`,
-		// so without this a build would target the host platform, which then
-		// fails the platform match at `up` time when a project overrides
-		// `platform:` (e.g. linux/amd64 on an arm64 host). Fixed up here,
-		// rather than only where DDEV explicitly builds, so every build
-		// triggered from the rendered compose file picks it up.
-		// See https://github.com/ddev/ddev/issues/8578.
-		if service.Build != nil && service.Platform != "" && len(service.Build.Platforms) == 0 {
-			service.Build.Platforms = []string{service.Platform}
+		// compose-go doesn't derive `build.platforms` from the service-level
+		// `platform`, so add it here to build an image matching the requested
+		// architecture. See https://github.com/ddev/ddev/issues/8578.
+		if service.Platform != "" && service.Build != nil && !slices.Contains(service.Build.Platforms, service.Platform) {
+			service.Build.Platforms = append(service.Build.Platforms, service.Platform)
 		}
 
 		// Add SELinux labels to bind mounts when SELinux is enabled

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1460,6 +1460,19 @@ func (app *DdevApp) composeBuild(args ...string) (string, error) {
 		return "", fmt.Errorf("docker-compose build failed: %v", err)
 	}
 
+	// Propagate each service's `platform` into `build.platforms` so the built
+	// image is produced for the requested architecture. The compose-go library
+	// does not derive `build.platforms` from the service-level `platform`, so
+	// without this the build would target the host platform. That built image
+	// would then fail the platform match at `up` time when a project overrides
+	// `platform:` (e.g. linux/amd64 on an arm64 host).
+	for name, service := range project.Services {
+		if service.Build != nil && service.Platform != "" && len(service.Build.Platforms) == 0 {
+			service.Build.Platforms = []string{service.Platform}
+			project.Services[name] = service
+		}
+	}
+
 	goCtx, _, err := dockerutil.GetDockerClient()
 	if err != nil {
 		return "", fmt.Errorf("docker-compose build failed: %v", err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1460,19 +1460,6 @@ func (app *DdevApp) composeBuild(args ...string) (string, error) {
 		return "", fmt.Errorf("docker-compose build failed: %v", err)
 	}
 
-	// Propagate each service's `platform` into `build.platforms` so the built
-	// image is produced for the requested architecture. The compose-go library
-	// does not derive `build.platforms` from the service-level `platform`, so
-	// without this the build would target the host platform. That built image
-	// would then fail the platform match at `up` time when a project overrides
-	// `platform:` (e.g. linux/amd64 on an arm64 host).
-	for name, service := range project.Services {
-		if service.Build != nil && service.Platform != "" && len(service.Build.Platforms) == 0 {
-			service.Build.Platforms = []string{service.Platform}
-			project.Services[name] = service
-		}
-	}
-
 	goCtx, _, err := dockerutil.GetDockerClient()
 	if err != nil {
 		return "", fmt.Errorf("docker-compose build failed: %v", err)

--- a/pkg/ddevapp/start_test.go
+++ b/pkg/ddevapp/start_test.go
@@ -3,9 +3,12 @@ package ddevapp_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/stretchr/testify/require"
 )
@@ -55,4 +58,42 @@ func TestDdevApp_StartOptionalProfiles(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, container)
 	}
+}
+
+// TestPlatformOverride makes sure that a project which overrides the web
+// service platform (e.g. `platform: linux/amd64` on an arm64 host) actually
+// builds and runs the web image for the requested architecture.
+// See https://github.com/ddev/ddev/issues/8578.
+// It only runs on macOS arm64 + OrbStack, where cross-platform emulation is
+// available and exercised in CI (Buildkite).
+func TestPlatformOverride(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" || !dockerutil.IsOrbStack() {
+		t.Skip("Skipping TestPlatformOverride; only runs on macOS arm64 with OrbStack")
+	}
+
+	origDir, _ := os.Getwd()
+	site := TestSites[0]
+
+	app, err := ddevapp.NewApp(site.Dir, false)
+	require.NoError(t, err)
+
+	overridePath := app.GetConfigPath("docker-compose.amd64.yaml")
+	t.Cleanup(func() {
+		_ = app.Stop(true, false)
+		_ = os.RemoveAll(overridePath)
+	})
+
+	err = fileutil.CopyFile(filepath.Join(origDir, "testdata", t.Name(), "docker-compose.amd64.yaml"), overridePath)
+	require.NoError(t, err)
+
+	err = app.Start()
+	require.NoError(t, err)
+
+	// The web container must be the amd64 (x86_64) architecture requested by the override,
+	// not the arm64 host architecture.
+	out, _, err := app.Exec(&ddevapp.ExecOpts{
+		Cmd: "uname -m",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "x86_64", strings.TrimSpace(out))
 }

--- a/pkg/ddevapp/testdata/TestPlatformOverride/docker-compose.amd64.yaml
+++ b/pkg/ddevapp/testdata/TestPlatformOverride/docker-compose.amd64.yaml
@@ -1,0 +1,3 @@
+services:
+  web:
+    platform: linux/amd64


### PR DESCRIPTION
## The Issue

- Fixes #8578

Since v1.25.3, projects that override the web service platform (e.g. `platform: linux/amd64` in a `.ddev/docker-compose.*.yaml` on an arm64 host) fail to start with:

```text
image with reference ddev/ddev-webserver:<ver>-<project>-built was found but its platform (linux/arm64) does not match the specified platform (linux/amd64)
```

This worked correctly in v1.25.2.

## How This PR Solves The Issue

v1.25.3 (commit `10fdd8574`) switched `composeBuild` from shelling out to the external `docker-compose` binary to calling the compose-go library directly. That library does not derive `build.platforms` from the service-level `platform:` field, so buildx builds for the host platform (arm64) regardless of an overridden `platform:`. At `up` time, convergence then compares the requested `service.Platform` against the (wrong-architecture) built image and errors on the mismatch.

The fix propagates each service's `platform` into `build.platforms` (when the latter is empty) before building, so the built image matches the requested architecture. The change is scoped: DDEV's own base compose config never sets a service-level `platform:`, so projects that don't override it are unaffected.

## Manual Testing Instructions

On an arm64 machine (e.g. Apple Silicon + OrbStack):

1. `ddev config --project-type=php`
2. Create `.ddev/docker-compose.amd64.yaml`:

   ```yaml
   services:
     web:
       platform: linux/amd64
   ```

3. `ddev start`
4. `ddev exec uname -m` should report `x86_64`

Without the fix, step 3 fails with the platform-mismatch error above.

## Automated Testing Overview

Adds `TestPlatformOverride` (`pkg/ddevapp/start_test.go`), which copies an amd64 platform override into a test project, starts it, and asserts the web container reports `x86_64`. It only runs on macOS arm64 with OrbStack (matching Buildkite's environment) and skips elsewhere, since cross-platform emulation isn't universally available.

## Release/Deployment Notes

Restores v1.25.2 behavior for projects that override the container platform. No impact on projects that don't set `platform:`.
