### PR TITLE
fix(typo3): don't overwrite additional.php DB config when db container is omitted or SQLite is configured

### DIFF
--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/semver/v3"
@@ -79,7 +80,18 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 	if app.Database.Type == nodeps.Postgres {
 		dbDriver = "pdo_pgsql"
 	}
-	settings := map[string]any{"DBHostname": "db", "DBDriver": dbDriver, "DBPort": GetInternalPort(app, "db")}
+
+	// Skip the DB connection block entirely if there's no db container
+	// to connect to, or if TYPO3 has already been configured for SQLite
+	// via the installer - don't let this file override that on restart.
+	skipDatabaseConfig := nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") || isTypo3ConfiguredForSqlite(app)
+
+	settings := map[string]any{
+		"DBHostname":         "db",
+		"DBDriver":           dbDriver,
+		"DBPort":             GetInternalPort(app, "db"),
+		"SkipDatabaseConfig": skipDatabaseConfig,
+	}
 
 	// Ensure target directory exists and is writable
 	if err := util.Chmod(dir, 0755); os.IsNotExist(err) {
@@ -330,4 +342,14 @@ func typo3ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string)
 	}
 
 	return nil
+}
+
+func isTypo3ConfiguredForSqlite(app *DdevApp) bool {
+	content, err := os.ReadFile(app.SiteSettingsPath)
+
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(string(content), "'driver' => 'pdo_sqlite'") || strings.Contains(string(content), `"driver" => "pdo_sqlite"`)
 }

--- a/pkg/ddevapp/typo3/AdditionalConfiguration.php
+++ b/pkg/ddevapp/typo3/AdditionalConfiguration.php
@@ -9,7 +9,7 @@
 if (getenv('IS_DDEV_PROJECT') == 'true') {
     $GLOBALS['TYPO3_CONF_VARS'] = array_replace_recursive(
         $GLOBALS['TYPO3_CONF_VARS'],
-        [
+        [{{if not .SkipDatabaseConfig}}
             'DB' => [
                 'Connections' => [
                     'Default' => [
@@ -21,7 +21,7 @@ if (getenv('IS_DDEV_PROJECT') == 'true') {
                         'user' => 'db',
                     ],
                 ],
-            ],
+            ],{{end}}
             // This GFX configuration allows processing by installed ImageMagick 6
             'GFX' => [
                 'processor' => 'ImageMagick',


### PR DESCRIPTION
## The Issue

TYPO3 projects using `omit_containers: [db]` fail during installation with a DNS resolution error (`getaddrinfo for db failed`), because `additional.php` unconditionally points to a `db` host that was never started. Separately, TYPO3 projects that complete a SQLite installation through the installer have their configuration silently reverted back to MySQL on every subsequent `ddev restart`, since `writeTypo3SettingsFile()` writes the DB connection block unconditionally on every start.

This is particularly relevant now that TYPO3 Core has an open patch adding a dedicated "SQLite (performance mode, WAL)" option to the installer: https://review.typo3.org/c/Packages/TYPO3.CMS/+/94767 — without this DDEV fix, that option is effectively unusable in a DDEV context.

## How This PR Solves The Issue

The DB connection block in `additional.php` is now skipped when:
- the `db` container is omitted (`omit_containers: [db]`), or
- `settings.php` already declares the `pdo_sqlite` driver for the Default connection

All other settings written to `additional.php` remain untouched in both cases.

## Manual Testing Instructions

1. `ddev config --project-type=typo3`
2. Add `omit_containers: [db]` to `.ddev/config.yaml`
3. `ddev start`
4. Run the TYPO3 installer, choose SQLite as database driver
5. Without this fix: installation fails at the database connect step with a DNS resolution error. With this fix: installation completes normally, since no MySQL connection block is written.
6. Alternatively (without `omit_containers`): complete a SQLite installation via the installer, then run `ddev restart`. Without this fix, `additional.php` reverts to `mysqli` on restart. With this fix, the SQLite configuration is preserved.

## Automated Testing Overview

No automated test added yet. `writeTypo3SettingsFile()` had no existing test coverage to extend. Happy to add one if a maintainer can point me to the preferred pattern for testing this kind of project-type-specific settings file generation.

## Release/Deployment Notes

None. This only affects the content DDEV itself writes for TYPO3 projects that use `omit_containers: [db]` or SQLite — existing MySQL/MariaDB-based TYPO3 projects are unaffected.
