### PR TITLE
fix(router): remove obsolete *.ddev.local from generated certs, fixes #8586

### DIFF
--- a/pkg/ddevapp/traefik.go
+++ b/pkg/ddevapp/traefik.go
@@ -150,7 +150,7 @@ func PushGlobalTraefikConfig(activeApps []*DdevApp) error {
 	// Install default certs, except when using Let's Encrypt (when they would
 	// get used instead of Let's Encrypt certs)
 	if !globalconfig.DdevGlobalConfig.UseLetsEncrypt && globalconfig.GetCAROOT() != "" {
-		c := []string{"--cert-file", filepath.Join(globalSourceCertsPath, "default_cert.crt"), "--key-file", filepath.Join(globalSourceCertsPath, "default_key.key"), "127.0.0.1", "localhost", "*.ddev.local", "ddev-router", "ddev-router.ddev", "ddev-router.ddev_default", "*.ddev.site"}
+		c := []string{"--cert-file", filepath.Join(globalSourceCertsPath, "default_cert.crt"), "--key-file", filepath.Join(globalSourceCertsPath, "default_key.key"), "127.0.0.1", "localhost", "ddev-router", "ddev-router.ddev", "ddev-router.ddev_default", "*.ddev.site"}
 		// Add a `*.<TLD>` wildcard for every TLD in use (global plus each active
 		// project's). This is the fallback for hosts that no per-project cert
 		// matches.

--- a/testing/ddev-perf-test.sh
+++ b/testing/ddev-perf-test.sh
@@ -34,7 +34,7 @@ downloads=(drupal-7.54 commerce_kickstart-7.x-2.45 drupal-8.3.2)
 
 for ((i=0; i<${#sites[@]}; ++i)); do
 	site=${sites[$i]}
-	base_url=http://$site.ddev.local
+	base_url=http://$site.ddev.site
 
 
 	if [ ! -d "$site" ] ; then
@@ -86,7 +86,7 @@ END
     elapsed=$($CURLIT -fL $base_url)
     echo "${BLUE}$site: anon curl ($?) again after site install: $elapsed ${RESET}"
 
-	$TIMEIT ddev exec drush uli -l $site.ddev.local >$site.uli.txt 2>&1 || (echo "Failed drush uli" && continue)
+	$TIMEIT ddev exec drush uli -l $site.ddev.site >$site.uli.txt 2>&1 || (echo "Failed drush uli" && continue)
 	echo "${BLUE}$site: ddev uli: $(cat time.out) ${RESET}"
 
 	# This technique doesn't work on d8 due to some new form fields on the uli page.


### PR DESCRIPTION
## The Issue

- Fixes #8586

`*.ddev.local` has been obsolete for years, since DDEV moved to `*.ddev.site` and mkcert-based trusted certificates. It was still being added to the SAN list when generating the global default cert, and referenced in an example testing script.

## How This PR Solves The Issue

- Removed `*.ddev.local` from the `mkcert` SAN list used to generate the global default cert in `pkg/ddevapp/traefik.go`. (The per-project cert path no longer included it either, following the recent per-project SAN cleanup in #8563.)
- Updated `testing/ddev-perf-test.sh`, which still referenced `.ddev.local` URLs in its example usage, to use `.ddev.site`.

## Manual Testing Instructions

1. Remove `~/.ddev/traefik/certs/default_cert.crt` and `default_key.key` (or just run `mkcert -uninstall && mkcert -install` to regenerate global certs) and start any project.
2. Run `openssl x509 -in ~/.ddev/traefik/certs/default_cert.crt -noout -text | grep -A1 "Subject Alternative Name"` and confirm `*.ddev.local` is no longer listed among the SANs.

## Automated Testing Overview

No new tests added; this is a removal of an obsolete cert SAN. Existing `TestTraefik*` tests in `pkg/ddevapp/traefik_test.go` continue to pass and don't assert on `ddev.local`.

## Release/Deployment Notes

Anyone still relying on the long-obsolete `*.ddev.local` TLD for HTTPS will no longer get a cert covering it. `*.ddev.site` (and any custom project TLD) is unaffected.
