### PR TITLE
feat(shopware6): bundle shopware-cli and hot-reload watchers

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2789,7 +2789,7 @@ ddev config --upload-dirs=sites/assets/files && ddev restart
 
 ### shopware-cli and hot-reload watchers
 
-For `shopware6` projects, DDEV bundles the [`shopware-cli`](https://hub.docker.com/r/shopware/shopware-cli) tool and hot-reload watcher commands automatically, with no add-on required. The `shopware-cli` binary is baked into the web image, and these commands become available:
+For `shopware6` projects, DDEV bundles the [`shopware-cli`](https://github.com/shopware/shopware-cli) tool and hot-reload watcher commands automatically, with no add-on required. The `shopware-cli` binary is baked into the web image, and these commands become available:
 
 - `ddev shopware-cli` — run `shopware-cli` inside the web container
 - `ddev storefront-watch` — hot-reload the storefront (proxy on port 9998)

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2761,12 +2761,6 @@ ddev config --upload-dirs=sites/assets/files && ddev restart
 
     Log into the admin site (`/admin`) using the web browser. The default credentials are username `admin` and password `shopware`. You can use the web UI to install sample data or accomplish many other tasks.
 
-    For more advanced tasks such as
-    - using shopware-cli,
-    - running the Storefront and Admin Watchers or
-    - mirroring production media
-    see [notebook.vanwittlaer.de](https://notebook.vanwittlaer.de/ddev-for-shopware/).
-
     ??? tip "Prefer to run as a script?"
         To run the whole setup as a script, examine and run this script:
 
@@ -2787,6 +2781,14 @@ ddev config --upload-dirs=sites/assets/files && ddev restart
         ./setup-shopware.sh
         ```
 
+    For more advanced tasks, such as
+
+    - setting up workers and the scheduler as automated tasks,
+    - installing additional services like RabbitMQ, or
+    - mirroring production media through an nginx proxy,
+
+    see [notebook.vanwittlaer.de](https://notebook.vanwittlaer.de/ddev-for-shopware/).
+
 ### shopware-cli and hot-reload watchers
 
 For `shopware6` projects, DDEV bundles the [`shopware-cli`](https://github.com/shopware/shopware-cli) tool and hot-reload watcher commands automatically, with no add-on required. The `shopware-cli` binary is baked into the web image, and these commands become available:
@@ -2797,7 +2799,7 @@ For `shopware6` projects, DDEV bundles the [`shopware-cli`](https://github.com/s
 
 Reach the watchers through your project's primary URL with the relevant port, for example `https://my-shopware-site.ddev.site:9998` for the storefront, not `localhost`.
 
-!!! note "Requires Shopware 6.7.4.2 or newer"
+!!!note "Requires Shopware 6.7.4.2 or newer"
     The bundled watchers target the Vite-based administration (port 5173) introduced in Shopware 6.7.4.2. Older Shopware versions use a different watcher setup.
 
 ## Silverstripe CMS

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2787,6 +2787,19 @@ ddev config --upload-dirs=sites/assets/files && ddev restart
         ./setup-shopware.sh
         ```
 
+### shopware-cli and hot-reload watchers
+
+For `shopware6` projects, DDEV bundles the [`shopware-cli`](https://hub.docker.com/r/shopware/shopware-cli) tool and hot-reload watcher commands automatically, with no add-on required. The `shopware-cli` binary is baked into the web image, and these commands become available:
+
+- `ddev shopware-cli` — run `shopware-cli` inside the web container
+- `ddev storefront-watch` — hot-reload the storefront (proxy on port 9998)
+- `ddev admin-watch <plugin-dir>` — hot-reload a plugin's administration (Vite, port 5173)
+
+Reach the watchers through your project's primary URL with the relevant port, for example `https://my-shopware-site.ddev.site:9998` for the storefront, not `localhost`.
+
+!!! note "Requires Shopware 6.7.4.2 or newer"
+    The bundled watchers target the Vite-based administration (port 5173) introduced in Shopware 6.7.4.2. Older Shopware versions use a different watcher setup.
+
 ## Silverstripe CMS
 
 Use a new or existing Composer project, or clone a Git repository.

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -36,6 +36,30 @@ teardown() {
   run ddev exec console system:install --basic-setup
   assert_success
 
+  # --- shopware-cli watcher tooling bundled with the shopware6 project type ---
+
+  # The shopware-cli binary is baked into the web image, and the wrapper execs it
+  # by absolute path so it can't recurse into itself via $PATH. A working
+  # --version proves both the COPY --from image build and the wrapper, and pins
+  # the baked-in binary to the version in ShopwareCLIImage.
+  # Keep in sync with ShopwareCLIImage in pkg/versionconstants/versionconstants.go.
+  run ddev shopware-cli --version
+  assert_success
+  assert_output --partial "0.16.7"
+
+  # The watcher commands are bundled and gated to shopware6: `ddev help` only
+  # resolves them if ProjectTypes let them register for this project type.
+  run ddev help admin-watch
+  assert_success
+  run ddev help storefront-watch
+  assert_success
+
+  # admin-watch validates its args (and thus actually runs in-container) without
+  # starting the long-running Vite server.
+  run ddev admin-watch
+  assert_failure
+  assert_output --partial "Usage: ddev admin-watch"
+
   DDEV_DEBUG=true run ddev launch /admin
   assert_output --partial "FULLURL https://${PROJNAME}.ddev.site/admin"
   assert_success

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -38,14 +38,14 @@ teardown() {
 
   # --- shopware-cli watcher tooling bundled with the shopware6 project type ---
 
-  # The shopware-cli binary is baked into the web image, and the wrapper execs it
-  # by absolute path so it can't recurse into itself via $PATH. A working
-  # --version proves both the COPY --from image build and the wrapper, and pins
-  # the baked-in binary to the version in ShopwareCLIImage.
-  # Keep in sync with ShopwareCLIImage in pkg/versionconstants/versionconstants.go.
+  # The shopware-cli binary is baked into the web image (downloaded from its
+  # GitHub release), and the wrapper execs it by absolute path so it can't recurse
+  # into itself via $PATH. A working --version proves both the image build and the
+  # wrapper. The version floats with the "latest" release, so we don't assert a
+  # literal; we just require a version-shaped string.
   run ddev shopware-cli --version
   assert_success
-  assert_output --partial "0.16.7"
+  assert_output --regexp '[0-9]+\.[0-9]+\.[0-9]+'
 
   # The watcher commands are bundled and gated to shopware6: `ddev help` only
   # resolves them if ProjectTypes let them register for this project type.

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -40,14 +40,14 @@ teardown() {
 
   # --- shopware-cli watcher tooling bundled with the shopware6 project type ---
 
-  # The shopware-cli binary is baked into the web image, and the wrapper execs it
-  # by absolute path so it can't recurse into itself via $PATH. A working
-  # --version proves both the COPY --from image build and the wrapper, and pins
-  # the baked-in binary to the version in ShopwareCLIImage.
-  # Keep in sync with ShopwareCLIImage in pkg/versionconstants/versionconstants.go.
+  # The shopware-cli binary is baked into the web image (downloaded from its
+  # GitHub release), and the wrapper execs it by absolute path so it can't recurse
+  # into itself via $PATH. A working --version proves both the image build and the
+  # wrapper. The version floats with the "latest" release, so we don't assert a
+  # literal; we just require a version-shaped string.
   run ddev shopware-cli --version
   assert_success
-  assert_output --partial "0.16.7"
+  assert_output --regexp '[0-9]+\.[0-9]+\.[0-9]+'
 
   # The watcher commands are bundled and gated to shopware6: `ddev help` only
   # resolves them if ProjectTypes let them register for this project type.

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -38,6 +38,30 @@ teardown() {
   run ddev exec console system:install --basic-setup
   assert_success
 
+  # --- shopware-cli watcher tooling bundled with the shopware6 project type ---
+
+  # The shopware-cli binary is baked into the web image, and the wrapper execs it
+  # by absolute path so it can't recurse into itself via $PATH. A working
+  # --version proves both the COPY --from image build and the wrapper, and pins
+  # the baked-in binary to the version in ShopwareCLIImage.
+  # Keep in sync with ShopwareCLIImage in pkg/versionconstants/versionconstants.go.
+  run ddev shopware-cli --version
+  assert_success
+  assert_output --partial "0.16.7"
+
+  # The watcher commands are bundled and gated to shopware6: `ddev help` only
+  # resolves them if ProjectTypes let them register for this project type.
+  run ddev help admin-watch
+  assert_success
+  run ddev help storefront-watch
+  assert_success
+
+  # admin-watch validates its args (and thus actually runs in-container) without
+  # starting the long-running Vite server.
+  run ddev admin-watch
+  assert_failure
+  assert_output --partial "Usage: ddev admin-watch"
+
   DDEV_DEBUG=true run ddev launch /admin
   assert_output --partial "FULLURL ${PRIMARY_URL}/admin"
   assert_success

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -269,6 +269,7 @@ func init() {
 			appTypeDetect:        isShopware6App,
 			appTypeSettingsPaths: setShopware6SiteSettingsPaths,
 			uploadDirs:           getShopwareUploadDirs,
+			configOverrideAction: shopware6ConfigOverrideAction,
 			postStartAction:      shopware6PostStartAction,
 			importFilesAction:    shopware6ImportFilesAction,
 		},

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/settings"
 	"github.com/ddev/ddev/pkg/util"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	copy2 "github.com/otiai10/copy"
 	"go.yaml.in/yaml/v4"
 )
@@ -1127,10 +1126,11 @@ stopasgroup=true
 
 	// For Shopware projects, bake the shopware-cli binary into the web image so
 	// the bundled shopware-cli/admin-watch/storefront-watch commands work without
-	// a separate add-on. It is pulled from the official scratch-based bin image,
+	// a separate add-on. It is downloaded from the official GitHub release (the
+	// version-less "latest" asset, so there's no fragile pinned version to bump),
 	// so nothing is compiled and no extra runtime deps land in the container.
 	if app.Type == nodeps.AppTypeShopware6 {
-		extraWebContent = extraWebContent + fmt.Sprintf("\nCOPY --from=%s /shopware-cli /usr/local/bin/shopware-cli\n", versionconstants.ShopwareCLIImage)
+		extraWebContent = extraWebContent + shopwareCLIInstallDockerfile
 	}
 
 	err = WriteBuildDockerfile(app, app.GetConfigPath(".webimageBuild/Dockerfile"), filepath.Join(globalconfig.GetGlobalDdevDir(), "web-build"), app.GetConfigPath("web-build"), app.WebImageExtraPackages, app.ComposerVersion, extraWebContent)

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/settings"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/ddev/ddev/pkg/versionconstants"
 	copy2 "github.com/otiai10/copy"
 	"go.yaml.in/yaml/v4"
 )
@@ -1123,6 +1124,14 @@ stopasgroup=true
 	extraWebContent = extraWebContent + "\nRUN log-stderr.sh mariadb-compat-install.sh || true\n"
 	// MariaDB 11.4+ has enabled SSL verification by default, which can cause issues.
 	extraWebContent = extraWebContent + "\nRUN log-stderr.sh mariadb-skip-ssl-wrapper-install.sh || true\n"
+
+	// For Shopware projects, bake the shopware-cli binary into the web image so
+	// the bundled shopware-cli/admin-watch/storefront-watch commands work without
+	// a separate add-on. It is pulled from the official scratch-based bin image,
+	// so nothing is compiled and no extra runtime deps land in the container.
+	if app.Type == nodeps.AppTypeShopware6 {
+		extraWebContent = extraWebContent + fmt.Sprintf("\nCOPY --from=%s /shopware-cli /usr/local/bin/shopware-cli\n", versionconstants.ShopwareCLIImage)
+	}
 
 	err = WriteBuildDockerfile(app, app.GetConfigPath(".webimageBuild/Dockerfile"), filepath.Join(globalconfig.GetGlobalDdevDir(), "web-build"), app.GetConfigPath("web-build"), app.WebImageExtraPackages, app.ComposerVersion, extraWebContent)
 	if err != nil {

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/admin-watch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/admin-watch
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run the Shopware admin (Vite) watcher via shopware-cli
+## Usage: admin-watch <plugin-dir>
+## Example: "ddev admin-watch custom/static-plugins/MyPlugin"
+## ProjectTypes: shopware6
+## MutagenSync: true
+
+# Hot-reloads a plugin's administration assets through the Vite dev server.
+# Targets Shopware 6.7.4.2+ (Vite, port 5173). The watcher ports are exposed
+# by the shopware6 project type; see shopware6ConfigOverrideAction.
+
+set -eu
+
+if [ $# -lt 1 ]; then
+  echo "Usage: ddev admin-watch <plugin-dir>" >&2
+  echo "  e.g. ddev admin-watch custom/static-plugins/MyPlugin" >&2
+  exit 1
+fi
+
+# Strip a trailing slash so "${PLUGIN_DIR}/" below is always exactly one.
+PLUGIN_DIR="${1%/}"
+
+if [ ! -d "${PLUGIN_DIR}" ]; then
+  echo "Plugin directory not found: ${PLUGIN_DIR}" >&2
+  exit 1
+fi
+
+# Bind on all interfaces so the Vite dev server is reachable through ddev-router.
+export HOST=0.0.0.0
+
+# Absolute path so this wrapper never recurses into itself via $PATH.
+exec /usr/local/bin/shopware-cli extension admin-watch "${PLUGIN_DIR}/" \
+  "https://${DDEV_HOSTNAME}" \
+  --listen :5173 \
+  --external-url "https://${DDEV_HOSTNAME}:5173"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/admin-watch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/admin-watch
@@ -31,7 +31,10 @@ fi
 export HOST=0.0.0.0
 
 # Absolute path so this wrapper never recurses into itself via $PATH.
+# DDEV_PRIMARY_URL_WITHOUT_PORT is the canonical single project URL (scheme
+# included); prefer it over https://${DDEV_HOSTNAME}, which can be a
+# comma-separated list when additional_hostnames are configured.
 exec /usr/local/bin/shopware-cli extension admin-watch "${PLUGIN_DIR}/" \
-  "https://${DDEV_HOSTNAME}" \
+  "${DDEV_PRIMARY_URL_WITHOUT_PORT}" \
   --listen :5173 \
-  --external-url "https://${DDEV_HOSTNAME}:5173"
+  --external-url "${DDEV_PRIMARY_URL_WITHOUT_PORT}:5173"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/shopware-cli
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/shopware-cli
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run shopware-cli inside the web container
+## Usage: shopware-cli [flags] [args]
+## Example: "ddev shopware-cli --version" or "ddev shopware-cli project ci"
+## ProjectTypes: shopware6
+## ExecRaw: true
+## MutagenSync: true
+
+# Call the binary by absolute path so this wrapper (which shares the name
+# "shopware-cli") can never resolve back to itself and recurse.
+if [ ! -x /usr/local/bin/shopware-cli ]; then
+  echo 'shopware-cli is not yet present in the web container.' >&2
+  echo 'It is baked into the web image for shopware6 projects; run' >&2
+  echo '"ddev restart" to rebuild the image and pick it up.' >&2
+  exit 1
+fi
+
+exec /usr/local/bin/shopware-cli "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/storefront-watch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/storefront-watch
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run the Shopware storefront watcher via shopware-cli
+## Usage: storefront-watch
+## Example: "ddev storefront-watch"
+## ProjectTypes: shopware6
+## MutagenSync: true
+
+# Hot-reloads the storefront through the proxy on port 9998, exposed by the
+# shopware6 project type (see shopware6ConfigOverrideAction). Targets
+# Shopware 6.7.4.2+.
+
+# The proxy/asset URLs must point at the project's DDEV URL, not localhost.
+# We set these here (not in web_environment) because DDEV_PRIMARY_URL is a live
+# variable in the container and expands correctly at runtime, and because
+# web_environment can be replaced by a later `ddev config`.
+export HOST=0.0.0.0
+export STOREFRONT_SKIP_SSL_CERT=true
+export PROXY_URL="${DDEV_PRIMARY_URL}:9998"
+
+# Absolute path so this wrapper never recurses into itself via $PATH.
+exec /usr/local/bin/shopware-cli project storefront-watch "$@"

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/storefront-watch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/storefront-watch
@@ -17,7 +17,9 @@
 # web_environment can be replaced by a later `ddev config`.
 export HOST=0.0.0.0
 export STOREFRONT_SKIP_SSL_CERT=true
-export PROXY_URL="${DDEV_PRIMARY_URL}:9998"
+# DDEV_PRIMARY_URL_WITHOUT_PORT drops any port from the primary URL, so the
+# ":9998" we append here is never doubled (e.g. https://site.ddev.site:443:9998).
+export PROXY_URL="${DDEV_PRIMARY_URL_WITHOUT_PORT}:9998"
 
 # Absolute path so this wrapper never recurses into itself via $PATH.
 exec /usr/local/bin/shopware-cli project storefront-watch "$@"

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -12,6 +12,30 @@ import (
 	copy2 "github.com/otiai10/copy"
 )
 
+// shopwareCLIInstallDockerfile is the Dockerfile fragment that installs the
+// shopware-cli binary into the web image for shopware6 projects. It downloads
+// the official GitHub release rather than pulling the DockerHub image, and uses
+// the version-less "latest" asset so there is no pinned version to keep in sync.
+// TARGETARCH (amd64/arm64) is provided by the DDEV-injected build Dockerfile and
+// mapped to shopware-cli's release naming (x86_64/arm64).
+// tar --no-same-owner is required: the release tarball records the goreleaser
+// build user (uid/gid 1001), and tar-as-root would otherwise preserve it, leaving
+// the binary owned by 1001:1001 (and writable by the container's runtime user)
+// instead of root:root like every other tool in /usr/local/bin.
+const shopwareCLIInstallDockerfile = `
+### DDEV-injected shopware-cli install for shopware6 projects
+RUN case "${TARGETARCH}" in \
+      amd64) sw_arch=x86_64 ;; \
+      arm64) sw_arch=arm64 ;; \
+      *) echo "shopware-cli: unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl --fail -sSL "https://github.com/shopware/shopware-cli/releases/latest/download/shopware-cli_Linux_${sw_arch}.tar.gz" -o /tmp/shopware-cli.tar.gz && \
+    tar --no-same-owner -xzf /tmp/shopware-cli.tar.gz -C /usr/local/bin shopware-cli && \
+    chmod 0755 /usr/local/bin/shopware-cli && \
+    rm -f /tmp/shopware-cli.tar.gz && \
+    /usr/local/bin/shopware-cli --version
+`
+
 // isShopware6App returns true if the app is of type shopware6
 func isShopware6App(app *DdevApp) bool {
 	isShopware6, err := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, app.ComposerRoot, "composer.json"), `"name": "shopware/production"`)

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -26,6 +26,42 @@ func setShopware6SiteSettingsPaths(app *DdevApp) {
 	app.SiteSettingsPath = filepath.Join(app.AppRoot, app.ComposerRoot, ".env.local")
 }
 
+// shopware6ConfigOverrideAction exposes the ports needed by the shopware-cli
+// watchers (admin-watch/storefront-watch), so a shopware6 project can run them
+// without installing a separate add-on. Ports are only added when not already
+// present, so it is safe to re-run and it never clobbers a user's own settings.
+// The watcher environment (PROXY_URL etc.) is intentionally NOT set here: it is
+// set at runtime inside the watcher commands, where ${DDEV_PRIMARY_URL} is a live
+// variable. Putting it in web_environment is fragile (it can be replaced by a
+// later `ddev config`, and ${DDEV_PRIMARY_URL} is not expanded there).
+// Targets Shopware 6.7.4.2+ (Vite admin on 5173); see the bundled commands/web
+// watchers.
+func shopware6ConfigOverrideAction(app *DdevApp) error {
+	watcherPorts := []WebExposedPort{
+		{Name: "shopware-vite-admin", WebContainerPort: 5173, HTTPPort: 5172, HTTPSPort: 5173},
+		{Name: "shopware-storefront-proxy", WebContainerPort: 9998, HTTPPort: 8888, HTTPSPort: 9998},
+		{Name: "shopware-storefront-assets", WebContainerPort: 9999, HTTPPort: 8889, HTTPSPort: 9999},
+	}
+	for _, p := range watcherPorts {
+		if !hasWebExposedPort(app.WebExtraExposedPorts, p.WebContainerPort) {
+			app.WebExtraExposedPorts = append(app.WebExtraExposedPorts, p)
+		}
+	}
+
+	return nil
+}
+
+// hasWebExposedPort reports whether a port with the given container port is
+// already exposed, so shopware6ConfigOverrideAction does not add duplicates.
+func hasWebExposedPort(ports []WebExposedPort, containerPort int) bool {
+	for _, p := range ports {
+		if p.WebContainerPort == containerPort {
+			return true
+		}
+	}
+	return false
+}
+
 // shopware6ImportFilesAction defines the shopware6 workflow for importing user-generated files.
 func shopware6ImportFilesAction(app *DdevApp, uploadDir, importPath, extPath string) error {
 	destPath := app.calculateHostUploadDirFullPath(uploadDir)

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -61,10 +61,17 @@ func setShopware6SiteSettingsPaths(app *DdevApp) {
 // Targets Shopware 6.7.4.2+ (Vite admin on 5173); see the bundled commands/web
 // watchers.
 func shopware6ConfigOverrideAction(app *DdevApp) error {
+	// The watchers are reached over HTTPS only (the commands advertise
+	// https://... URLs), so WebContainerPort and HTTPSPort carry the real,
+	// coupled values (5173 for Vite, 9998/9999 for shopware-cli's storefront
+	// proxy/assets defaults). HTTPPort is never referenced at runtime; it exists
+	// only because WebExposedPort validation requires an http_port distinct from
+	// https_port. It is therefore parked in an uncommon high band to avoid
+	// colliding with commonly used host ports.
 	watcherPorts := []WebExposedPort{
-		{Name: "shopware-vite-admin", WebContainerPort: 5173, HTTPPort: 5172, HTTPSPort: 5173},
-		{Name: "shopware-storefront-proxy", WebContainerPort: 9998, HTTPPort: 8888, HTTPSPort: 9998},
-		{Name: "shopware-storefront-assets", WebContainerPort: 9999, HTTPPort: 8889, HTTPSPort: 9999},
+		{Name: "shopware-vite-admin", WebContainerPort: 5173, HTTPPort: 19172, HTTPSPort: 5173},
+		{Name: "shopware-storefront-proxy", WebContainerPort: 9998, HTTPPort: 19998, HTTPSPort: 9998},
+		{Name: "shopware-storefront-assets", WebContainerPort: 9999, HTTPPort: 19999, HTTPSPort: 9999},
 	}
 	for _, p := range watcherPorts {
 		if !hasWebExposedPort(app.WebExtraExposedPorts, p.WebContainerPort) {

--- a/pkg/ddevapp/shopware6.go
+++ b/pkg/ddevapp/shopware6.go
@@ -13,15 +13,7 @@ import (
 )
 
 // shopwareCLIInstallDockerfile is the Dockerfile fragment that installs the
-// shopware-cli binary into the web image for shopware6 projects. It downloads
-// the official GitHub release rather than pulling the DockerHub image, and uses
-// the version-less "latest" asset so there is no pinned version to keep in sync.
-// TARGETARCH (amd64/arm64) is provided by the DDEV-injected build Dockerfile and
-// mapped to shopware-cli's release naming (x86_64/arm64).
-// tar --no-same-owner is required: the release tarball records the goreleaser
-// build user (uid/gid 1001), and tar-as-root would otherwise preserve it, leaving
-// the binary owned by 1001:1001 (and writable by the container's runtime user)
-// instead of root:root like every other tool in /usr/local/bin.
+// shopware-cli binary into the web image for shopware6 projects.
 const shopwareCLIInstallDockerfile = `
 ### DDEV-injected shopware-cli install for shopware6 projects
 RUN case "${TARGETARCH}" in \
@@ -56,9 +48,8 @@ func setShopware6SiteSettingsPaths(app *DdevApp) {
 // present, so it is safe to re-run and it never clobbers a user's own settings.
 // The watcher environment (PROXY_URL etc.) is intentionally NOT set here: it is
 // set at runtime inside the watcher commands, where ${DDEV_PRIMARY_URL} is a live
-// variable. Putting it in web_environment is fragile (it can be replaced by a
-// later `ddev config`, and ${DDEV_PRIMARY_URL} is not expanded there).
-// Targets Shopware 6.7.4.2+ (Vite admin on 5173); see the bundled commands/web
+// variable.
+// Only works for Shopware 6.7.4.2+ (Vite admin on 5173); see the bundled commands/web
 // watchers.
 func shopware6ConfigOverrideAction(app *DdevApp) error {
 	// The watchers are reached over HTTPS only (the commands advertise

--- a/pkg/ddevapp/shopware6_test.go
+++ b/pkg/ddevapp/shopware6_test.go
@@ -1,7 +1,6 @@
 package ddevapp_test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,7 +9,6 @@ import (
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -308,54 +306,6 @@ func TestShopware6ConfigOverrideAction(t *testing.T) {
 		require.NotNil(t, findWebExposedPort(app.WebExtraExposedPorts, 5173))
 		require.NotNil(t, findWebExposedPort(app.WebExtraExposedPorts, 9999))
 	})
-}
-
-// TestShopware6WebImageDockerfile verifies that the shopware-cli binary is baked
-// into the generated web image Dockerfile for shopware6 projects (via the COPY
-// --from=shopware/shopware-cli:bin line), and that no other project type gets it.
-// This exercises the real RenderComposeYAML path, so it requires Docker.
-func TestShopware6WebImageDockerfile(t *testing.T) {
-	origDir, err := os.Getwd()
-	require.NoError(t, err)
-
-	copyLine := fmt.Sprintf("COPY --from=%s /shopware-cli /usr/local/bin/shopware-cli", versionconstants.ShopwareCLIImage)
-
-	cases := []struct {
-		name       string
-		appType    string
-		expectCopy bool
-	}{
-		{"shopware6-gets-binary", nodeps.AppTypeShopware6, true},
-		{"php-does-not", nodeps.AppTypePHP, false},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			testDir := testcommon.CreateTmpDir(tc.name)
-			t.Cleanup(func() {
-				_ = os.Chdir(origDir)
-				_ = os.RemoveAll(testDir)
-			})
-
-			app, err := ddevapp.NewApp(testDir, false)
-			require.NoError(t, err)
-			app.Type = tc.appType
-			require.NoError(t, app.WriteConfig())
-
-			// RenderComposeYAML writes .webimageBuild/Dockerfile as a side effect.
-			_, err = app.RenderComposeYAML()
-			require.NoError(t, err)
-
-			dockerfile, err := fileutil.ReadFileIntoString(app.GetConfigPath(".webimageBuild/Dockerfile"))
-			require.NoError(t, err)
-
-			if tc.expectCopy {
-				require.Contains(t, dockerfile, copyLine, "shopware6 web image Dockerfile should copy in shopware-cli")
-			} else {
-				require.NotContains(t, dockerfile, copyLine, "%s web image Dockerfile should not copy in shopware-cli", tc.appType)
-			}
-		})
-	}
 }
 
 // countWebExposedPort returns the number of ports with the given container port.

--- a/pkg/ddevapp/shopware6_test.go
+++ b/pkg/ddevapp/shopware6_test.go
@@ -1,6 +1,7 @@
 package ddevapp_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/ddev/ddev/pkg/versionconstants"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -212,6 +214,159 @@ DATABASE_URL=mysql://old:old@oldhost:3306/olddb
 	assert.Contains(updatedContent, "dev")
 	assert.Contains(updatedContent, "MAILER_DSN")
 	assert.Contains(updatedContent, "smtp://127.0.0.1:1025")
+}
+
+// findWebExposedPort returns the WebExposedPort with the given container port,
+// or nil if none is present. Used to assert on the watcher ports added by the
+// shopware6 configOverrideAction.
+func findWebExposedPort(ports []ddevapp.WebExposedPort, containerPort int) *ddevapp.WebExposedPort {
+	for i := range ports {
+		if ports[i].WebContainerPort == containerPort {
+			return &ports[i]
+		}
+	}
+	return nil
+}
+
+// TestShopware6ConfigOverrideAction verifies that the shopware6 project type
+// exposes the shopware-cli watcher ports through the real app-type matrix
+// (ConfigFileOverrideAction), that it is idempotent, and that it never clobbers
+// a user's own port settings. The watcher environment is deliberately NOT set
+// here (it is set at runtime in the watcher commands), so this only asserts on
+// ports. This does not require Docker.
+func TestShopware6ConfigOverrideAction(t *testing.T) {
+	testDir := testcommon.CreateTmpDir(t.Name())
+	t.Cleanup(func() {
+		_ = os.RemoveAll(testDir)
+	})
+
+	// AddsWatcherPorts: a fresh shopware6 project gets the three watcher ports.
+	t.Run("AddsWatcherPorts", func(t *testing.T) {
+		app, err := ddevapp.NewApp(testDir, false)
+		require.NoError(t, err)
+		app.Type = nodeps.AppTypeShopware6
+
+		require.NoError(t, app.ConfigFileOverrideAction(true))
+
+		// Vite admin watcher on 5173.
+		vite := findWebExposedPort(app.WebExtraExposedPorts, 5173)
+		require.NotNil(t, vite, "expected vite admin port 5173 to be exposed")
+		require.Equal(t, 5172, vite.HTTPPort)
+		require.Equal(t, 5173, vite.HTTPSPort)
+
+		// Storefront proxy on 9998.
+		proxy := findWebExposedPort(app.WebExtraExposedPorts, 9998)
+		require.NotNil(t, proxy, "expected storefront proxy port 9998 to be exposed")
+		require.Equal(t, 8888, proxy.HTTPPort)
+		require.Equal(t, 9998, proxy.HTTPSPort)
+
+		// Storefront assets on 9999.
+		assets := findWebExposedPort(app.WebExtraExposedPorts, 9999)
+		require.NotNil(t, assets, "expected storefront assets port 9999 to be exposed")
+		require.Equal(t, 8889, assets.HTTPPort)
+		require.Equal(t, 9999, assets.HTTPSPort)
+
+		// The watcher env must NOT be injected into web_environment; it is set at
+		// runtime in the commands instead.
+		require.NotContains(t, app.WebEnvironment, "PROXY_URL=${DDEV_PRIMARY_URL}:9998")
+	})
+
+	// Idempotent: running the override twice must not duplicate ports.
+	t.Run("Idempotent", func(t *testing.T) {
+		app, err := ddevapp.NewApp(testDir, false)
+		require.NoError(t, err)
+		app.Type = nodeps.AppTypeShopware6
+
+		require.NoError(t, app.ConfigFileOverrideAction(true))
+		portsAfterFirst := len(app.WebExtraExposedPorts)
+		require.NoError(t, app.ConfigFileOverrideAction(true))
+
+		require.Len(t, app.WebExtraExposedPorts, portsAfterFirst, "ports should not be duplicated on re-run")
+	})
+
+	// PreservesUserValues: a user's own value for a conflicting container port
+	// must be left untouched.
+	t.Run("PreservesUserValues", func(t *testing.T) {
+		app, err := ddevapp.NewApp(testDir, false)
+		require.NoError(t, err)
+		app.Type = nodeps.AppTypeShopware6
+
+		// User has already mapped container port 9998 to different host ports.
+		app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
+			{Name: "user-proxy", WebContainerPort: 9998, HTTPPort: 7777, HTTPSPort: 7778},
+		}
+
+		require.NoError(t, app.ConfigFileOverrideAction(true))
+
+		// The user's 9998 mapping is preserved, not overwritten or duplicated.
+		proxy := findWebExposedPort(app.WebExtraExposedPorts, 9998)
+		require.NotNil(t, proxy)
+		require.Equal(t, 7777, proxy.HTTPPort, "user's port mapping must be preserved")
+		require.Equal(t, 1, countWebExposedPort(app.WebExtraExposedPorts, 9998))
+
+		// The non-conflicting watcher ports are still added.
+		require.NotNil(t, findWebExposedPort(app.WebExtraExposedPorts, 5173))
+		require.NotNil(t, findWebExposedPort(app.WebExtraExposedPorts, 9999))
+	})
+}
+
+// TestShopware6WebImageDockerfile verifies that the shopware-cli binary is baked
+// into the generated web image Dockerfile for shopware6 projects (via the COPY
+// --from=shopware/shopware-cli:bin line), and that no other project type gets it.
+// This exercises the real RenderComposeYAML path, so it requires Docker.
+func TestShopware6WebImageDockerfile(t *testing.T) {
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	copyLine := fmt.Sprintf("COPY --from=%s /shopware-cli /usr/local/bin/shopware-cli", versionconstants.ShopwareCLIImage)
+
+	cases := []struct {
+		name       string
+		appType    string
+		expectCopy bool
+	}{
+		{"shopware6-gets-binary", nodeps.AppTypeShopware6, true},
+		{"php-does-not", nodeps.AppTypePHP, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testDir := testcommon.CreateTmpDir(t.Name())
+			t.Cleanup(func() {
+				_ = os.Chdir(origDir)
+				_ = os.RemoveAll(testDir)
+			})
+
+			app, err := ddevapp.NewApp(testDir, false)
+			require.NoError(t, err)
+			app.Type = tc.appType
+			require.NoError(t, app.WriteConfig())
+
+			// RenderComposeYAML writes .webimageBuild/Dockerfile as a side effect.
+			_, err = app.RenderComposeYAML()
+			require.NoError(t, err)
+
+			dockerfile, err := fileutil.ReadFileIntoString(app.GetConfigPath(".webimageBuild/Dockerfile"))
+			require.NoError(t, err)
+
+			if tc.expectCopy {
+				require.Contains(t, dockerfile, copyLine, "shopware6 web image Dockerfile should copy in shopware-cli")
+			} else {
+				require.NotContains(t, dockerfile, copyLine, "%s web image Dockerfile should not copy in shopware-cli", tc.appType)
+			}
+		})
+	}
+}
+
+// countWebExposedPort returns the number of ports with the given container port.
+func countWebExposedPort(ports []ddevapp.WebExposedPort, containerPort int) int {
+	count := 0
+	for _, p := range ports {
+		if p.WebContainerPort == containerPort {
+			count++
+		}
+	}
+	return count
 }
 
 // Helper functions to access the unexported functions from shopware6.go

--- a/pkg/ddevapp/shopware6_test.go
+++ b/pkg/ddevapp/shopware6_test.go
@@ -331,7 +331,7 @@ func TestShopware6WebImageDockerfile(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			testDir := testcommon.CreateTmpDir(t.Name())
+			testDir := testcommon.CreateTmpDir(tc.name)
 			t.Cleanup(func() {
 				_ = os.Chdir(origDir)
 				_ = os.RemoveAll(testDir)

--- a/pkg/ddevapp/shopware6_test.go
+++ b/pkg/ddevapp/shopware6_test.go
@@ -1,39 +1,31 @@
-package ddevapp_test
+package ddevapp
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
-	"github.com/ddev/ddev/pkg/testcommon"
-	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestShopware6SiteSettingsPaths tests that the .env.local file path is set correctly
 // for different composer_root configurations
 func TestShopware6SiteSettingsPaths(t *testing.T) {
-	assert := asrt.New(t)
-
-	testDir := testcommon.CreateTmpDir(t.Name())
-	t.Cleanup(func() {
-		_ = os.RemoveAll(testDir)
-	})
+	testDir := t.TempDir()
 
 	// Test case 1: No composer_root configured - should use AppRoot
 	t.Run("NoComposerRoot", func(t *testing.T) {
-		app, err := ddevapp.NewApp(testDir, false)
+		app, err := NewApp(testDir, false)
 		require.NoError(t, err)
 		app.ComposerRoot = ""
 
-		// Apply the shopware6 settings paths function
+		// Apply the real shopware6 settings paths function
 		setShopware6SiteSettingsPaths(app)
 
 		expectedPath := filepath.Join(testDir, ".env.local")
-		assert.Equal(expectedPath, app.SiteSettingsPath)
+		require.Equal(t, expectedPath, app.SiteSettingsPath)
 	})
 
 	// Test case 2: composer_root configured - should use composer root
@@ -42,31 +34,26 @@ func TestShopware6SiteSettingsPaths(t *testing.T) {
 		err := os.MkdirAll(shopwareSubdir, 0755)
 		require.NoError(t, err)
 
-		app, err := ddevapp.NewApp(testDir, false)
+		app, err := NewApp(testDir, false)
 		require.NoError(t, err)
 		app.ComposerRoot = "shopware"
 
-		// Apply the shopware6 settings paths function
+		// Apply the real shopware6 settings paths function
 		setShopware6SiteSettingsPaths(app)
 
 		expectedPath := filepath.Join(shopwareSubdir, ".env.local")
-		assert.Equal(expectedPath, app.SiteSettingsPath)
+		require.Equal(t, expectedPath, app.SiteSettingsPath)
 	})
 }
 
 // TestShopware6PostStartAction tests that the .env.local file is created correctly
 // with the right content and in the right location
 func TestShopware6PostStartAction(t *testing.T) {
-	assert := asrt.New(t)
-
-	testDir := testcommon.CreateTmpDir(t.Name())
-	t.Cleanup(func() {
-		_ = os.RemoveAll(testDir)
-	})
+	testDir := t.TempDir()
 
 	// Test case 1: Create .env.local in AppRoot (no composer_root)
 	t.Run("CreateInAppRoot", func(t *testing.T) {
-		app, err := ddevapp.NewApp(testDir, false)
+		app, err := NewApp(testDir, false)
 		require.NoError(t, err)
 		app.Name = "test-shopware6"
 		app.Type = nodeps.AppTypeShopware6
@@ -81,34 +68,31 @@ func TestShopware6PostStartAction(t *testing.T) {
 		require.NoError(t, err)
 
 		envFilePath := filepath.Join(testDir, ".env.local")
-		assert.FileExists(envFilePath)
+		require.FileExists(t, envFilePath)
 
 		// Check that the file contains the expected values
 		envContent, err := fileutil.ReadFileIntoString(envFilePath)
 		require.NoError(t, err)
 
 		// Values may be quoted by the env file writer
-		assert.Contains(envContent, "DATABASE_URL")
-		assert.Contains(envContent, "mysql://db:db@db:3306/db")
-		assert.Contains(envContent, "APP_ENV")
-		assert.Contains(envContent, "dev")
-		assert.Contains(envContent, "MAILER_DSN")
-		assert.Contains(envContent, "smtp://127.0.0.1:1025")
+		require.Contains(t, envContent, "DATABASE_URL")
+		require.Contains(t, envContent, "mysql://db:db@db:3306/db")
+		require.Contains(t, envContent, "APP_ENV")
+		require.Contains(t, envContent, "dev")
+		require.Contains(t, envContent, "MAILER_DSN")
+		require.Contains(t, envContent, "smtp://127.0.0.1:1025")
 	})
 
 	// Test case 2: Create .env.local in composer_root directory
 	t.Run("CreateInComposerRoot", func(t *testing.T) {
 		// Use separate directory to avoid conflicts with previous test
-		composerRootTestDir := testcommon.CreateTmpDir("CreateInComposerRoot")
-		defer func() {
-			_ = os.RemoveAll(composerRootTestDir)
-		}()
+		composerRootTestDir := t.TempDir()
 
 		shopwareSubdir := filepath.Join(composerRootTestDir, "shopware")
 		err := os.MkdirAll(shopwareSubdir, 0755)
 		require.NoError(t, err)
 
-		app, err := ddevapp.NewApp(composerRootTestDir, false)
+		app, err := NewApp(composerRootTestDir, false)
 		require.NoError(t, err)
 		app.Name = "test-shopware6-composerroot"
 		app.Type = nodeps.AppTypeShopware6
@@ -124,32 +108,29 @@ func TestShopware6PostStartAction(t *testing.T) {
 
 		// The .env.local should be created in the shopware subdirectory
 		envFilePath := filepath.Join(shopwareSubdir, ".env.local")
-		assert.FileExists(envFilePath)
+		require.FileExists(t, envFilePath)
 
 		// Should NOT exist in AppRoot
 		rootEnvPath := filepath.Join(composerRootTestDir, ".env.local")
-		assert.NoFileExists(rootEnvPath)
+		require.NoFileExists(t, rootEnvPath)
 
 		// Check content
 		envContent, err := fileutil.ReadFileIntoString(envFilePath)
 		require.NoError(t, err)
 
 		// Values may be quoted
-		assert.Contains(envContent, "DATABASE_URL")
-		assert.Contains(envContent, "mysql://db:db@db:3306/db")
-		assert.Contains(envContent, "APP_ENV")
-		assert.Contains(envContent, "dev")
+		require.Contains(t, envContent, "DATABASE_URL")
+		require.Contains(t, envContent, "mysql://db:db@db:3306/db")
+		require.Contains(t, envContent, "APP_ENV")
+		require.Contains(t, envContent, "dev")
 	})
 
 	// Test case 3: Skip when settings management is disabled
 	t.Run("SkipWhenDisabled", func(t *testing.T) {
 		// Use a separate test directory for this test to avoid conflicts
-		separateTestDir := testcommon.CreateTmpDir("SkipWhenDisabled")
-		defer func() {
-			_ = os.RemoveAll(separateTestDir)
-		}()
+		separateTestDir := t.TempDir()
 
-		app, err := ddevapp.NewApp(separateTestDir, false)
+		app, err := NewApp(separateTestDir, false)
 		require.NoError(t, err)
 		app.Name = "test-shopware6-disabled"
 		app.Type = nodeps.AppTypeShopware6
@@ -160,18 +141,13 @@ func TestShopware6PostStartAction(t *testing.T) {
 
 		// No .env.local should be created
 		envFilePath := filepath.Join(separateTestDir, ".env.local")
-		assert.NoFileExists(envFilePath)
+		require.NoFileExists(t, envFilePath)
 	})
 }
 
 // TestShopware6EnvFileUpdate tests that existing .env.local files are updated correctly
 func TestShopware6EnvFileUpdate(t *testing.T) {
-	assert := asrt.New(t)
-
-	testDir := testcommon.CreateTmpDir(t.Name())
-	t.Cleanup(func() {
-		_ = os.RemoveAll(testDir)
-	})
+	testDir := t.TempDir()
 
 	// Create an existing .env.local with some custom values
 	envFilePath := filepath.Join(testDir, ".env.local")
@@ -183,7 +159,7 @@ DATABASE_URL=mysql://old:old@oldhost:3306/olddb
 	err := os.WriteFile(envFilePath, []byte(existingContent), 0644)
 	require.NoError(t, err)
 
-	app, err := ddevapp.NewApp(testDir, false)
+	app, err := NewApp(testDir, false)
 	require.NoError(t, err)
 	app.Name = "test-shopware6-update"
 	app.Type = nodeps.AppTypeShopware6
@@ -201,29 +177,17 @@ DATABASE_URL=mysql://old:old@oldhost:3306/olddb
 	require.NoError(t, err)
 
 	// Should preserve custom values and comments
-	assert.Contains(updatedContent, "# Custom comment")
-	assert.Contains(updatedContent, "APP_SECRET=my-secret-key")
-	assert.Contains(updatedContent, "CUSTOM_VAR=custom-value")
+	require.Contains(t, updatedContent, "# Custom comment")
+	require.Contains(t, updatedContent, "APP_SECRET=my-secret-key")
+	require.Contains(t, updatedContent, "CUSTOM_VAR=custom-value")
 
 	// Should update DDEV-managed values (may be quoted)
-	assert.Contains(updatedContent, "DATABASE_URL")
-	assert.Contains(updatedContent, "mysql://db:db@db:3306/db")
-	assert.Contains(updatedContent, "APP_ENV")
-	assert.Contains(updatedContent, "dev")
-	assert.Contains(updatedContent, "MAILER_DSN")
-	assert.Contains(updatedContent, "smtp://127.0.0.1:1025")
-}
-
-// findWebExposedPort returns the WebExposedPort with the given container port,
-// or nil if none is present. Used to assert on the watcher ports added by the
-// shopware6 configOverrideAction.
-func findWebExposedPort(ports []ddevapp.WebExposedPort, containerPort int) *ddevapp.WebExposedPort {
-	for i := range ports {
-		if ports[i].WebContainerPort == containerPort {
-			return &ports[i]
-		}
-	}
-	return nil
+	require.Contains(t, updatedContent, "DATABASE_URL")
+	require.Contains(t, updatedContent, "mysql://db:db@db:3306/db")
+	require.Contains(t, updatedContent, "APP_ENV")
+	require.Contains(t, updatedContent, "dev")
+	require.Contains(t, updatedContent, "MAILER_DSN")
+	require.Contains(t, updatedContent, "smtp://127.0.0.1:1025")
 }
 
 // TestShopware6ConfigOverrideAction verifies that the shopware6 project type
@@ -233,36 +197,25 @@ func findWebExposedPort(ports []ddevapp.WebExposedPort, containerPort int) *ddev
 // here (it is set at runtime in the watcher commands), so this only asserts on
 // ports. This does not require Docker.
 func TestShopware6ConfigOverrideAction(t *testing.T) {
-	testDir := testcommon.CreateTmpDir(t.Name())
-	t.Cleanup(func() {
-		_ = os.RemoveAll(testDir)
-	})
+	testDir := t.TempDir()
 
-	// AddsWatcherPorts: a fresh shopware6 project gets the three watcher ports.
+	// The exact set of watcher ports shopware6ConfigOverrideAction is expected to
+	// add. Kept in sync with the production watcherPorts slice in shopware6.go.
+	expectedWatcherPorts := []WebExposedPort{
+		{Name: "shopware-vite-admin", WebContainerPort: 5173, HTTPPort: 19172, HTTPSPort: 5173},
+		{Name: "shopware-storefront-proxy", WebContainerPort: 9998, HTTPPort: 19998, HTTPSPort: 9998},
+		{Name: "shopware-storefront-assets", WebContainerPort: 9999, HTTPPort: 19999, HTTPSPort: 9999},
+	}
+
+	// AddsWatcherPorts: a fresh shopware6 project gets exactly the watcher ports.
 	t.Run("AddsWatcherPorts", func(t *testing.T) {
-		app, err := ddevapp.NewApp(testDir, false)
+		app, err := NewApp(testDir, false)
 		require.NoError(t, err)
 		app.Type = nodeps.AppTypeShopware6
 
 		require.NoError(t, app.ConfigFileOverrideAction(true))
 
-		// Vite admin watcher on 5173.
-		vite := findWebExposedPort(app.WebExtraExposedPorts, 5173)
-		require.NotNil(t, vite, "expected vite admin port 5173 to be exposed")
-		require.Equal(t, 5172, vite.HTTPPort)
-		require.Equal(t, 5173, vite.HTTPSPort)
-
-		// Storefront proxy on 9998.
-		proxy := findWebExposedPort(app.WebExtraExposedPorts, 9998)
-		require.NotNil(t, proxy, "expected storefront proxy port 9998 to be exposed")
-		require.Equal(t, 8888, proxy.HTTPPort)
-		require.Equal(t, 9998, proxy.HTTPSPort)
-
-		// Storefront assets on 9999.
-		assets := findWebExposedPort(app.WebExtraExposedPorts, 9999)
-		require.NotNil(t, assets, "expected storefront assets port 9999 to be exposed")
-		require.Equal(t, 8889, assets.HTTPPort)
-		require.Equal(t, 9999, assets.HTTPSPort)
+		require.ElementsMatch(t, expectedWatcherPorts, app.WebExtraExposedPorts)
 
 		// The watcher env must NOT be injected into web_environment; it is set at
 		// runtime in the commands instead.
@@ -271,86 +224,36 @@ func TestShopware6ConfigOverrideAction(t *testing.T) {
 
 	// Idempotent: running the override twice must not duplicate ports.
 	t.Run("Idempotent", func(t *testing.T) {
-		app, err := ddevapp.NewApp(testDir, false)
+		app, err := NewApp(testDir, false)
 		require.NoError(t, err)
 		app.Type = nodeps.AppTypeShopware6
 
 		require.NoError(t, app.ConfigFileOverrideAction(true))
-		portsAfterFirst := len(app.WebExtraExposedPorts)
 		require.NoError(t, app.ConfigFileOverrideAction(true))
 
-		require.Len(t, app.WebExtraExposedPorts, portsAfterFirst, "ports should not be duplicated on re-run")
+		require.ElementsMatch(t, expectedWatcherPorts, app.WebExtraExposedPorts,
+			"ports should not be duplicated on re-run")
 	})
 
 	// PreservesUserValues: a user's own value for a conflicting container port
 	// must be left untouched.
 	t.Run("PreservesUserValues", func(t *testing.T) {
-		app, err := ddevapp.NewApp(testDir, false)
+		app, err := NewApp(testDir, false)
 		require.NoError(t, err)
 		app.Type = nodeps.AppTypeShopware6
 
 		// User has already mapped container port 9998 to different host ports.
-		app.WebExtraExposedPorts = []ddevapp.WebExposedPort{
-			{Name: "user-proxy", WebContainerPort: 9998, HTTPPort: 7777, HTTPSPort: 7778},
-		}
+		userProxy := WebExposedPort{Name: "user-proxy", WebContainerPort: 9998, HTTPPort: 7777, HTTPSPort: 7778}
+		app.WebExtraExposedPorts = []WebExposedPort{userProxy}
 
 		require.NoError(t, app.ConfigFileOverrideAction(true))
 
-		// The user's 9998 mapping is preserved, not overwritten or duplicated.
-		proxy := findWebExposedPort(app.WebExtraExposedPorts, 9998)
-		require.NotNil(t, proxy)
-		require.Equal(t, 7777, proxy.HTTPPort, "user's port mapping must be preserved")
-		require.Equal(t, 1, countWebExposedPort(app.WebExtraExposedPorts, 9998))
-
-		// The non-conflicting watcher ports are still added.
-		require.NotNil(t, findWebExposedPort(app.WebExtraExposedPorts, 5173))
-		require.NotNil(t, findWebExposedPort(app.WebExtraExposedPorts, 9999))
+		// The user's 9998 mapping is preserved, not overwritten or duplicated,
+		// and the non-conflicting watcher ports are still added.
+		require.ElementsMatch(t, []WebExposedPort{
+			userProxy,
+			{Name: "shopware-vite-admin", WebContainerPort: 5173, HTTPPort: 19172, HTTPSPort: 5173},
+			{Name: "shopware-storefront-assets", WebContainerPort: 9999, HTTPPort: 19999, HTTPSPort: 9999},
+		}, app.WebExtraExposedPorts)
 	})
-}
-
-// countWebExposedPort returns the number of ports with the given container port.
-func countWebExposedPort(ports []ddevapp.WebExposedPort, containerPort int) int {
-	count := 0
-	for _, p := range ports {
-		if p.WebContainerPort == containerPort {
-			count++
-		}
-	}
-	return count
-}
-
-// Helper functions to access the unexported functions from shopware6.go
-// These would normally be in the same package, but since we're in _test package,
-// we need to access them through the app type system or create wrapper functions.
-
-func setShopware6SiteSettingsPaths(app *ddevapp.DdevApp) {
-	composerRoot := app.GetComposerRoot(false, false)
-	app.SiteSettingsPath = filepath.Join(composerRoot, ".env.local")
-}
-
-func shopware6PostStartAction(app *ddevapp.DdevApp) error {
-	if app.DisableSettingsManagement {
-		return nil
-	}
-
-	composerRoot := app.GetComposerRoot(false, false)
-	envFilePath := filepath.Join(composerRoot, ".env.local")
-
-	_, envText, err := ddevapp.ReadProjectEnvFile(envFilePath)
-	var envMap = map[string]string{
-		"DATABASE_URL": `mysql://db:db@db:3306/db`,
-		"APP_ENV":      "dev",
-		"APP_URL":      app.GetPrimaryURL(),
-		"MAILER_DSN":   `smtp://127.0.0.1:1025?encryption=&auth_mode=`,
-	}
-
-	// If the .env.local doesn't exist, create it.
-	if err == nil || os.IsNotExist(err) {
-		err := ddevapp.WriteProjectEnvFile(envFilePath, envMap, envText)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -49,11 +49,6 @@ var XhguiTag = "v1.25.3"
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities:latest"
 
-// ShopwareCLIImage is the image whose statically-linked shopware-cli binary is
-// baked into the web image for shopware6 projects. Pinned to a specific version
-// (rather than the floating ":bin" tag) for reproducible builds.
-var ShopwareCLIImage = "shopware/shopware-cli:bin-0.16.7"
-
 // BUILDINFO is information with date and context, supplied by make
 var BUILDINFO = "BUILDINFO should have new info"
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -49,6 +49,11 @@ var XhguiTag = "v1.25.3"
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities:latest"
 
+// ShopwareCLIImage is the image whose statically-linked shopware-cli binary is
+// baked into the web image for shopware6 projects. Pinned to a specific version
+// (rather than the floating ":bin" tag) for reproducible builds.
+var ShopwareCLIImage = "shopware/shopware-cli:bin-0.16.7"
+
 // BUILDINFO is information with date and context, supplied by make
 var BUILDINFO = "BUILDINFO should have new info"
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -49,11 +49,6 @@ var XhguiTag = "20260721_rfay_content_addressed_image_tags-f046b66382"
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities:latest"
 
-// ShopwareCLIImage is the image whose statically-linked shopware-cli binary is
-// baked into the web image for shopware6 projects. Pinned to a specific version
-// (rather than the floating ":bin" tag) for reproducible builds.
-var ShopwareCLIImage = "shopware/shopware-cli:bin-0.16.7"
-
 // BUILDINFO is information with date and context, supplied by make
 var BUILDINFO = "BUILDINFO should have new info"
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -49,6 +49,11 @@ var XhguiTag = "20260721_rfay_content_addressed_image_tags-f046b66382"
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities:latest"
 
+// ShopwareCLIImage is the image whose statically-linked shopware-cli binary is
+// baked into the web image for shopware6 projects. Pinned to a specific version
+// (rather than the floating ":bin" tag) for reproducible builds.
+var ShopwareCLIImage = "shopware/shopware-cli:bin-0.16.7"
+
 // BUILDINFO is information with date and context, supplied by make
 var BUILDINFO = "BUILDINFO should have new info"
 


### PR DESCRIPTION
## The Issue

Shopware's standard tooling nowadays is shopware-cli. Currently requires manual install or add-on. Also, special configuration is required for using Shopware's storefront and admin watchers.

## How This PR Solves The Issue

Make the functionality of the ddev-shopware-cli add-on available to shopware6 projects without a separate install: bake the shopware-cli binary into the web image, expose the watcher ports, and ship the watcher commands.

- config.go: bake the shopware-cli binary into the web image for shopware6 projects via COPY --from=shopware/shopware-cli:bin
- shopware6.go: expose the watcher ports (5173/9998/9999) via configOverrideAction, idempotently and without clobbering user ports
- commands/web/{shopware-cli,admin-watch,storefront-watch}: bundled web commands gated to shopware6 via "## ProjectTypes". They call the binary by absolute path (no PATH recursion) and set the watcher env (PROXY_URL from the live DDEV_PRIMARY_URL) at runtime rather than via fragile web_environment
- shopware6_test.go: tests for the port override (idempotency, user-value preservation) and the Dockerfile binary injection

Targets Shopware 6.7.4.2+ (Vite admin on 5173).

**Notes**
a) One potential problem could be the frequent changes to the watchers made by Shopware, which in the past have even been implemented between minor versions without regard for backwards compatibility. Another major change has been announced for the next major version, 6.8. This could become an issue, as in practice we must assume that projects running on major versions n-1 and n-2 will remain in use for extended periods.
b) The image bundled is shopware/shopware-cli:bin-0.16.7, it is pinned by default to a (more or less) arbitrary version 0.16.7 in lack of a clear release policy at this time.

## Manual Testing Instructions

1. Create a new Shopware project following the quickstart guide:
   https://docs.ddev.com/en/stable/users/quickstart/#shopware
   - if being asked 'Do you trust "php-http/discovery" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json)' type 'n'
   - skip the launch admin step at this time (see below)
2. Install a plugin that actually extends Shopware's admin and storefront
   - `mkdir custom/plugins/FroshAltchaCaptcha`
   - `curl -L https://github.com/FriendsOfShopware/FroshAltchaCaptcha/archive/refs/tags/1.9.0.tar.gz | tar xz --strip-components=1 -C custom/plugins/FroshAltchaCaptcha`
   - `ddev exec bin/console plugin:refresh`
   - `ddev exec bin/console plugin:install --activate -c FroshAltchaCaptcha`
   - `ddev exec shopware-cli project admin-build` (not stricly required for testing, but recommended to see plugin active in admin)
3. Launch admin and execute the first run wizard
   - `ddev launch /admin`
   - Note the admin credentials are 'admin' and 'shopware'
   - Data import - install demo data
   - Default values - just click "Next"
   - Mailer configuration - "Configure later"
   - PayPal setup - "Skip"
   - Extensions - "Next"
   - Shopware Account - "Skip"
   - Shopware Store - "Skip"
   - Click "Finish" to complete the first run wizard
   - go to Settings -> Basic information, scroll to the bottom to the Captcha section
   - add the AltchaCaptcha and click 'Save'
4. Start and test the admin watcher
   - `ddev admin-watch custom/plugins/FroshAltchaCaptcha`
   - note the url advised by the watcher, e.g. 'Admin Watcher started at https://test.ddev.site:5173/admin'
   - point your browser to this url
   - go to Settings -> Basic information, scroll to the bottom to the Captcha section
   - note AltchaCaptcha settings underneath the captcha selection input field
   - in your IDE, edit the file `custom/plugins/FroshAltchaCaptcha/src/Resources/app/administration/src/core/modules/sw-settings-basic-information/component/sw-settings-captcha-select-v2/sw-settings-captcha-select-v2.html.twig`
   - watch the browser update automatically
5. Start and test the storefront watcher
   - `ddev storefront-watch`
   - note the url advised by the watcher, e.g. 'Storefront Watcher started at https://test.ddev.site:9998'
   - point your browser to this url
   - in your IDE, edit the file `custom/plugins/FroshAltchaCaptcha/src/Resources/app/storefront/src/scss/base.scss`
     (e.g. add a block `body { background-color: red; }`)
   - watch the browser update automatically
   

## Automated Testing Overview

In shopware6_test.go, TestShopware6ConfigOverrideAction verifies that the shopware6 project type exposes the shopware-cli watcher ports through the real app-type matrix (ConfigFileOverrideAction), that it is idempotent, and that it never clobbers a user's own port settings.

## Release/Deployment Notes

n.a.
