### PR TITLE
feat(maho): add Maho project type

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -110,6 +110,7 @@ Livewire
 MAMP
 Magento
 Magento's
+Maho
 Mailpit
 Mailpit's
 Mailgun
@@ -475,6 +476,8 @@ lts
 macOS
 macos
 magento
+maho
+mahocommerce
 mailgun
 mailhandling
 mailhog

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -192,7 +192,7 @@ func TestCustomCommands(t *testing.T) {
 		assert.NoError(err, "Failed to run ddev %s --version", c)
 	}
 	// The various CMS commands should not be available here
-	for _, c := range []string{"artisan", "art", "cake", "dr", "drush", "magento", "typo3", "wp"} {
+	for _, c := range []string{"artisan", "art", "cake", "dr", "drush", "magento", "maho", "typo3", "wp"} {
 		_, err = exec.RunHostCommand(DdevBin, c, "-h")
 		assert.Error(err, "found command %s when it should not have been there (no error) app.Type=%s", c, app.Type)
 	}
@@ -299,6 +299,17 @@ func TestCustomCommands(t *testing.T) {
 	err = app.MutagenSyncFlush()
 	assert.NoError(err)
 	for _, c := range []string{"spark"} {
+		_, err = exec.RunHostCommand(DdevBin, "help", c)
+		assert.NoError(err)
+	}
+
+	// Maho commands should only be available for type maho
+	app.Type = nodeps.AppTypeMaho
+	_ = app.WriteConfig()
+	_, _ = exec.RunHostCommand(DdevBin)
+	err = app.MutagenSyncFlush()
+	assert.NoError(err)
+	for _, c := range []string{"maho"} {
 		_, err = exec.RunHostCommand(DdevBin, "help", c)
 		assert.NoError(err)
 	}

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -91,7 +91,7 @@ for PHP_VERSION in 8.2 8.3 8.4 8.5; do
   done
 done
 
-for project_type in backdrop craftcms drupal drupal7 drupal10 drupal11 laravel magento magento2 symfony typo3 wordpress default; do
+for project_type in backdrop craftcms drupal drupal7 drupal10 drupal11 laravel magento magento2 maho symfony typo3 wordpress default; do
   export PHP_VERSION="8.4"
   export project_type
   docker run -u "$MOUNTUID:$MOUNTGID" -p "$HOST_HTTP_PORT:$CONTAINER_HTTP_PORT" -p "$HOST_HTTPS_PORT:$CONTAINER_HTTPS_PORT" -e "DOCROOT=docroot" -e "DDEV_PHP_VERSION=$PHP_VERSION" -e "DDEV_PROJECT_TYPE=$project_type" --name "$CONTAINER_NAME" -v ddev-global-cache:/mnt/ddev-global-cache -d "$DOCKER_IMAGE" >/dev/null

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -662,7 +662,7 @@ The DDEV-specific project type.
 
 | Type | Default | Usage
 | -- | -- | --
-| :octicons-file-directory-16: project | `php` | Can be `asterios`, `backdrop`, `cakephp`, `codeigniter`, `craftcms`, `drupal`, `drupal6`, `drupal7`, `drupal8`, `drupal9`, `drupal10`, `drupal11`, `drupal12`, `generic`, `joomla`, `laravel`, `magento`, `magento2`, `php`, `shopware6`, `silverstripe`, `symfony`, `typo3`, `wordpress`, or `wp-bedrock`.
+| :octicons-file-directory-16: project | `php` | Can be `asterios`, `backdrop`, `cakephp`, `codeigniter`, `craftcms`, `drupal`, `drupal6`, `drupal7`, `drupal8`, `drupal9`, `drupal10`, `drupal11`, `drupal12`, `generic`, `joomla`, `laravel`, `magento`, `magento2`, `maho`, `php`, `shopware6`, `silverstripe`, `symfony`, `typo3`, `wordpress`, or `wp-bedrock`.
 
 The `php` type doesn’t attempt [CMS configuration](../../users/quickstart.md) or settings file management and can work with any project.
 

--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1843,6 +1843,165 @@ ddev magento sampledata:deploy
 ddev magento setup:upgrade
 ```
 
+## Maho
+
+You can start a new [Maho](https://mahocommerce.com) project or configure an existing one. Maho is an e-commerce platform derived from Magento 1, with modern PHP support and no external service requirements: it needs only a web server, PHP and a database.
+
+DDEV automatically creates `app/etc/local.xml` with the database connection details, so importing an existing site is just `ddev import-db` and `ddev import-files` away. For a fresh installation the Maho installer needs `--force` to take over that pre-created file.
+
+=== "Composer"
+
+    Create the project directory and configure DDEV:
+
+    ```bash
+    mkdir -p my-maho-site && cd my-maho-site
+    ddev config --project-type=maho --docroot=public
+    ```
+
+    Start DDEV (this may take a minute):
+
+    ```bash
+    ddev start
+    ```
+
+    Install Maho via Composer:
+
+    ```bash
+    ddev composer create-project mahocommerce/maho-starter
+    ```
+
+    Run the Maho installer with sample data:
+
+    ```bash
+    ddev maho install --force \
+      --license_agreement_accepted yes \
+      --locale en_US --timezone UTC --default_currency USD \
+      --db_host db --db_name db --db_user db --db_pass db \
+      --url "https://my-maho-site.ddev.site/" \
+      --use_secure 1 --secure_base_url "https://my-maho-site.ddev.site/" --use_secure_admin 1 \
+      --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
+      --admin_username admin --admin_password veryl0ngpassw0rd \
+      --sample_data 1
+    ```
+
+    Re-index and flush the cache:
+
+    ```bash
+    ddev maho index:reindex:all && ddev maho cache:flush
+    ```
+
+    Launch the admin interface (login with `admin` and `veryl0ngpassw0rd`):
+
+    ```bash
+    ddev launch /admin
+    ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-maho.sh << 'EOF'
+        #!/usr/bin/env bash
+        set -euo pipefail
+        mkdir -p my-maho-site && cd my-maho-site
+        ddev config --project-type=maho --docroot=public
+        ddev start -y
+        ddev composer create-project mahocommerce/maho-starter
+        ddev maho install --force \
+          --license_agreement_accepted yes \
+          --locale en_US --timezone UTC --default_currency USD \
+          --db_host db --db_name db --db_user db --db_pass db \
+          --url "https://my-maho-site.ddev.site/" \
+          --use_secure 1 --secure_base_url "https://my-maho-site.ddev.site/" --use_secure_admin 1 \
+          --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
+          --admin_username admin --admin_password veryl0ngpassw0rd \
+          --sample_data 1
+        ddev maho index:reindex:all && ddev maho cache:flush
+        ddev launch /admin
+        EOF
+        chmod +x setup-maho.sh
+        ./setup-maho.sh
+        ```
+
+=== "Git Clone (for contributors)"
+
+    !!!warning "For contributing to Maho core only"
+        This setup is only for contributing to Maho itself. Never build a store on a clone of the core repository — use the Composer setup instead.
+
+    Create the project directory and clone the repository:
+
+    ```bash
+    mkdir -p maho && cd maho
+    git clone https://github.com/MahoCommerce/maho .
+    ```
+
+    Configure and start DDEV:
+
+    ```bash
+    ddev config --project-type=maho --docroot=public
+    ddev start
+    ```
+
+    Install Composer dependencies:
+
+    ```bash
+    ddev composer install
+    ```
+
+    Run the Maho installer with sample data:
+
+    ```bash
+    ddev maho install --force \
+      --license_agreement_accepted yes \
+      --locale en_US --timezone UTC --default_currency USD \
+      --db_host db --db_name db --db_user db --db_pass db \
+      --url "https://maho.ddev.site/" \
+      --use_secure 1 --secure_base_url "https://maho.ddev.site/" --use_secure_admin 1 \
+      --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
+      --admin_username admin --admin_password veryl0ngpassw0rd \
+      --sample_data 1
+    ```
+
+    Re-index and flush the cache:
+
+    ```bash
+    ddev maho index:reindex:all && ddev maho cache:flush
+    ```
+
+    Launch the admin interface (login with `admin` and `veryl0ngpassw0rd`):
+
+    ```bash
+    ddev launch /admin
+    ```
+
+    ??? tip "Prefer to run as a script?"
+        To run the whole setup as a script, examine and run this script:
+
+        ```bash
+        cat > setup-maho-git.sh << 'EOF'
+        #!/usr/bin/env bash
+        set -euo pipefail
+        mkdir -p maho && cd maho
+        git clone https://github.com/MahoCommerce/maho .
+        ddev config --project-type=maho --docroot=public
+        ddev start -y
+        ddev composer install
+        ddev maho install --force \
+          --license_agreement_accepted yes \
+          --locale en_US --timezone UTC --default_currency USD \
+          --db_host db --db_name db --db_user db --db_pass db \
+          --url "https://maho.ddev.site/" \
+          --use_secure 1 --secure_base_url "https://maho.ddev.site/" --use_secure_admin 1 \
+          --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
+          --admin_username admin --admin_password veryl0ngpassw0rd \
+          --sample_data 1
+        ddev maho index:reindex:all && ddev maho cache:flush
+        ddev launch /admin
+        EOF
+        chmod +x setup-maho-git.sh
+        ./setup-maho-git.sh
+        ```
+
 ## Moodle
 
 === "Composer"

--- a/docs/content/users/usage/cli.md
+++ b/docs/content/users/usage/cli.md
@@ -64,6 +64,7 @@ The dashboard automatically detects your terminal's color capabilities and adapt
 * [`ddev artisan`](../usage/commands.md#artisan) (Laravel only) gives direct access to the Laravel `artisan` CLI.
 * [`ddev asterios`](../usage/commands.md#asterios) (Asterios only) gives direct access to the Asterios `asterios` CLI.
 * [`ddev magento`](../usage/commands.md#magento) (Magento2 only) gives access to the `magento` CLI.
+* [`ddev maho`](../usage/commands.md#maho) (Maho only) gives direct access to the `maho` CLI.
 * [`ddev console`](../usage/commands.md#console) (Symfony only) gives access to the `symfony console` CLI.
 * [`ddev craft`](../usage/commands.md#craft) (Craft CMS only) gives access to the `craft` CLI.
 * [`ddev npm`](../usage/commands.md#npm) gives direct access to the `npm` CLI.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -917,6 +917,18 @@ Run the `magento` command; available only in projects of type `magento2`, and on
 ddev magento list
 ```
 
+## `maho`
+
+Run the `maho` command; available only in projects of type `maho`, and only works if the `maho` script is in the project root (it is copied there by Composer on install).
+
+```shell
+# Show all maho subcommands
+ddev maho list
+
+# Flush the cache
+ddev maho cache:flush
+```
+
 ## `mailpit`
 
 Launch a browser with mailpit for the current project (global shell host container command).

--- a/docs/content/users/usage/managing-projects.md
+++ b/docs/content/users/usage/managing-projects.md
@@ -14,6 +14,8 @@ For **Magento 1**, DDEV settings go into `app/etc/local.xml`.
 
 In **Magento 2**, DDEV settings go into `app/etc/env.php`.
 
+For **Maho**, DDEV settings go into `app/etc/local.xml`.
+
 For **TYPO3**, DDEV settings are written to `config/system/additional.php`. If `additional.php` exists and is not managed by DDEV, it will not be modified.
 
 For **WordPress**, DDEV settings are written to a DDEV-managed file, `wp-config-ddev.php`. The `ddev config` command will attempt to write settings through the following steps:

--- a/docs/tests/maho.bats
+++ b/docs/tests/maho.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+setup() {
+  PROJNAME=my-maho-site
+  load 'common-setup'
+  _common_setup
+}
+
+# executed after each test
+teardown() {
+  _common_teardown
+}
+
+@test "Maho Composer quickstart with $(ddev --version)" {
+  PROJNAME=my-maho-site
+
+  run mkdir -p ${PROJNAME} && cd ${PROJNAME}
+  assert_success
+
+  run ddev config --project-type=maho --docroot=public
+  assert_success
+
+  run ddev start -y
+  assert_success
+
+  run ddev composer create-project mahocommerce/maho-starter
+  assert_success
+
+  # Silent Maho install with sample data; --force is needed because
+  # ddev pre-creates app/etc/local.xml
+  run ddev maho install --force \
+    --license_agreement_accepted yes \
+    --locale en_US --timezone UTC --default_currency USD \
+    --db_host db --db_name db --db_user db --db_pass db \
+    --url "https://${PROJNAME}.ddev.site/" \
+    --use_secure 1 --secure_base_url "https://${PROJNAME}.ddev.site/" --use_secure_admin 1 \
+    --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
+    --admin_username admin --admin_password veryl0ngpassw0rd \
+    --sample_data 1
+  assert_success
+
+  run ddev maho index:reindex:all
+  assert_success
+
+  run ddev maho cache:flush
+  assert_success
+
+  # validate ddev launch
+  DDEV_DEBUG=true run ddev launch
+  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_success
+
+  # validate running project
+  run curl -sfIv https://${PROJNAME}.ddev.site
+  assert_output --partial "server: nginx"
+  assert_output --partial "HTTP/2 200"
+  assert_success
+
+  # Check if the admin is working
+  run curl -sfvL https://${PROJNAME}.ddev.site/admin
+  assert_output --partial "Log in to Admin Panel"
+  assert_success
+}

--- a/pkg/ddevapp/apptypes.go
+++ b/pkg/ddevapp/apptypes.go
@@ -243,6 +243,14 @@ func init() {
 			importFilesAction:    magentoImportFilesAction,
 		},
 
+		nodeps.AppTypeMaho: {
+			settingsCreator:      createMahoSettingsFile,
+			uploadDirs:           getMahoUploadDirs,
+			appTypeSettingsPaths: setMahoSiteSettingsPaths,
+			appTypeDetect:        isMahoApp,
+			importFilesAction:    magentoImportFilesAction,
+		},
+
 		nodeps.AppTypePHP: {
 			postStartAction: nil,
 		},

--- a/pkg/ddevapp/apptypes_test.go
+++ b/pkg/ddevapp/apptypes_test.go
@@ -77,6 +77,7 @@ func TestConfigOverrideAction(t *testing.T) {
 		nodeps.AppTypeLaravel:      nodeps.PHPDefault,
 		nodeps.AppTypeMagento:      nodeps.PHPDefault,
 		nodeps.AppTypeMagento2:     nodeps.PHPDefault,
+		nodeps.AppTypeMaho:         nodeps.PHPDefault,
 		nodeps.AppTypeSilverstripe: nodeps.PHPDefault,
 		nodeps.AppTypeSymfony:      nodeps.PHPDefault,
 		nodeps.AppTypeWordPress:    nodeps.PHPDefault,

--- a/pkg/ddevapp/assets.go
+++ b/pkg/ddevapp/assets.go
@@ -27,6 +27,7 @@ import (
 //go:embed traefik_global_config_template.yaml
 //go:embed drupal/*
 //go:embed magento/*
+//go:embed maho/*
 //go:embed wordpress/*
 //go:embed typo3/*
 //go:embed postgres/*

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -383,6 +383,7 @@ func TestConfigCommand(t *testing.T) {
 	const phpVersionPos = 1
 	testMatrix := map[string][]string{
 		"magentophpversion":  {nodeps.AppTypeMagento, nodeps.PHPDefault},
+		"mahophpversion":     {nodeps.AppTypeMaho, nodeps.PHPDefault},
 		"drupal7phpversion":  {nodeps.AppTypeDrupal7, nodeps.PHP82},
 		"Drupal11phpversion": {nodeps.AppTypeDrupal11, nodeps.PHPDefault},
 	}

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/maho
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/maho
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run Maho CLI inside the web container
+## Usage: maho [command] [flags] [args]
+## Example: "ddev maho install --help" or "ddev maho cache:flush" or "ddev maho cron:run default"
+## ProjectTypes: maho
+## ExecRaw: true
+## MutagenSync: true
+
+cd "${DDEV_COMPOSER_ROOT:-/var/www/html}" || exit 1
+if [ ! -f ./maho ]; then
+  echo "The './maho' script does not exist, run 'ddev composer install' first" && exit 1
+fi
+php ./maho "$@"

--- a/pkg/ddevapp/maho.go
+++ b/pkg/ddevapp/maho.go
@@ -1,0 +1,67 @@
+package ddevapp
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+)
+
+// isMahoApp returns true if the app is of type maho
+func isMahoApp(app *DdevApp) bool {
+	isMaho, err := fileutil.FgrepStringInFile(filepath.Join(app.AppRoot, app.ComposerRoot, "composer.json"), `"mahocommerce/maho"`)
+	if err == nil && isMaho {
+		return true
+	}
+	return false
+}
+
+// createMahoSettingsFile manages creation and modification of app/etc/local.xml.
+func createMahoSettingsFile(app *DdevApp) (string, error) {
+	if fileutil.FileExists(app.SiteSettingsPath) {
+		// Check if the file is managed by ddev.
+		signatureFound, err := fileutil.FgrepStringInFile(app.SiteSettingsPath, nodeps.DdevFileSignature)
+		if err != nil {
+			return "", err
+		}
+
+		// If the signature wasn't found, warn the user and return.
+		if !signatureFound {
+			util.Warning("%s already exists and is managed by the user.", app.SiteSettingsPath)
+			return "", nil
+		}
+	} else {
+		output.UserOut.Printf("No %s file exists, creating one", app.SiteSettingsPath)
+
+		// app/etc does not exist in a fresh maho-starter project
+		if err := os.MkdirAll(filepath.Dir(app.SiteSettingsPath), 0755); err != nil {
+			return "", err
+		}
+
+		content, err := bundledAssets.ReadFile("maho/local.xml")
+		if err != nil {
+			return "", err
+		}
+		templateVars := map[string]any{"DBHostname": "db"}
+		err = fileutil.TemplateStringToFile(string(content), templateVars, app.SiteSettingsPath)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return app.SiteDdevSettingsFile, nil
+}
+
+// setMahoSiteSettingsPaths sets the paths to local.xml for templating.
+// Maho keeps app/etc/local.xml at the project root, outside the public docroot.
+func setMahoSiteSettingsPaths(app *DdevApp) {
+	app.SiteSettingsPath = filepath.Join(app.AppRoot, "app", "etc", "local.xml")
+}
+
+// getMahoUploadDirs will return the default paths.
+func getMahoUploadDirs(_ *DdevApp) []string {
+	return []string{"media"}
+}

--- a/pkg/ddevapp/maho/local.xml
+++ b/pkg/ddevapp/maho/local.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+#ddev-generated: Automatically generated ddev local.xml
+Remove the line above or this whole comment if you want
+ddev to ignore this file and not regenerate it.
+-->
+<config>
+    <global>
+        <install>
+            <date><![CDATA[Thu, 09 Jan 2020 18:37:54 +0000]]></date>
+        </install>
+        <crypt>
+            <key><![CDATA[35e56e486261e071f3a5a93e49d07985]]></key>
+        </crypt>
+        <resources>
+            <db>
+                <table_prefix><![CDATA[]]></table_prefix>
+            </db>
+            <default_setup>
+                <connection>
+                    <host><![CDATA[{{ .DBHostname }}]]></host>
+                    <username><![CDATA[db]]></username>
+                    <password><![CDATA[db]]></password>
+                    <dbname><![CDATA[db]]></dbname>
+                    <initStatements><![CDATA[SET NAMES utf8]]></initStatements>
+                    <engine><![CDATA[mysql]]></engine>
+                    <active>1</active>
+                </connection>
+            </default_setup>
+        </resources>
+        <session_save><![CDATA[files]]></session_save>
+    </global>
+    <admin>
+        <base_path><![CDATA[admin]]></base_path>
+    </admin>
+</config>

--- a/pkg/ddevapp/mutagen.go
+++ b/pkg/ddevapp/mutagen.go
@@ -1425,6 +1425,7 @@ func getCMSDefaultUploadDirsSuggestion(projectType string) string {
 		"typo3":        "fileadmin",
 		"magento":      "media",
 		"magento2":     "media",
+		"maho":         "media",
 		"shopware6":    "media",
 		"silverstripe": "assets",
 		"craftcms":     "files",

--- a/pkg/ddevapp/schema.json
+++ b/pkg/ddevapp/schema.json
@@ -638,6 +638,7 @@
         "laravel",
         "magento",
         "magento2",
+        "maho",
         "php",
         "shopware6",
         "silverstripe",

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -9,7 +9,7 @@ const ConfigInstructions = `
 # If the name is omitted, the project will take the name of the enclosing directory,
 # which is useful if you want to have a copy of the project side by side with this one.
 
-# type: <projecttype>  # asterios, backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, joomla, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress, wp-bedrock
+# type: <projecttype>  # asterios, backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, joomla, laravel, magento, magento2, maho, php, shopware6, silverstripe, symfony, typo3, wordpress, wp-bedrock
 # See https://docs.ddev.com/en/stable/users/quickstart/ for more
 # information on the different project types
 

--- a/pkg/ddevapp/testdata/TestDetectAppType/maho/composer.json
+++ b/pkg/ddevapp/testdata/TestDetectAppType/maho/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "mahocommerce/maho-starter",
+    "type": "project",
+    "require": {
+        "mahocommerce/maho": "*"
+    }
+}

--- a/pkg/ddevapp/testdata/TestDetectAppType/maho/public/index.php
+++ b/pkg/ddevapp/testdata/TestDetectAppType/maho/public/index.php
@@ -1,0 +1,2 @@
+<?php
+// Stub front controller for Maho app type detection test

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-maho.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-maho.conf
@@ -1,0 +1,115 @@
+# ddev maho config
+# https://mahocommerce.com
+
+#ddev-generated
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://docs.ddev.com/en/stable/users/extend/customization-extendibility/#custom-nginx-configuration
+
+server {
+    listen 80 default_server;
+    listen 443 ssl default_server;
+
+    root {{ .Docroot }};
+
+    ssl_certificate /etc/ssl/certs/master.crt;
+    ssl_certificate_key /etc/ssl/certs/master.key;
+
+    include /etc/nginx/monitoring.conf;
+
+    index index.php index.htm index.html;
+
+    # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+    sendfile off;
+    error_log /dev/stdout info;
+    access_log /var/log/nginx/access.log;
+
+    if ($mage_run_code = '') {
+        set $mage_run_code '';
+    }
+
+    if ($mage_run_type = '') {
+        set $mage_run_type store;
+    }
+
+    location / {
+        absolute_redirect off;
+        try_files $uri $uri/ /index.php$is_args$args;
+    }
+
+    location = /favicon.ico {
+        access_log off;
+        log_not_found off;
+    }
+
+    location = /robots.txt {
+        access_log off;
+        log_not_found off;
+    }
+
+    # Maho API Platform routing (mirrors public/.htaccess):
+    #   /api/rest/v2/*                  -> rest.php (REST API, Symfony API Platform)
+    #   /api/rest/*                     -> api.php?type=rest (legacy Magento 1 REST)
+    #   /api/{soap,v2_soap,xmlrpc,jsonrpc} -> index.php (legacy protocol dispatchers)
+    #   /api/* (graphql, docs, ...)     -> rest.php
+    # Order matters: /api/rest/v2 must come before the bare /api/rest rule.
+    location /api {
+        rewrite ^/api/rest/v2 /rest.php last;
+        rewrite ^/api/rest /api.php?type=rest&$args last;
+        rewrite ^/api/(soap|v2_soap|xmlrpc|jsonrpc) /index.php last;
+        rewrite ^/api /rest.php last;
+    }
+
+    # pass the PHP scripts to FastCGI server listening on socket
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php/php-fpm.sock;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_intercept_errors on;
+        # fastcgi_read_timeout should match max_execution_time in php.ini
+        fastcgi_read_timeout 10m;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTPS $fcgi_https;
+        fastcgi_param MAGE_RUN_CODE $mage_run_code;
+        fastcgi_param MAGE_RUN_TYPE $mage_run_type;
+        # Pass the X-Accel-* headers to facilitate testing.
+        fastcgi_pass_header "X-Accel-Buffering";
+        fastcgi_pass_header "X-Accel-Charset";
+        fastcgi_pass_header "X-Accel-Expires";
+        fastcgi_pass_header "X-Accel-Limit-Rate";
+        fastcgi_pass_header "X-Accel-Redirect";
+    }
+
+    # Expire rules for static content
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc)$ {
+        expires 1M;
+        access_log off;
+        add_header Cache-Control "public";
+        try_files $uri /index.php$is_args$args;
+    }
+
+    # Prevent clients from accessing hidden files (starting with a dot)
+    # This is particularly important if you store .htpasswd files in the site hierarchy
+    # Access to `/.well-known/` is allowed.
+    # https://www.mnot.net/blog/2010/04/07/well-known
+    # https://tools.ietf.org/html/rfc5785
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    # Prevent clients from accessing to backup/config/source files
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    include /etc/nginx/common.d/*.conf;
+    include /mnt/ddev_config/nginx/*.conf;
+}

--- a/pkg/nodeps/values.go
+++ b/pkg/nodeps/values.go
@@ -106,6 +106,7 @@ const (
 	AppTypeSymfony      = "symfony"
 	AppTypeMagento      = "magento"
 	AppTypeMagento2     = "magento2"
+	AppTypeMaho         = "maho"
 	AppTypePHP          = "php"
 	AppTypeShopware6    = "shopware6"
 	AppTypeTYPO3        = "typo3"


### PR DESCRIPTION
## The Issue

[Maho](https://mahocommerce.com) is an open source ecommerce platform forked from OpenMage / Magento 1 in 2024 and heavily modernized: PHP 8.3+, Symfony components in place of the removed Zend/Varien layers, a Symfony API Platform based API, and its own `./maho` CLI. I am its maintainer.

DDEV has no project type that fits it. The existing `magento` type is actively wrong for Maho:

- the docroot is the project's `public/` directory, not the project root
- `app/etc/local.xml` lives at the project root (outside the docroot) and uses a different schema (`<engine>mysql</engine>` instead of `<model>/<type>/<pdoType>`, `<admin><base_path>` instead of the `<routers>` block)
- detection: a Maho project has no `README.md` with the OpenMage marker; it is identified by `mahocommerce/maho` in `composer.json`
- the API routing differs: modern `/api/*` requests go to `rest.php` (Symfony API Platform), with legacy Magento 1 endpoints carved out

## How This PR Solves The Issue

Adds a `maho` project type, closely modeled on the existing magento (M1) type:

- `pkg/ddevapp/maho.go`: detection via `"mahocommerce/maho"` in `composer.json` (works before `composer install`, matches both the `maho-starter` skeleton and the monorepo), settings management for `app/etc/local.xml` from a new embedded `pkg/ddevapp/maho/local.xml` template, `media` upload dir, and the same import-files behavior as magento
- `pkg/ddevapp/webserver_config_assets/nginx-site-maho.conf`: based on `nginx-site-magento.conf` with the `/api` routing updated to mirror Maho's `public/.htaccess` (REST v2 / GraphQL / OpenAPI docs to `rest.php`, legacy M1 REST to `api.php`, legacy SOAP/XML-RPC/JSON-RPC to `index.php`)
- `ddev maho` web command (`php ./maho` in the project root), only visible for `maho` projects
- quickstart docs section, `docs/tests/maho.bats`, detection testdata, and registration in the usual places (`values.go`, `apptypes.go`, `schema.json`, `templates.go`, `mutagen.go` upload dirs, config docs, spellcheck wordlist, ddev-webserver test loop)

No `configOverrideAction` is needed: DDEV's PHP and database defaults already satisfy Maho's requirements (PHP >= 8.3, MySQL/MariaDB).

A note on the settings management design: the embedded `local.xml` carries a fixed install date, exactly like the magento type. This makes the import-existing-site workflow instant (`ddev config` + `ddev import-db` + `ddev import-files`). For fresh installs the quickstart uses `ddev maho install --force`, which is Maho's supported path for reinstalling over an existing `local.xml`. If you would rather not have DDEV manage the settings file at all, I am happy to drop the `settingsCreator` and let `maho install` write it; the quickstart then loses the `--force` flag.

Not included: a `TestSites` full integration entry in `ddevapp_test.go`, since that requires test artifacts hosted in the ddev org. Happy to provide a `test-maho` repo and artifacts if you want that coverage.

## Manual Testing Instructions

Quickstart: https://ddev--8606.org.readthedocs.build/en/8606/users/quickstart/#maho
`ddev maho`: https://ddev--8606.org.readthedocs.build/en/8606/users/usage/commands/#maho

```bash
mkdir maho-test && cd maho-test
ddev config --project-type=maho --docroot=public
ddev start -y
ddev composer create-project mahocommerce/maho-starter
ddev maho install --force \
  --license_agreement_accepted yes \
  --locale en_US --timezone UTC --default_currency USD \
  --db_host db --db_name db --db_user db --db_pass db \
  --url "https://maho-test.ddev.site/" \
  --use_secure 1 --secure_base_url "https://maho-test.ddev.site/" --use_secure_admin 1 \
  --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
  --admin_username admin --admin_password veryl0ngpassw0rd \
  --sample_data 1
ddev launch /admin
```

Auto-detection can be checked by running `ddev config` with no `--project-type` in a directory containing a Maho `composer.json`.

## Automated Testing Overview

- `TestDetectAppType` picks up the new `testdata/TestDetectAppType/maho/` fixture automatically and passes (also confirming no cross-detection with magento/magento2, whose detectors sort earlier)
- `TestConfigOverrideAction` and `TestConfigCommand` maps gained maho entries
- `TestCustomCommands` checks `ddev maho` visibility (available for maho, hidden for php projects)
- `docs/tests/maho.bats` covers the quickstart
- `maho` added to the ddev-webserver container test project-type loop

## Related Issue Link(s)

None; happy to open a tracking issue if preferred.

## Release/Deployment Notes

New project type `maho`; no impact on existing project types.
