### PR TITLE
feat(dbserver): support zstd-compressed base_db for faster first-boot restore

### DIFF
--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -265,6 +265,44 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 		}
 	})
 
+	// A db-build Dockerfile that bakes a base_db seed into the dbimage replaces
+	// the stock starter database, so it gets called out on its own.
+	t.Run("db-build base_db seed", func(t *testing.T) {
+		dbBuildDir := filepath.Join(tmpdir, ".ddev", "db-build")
+		err := os.MkdirAll(dbBuildDir, 0755)
+		require.NoError(t, err)
+		seedDockerfile := filepath.Join(dbBuildDir, "Dockerfile.seed")
+		err = os.WriteFile(seedDockerfile, []byte("COPY base_db.zst /mysqlbase/custom/base_db.zst\n"), 0644)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = os.Remove(seedDockerfile)
+		})
+
+		out, err := exec.RunCommand(DdevBin, []string{"utility", "check-custom-config"})
+		require.NoError(t, err)
+		require.Contains(t, out, "Custom configuration detected in project '"+projectName+"':")
+		require.Contains(t, out, "/mysqlbase/custom/base_db.* baked into dbimage (seeds a new database volume)")
+	})
+
+	// An `initializer` snapshot seeds a fresh database volume, so it's reported
+	// even though it isn't an ordinary config file.
+	t.Run("initializer snapshot", func(t *testing.T) {
+		snapshotDir := filepath.Join(tmpdir, ".ddev", "db_snapshots")
+		err := os.MkdirAll(snapshotDir, 0755)
+		require.NoError(t, err)
+		initializer := filepath.Join(snapshotDir, "initializer-"+nodeps.MariaDB+"_"+nodeps.MariaDBDefaultVersion+".zst")
+		err = os.WriteFile(initializer, []byte("not really a snapshot\n"), 0644)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = os.Remove(initializer)
+		})
+
+		out, err := exec.RunCommand(DdevBin, []string{"utility", "check-custom-config"})
+		require.NoError(t, err)
+		require.Contains(t, out, "Custom configuration detected in project '"+projectName+"':")
+		require.Contains(t, out, "initializer-"+nodeps.MariaDB+"_"+nodeps.MariaDBDefaultVersion+".zst (seeds a new database volume)")
+	})
+
 	// Test mutagen (conditional: only when mutagen is enabled)
 	t.Run("mutagen config", func(t *testing.T) {
 		// Configure to use mutagen

--- a/containers/ddev-dbserver/files/create_base_db.sh
+++ b/containers/ddev-dbserver/files/create_base_db.sh
@@ -110,7 +110,13 @@ PATH=$PATH:/usr/sbin:/usr/local/bin:/usr/local/mysql/bin mysqld -V 2>/dev/null  
 # mysql-8.0 or mariadb-10.5.
 server_db_version=$(awk -F- '{ sub( /\.[0-9]+(-.*)?$/, "", $1); server_type="mysql"; if ($2 ~ /^MariaDB/) { server_type="mariadb" }; print server_type "_" $1 }' /tmp/raw_mysql_version.txt)
 echo ${server_db_version} >${DATADIR:-/var/lib/mysql}/db_mariadb_version.txt
-${backuptool} --backup --stream=${streamtool} --user=root --password=root --socket=${MYSQL_UNIX_PORT}  | gzip >${OUTDIR}/base_db.gz
+# Prefer zstd (parallel decompression, smaller archive); fall back to gzip
+# for base images that lack zstd (e.g. MariaDB 5.5 on Ubuntu 14.04).
+if command -v zstdmt >/dev/null 2>&1 || command -v zstd >/dev/null 2>&1; then
+  ${backuptool} --backup --stream=${streamtool} --user=root --password=root --socket=${MYSQL_UNIX_PORT} | "$(command -v zstdmt 2>/dev/null || echo zstd)" --quiet >${OUTDIR}/base_db.zst
+else
+  ${backuptool} --backup --stream=${streamtool} --user=root --password=root --socket=${MYSQL_UNIX_PORT} | gzip >${OUTDIR}/base_db.gz
+fi
 rm -f /tmp/raw_mysql_version.txt
 
 if ! kill -s TERM "$pid" || ! wait "$pid"; then

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -137,8 +137,8 @@ fi
 # chmod -f ugo-w /etc/mysql/version-conf.d/*.cnf
 
 
-# If mariadb has not been initialized, copy in the base image from either the default starter image (/mysqlbase/base_db.gz)
-# or from a provided $snapshot_dir.
+# If mariadb has not been initialized, copy in the base image from either the default starter image
+# (/mysqlbase/base_db.zst if present, otherwise /mysqlbase/base_db.gz) or from a provided $snapshot_dir.
 if [ ! -f "${DATADIR}/db_mariadb_version.txt" ]; then
     # If snapshot_dir is not set, this is a normal startup, so
     # tell healthcheck to wait by touching /tmp/initializing
@@ -148,8 +148,16 @@ if [ ! -f "${DATADIR}/db_mariadb_version.txt" ]; then
     if [ "${target:-}" = "" ]; then
       target=${snapshot:-/var/tmp/base_db}
       mkdir -p ${target} && cd ${target}
-      snapshot=/mysqlbase/base_db.gz
-      gunzip -c ${snapshot} | ${STREAMTOOL} -x
+      # Prefer a zstd-compressed base database if present; zstdmt decompresses
+      # in parallel and is much faster than single-threaded gunzip.
+      if [ -f /mysqlbase/base_db.zst ]; then
+        snapshot=/mysqlbase/base_db.zst
+        # Only use zstdmt if multithreading is supported (zstd 1.2.0+).
+        "$(command -v zstdmt 2>/dev/null || echo zstd)" -dc --quiet ${snapshot} | ${STREAMTOOL} -x
+      else
+        snapshot=/mysqlbase/base_db.gz
+        gunzip -c ${snapshot} | ${STREAMTOOL} -x
+      fi
     fi
     name=$(basename $target)
 

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -137,8 +137,15 @@ fi
 # chmod -f ugo-w /etc/mysql/version-conf.d/*.cnf
 
 
-# If mariadb has not been initialized, copy in the base image from either the default starter image
-# (/mysqlbase/base_db.zst if present, otherwise /mysqlbase/base_db.gz) or from a provided $snapshot_dir.
+# If mariadb has not been initialized, copy in the base image from a base_db
+# seed or from a provided $snapshot_dir. The base_db seed is looked up in
+# priority order:
+#   1. /mnt/snapshots/initializer-<db_type>_<db_version>.*  - project-supplied,
+#      living alongside regular snapshots in .ddev/db_snapshots
+#   2. /mysqlbase/custom/base_db.*                          - baked into a derived image
+#   3. /mysqlbase/base_db.*                                 - the stock DDEV starter database
+# At each location, a .zst seed is preferred over .gz; .gz only exists at all
+# for db versions (e.g. MariaDB 5.5) whose base image lacks zstd.
 if [ ! -f "${DATADIR}/db_mariadb_version.txt" ]; then
     # If snapshot_dir is not set, this is a normal startup, so
     # tell healthcheck to wait by touching /tmp/initializing
@@ -148,16 +155,34 @@ if [ ! -f "${DATADIR}/db_mariadb_version.txt" ]; then
     if [ "${target:-}" = "" ]; then
       target=${snapshot:-/var/tmp/base_db}
       mkdir -p ${target} && cd ${target}
-      # Prefer a zstd-compressed base database if present; zstdmt decompresses
-      # in parallel and is much faster than single-threaded gunzip.
-      if [ -f /mysqlbase/base_db.zst ]; then
-        snapshot=/mysqlbase/base_db.zst
-        # Only use zstdmt if multithreading is supported (zstd 1.2.0+).
-        "$(command -v zstdmt 2>/dev/null || echo zstd)" -dc --quiet ${snapshot} | ${STREAMTOOL} -x
-      else
-        snapshot=/mysqlbase/base_db.gz
-        gunzip -c ${snapshot} | ${STREAMTOOL} -x
+
+      snapshot=""
+      for candidate in \
+        "/mnt/snapshots/initializer-${server_db_version}.zst" \
+        "/mnt/snapshots/initializer-${server_db_version}.gz" \
+        "/mysqlbase/custom/base_db.zst" \
+        "/mysqlbase/custom/base_db.gz" \
+        "/mysqlbase/base_db.zst" \
+        "/mysqlbase/base_db.gz" \
+      ; do
+        if [ -f "${candidate}" ]; then
+          snapshot="${candidate}"
+          break
+        fi
+      done
+      if [ -z "${snapshot}" ]; then
+        echo "No base_db seed found in /mnt/snapshots, /mysqlbase/custom, or /mysqlbase"
+        exit 102
       fi
+      case "${snapshot}" in
+        *.zst)
+          # Only use zstdmt if multithreading is supported (zstd 1.2.0+).
+          "$(command -v zstdmt 2>/dev/null || echo zstd)" -dc --quiet "${snapshot}" | ${STREAMTOOL} -x
+          ;;
+        *.gz)
+          gunzip -c "${snapshot}" | ${STREAMTOOL} -x
+          ;;
+      esac
     fi
     name=$(basename $target)
 

--- a/containers/ddev-dbserver/test/base_db_seed.bats
+++ b/containers/ddev-dbserver/test/base_db_seed.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+
+# Run these tests from the repo root directory, for example
+# ./test/bats tests
+#
+# Exercises the base_db seed lookup in docker-entrypoint.sh, which is
+# checked in priority order:
+#   1. /mnt/snapshots/initializer-<db_type>_<db_version>.*  - project-supplied,
+#      living alongside regular snapshots in .ddev/db_snapshots
+#   2. /mysqlbase/custom/base_db.*                          - baked into a derived image
+#   3. /mysqlbase/base_db.*                                 - the stock DDEV starter database
+# A .zst seed is preferred over .gz at each location; .gz is exercised too,
+# since db versions without zstd (e.g. MariaDB 5.5) still produce it.
+
+load functions.sh
+
+function setup_file {
+  export SEED_DIR="${BATS_FILE_TMPDIR}/base_db_seeds"
+  mkdir -p "${SEED_DIR}"
+
+  # Match whatever compressor create_base_db.sh actually used to build this
+  # image's stock seed, so the override seeds we build here use the same
+  # extension the entrypoint expects for this ${DB_TYPE} ${DB_VERSION}.
+  if docker run --rm --entrypoint bash "${IMAGE}" -c 'command -v zstdmt || command -v zstd' >/dev/null 2>&1; then
+    export SEED_EXT="zst"
+    export SEED_COMPRESS="zstdmt --quiet"
+  else
+    export SEED_EXT="gz"
+    export SEED_COMPRESS="gzip"
+  fi
+
+  # Matches the server_db_version computed by docker-entrypoint.sh, e.g. mariadb_11.8
+  export INITIALIZER_NAME="initializer-${DB_TYPE}_${DB_VERSION}.${SEED_EXT}"
+
+  make_seed "marker_seed_a" "${SEED_DIR}/seed_a.${SEED_EXT}"
+  make_seed "marker_seed_b" "${SEED_DIR}/seed_b.${SEED_EXT}"
+}
+
+# Build a base_db seed containing a single marker table, using the same
+# backup tool (mariabackup/xtrabackup via xbstream) the entrypoint expects.
+function make_seed {
+  local marker_table=$1
+  local outfile=$2
+  local name="seedbuilder-$$-${RANDOM}"
+  local vol="seedbuilder-vol-$$-${RANDOM}"
+
+  docker run --rm -v "${vol}:/var/lib/mysql:nocopy" busybox:stable chown -R 33:33 /var/lib/mysql
+  docker run -d --user=33:33 -v "${vol}:/var/lib/mysql:nocopy" --name="${name}" "${IMAGE}"
+
+  local health=""
+  for i in {60..0}; do
+    health="$(docker inspect --format '{{json .State.Health }}' "${name}" | jq -r .Status)"
+    if [ "${health}" = "healthy" ]; then
+      break
+    fi
+    sleep 1
+  done
+  [ "${health}" = "healthy" ]
+
+  docker exec "${name}" mysql -udb -pdb --database=db -e "CREATE TABLE ${marker_table} (id INT);"
+  docker exec "${name}" bash -c "mariabackup --backup --stream=xbstream --user=root --password=root --socket=/var/tmp/mysql.sock 2>/tmp/seed.log | ${SEED_COMPRESS}" >"${outfile}"
+
+  docker rm -f "${name}" >/dev/null
+  docker volume rm "${vol}" >/dev/null
+}
+
+function setup {
+  basic_setup
+}
+
+@test "stock base_db seed is used when no override is present for ${DB_TYPE} ${DB_VERSION}" {
+  docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
+  containercheck
+  run docker logs $CONTAINER_NAME
+  [[ "$output" == *"snapshot=/mysqlbase/base_db.${SEED_EXT}"* ]]
+  mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
+}
+
+@test "project-mounted initializer seed overrides the stock seed for ${DB_TYPE} ${DB_VERSION}" {
+  docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy \
+    -v "${SEED_DIR}/seed_a.${SEED_EXT}:/mnt/snapshots/${INITIALIZER_NAME}:ro" \
+    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
+  containercheck
+  run docker logs $CONTAINER_NAME
+  [[ "$output" == *"snapshot=/mnt/snapshots/${INITIALIZER_NAME}"* ]]
+  run mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
+  [[ "$output" == *"marker_seed_a"* ]]
+}
+
+@test "derived-image custom base_db seed overrides the stock seed for ${DB_TYPE} ${DB_VERSION}" {
+  docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy \
+    -v "${SEED_DIR}/seed_b.${SEED_EXT}:/mysqlbase/custom/base_db.${SEED_EXT}:ro" \
+    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
+  containercheck
+  run docker logs $CONTAINER_NAME
+  [[ "$output" == *"snapshot=/mysqlbase/custom/base_db.${SEED_EXT}"* ]]
+  run mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
+  [[ "$output" == *"marker_seed_b"* ]]
+}
+
+@test "project-mounted initializer seed takes precedence over derived-image seed for ${DB_TYPE} ${DB_VERSION}" {
+  docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy \
+    -v "${SEED_DIR}/seed_a.${SEED_EXT}:/mnt/snapshots/${INITIALIZER_NAME}:ro" \
+    -v "${SEED_DIR}/seed_b.${SEED_EXT}:/mysqlbase/custom/base_db.${SEED_EXT}:ro" \
+    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
+  containercheck
+  run docker logs $CONTAINER_NAME
+  [[ "$output" == *"snapshot=/mnt/snapshots/${INITIALIZER_NAME}"* ]]
+  run mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
+  [[ "$output" == *"marker_seed_a"* ]]
+}

--- a/containers/ddev-dbserver/test/base_db_seed.bats
+++ b/containers/ddev-dbserver/test/base_db_seed.bats
@@ -21,9 +21,14 @@ function setup_file {
   # Match whatever compressor create_base_db.sh actually used to build this
   # image's stock seed, so the override seeds we build here use the same
   # extension the entrypoint expects for this ${DB_TYPE} ${DB_VERSION}.
-  if docker run --rm --entrypoint bash "${IMAGE}" -c 'command -v zstdmt || command -v zstd' >/dev/null 2>&1; then
+  # zstdmt isn't available on every image that has zstd, so check (and use)
+  # each individually rather than assuming zstdmt if either is present.
+  if docker run --rm --entrypoint bash "${IMAGE}" -c 'command -v zstdmt' >/dev/null 2>&1; then
     export SEED_EXT="zst"
     export SEED_COMPRESS="zstdmt --quiet"
+  elif docker run --rm --entrypoint bash "${IMAGE}" -c 'command -v zstd' >/dev/null 2>&1; then
+    export SEED_EXT="zst"
+    export SEED_COMPRESS="zstd --quiet"
   else
     export SEED_EXT="gz"
     export SEED_COMPRESS="gzip"

--- a/containers/ddev-dbserver/test/base_db_seed.bats
+++ b/containers/ddev-dbserver/test/base_db_seed.bats
@@ -58,7 +58,13 @@ function make_seed {
   [ "${health}" = "healthy" ]
 
   docker exec "${name}" mysql -udb -pdb --database=db -e "CREATE TABLE ${marker_table} (id INT);"
-  docker exec "${name}" bash -c "mariabackup --backup --stream=xbstream --user=root --password=root --socket=/var/tmp/mysql.sock 2>/tmp/seed.log | ${SEED_COMPRESS}" >"${outfile}"
+  # mariabackup/mbstream on MariaDB, xtrabackup/xbstream on MySQL (and some
+  # older MariaDB) -- same detection docker-entrypoint.sh itself uses.
+  docker exec "${name}" bash -c "
+    backuptool=mariabackup; streamtool=mbstream
+    if command -v xtrabackup >/dev/null 2>&1; then backuptool=xtrabackup; streamtool=xbstream; fi
+    \${backuptool} --backup --stream=\${streamtool} --user=root --password=root --socket=/var/tmp/mysql.sock 2>/tmp/seed.log | ${SEED_COMPRESS}
+  " >"${outfile}"
 
   docker rm -f "${name}" >/dev/null
   docker volume rm "${vol}" >/dev/null

--- a/containers/ddev-dbserver/test/base_db_seed.bats
+++ b/containers/ddev-dbserver/test/base_db_seed.bats
@@ -15,6 +15,13 @@
 load functions.sh
 
 function setup_file {
+  # base_db seed overrides aren't supported on these very old, EOL database
+  # versions. (The stock, unmounted base_db path for them is still covered
+  # by basic_database.bats.)
+  if [ "${DB_TYPE}:${DB_VERSION}" = "mysql:5.5" ] || [ "${DB_TYPE}:${DB_VERSION}" = "mariadb:5.5" ]; then
+    skip "base_db seed overrides are not supported on ${DB_TYPE} ${DB_VERSION}"
+  fi
+
   export SEED_DIR="${BATS_FILE_TMPDIR}/base_db_seeds"
   mkdir -p "${SEED_DIR}"
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -254,7 +254,7 @@ If you publish a derived `dbimage` (for example a CI-built image with your produ
 COPY base_db.zst /mysqlbase/custom/base_db.zst
 ```
 
-The database container uses this seed the first time its data volume is created (a brand-new project, or after `ddev delete` and `ddev start`), instead of the stock DDEV starter database. It's checked ahead of the stock seed but *after* any project-level [`initializer` snapshot](../usage/database-management.md#snapshots) — so a teammate can still override your baked-in seed for their own project just by dropping an `initializer` snapshot into `.ddev/db_snapshots`, without rebuilding the image.
+The database container uses this seed the first time its data volume is created (a brand-new project, or after `ddev delete` and `ddev start`), instead of the stock DDEV starter database. It's checked ahead of the stock seed but _after_ any project-level [`initializer` snapshot](../usage/database-management.md#snapshots) — so a teammate can still override your baked-in seed for their own project just by dropping an `initializer` snapshot into `.ddev/db_snapshots`, without rebuilding the image.
 
 !!!note
     Not supported on the very old, EOL `mysql:5.5` and `mariadb:5.5` database types.

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -246,6 +246,16 @@ An example of using `$TARGETARCH` would be:
 RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=linux/${TARGETARCH}"
 ```
 
+## Seeding a Custom Starter Database in `dbimage`
+
+If you publish a derived `dbimage` (for example a CI-built image with your production dataset baked in, so teammates or preview environments get a ready-to-use database with no import step), bake it in as `/mysqlbase/custom/base_db.zst` using a `.ddev/db-build/Dockerfile`:
+
+```dockerfile
+COPY base_db.zst /mysqlbase/custom/base_db.zst
+```
+
+The database container uses this seed the first time its data volume is created (a brand-new project, or after `ddev delete` and `ddev start`), instead of the stock DDEV starter database. It's checked ahead of the stock seed but *after* any project-level [`initializer` snapshot](../usage/database-management.md#snapshots) — so a teammate can still override your baked-in seed for their own project just by dropping an `initializer` snapshot into `.ddev/db_snapshots`, without rebuilding the image.
+
 ## Adding EOL Versions of PHP
 
 If your project requires multiple versions of PHP—such as using PHP 8.3 but also needing an older, unsupported, unmaintained version like PHP 7.4 for specific scripts—and you don’t want to fully switch to PHP 7.4 with `ddev config --php-version=7.4`, you can install it using the `pre.Dockerfile.*` technique from the previous section.

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -256,6 +256,9 @@ COPY base_db.zst /mysqlbase/custom/base_db.zst
 
 The database container uses this seed the first time its data volume is created (a brand-new project, or after `ddev delete` and `ddev start`), instead of the stock DDEV starter database. It's checked ahead of the stock seed but *after* any project-level [`initializer` snapshot](../usage/database-management.md#snapshots) — so a teammate can still override your baked-in seed for their own project just by dropping an `initializer` snapshot into `.ddev/db_snapshots`, without rebuilding the image.
 
+!!!note
+    Not supported on the very old, EOL `mysql:5.5` and `mariadb:5.5` database types.
+
 ## Adding EOL Versions of PHP
 
 If your project requires multiple versions of PHP—such as using PHP 8.3 but also needing an older, unsupported, unmaintained version like PHP 7.4 for specific scripts—and you don’t want to fully switch to PHP 7.4 with `ddev config --php-version=7.4`, you can install it using the `pre.Dockerfile.*` technique from the previous section.

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -256,6 +256,13 @@ COPY base_db.zst /mysqlbase/custom/base_db.zst
 
 The database container uses this seed the first time its data volume is created (a brand-new project, or after `ddev delete` and `ddev start`), instead of the stock DDEV starter database. It's checked ahead of the stock seed but _after_ any project-level [`initializer` snapshot](../usage/database-management.md#snapshots) — so a teammate can still override your baked-in seed for their own project just by dropping an `initializer` snapshot into `.ddev/db_snapshots`, without rebuilding the image.
 
+When `ddev start` seeds a fresh database volume from a baked-in seed, it says so and warns that a large one may take a while:
+
+```
+Initializing new database volume from /mysqlbase/custom/base_db.zst baked into dbimage ddev/ddev-dbserver-mariadb-11.8:v1.25.0...
+With a large database this may take a long time.
+```
+
 !!!note
     Not supported on the very old, EOL `mysql:5.5` and `mariadb:5.5` database types.
 

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -63,6 +63,9 @@ ddev snapshot --name=initializer
 
 Unlike other snapshots, `initializer` isn't meant to be restored with `ddev snapshot restore` — it's only consulted for an uninitialized database. Commit the resulting `initializer-*` file in `.ddev/db_snapshots` to your repository if you want teammates and CI to get the same starting dataset on their first `ddev start`.
 
+!!!note
+    Not supported on the very old, EOL `mysql:5.5` and `mariadb:5.5` database types.
+
 ## Database Clients
 
 The `ddev mysql` and `ddev psql` commands give you direct access to the `mysql` and `psql` clients in the database container, which can be useful for quickly running commands while you work. You might run `ddev mysql` to use interactive commands like `DROP DATABASE backend;` or `SHOW TABLES;`, or do things like `echo "SHOW TABLES;" | ddev mysql` or `ddev mysql -udb -pdb` to run with `db` user privileges.

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -51,6 +51,18 @@ Use the [`ddev snapshot restore`](../usage/commands.md#snapshot-restore) command
 
 Snapshots are stored as simple gzipped files in the project's `.ddev/db_snapshots` directory, and any or all snapshots can be removed with the `ddev snapshot --cleanup` command or by manually deleting the files when you want to save disk space or have no further use for them.
 
+### Seeding a Fresh Database with an `initializer` Snapshot
+
+`initializer` is a reserved snapshot name. If a snapshot named `initializer` exists in `.ddev/db_snapshots`, it's used automatically the first time a project's database volume is created — a brand-new project, or after `ddev delete` and [`ddev start`](../usage/commands.md#start) — instead of DDEV's normal empty starter database. This is a fast, direct restore of the database files, much quicker than importing a SQL dump on every fresh start.
+
+Create one from a running project's current database with:
+
+```bash
+ddev snapshot --name=initializer
+```
+
+Unlike other snapshots, `initializer` isn't meant to be restored with `ddev snapshot restore` — it's only consulted for an uninitialized database. Commit the resulting `initializer-*` file in `.ddev/db_snapshots` to your repository if you want teammates and CI to get the same starting dataset on their first `ddev start`.
+
 ## Database Clients
 
 The `ddev mysql` and `ddev psql` commands give you direct access to the `mysql` and `psql` clients in the database container, which can be useful for quickly running commands while you work. You might run `ddev mysql` to use interactive commands like `DROP DATABASE backend;` or `SHOW TABLES;`, or do things like `echo "SHOW TABLES;" | ddev mysql` or `ddev mysql -udb -pdb` to run with `db` user privileges.

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -61,7 +61,7 @@ Create one from a running project's current database with:
 ddev snapshot --name=initializer
 ```
 
-Unlike other snapshots, `initializer` isn't meant to be restored with `ddev snapshot restore` — it's only consulted for an uninitialized database. Commit the resulting `initializer-*` file in `.ddev/db_snapshots` to your repository if you want teammates and CI to get the same starting dataset on their first `ddev start`.
+Unlike other snapshots, `initializer` isn't meant to be restored with `ddev snapshot restore` — it's only consulted for an uninitialized database. You can choose to commit the resulting `initializer-*` file in `.ddev/db_snapshots` to your repository if you want teammates and CI to get the same starting dataset on their first `ddev start`, but it may be large and you may want to use another distribution technique.
 
 An `initializer` snapshot is listed as [custom configuration](../extend/customization-extendibility.md), so `ddev start` and [`ddev utility check-custom-config`](../usage/commands.md#utility-check-custom-config) both show it. When `ddev start` actually seeds a fresh database volume from it, it says so, naming the snapshot and its size and warning that a large one may take a while:
 

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -63,6 +63,13 @@ ddev snapshot --name=initializer
 
 Unlike other snapshots, `initializer` isn't meant to be restored with `ddev snapshot restore` — it's only consulted for an uninitialized database. Commit the resulting `initializer-*` file in `.ddev/db_snapshots` to your repository if you want teammates and CI to get the same starting dataset on their first `ddev start`.
 
+An `initializer` snapshot is listed as [custom configuration](../extend/customization-extendibility.md), so `ddev start` and [`ddev utility check-custom-config`](../usage/commands.md#utility-check-custom-config) both show it. When `ddev start` actually seeds a fresh database volume from it, it says so, naming the snapshot and its size and warning that a large one may take a while:
+
+```
+Initializing new database volume from the 'initializer' snapshot /path/to/project/.ddev/db_snapshots/initializer-mariadb_11.8.zst (2.2 GiB)...
+With a large database this may take a long time.
+```
+
 !!!note
     Not supported on the very old, EOL `mysql:5.5` and `mariadb:5.5` database types.
 

--- a/pkg/ddevapp/base_db_seed.go
+++ b/pkg/ddevapp/base_db_seed.go
@@ -93,6 +93,21 @@ func (app *DdevApp) mayHaveDerivedDBImageSeed() bool {
 	return len(app.GetDBBuildDockerfiles()) > 0
 }
 
+// derivedBuiltImageRef returns the tag of the project's built "-<project>-built"
+// image for a given base image, matching what `docker compose build` actually
+// tags it as: the image string is used as-is as the new tag, and Docker
+// defaults a tag-less repo to ":latest". dockerutil.RunSimpleContainer
+// requires an explicit tag on its input, so a bare repo (e.g. `dbimage:
+// randyfay/dbserver-2m` with no ":tag") needs ":latest" appended here too, or
+// it's rejected before ever reaching Docker.
+func derivedBuiltImageRef(baseImage, appName string) string {
+	image := baseImage + "-" + appName + "-built"
+	if !strings.Contains(image, ":") {
+		image += ":latest"
+	}
+	return image
+}
+
 // getDerivedDBImageSeed returns the in-image path and byte size of a base_db
 // seed baked into the built dbimage. path is empty if there is none; size is
 // -1 if it could not be determined. This runs a container against the image,
@@ -105,7 +120,7 @@ func (app *DdevApp) getDerivedDBImageSeed() (path string, size int64) {
 	script := fmt.Sprintf(`for f in %s; do if [ -f "$f" ]; then printf '%%s %%s\n' "$f" "$(wc -c <"$f")"; break; fi; done`, strings.Join(candidates, " "))
 
 	_, out, err := dockerutil.RunSimpleContainer(
-		app.GetDBImage()+"-"+app.Name+"-built",
+		derivedBuiltImageRef(app.GetDBImage(), app.Name),
 		"db-seed-check-"+app.Name+"-"+util.RandString(6),
 		[]string{"-c", script},
 		[]string{"/bin/sh"},

--- a/pkg/ddevapp/base_db_seed.go
+++ b/pkg/ddevapp/base_db_seed.go
@@ -152,7 +152,7 @@ func (app *DdevApp) BaseDBSeedDescription() string {
 	}
 
 	if initializer := app.GetInitializerSnapshotFile(); initializer != "" {
-		return fmt.Sprintf("the '%s' snapshot %s%s", InitializerSnapshotName, filepath.ToSlash(initializer), fileSizeSuffix(initializer))
+		return fmt.Sprintf("the '%s' snapshot\n%s%s", InitializerSnapshotName, fileutil.ShortHomeJoin(initializer), fileSizeSuffix(initializer))
 	}
 	if app.mayHaveDerivedDBImageSeed() {
 		if seed, size := app.getDerivedDBImageSeed(); seed != "" {

--- a/pkg/ddevapp/base_db_seed.go
+++ b/pkg/ddevapp/base_db_seed.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/docker"
@@ -92,15 +93,16 @@ func (app *DdevApp) mayHaveDerivedDBImageSeed() bool {
 	return len(app.GetDBBuildDockerfiles()) > 0
 }
 
-// getDerivedDBImageSeed returns the in-image path of a base_db seed baked into
-// the built dbimage, or an empty string if there is none. This runs a container
-// against the image, so callers gate it on mayHaveDerivedDBImageSeed().
-func (app *DdevApp) getDerivedDBImageSeed() string {
+// getDerivedDBImageSeed returns the in-image path and byte size of a base_db
+// seed baked into the built dbimage. path is empty if there is none; size is
+// -1 if it could not be determined. This runs a container against the image,
+// so callers gate it on mayHaveDerivedDBImageSeed().
+func (app *DdevApp) getDerivedDBImageSeed() (path string, size int64) {
 	var candidates []string
 	for _, ext := range baseDBSeedExtensions {
 		candidates = append(candidates, CustomBaseDBSeedPathPrefix+"."+ext)
 	}
-	script := fmt.Sprintf(`for f in %s; do if [ -f "$f" ]; then echo "$f"; break; fi; done`, strings.Join(candidates, " "))
+	script := fmt.Sprintf(`for f in %s; do if [ -f "$f" ]; then printf '%%s %%s\n' "$f" "$(wc -c <"$f")"; break; fi; done`, strings.Join(candidates, " "))
 
 	_, out, err := dockerutil.RunSimpleContainer(
 		app.GetDBImage()+"-"+app.Name+"-built",
@@ -118,17 +120,24 @@ func (app *DdevApp) getDerivedDBImageSeed() string {
 	)
 	if err != nil {
 		util.Debug("Unable to check dbimage for a baked-in base_db seed: %v, output=%s", err, out)
-		return ""
+		return "", -1
 	}
 	// The container's output can carry unrelated noise, so only accept a line
-	// that actually names one of the seed paths we asked about.
+	// whose first field actually names one of the seed paths we asked about.
 	for line := range strings.SplitSeq(out, "\n") {
-		line = strings.TrimSpace(line)
-		if slices.Contains(candidates, line) {
-			return line
+		fields := strings.Fields(line)
+		if len(fields) == 0 || !slices.Contains(candidates, fields[0]) {
+			continue
 		}
+		size = -1
+		if len(fields) > 1 {
+			if n, convErr := strconv.ParseInt(fields[1], 10, 64); convErr == nil {
+				size = n
+			}
+		}
+		return fields[0], size
 	}
-	return ""
+	return "", -1
 }
 
 // BaseDBSeedDescription returns a human-readable description of what a
@@ -146,8 +155,8 @@ func (app *DdevApp) BaseDBSeedDescription() string {
 		return fmt.Sprintf("the '%s' snapshot %s%s", InitializerSnapshotName, filepath.ToSlash(initializer), fileSizeSuffix(initializer))
 	}
 	if app.mayHaveDerivedDBImageSeed() {
-		if seed := app.getDerivedDBImageSeed(); seed != "" {
-			return fmt.Sprintf("%s baked into dbimage %s", seed, app.GetDBImage())
+		if seed, size := app.getDerivedDBImageSeed(); seed != "" {
+			return fmt.Sprintf("%s%s baked into dbimage %s", seed, byteSizeSuffix(size), app.GetDBImage())
 		}
 	}
 	return ""
@@ -171,5 +180,14 @@ func fileSizeSuffix(path string) string {
 	if err != nil || fi.IsDir() {
 		return ""
 	}
-	return fmt.Sprintf(" (%s)", util.FormatBytes(fi.Size()))
+	return byteSizeSuffix(fi.Size())
+}
+
+// byteSizeSuffix returns a " (2.3GB)" style suffix for a byte count, or an
+// empty string if size is negative (unknown).
+func byteSizeSuffix(size int64) string {
+	if size < 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (%s)", util.FormatBytes(size))
 }

--- a/pkg/ddevapp/base_db_seed.go
+++ b/pkg/ddevapp/base_db_seed.go
@@ -131,48 +131,45 @@ func (app *DdevApp) getDerivedDBImageSeed() string {
 	return ""
 }
 
-// announceBaseDBSeed tells the user what a brand-new database volume is about to
-// be seeded from, in the same spirit as RestoreSnapshot: what it's doing, which
-// seed it's using, and that it may take a while. It stays quiet for the stock
-// starter database, which is small and fast.
-func (app *DdevApp) announceBaseDBSeed() {
+// BaseDBSeedDescription returns a human-readable description of what a
+// brand-new database volume will be seeded from (an initializer snapshot, or
+// a seed baked into a derived dbimage), or an empty string if it'll just be
+// the stock starter database. Callers use this to decide whether to warn
+// about a long first-boot restore and extend the container-ready timeout
+// accordingly.
+func (app *DdevApp) BaseDBSeedDescription() string {
 	if !app.UsesBaseDBSeed() {
-		return
+		return ""
 	}
 
-	var description string
 	if initializer := app.GetInitializerSnapshotFile(); initializer != "" {
-		description = fmt.Sprintf("the '%s' snapshot %s%s", InitializerSnapshotName, filepath.ToSlash(initializer), fileSizeSuffix(initializer))
-	} else if app.mayHaveDerivedDBImageSeed() {
+		return fmt.Sprintf("the '%s' snapshot %s%s", InitializerSnapshotName, filepath.ToSlash(initializer), fileSizeSuffix(initializer))
+	}
+	if app.mayHaveDerivedDBImageSeed() {
 		if seed := app.getDerivedDBImageSeed(); seed != "" {
-			description = fmt.Sprintf("%s baked into dbimage %s", seed, app.GetDBImage())
+			return fmt.Sprintf("%s baked into dbimage %s", seed, app.GetDBImage())
 		}
 	}
-	if description == "" {
-		return
-	}
+	return ""
+}
 
+// announceBaseDBSeed tells the user what a brand-new database volume is about to
+// be seeded from, in the same spirit as RestoreSnapshot: what it's doing, which
+// seed it's using, and that it may take a while. maxWaitTime is the
+// container-ready timeout that will actually be in effect, so the message
+// matches reality.
+func (app *DdevApp) announceBaseDBSeed(description string, maxWaitTime int) {
 	util.Success("Initializing new database volume from %s...", description)
-	util.Success("With a large database this may take a long time.\nThis may time out after %d seconds \nbut you can increase it by changing default_container_timeout.", app.GetMaxContainerWaitTime())
+	util.Success("With a large database this may take a long time.\nThis may time out after %d seconds \nbut you can increase it by changing default_container_timeout.", maxWaitTime)
 	output.UserOut.Printf("You can follow the progress in another terminal window with `ddev logs -s db -f %s`", app.Name)
 }
 
-// fileSizeSuffix returns a " (2.2 GiB)" style suffix for a file, or an empty
+// fileSizeSuffix returns a " (2.3GB)" style suffix for a file, or an empty
 // string if the size can't be determined.
 func fileSizeSuffix(path string) string {
 	fi, err := os.Stat(path)
 	if err != nil || fi.IsDir() {
 		return ""
 	}
-	units := []string{"bytes", "KiB", "MiB", "GiB", "TiB"}
-	size := float64(fi.Size())
-	i := 0
-	for size >= 1024 && i < len(units)-1 {
-		size /= 1024
-		i++
-	}
-	if i == 0 {
-		return fmt.Sprintf(" (%d %s)", fi.Size(), units[0])
-	}
-	return fmt.Sprintf(" (%.1f %s)", size, units[i])
+	return fmt.Sprintf(" (%s)", util.FormatBytes(fi.Size()))
 }

--- a/pkg/ddevapp/base_db_seed.go
+++ b/pkg/ddevapp/base_db_seed.go
@@ -1,0 +1,178 @@
+package ddevapp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/ddev/ddev/pkg/docker"
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+)
+
+// InitializerSnapshotName is the reserved snapshot name that ddev-dbserver uses
+// to seed a brand-new database volume instead of the stock starter database.
+// See containers/ddev-dbserver/files/docker-entrypoint.sh
+const InitializerSnapshotName = "initializer"
+
+// CustomBaseDBSeedPathPrefix is where a derived dbimage bakes in its own
+// base_db seed; ddev-dbserver checks it ahead of the stock /mysqlbase/base_db.*
+const CustomBaseDBSeedPathPrefix = "/mysqlbase/custom/base_db"
+
+// baseDBSeedExtensions lists the base_db seed compression suffixes in the same
+// preference order that ddev-dbserver's docker-entrypoint.sh uses.
+var baseDBSeedExtensions = []string{"zst", "gz"}
+
+// UsesBaseDBSeed reports whether this project's database volume gets initialized
+// from a base_db seed. Only MariaDB/MySQL do; PostgreSQL uses the upstream
+// postgres entrypoint.
+func (app *DdevApp) UsesBaseDBSeed() bool {
+	return !app.IsDBOmitted() && slices.Contains([]string{nodeps.MariaDB, nodeps.MySQL}, app.Database.Type)
+}
+
+// GetInitializerSnapshotFile returns the host path of the project's reserved
+// `initializer` snapshot for the configured database type/version, or an empty
+// string if there isn't one. ddev-dbserver looks for
+// /mnt/snapshots/initializer-<type>_<version>.{zst,gz}, preferring .zst.
+func (app *DdevApp) GetInitializerSnapshotFile() string {
+	if !app.UsesBaseDBSeed() {
+		return ""
+	}
+	for _, ext := range baseDBSeedExtensions {
+		f := app.GetConfigPath(filepath.Join("db_snapshots", fmt.Sprintf("%s-%s_%s.%s", InitializerSnapshotName, app.Database.Type, app.Database.Version, ext)))
+		if fileutil.FileExists(f) {
+			return f
+		}
+	}
+	return ""
+}
+
+// GetDBBuildDockerfiles returns the global and project db-build Dockerfiles.
+func (app *DdevApp) GetDBBuildDockerfiles() []string {
+	var dockerfiles []string
+	for _, dir := range []string{filepath.Join(globalconfig.GetGlobalDdevDir(), "db-build"), app.GetConfigPath("db-build")} {
+		found, err := getBuildDockerfilesInDir(dir)
+		if err != nil {
+			continue
+		}
+		dockerfiles = append(dockerfiles, found...)
+	}
+	return dockerfiles
+}
+
+// GetDBBuildSeedDockerfiles returns the db-build Dockerfiles that bake a
+// base_db seed into the derived dbimage.
+func (app *DdevApp) GetDBBuildSeedDockerfiles() []string {
+	if !app.UsesBaseDBSeed() {
+		return nil
+	}
+	var seedDockerfiles []string
+	for _, dockerfile := range app.GetDBBuildDockerfiles() {
+		if found, err := fileutil.FgrepStringInFile(dockerfile, CustomBaseDBSeedPathPrefix); err == nil && found {
+			seedDockerfiles = append(seedDockerfiles, dockerfile)
+		}
+	}
+	return seedDockerfiles
+}
+
+// mayHaveDerivedDBImageSeed reports whether a base_db seed could possibly be
+// baked into this project's dbimage: either the dbimage is an explicitly
+// configured non-default one, or a db-build Dockerfile could COPY a seed in.
+// Used to skip inspecting the image at all in the ordinary stock-image case.
+func (app *DdevApp) mayHaveDerivedDBImageSeed() bool {
+	if app.DBImage != "" && app.DBImage != docker.GetDBImage(app.Database.Type, app.Database.Version) {
+		return true
+	}
+	return len(app.GetDBBuildDockerfiles()) > 0
+}
+
+// getDerivedDBImageSeed returns the in-image path of a base_db seed baked into
+// the built dbimage, or an empty string if there is none. This runs a container
+// against the image, so callers gate it on mayHaveDerivedDBImageSeed().
+func (app *DdevApp) getDerivedDBImageSeed() string {
+	var candidates []string
+	for _, ext := range baseDBSeedExtensions {
+		candidates = append(candidates, CustomBaseDBSeedPathPrefix+"."+ext)
+	}
+	script := fmt.Sprintf(`for f in %s; do if [ -f "$f" ]; then echo "$f"; break; fi; done`, strings.Join(candidates, " "))
+
+	_, out, err := dockerutil.RunSimpleContainer(
+		app.GetDBImage()+"-"+app.Name+"-built",
+		"db-seed-check-"+app.Name+"-"+util.RandString(6),
+		[]string{"-c", script},
+		[]string{"/bin/sh"},
+		nil,   // env
+		nil,   // binds
+		"",    // uid
+		true,  // rm
+		false, // detach
+		map[string]string{`com.ddev.site-name`: ""},
+		nil, // portBindings
+		nil, // healthcheck
+	)
+	if err != nil {
+		util.Debug("Unable to check dbimage for a baked-in base_db seed: %v, output=%s", err, out)
+		return ""
+	}
+	// The container's output can carry unrelated noise, so only accept a line
+	// that actually names one of the seed paths we asked about.
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimSpace(line)
+		if slices.Contains(candidates, line) {
+			return line
+		}
+	}
+	return ""
+}
+
+// announceBaseDBSeed tells the user what a brand-new database volume is about to
+// be seeded from, in the same spirit as RestoreSnapshot: what it's doing, which
+// seed it's using, and that it may take a while. It stays quiet for the stock
+// starter database, which is small and fast.
+func (app *DdevApp) announceBaseDBSeed() {
+	if !app.UsesBaseDBSeed() {
+		return
+	}
+
+	var description string
+	if initializer := app.GetInitializerSnapshotFile(); initializer != "" {
+		description = fmt.Sprintf("the '%s' snapshot %s%s", InitializerSnapshotName, filepath.ToSlash(initializer), fileSizeSuffix(initializer))
+	} else if app.mayHaveDerivedDBImageSeed() {
+		if seed := app.getDerivedDBImageSeed(); seed != "" {
+			description = fmt.Sprintf("%s baked into dbimage %s", seed, app.GetDBImage())
+		}
+	}
+	if description == "" {
+		return
+	}
+
+	util.Success("Initializing new database volume from %s...", description)
+	util.Success("With a large database this may take a long time.\nThis may time out after %d seconds \nbut you can increase it by changing default_container_timeout.", app.GetMaxContainerWaitTime())
+	output.UserOut.Printf("You can follow the progress in another terminal window with `ddev logs -s db -f %s`", app.Name)
+}
+
+// fileSizeSuffix returns a " (2.2 GiB)" style suffix for a file, or an empty
+// string if the size can't be determined.
+func fileSizeSuffix(path string) string {
+	fi, err := os.Stat(path)
+	if err != nil || fi.IsDir() {
+		return ""
+	}
+	units := []string{"bytes", "KiB", "MiB", "GiB", "TiB"}
+	size := float64(fi.Size())
+	i := 0
+	for size >= 1024 && i < len(units)-1 {
+		size /= 1024
+		i++
+	}
+	if i == 0 {
+		return fmt.Sprintf(" (%d %s)", fi.Size(), units[0])
+	}
+	return fmt.Sprintf(" (%.1f %s)", size, units[i])
+}

--- a/pkg/ddevapp/base_db_seed_test.go
+++ b/pkg/ddevapp/base_db_seed_test.go
@@ -1,0 +1,131 @@
+package ddevapp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+// newBaseDBSeedTestApp returns an unstarted app rooted in a temp directory with
+// a .ddev directory, enough for the host-side base_db seed lookups.
+func newBaseDBSeedTestApp(t *testing.T, dbType, dbVersion string) *DdevApp {
+	t.Helper()
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".ddev"), 0755))
+	app := &DdevApp{
+		Name:       "base-db-seed-test",
+		AppRoot:    tmpDir,
+		ConfigPath: filepath.Join(tmpDir, ".ddev", "config.yaml"),
+	}
+	app.Database.Type = dbType
+	app.Database.Version = dbVersion
+	return app
+}
+
+// writeBaseDBSeedTestFile writes content to a path under the project's .ddev directory.
+func writeBaseDBSeedTestFile(t *testing.T, app *DdevApp, relPath, content string) string {
+	t.Helper()
+	fullPath := app.GetConfigPath(relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0755))
+	require.NoError(t, os.WriteFile(fullPath, []byte(content), 0644))
+	return fullPath
+}
+
+// TestGetInitializerSnapshotFile verifies the host-side lookup of the reserved
+// `initializer` snapshot, which must match ddev-dbserver's docker-entrypoint.sh:
+// named for the exact db type/version, preferring .zst over .gz.
+func TestGetInitializerSnapshotFile(t *testing.T) {
+	app := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
+	require.Empty(t, app.GetInitializerSnapshotFile())
+
+	gz := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "initializer-mariadb_10.11.gz"), "seed")
+	require.Equal(t, gz, app.GetInitializerSnapshotFile())
+
+	// .zst wins over .gz when both are present.
+	zst := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "initializer-mariadb_10.11.zst"), "seed")
+	require.Equal(t, zst, app.GetInitializerSnapshotFile())
+
+	// A snapshot for a different db version is not this project's initializer.
+	other := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB106)
+	writeBaseDBSeedTestFile(t, other, filepath.Join("db_snapshots", "initializer-mariadb_10.11.zst"), "seed")
+	require.Empty(t, other.GetInitializerSnapshotFile())
+
+	// PostgreSQL doesn't use base_db seeding at all.
+	pg := newBaseDBSeedTestApp(t, nodeps.Postgres, nodeps.Postgres17)
+	writeBaseDBSeedTestFile(t, pg, filepath.Join("db_snapshots", "initializer-postgres_17.zst"), "seed")
+	require.Empty(t, pg.GetInitializerSnapshotFile())
+
+	// Neither does a project with no db container.
+	omitted := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
+	omitted.OmitContainers = []string{"db"}
+	writeBaseDBSeedTestFile(t, omitted, filepath.Join("db_snapshots", "initializer-mariadb_10.11.zst"), "seed")
+	require.Empty(t, omitted.GetInitializerSnapshotFile())
+}
+
+// TestGetDBBuildSeedDockerfiles verifies that only db-build Dockerfiles that
+// actually bake a base_db seed into the dbimage are reported, and that the
+// bundled Dockerfile.example is ignored.
+func TestGetDBBuildSeedDockerfiles(t *testing.T) {
+	app := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
+
+	writeBaseDBSeedTestFile(t, app, filepath.Join("db-build", "Dockerfile"), "RUN echo hi\n")
+	require.Empty(t, app.GetDBBuildSeedDockerfiles())
+	require.True(t, app.mayHaveDerivedDBImageSeed(), "a db-build Dockerfile makes a derived-image seed possible")
+
+	seed := writeBaseDBSeedTestFile(t, app, filepath.Join("db-build", "Dockerfile.seed"), "COPY base_db.zst /mysqlbase/custom/base_db.zst\n")
+	require.Equal(t, []string{seed}, app.GetDBBuildSeedDockerfiles())
+
+	// Dockerfile.example ships in every project and is never built, so it must
+	// not make us think a derived image (or a seed) is in play.
+	clean := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
+	writeBaseDBSeedTestFile(t, clean, filepath.Join("db-build", "Dockerfile.example"), "COPY base_db.zst /mysqlbase/custom/base_db.zst\n")
+	require.Empty(t, clean.GetDBBuildSeedDockerfiles())
+	require.False(t, clean.mayHaveDerivedDBImageSeed())
+}
+
+// TestAnnounceBaseDBSeed verifies that seeding a fresh database volume from a
+// project `initializer` snapshot is announced with what it's doing, which
+// snapshot, and that it may take a while — and that the stock starter database
+// (no initializer, no derived image) stays quiet.
+func TestAnnounceBaseDBSeed(t *testing.T) {
+	app := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
+	app.DefaultContainerTimeout = nodeps.DefaultDefaultContainerTimeout
+
+	outFunc := util.CaptureUserOut()
+	app.announceBaseDBSeed()
+	require.Empty(t, strings.TrimSpace(outFunc()), "stock starter database should not be announced")
+
+	initializer := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "initializer-mariadb_10.11.zst"), strings.Repeat("x", 2048))
+	outFunc = util.CaptureUserOut()
+	app.announceBaseDBSeed()
+	out := outFunc()
+
+	require.Contains(t, out, "Initializing new database volume from the 'initializer' snapshot")
+	require.Contains(t, out, filepath.ToSlash(initializer))
+	require.Contains(t, out, "(2.0 KiB)")
+	require.Contains(t, out, "this may take a long time")
+	require.Contains(t, out, "default_container_timeout")
+	require.Contains(t, out, "ddev logs -s db -f "+app.Name)
+}
+
+// TestFileSizeSuffix verifies the human-readable size suffix used when
+// announcing an `initializer` snapshot restore.
+func TestFileSizeSuffix(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	small := filepath.Join(tmpDir, "small")
+	require.NoError(t, os.WriteFile(small, make([]byte, 512), 0644))
+	require.Equal(t, " (512 bytes)", fileSizeSuffix(small))
+
+	large := filepath.Join(tmpDir, "large")
+	require.NoError(t, os.WriteFile(large, make([]byte, 3*1024*1024), 0644))
+	require.Equal(t, " (3.0 MiB)", fileSizeSuffix(large))
+
+	require.Empty(t, fileSizeSuffix(filepath.Join(tmpDir, "nonexistent")))
+	require.Empty(t, fileSizeSuffix(tmpDir))
+}

--- a/pkg/ddevapp/base_db_seed_test.go
+++ b/pkg/ddevapp/base_db_seed_test.go
@@ -116,6 +116,23 @@ func TestAnnounceBaseDBSeed(t *testing.T) {
 	require.Contains(t, out, strconv.Itoa(SnapshotRestoreDefaultWaitTime))
 }
 
+// TestDerivedBuiltImageRef verifies the "-<project>-built" image reference
+// getDerivedDBImageSeed() checks always carries an explicit tag, since
+// dockerutil.RunSimpleContainer rejects a bare repo with no ":tag" outright.
+// A `dbimage:` set without an explicit tag (e.g. "randyfay/dbserver-2m") is a
+// common way to configure it, and previously produced an untagged
+// "repo-project-built" reference that RunSimpleContainer flatly rejected,
+// silently swallowed by util.Debug -- see base_db_seed.go.
+func TestDerivedBuiltImageRef(t *testing.T) {
+	// No tag on the base image: matches what `docker compose build` actually
+	// tags it as, since Docker itself defaults a tag-less repo to ":latest".
+	require.Equal(t, "randyfay/dbserver-2m-myproject-built:latest", derivedBuiltImageRef("randyfay/dbserver-2m", "myproject"))
+
+	// An explicit tag already present: the suffix lands in the tag portion,
+	// same convention used for app.WebImage elsewhere in this package.
+	require.Equal(t, "ddev/ddev-dbserver-mariadb-11.8:v1.25.3-myproject-built", derivedBuiltImageRef("ddev/ddev-dbserver-mariadb-11.8:v1.25.3", "myproject"))
+}
+
 // TestFileSizeSuffix verifies the human-readable size suffix used when
 // announcing an `initializer` snapshot restore.
 func TestFileSizeSuffix(t *testing.T) {

--- a/pkg/ddevapp/base_db_seed_test.go
+++ b/pkg/ddevapp/base_db_seed_test.go
@@ -3,6 +3,7 @@ package ddevapp
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -96,21 +97,23 @@ func TestAnnounceBaseDBSeed(t *testing.T) {
 	app := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
 	app.DefaultContainerTimeout = nodeps.DefaultDefaultContainerTimeout
 
-	outFunc := util.CaptureUserOut()
-	app.announceBaseDBSeed()
-	require.Empty(t, strings.TrimSpace(outFunc()), "stock starter database should not be announced")
+	require.Empty(t, app.BaseDBSeedDescription(), "stock starter database should not be announced")
 
 	initializer := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "initializer-mariadb_10.11.zst"), strings.Repeat("x", 2048))
-	outFunc = util.CaptureUserOut()
-	app.announceBaseDBSeed()
+	description := app.BaseDBSeedDescription()
+	require.NotEmpty(t, description)
+
+	outFunc := util.CaptureUserOut()
+	app.announceBaseDBSeed(description, SnapshotRestoreDefaultWaitTime)
 	out := outFunc()
 
 	require.Contains(t, out, "Initializing new database volume from the 'initializer' snapshot")
 	require.Contains(t, out, filepath.ToSlash(initializer))
-	require.Contains(t, out, "(2.0 KiB)")
+	require.Contains(t, out, "(2.0KB)")
 	require.Contains(t, out, "this may take a long time")
 	require.Contains(t, out, "default_container_timeout")
 	require.Contains(t, out, "ddev logs -s db -f "+app.Name)
+	require.Contains(t, out, strconv.Itoa(SnapshotRestoreDefaultWaitTime))
 }
 
 // TestFileSizeSuffix verifies the human-readable size suffix used when
@@ -120,11 +123,11 @@ func TestFileSizeSuffix(t *testing.T) {
 
 	small := filepath.Join(tmpDir, "small")
 	require.NoError(t, os.WriteFile(small, make([]byte, 512), 0644))
-	require.Equal(t, " (512 bytes)", fileSizeSuffix(small))
+	require.Equal(t, " (512B)", fileSizeSuffix(small))
 
 	large := filepath.Join(tmpDir, "large")
 	require.NoError(t, os.WriteFile(large, make([]byte, 3*1024*1024), 0644))
-	require.Equal(t, " (3.0 MiB)", fileSizeSuffix(large))
+	require.Equal(t, " (3.0MB)", fileSizeSuffix(large))
 
 	require.Empty(t, fileSizeSuffix(filepath.Join(tmpDir, "nonexistent")))
 	require.Empty(t, fileSizeSuffix(tmpDir))

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -427,7 +427,7 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 	if initializer := app.GetInitializerSnapshotFile(); initializer != "" {
 		findings = append(findings, finding{
 			category: "Database",
-			files:    []fileInfo{{path: fmt.Sprintf("%s (seeds a new database volume)", initializer)}},
+			files:    []fileInfo{{path: fmt.Sprintf("%s (seeds a new database volume)", fileutil.ShortHomeJoin(initializer))}},
 		})
 	}
 	// The db-build Dockerfile itself is already listed by the check above, so

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -24,6 +24,26 @@ type customConfigCheck struct {
 	displayName       string                   // category name for grouped display (e.g., "Router (global)")
 }
 
+// getBuildDockerfilesInDir returns the Dockerfile*, pre.Dockerfile* and
+// prepend.Dockerfile* files in dir, i.e. only the ones WriteBuildDockerfile()
+// actually incorporates into a derived image. Like WriteBuildDockerfile(), the
+// bundled Dockerfile.example is not one of them.
+func getBuildDockerfilesInDir(dir string) ([]string, error) {
+	allFiles, err := filepath.Glob(filepath.Join(dir, "*Dockerfile*"))
+	if err != nil {
+		return nil, err
+	}
+	return slices.DeleteFunc(allFiles, func(file string) bool {
+		base := filepath.Base(file)
+		if strings.HasSuffix(base, ".example") {
+			return true
+		}
+		return !strings.HasPrefix(base, "Dockerfile") &&
+			!strings.HasPrefix(base, "pre.Dockerfile") &&
+			!strings.HasPrefix(base, "prepend.Dockerfile")
+	}), nil
+}
+
 // addPathToAddonMap adds a file path (or all files under a directory) to the add-on map.
 // Manifest ProjectFiles/GlobalFiles may contain directory paths; this expands them.
 func addPathToAddonMap(fullPath string, addonName string, addonFileMap map[string]string) {
@@ -115,34 +135,14 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 		},
 		{
 			collectFiles: func() ([]string, error) {
-				allFiles, err := filepath.Glob(filepath.Join(globalconfig.GetGlobalDdevDir(), "db-build", "*Dockerfile*"))
-				if err != nil {
-					return nil, err
-				}
-				// Filter to only valid Dockerfile patterns
-				return slices.DeleteFunc(allFiles, func(file string) bool {
-					base := filepath.Base(file)
-					return !strings.HasPrefix(base, "Dockerfile") &&
-						!strings.HasPrefix(base, "pre.Dockerfile") &&
-						!strings.HasPrefix(base, "prepend.Dockerfile")
-				}), nil
+				return getBuildDockerfilesInDir(filepath.Join(globalconfig.GetGlobalDdevDir(), "db-build"))
 			},
 			checkOnlyWhen: func() bool { return !slices.Contains(app.OmitContainers, "db") },
 			displayName:   "Database (global)",
 		},
 		{
 			collectFiles: func() ([]string, error) {
-				allFiles, err := filepath.Glob(filepath.Join(ddevDir, "db-build", "*Dockerfile*"))
-				if err != nil {
-					return nil, err
-				}
-				// Filter to only valid Dockerfile patterns
-				return slices.DeleteFunc(allFiles, func(file string) bool {
-					base := filepath.Base(file)
-					return !strings.HasPrefix(base, "Dockerfile") &&
-						!strings.HasPrefix(base, "pre.Dockerfile") &&
-						!strings.HasPrefix(base, "prepend.Dockerfile")
-				}), nil
+				return getBuildDockerfilesInDir(filepath.Join(ddevDir, "db-build"))
 			},
 			checkOnlyWhen: func() bool { return !slices.Contains(app.OmitContainers, "db") },
 			displayName:   "Database",
@@ -270,33 +270,13 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 		},
 		{
 			collectFiles: func() ([]string, error) {
-				allFiles, err := filepath.Glob(filepath.Join(globalconfig.GetGlobalDdevDir(), "web-build", "*Dockerfile*"))
-				if err != nil {
-					return nil, err
-				}
-				// Filter to only valid Dockerfile patterns
-				return slices.DeleteFunc(allFiles, func(file string) bool {
-					base := filepath.Base(file)
-					return !strings.HasPrefix(base, "Dockerfile") &&
-						!strings.HasPrefix(base, "pre.Dockerfile") &&
-						!strings.HasPrefix(base, "prepend.Dockerfile")
-				}), nil
+				return getBuildDockerfilesInDir(filepath.Join(globalconfig.GetGlobalDdevDir(), "web-build"))
 			},
 			displayName: "Web server (global)",
 		},
 		{
 			collectFiles: func() ([]string, error) {
-				allFiles, err := filepath.Glob(filepath.Join(ddevDir, "web-build", "*Dockerfile*"))
-				if err != nil {
-					return nil, err
-				}
-				// Filter to only valid Dockerfile patterns
-				return slices.DeleteFunc(allFiles, func(file string) bool {
-					base := filepath.Base(file)
-					return !strings.HasPrefix(base, "Dockerfile") &&
-						!strings.HasPrefix(base, "pre.Dockerfile") &&
-						!strings.HasPrefix(base, "prepend.Dockerfile")
-				}), nil
+				return getBuildDockerfilesInDir(filepath.Join(ddevDir, "web-build"))
 			},
 			displayName: "Web server",
 		},
@@ -438,6 +418,24 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 		findings = append(findings, finding{
 			category: "Database",
 			files:    []fileInfo{{path: fmt.Sprintf("dbimage: %s (non-default)", app.DBImage)}},
+		})
+	}
+
+	// An `initializer` snapshot or a base_db seed baked into a derived dbimage
+	// replaces the stock starter database when a fresh database volume is created,
+	// so report them even though neither is an ordinary config file.
+	if initializer := app.GetInitializerSnapshotFile(); initializer != "" {
+		findings = append(findings, finding{
+			category: "Database",
+			files:    []fileInfo{{path: fmt.Sprintf("%s (seeds a new database volume)", initializer)}},
+		})
+	}
+	// The db-build Dockerfile itself is already listed by the check above, so
+	// name the seed rather than repeating the path.
+	if len(app.GetDBBuildSeedDockerfiles()) > 0 {
+		findings = append(findings, finding{
+			category: "Database",
+			files:    []fileInfo{{path: fmt.Sprintf("%s.* baked into dbimage (seeds a new database volume)", CustomBaseDBSeedPathPrefix)}},
 		})
 	}
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1885,10 +1885,17 @@ func (app *DdevApp) Start() error {
 	}
 
 	// Say what a brand-new database volume is about to be seeded from, before the
-	// (possibly long) wait for the db container to become healthy. The dbimage is
-	// built by now, so a seed baked into a derived image can be seen.
+	// (possibly long) wait for the db container to become healthy, and extend that
+	// wait's timeout to accommodate a large seed. The dbimage is built by now, so a
+	// seed baked into a derived image can be seen.
+	origDefaultContainerTimeout := app.DefaultContainerTimeout
 	if dbNeedsInitialization {
-		app.announceBaseDBSeed()
+		if description := app.BaseDBSeedDescription(); description != "" {
+			if t, _ := strconv.Atoi(app.DefaultContainerTimeout); t <= SnapshotRestoreDefaultWaitTime {
+				app.DefaultContainerTimeout = strconv.Itoa(SnapshotRestoreDefaultWaitTime)
+			}
+			app.announceBaseDBSeed(description, app.GetMaxContainerWaitTime())
+		}
 	}
 
 	util.Debug("Executing docker-compose -f %s up -d", app.DockerComposeFullRenderedYAMLPath())
@@ -2046,6 +2053,7 @@ func (app *DdevApp) Start() error {
 	wait := output.StartWait(fmt.Sprintf("Waiting for containers to become ready: %v", dependers))
 	waitErr := app.Wait(dependers)
 	wait.Complete(waitErr)
+	app.DefaultContainerTimeout = origDefaultContainerTimeout
 
 	if !slices.Contains(app.OmitContainers, "db") && app.Database.Type == nodeps.MySQL && (app.Database.Version == nodeps.MySQL80 || app.Database.Version == nodeps.MySQL84) && slices.Contains([]string{nodeps.PHP73, nodeps.PHP72, nodeps.PHP71, nodeps.PHP70, nodeps.PHP56}, app.PHPVersion) {
 		alterString := `ALTER USER 'db'@'%' IDENTIFIED WITH mysql_native_password BY 'db';

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1564,11 +1564,18 @@ func (app *DdevApp) Start() error {
 		util.Warning("Unable to pull Docker images: %v", pullErr)
 	}
 
+	// dbNeedsInitialization means the database volume has no database in it yet,
+	// so the db container will seed it from a base_db seed during this start.
+	dbNeedsInitialization := false
 	if !app.IsDBOmitted() {
 		// OK to start if dbType is empty (nonexistent) or if it matches
-		if dbType, err := app.GetExistingDBType(); err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
+		dbType, err := app.GetExistingDBType()
+		if err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
 			return fmt.Errorf("unable to start project %s because the configured database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s' and then you might want to try 'ddev utility migrate-database %s', see docs at %s", app.Name, dbType, dbType, app.Database.Type+":"+app.Database.Version, "https://docs.ddev.com/en/stable/users/extend/database-types/")
 		}
+		// A snapshot restore hands the db container its own restore target, so it
+		// never consults a base_db seed even with an empty volume.
+		dbNeedsInitialization = dbType == "" && !strings.HasPrefix(os.Getenv("DDEV_DB_CONTAINER_COMMAND"), RestoreSnapshotCommand)
 	}
 
 	app.CreateUploadDirsIfNecessary()
@@ -1804,6 +1811,18 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
+	// With no_bind_mounts the db container sees /mnt/snapshots as a Docker volume
+	// instead of .ddev/db_snapshots, so an `initializer` snapshot has to be copied
+	// in for the db container to find it when it seeds a fresh database volume.
+	if globalconfig.DdevGlobalConfig.NoBindMounts && dbNeedsInitialization {
+		if initializer := app.GetInitializerSnapshotFile(); initializer != "" {
+			err = dockerutil.CopyIntoVolume(initializer, "ddev-"+app.Name+"-snapshots", "", uid, "", false)
+			if err != nil {
+				return fmt.Errorf("failed to copy %s into the snapshots volume: %v", initializer, err)
+			}
+		}
+	}
+
 	// Wait for background chown to finish before proceeding.
 	// SSH agent runs after chown (needs volumes ready) and after WriteDockerComposeYAML
 	// (reads app.ComposeYaml) — so it runs sequentially here to avoid a data race.
@@ -1863,6 +1882,13 @@ func (app *DdevApp) Start() error {
 	}
 	for _, danglingImage := range danglingImages {
 		_ = dockerutil.RemoveImage(danglingImage.ID)
+	}
+
+	// Say what a brand-new database volume is about to be seeded from, before the
+	// (possibly long) wait for the db container to become healthy. The dbimage is
+	// built by now, so a seed baked into a derived image can be seen.
+	if dbNeedsInitialization {
+		app.announceBaseDBSeed()
 	}
 
 	util.Debug("Executing docker-compose -f %s up -d", app.DockerComposeFullRenderedYAMLPath())

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1960,7 +1960,9 @@ func TestDdevAllDatabases(t *testing.T) {
 
 		// base_db "initializer" seeding is only wired up for MariaDB/MySQL
 		// (containers/ddev-dbserver); PostgreSQL uses a different image/entrypoint.
-		if dbType == nodeps.MariaDB || dbType == nodeps.MySQL {
+		// Not supported on the very old, EOL 5.5 versions of either.
+		isVeryOldDB := dbVersion == "5.5"
+		if (dbType == nodeps.MariaDB || dbType == nodeps.MySQL) && !isVeryOldDB {
 			// db currently has the 2-row "users" table from the snapshot restore above.
 			// Snapshotting it as "initializer" and then wiping the db volume and
 			// restarting should restore this same data automatically, ahead of the

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1958,6 +1958,35 @@ func TestDdevAllDatabases(t *testing.T) {
 		out = strings.Trim(out, "\n\r ")
 		assert.Equal("2", out)
 
+		// base_db "initializer" seeding is only wired up for MariaDB/MySQL
+		// (containers/ddev-dbserver); PostgreSQL uses a different image/entrypoint.
+		if dbType == nodeps.MariaDB || dbType == nodeps.MySQL {
+			// db currently has the 2-row "users" table from the snapshot restore above.
+			// Snapshotting it as "initializer" and then wiping the db volume and
+			// restarting should restore this same data automatically, ahead of the
+			// normal empty starter database.
+			_, err = app.Snapshot("initializer")
+			require.NoError(t, err, "could not create initializer snapshot for %s", dbTypeVersion)
+
+			err = app.Stop(true, false)
+			require.NoError(t, err)
+			err = app.Start()
+			require.NoError(t, err, "failed to start %s after seeding from initializer snapshot", dbTypeVersion)
+
+			out, _, err = app.Exec(&ddevapp.ExecOpts{
+				Service: "db",
+				Cmd:     c[dbType],
+			})
+			assert.NoError(err)
+			out = strings.Trim(out, "\n\r ")
+			assert.Equal("2", out, "initializer snapshot did not seed a fresh db volume for %s", dbTypeVersion)
+
+			// "initializer" is a reserved name; clear it so the next dbTypeVersion
+			// iteration can create its own.
+			err = os.RemoveAll(app.GetConfigPath("db_snapshots"))
+			assert.NoError(err)
+		}
+
 		err = app.Stop(true, false)
 		assert.NoError(err)
 	}

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -29,6 +29,11 @@ type Snapshot struct {
 // If default_container_timeout is set higher than that it can be more
 const SnapshotRestoreDefaultWaitTime = 600
 
+// RestoreSnapshotCommand is the ddev-dbserver entrypoint argument that makes it
+// restore a snapshot instead of looking for a base_db seed.
+// See containers/ddev-dbserver/files/docker-entrypoint.sh
+const RestoreSnapshotCommand = "restore_snapshot"
+
 // DeleteSnapshot removes the snapshot tarball or directory inside a project
 func (app *DdevApp) DeleteSnapshot(snapshotName string) error {
 	var err error
@@ -233,7 +238,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 		}
 	}
 
-	restoreCmd := "restore_snapshot " + snapshotFile
+	restoreCmd := RestoreSnapshotCommand + " " + snapshotFile
 	// Determine compression type for potential conditional restore handling
 	isGzip := strings.HasSuffix(snapshotFile, ".gz")
 	isZstd := strings.HasSuffix(snapshotFile, ".zst")

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -26,7 +26,7 @@ var WebTag = "20260716_stasadev_webserver_403_message" // Note that this can be 
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20260729_rfay_mysql_97"
+var BaseDBTag = "20260720_weitzman_zstd_base_db"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION
I have a new iteration on the [DDEV-MTK](https://github.com/weitzman/ddev-mtk) approach which has far superior DX. I can't show it yet - will do so soon. Meanwhile, this PR speeds up one piece of the puzzle. 

The gist of my new approach is that I use Github Actions to build a DB image thats based on the DDEV DB Image (I'm aware that you don't provide guarantees regarding future changes of this). The new image has our Prod DB data baked in via a `mysqlbase/base_db.gz`. The DB image restores that data into datadir upon startup. This PR speeds up that startup using an optimization that `ddev snapshot restore` [already uses in this same file](https://github.com/ddev/ddev/blob/main/containers/ddev-dbserver/files/docker-entrypoint.sh#L58).

Sorry for the wall of text below. I hope some of it is helpful. The diff is small, thankfully.

## The Issue

The dbserver first-boot restore path is hardcoded to gzip: it always runs
`gunzip -c /mysqlbase/base_db.gz | xbstream -x`. The snapshot restore path in
the same entrypoint already auto-detects `.zst` vs `.gz`. gzip decompression
is single-threaded and dominates first-boot restore time, which matters most
for derived images that bake a large production dataset into
`/mysqlbase/base_db.gz` (and for ephemeral/CI containers that restore on
every startup).

Benchmarked against a real 21GB datadir (2.99GB gzipped) on an 18-core
Docker VM:

| Phase                     | gzip   | zstd  |
|---------------------------|--------|-------|
| decompress + xbstream -x  | 105.2s | 30.5s |
| xtrabackup --prepare      | 4.5s   | 4.5s  |
| xtrabackup --copy-back    | 16.2s  | 16.2s |
| total restore             | ~126s  | ~51s  |

Decompression is ~84% of restore time. End-to-end, container start to mysqld
ready dropped from 117s to 40s. The zstd archive is also 25-32% smaller
(2.24GB at level 3, 2.03GB at level 9) than the 2.99GB gzip archive.

## How This PR Solves The Issue

The base-database first-boot path now prefers `/mysqlbase/base_db.zst` when
present, decompressing with `zstdmt` (parallel; falls back to `zstd`), using
the same tool invocation as the existing snapshot restore path. It falls
back to `base_db.gz` exactly as before.

`create_base_db.sh` intentionally still emits gzip: if stock images shipped
`base_db.zst`, a derived image that COPYs a custom `base_db.gz` over the
stock image would be silently shadowed by the preferred stock `.zst`.
Accepting zstd only on the consume side keeps every existing derived image
working while letting projects opt in by baking `base_db.zst` instead
(e.g. `xtrabackup --backup --stream=xbstream ... | zstdmt -3`).

zstd is already installed in the images; the snapshot path uses it. Nothing
in ddev Go code, docs, or container tests references the `base_db.gz`
filename, so no other changes are needed.

## Manual Testing Instructions

1. Build a dbserver image, or use any existing v1.25 image.
2. Transcode its starter db:
   `docker run --rm --entrypoint bash <image> -c 'gunzip -c /mysqlbase/base_db.gz' | zstdmt -3 -o base_db.zst`
3. Start with the new entrypoint, a fresh datadir volume, and the zst
   archive mounted:
   `docker run -d --user=501:20 -v $PWD/base_db.zst:/mysqlbase/base_db.zst:ro -v /var/lib/mysql <image>`
4. Verify logs show `zstdmt -dc --quiet /mysqlbase/base_db.zst` and
   `Database initialized`, and that mysql answers queries.
5. Repeat without the zst mount to confirm the gzip fallback path.

## Automated Testing Overview

Existing dbserver container tests exercise the gzip fallback path on every
image build (stock images contain only `base_db.gz`). Manually verified both
paths against a production-sized derived image: zstd restore (506 tables
intact, mysqld healthy) and gzip fallback (identical result).

## Release/Deployment Notes

Additive and backward compatible. Stock images are unchanged in behavior.
Derived images gain the option to ship `base_db.zst` for ~3x faster first
boot and smaller images; `.zst` takes precedence when both files exist.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>