### PR TITLE
docs(quickstart): update Shopware 6 references to up-to-date information

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -190,6 +190,7 @@ Usage
 Use
 Uses
 Uz
+vanwittlaer
 VCS
 Vitest
 VM

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2506,7 +2506,11 @@ ddev config --upload-dirs=sites/assets/files && ddev restart
 
     Log into the admin site (`/admin`) using the web browser. The default credentials are username `admin` and password `shopware`. You can use the web UI to install sample data or accomplish many other tasks.
 
-    For more advanced tasks like adding elasticsearch, building and watching storefront and administration, see [susi.dev](https://susi.dev/ddev-shopware-6).
+    For more advanced tasks such as
+    - using shopware-cli,
+    - running the Storefront and Admin Watchers or
+    - mirroring production media
+    see [notebook.vanwittlaer.de](https://notebook.vanwittlaer.de/ddev-for-shopware/).
 
     ??? tip "Prefer to run as a script?"
         To run the whole setup as a script, examine and run this script:


### PR DESCRIPTION
The formerly referred site is somewhat out-dated

## The Issue

Shopware quickstart refers to a blog on susi.dev which looks out-dated (older Shopware version, out-dated watcher instructions)

## How This PR Solves The Issue

Refer to https://notebook.vanwittlaer.de/ddev-for-shopware/
