### PR TITLE
feat(config): re-implement dbimage config option, mirroring webimage

### DIFF
--- a/cmd/ddev/cmd/cmd_version.go
+++ b/cmd/ddev/cmd/cmd_version.go
@@ -34,7 +34,12 @@ var versionCmd = &cobra.Command{
 
 		// If in a project context, show the project's actual web image instead of the default.
 		if app, err := ddevapp.GetActiveApp(""); err == nil {
-			v["web"] = app.WebImage
+			if app.WebImage != "" {
+				v["web"] = app.WebImage
+			}
+			if app.DBImage != "" {
+				v["db"] = app.DBImage
+			}
 		}
 
 		var out bytes.Buffer

--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -67,6 +67,12 @@ var (
 	// webImageDefaultArg allows a user to unset the specific web server container image
 	webImageDefaultArg bool
 
+	// dbImageArg allows a user to set the project's db server container image
+	dbImageArg string
+
+	// dbImageDefaultArg allows a user to unset the specific db server container image
+	dbImageDefaultArg bool
+
 	// webWorkingDirArg allows a user to define the working directory for the web service
 	webWorkingDirArg string
 
@@ -242,6 +248,8 @@ func init() {
 	_ = ConfigCommand.RegisterFlagCompletionFunc("webserver-type", configCompletionFunc(nodeps.GetValidWebserverTypes()))
 	ConfigCommand.Flags().StringVar(&webImageArg, "web-image", "", "Set the web container image (for advanced use only)")
 	ConfigCommand.Flags().BoolVar(&webImageDefaultArg, "web-image-default", false, `Sets the default web container image, the same as --web-image=""`)
+	ConfigCommand.Flags().StringVar(&dbImageArg, "db-image", "", "Set the db container image (for advanced use only)")
+	ConfigCommand.Flags().BoolVar(&dbImageDefaultArg, "db-image-default", false, `Sets the default db container image, the same as --db-image=""`)
 	ConfigCommand.Flags().StringVar(&webWorkingDirArg, "web-working-dir", "", "Override the default working directory for the web service")
 	ConfigCommand.Flags().StringVar(&dbWorkingDirArg, "db-working-dir", "", "Override the default working directory for the db service")
 	ConfigCommand.Flags().BoolVar(&webWorkingDirDefaultArg, "web-working-dir-default", false, `Unset a web service working directory override, the same as --web-working-dir=""`)
@@ -683,6 +691,14 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 
 	if webImageDefaultArg {
 		app.WebImage = ""
+	}
+
+	if cmd.Flag("db-image").Changed {
+		app.DBImage = dbImageArg
+	}
+
+	if dbImageDefaultArg {
+		app.DBImage = ""
 	}
 
 	if app.WorkingDir == nil {

--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -176,6 +176,7 @@ func TestConfigSetValues(t *testing.T) {
 	uploadDirsSlice := []string{"custom", "config", "path"}
 	webserverType := nodeps.WebserverApacheFPM
 	webImage := "custom-web-image"
+	dbImage := "custom-db-image"
 	webWorkingDir := "/custom/web/dir"
 	dbWorkingDir := "/custom/db/dir"
 	mailpitHTTPPort := "5001"
@@ -203,6 +204,7 @@ func TestConfigSetValues(t *testing.T) {
 		"--upload-dirs=" + strings.Join(uploadDirsSlice, ","),
 		"--webserver-type", webserverType,
 		"--web-image", webImage,
+		"--db-image", dbImage,
 		"--web-working-dir", webWorkingDir,
 		"--db-working-dir", dbWorkingDir,
 		"--omit-containers", omitContainers,
@@ -254,6 +256,7 @@ func TestConfigSetValues(t *testing.T) {
 	assert.Equal(uploadDirsSlice, app.GetUploadDirs())
 	assert.Equal(webserverType, app.WebserverType)
 	assert.Equal(webImage, app.WebImage)
+	assert.Equal(dbImage, app.DBImage)
 	assert.Equal(webWorkingDir, app.WorkingDir["web"])
 	assert.Equal(dbWorkingDir, app.WorkingDir["db"])
 	assert.Equal(webimageExtraPackagesSlice, app.WebImageExtraPackages)
@@ -273,6 +276,7 @@ func TestConfigSetValues(t *testing.T) {
 		"config",
 		"--composer-root-default",
 		"--web-image-default",
+		"--db-image-default",
 		"--web-working-dir-default",
 		"--db-working-dir-default",
 		`--omit-containers=""`,
@@ -296,6 +300,7 @@ func TestConfigSetValues(t *testing.T) {
 
 	assert.Equal(app.ComposerRoot, "")
 	assert.Equal(app.WebImage, "")
+	assert.Equal(app.DBImage, "")
 	assert.Equal(len(app.WorkingDir), 0)
 	assert.Empty(app.AdditionalHostnames)
 	assert.Empty(app.AdditionalFQDNs)
@@ -309,6 +314,7 @@ func TestConfigSetValues(t *testing.T) {
 	args = []string{
 		"config",
 		"--web-image", webImage,
+		"--db-image", dbImage,
 		"--web-working-dir", webWorkingDir,
 		"--db-working-dir", dbWorkingDir,
 	}
@@ -320,6 +326,7 @@ func TestConfigSetValues(t *testing.T) {
 		"config",
 		"--working-dir-defaults",
 		"--web-image-default",
+		"--db-image-default",
 	}
 
 	out, err = exec.RunHostCommand(DdevBin, args...)
@@ -333,6 +340,7 @@ func TestConfigSetValues(t *testing.T) {
 	require.NoError(t, err, "Could not unmarshal %s: %v", configFile, err)
 
 	assert.Equal(app.WebImage, "")
+	assert.Equal(app.DBImage, "")
 	assert.Equal(len(app.WorkingDir), 0)
 
 	// Test that variables can be appended to the web environment

--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -59,6 +59,23 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 		require.Contains(t, out, "No custom configuration detected in project '"+projectName+"'.")
 	})
 
+	// Test webimage/dbimage overrides (config.yaml values, not files)
+	t.Run("webimage and dbimage overrides", func(t *testing.T) {
+		_, err := exec.RunCommand(DdevBin, []string{"config", "--web-image=custom-web-image:latest", "--db-image=custom-db-image:latest"})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, _ = exec.RunCommand(DdevBin, []string{"config", "--web-image-default", "--db-image-default"})
+		})
+
+		out, err := exec.RunCommand(DdevBin, []string{"utility", "check-custom-config"})
+		require.NoError(t, err)
+		require.Contains(t, out, "Custom configuration detected in project '"+projectName+"':")
+		require.Contains(t, out, "Web server")
+		require.Contains(t, out, "webimage: custom-web-image:latest")
+		require.Contains(t, out, "Database")
+		require.Contains(t, out, "dbimage: custom-db-image:latest")
+	})
+
 	// GLOBAL CHECKS (matching order in CheckCustomConfig)
 
 	// Test global router-compose

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -158,6 +158,17 @@ See [Database Server Types](../extend/database-types.md) for examples (e.g. `dde
 
 !!!tip "For very old database types, see [Using DDEV to spin up a legacy PHP application](https://ddev.com/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev/)."
 
+## `dbimage`
+
+!!!warning "Proceed with caution"
+    It's unusual to change this option, and we don't recommend it without Docker experience and a good reason. Typically, this means additions to the existing db image using a `.ddev/db-build/Dockerfile.*`.
+
+The Docker image to use for the database server.
+
+| Type | Default | Usage
+| -- | -- | --
+| :octicons-file-directory-16: project | [`ddev/ddev-dbserver`](https://hub.docker.com/u/ddev) | Specify your own image based on the [ddev-dbserver](https://github.com/ddev/ddev/tree/main/containers/ddev-dbserver) image matching your project's `database` type and version.
+
 ## `dbimage_extra_packages`
 
 Extra Debian packages for the project’s database container. (This is rarely used.)

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -402,6 +402,8 @@ Flags:
 * `--composer-version`: Specify override for Composer version in the web container. This may be `""`, `"2"`, `"2.2"`, `"stable"`, `"preview"`, `"snapshot"`, or a specific version.
 * `--corepack-enable`: Whether to run `corepack enable` on Node.js configuration.
 * `--database`: Specify the database `type:version` to use (see [default](../configuration/config.md#database)).
+* `--db-image`: Set the `db` container image ([for advanced use only](../configuration/config.md#dbimage)).
+* `--db-image-default`: Set the default `db` container image, the same as `--db-image=""`.
 * `--db-working-dir`: Override the default working directory for the `db` service.
 * `--db-working-dir-default`: Unset a `db` service working directory override, the same as `--db-working-dir=""`.
 * `--dbimage-extra-packages`: Comma-delimited list of Debian packages that should be added to `db` container when the project is started or `--dbimage-extra-packages=""` to remove previously configured packages.

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -239,6 +239,9 @@ func (app *DdevApp) WriteConfig() error {
 	if appcopy.WebImage == docker.GetWebImage() {
 		appcopy.WebImage = ""
 	}
+	if appcopy.DBImage == docker.GetDBImage(appcopy.Database.Type, appcopy.Database.Version) {
+		appcopy.DBImage = ""
+	}
 	if appcopy.RouterHTTPPort == nodeps.DdevDefaultRouterHTTPPort {
 		appcopy.RouterHTTPPort = ""
 	}

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ddev/ddev/pkg/config/types"
+	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -423,6 +424,21 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 				files:    customFiles,
 			})
 		}
+	}
+
+	// Non-default webimage/dbimage are custom configuration even though they're
+	// config.yaml values rather than files.
+	if app.WebImage != "" && app.WebImage != docker.GetWebImage() {
+		findings = append(findings, finding{
+			category: "Web server",
+			files:    []fileInfo{{path: fmt.Sprintf("webimage: %s (non-default)", app.WebImage)}},
+		})
+	}
+	if app.DBImage != "" && app.DBImage != docker.GetDBImage(app.Database.Type, app.Database.Version) {
+		findings = append(findings, finding{
+			category: "Database",
+			files:    []fileInfo{{path: fmt.Sprintf("dbimage: %s (non-default)", app.DBImage)}},
+		})
 	}
 
 	// Build message for all findings

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -628,6 +628,7 @@ func TestReadConfig(t *testing.T) {
 	assert.Equal(app.Type, nodeps.AppTypeDrupal8)
 	assert.Equal(app.Docroot, "test")
 	assert.Equal(app.WebImage, "test/testimage:latest")
+	assert.Equal(app.DBImage, "test/testdbimage:latest")
 }
 
 // TestReadConfigCRLF tests reading config values from a file with Windows

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -97,6 +97,7 @@ type DdevApp struct {
 	PHPVersion                string                `yaml:"php_version"`
 	WebserverType             string                `yaml:"webserver_type"`
 	WebImage                  string                `yaml:"webimage,omitempty"`
+	DBImage                   string                `yaml:"dbimage,omitempty"`
 	RouterHTTPPort            string                `yaml:"router_http_port,omitempty"`
 	RouterHTTPSPort           string                `yaml:"router_https_port,omitempty"`
 	XdebugEnabled             bool                  `yaml:"xdebug_enabled"`
@@ -1434,10 +1435,13 @@ func (app *DdevApp) ProcessHooks(hookName string) error {
 	return nil
 }
 
-// GetDBImage uses the available version info
+// GetDBImage returns the db image to use, preferring an explicitly configured
+// DBImage over the default computed from the database type and version.
 func (app *DdevApp) GetDBImage() string {
-	dbImage := ddevImages.GetDBImage(app.Database.Type, app.Database.Version)
-	return dbImage
+	if app.DBImage != "" {
+		return app.DBImage
+	}
+	return ddevImages.GetDBImage(app.Database.Type, app.Database.Version)
 }
 
 // composeBuild executes docker-compose build with retry logic for BuildKit snapshot race conditions.

--- a/pkg/ddevapp/schema.json
+++ b/pkg/ddevapp/schema.json
@@ -267,6 +267,10 @@
         }
       }
     },
+    "dbimage": {
+      "description": "Set the db container image.",
+      "type": "string"
+    },
     "dbimage_extra_packages": {
       "description": "List of Debian packages that should be added to db container when the project is started.",
       "type": "array",

--- a/pkg/ddevapp/templates.go
+++ b/pkg/ddevapp/templates.go
@@ -32,6 +32,14 @@ const ConfigInstructions = `
 #   MySQL versions can be 5.5-8.0, 8.4
 #   PostgreSQL versions can be 9-18
 
+# You can explicitly specify the dbimage but this
+# is not recommended, as the images are often closely tied to DDEV's behavior,
+# so this can break upgrades.
+
+# dbimage: <docker_image>
+# It’s unusual to change this option, and we don’t recommend it without Docker experience and a good reason.
+# Typically, this means additions to the existing db image using a .ddev/db-build/Dockerfile.*
+
 # router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
 # router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
 

--- a/pkg/ddevapp/testdata/config.yaml
+++ b/pkg/ddevapp/testdata/config.yaml
@@ -1,3 +1,4 @@
 type: drupal8
 docroot: test
 webimage: test/testimage:latest
+dbimage: test/testdbimage:latest


### PR DESCRIPTION
## The Issue

There is no linked issue. While investigating why `dbimage` no longer works in `config.yaml` (it was removed from the `DdevApp` struct in #5274 back in 2023), we found that its sibling option, `webimage`, was kept as an unofficial, discouraged way to pin a custom container image. This PR restores the same capability for the db container, for parity.

## How This PR Solves The Issue

- Adds `DBImage` back to `DdevApp` (`yaml:"dbimage,omitempty"`), matching the existing `WebImage` field.
- `GetDBImage()` now prefers an explicit `DBImage` override, falling back to the default computed from database type/version.
- `WriteConfig()` strips `dbimage` back out when it matches the computed default, exactly as it already does for `webimage`.
- Adds `--db-image` / `--db-image-default` flags to `ddev config`, mirroring `--web-image` / `--web-image-default`.
- Adds the same "not recommended" discouragement comments to the generated `config.yaml` and to `docs/content/users/configuration/config.md` / `docs/content/users/usage/commands.md`.
- Adds `dbimage` to `pkg/ddevapp/schema.json`.
- As a related fix, `ddev debug check-custom-config` previously only detected custom *files*, with no notion of a customized `config.yaml` value. It now also flags non-default `webimage`/`dbimage` as custom configuration.

## Manual Testing Instructions

1. `ddev config --project-type=php --docroot=web`
2. `ddev config --db-image=ddev/ddev-dbserver-mariadb-11.8:v1.24.10` (pick any valid tag different from the project's default db image)
3. Confirm `.ddev/config.yaml` has a `dbimage:` line with a "not recommended" comment above it.
4. `ddev start`
5. `docker inspect <project>-db --format '{{.Config.Image}}'` and confirm it matches the pinned tag (with a `-<project>-built` suffix).
6. `ddev debug check-custom-config` should report the `dbimage` override under "Database" (and a `webimage` override, if set, under "Web server").
7. `ddev config --db-image-default` should remove the line from `config.yaml` again.

## Automated Testing Overview

- `pkg/ddevapp/config_test.go`: `TestReadConfig` now asserts `dbimage:` is read from `testdata/config.yaml` into `app.DBImage`; `TestNewConfig` already exercises the default-image fallback via `GetDBImage()`.
- `cmd/ddev/cmd/config_test.go`: `TestConfigSetValues` now round-trips `--db-image` / `--db-image-default` through `ddev config`, matching the existing `--web-image` coverage.
- `cmd/ddev/cmd/utility-check-custom-config_test.go`: new subtest verifies both `webimage` and `dbimage` overrides are reported by `ddev debug check-custom-config`.

## Release/Deployment Notes

`dbimage` is intentionally undocumented as a "supported" feature — like `webimage`, it's an advanced/discouraged escape hatch that can break on DDEV upgrades if the pinned image diverges from what DDEV expects. No migration is needed; existing `dbimage:` lines in `config.yaml` (which have been silently ignored since 2023) will now take effect again.
