### PR TITLE
fix(buildkite): run orb start/stop synchronously so orbstack reliably ends up running (#8605) [skip ci]

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -37,6 +37,34 @@ export DDEV_SKIP_NODEJS_TEST=true
 export DOCKER_SCAN_SUGGEST=false
 export DOCKER_SCOUT_SUGGEST=false
 
+# Find a suitable timeout command for reliability and readability
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT="gtimeout"
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT="timeout"
+else
+  echo "Error: Neither 'gtimeout' nor 'timeout' found in PATH." >&2
+  exit 1
+fi
+
+# Helper: stop orbstack synchronously, bounded by TIMEOUT so a hang can't wedge the job.
+function stop_orbstack {
+  command -v orb >/dev/null 2>&1 || return 0
+  echo "Stopping orbstack"
+  ${TIMEOUT} 60s orb stop || true
+}
+
+# Helper: start orbstack synchronously, bounded by TIMEOUT, then switch to its docker
+# context. orb start is run in the foreground (not backgrounded) so the caller knows
+# it has actually run to completion or timed out before moving on; a backgrounded
+# orb start can be killed by CI job-cleanup before the VM finishes coming up, leaving
+# the docker context set to orbstack but the daemon not running.
+function start_orbstack {
+  echo "Starting orbstack"
+  ${TIMEOUT} 60s orb start || true
+  docker context use orbstack || true
+}
+
 # Helper: try to remove all containers via an SSH-style shell command.
 # Usage: try_cleanup_containers_via_ssh <cmd> [<args>...]
 # Returns 0 if containers are clean, 1 if containers remain (deep cleanup needed).
@@ -87,23 +115,21 @@ if [ "${os:-}" = "darwin" ]; then
       echo "--- running testbot_maintenance.sh (post-test)"
       ${TIMEOUT} 10m bash "$(dirname "$0")/testbot_maintenance.sh" || true
     fi
-    command -v orb 2>/dev/null && echo "Stopping orbstack" && (nohup orb stop &)
-    sleep 3 # Since we backgrounded orb stop, make sure it completes
+    stop_orbstack
     if [ -f /Applications/Docker.app ]; then echo "Stopping Docker Desktop" && (killall com.docker.backend || true); fi
     command -v colima 2>/dev/null && echo "Stopping colima_vz" && (colima stop -f vz || true)
     command -v limactl 2>/dev/null && echo "Stopping lima" && (limactl stop -f lima-vz || true)
     if [ -f ~/.rd/bin/rdctl ]; then echo "Stopping Rancher Desktop" && (~/.rd/bin/rdctl shutdown || true); fi
     command -v podman 2>/dev/null && echo "Stopping podman machine" && (podman machine stop || true)
-    docker context use default
-    # Leave orbstack running as the most likely to be reliable, otherwise Docker Desktop
+    docker context use default || true
+    # Leave orbstack running as the most likely to be reliable, otherwise Docker Desktop.
     if command -v orb 2>/dev/null ; then
-      docker context use orbstack
-      echo "Starting orbstack" && (nohup orb start &)
+      start_orbstack
     else
-      docker context use desktop-linux
-      open -a Docker
+      docker context use desktop-linux || true
+      open -a Docker || true
+      sleep 5
     fi
-    sleep 5
   }
   trap cleanup EXIT
 
@@ -115,8 +141,7 @@ if [ "${os:-}" = "darwin" ]; then
 
   # For Lima and Colima, as of Lima 1.0.4, having orbstack running
   # makes lima fail, see https://github.com/lima-vm/lima/issues/3145#issuecomment-2613728408
-  command -v orb 2>/dev/null && echo "Stopping orbstack" && (nohup orb stop &)
-  sleep 3 # Since we backgrounded orb stop, make sure it completes
+  stop_orbstack
 
   # Now start the docker provider we want
   case ${DOCKER_TYPE:=none} in
@@ -178,9 +203,7 @@ if [ "${os:-}" = "darwin" ]; then
       ;;
 
     "orbstack")
-      nohup orb start &
-      sleep 3
-      docker context use orbstack
+      start_orbstack
       ;;
 
     "rancher-desktop")
@@ -242,16 +265,6 @@ if [ "${DOCKER_TYPE:-}" = "docker-ce" ] || [ "${DOCKER_TYPE:-}" = "wsl2dockerins
     fi
     echo "Deep cleanup succeeded: all containers removed"
   fi
-fi
-
-# Find a suitable timeout command for reliability and readability
-if command -v gtimeout >/dev/null 2>&1; then
-  TIMEOUT="gtimeout"
-elif command -v timeout >/dev/null 2>&1; then
-  TIMEOUT="timeout"
-else
-  echo "Error: Neither 'gtimeout' nor 'timeout' found in PATH." >&2
-  exit 1
 fi
 
 # On Windows, start Docker Desktop if this job uses it, before waiting on docker.


### PR DESCRIPTION
## The Issue

No tracked issue — observed directly while monitoring `tb-macos-arm64-5/6/7`: after a Buildkite
job finished, orbstack was sometimes not left running, even though the docker context was
correctly switched to `orbstack`.

This really only matters because we monitor docker status on these machines.

## How This PR Solves The Issue

`.buildkite/test.sh`'s `cleanup` (the `EXIT` trap) backgrounded `orb start`/`orb stop` via
`(nohup orb start &)` and just slept a fixed amount hoping it finished in time. `nohup` only
blocks `SIGHUP` — it does nothing against the `SIGTERM`/`SIGKILL` a CI job supervisor sends to
the whole process group when the job's shell exits. So `docker context use orbstack` (run
synchronously, right before) reliably took effect, while the backgrounded `orb start` could be
killed mid-launch, leaving the context pointed at orbstack with the daemon never actually up.

Both `orb start` and `orb stop` now run synchronously (foreground), bounded by the existing
`$TIMEOUT` (`gtimeout`/`timeout`) command so a hang can't wedge the job — matching how the other
providers (`colima start`, `limactl start`, `rdctl start`) are already started elsewhere in this
script. The four call sites (cleanup's stop, cleanup's start, the pre-`DOCKER_TYPE` stop, and the
`"orbstack")` case arm) are DRYed into two helpers, `stop_orbstack`/`start_orbstack`.

## Manual Testing Instructions

This only affects the macOS Buildkite runner cleanup/setup path. To verify on a macOS orbstack
runner:

1. Run a Buildkite build on `tb-macos-arm64-5/6/7` (or manually run `.buildkite/test.sh` on such a
   host) with `DOCKER_TYPE` set to something other than `orbstack` (e.g. `colima_vz`).
2. After the job completes, confirm on the host that `orb status`/`orbctl status` shows orbstack
   running and `docker context show` is `orbstack`.
3. Repeat a few times to confirm it's no longer intermittent.

## Automated Testing Overview

None added — this is CI infrastructure/tooling (a Bash script orchestrating docker providers on
Buildkite macOS runners), not something exercised by the Go test suite.

## Release/Deployment Notes

No user-facing impact. Affects only the reliability of DDEV's own Buildkite macOS test runners.
