### PR TITLE
fix: don't write CMS db connection settings when db container is omitted or another driver is configured, for #8582 (#8594) [skip ci]

### DIFF
--- a/pkg/ddevapp/backdrop.go
+++ b/pkg/ddevapp/backdrop.go
@@ -30,6 +30,7 @@ type BackdropSettings struct {
 	SiteSettingsDdev string
 	DockerIP         string
 	DBPublishedPort  int
+	HasDBContainer   bool
 }
 
 // NewBackdropSettings produces a BackdropSettings object with default values.
@@ -50,6 +51,7 @@ func NewBackdropSettings(app *DdevApp) *BackdropSettings {
 		SiteSettingsDdev: "settings.ddev.php",
 		DockerIP:         dockerIP,
 		DBPublishedPort:  dbPublishedPort,
+		HasDBContainer:   !app.IsDBOmitted(),
 	}
 }
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -912,7 +912,7 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		DBPort:                    GetInternalPort(app, "db"),
 		DdevGenerated:             nodeps.DdevFileSignature,
 		DisableSettingsManagement: app.DisableSettingsManagement,
-		OmitDB:                    nodeps.ArrayContainsString(app.GetOmittedContainers(), nodeps.DBContainer),
+		OmitDB:                    app.IsDBOmitted(),
 		OmitRouter:                nodeps.ArrayContainsString(app.GetOmittedContainers(), globalconfig.DdevRouterContainer),
 		OmitSSHAgent:              nodeps.ArrayContainsString(app.GetOmittedContainers(), "ddev-ssh-agent"),
 		BindAllInterfaces:         app.BindAllInterfaces,

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -274,7 +274,7 @@ func (app *DdevApp) Describe(short bool) (map[string]any, error) {
 	appDesc["database_type"] = app.Database.Type
 	appDesc["database_version"] = app.Database.Version
 
-	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+	if !app.IsDBOmitted() {
 		dbinfo := make(map[string]any)
 		dbinfo["username"] = "db"
 		dbinfo["password"] = "db"
@@ -623,6 +623,12 @@ func (app *DdevApp) GetOmittedContainers() []string {
 	omitted := app.OmitContainersGlobal
 	omitted = append(omitted, app.OmitContainers...)
 	return omitted
+}
+
+// IsDBOmitted returns true if the db container is omitted
+// via project or global omit_containers
+func (app *DdevApp) IsDBOmitted() bool {
+	return nodeps.ArrayContainsString(app.GetOmittedContainers(), nodeps.DBContainer)
 }
 
 // GetAppRoot return the full path from root to the app directory
@@ -1199,7 +1205,7 @@ func (app *DdevApp) SiteStatus() (string, string) {
 	}
 
 	statuses := map[string]string{"web": ""}
-	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+	if !app.IsDBOmitted() {
 		statuses["db"] = ""
 	}
 
@@ -1586,7 +1592,7 @@ func (app *DdevApp) Start() error {
 		util.Warning("Unable to pull Docker images: %v", pullErr)
 	}
 
-	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+	if !app.IsDBOmitted() {
 		// OK to start if dbType is empty (nonexistent) or if it matches
 		if dbType, err := app.GetExistingDBType(); err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
 			return fmt.Errorf("unable to start project %s because the configured database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s' and then you might want to try 'ddev utility migrate-database %s', see docs at %s", app.Name, dbType, dbType, app.Database.Type+":"+app.Database.Version, "https://docs.ddev.com/en/stable/users/extend/database-types/")
@@ -1647,7 +1653,7 @@ func (app *DdevApp) Start() error {
 	if globalconfig.DdevGlobalConfig.NoBindMounts {
 		volumesNeeded = append(volumesNeeded, app.Name+"-ddev-config")
 	}
-	if !slices.Contains(app.GetOmittedContainers(), "db") {
+	if !app.IsDBOmitted() {
 		volumesNeeded = append(volumesNeeded, "ddev-"+app.Name+"-snapshots")
 		if app.Database.Type == nodeps.Postgres {
 			volumesNeeded = append(volumesNeeded, app.GetPostgresVolumeName())
@@ -1757,7 +1763,7 @@ func (app *DdevApp) Start() error {
 		labels["com.ddev.userns"] = "keep-id"
 	}
 
-	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+	if !app.IsDBOmitted() {
 		if app.Database.Type == nodeps.Postgres {
 			postgresDataDir := app.GetPostgresDataDir()
 			volumeMounts = append(volumeMounts, app.GetPostgresVolumeName()+":"+postgresDataDir)
@@ -2036,7 +2042,7 @@ func (app *DdevApp) Start() error {
 
 	// Wait for web/db containers to become healthy
 	dependers := []string{"web"}
-	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+	if !app.IsDBOmitted() {
 		dependers = append(dependers, "db")
 	}
 	wait := output.StartWait(fmt.Sprintf("Waiting for containers to become ready: %v", dependers))

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -36,6 +36,7 @@ type DrupalSettings struct {
 	SyncDir          string
 	DockerIP         string
 	DBPublishedPort  int
+	HasDBContainer   bool
 }
 
 // NewDrupalSettings produces a DrupalSettings object with default.
@@ -58,6 +59,7 @@ func NewDrupalSettings(app *DdevApp) *DrupalSettings {
 		SyncDir:          path.Join("files", "sync"),
 		DockerIP:         dockerIP,
 		DBPublishedPort:  dbPublishedPort,
+		HasDBContainer:   !app.IsDBOmitted(),
 	}
 	if app.Type == "drupal6" {
 		settings.DatabaseDriver = "mysqli"
@@ -457,7 +459,7 @@ func drupalConfigOverrideAction(app *DdevApp) error {
 	}
 	// If there is no database, update it to the default one,
 	// otherwise show a warning to the user.
-	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
+	if !app.IsDBOmitted() {
 		if dbType, err := app.GetExistingDBType(); err == nil && dbType == "" {
 			app.Database = DatabaseDefault
 		} else if app.Database.Type == DatabaseDefault.Type && app.Database != DatabaseDefault && drupalVersion >= 8 {
@@ -470,7 +472,7 @@ func drupalConfigOverrideAction(app *DdevApp) error {
 }
 
 func drupalPostStartAction(app *DdevApp) error {
-	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") && (isDrupalApp(app)) {
+	if !app.IsDBOmitted() && (isDrupalApp(app)) {
 		err := app.Wait([]string{nodeps.DBContainer})
 		if err != nil {
 			return err

--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -472,7 +472,7 @@ func drupalConfigOverrideAction(app *DdevApp) error {
 }
 
 func drupalPostStartAction(app *DdevApp) error {
-	if !app.IsDBOmitted() && (isDrupalApp(app)) {
+	if !app.IsDBOmitted() && isDrupalApp(app) {
 		err := app.Wait([]string{nodeps.DBContainer})
 		if err != nil {
 			return err

--- a/pkg/ddevapp/drupal/backdrop/settings.ddev.php
+++ b/pkg/ddevapp/drupal/backdrop/settings.ddev.php
@@ -6,6 +6,7 @@
  * DDEV manages this file and may delete or overwrite the file unless this comment is removed.
  */
 
+{{ if $config.HasDBContainer -}}
 $host = "{{ $config.DatabaseHost }}";
 $port = {{ $config.DatabasePort }};
 $driver = "{{ $config.DatabaseDriver }}";
@@ -19,4 +20,5 @@ if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == "true")) {
 
 $database = "$driver://{{ $config.DatabaseUsername }}:{{ $config.DatabasePassword }}@$host:$port/{{ $config.DatabaseName }}";
 
+{{ end -}}
 $settings['hash_salt'] = '{{ $config.HashSalt }}';

--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -9,6 +9,7 @@
  * that you leave this file alone.
  */
 
+{{ if $config.HasDBContainer -}}
 $host = "{{ $config.DatabaseHost }}";
 $port = {{ $config.DatabasePort }};
 $driver = "{{ $config.DatabaseDriver }}";
@@ -20,6 +21,7 @@ $databases['default']['default']['host'] = $host;
 $databases['default']['default']['port'] = $port;
 $databases['default']['default']['driver'] = $driver;
 
+{{ end -}}
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 
 // Recommended setting for Drupal 10 only

--- a/pkg/ddevapp/drupal/drupal11/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal11/settings.ddev.php
@@ -9,6 +9,7 @@
  * that you leave this file alone.
  */
 
+{{ if $config.HasDBContainer -}}
 $host = "{{ $config.DatabaseHost }}";
 $port = {{ $config.DatabasePort }};
 $driver = "{{ $config.DatabaseDriver }}";
@@ -20,6 +21,7 @@ $databases['default']['default']['host'] = $host;
 $databases['default']['default']['port'] = $port;
 $databases['default']['default']['driver'] = $driver;
 
+{{ end -}}
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 
 // This will prevent Drupal from setting read-only permissions on sites/default.

--- a/pkg/ddevapp/drupal/drupal12/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal12/settings.ddev.php
@@ -9,6 +9,7 @@
  * that you leave this file alone.
  */
 
+{{ if $config.HasDBContainer -}}
 $host = "{{ $config.DatabaseHost }}";
 $port = {{ $config.DatabasePort }};
 $driver = "{{ $config.DatabaseDriver }}";
@@ -20,6 +21,7 @@ $databases['default']['default']['host'] = $host;
 $databases['default']['default']['port'] = $port;
 $databases['default']['default']['driver'] = $driver;
 
+{{ end -}}
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 
 // This will prevent Drupal from setting read-only permissions on sites/default.

--- a/pkg/ddevapp/drupal/drupal6/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal6/settings.ddev.php
@@ -7,6 +7,7 @@
  * ddev manages this file and may delete or overwrite the file unless this
  * comment is removed.
  */
+{{ if $config.HasDBContainer -}}
 $host = "{{ $config.DatabaseHost }}";
 $port = {{ $config.DatabasePort }};
 $driver = "{{ $config.DatabaseDriver }}";
@@ -19,3 +20,4 @@ if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
 }
 
 $db_url = "$driver://{{ $config.DatabaseUsername }}:{{ $config.DatabasePassword }}@$host:$port/{{ $config.DatabaseName }}";
+{{ end -}}

--- a/pkg/ddevapp/drupal/drupal7/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal7/settings.ddev.php
@@ -9,6 +9,7 @@
  * comment is removed.
  */
 
+{{ if $config.HasDBContainer -}}
 $host = "{{ $config.DatabaseHost }}";
 $port = {{ $config.DatabasePort }};
 $driver = "{{ $config.DatabaseDriver }}";
@@ -27,6 +28,7 @@ $databases['default']['default']['host'] = $host;
 $databases['default']['default']['driver'] = $driver;
 $databases['default']['default']['port'] = $port;
 
+{{ end -}}
 $drupal_hash_salt = '{{ $config.HashSalt }}';
 
 // This will prevent Drupal from setting read-only permissions on sites/default.

--- a/pkg/ddevapp/drupal/drupal8/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal8/settings.ddev.php
@@ -9,6 +9,7 @@
  * that you leave this file alone.
  */
 
+{{ if $config.HasDBContainer -}}
 $host = "{{ $config.DatabaseHost }}";
 $port = {{ $config.DatabasePort }};
 $driver = "{{ $config.DatabaseDriver }}";
@@ -27,6 +28,7 @@ $databases['default']['default']['host'] = $host;
 $databases['default']['default']['port'] = $port;
 $databases['default']['default']['driver'] = $driver;
 
+{{ end -}}
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 
 // This will prevent Drupal from setting read-only permissions on sites/default.

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -9,6 +9,7 @@
  * that you leave this file alone.
  */
 
+{{ if $config.HasDBContainer -}}
 $host = "{{ $config.DatabaseHost }}";
 $port = {{ $config.DatabasePort }};
 $driver = "{{ $config.DatabaseDriver }}";
@@ -20,6 +21,7 @@ $databases['default']['default']['host'] = $host;
 $databases['default']['default']['port'] = $port;
 $databases['default']['default']['driver'] = $driver;
 
+{{ end -}}
 $settings['hash_salt'] = '{{ $config.HashSalt }}';
 
 // This will prevent Drupal from setting read-only permissions on sites/default.

--- a/pkg/ddevapp/settings_omitdb_test.go
+++ b/pkg/ddevapp/settings_omitdb_test.go
@@ -1,0 +1,112 @@
+package ddevapp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteTypo3SettingsFileDBConfig verifies that the generated TYPO3
+// additional.php only contains a database connection block when the db
+// container exists, and that the block is guarded at runtime so it can't
+// override a project that has been configured for SQLite (or any other
+// driver the db container doesn't provide). See
+// https://github.com/ddev/ddev/pull/8582 for background.
+func TestWriteTypo3SettingsFileDBConfig(t *testing.T) {
+	writeSettings := func(t *testing.T, app *DdevApp) string {
+		app.SiteDdevSettingsFile = filepath.Join(t.TempDir(), "config", "system", "additional.php")
+		require.NoError(t, writeTypo3SettingsFile(app))
+		content, err := os.ReadFile(app.SiteDdevSettingsFile)
+		require.NoError(t, err)
+		return string(content)
+	}
+
+	t.Run("db container present", func(t *testing.T) {
+		app := &DdevApp{Name: t.Name(), Type: nodeps.AppTypeTYPO3}
+		content := writeSettings(t, app)
+
+		require.Contains(t, content, `'host' => 'db'`)
+		require.Contains(t, content, `'driver' => 'mysqli'`)
+		require.Contains(t, content, `'port' => 3306`)
+		// The non-DB settings must be present too.
+		require.Contains(t, content, `'GFX'`)
+		require.Contains(t, content, `'MAIL'`)
+
+		// The DB connection must only be applied inside the runtime driver
+		// guard, so a settings.php configured for pdo_sqlite is left alone
+		// on every restart.
+		guardPos := strings.Index(content, `in_array($ddevDriver, ['mysqli', 'pdo_mysql', 'pdo_pgsql'], true)`)
+		dbBlockPos := strings.Index(content, `$ddevConfig['DB']`)
+		require.NotEqual(t, -1, guardPos, "runtime driver guard not found in generated additional.php")
+		require.NotEqual(t, -1, dbBlockPos, "DB connection block not found in generated additional.php")
+		require.Less(t, guardPos, dbBlockPos, "DB connection block must be inside the runtime driver guard")
+		require.Contains(t, content, `$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['driver'] ??`)
+	})
+
+	t.Run("postgres db container", func(t *testing.T) {
+		app := &DdevApp{Name: t.Name(), Type: nodeps.AppTypeTYPO3}
+		app.Database.Type = nodeps.Postgres
+		content := writeSettings(t, app)
+
+		require.Contains(t, content, `'driver' => 'pdo_pgsql'`)
+		require.Contains(t, content, `'port' => 5432`)
+	})
+
+	t.Run("db container omitted in project config", func(t *testing.T) {
+		app := &DdevApp{Name: t.Name(), Type: nodeps.AppTypeTYPO3, OmitContainers: []string{"db"}}
+		content := writeSettings(t, app)
+
+		require.NotContains(t, content, `'host' => 'db'`)
+		require.NotContains(t, content, `'Connections'`)
+		require.NotContains(t, content, `$ddevDriver`)
+		// The non-DB settings must survive.
+		require.Contains(t, content, `'GFX'`)
+		require.Contains(t, content, `'MAIL'`)
+		require.Contains(t, content, `array_replace_recursive`)
+	})
+
+	t.Run("db container omitted in global config", func(t *testing.T) {
+		app := &DdevApp{Name: t.Name(), Type: nodeps.AppTypeTYPO3, OmitContainersGlobal: []string{"db"}}
+		content := writeSettings(t, app)
+
+		require.NotContains(t, content, `'host' => 'db'`)
+		require.Contains(t, content, `'GFX'`)
+	})
+}
+
+// TestWriteDrupalSettingsDdevPhpDBConfig verifies that settings.ddev.php
+// only contains database connection settings when the db container exists.
+func TestWriteDrupalSettingsDdevPhpDBConfig(t *testing.T) {
+	writeSettings := func(t *testing.T, hasDBContainer bool) string {
+		app := &DdevApp{Name: t.Name(), Type: nodeps.AppTypeDrupal11}
+		settings := NewDrupalSettings(app)
+		settings.HasDBContainer = hasDBContainer
+
+		filePath := filepath.Join(t.TempDir(), "settings.ddev.php")
+		require.NoError(t, writeDrupalSettingsDdevPhp(settings, filePath, app))
+		content, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		return string(content)
+	}
+
+	t.Run("db container present", func(t *testing.T) {
+		content := writeSettings(t, true)
+
+		require.Contains(t, content, `$databases['default']['default']['host'] = $host;`)
+		require.Contains(t, content, `$settings['hash_salt']`)
+	})
+
+	t.Run("db container omitted", func(t *testing.T) {
+		content := writeSettings(t, false)
+
+		require.NotContains(t, content, `$databases`)
+		require.NotContains(t, content, `$host`)
+		// The non-DB settings must survive.
+		require.Contains(t, content, `$settings['hash_salt']`)
+		require.Contains(t, content, `trusted_host_patterns`)
+	})
+}

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -79,7 +79,14 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 	if app.Database.Type == nodeps.Postgres {
 		dbDriver = "pdo_pgsql"
 	}
-	settings := map[string]any{"DBHostname": "db", "DBDriver": dbDriver, "DBPort": GetInternalPort(app, "db")}
+	settings := map[string]any{
+		"DBHostname": "db",
+		"DBDriver":   dbDriver,
+		"DBPort":     GetInternalPort(app, "db"),
+		// When the db container is omitted there is nothing to connect to,
+		// so no DB connection is written at all.
+		"HasDBContainer": !app.IsDBOmitted(),
+	}
 
 	// Ensure target directory exists and is writable
 	if err := util.Chmod(dir, 0755); os.IsNotExist(err) {

--- a/pkg/ddevapp/typo3/AdditionalConfiguration.php
+++ b/pkg/ddevapp/typo3/AdditionalConfiguration.php
@@ -7,38 +7,48 @@
  */
 
 if (getenv('IS_DDEV_PROJECT') == 'true') {
-    $GLOBALS['TYPO3_CONF_VARS'] = array_replace_recursive(
-        $GLOBALS['TYPO3_CONF_VARS'],
-        [
-            'DB' => [
-                'Connections' => [
-                    'Default' => [
-                        'dbname' => 'db',
-                        'driver' => '{{ .DBDriver }}',
-                        'host' => '{{ .DBHostname }}',
-                        'password' => 'db',
-                        'port' => {{ .DBPort }},
-                        'user' => 'db',
-                    ],
+    $ddevConfig = [
+        // This GFX configuration allows processing by installed ImageMagick 6
+        'GFX' => [
+            'processor' => 'ImageMagick',
+            'processor_path' => '/usr/bin/',
+            'processor_path_lzw' => '/usr/bin/',
+        ],
+        // This mail configuration sends all emails to mailpit
+        'MAIL' => [
+            'transport' => 'smtp',
+            'transport_smtp_encrypt' => false,
+            'transport_smtp_server' => 'localhost:1025',
+        ],
+        'SYS' => [
+            'trustedHostsPattern' => '.*.*',
+            'devIPmask' => '*',
+            'displayErrors' => 1,
+        ],
+    ];
+{{if .HasDBContainer}}
+    // Only override the database connection if the project uses a driver
+    // provided by the DDEV db container. If the Default connection has been
+    // configured for anything else (like SQLite), leave it alone.
+    $ddevDriver = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['driver'] ?? '{{ .DBDriver }}';
+    if (in_array($ddevDriver, ['mysqli', 'pdo_mysql', 'pdo_pgsql'], true)) {
+        $ddevConfig['DB'] = [
+            'Connections' => [
+                'Default' => [
+                    'dbname' => 'db',
+                    'driver' => '{{ .DBDriver }}',
+                    'host' => '{{ .DBHostname }}',
+                    'password' => 'db',
+                    'port' => {{ .DBPort }},
+                    'user' => 'db',
                 ],
             ],
-            // This GFX configuration allows processing by installed ImageMagick 6
-            'GFX' => [
-                'processor' => 'ImageMagick',
-                'processor_path' => '/usr/bin/',
-                'processor_path_lzw' => '/usr/bin/',
-            ],
-            // This mail configuration sends all emails to mailpit
-            'MAIL' => [
-                'transport' => 'smtp',
-                'transport_smtp_encrypt' => false,
-                'transport_smtp_server' => 'localhost:1025',
-            ],
-            'SYS' => [
-                'trustedHostsPattern' => '.*.*',
-                'devIPmask' => '*',
-                'displayErrors' => 1,
-            ],
-        ]
+        ];
+    }
+{{end}}
+    $GLOBALS['TYPO3_CONF_VARS'] = array_replace_recursive(
+        $GLOBALS['TYPO3_CONF_VARS'],
+        $ddevConfig
     );
+    unset($ddevConfig{{if .HasDBContainer}}, $ddevDriver{{end}});
 }


### PR DESCRIPTION
## The Issue

- For #8582 — this is a generalized version of that fix. Full credit to @staatzstreich for the diagnosis and the original PR; this implements the same behavior at a more general level so other CMSs benefit too.

TYPO3 projects using `omit_containers: [db]` fail during installation with a DNS resolution error (`getaddrinfo for db failed`), because `additional.php` unconditionally points to a `db` host that was never started. Separately, TYPO3 projects that complete a SQLite installation through the installer have their configuration silently reverted back to MySQL on every subsequent `ddev restart`, since `writeTypo3SettingsFile()` writes the DB connection block unconditionally on every start.

The same omit-db problem exists latently for Drupal 6–12 and Backdrop, whose `settings.ddev.php` also writes `$databases`/`$db_url` pointing at `db` unconditionally.

## How This PR Solves The Issue

- Adds a `DdevApp.IsDBOmitted()` helper (checks both project and global `omit_containers`) and converts the existing hand-rolled equivalents in `ddevapp.go`, `drupal.go`, and `config.go` to use it. This also gives future explicit SQLite support (#6147) a single place to hook in.
- **TYPO3**: when the db container is omitted, no DB connection block is written at all. When it exists, the generated `additional.php` now applies the DB connection **at PHP runtime** only if the Default connection driver is one the db container provides (`mysqli`/`pdo_mysql`/`pdo_pgsql`), so a SQLite — or any other — configuration in `settings.php` is left alone on every restart. This replaces Go-side sniffing of `settings.php` contents, which was sensitive to quoting and formatting. The GFX/Mailpit/SYS settings are kept in all cases.
- **Drupal 6–12 and Backdrop**: `DrupalSettings`/`BackdropSettings` gain a `HasDBContainer` field and the `settings.ddev.php` templates wrap their DB blocks in a template conditional. With the db container present, rendered output is byte-identical to before (verified for all eight templates).
- **WordPress** needs no change: its `defined() ||` guards already allow user overrides.

## Manual Testing Instructions

1. `ddev config --project-type=typo3`
2. Add `omit_containers: [db]` to `.ddev/config.yaml`
3. `ddev start`; run the TYPO3 installer and choose SQLite
4. Installation completes; `additional.php` contains no DB connection block
5. Alternatively without `omit_containers`: complete a SQLite installation via the installer, then `ddev restart`; the SQLite configuration is preserved
6. For Drupal with `omit_containers: [db]`: `settings.ddev.php` contains no `$databases` block but keeps hash_salt and Mailpit settings

## Automated Testing Overview

New unit tests in `pkg/ddevapp/settings_omitdb_test.go` cover TYPO3 with db present (mysql/postgres), db omitted via project and global config, the presence and placement of the runtime driver guard, and Drupal settings with and without the db container.

Additionally validated during development: rendered templates for both branches pass `php -l`, and the runtime guard semantics (SQLite preserved across restart, `mysqli` repointed at `db`, fresh install gets the connection, omit-db writes none) were exercised with PHP in the ddev-webserver image.

## Release/Deployment Notes

No change for projects with a db container: rendered settings files are byte-identical (Drupal/Backdrop) or functionally equivalent (TYPO3, now with a runtime driver guard). Projects using `omit_containers: [db]` or a non-container database driver no longer get a dangling `db` connection written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
