### PR TITLE
fix(nodejs): stop recursively chgrp/chmod'ing /usr/local/n on every project build, fixes #8600

### DIFF
--- a/.github/workflows/perf-start-time.yml
+++ b/.github/workflows/perf-start-time.yml
@@ -62,6 +62,24 @@ jobs:
           # Need history for both the current commit and the baseline ref.
           fetch-depth: 0
 
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
+          setup-sandbox: true
+
+      - name: Remove unnecessary items on disk
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
       - name: Install test dependencies (linux-setup.sh)
         run: ./.github/workflows/linux-setup.sh
 
@@ -108,6 +126,6 @@ jobs:
           {
             echo "### Start/rebuild performance: baseline (\`${{ steps.baseline.outputs.ref }}\`) vs this commit"
             echo '```'
-            cat /tmp/perf-compare.log
+            cat /tmp/perf-compare.log 2>/dev/null || echo "(no output captured; the comparison step likely failed before finishing)"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/perf-start-time.yml
+++ b/.github/workflows/perf-start-time.yml
@@ -1,0 +1,113 @@
+name: Start-time performance check
+defaults:
+  run:
+    shell: bash
+
+# This checks the performance of the Dockerfile/docker-compose layers DDEV
+# generates and builds at project-build/start time (WriteBuildDockerfile,
+# app_compose_template.yaml, and the base images they build from) - not
+# container correctness, which is covered by container-tests.yml. See
+# https://github.com/ddev/ddev/issues/8600, where a change to those layers
+# regressed `ddev utility rebuild` from ~10s to 27s+ (and much worse on
+# some filesystems) without failing any existing test.
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "pkg/ddevapp/config.go"
+      - "pkg/ddevapp/app_compose_template.yaml"
+      - "containers/ddev-php-base/Dockerfile"
+      - "containers/ddev-webserver/Dockerfile"
+      - "scripts/compare-start-perf.sh"
+      - ".github/workflows/perf-start-time.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "pkg/ddevapp/config.go"
+      - "pkg/ddevapp/app_compose_template.yaml"
+      - "containers/ddev-php-base/Dockerfile"
+      - "containers/ddev-webserver/Dockerfile"
+      - "scripts/compare-start-perf.sh"
+  schedule:
+    # Nightly trend check against the latest release, regardless of what
+    # changed - catches drift from base-image updates on Docker Hub, etc.
+    - cron: '17 00 * * *'
+  workflow_dispatch:
+    inputs:
+      baseline:
+        description: 'Baseline ref to compare against (default: latest release tag on schedule/push, PR base commit on pull_request)'
+        required: false
+        default: ''
+      debug_enabled:
+        description: 'Run the build with tmate set "debug_enabled"'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  start-perf-regression:
+    name: ddev start / ddev utility rebuild performance
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Need history for both the current commit and the baseline ref.
+          fetch-depth: 0
+
+      - name: Install test dependencies (linux-setup.sh)
+        run: ./.github/workflows/linux-setup.sh
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.23'
+          check-latest: true
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+
+      - name: Determine baseline ref
+        id: baseline
+        run: |
+          if [ -n "${{ inputs.baseline }}" ]; then
+            ref="${{ inputs.baseline }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            ref="${{ github.event.pull_request.base.sha }}"
+          else
+            ref=$(git describe --tags --abbrev=0)
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      # Comparing two refs on the same runner in the same job cancels out
+      # most of the noise inherent to shared GitHub-hosted runners, but
+      # some run-to-run jitter is unavoidable. This is informational only
+      # (not a required check) until we've watched it for stability.
+      - name: Compare ddev start / ddev utility rebuild performance
+        env:
+          DDEV_NO_INSTRUMENTATION: "true"
+        run: |
+          set -eu -o pipefail
+          scripts/compare-start-perf.sh -n 3 -b 3 -m off -P \
+            "${{ steps.baseline.outputs.ref }}" "${{ github.sha }}" \
+            2>&1 | tee /tmp/perf-compare.log
+
+      - name: Post summary
+        if: always()
+        run: |
+          {
+            echo "### Start/rebuild performance: baseline (\`${{ steps.baseline.outputs.ref }}\`) vs this commit"
+            echo '```'
+            cat /tmp/perf-compare.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/containers/ddev-php-base/Dockerfile
+++ b/containers/ddev-php-base/Dockerfile
@@ -117,6 +117,16 @@ RUN curl -L --fail -o /usr/local/bin/n -sSL https://raw.githubusercontent.com/tj
 RUN N_PREFIX=/usr/local/n n install --cleanup "${NODE_VERSION}"
 RUN npm install --unsafe-perm=true --global gulp-cli yarn
 
+# Make /usr/local/n writable here, once, for any container user, instead of
+# recursively chgrp/chmod'ing it on every project's web image build (which was
+# slow, see https://github.com/ddev/ddev/issues/8600): use the "arbitrary UID"
+# technique of owning it by the root group (gid 0) and making it group-writable,
+# so any per-project user just needs to be a member of group 0 (added in
+# WriteBuildDockerfile in pkg/ddevapp/config.go) to get write access, with no
+# per-project recursive walk of this directory needed. See
+# https://developers.redhat.com/blog/2020/10/26/adapting-docker-and-kubernetes-containers-to-run-on-red-hat-openshift-container-platform
+RUN chgrp -R 0 /usr/local/n && chmod -R g+rwX,o-w /usr/local/n
+
 # Loop through $PHP_VERSIONS, selecting packages for the target architecture.
 RUN for v in ${PHP_VERSIONS}; do \
     /usr/local/bin/install_php_extensions.sh "$v" "${TARGETPLATFORM#linux/}"; \

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
 ARG DOCKER_ORG=ddev
-FROM ${DOCKER_ORG}/ddev-php-base:v1.25.3 AS ddev-webserver-base
+FROM ${DOCKER_ORG}/ddev-php-base:20260719_rfay_n_prefix_group0 AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -3,7 +3,7 @@
 ### ddev-php-base is the basic of ddev-php-prod
 ### and ddev-webserver-* (For DDEV local Usage)
 ARG DOCKER_ORG=ddev
-FROM ${DOCKER_ORG}/ddev-php-base:20260719_rfay_n_prefix_group0 AS ddev-webserver-base
+FROM ${DOCKER_ORG}/ddev-php-base:20260719_build_perf_script AS ddev-webserver-base
 SHELL ["/bin/bash", "-eu","-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -160,6 +160,16 @@ services:
 
     restart: "no"
     user: '$DDEV_UID:$DDEV_GID'
+    # Group 0 (root) is added here because Docker does not derive supplementary
+    # groups from /etc/group when both uid and gid are given explicitly (as
+    # above); it must be requested with group_add. This lets the container user
+    # read/write directories baked group-writable-by-root in the image (e.g.
+    # /usr/local/n, see containers/ddev-php-base/Dockerfile and the useradd
+    # command in WriteBuildDockerfile), instead of DDEV chgrp/chmod'ing them
+    # for every project. See
+    # https://developers.redhat.com/blog/2020/10/26/adapting-docker-and-kubernetes-containers-to-run-on-red-hat-openshift-container-platform
+    group_add:
+      - "0"
     hostname: {{ .Name }}-web
 
     ports:

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1051,6 +1051,12 @@ if [ -n "$INSTALL_PKGS" ]; then
   log-stderr.sh npm install --unsafe-perm=true --global $INSTALL_PKGS -f || true
 fi
 cd /tmp && rm -rf /tmp/n-version-files
+# n installs by overwriting the files baked into the base image (see
+# containers/ddev-php-base/Dockerfile), which resets them to root-only
+# permissions, so group-writability by root (gid 0) has to be reapplied here.
+# Only needed on this non-default Node.js version path; the common case
+# (default Node.js version) is already handled once in the base image.
+chgrp -R 0 /usr/local/n && chmod -R g+rwX,o-w /usr/local/n
 EOF
 `, app.NodeJSVersion)
 	}
@@ -1257,11 +1263,16 @@ ARG gid
 ARG DDEV_PHP_VERSION
 ARG DDEV_DATABASE
 RUN getent group tty || groupadd tty
+# Group 0 (root) is added here so this user can read/write directories that are
+# baked group-writable-by-root in the base image (e.g. /usr/local/n, see
+# containers/ddev-php-base/Dockerfile) without a per-project chgrp/chmod of
+# those directories. See the note near the chmod -R below, and
+# https://developers.redhat.com/blog/2020/10/26/adapting-docker-and-kubernetes-containers-to-run-on-red-hat-openshift-container-platform
 RUN (groupadd --gid "$gid" "$username" || groupadd "$username" || true) && \
-    (useradd -G tty -l -m -s "/bin/bash" --gid "$username" --comment '' --uid "$uid" "$username" || \
-    useradd -G tty -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || \
-    useradd -G tty -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username" || \
-    useradd -G tty -l -m -s "/bin/bash" --comment '' "$username")
+    (useradd -G tty,0 -l -m -s "/bin/bash" --gid "$username" --comment '' --uid "$uid" "$username" || \
+    useradd -G tty,0 -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || \
+    useradd -G tty,0 -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username" || \
+    useradd -G tty,0 -l -m -s "/bin/bash" --comment '' "$username")
 `
 
 	// If there are user pre.Dockerfile* files, insert their contents
@@ -1425,8 +1436,8 @@ RUN mkdir -p /run/php /var/run/nginx /var/run/supervisor /var/run/apache2 /var/l
     touch /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log /var/log/supervisord.log && \
     chmod ugo+rw /var/log/nginx/error.log /var/log/nginx/access.log /var/log/php-fpm.log /var/log/supervisord.log && \
     chmod ugo+rwX /var/log/nginx /var/log/apache2 && \
-    chgrp -R "$gid" /etc/alternatives /var/lib/dpkg/alternatives /usr/local/n && \
-    chmod -R g+rwX,o-w /etc/alternatives /var/lib/dpkg/alternatives /usr/local/n && \
+    chgrp -R "$gid" /etc/alternatives /var/lib/dpkg/alternatives && \
+    chmod -R g+rwX,o-w /etc/alternatives /var/lib/dpkg/alternatives && \
     chmod -f ugo+rx /usr/local/bin /usr/local/bin/* && \
     chgrp "$gid" /usr/local/bin/composer && chmod g+rwx,o-w /usr/local/bin/composer && \
     mkdir -p /tmp/xhprof && chmod -R ugo+w /etc/php /var/lib/php /tmp/xhprof

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260719_rfay_n_prefix_group0" // Note that this can be overridden by make
+var WebTag = "20260719_build_perf_script" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260715_rfay_webserver_404_message" // Note that this can be overridden by make
+var WebTag = "20260719_rfay_n_prefix_group0" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"

--- a/scripts/compare-start-perf.sh
+++ b/scripts/compare-start-perf.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # compare-start-perf.sh
 #
-# Compare `ddev start` performance between any two DDEV commits.
+# Compare `ddev start` and `ddev utility rebuild` performance between any two
+# DDEV commits.
 #
 # It builds each commit in an isolated git worktree (your working tree is left
 # untouched), creates a throwaway project for each, and times repeated
-# `ddev start` runs. Results are printed as plain text.
+# `ddev start` and `ddev utility rebuild` runs. Results are printed as plain
+# text.
 #
 # Works on macOS (bash 3.2 / BSD date) and Linux. It has no hard dependency on
 # Mutagen and runs whether or not Mutagen is installed. By default it uses your
@@ -24,7 +26,9 @@
 # projects you have running. Use -P to skip it.
 #
 # Options:
-#   -n NUM     number of timed (warm) start runs per commit   (default: 5)
+#   -n NUM     number of timed (warm) start runs per commit     (default: 5)
+#   -b NUM     number of timed 'ddev utility rebuild' runs      (default: 3)
+#              per commit; 0 disables the rebuild comparison
 #   -t TYPE    ddev project type for the test project          (default: php)
 #   -m MODE    Mutagen: on | off | default (global config)     (default: default)
 #   -P         do NOT run 'ddev poweroff' before each commit   (default: do it)
@@ -35,23 +39,26 @@
 #   scripts/compare-start-perf.sh upstream/main HEAD
 #   scripts/compare-start-perf.sh -n 10 -m off v1.25.0 HEAD
 #   scripts/compare-start-perf.sh -m on upstream/main HEAD
+#   scripts/compare-start-perf.sh -b 5 upstream/main HEAD
 
 set -u
 
 RUNS=5
+REBUILD_RUNS=3
 PROJECT_TYPE=php
 KEEP=0
 MUTAGEN_MODE=default
 POWEROFF=1
 
 usage() {
-  sed -n '2,37p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 
-while getopts ":n:t:m:Pkh" opt; do
+while getopts ":n:b:t:m:Pkh" opt; do
   case "$opt" in
     n) RUNS=$OPTARG ;;
+    b) REBUILD_RUNS=$OPTARG ;;
     t) PROJECT_TYPE=$OPTARG ;;
     m) MUTAGEN_MODE=$OPTARG ;;
     P) POWEROFF=0 ;;
@@ -74,6 +81,10 @@ case "$RUNS" in
   ''|*[!0-9]*) echo "Error: -n must be a positive integer" >&2; exit 1 ;;
 esac
 [ "$RUNS" -ge 1 ] || { echo "Error: -n must be >= 1" >&2; exit 1; }
+
+case "$REBUILD_RUNS" in
+  ''|*[!0-9]*) echo "Error: -b must be a non-negative integer" >&2; exit 1 ;;
+esac
 
 # Map Mutagen mode to the config flag value and the config.yaml key fallback.
 case "$MUTAGEN_MODE" in
@@ -159,17 +170,18 @@ outlier_runs() {
     fi
   done
 }
-# report_warm <label> <values...> : per-commit warm-start lines, with outlier note.
-report_warm() {
-  label=$1; shift
+# report_stats <name> <values...> : per-commit stats line for a named metric
+# (e.g. "start", "rebuild"), with an outlier note when a run looks anomalous.
+report_stats() {
+  name=$1; shift
   med=$(median "$@")
-  echo "  start: $(stats "$@")"
+  echo "  $name: $(stats "$@")"
   outs=$(outlier_runs "$med" "$@")
   if [ -n "$outs" ]; then
     echo "  NOTE: anomalous run(s) excluded from trimmed mean: $outs"
     echo "        (a one-time 'docker build --no-cache' rebuild or a Docker/network stall"
     echo "         can cause this; median and trimmed mean are the reliable numbers)"
-    echo "  start (trimmed): median=${med}s  mean=$(trimmed_mean "$med" "$@")s"
+    echo "  $name (trimmed): median=${med}s  mean=$(trimmed_mean "$med" "$@")s"
   fi
 }
 
@@ -231,16 +243,24 @@ build_commit() {
   git -C "$REPO_ROOT" worktree remove --force "$wt" >/dev/null 2>&1
   ver=$("$bindir/ddev" --version 2>/dev/null)
   eval "RESULT_VERSION_$label=\$ver"
+  # `ddev debug` was renamed to `ddev utility` (with `debug` kept as an alias),
+  # so this only matters for commits that predate the rename.
+  if "$bindir/ddev" utility --help >/dev/null 2>&1; then
+    eval "REBUILD_CMD_$label=utility"
+  else
+    eval "REBUILD_CMD_$label=debug"
+  fi
 }
 
 # --- benchmark one binary ----------------------------------------------------
-# Sets globals: RESULT_VERSION, RESULT_COLD, and fills the named array via eval.
+# Sets globals: RESULT_VERSION, RESULT_COLD, and fills the named arrays via eval.
 benchmark() {
-  label=$1; proj=$2; arrname=$3
+  label=$1; proj=$2; warm_arrname=$3; rebuild_arrname=$4
   bindir="$WORKDIR/bin-$label"
   projdir="$PROJ_BASE/proj-$label"
   log="$WORKDIR/run-$label.log"
   REF_VAL=$(eval "echo \$RESULT_VERSION_$label")
+  rebuild_cmd=$(eval "echo \$REBUILD_CMD_$label")
   export PATH="$bindir:$PATH_ORIG"
   : >"$log"
 
@@ -307,14 +327,17 @@ benchmark() {
       || echo "  Warning: image pre-download failed for $label (continuing anyway)" >&2
   fi
 
-  # Cold start (first build is uncached for this project).
-  echo "  cold start (build + up; may take a few minutes) ..."
+  # Prime the project: the very first build for this project is always
+  # uncached, so use `ddev utility rebuild` (build the web image + restart)
+  # rather than `ddev start`. This also means the warm-start runs below never
+  # need to build anything, since nothing changes between them.
+  echo "  cold build (ddev $rebuild_cmd rebuild; may take a few minutes) ..."
   t0=$(now)
-  run_ddev "cold 'ddev start' failed" start -y
+  run_ddev "cold 'ddev $rebuild_cmd rebuild' failed" "$rebuild_cmd" rebuild
   t1=$(now)
   cold=$(elapsed "$t0" "$t1")
   eval "RESULT_COLD_$label=\$cold"
-  echo "    cold start: ${cold}s"
+  echo "    cold build: ${cold}s"
 
   # Each timed run measures `ddev start` from a STOPPED state: an untimed
   # `ddev stop` first, then time `ddev start`. This is the representative
@@ -326,7 +349,7 @@ benchmark() {
   run_ddev "warmup 'ddev start' failed" start -y
 
   echo "  timed starts from stopped state ($RUNS):"
-  eval "$arrname=()"
+  eval "$warm_arrname=()"
   i=1
   while [ "$i" -le "$RUNS" ]; do
     run_ddev "'ddev stop' before run $i failed" stop
@@ -334,10 +357,30 @@ benchmark() {
     run_ddev "'ddev start' run $i failed" start -y
     t1=$(now)
     e=$(elapsed "$t0" "$t1")
-    eval "$arrname+=(\"\$e\")"
+    eval "$warm_arrname+=(\"\$e\")"
     printf "    run %d: %ss\n" "$i" "$e"
     i=$((i + 1))
   done
+
+  # Timed `ddev utility rebuild` runs: this is a full `docker build --no-cache`
+  # of the web image followed by a project restart, and is the operation that
+  # regressed in https://github.com/ddev/ddev/issues/8600 (a slow `chmod -R` in
+  # the webimage Dockerfile). `ddev start` alone does not exercise this once the
+  # image is cached, so it is timed separately here.
+  eval "$rebuild_arrname=()"
+  if [ "$REBUILD_RUNS" -gt 0 ]; then
+    echo "  timed '$rebuild_cmd rebuild' runs ($REBUILD_RUNS; may take a few minutes) ..."
+    i=1
+    while [ "$i" -le "$REBUILD_RUNS" ]; do
+      t0=$(now)
+      run_ddev "'ddev $rebuild_cmd rebuild' run $i failed" "$rebuild_cmd" rebuild
+      t1=$(now)
+      e=$(elapsed "$t0" "$t1")
+      eval "$rebuild_arrname+=(\"\$e\")"
+      printf "    run %d: %ss\n" "$i" "$e"
+      i=$((i + 1))
+    done
+  fi
 }
 
 # --- run ---------------------------------------------------------------------
@@ -346,12 +389,12 @@ SHA_A=$(git -C "$REPO_ROOT" rev-parse --short "$REF_A")
 SHA_B=$(git -C "$REPO_ROOT" rev-parse --short "$REF_B")
 
 echo "==================================================================="
-echo "DDEV  ddev start  performance comparison"
+echo "DDEV  ddev start / ddev utility rebuild  performance comparison"
 echo "==================================================================="
-echo "Commit A : $REF_A ($SHA_A)"
-echo "Commit B : $REF_B ($SHA_B)"
-echo "Warm runs: $RUNS    Project type: $PROJECT_TYPE    Timer: $TIMER"
-echo "Mutagen  : $MUTAGEN_MODE (start time includes Mutagen sync when enabled)"
+echo "Commit A    : $REF_A ($SHA_A)"
+echo "Commit B    : $REF_B ($SHA_B)"
+echo "Warm runs   : $RUNS    Rebuild runs: $REBUILD_RUNS    Project type: $PROJECT_TYPE    Timer: $TIMER"
+echo "Mutagen     : $MUTAGEN_MODE (start time includes Mutagen sync when enabled)"
 echo
 
 build_commit "$REF_A" a
@@ -359,27 +402,42 @@ build_commit "$REF_B" b
 echo
 
 echo "Commit A  $REF_A ($SHA_A)  $(eval echo \$RESULT_VERSION_a 2>/dev/null)"
-benchmark a "$PROJ_A" WARM_A
-report_warm a "${WARM_A[@]}"
+benchmark a "$PROJ_A" WARM_A REBUILD_A
+report_stats start "${WARM_A[@]}"
+[ "$REBUILD_RUNS" -gt 0 ] && report_stats rebuild "${REBUILD_A[@]}"
 echo
 
 echo "Commit B  $REF_B ($SHA_B)  $(eval echo \$RESULT_VERSION_b 2>/dev/null)"
-benchmark b "$PROJ_B" WARM_B
-report_warm b "${WARM_B[@]}"
+benchmark b "$PROJ_B" WARM_B REBUILD_B
+report_stats start "${WARM_B[@]}"
+[ "$REBUILD_RUNS" -gt 0 ] && report_stats rebuild "${REBUILD_B[@]}"
 echo
 
-MED_A=$(median "${WARM_A[@]}"); TM_A=$(trimmed_mean "$MED_A" "${WARM_A[@]}")
-MED_B=$(median "${WARM_B[@]}"); TM_B=$(trimmed_mean "$MED_B" "${WARM_B[@]}")
+# print_summary <title> <arrname-a> <arrname-b> : median/trimmed-mean comparison
+# for one metric. Arrays are passed by name (not value) for bash 3.2 compatibility.
+print_summary() {
+  title=$1; an=$2; bn=$3
+  eval "aset=(\"\${$an[@]}\")"
+  eval "bset=(\"\${$bn[@]}\")"
+  med_a=$(median "${aset[@]}"); tm_a=$(trimmed_mean "$med_a" "${aset[@]}")
+  med_b=$(median "${bset[@]}"); tm_b=$(trimmed_mean "$med_b" "${bset[@]}")
+  echo "Summary ($title)"
+  echo "-------------------------------------------------------------------"
+  printf "  A (%s): median=%ss  trimmed-mean=%ss\n" "$SHA_A" "$med_a" "$tm_a"
+  printf "  B (%s): median=%ss  trimmed-mean=%ss\n" "$SHA_B" "$med_b" "$tm_b"
+  awk -v a="$med_a" -v b="$med_b" 'BEGIN {
+    d = b - a
+    pct = (a != 0) ? d / a * 100 : 0
+    if (d > 0)      printf "  B is SLOWER than A by %.2fs (%+.1f%%) on median\n", d, pct
+    else if (d < 0) printf "  B is FASTER than A by %.2fs (%+.1f%%) on median\n", -d, pct
+    else            printf "  No median difference\n"
+  }'
+}
+
 echo "==================================================================="
-echo "Summary (ddev start from stopped state)"
-echo "-------------------------------------------------------------------"
-printf "  A (%s): median=%ss  trimmed-mean=%ss\n" "$SHA_A" "$MED_A" "$TM_A"
-printf "  B (%s): median=%ss  trimmed-mean=%ss\n" "$SHA_B" "$MED_B" "$TM_B"
-awk -v a="$MED_A" -v b="$MED_B" 'BEGIN {
-  d = b - a
-  pct = (a != 0) ? d / a * 100 : 0
-  if (d > 0)      printf "  B is SLOWER than A by %.2fs (%+.1f%%) on median\n", d, pct
-  else if (d < 0) printf "  B is FASTER than A by %.2fs (%+.1f%%) on median\n", -d, pct
-  else            printf "  No median difference\n"
-}'
+print_summary "ddev start from stopped state" WARM_A WARM_B
+if [ "$REBUILD_RUNS" -gt 0 ]; then
+  echo
+  print_summary "ddev utility rebuild" REBUILD_A REBUILD_B
+fi
 echo "==================================================================="


### PR DESCRIPTION
## The Issue

- Fixes #8600

`ddev utility rebuild` regressed from ~10s in v1.25.2 to 27s+ in v1.25.3 (and much worse on some filesystems). #8467 made `/usr/local/n` (a full Node.js + npm + globally-installed yarn/gulp-cli install baked into the `ddev-php-base` image) writable for the container's runtime user by recursively `chgrp`/`chmod`-ing it on **every single project's** web image build. That directory has thousands of files, so the recursive walk is what regressed.

`compare-start-perf.sh` also didn't measure this at all - it only timed `ddev start` from an already-built, stopped project, so a build-time regression like this was invisible to it.

## How This PR Solves The Issue

**Script (`scripts/compare-start-perf.sh`):**
- Primes each commit with `ddev utility rebuild` instead of `ddev start -y`, since the first build for a throwaway project is uncached either way.
- Adds a new timed loop of `ddev utility rebuild` runs (`-b`, default 3), reported and summarized the same way as the existing warm-start runs.

**Root-cause fix:** rather than re-chowning the large, effectively-static `/usr/local/n` tree on every project build, this uses the standard "arbitrary UID" container technique (the same one OpenShift/Kubernetes-compatible images use): bake group-writability by the root group (gid 0) into the image once, and make the per-project runtime user a member of group 0, instead of dynamically chgrp/chmod'ing the directory to match that user's own group every time. See https://developers.redhat.com/blog/2020/10/26/adapting-docker-and-kubernetes-containers-to-run-on-red-hat-openshift-container-platform

- `containers/ddev-php-base/Dockerfile`: `chgrp -R 0` + `chmod -R g+rwX,o-w` on `/usr/local/n` once, right after Node.js/npm/yarn/gulp-cli are installed into it.
- `pkg/ddevapp/config.go` (`WriteBuildDockerfile`): the per-project `useradd` now also adds the container user to group 0 (`-G tty,0`).
- `pkg/ddevapp/app_compose_template.yaml`: the web service now sets `group_add: ["0"]`, since Docker does not derive supplementary groups from `/etc/group` when both `uid` and `gid` are given explicitly (as DDEV does) - it has to be requested explicitly.
- Removed `/usr/local/n` from the per-project `chgrp -R "$gid" ... && chmod -R g+rwX,o-w ...` line (kept for `/etc/alternatives` and `/var/lib/dpkg/alternatives`, which are small and not the slow part).
- For projects with a non-default `nodejs_version`, the per-project `n install` overwrites the baked-in files (resetting their permissions), so `chgrp -R 0`/`chmod -R g+rwX,o-w /usr/local/n` is reapplied right after that install. This only runs for that (uncommon) path, not on every project.
- `containers/ddev-webserver/Dockerfile` / `pkg/versionconstants/versionconstants.go`: bumped to this branch's tag (`20260719_build_perf_script`) so CI/reviewers can build and test the real fix.

**CI (`.github/workflows/perf-start-time.yml`):** a new, standalone, non-blocking workflow that runs `compare-start-perf.sh` (baseline vs. current commit, same runner/job) whenever the files responsible for these start-time build layers change, plus a nightly run for drift detection. Posts the comparison table to the job summary. Deliberately not a required/failing check yet, since GitHub-hosted runners are noisy enough that a hard threshold would likely be flaky - can graduate to one once we've watched it run for a while.

## Manual Testing Instructions

1. Build the images locally:
   ```
   cd containers/ddev-php-base && docker buildx build --platform linux/amd64 --target=ddev-php-base -t ddev/ddev-php-base:20260719_build_perf_script --load .
   cd ../ddev-webserver && docker buildx build --platform linux/amd64 --target=ddev-webserver -t ddev/ddev-webserver:20260719_build_perf_script --load .
   ```
2. `make`, then in a fresh project: `ddev config --project-type=php --docroot=.` and `ddev utility rebuild`; confirm it's fast (no long `chmod -R` step) and `ddev exec id` includes `0(root)` in `groups=`.
3. Repeat the manual tests from #8467: `ddev npm install -g bun@latest`, `ddev npm install -g npm@latest`, and `ddev exec n install 20 && ddev exec node -v`; all three should succeed.
4. Configure a project with `--nodejs-version=20` (non-default), rebuild, and confirm `ddev npm install -g bun@latest` still succeeds there too.
5. `scripts/compare-start-perf.sh -n 2 -b 3 -m off v1.25.3 HEAD` to see the before/after comparison directly.

## Automated Testing Overview

No new Go unit tests; this is a container-image/permissions fix without an existing docker-image test harness for this specific path. Manually verified all steps above end-to-end, including timing:

- `ddev utility rebuild`: v1.25.3 median 99.64s -> this branch median 35.99s (-63.9%) in one test environment (a slow-filesystem sandbox that reproduces the regression severely; absolute numbers will differ on typical hardware, but the relative fix is the same).
- `ddev start` from stopped: unaffected either way (median 18.60s vs 17.78s), as expected since it never touched `/usr/local/n`.

The new (optional?) `perf-start-time.yml` workflow is itself the ongoing automated check for this class of regression going forward. It won't normally be run until this is pulled, but a test run in https://github.com/ddev-test/ddev/actions/runs/29705119282 was "interesting". Script should be run manually to understand our situation.

## Release/Deployment Notes

- Requires publishing new `ddev-php-base` and `ddev-webserver` images. The tags referenced here (`20260719_build_perf_script`) are this branch's test tags, built via `push-tagged-image.yml`; a maintainer needs to bump them to real release tags before/at merge.
- Projects built with the old image will get the new permissions/groups the next time their web image is rebuilt.
