### PR TITLE
docs(commands): add precision about `launch` which start project, fixes #8583

### DIFF
--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -821,7 +821,8 @@ ddev import-files -s=.tarballs/files.tar.gz -t=sites/default/files
 
 ## `launch`
 
-Launch a browser with the current site (global shell host container command).
+Launch a browser with the current site (global shell host container command). If the current project is not running,
+it will be started first.
 
 Flags:
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- Fixes #8583
 
In this issue, I suggested a `--launch` flag for `start` command, but https://github.com/ddev/ddev/issues/8583#issuecomment-4961410450 le me know the `launch` command can start project

## How This PR Solves The Issue

If it's obvious `launch` will start a project, the flag is probably no longer relevant

## Manual Testing Instructions


## Automated Testing Overview


## Release/Deployment Notes

