### PR TITLE
feat: add `ddev utility download-ddev` to download CI and release builds

### DIFF
--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -144,6 +144,7 @@ jobs:
               return acc;
             }, 'Download the artifacts for this pull request:\n');
 
+            body += `\n\nOr, if you already have DDEV installed, download this PR's build for your OS and architecture with:\n\n\`\`\`bash\nddev utility download-ddev --pr ${prNumber}\n\`\`\``;
             body += `\n\nSee [Testing a PR](https://docs.ddev.com/en/stable/developers/building-contributing/#testing-a-pr).`;
             const codespacesLink = prRef && prRepoId
               ? `https://github.com/codespaces/new?ref=${prRef}&repo=${prRepoId}`

--- a/.github/workflows/pr-artifacts-comment.yml
+++ b/.github/workflows/pr-artifacts-comment.yml
@@ -138,13 +138,14 @@ jobs:
             }
 
             // Construct the comment body
-            let body = allArtifacts.reduce((acc, item) => {
+            let body = `Download this PR's build for your OS and architecture with:\n\n\`\`\`bash\nddev utility download-ddev --pr ${prNumber}\n\`\`\``;
+
+            body += allArtifacts.reduce((acc, item) => {
               if (item.name === "assets") return acc;
               acc += `\n* [${item.name}.zip](https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/artifacts/${item.id}.zip)`;
               return acc;
-            }, 'Download the artifacts for this pull request:\n');
+            }, '\n\nOr download the artifact for your OS and architecture directly:\n');
 
-            body += `\n\nOr, if you already have DDEV installed, download this PR's build for your OS and architecture with:\n\n\`\`\`bash\nddev utility download-ddev --pr ${prNumber}\n\`\`\``;
             body += `\n\nSee [Testing a PR](https://docs.ddev.com/en/stable/developers/building-contributing/#testing-a-pr).`;
             const codespacesLink = prRef && prRepoId
               ? `https://github.com/codespaces/new?ref=${prRef}&repo=${prRepoId}`

--- a/.github/workflows/test-nginx-fpm.yml
+++ b/.github/workflows/test-nginx-fpm.yml
@@ -63,6 +63,7 @@ jobs:
     with:
       ddev_test_webserver_type: "nginx-fpm"
       ddev_skip_nodejs_test: "false"
+      ddev_run_download_ddev_test: "true"
       testargs: ""
       debug_enabled: ${{ inputs.debug_enabled || false }}
 
@@ -77,4 +78,5 @@ jobs:
       gotest_short: ${{ inputs.gotest_short }}
       ddev_test_webserver_type: "nginx-fpm"
       ddev_skip_nodejs_test: "false"
+      ddev_run_download_ddev_test: "true"
       debug_enabled: ${{ inputs.debug_enabled || false }}

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: string
         default: 'false'
+      ddev_run_download_ddev_test:
+        description: 'DDEV_RUN_DOWNLOAD_DDEV_TEST value (run the download-ddev live download test)'
+        required: false
+        type: string
+        default: 'false'
       cgo_enabled:
         description: 'CGO_ENABLED value'
         required: false
@@ -139,6 +144,7 @@ jobs:
       DDEV_TEST_PODMAN_ROOTLESS: ${{ inputs.ddev_test_podman_rootless }}
       DDEV_TEST_PODMAN_ROOT: ${{ inputs.ddev_test_podman_root }}
       DDEV_TEST_DOCKER_ROOTLESS: ${{ inputs.ddev_test_docker_rootless }}
+      DDEV_RUN_DOWNLOAD_DDEV_TEST: ${{ inputs.ddev_run_download_ddev_test }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: 'false'
+      ddev_run_download_ddev_test:
+        description: 'DDEV_RUN_DOWNLOAD_DDEV_TEST value (run the download-ddev live download test)'
+        required: false
+        type: string
+        default: 'false'
       cgo_enabled:
         description: 'CGO_ENABLED value'
         required: false
@@ -138,6 +143,7 @@ jobs:
       # runs through gotestsum and writes per-test JSON events here, for the
       # CI test-runtime collector (perf/collector/README.md).
       GOTESTSUM_JSONFILE_DIR: test-results
+      DDEV_RUN_DOWNLOAD_DDEV_TEST: ${{ inputs.ddev_run_download_ddev_test }}
 
     steps:
       - uses: actions/checkout@v7

--- a/cmd/ddev/cmd/utility-download-ddev.go
+++ b/cmd/ddev/cmd/utility-download-ddev.go
@@ -1,0 +1,515 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/ddev/ddev/pkg/archive"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/github"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+var (
+	downloadDdevPR     int
+	downloadDdevBranch string
+	downloadDdevCommit string
+	downloadDdevTag    string
+	downloadDdevStable bool
+	downloadDdevHead   bool
+	downloadDdevOwner  string
+	downloadDdevRepo   string
+	downloadDdevOutput string
+	downloadDdevOS     string
+	downloadDdevArch   string
+)
+
+// DownloadDdevCmd implements the "ddev utility download-ddev" command
+var DownloadDdevCmd = &cobra.Command{
+	Use:   "download-ddev",
+	Short: "Download ddev and ddev-hostname binaries built by CI or a release",
+	Long: `Download the ddev and ddev-hostname binaries built by DDEV CI for a given
+source (PR, branch, commit, release tag, latest stable release, or main HEAD)
+and write them into a directory. Exactly one source flag is required.
+
+--tag, --stable, and --head download signed binaries and need no GitHub token
+(releases from github.com, the main build from nightly.link). --pr, --branch,
+and --commit download unsigned GitHub Actions artifacts and use a GitHub token
+(DDEV_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN) if one is set to avoid the low
+anonymous rate limit; without a token, --pr falls back to the build links
+posted on the pull request.
+
+This command only downloads the binaries; it does not modify your installed ddev.`,
+	Example: `# Download the current platform's build from PR 1234 into the current directory
+ddev utility download-ddev --pr 1234
+
+# Download the latest main build into ~/tmp/head
+ddev utility download-ddev --head --output ~/tmp/head
+
+# Download a specific released version
+ddev utility download-ddev --tag v1.24.5
+
+# Download the latest stable release
+ddev utility download-ddev --stable
+
+# Cross-download a macOS arm64 build of a branch
+ddev utility download-ddev --branch 20250101_feature --os macos --arch arm64 --output ./out`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		if err := runDownloadDdev(cmd); err != nil {
+			util.Failed("%v", err)
+		}
+	},
+}
+
+func init() {
+	registerDownloadDdevFlags(DownloadDdevCmd)
+	DebugCmd.AddCommand(DownloadDdevCmd)
+}
+
+// registerDownloadDdevFlags wires up the download-ddev flags and flag groups.
+// It is separated from init() so the flag-group rules can be tested on a
+// throwaway command.
+func registerDownloadDdevFlags(cmd *cobra.Command) {
+	f := cmd.Flags()
+	f.IntVar(&downloadDdevPR, "pr", 0, "Pull request number to download the build from")
+	f.StringVar(&downloadDdevBranch, "branch", "", "Branch name to download the build from")
+	f.StringVar(&downloadDdevCommit, "commit", "", "Commit SHA to download the build from")
+	f.StringVar(&downloadDdevTag, "tag", "", "Release tag to download (e.g. v1.24.5)")
+	f.BoolVar(&downloadDdevStable, "stable", false, "Download the latest stable release")
+	f.BoolVar(&downloadDdevHead, "head", false, "Download the latest main build")
+	f.StringVar(&downloadDdevOwner, "owner", "ddev", "GitHub owner/org (for PR builds this is the base repo, not a fork)")
+	f.StringVar(&downloadDdevRepo, "repo", "ddev", "GitHub repo")
+	f.StringVarP(&downloadDdevOutput, "output", "o", "", "Output directory (default: current directory)")
+	f.StringVar(&downloadDdevOS, "os", "", "OS override: macos, linux, or windows (default: current OS)")
+	f.StringVar(&downloadDdevArch, "arch", "", "Architecture override: amd64 or arm64 (default: current architecture)")
+
+	cmd.MarkFlagsMutuallyExclusive("pr", "branch", "commit", "tag", "stable", "head")
+	cmd.MarkFlagsOneRequired("pr", "branch", "commit", "tag", "stable", "head")
+
+	_ = cmd.RegisterFlagCompletionFunc("os", configCompletionFunc([]string{"macos", "linux", "windows"}))
+	_ = cmd.RegisterFlagCompletionFunc("arch", configCompletionFunc([]string{"amd64", "arm64"}))
+}
+
+// buildTarget describes the OS/arch of the build to download and how its files
+// are named.
+type buildTarget struct {
+	goos     string // runtime-style OS: darwin, linux, or windows
+	osName   string // artifact/release naming: macos, linux, or windows
+	arch     string // amd64 or arm64
+	exeExt   string // "" or ".exe"
+	isNative bool   // true when goos/arch match the current machine
+}
+
+// artifactName returns the CI artifact name, e.g. "ddev-linux-amd64".
+// CI artifacts (uploaded via actions/upload-artifact) use a hyphen after "ddev".
+func (t buildTarget) artifactName() string {
+	return fmt.Sprintf("ddev-%s-%s", t.osName, t.arch)
+}
+
+// releaseAssetName returns the goreleaser release archive name for a tag, e.g.
+// "ddev_linux-amd64.v1.24.5.tar.gz". Release archives use an underscore after
+// "ddev", embed the tag verbatim (which already includes the leading "v"), and
+// are zip files on Windows.
+func (t buildTarget) releaseAssetName(tag string) string {
+	ext := ".tar.gz"
+	if t.goos == "windows" {
+		ext = ".zip"
+	}
+	return fmt.Sprintf("ddev_%s-%s.%s%s", t.osName, t.arch, tag, ext)
+}
+
+// downloadSpec describes a resolved, ready-to-fetch archive.
+type downloadSpec struct {
+	url        string
+	shaSumURL  string // "" when no checksum file is available (CI artifacts)
+	isZip      bool   // true = unzip, false = untar
+	signed     bool   // signed/notarized build (releases, main)
+	sourceDesc string
+}
+
+// runDownloadDdev is the testable entry point for the command.
+func runDownloadDdev(cmd *cobra.Command) error {
+	target, err := resolveTarget(downloadDdevOS, downloadDdevArch)
+	if err != nil {
+		return err
+	}
+
+	spec, err := resolveSource(cmd, target)
+	if err != nil {
+		return err
+	}
+
+	output.UserOut.Printf("Downloading ddev %s/%s from %s...", target.osName, target.arch, spec.sourceDesc)
+
+	tmpDir, err := os.MkdirTemp("", "ddev-download-ddev-")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	archiveName, extract := "download.tar.gz", archive.Untar
+	if spec.isZip {
+		archiveName, extract = "download.zip", archive.Unzip
+	}
+	archivePath := filepath.Join(tmpDir, archiveName)
+	if err := util.DownloadFile(archivePath, spec.url, true, spec.shaSumURL); err != nil {
+		return fmt.Errorf("failed to download %s: %w", spec.url, err)
+	}
+
+	extractDir := filepath.Join(tmpDir, "extracted")
+	if err := extract(archivePath, extractDir, ""); err != nil {
+		return fmt.Errorf("failed to extract downloaded archive: %w", err)
+	}
+
+	// The archive also contains mkcert, but we copy only ddev and ddev-hostname:
+	// mkcert doesn't change per build, and overwriting a user's mkcert-installed
+	// binary is more likely to break trust than to help.
+	ddevBin := "ddev" + target.exeExt
+	hostnameBin := "ddev-hostname" + target.exeExt
+	srcDdev := filepath.Join(extractDir, ddevBin)
+	srcHostname := filepath.Join(extractDir, hostnameBin)
+	if !fileutil.FileExists(srcDdev) {
+		return fmt.Errorf("downloaded archive did not contain %s", ddevBin)
+	}
+
+	outputDir := downloadDdevOutput
+	if outputDir == "" {
+		if outputDir, err = os.Getwd(); err != nil {
+			return err
+		}
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return err
+	}
+	if abs, absErr := filepath.Abs(outputDir); absErr == nil {
+		outputDir = abs
+	}
+
+	ddevDest := filepath.Join(outputDir, ddevBin)
+	if err := copyExecutable(srcDdev, ddevDest); err != nil {
+		return err
+	}
+	hostnameDest := ""
+	if fileutil.FileExists(srcHostname) {
+		hostnameDest = filepath.Join(outputDir, hostnameBin)
+		if err := copyExecutable(srcHostname, hostnameDest); err != nil {
+			return err
+		}
+	}
+
+	printResult(ddevDest, hostnameDest, target, spec.signed)
+	return nil
+}
+
+// resolveTarget maps --os/--arch overrides (or the current machine) to a buildTarget.
+func resolveTarget(osFlag, archFlag string) (buildTarget, error) {
+	goos := runtime.GOOS
+	switch osFlag {
+	case "":
+		// use runtime.GOOS
+	case "macos", "darwin":
+		goos = "darwin"
+	case "linux", "windows":
+		goos = osFlag
+	default:
+		return buildTarget{}, fmt.Errorf("unsupported --os %q; supported: macos, linux, windows", osFlag)
+	}
+
+	arch := runtime.GOARCH
+	if archFlag != "" {
+		arch = archFlag
+	}
+	if arch != "amd64" && arch != "arm64" {
+		return buildTarget{}, fmt.Errorf("unsupported architecture %q; supported: amd64, arm64", arch)
+	}
+
+	var osName, exeExt string
+	switch goos {
+	case "darwin":
+		osName = "macos"
+	case "linux":
+		osName = "linux"
+	case "windows":
+		osName, exeExt = "windows", ".exe"
+	default:
+		return buildTarget{}, fmt.Errorf("unsupported OS %q; supported: macos, linux, windows", goos)
+	}
+
+	return buildTarget{
+		goos:     goos,
+		osName:   osName,
+		arch:     arch,
+		exeExt:   exeExt,
+		isNative: goos == runtime.GOOS && arch == runtime.GOARCH,
+	}, nil
+}
+
+// resolveSource dispatches on the selected source flag and returns a downloadSpec.
+func resolveSource(cmd *cobra.Command, t buildTarget) (downloadSpec, error) {
+	owner, repo := downloadDdevOwner, downloadDdevRepo
+	f := cmd.Flags()
+	switch {
+	case f.Changed("tag"):
+		if downloadDdevTag == "" {
+			return downloadSpec{}, fmt.Errorf("--tag requires a value, e.g. --tag v1.24.5")
+		}
+		return resolveReleaseTag(owner, repo, downloadDdevTag, t), nil
+	case downloadDdevStable:
+		return resolveLatestRelease(owner, repo, t)
+	case downloadDdevHead:
+		return resolveHead(owner, repo, t), nil
+	case f.Changed("pr"):
+		return resolvePR(owner, repo, downloadDdevPR, t)
+	case f.Changed("branch"):
+		if downloadDdevBranch == "" {
+			return downloadSpec{}, fmt.Errorf("--branch requires a value, e.g. --branch main")
+		}
+		return resolveBranch(owner, repo, downloadDdevBranch, t)
+	case f.Changed("commit"):
+		if downloadDdevCommit == "" {
+			return downloadSpec{}, fmt.Errorf("--commit requires a commit SHA")
+		}
+		return resolveCommit(owner, repo, downloadDdevCommit, t)
+	}
+	return downloadSpec{}, fmt.Errorf("exactly one of --pr, --branch, --commit, --tag, --stable, --head is required")
+}
+
+// resolveReleaseTag builds the release-archive URL for an explicit tag without
+// any API call; a 404 from the download is the "unknown tag" signal.
+func resolveReleaseTag(owner, repo, tag string, t buildTarget) downloadSpec {
+	base := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s", owner, repo, tag)
+	return downloadSpec{
+		url:        base + "/" + t.releaseAssetName(tag),
+		shaSumURL:  base + "/checksums.txt",
+		isZip:      t.goos == "windows",
+		signed:     true,
+		sourceDesc: fmt.Sprintf("release %s", tag),
+	}
+}
+
+// resolveLatestRelease discovers the newest release tag, then builds its URL.
+func resolveLatestRelease(owner, repo string, t buildTarget) (downloadSpec, error) {
+	tag, err := github.GetLatestReleaseTag(owner, repo)
+	if err != nil {
+		return downloadSpec{}, err
+	}
+	output.UserOut.Printf("Latest stable release is %s", tag)
+	return resolveReleaseTag(owner, repo, tag, t), nil
+}
+
+// resolveHead builds the nightly.link URL for the latest main build. nightly.link
+// serves the most recent main-build artifact without a GitHub token.
+func resolveHead(owner, repo string, t buildTarget) downloadSpec {
+	return downloadSpec{
+		url:        fmt.Sprintf("https://nightly.link/%s/%s/workflows/main-build/main/%s.zip", owner, repo, t.artifactName()),
+		isZip:      true,
+		signed:     true,
+		sourceDesc: "the latest main build",
+	}
+}
+
+// resolvePR resolves a PR number to its CI artifact. It tries the GitHub API
+// first; if that fails (commonly the anonymous rate limit when no token is set),
+// it falls back to reading the PR page for the nightly.link URL posted by the
+// pr-artifacts-comment bot, which needs no API access. pull_request CI artifacts
+// live in the base repo (ddev/ddev) even for fork PRs, so owner/repo stay put.
+func resolvePR(owner, repo string, pr int, t buildTarget) (downloadSpec, error) {
+	if pr <= 0 {
+		return downloadSpec{}, fmt.Errorf("--pr requires a positive PR number")
+	}
+	spec := downloadSpec{isZip: true, sourceDesc: fmt.Sprintf("PR #%d", pr)}
+
+	url, apiErr := resolvePRViaAPI(owner, repo, pr, t)
+	if apiErr == nil {
+		spec.url = url
+		return spec, nil
+	}
+
+	// API failed; fall back to the token-free PR page.
+	output.UserOut.Println("GitHub API lookup failed; falling back to the PR page.")
+	url, pageErr := github.PullRequestArtifactURL(owner, repo, pr, t.artifactName())
+	if pageErr != nil {
+		return downloadSpec{}, fmt.Errorf("PR #%d: %w\nPR-page fallback also failed: %v", pr, apiErr, pageErr)
+	}
+	spec.url = url
+	return spec, nil
+}
+
+// resolvePRViaAPI resolves a PR's artifact download URL through the GitHub API.
+func resolvePRViaAPI(owner, repo string, pr int, t buildTarget) (string, error) {
+	sha, err := github.GetPullRequestHeadSHA(owner, repo, pr)
+	if err != nil {
+		return "", err
+	}
+	url, err := github.ResolveWorkflowArtifactURL(owner, repo, "pr-build.yml", t.artifactName(), github.WorkflowRunFilter{HeadSHA: sha, Event: "pull_request"})
+	if err != nil {
+		return "", fmt.Errorf("commit %s: %w", shortSHA(sha), err)
+	}
+	return url, nil
+}
+
+// resolveBranch resolves a branch name to its CI artifact. Only main (main-build)
+// and branches with an open PR (pr-build) have CI artifacts.
+func resolveBranch(owner, repo, branch string, t buildTarget) (downloadSpec, error) {
+	workflow, signed := "pr-build.yml", false
+	if branch == "main" {
+		workflow, signed = "main-build.yml", true
+	}
+	url, err := github.ResolveWorkflowArtifactURL(owner, repo, workflow, t.artifactName(), github.WorkflowRunFilter{Branch: branch})
+	if err != nil {
+		return downloadSpec{}, fmt.Errorf("branch %q: %w (branch builds exist only for 'main' or branches with an open PR)", branch, err)
+	}
+	return downloadSpec{url: url, isZip: true, signed: signed, sourceDesc: fmt.Sprintf("branch %s", branch)}, nil
+}
+
+// resolveCommit resolves a commit SHA to its CI artifact, trying PR builds first
+// and then the main-branch build.
+func resolveCommit(owner, repo, commit string, t buildTarget) (downloadSpec, error) {
+	signed := false
+	url, err := github.ResolveWorkflowArtifactURL(owner, repo, "pr-build.yml", t.artifactName(), github.WorkflowRunFilter{HeadSHA: commit})
+	if err != nil {
+		var mainErr error
+		url, mainErr = github.ResolveWorkflowArtifactURL(owner, repo, "main-build.yml", t.artifactName(), github.WorkflowRunFilter{HeadSHA: commit})
+		if mainErr != nil {
+			return downloadSpec{}, fmt.Errorf("commit %s: %w", shortSHA(commit), err)
+		}
+		signed = true
+	}
+	return downloadSpec{url: url, isZip: true, signed: signed, sourceDesc: fmt.Sprintf("commit %s", shortSHA(commit))}, nil
+}
+
+// copyExecutable copies src to dest and makes it executable.
+func copyExecutable(src, dest string) error {
+	if err := fileutil.CopyFile(src, dest); err != nil {
+		return fmt.Errorf("failed to copy %s to %s: %w", src, dest, err)
+	}
+	if err := os.Chmod(dest, 0755); err != nil {
+		return fmt.Errorf("failed to make %s executable: %w", dest, err)
+	}
+	return nil
+}
+
+// printResult reports where the binaries landed and how to use or install them.
+// UserOut appends a newline per call, so blank separator lines use Println("").
+func printResult(ddevDest, hostnameDest string, t buildTarget, signed bool) {
+	util.Success("Downloaded ddev to %s", ddevDest)
+	if hostnameDest != "" {
+		util.Success("Downloaded ddev-hostname to %s", hostnameDest)
+	}
+
+	// macOS Gatekeeper refuses to run downloaded binaries it considers
+	// quarantined or unsigned. main-branch and released builds are signed, but
+	// PR/branch/commit builds are not, so tell macOS users how to clear the
+	// quarantine if the binary won't start.
+	if t.goos == "darwin" && !signed {
+		output.UserOut.Println("")
+		output.UserOut.Println("On macOS, if the binary is blocked (\"cannot be opened\" or \"killed\"), remove the quarantine attribute:")
+		output.UserOut.Printf("  xattr -r -d com.apple.quarantine %q", ddevDest)
+		if hostnameDest != "" {
+			output.UserOut.Printf("  xattr -r -d com.apple.quarantine %q", hostnameDest)
+		}
+	}
+
+	if !t.isNative {
+		util.Warning("This is a %s/%s build for another machine (%s/%s); skipping the install hints.", t.osName, t.arch, runtime.GOOS, runtime.GOARCH)
+		return
+	}
+
+	outputDir := filepath.Dir(ddevDest)
+
+	// Temporary: prepend the download directory so `ddev` in the current shell
+	// resolves to it. `hash -r` clears the shell's cached path to the old ddev,
+	// which bash/zsh would otherwise keep using despite the changed PATH.
+	output.UserOut.Println("")
+	output.UserOut.Println("To use this build in the current shell (this window only):")
+	if t.goos == "windows" {
+		output.UserOut.Printf("  $env:PATH = \"%s;$env:PATH\"", outputDir)
+	} else {
+		output.UserOut.Printf("  export PATH=\"%s:$PATH\"", outputDir)
+		output.UserOut.Println("  hash -r")
+	}
+	output.UserOut.Println("  ddev version")
+
+	// Permanent (Unix): replace the binary that `ddev` currently resolves to on
+	// PATH, following a symlink (e.g. Homebrew) to the real file so we replace
+	// the destination, not the link. Back up each current binary to <path>.bak
+	// first so the change can be reverted.
+	if t.goos == "windows" {
+		return
+	}
+	curDdev, ddevWasLink := currentBinaryPath("ddev")
+	if curDdev == "" {
+		return
+	}
+
+	// Pair each on-PATH binary with its freshly downloaded replacement.
+	type replacement struct{ cur, src string }
+	replacements := []replacement{{cur: curDdev, src: ddevDest}}
+	if hostnameDest != "" {
+		if curHostname, _ := currentBinaryPath("ddev-hostname"); curHostname != "" {
+			replacements = append(replacements, replacement{cur: curHostname, src: hostnameDest})
+		}
+	}
+
+	sudo := ""
+	if !isDirWritable(filepath.Dir(curDdev)) {
+		sudo = "sudo "
+	}
+
+	output.UserOut.Println("")
+	output.UserOut.Println("To install this build permanently, back up your current binary and replace it:")
+	for _, r := range replacements {
+		output.UserOut.Printf("  %scp %q %q", sudo, r.cur, r.cur+".bak")
+		output.UserOut.Printf("  %scp %q %q", sudo, r.src, r.cur)
+	}
+	if ddevWasLink {
+		output.UserOut.Println("  (ddev on your PATH is a symlink; the path above is its real target)")
+	}
+
+	output.UserOut.Println("")
+	output.UserOut.Println("To revert to your previous binary:")
+	for _, r := range replacements {
+		output.UserOut.Printf("  %smv %q %q", sudo, r.cur+".bak", r.cur)
+	}
+}
+
+// currentBinaryPath returns the real path of the named binary as found on PATH,
+// resolving any symlink to its target. The bool reports whether a symlink was
+// resolved. Returns ("", false) when the binary is not on PATH.
+func currentBinaryPath(name string) (string, bool) {
+	p, err := exec.LookPath(name)
+	if err != nil {
+		return "", false
+	}
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return p, false
+	}
+	return resolved, resolved != p
+}
+
+// isDirWritable reports whether a file can be created in dir.
+func isDirWritable(dir string) bool {
+	f, err := os.CreateTemp(dir, ".ddev-write-test-")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	return true
+}
+
+// shortSHA returns the first 7 characters of a commit SHA for display.
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}

--- a/cmd/ddev/cmd/utility-download-ddev.go
+++ b/cmd/ddev/cmd/utility-download-ddev.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/ddev/ddev/pkg/archive"
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -44,8 +45,12 @@ and --commit download unsigned GitHub Actions artifacts and use a GitHub token
 anonymous rate limit; without a token, --pr falls back to the build links
 posted on the pull request.
 
+By default the binaries are written to ~/tmp/ddev-download-ddev rather than
+the current directory, so a download can't accidentally end up on PATH or as
+a stray file in a git checkout.
+
 This command only downloads the binaries; it does not modify your installed ddev.`,
-	Example: `# Download the current platform's build from PR 1234 into the current directory
+	Example: `# Download the current platform's build from PR 1234 into ~/tmp/ddev-download-ddev
 ddev utility download-ddev --pr 1234
 
 # Download the latest main build into ~/tmp/head
@@ -58,7 +63,7 @@ ddev utility download-ddev --tag v1.24.5
 ddev utility download-ddev --stable
 
 # Cross-download a macOS arm64 build of a branch
-ddev utility download-ddev --branch 20250101_feature --os macos --arch arm64 --output ./out`,
+ddev utility download-ddev --branch 20250101_feature --os macos --arch arm64 --output ~/tmp/ddev-macos-arm64`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
 		if err := runDownloadDdev(cmd); err != nil {
@@ -85,7 +90,7 @@ func registerDownloadDdevFlags(cmd *cobra.Command) {
 	f.BoolVar(&downloadDdevHead, "head", false, "Download the latest main build")
 	f.StringVar(&downloadDdevOwner, "owner", "ddev", "GitHub owner/org (for PR builds this is the base repo, not a fork)")
 	f.StringVar(&downloadDdevRepo, "repo", "ddev", "GitHub repo")
-	f.StringVarP(&downloadDdevOutput, "output", "o", "", "Output directory (default: current directory)")
+	f.StringVarP(&downloadDdevOutput, "output", "o", "", "Output directory (default: ~/tmp/ddev-download-ddev)")
 	f.StringVar(&downloadDdevOS, "os", "", "OS override: macos, linux, or windows (default: current OS)")
 	f.StringVar(&downloadDdevArch, "arch", "", "Architecture override: amd64 or arm64 (default: current architecture)")
 
@@ -180,9 +185,7 @@ func runDownloadDdev(cmd *cobra.Command) error {
 
 	outputDir := downloadDdevOutput
 	if outputDir == "" {
-		if outputDir, err = os.Getwd(); err != nil {
-			return err
-		}
+		outputDir = defaultOutputDir()
 	}
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return err
@@ -203,8 +206,67 @@ func runDownloadDdev(cmd *cobra.Command) error {
 		}
 	}
 
-	printResult(ddevDest, hostnameDest, target, spec.signed)
+	paths := []string{ddevDest}
+	if hostnameDest != "" {
+		paths = append(paths, hostnameDest)
+	}
+	autoUnblocked := false
+	if !spec.signed {
+		switch target.goos {
+		case "darwin":
+			autoUnblocked = clearMacQuarantine(paths)
+		case "windows":
+			autoUnblocked = clearWindowsBlock(paths)
+		}
+	}
+
+	printResult(ddevDest, hostnameDest, target, spec.signed, autoUnblocked)
 	return nil
+}
+
+// clearMacQuarantine best-effort clears the macOS "com.apple.quarantine" xattr
+// from freshly downloaded files, so Gatekeeper doesn't refuse to run them.
+// Returns whether it attempted the clear (the xattr tool was found); a missing
+// or absent attribute is not treated as a failure, since the file may not
+// have been quarantined in the first place.
+func clearMacQuarantine(paths []string) bool {
+	if _, err := exec.LookPath("xattr"); err != nil {
+		return false
+	}
+	for _, p := range paths {
+		_ = exec.Command("xattr", "-d", "com.apple.quarantine", p).Run()
+	}
+	return true
+}
+
+// clearWindowsBlock best-effort clears the Windows "mark of the web" (the
+// Zone.Identifier alternate data stream) from freshly downloaded files via
+// PowerShell's Unblock-File, so SmartScreen doesn't refuse to run them.
+// Returns whether it attempted the clear (PowerShell was found); an absent
+// mark is not treated as a failure.
+func clearWindowsBlock(paths []string) bool {
+	if _, err := exec.LookPath("powershell"); err != nil {
+		return false
+	}
+	for _, p := range paths {
+		cmd := fmt.Sprintf("Unblock-File -LiteralPath %s", psQuote(p))
+		_ = exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", cmd).Run()
+	}
+	return true
+}
+
+// psQuote single-quotes a string for use in a PowerShell command, doubling
+// any embedded single quotes per PowerShell's escaping rule.
+func psQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// defaultOutputDir returns the default download destination used when --output
+// is not given: a fixed, out-of-the-way directory rather than the current
+// directory, so a download can't accidentally end up on PATH or as a stray
+// file in a git checkout.
+func defaultOutputDir() string {
+	return filepath.Join(util.GetHomeDir(), "tmp", "ddev-download-ddev")
 }
 
 // resolveTarget maps --os/--arch overrides (or the current machine) to a buildTarget.
@@ -397,22 +459,43 @@ func copyExecutable(src, dest string) error {
 
 // printResult reports where the binaries landed and how to use or install them.
 // UserOut appends a newline per call, so blank separator lines use Println("").
-func printResult(ddevDest, hostnameDest string, t buildTarget, signed bool) {
+func printResult(ddevDest, hostnameDest string, t buildTarget, signed, autoUnblocked bool) {
 	util.Success("Downloaded ddev to %s", ddevDest)
 	if hostnameDest != "" {
 		util.Success("Downloaded ddev-hostname to %s", hostnameDest)
 	}
 
-	// macOS Gatekeeper refuses to run downloaded binaries it considers
-	// quarantined or unsigned. main-branch and released builds are signed, but
-	// PR/branch/commit builds are not, so tell macOS users how to clear the
-	// quarantine if the binary won't start.
-	if t.goos == "darwin" && !signed {
-		output.UserOut.Println("")
-		output.UserOut.Println("On macOS, if the binary is blocked (\"cannot be opened\" or \"killed\"), remove the quarantine attribute:")
-		output.UserOut.Printf("  xattr -r -d com.apple.quarantine %q", ddevDest)
-		if hostnameDest != "" {
-			output.UserOut.Printf("  xattr -r -d com.apple.quarantine %q", hostnameDest)
+	// macOS Gatekeeper and Windows SmartScreen can refuse to run downloaded
+	// binaries they consider quarantined/unsigned. main-branch and released
+	// builds are signed, but PR/branch/commit builds are not. runDownloadDdev
+	// already tried to clear the quarantine/block automatically; fall back to
+	// printing the manual command only if that tool wasn't available.
+	if !signed {
+		switch t.goos {
+		case "darwin":
+			if autoUnblocked {
+				output.UserOut.Println("")
+				output.UserOut.Println("Cleared the macOS quarantine attribute automatically.")
+			} else {
+				output.UserOut.Println("")
+				output.UserOut.Println("On macOS, if the binary is blocked (\"cannot be opened\" or \"killed\"), remove the quarantine attribute:")
+				output.UserOut.Printf("  xattr -d com.apple.quarantine %q", ddevDest)
+				if hostnameDest != "" {
+					output.UserOut.Printf("  xattr -d com.apple.quarantine %q", hostnameDest)
+				}
+			}
+		case "windows":
+			if autoUnblocked {
+				output.UserOut.Println("")
+				output.UserOut.Println("Unblocked the downloaded files automatically (cleared the Windows \"mark of the web\").")
+			} else {
+				output.UserOut.Println("")
+				output.UserOut.Println("On Windows, if the binary is blocked by SmartScreen, unblock it:")
+				output.UserOut.Printf("  Unblock-File -LiteralPath %q", ddevDest)
+				if hostnameDest != "" {
+					output.UserOut.Printf("  Unblock-File -LiteralPath %q", hostnameDest)
+				}
+			}
 		}
 	}
 
@@ -463,7 +546,7 @@ func printResult(ddevDest, hostnameDest string, t buildTarget, signed bool) {
 	}
 
 	output.UserOut.Println("")
-	output.UserOut.Println("To install this build permanently, back up your current binary and replace it:")
+	output.UserOut.Println("Prefer the temporary use above. If you still want to replace your installed ddev with this build, back up your current binary first:")
 	for _, r := range replacements {
 		output.UserOut.Printf("  %scp %q %q", sudo, r.cur, r.cur+".bak")
 		output.UserOut.Printf("  %scp %q %q", sudo, r.src, r.cur)

--- a/cmd/ddev/cmd/utility-download-ddev.go
+++ b/cmd/ddev/cmd/utility-download-ddev.go
@@ -45,19 +45,20 @@ and --commit download unsigned GitHub Actions artifacts and use a GitHub token
 anonymous rate limit; without a token, --pr falls back to the build links
 posted on the pull request.
 
-By default the binaries are written to ~/tmp/ddev-download-ddev rather than
-the current directory, so a download can't accidentally end up on PATH or as
-a stray file in a git checkout.
+By default the binaries are written to ~/tmp/ddev-download-ddev/<version>
+rather than the current directory, so a download can't accidentally end up on
+PATH or as a stray file in a git checkout, and each build stays separate from
+the ones downloaded before it.
 
 This command only downloads the binaries; it does not modify your installed ddev.`,
-	Example: `# Download the current platform's build from PR 1234 into ~/tmp/ddev-download-ddev
-ddev utility download-ddev --pr 1234
+	Example: `# Download the current platform's build from PR 8611 into ~/tmp/ddev-download-ddev/pr-8611
+ddev utility download-ddev --pr 8611
 
 # Download the latest main build into ~/tmp/head
 ddev utility download-ddev --head --output ~/tmp/head
 
 # Download a specific released version
-ddev utility download-ddev --tag v1.24.5
+ddev utility download-ddev --tag v1.25.3
 
 # Download the latest stable release
 ddev utility download-ddev --stable
@@ -85,12 +86,12 @@ func registerDownloadDdevFlags(cmd *cobra.Command) {
 	f.IntVar(&downloadDdevPR, "pr", 0, "Pull request number to download the build from")
 	f.StringVar(&downloadDdevBranch, "branch", "", "Branch name to download the build from")
 	f.StringVar(&downloadDdevCommit, "commit", "", "Commit SHA to download the build from")
-	f.StringVar(&downloadDdevTag, "tag", "", "Release tag to download (e.g. v1.24.5)")
+	f.StringVar(&downloadDdevTag, "tag", "", "Release tag to download (e.g. v1.25.3)")
 	f.BoolVar(&downloadDdevStable, "stable", false, "Download the latest stable release")
 	f.BoolVar(&downloadDdevHead, "head", false, "Download the latest main build")
 	f.StringVar(&downloadDdevOwner, "owner", "ddev", "GitHub owner/org (for PR builds this is the base repo, not a fork)")
 	f.StringVar(&downloadDdevRepo, "repo", "ddev", "GitHub repo")
-	f.StringVarP(&downloadDdevOutput, "output", "o", "", "Output directory (default: ~/tmp/ddev-download-ddev)")
+	f.StringVarP(&downloadDdevOutput, "output", "o", "", "Output directory (default: ~/tmp/ddev-download-ddev/<version>)")
 	f.StringVar(&downloadDdevOS, "os", "", "OS override: macos, linux, or windows (default: current OS)")
 	f.StringVar(&downloadDdevArch, "arch", "", "Architecture override: amd64 or arm64 (default: current architecture)")
 
@@ -118,7 +119,7 @@ func (t buildTarget) artifactName() string {
 }
 
 // releaseAssetName returns the goreleaser release archive name for a tag, e.g.
-// "ddev_linux-amd64.v1.24.5.tar.gz". Release archives use an underscore after
+// "ddev_linux-amd64.v1.25.3.tar.gz". Release archives use an underscore after
 // "ddev", embed the tag verbatim (which already includes the leading "v"), and
 // are zip files on Windows.
 func (t buildTarget) releaseAssetName(tag string) string {
@@ -136,6 +137,7 @@ type downloadSpec struct {
 	isZip      bool   // true = unzip, false = untar
 	signed     bool   // signed/notarized build (releases, main)
 	sourceDesc string
+	version    string // subdirectory name under the default output dir, e.g. "pr-8611"
 }
 
 // runDownloadDdev is the testable entry point for the command.
@@ -185,7 +187,7 @@ func runDownloadDdev(cmd *cobra.Command) error {
 
 	outputDir := downloadDdevOutput
 	if outputDir == "" {
-		outputDir = defaultOutputDir()
+		outputDir = defaultOutputDir(spec.version)
 	}
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return err
@@ -261,12 +263,24 @@ func psQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
-// defaultOutputDir returns the default download destination used when --output
-// is not given: a fixed, out-of-the-way directory rather than the current
-// directory, so a download can't accidentally end up on PATH or as a stray
-// file in a git checkout.
-func defaultOutputDir() string {
-	return filepath.Join(util.GetHomeDir(), "tmp", "ddev-download-ddev")
+// defaultOutputDir returns the download destination used when --output is not
+// given. Downloads accumulate here and the set of binaries differs between
+// versions (older releases have no ddev-hostname), so each build gets its own
+// subdirectory.
+func defaultOutputDir(version string) string {
+	return filepath.Join(util.GetHomeDir(), "tmp", "ddev-download-ddev", version)
+}
+
+// versionDirName makes s safe to use as a single directory name; branch names
+// in particular can contain slashes and characters Windows forbids.
+func versionDirName(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			return r
+		}
+		return '-'
+	}, s)
 }
 
 // resolveTarget maps --os/--arch overrides (or the current machine) to a buildTarget.
@@ -319,7 +333,7 @@ func resolveSource(cmd *cobra.Command, t buildTarget) (downloadSpec, error) {
 	switch {
 	case f.Changed("tag"):
 		if downloadDdevTag == "" {
-			return downloadSpec{}, fmt.Errorf("--tag requires a value, e.g. --tag v1.24.5")
+			return downloadSpec{}, fmt.Errorf("--tag requires a value, e.g. --tag v1.25.3")
 		}
 		return resolveReleaseTag(owner, repo, downloadDdevTag, t), nil
 	case downloadDdevStable:
@@ -352,6 +366,7 @@ func resolveReleaseTag(owner, repo, tag string, t buildTarget) downloadSpec {
 		isZip:      t.goos == "windows",
 		signed:     true,
 		sourceDesc: fmt.Sprintf("release %s", tag),
+		version:    versionDirName(tag),
 	}
 }
 
@@ -373,6 +388,7 @@ func resolveHead(owner, repo string, t buildTarget) downloadSpec {
 		isZip:      true,
 		signed:     true,
 		sourceDesc: "the latest main build",
+		version:    "main",
 	}
 }
 
@@ -385,7 +401,7 @@ func resolvePR(owner, repo string, pr int, t buildTarget) (downloadSpec, error) 
 	if pr <= 0 {
 		return downloadSpec{}, fmt.Errorf("--pr requires a positive PR number")
 	}
-	spec := downloadSpec{isZip: true, sourceDesc: fmt.Sprintf("PR #%d", pr)}
+	spec := downloadSpec{isZip: true, sourceDesc: fmt.Sprintf("PR #%d", pr), version: fmt.Sprintf("pr-%d", pr)}
 
 	url, apiErr := resolvePRViaAPI(owner, repo, pr, t)
 	if apiErr == nil {
@@ -427,7 +443,7 @@ func resolveBranch(owner, repo, branch string, t buildTarget) (downloadSpec, err
 	if err != nil {
 		return downloadSpec{}, fmt.Errorf("branch %q: %w (branch builds exist only for 'main' or branches with an open PR)", branch, err)
 	}
-	return downloadSpec{url: url, isZip: true, signed: signed, sourceDesc: fmt.Sprintf("branch %s", branch)}, nil
+	return downloadSpec{url: url, isZip: true, signed: signed, sourceDesc: fmt.Sprintf("branch %s", branch), version: versionDirName("branch-" + branch)}, nil
 }
 
 // resolveCommit resolves a commit SHA to its CI artifact, trying PR builds first
@@ -443,7 +459,7 @@ func resolveCommit(owner, repo, commit string, t buildTarget) (downloadSpec, err
 		}
 		signed = true
 	}
-	return downloadSpec{url: url, isZip: true, signed: signed, sourceDesc: fmt.Sprintf("commit %s", shortSHA(commit))}, nil
+	return downloadSpec{url: url, isZip: true, signed: signed, sourceDesc: fmt.Sprintf("commit %s", shortSHA(commit)), version: versionDirName("commit-" + shortSHA(commit))}, nil
 }
 
 // copyExecutable copies src to dest and makes it executable.
@@ -457,7 +473,7 @@ func copyExecutable(src, dest string) error {
 	return nil
 }
 
-// printResult reports where the binaries landed and how to use or install them.
+// printResult reports where the binaries landed and how to use them.
 // UserOut appends a newline per call, so blank separator lines use Println("").
 func printResult(ddevDest, hostnameDest string, t buildTarget, signed, autoUnblocked bool) {
 	util.Success("Downloaded ddev to %s", ddevDest)
@@ -500,15 +516,15 @@ func printResult(ddevDest, hostnameDest string, t buildTarget, signed, autoUnblo
 	}
 
 	if !t.isNative {
-		util.Warning("This is a %s/%s build for another machine (%s/%s); skipping the install hints.", t.osName, t.arch, runtime.GOOS, runtime.GOARCH)
+		util.Warning("This is a %s/%s build for another machine (%s/%s); skipping the usage hints.", t.osName, t.arch, runtime.GOOS, runtime.GOARCH)
 		return
 	}
 
 	outputDir := filepath.Dir(ddevDest)
 
-	// Temporary: prepend the download directory so `ddev` in the current shell
-	// resolves to it. `hash -r` clears the shell's cached path to the old ddev,
-	// which bash/zsh would otherwise keep using despite the changed PATH.
+	// Prepend the download directory so `ddev` in the current shell resolves to
+	// it. `hash -r` clears the shell's cached path to the old ddev, which
+	// bash/zsh would otherwise keep using despite the changed PATH.
 	output.UserOut.Println("")
 	output.UserOut.Println("To use this build in the current shell (this window only):")
 	if t.goos == "windows" {
@@ -518,75 +534,6 @@ func printResult(ddevDest, hostnameDest string, t buildTarget, signed, autoUnblo
 		output.UserOut.Println("  hash -r")
 	}
 	output.UserOut.Println("  ddev version")
-
-	// Permanent (Unix): replace the binary that `ddev` currently resolves to on
-	// PATH, following a symlink (e.g. Homebrew) to the real file so we replace
-	// the destination, not the link. Back up each current binary to <path>.bak
-	// first so the change can be reverted.
-	if t.goos == "windows" {
-		return
-	}
-	curDdev, ddevWasLink := currentBinaryPath("ddev")
-	if curDdev == "" {
-		return
-	}
-
-	// Pair each on-PATH binary with its freshly downloaded replacement.
-	type replacement struct{ cur, src string }
-	replacements := []replacement{{cur: curDdev, src: ddevDest}}
-	if hostnameDest != "" {
-		if curHostname, _ := currentBinaryPath("ddev-hostname"); curHostname != "" {
-			replacements = append(replacements, replacement{cur: curHostname, src: hostnameDest})
-		}
-	}
-
-	sudo := ""
-	if !isDirWritable(filepath.Dir(curDdev)) {
-		sudo = "sudo "
-	}
-
-	output.UserOut.Println("")
-	output.UserOut.Println("Prefer the temporary use above. If you still want to replace your installed ddev with this build, back up your current binary first:")
-	for _, r := range replacements {
-		output.UserOut.Printf("  %scp %q %q", sudo, r.cur, r.cur+".bak")
-		output.UserOut.Printf("  %scp %q %q", sudo, r.src, r.cur)
-	}
-	if ddevWasLink {
-		output.UserOut.Println("  (ddev on your PATH is a symlink; the path above is its real target)")
-	}
-
-	output.UserOut.Println("")
-	output.UserOut.Println("To revert to your previous binary:")
-	for _, r := range replacements {
-		output.UserOut.Printf("  %smv %q %q", sudo, r.cur+".bak", r.cur)
-	}
-}
-
-// currentBinaryPath returns the real path of the named binary as found on PATH,
-// resolving any symlink to its target. The bool reports whether a symlink was
-// resolved. Returns ("", false) when the binary is not on PATH.
-func currentBinaryPath(name string) (string, bool) {
-	p, err := exec.LookPath(name)
-	if err != nil {
-		return "", false
-	}
-	resolved, err := filepath.EvalSymlinks(p)
-	if err != nil {
-		return p, false
-	}
-	return resolved, resolved != p
-}
-
-// isDirWritable reports whether a file can be created in dir.
-func isDirWritable(dir string) bool {
-	f, err := os.CreateTemp(dir, ".ddev-write-test-")
-	if err != nil {
-		return false
-	}
-	name := f.Name()
-	_ = f.Close()
-	_ = os.Remove(name)
-	return true
 }
 
 // shortSHA returns the first 7 characters of a commit SHA for display.

--- a/cmd/ddev/cmd/utility-download-ddev_test.go
+++ b/cmd/ddev/cmd/utility-download-ddev_test.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/archive"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/github"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDownloadDdevResolveTarget verifies OS/arch mapping, .exe suffix, native
+// detection, and rejection of unsupported values.
+func TestDownloadDdevResolveTarget(t *testing.T) {
+	tests := []struct {
+		osFlag, archFlag  string
+		wantGoos, wantOS  string
+		wantArch, wantExe string
+		wantErr           bool
+	}{
+		{"macos", "arm64", "darwin", "macos", "arm64", "", false},
+		{"darwin", "amd64", "darwin", "macos", "amd64", "", false},
+		{"linux", "amd64", "linux", "linux", "amd64", "", false},
+		{"windows", "amd64", "windows", "windows", "amd64", ".exe", false},
+		{"windows", "arm64", "windows", "windows", "arm64", ".exe", false},
+		{"freebsd", "amd64", "", "", "", "", true},
+		{"linux", "386", "", "", "", "", true},
+	}
+	for _, tc := range tests {
+		got, err := resolveTarget(tc.osFlag, tc.archFlag)
+		if tc.wantErr {
+			require.Error(t, err, "os=%q arch=%q", tc.osFlag, tc.archFlag)
+			continue
+		}
+		require.NoError(t, err, "os=%q arch=%q", tc.osFlag, tc.archFlag)
+		require.Equal(t, tc.wantGoos, got.goos)
+		require.Equal(t, tc.wantOS, got.osName)
+		require.Equal(t, tc.wantArch, got.arch)
+		require.Equal(t, tc.wantExe, got.exeExt)
+	}
+
+	// Defaults should match the current machine and be marked native.
+	native, err := resolveTarget("", "")
+	require.NoError(t, err)
+	require.Equal(t, runtime.GOOS, native.goos)
+	require.Equal(t, runtime.GOARCH, native.arch)
+	require.True(t, native.isNative, "no overrides should produce a native target")
+}
+
+// TestDownloadDdevArtifactName locks down the CI artifact naming (hyphen after ddev).
+func TestDownloadDdevArtifactName(t *testing.T) {
+	require.Equal(t, "ddev-linux-amd64", buildTarget{osName: "linux", arch: "amd64"}.artifactName())
+	require.Equal(t, "ddev-macos-arm64", buildTarget{osName: "macos", arch: "arm64"}.artifactName())
+	require.Equal(t, "ddev-windows-amd64", buildTarget{osName: "windows", arch: "amd64"}.artifactName())
+}
+
+// TestDownloadDdevReleaseAssetName locks down goreleaser release naming: underscore
+// after ddev, the tag embedded verbatim (already includes the "v"), and .zip on
+// Windows.
+func TestDownloadDdevReleaseAssetName(t *testing.T) {
+	require.Equal(t, "ddev_linux-amd64.v1.24.5.tar.gz",
+		buildTarget{goos: "linux", osName: "linux", arch: "amd64"}.releaseAssetName("v1.24.5"))
+	require.Equal(t, "ddev_macos-arm64.v1.24.5.tar.gz",
+		buildTarget{goos: "darwin", osName: "macos", arch: "arm64"}.releaseAssetName("v1.24.5"))
+	require.Equal(t, "ddev_windows-amd64.v1.24.5.zip",
+		buildTarget{goos: "windows", osName: "windows", arch: "amd64"}.releaseAssetName("v1.24.5"))
+}
+
+// TestDownloadDdevURLs verifies the nightly.link and release URLs that are built
+// without any network access.
+func TestDownloadDdevURLs(t *testing.T) {
+	linux := buildTarget{goos: "linux", osName: "linux", arch: "amd64"}
+
+	head := resolveHead("ddev", "ddev", linux)
+	require.Equal(t, "https://nightly.link/ddev/ddev/workflows/main-build/main/ddev-linux-amd64.zip", head.url)
+	require.True(t, head.isZip)
+	require.Empty(t, head.shaSumURL)
+
+	require.Equal(t, "https://nightly.link/ddev/ddev/actions/artifacts/12345.zip",
+		github.NightlyLinkArtifactURL("ddev", "ddev", 12345))
+
+	rel := resolveReleaseTag("ddev", "ddev", "v1.24.5", linux)
+	require.Equal(t, "https://github.com/ddev/ddev/releases/download/v1.24.5/ddev_linux-amd64.v1.24.5.tar.gz", rel.url)
+	require.Equal(t, "https://github.com/ddev/ddev/releases/download/v1.24.5/checksums.txt", rel.shaSumURL)
+	require.False(t, rel.isZip)
+
+	// Windows release uses a zip archive.
+	win := buildTarget{goos: "windows", osName: "windows", arch: "amd64", exeExt: ".exe"}
+	relWin := resolveReleaseTag("ddev", "ddev", "v1.24.5", win)
+	require.Equal(t, "https://github.com/ddev/ddev/releases/download/v1.24.5/ddev_windows-amd64.v1.24.5.zip", relWin.url)
+	require.True(t, relWin.isZip)
+}
+
+// TestDownloadDdevExtractAndCopy exercises the real unzip + copyExecutable path used
+// after a download: a flat artifact zip is extracted and its ddev binary is
+// copied into the output directory with an executable mode.
+func TestDownloadDdevExtractAndCopy(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Build a flat artifact zip like the ones CI uploads.
+	zipPath := filepath.Join(tmp, "ddev-linux-amd64.zip")
+	zf, err := os.Create(zipPath)
+	require.NoError(t, err)
+	zw := zip.NewWriter(zf)
+	for _, name := range []string{"ddev", "ddev-hostname", "mkcert"} {
+		w, werr := zw.Create(name)
+		require.NoError(t, werr)
+		_, werr = w.Write([]byte("#!/bin/sh\necho " + name + "\n"))
+		require.NoError(t, werr)
+	}
+	require.NoError(t, zw.Close())
+	require.NoError(t, zf.Close())
+
+	extractDir := filepath.Join(tmp, "extracted")
+	require.NoError(t, archive.Unzip(zipPath, extractDir, ""))
+	require.FileExists(t, filepath.Join(extractDir, "ddev"))
+	require.FileExists(t, filepath.Join(extractDir, "ddev-hostname"))
+
+	outDir := filepath.Join(tmp, "out")
+	require.NoError(t, os.MkdirAll(outDir, 0755))
+
+	dest := filepath.Join(outDir, "ddev")
+	require.NoError(t, copyExecutable(filepath.Join(extractDir, "ddev"), dest))
+	require.FileExists(t, dest)
+
+	if runtime.GOOS != "windows" {
+		info, statErr := os.Stat(dest)
+		require.NoError(t, statErr)
+		require.NotZero(t, info.Mode()&0111, "copied binary must be executable")
+	}
+}
+
+// TestDownloadDdevFlagGroups verifies the mutually-exclusive / one-required source
+// selectors on a throwaway command (so the shared command's flag state is not
+// mutated).
+func TestDownloadDdevFlagGroups(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		c := &cobra.Command{Use: "download-ddev", Run: func(_ *cobra.Command, _ []string) {}}
+		c.SilenceUsage = true
+		c.SilenceErrors = true
+		registerDownloadDdevFlags(c)
+		return c
+	}
+
+	// No source selector -> error (one required).
+	none := newCmd()
+	none.SetArgs([]string{})
+	require.Error(t, none.Execute(), "no source selector should be rejected")
+
+	// Two source selectors -> error (mutually exclusive).
+	two := newCmd()
+	two.SetArgs([]string{"--pr", "1", "--head"})
+	require.Error(t, two.Execute(), "two source selectors should be rejected")
+
+	// A single selector passes flag validation (the no-op Run does nothing).
+	one := newCmd()
+	one.SetArgs([]string{"--head"})
+	require.NoError(t, one.Execute(), "a single source selector should pass validation")
+
+	// A --tag value passes flag validation.
+	tag := newCmd()
+	tag.SetArgs([]string{"--tag", "v1.2.3"})
+	require.NoError(t, tag.Execute(), "--tag should be accepted")
+}
+
+// TestDownloadDdevHeadDownload is a live, opt-in integration test (gated on
+// DDEV_RUN_DOWNLOAD_DDEV_TEST, which the nginx-fpm CI job sets) that runs the
+// real `ddev utility download-ddev --head` and then runs the downloaded binary.
+//
+// It exercises only --head: it always resolves (main is built continuously),
+// needs no token or API budget (plain nightly.link), and covers the shared
+// download → extract → verify → copy pipeline that every source funnels into.
+// PR/branch/commit artifacts expire after ~90 days, so hardcoding one would rot;
+// their URL logic is already covered offline by TestDownloadDdevURLs above.
+func TestDownloadDdevHeadDownload(t *testing.T) {
+	if nodeps.IsEnvFalse("DDEV_RUN_DOWNLOAD_DDEV_TEST") {
+		t.Skip("Skip live download test unless DDEV_RUN_DOWNLOAD_DDEV_TEST=true")
+	}
+
+	outDir := testcommon.CreateTmpDir(filepath.Base(t.Name()))
+	defer testcommon.CleanupDir(outDir)
+
+	out, err := exec.RunHostCommand(DdevBin, "utility", "download-ddev", "--head", "--output", outDir)
+	require.NoError(t, err, "download-ddev --head failed, out='%s'", out)
+
+	exe := ""
+	if runtime.GOOS == "windows" {
+		exe = ".exe"
+	}
+	ddevPath := filepath.Join(outDir, "ddev"+exe)
+	require.FileExists(t, ddevPath)
+	require.FileExists(t, filepath.Join(outDir, "ddev-hostname"+exe))
+
+	// --head downloads the current machine's build, so the copied binary must run.
+	out, err = exec.RunHostCommand(ddevPath, "version")
+	require.NoError(t, err, "downloaded ddev failed to run, out='%s'", out)
+	require.Contains(t, out, "DDEV version")
+}

--- a/cmd/ddev/cmd/utility-download-ddev_test.go
+++ b/cmd/ddev/cmd/utility-download-ddev_test.go
@@ -12,9 +12,48 @@ import (
 	"github.com/ddev/ddev/pkg/github"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/ddev/ddev/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
+
+// TestDownloadDdevDefaultOutputDir verifies the default download destination
+// is a fixed directory under the user's home, not the current directory.
+func TestDownloadDdevDefaultOutputDir(t *testing.T) {
+	require.Equal(t, filepath.Join(util.GetHomeDir(), "tmp", "ddev-download-ddev"), defaultOutputDir())
+}
+
+// TestDownloadDdevPSQuote verifies PowerShell single-quote escaping.
+func TestDownloadDdevPSQuote(t *testing.T) {
+	require.Equal(t, `'C:\Users\test'`, psQuote(`C:\Users\test`))
+	require.Equal(t, `'it''s a test'`, psQuote("it's a test"))
+}
+
+// TestDownloadDdevClearMacQuarantine verifies the auto-unblock is attempted
+// only when the xattr tool is available (i.e. on macOS), and never panics.
+func TestDownloadDdevClearMacQuarantine(t *testing.T) {
+	tmp := t.TempDir()
+	f := filepath.Join(tmp, "somefile")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0644))
+
+	attempted := clearMacQuarantine([]string{f})
+	if runtime.GOOS == "darwin" {
+		require.True(t, attempted, "xattr should be available on macOS")
+	}
+}
+
+// TestDownloadDdevClearWindowsBlock verifies the auto-unblock is attempted
+// only when PowerShell is available (i.e. on Windows), and never panics.
+func TestDownloadDdevClearWindowsBlock(t *testing.T) {
+	tmp := t.TempDir()
+	f := filepath.Join(tmp, "somefile")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0644))
+
+	attempted := clearWindowsBlock([]string{f})
+	if runtime.GOOS == "windows" {
+		require.True(t, attempted, "PowerShell should be available on Windows")
+	}
+}
 
 // TestDownloadDdevResolveTarget verifies OS/arch mapping, .exe suffix, native
 // detection, and rejection of unsupported values.

--- a/cmd/ddev/cmd/utility-download-ddev_test.go
+++ b/cmd/ddev/cmd/utility-download-ddev_test.go
@@ -18,9 +18,29 @@ import (
 )
 
 // TestDownloadDdevDefaultOutputDir verifies the default download destination
-// is a fixed directory under the user's home, not the current directory.
+// is a per-version directory under the user's home, not the current directory.
 func TestDownloadDdevDefaultOutputDir(t *testing.T) {
-	require.Equal(t, filepath.Join(util.GetHomeDir(), "tmp", "ddev-download-ddev"), defaultOutputDir())
+	base := filepath.Join(util.GetHomeDir(), "tmp", "ddev-download-ddev")
+	require.Equal(t, filepath.Join(base, "pr-8611"), defaultOutputDir("pr-8611"))
+	require.Equal(t, filepath.Join(base, "v1.25.3"), defaultOutputDir("v1.25.3"))
+}
+
+// TestDownloadDdevVersionDirName verifies the version subdirectory is a single
+// directory name even for branch names containing slashes or other characters
+// that a path (or Windows) would choke on.
+func TestDownloadDdevVersionDirName(t *testing.T) {
+	require.Equal(t, "v1.25.3", versionDirName("v1.25.3"))
+	require.Equal(t, "branch-20250101_feature", versionDirName("branch-20250101_feature"))
+	require.Equal(t, "branch-feature-foo", versionDirName("branch-feature/foo"))
+	require.Equal(t, "branch-a-b-c-d", versionDirName(`branch-a:b\c d`))
+}
+
+// TestDownloadDdevSpecVersions verifies each source resolves to its own
+// subdirectory, so downloads of different builds don't mix together.
+func TestDownloadDdevSpecVersions(t *testing.T) {
+	linux := buildTarget{goos: "linux", osName: "linux", arch: "amd64"}
+	require.Equal(t, "v1.25.3", resolveReleaseTag("ddev", "ddev", "v1.25.3", linux).version)
+	require.Equal(t, "main", resolveHead("ddev", "ddev", linux).version)
 }
 
 // TestDownloadDdevPSQuote verifies PowerShell single-quote escaping.
@@ -104,12 +124,12 @@ func TestDownloadDdevArtifactName(t *testing.T) {
 // after ddev, the tag embedded verbatim (already includes the "v"), and .zip on
 // Windows.
 func TestDownloadDdevReleaseAssetName(t *testing.T) {
-	require.Equal(t, "ddev_linux-amd64.v1.24.5.tar.gz",
-		buildTarget{goos: "linux", osName: "linux", arch: "amd64"}.releaseAssetName("v1.24.5"))
-	require.Equal(t, "ddev_macos-arm64.v1.24.5.tar.gz",
-		buildTarget{goos: "darwin", osName: "macos", arch: "arm64"}.releaseAssetName("v1.24.5"))
-	require.Equal(t, "ddev_windows-amd64.v1.24.5.zip",
-		buildTarget{goos: "windows", osName: "windows", arch: "amd64"}.releaseAssetName("v1.24.5"))
+	require.Equal(t, "ddev_linux-amd64.v1.25.3.tar.gz",
+		buildTarget{goos: "linux", osName: "linux", arch: "amd64"}.releaseAssetName("v1.25.3"))
+	require.Equal(t, "ddev_macos-arm64.v1.25.3.tar.gz",
+		buildTarget{goos: "darwin", osName: "macos", arch: "arm64"}.releaseAssetName("v1.25.3"))
+	require.Equal(t, "ddev_windows-amd64.v1.25.3.zip",
+		buildTarget{goos: "windows", osName: "windows", arch: "amd64"}.releaseAssetName("v1.25.3"))
 }
 
 // TestDownloadDdevURLs verifies the nightly.link and release URLs that are built
@@ -125,15 +145,15 @@ func TestDownloadDdevURLs(t *testing.T) {
 	require.Equal(t, "https://nightly.link/ddev/ddev/actions/artifacts/12345.zip",
 		github.NightlyLinkArtifactURL("ddev", "ddev", 12345))
 
-	rel := resolveReleaseTag("ddev", "ddev", "v1.24.5", linux)
-	require.Equal(t, "https://github.com/ddev/ddev/releases/download/v1.24.5/ddev_linux-amd64.v1.24.5.tar.gz", rel.url)
-	require.Equal(t, "https://github.com/ddev/ddev/releases/download/v1.24.5/checksums.txt", rel.shaSumURL)
+	rel := resolveReleaseTag("ddev", "ddev", "v1.25.3", linux)
+	require.Equal(t, "https://github.com/ddev/ddev/releases/download/v1.25.3/ddev_linux-amd64.v1.25.3.tar.gz", rel.url)
+	require.Equal(t, "https://github.com/ddev/ddev/releases/download/v1.25.3/checksums.txt", rel.shaSumURL)
 	require.False(t, rel.isZip)
 
 	// Windows release uses a zip archive.
 	win := buildTarget{goos: "windows", osName: "windows", arch: "amd64", exeExt: ".exe"}
-	relWin := resolveReleaseTag("ddev", "ddev", "v1.24.5", win)
-	require.Equal(t, "https://github.com/ddev/ddev/releases/download/v1.24.5/ddev_windows-amd64.v1.24.5.zip", relWin.url)
+	relWin := resolveReleaseTag("ddev", "ddev", "v1.25.3", win)
+	require.Equal(t, "https://github.com/ddev/ddev/releases/download/v1.25.3/ddev_windows-amd64.v1.25.3.zip", relWin.url)
 	require.True(t, relWin.isZip)
 }
 

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -9,6 +9,7 @@ search:
 There are several ways to use DDEV’s latest-committed HEAD version:
 
 * **Download** the latest `main` branch artifacts from [nightly.link](https://nightly.link/ddev/ddev/workflows/main-build/main). Each of these is built by the CI system, signed, and notarized. Get the one you need and place it in your `$PATH`.
+* **[`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev)**: If you already have DDEV installed, run `ddev utility download-ddev --head` to download the latest `main` build into the current directory. It prints how to use the new binary in your current shell or install it permanently.
 * **Homebrew install HEAD**: On macOS and Linux, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD --fetch-HEAD` to get the latest DDEV commit, even if it’s unreleased.
 * **Install via script**: You can download and run the [install_ddev_head.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_head.sh)  script, or run it automatically:
 
@@ -24,6 +25,21 @@ There are several ways to use DDEV’s latest-committed HEAD version:
 Each [PR build](https://github.com/ddev/ddev/actions/workflows/pr-build.yml) creates GitHub artifacts you can use for testing, so you can download the one you need from the PR page, install it locally, and test using that build.
 
 !!!tip "You can also [downgrade to an older version of DDEV](../users/usage/faq.md#how-can-i-install-a-specific-version-of-ddev) (perform a rollback)."
+
+### Downloading a build with `ddev utility download-ddev`
+
+If you already have DDEV installed, [`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev) downloads the `ddev` and `ddev-hostname` binaries for a build and prints how to use them in your current shell or install them permanently:
+
+```bash
+# Download this PR's build for your current OS and architecture into the current directory
+ddev utility download-ddev --pr <PR_NUMBER>
+# See the help for more options:
+ddev utility download-ddev --help
+```
+
+It can also fetch builds by branch, commit, release tag, or `main` HEAD, and cross-download other platforms.
+
+### Downloading a build manually
 
 Normally, you can put any executable in your path, and it takes precedence, so you don't need to remove or disable an already installed DDEV instance, which we will use here. This example uses `~/bin`. Since not every OS has `$HOME/bin` in `$PATH`, you can create the folder and add it to your path by updating `~/.bashrc`, `~/.zshrc`, or another relevant shell configuration file with these commands:
 

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -9,7 +9,7 @@ search:
 There are several ways to use DDEV’s latest-committed HEAD version:
 
 * **Download** the latest `main` branch artifacts from [nightly.link](https://nightly.link/ddev/ddev/workflows/main-build/main). Each of these is built by the CI system, signed, and notarized. Get the one you need and place it in your `$PATH`.
-* **[`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev)**: If you already have DDEV installed, run `ddev utility download-ddev --head` to download the latest `main` build into the current directory. It prints how to use the new binary in your current shell or install it permanently.
+* **[`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev)**: If you already have DDEV installed, run `ddev utility download-ddev --head` to download the latest `main` build into `~/tmp/ddev-download-ddev`. It prints how to use the new binary in your current shell or install it permanently.
 * **Homebrew install HEAD**: On macOS and Linux, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD --fetch-HEAD` to get the latest DDEV commit, even if it’s unreleased.
 * **Install via script**: You can download and run the [install_ddev_head.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_head.sh)  script, or run it automatically:
 

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -9,7 +9,7 @@ search:
 There are several ways to use DDEV’s latest-committed HEAD version:
 
 * **Download** the latest `main` branch artifacts from [nightly.link](https://nightly.link/ddev/ddev/workflows/main-build/main). Each of these is built by the CI system, signed, and notarized. Get the one you need and place it in your `$PATH`.
-* **[`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev)**: If you already have DDEV installed, run `ddev utility download-ddev --head` to download the latest `main` build into `~/tmp/ddev-download-ddev`. It prints how to use the new binary in your current shell or install it permanently.
+* **[`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev)**: If you already have DDEV installed, run `ddev utility download-ddev --head` to download the latest `main` build into `~/tmp/ddev-download-ddev/main`. It prints how to use the new binary in your current shell.
 * **Homebrew install HEAD**: On macOS and Linux, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD --fetch-HEAD` to get the latest DDEV commit, even if it’s unreleased.
 * **Install via script**: You can download and run the [install_ddev_head.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_head.sh)  script, or run it automatically:
 
@@ -28,10 +28,10 @@ Each [PR build](https://github.com/ddev/ddev/actions/workflows/pr-build.yml) cre
 
 ### Downloading a build with `ddev utility download-ddev`
 
-If you already have DDEV installed, [`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev) downloads the `ddev` and `ddev-hostname` binaries for a build and prints how to use them in your current shell or install them permanently:
+If you already have DDEV installed, [`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev) downloads the `ddev` and `ddev-hostname` binaries for a build and prints how to use them in your current shell:
 
 ```bash
-# Download this PR's build for your current OS and architecture into the current directory
+# Download this PR's build for your current OS and architecture into ~/tmp/ddev-download-ddev/pr-<PR_NUMBER>
 ddev utility download-ddev --pr <PR_NUMBER>
 # See the help for more options:
 ddev utility download-ddev --help

--- a/docs/content/developers/building-contributing.md
+++ b/docs/content/developers/building-contributing.md
@@ -8,8 +8,8 @@ search:
 
 There are several ways to use DDEV’s latest-committed HEAD version:
 
+* **[`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev)**: Run `ddev utility download-ddev --head` to download the latest `main` build into `~/tmp/ddev-download-ddev/main`. It prints how to use the new binary in your current shell.
 * **Download** the latest `main` branch artifacts from [nightly.link](https://nightly.link/ddev/ddev/workflows/main-build/main). Each of these is built by the CI system, signed, and notarized. Get the one you need and place it in your `$PATH`.
-* **[`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev)**: If you already have DDEV installed, run `ddev utility download-ddev --head` to download the latest `main` build into `~/tmp/ddev-download-ddev/main`. It prints how to use the new binary in your current shell.
 * **Homebrew install HEAD**: On macOS and Linux, run `brew unlink ddev && brew install ddev/ddev/ddev --HEAD --fetch-HEAD` to get the latest DDEV commit, even if it’s unreleased.
 * **Install via script**: You can download and run the [install_ddev_head.sh](https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev_head.sh)  script, or run it automatically:
 
@@ -22,13 +22,13 @@ There are several ways to use DDEV’s latest-committed HEAD version:
 
 ## Testing a PR
 
-Each [PR build](https://github.com/ddev/ddev/actions/workflows/pr-build.yml) creates GitHub artifacts you can use for testing, so you can download the one you need from the PR page, install it locally, and test using that build.
+Each [PR build](https://github.com/ddev/ddev/actions/workflows/pr-build.yml) creates GitHub artifacts you can use for testing. The easiest way is [`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev), described first below; you can also download the artifact you need from the PR page manually and install it yourself.
 
 !!!tip "You can also [downgrade to an older version of DDEV](../users/usage/faq.md#how-can-i-install-a-specific-version-of-ddev) (perform a rollback)."
 
 ### Downloading a build with `ddev utility download-ddev`
 
-If you already have DDEV installed, [`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev) downloads the `ddev` and `ddev-hostname` binaries for a build and prints how to use them in your current shell:
+[`ddev utility download-ddev`](../users/usage/commands.md#utility-download-ddev) downloads the `ddev` and `ddev-hostname` binaries for a build and prints how to use them in your current shell:
 
 ```bash
 # Download this PR's build for your current OS and architecture into ~/tmp/ddev-download-ddev/pr-<PR_NUMBER>

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1691,7 +1691,7 @@ ddev utility dockercheck
 
 ### `utility download-ddev`
 
-Download the `ddev` and `ddev-hostname` binaries built by CI or a release, for testing a specific build without replacing your installed DDEV. It only downloads the binaries into a directory (the current directory by default) and prints how to use them in the current shell or install them permanently; it does not modify your installed DDEV.
+Download the `ddev` and `ddev-hostname` binaries built by CI or a release, for testing a specific build without replacing your installed DDEV. It only downloads the binaries into a directory (`~/tmp/ddev-download-ddev` by default, so a download can't accidentally end up on `$PATH` or as a stray file in a git checkout) and prints how to use them in the current shell or install them permanently; it does not modify your installed DDEV.
 
 Flags:
 
@@ -1701,7 +1701,7 @@ Flags:
 * `--tag <tag>`: Download a release tag, for example `v1.24.5`
 * `--stable`: Download the latest stable release (default `false`)
 * `--head`: Download the latest main build (default `false`)
-* `--output <dir>`, `-o <dir>`: Output directory (default: current directory)
+* `--output <dir>`, `-o <dir>`: Output directory (default: `~/tmp/ddev-download-ddev`)
 * `--os <os>`: OS override: `macos`, `linux`, or `windows` (default: current OS)
 * `--arch <arch>`: Architecture override: `amd64` or `arm64` (default: current architecture)
 * `--owner <owner>`: GitHub owner/org (default `ddev`; for PR builds this is the base repository, not a fork)
@@ -1714,7 +1714,7 @@ Note: Exactly one source flag (`--pr`, `--branch`, `--commit`, `--tag`, `--stabl
 Examples:
 
 ```shell
-# Download this PR's build for your current OS and architecture into the current directory
+# Download this PR's build for your current OS and architecture into ~/tmp/ddev-download-ddev
 ddev utility download-ddev --pr 1234
 
 # Download the latest main build into ~/tmp/head
@@ -1727,7 +1727,7 @@ ddev utility download-ddev --tag v1.24.5
 ddev utility download-ddev --stable
 
 # Cross-download a macOS arm64 build of a branch
-ddev utility download-ddev --branch 20250101_feature --os macos --arch arm64 --output ./out
+ddev utility download-ddev --branch 20250101_feature --os macos --arch arm64 --output ~/tmp/ddev-macos-arm64
 ```
 
 ### `utility download-images`

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1689,6 +1689,47 @@ Example:
 ddev utility dockercheck
 ```
 
+### `utility download-ddev`
+
+Download the `ddev` and `ddev-hostname` binaries built by CI or a release, for testing a specific build without replacing your installed DDEV. It only downloads the binaries into a directory (the current directory by default) and prints how to use them in the current shell or install them permanently; it does not modify your installed DDEV.
+
+Flags:
+
+* `--pr <number>`: Download the build from a pull request number
+* `--branch <name>`: Download the build from a branch name
+* `--commit <sha>`: Download the build from a commit SHA
+* `--tag <tag>`: Download a release tag, for example `v1.24.5`
+* `--stable`: Download the latest stable release (default `false`)
+* `--head`: Download the latest main build (default `false`)
+* `--output <dir>`, `-o <dir>`: Output directory (default: current directory)
+* `--os <os>`: OS override: `macos`, `linux`, or `windows` (default: current OS)
+* `--arch <arch>`: Architecture override: `amd64` or `arm64` (default: current architecture)
+* `--owner <owner>`: GitHub owner/org (default `ddev`; for PR builds this is the base repository, not a fork)
+* `--repo <repo>`: GitHub repository (default `ddev`)
+
+Note: Exactly one source flag (`--pr`, `--branch`, `--commit`, `--tag`, `--stable`, or `--head`) is required, and they are mutually exclusive.
+
+`--tag`, `--stable`, and `--head` download signed binaries and need no GitHub token. `--pr`, `--branch`, and `--commit` download unsigned GitHub Actions artifacts and use a [GitHub token](#add-on) if one is set, which avoids the low anonymous rate limit; without a token, `--pr` still works by falling back to the build links posted on the pull request.
+
+Examples:
+
+```shell
+# Download this PR's build for your current OS and architecture into the current directory
+ddev utility download-ddev --pr 1234
+
+# Download the latest main build into ~/tmp/head
+ddev utility download-ddev --head --output ~/tmp/head
+
+# Download a specific released version
+ddev utility download-ddev --tag v1.24.5
+
+# Download the latest stable release
+ddev utility download-ddev --stable
+
+# Cross-download a macOS arm64 build of a branch
+ddev utility download-ddev --branch 20250101_feature --os macos --arch arm64 --output ./out
+```
+
 ### `utility download-images`
 
 Download the basic Docker images required by DDEV. This can be useful on a new machine to prevent `ddev start` or other commands having to download the various images.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1754,6 +1754,47 @@ Example:
 ddev utility dockercheck
 ```
 
+### `utility download-ddev`
+
+Download the `ddev` and `ddev-hostname` binaries built by CI or a release, for testing a specific build without replacing your installed DDEV. It only downloads the binaries into a directory (the current directory by default) and prints how to use them in the current shell or install them permanently; it does not modify your installed DDEV.
+
+Flags:
+
+* `--pr <number>`: Download the build from a pull request number
+* `--branch <name>`: Download the build from a branch name
+* `--commit <sha>`: Download the build from a commit SHA
+* `--tag <tag>`: Download a release tag, for example `v1.24.5`
+* `--stable`: Download the latest stable release (default `false`)
+* `--head`: Download the latest main build (default `false`)
+* `--output <dir>`, `-o <dir>`: Output directory (default: current directory)
+* `--os <os>`: OS override: `macos`, `linux`, or `windows` (default: current OS)
+* `--arch <arch>`: Architecture override: `amd64` or `arm64` (default: current architecture)
+* `--owner <owner>`: GitHub owner/org (default `ddev`; for PR builds this is the base repository, not a fork)
+* `--repo <repo>`: GitHub repository (default `ddev`)
+
+Note: Exactly one source flag (`--pr`, `--branch`, `--commit`, `--tag`, `--stable`, or `--head`) is required, and they are mutually exclusive.
+
+`--tag`, `--stable`, and `--head` download signed binaries and need no GitHub token. `--pr`, `--branch`, and `--commit` download unsigned GitHub Actions artifacts and use a [GitHub token](#add-on) if one is set, which avoids the low anonymous rate limit; without a token, `--pr` still works by falling back to the build links posted on the pull request.
+
+Examples:
+
+```shell
+# Download this PR's build for your current OS and architecture into the current directory
+ddev utility download-ddev --pr 1234
+
+# Download the latest main build into ~/tmp/head
+ddev utility download-ddev --head --output ~/tmp/head
+
+# Download a specific released version
+ddev utility download-ddev --tag v1.24.5
+
+# Download the latest stable release
+ddev utility download-ddev --stable
+
+# Cross-download a macOS arm64 build of a branch
+ddev utility download-ddev --branch 20250101_feature --os macos --arch arm64 --output ./out
+```
+
 ### `utility download-images`
 
 Download the basic Docker images required by DDEV. This can be useful on a new machine to prevent `ddev start` or other commands having to download the various images.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1756,17 +1756,17 @@ ddev utility dockercheck
 
 ### `utility download-ddev`
 
-Download the `ddev` and `ddev-hostname` binaries built by CI or a release, for testing a specific build without replacing your installed DDEV. It only downloads the binaries into a directory (`~/tmp/ddev-download-ddev` by default, so a download can't accidentally end up on `$PATH` or as a stray file in a git checkout) and prints how to use them in the current shell or install them permanently; it does not modify your installed DDEV.
+Download the `ddev` and `ddev-hostname` binaries built by CI or a release, for testing a specific build without replacing your installed DDEV. It only downloads the binaries into a directory (`~/tmp/ddev-download-ddev/<version>` by default, so a download can't accidentally end up on `$PATH` or as a stray file in a git checkout, and each build stays separate from the ones downloaded before it) and prints how to use them in the current shell; it does not modify your installed DDEV.
 
 Flags:
 
 * `--pr <number>`: Download the build from a pull request number
 * `--branch <name>`: Download the build from a branch name
 * `--commit <sha>`: Download the build from a commit SHA
-* `--tag <tag>`: Download a release tag, for example `v1.24.5`
+* `--tag <tag>`: Download a release tag, for example `v1.25.3`
 * `--stable`: Download the latest stable release (default `false`)
 * `--head`: Download the latest main build (default `false`)
-* `--output <dir>`, `-o <dir>`: Output directory (default: `~/tmp/ddev-download-ddev`)
+* `--output <dir>`, `-o <dir>`: Output directory, used as given (default: `~/tmp/ddev-download-ddev/<version>`, where `<version>` is the build, for example `pr-8611`, `v1.25.3`, or `main`)
 * `--os <os>`: OS override: `macos`, `linux`, or `windows` (default: current OS)
 * `--arch <arch>`: Architecture override: `amd64` or `arm64` (default: current architecture)
 * `--owner <owner>`: GitHub owner/org (default `ddev`; for PR builds this is the base repository, not a fork)
@@ -1779,14 +1779,14 @@ Note: Exactly one source flag (`--pr`, `--branch`, `--commit`, `--tag`, `--stabl
 Examples:
 
 ```shell
-# Download this PR's build for your current OS and architecture into ~/tmp/ddev-download-ddev
-ddev utility download-ddev --pr 1234
+# Download this PR's build for your current OS and architecture into ~/tmp/ddev-download-ddev/pr-8611
+ddev utility download-ddev --pr 8611
 
 # Download the latest main build into ~/tmp/head
 ddev utility download-ddev --head --output ~/tmp/head
 
 # Download a specific released version
-ddev utility download-ddev --tag v1.24.5
+ddev utility download-ddev --tag v1.25.3
 
 # Download the latest stable release
 ddev utility download-ddev --stable

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1756,7 +1756,7 @@ ddev utility dockercheck
 
 ### `utility download-ddev`
 
-Download the `ddev` and `ddev-hostname` binaries built by CI or a release, for testing a specific build without replacing your installed DDEV. It only downloads the binaries into a directory (the current directory by default) and prints how to use them in the current shell or install them permanently; it does not modify your installed DDEV.
+Download the `ddev` and `ddev-hostname` binaries built by CI or a release, for testing a specific build without replacing your installed DDEV. It only downloads the binaries into a directory (`~/tmp/ddev-download-ddev` by default, so a download can't accidentally end up on `$PATH` or as a stray file in a git checkout) and prints how to use them in the current shell or install them permanently; it does not modify your installed DDEV.
 
 Flags:
 
@@ -1766,7 +1766,7 @@ Flags:
 * `--tag <tag>`: Download a release tag, for example `v1.24.5`
 * `--stable`: Download the latest stable release (default `false`)
 * `--head`: Download the latest main build (default `false`)
-* `--output <dir>`, `-o <dir>`: Output directory (default: current directory)
+* `--output <dir>`, `-o <dir>`: Output directory (default: `~/tmp/ddev-download-ddev`)
 * `--os <os>`: OS override: `macos`, `linux`, or `windows` (default: current OS)
 * `--arch <arch>`: Architecture override: `amd64` or `arm64` (default: current architecture)
 * `--owner <owner>`: GitHub owner/org (default `ddev`; for PR builds this is the base repository, not a fork)
@@ -1779,7 +1779,7 @@ Note: Exactly one source flag (`--pr`, `--branch`, `--commit`, `--tag`, `--stabl
 Examples:
 
 ```shell
-# Download this PR's build for your current OS and architecture into the current directory
+# Download this PR's build for your current OS and architecture into ~/tmp/ddev-download-ddev
 ddev utility download-ddev --pr 1234
 
 # Download the latest main build into ~/tmp/head
@@ -1792,7 +1792,7 @@ ddev utility download-ddev --tag v1.24.5
 ddev utility download-ddev --stable
 
 # Cross-download a macOS arm64 build of a branch
-ddev utility download-ddev --branch 20250101_feature --os macos --arch arm64 --output ./out
+ddev utility download-ddev --branch 20250101_feature --os macos --arch arm64 --output ~/tmp/ddev-macos-arm64
 ```
 
 ### `utility download-images`

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -221,6 +221,10 @@ brew install ddev/ddev/ddev
 
 Your projects are not affected by these changes.
 
+#### Any platform
+
+On any platform you can download the binaries for a specific release with [`ddev utility download-ddev`](../usage/commands.md#utility-download-ddev), for example `ddev utility download-ddev --tag v1.25.3`. It prints the exact commands to move `ddev` and `ddev-hostname` into your `$PATH`.
+
 ### Why do I have an old DDEV?
 
 You may have installed DDEV several times using different techniques. Use `which -a ddev` to find all installed binaries. For example, you could install a DDEV in WSL2 with Homebrew, forget about it for a while, install it manually, and then install it again with `apt`:

--- a/docs/content/users/usage/faq.md
+++ b/docs/content/users/usage/faq.md
@@ -223,7 +223,7 @@ Your projects are not affected by these changes.
 
 #### Any platform
 
-On any platform you can download the binaries for a specific release with [`ddev utility download-ddev`](../usage/commands.md#utility-download-ddev), for example `ddev utility download-ddev --tag v1.25.3`. It prints the exact commands to move `ddev` and `ddev-hostname` into your `$PATH`.
+On any platform you can download the binaries for a specific release with [`ddev utility download-ddev`](../usage/commands.md#utility-download-ddev), for example `ddev utility download-ddev --tag v1.25.3`, which writes `ddev` and `ddev-hostname` to `~/tmp/ddev-download-ddev/v1.25.3` so you can try that version before moving them into your `$PATH`.
 
 ### Why do I have an old DDEV?
 

--- a/pkg/github/artifacts.go
+++ b/pkg/github/artifacts.go
@@ -1,0 +1,189 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
+
+	"github.com/google/go-github/v88/github"
+)
+
+// WorkflowRunFilter selects a GitHub Actions workflow run by branch and/or head SHA.
+type WorkflowRunFilter struct {
+	Branch  string
+	HeadSHA string
+	Event   string
+}
+
+// GetLatestReleaseTag returns the tag name of the latest release for owner/repo.
+// It uses GitHub's "latest release" endpoint, which excludes drafts and prereleases.
+func GetLatestReleaseTag(owner, repo string) (string, error) {
+	release, err := withAuthFallback(func(ctx context.Context, client *Client) (*github.RepositoryRelease, *github.Response, error) {
+		return client.Repositories.GetLatestRelease(ctx, owner, repo)
+	})
+	if err != nil {
+		return "", fmt.Errorf("unable to get latest release for %s/%s: %w", owner, repo, err)
+	}
+	return release.GetTagName(), nil
+}
+
+// GetPullRequestHeadSHA returns the head commit SHA of a pull request.
+func GetPullRequestHeadSHA(owner, repo string, number int) (string, error) {
+	pr, err := withAuthFallback(func(ctx context.Context, client *Client) (*github.PullRequest, *github.Response, error) {
+		return client.PullRequests.Get(ctx, owner, repo, number)
+	})
+	if err != nil {
+		return "", fmt.Errorf("unable to look up PR #%d in %s/%s: %w", number, owner, repo, err)
+	}
+	sha := pr.GetHead().GetSHA()
+	if sha == "" {
+		return "", fmt.Errorf("could not determine head SHA for PR #%d", number)
+	}
+	return sha, nil
+}
+
+// ResolveWorkflowArtifactURL finds the newest successful run of workflowFile
+// matching filter and returns a URL from which the artifact named artifactName
+// can be downloaded as a .zip.
+//
+// Listing runs and artifacts works anonymously for public repositories (subject
+// to GitHub's unauthenticated rate limit). The artifact zip itself cannot be
+// downloaded anonymously from the GitHub API, so when a token is available this
+// returns the authenticated Actions download URL; otherwise it returns a
+// nightly.link URL (a third-party redirector that works only for public repos).
+func ResolveWorkflowArtifactURL(owner, repo, workflowFile, artifactName string, filter WorkflowRunFilter) (string, error) {
+	opts := &github.ListWorkflowRunsOptions{
+		Branch:      filter.Branch,
+		HeadSHA:     filter.HeadSHA,
+		Event:       filter.Event,
+		ListOptions: github.ListOptions{PerPage: 30},
+	}
+	runs, err := withAuthFallback(func(ctx context.Context, client *Client) (*github.WorkflowRuns, *github.Response, error) {
+		return client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflowFile, opts)
+	})
+	if err != nil {
+		return "", err
+	}
+	run := newestSuccessfulRun(runs.WorkflowRuns)
+	if run == nil {
+		return "", fmt.Errorf("no successful %s run found", workflowFile)
+	}
+	runID := run.GetID()
+
+	artifacts, err := withAuthFallback(func(ctx context.Context, client *Client) (*github.ArtifactList, *github.Response, error) {
+		return client.Actions.ListWorkflowRunArtifacts(ctx, owner, repo, runID, &github.ListOptions{PerPage: 100})
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var found *github.Artifact
+	for _, a := range artifacts.Artifacts {
+		if a.GetName() == artifactName {
+			found = a
+			break
+		}
+	}
+	if found == nil {
+		return "", fmt.Errorf("workflow run %d has no artifact named %q", runID, artifactName)
+	}
+	if found.GetExpired() {
+		return "", fmt.Errorf("artifact %q (run %d) has expired; GitHub keeps run artifacts for ~90 days, so choose a newer run", artifactName, runID)
+	}
+	artifactID := found.GetID()
+
+	// With a token, use the authenticated Actions API, which works for private
+	// repos too and returns a short-lived (~1 minute) presigned URL.
+	if HasGitHubToken() {
+		u, downloadErr := withAuthFallback(func(ctx context.Context, client *Client) (*url.URL, *github.Response, error) {
+			return client.Actions.DownloadArtifact(ctx, owner, repo, artifactID, 5)
+		})
+		if downloadErr == nil && u != nil {
+			return u.String(), nil
+		}
+	}
+
+	// No token (or the API download failed): fall back to nightly.link.
+	return NightlyLinkArtifactURL(owner, repo, artifactID), nil
+}
+
+// NightlyLinkArtifactURL returns the nightly.link URL for a specific artifact ID.
+// nightly.link is a third-party service that serves GitHub Actions artifacts for
+// public repositories without requiring authentication.
+func NightlyLinkArtifactURL(owner, repo string, artifactID int64) string {
+	return fmt.Sprintf("https://nightly.link/%s/%s/actions/artifacts/%d.zip", owner, repo, artifactID)
+}
+
+// PullRequestArtifactURL returns a nightly.link download URL for artifactName by
+// reading the pull request's HTML page and extracting the link posted there by
+// the pr-artifacts-comment workflow. It uses no GitHub API token or API-rate
+// budget, so it is a useful fallback when the API is rate-limited, but it works
+// only for public repositories and only once that bot comment exists (that is,
+// after the PR's build has finished).
+func PullRequestArtifactURL(owner, repo string, number int, artifactName string) (string, error) {
+	pageURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, number)
+	req, err := http.NewRequest(http.MethodGet, pageURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "ddev")
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("unable to fetch %s: %w", pageURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return "", fmt.Errorf("no pull request #%d in %s/%s", number, owner, repo)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %q fetching %s", resp.Status, pageURL)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 20<<20))
+	if err != nil {
+		return "", err
+	}
+	u := parseArtifactURLFromHTML(string(body), artifactName)
+	if u == "" {
+		return "", fmt.Errorf("no %s.zip download link found on %s (the PR build may not have finished)", artifactName, pageURL)
+	}
+	return u, nil
+}
+
+// parseArtifactURLFromHTML extracts the nightly.link download URL for
+// artifactName from a rendered pull request page. The pr-artifacts-comment
+// workflow posts each artifact as a Markdown link, which GitHub serves as
+// <a href="https://nightly.link/.../artifacts/<id>.zip">artifactName.zip</a>.
+// The last match wins, since the bot edits a single comment in place.
+func parseArtifactURLFromHTML(html, artifactName string) string {
+	name := regexp.QuoteMeta(artifactName + ".zip")
+	for _, pattern := range []string{
+		`href="(https://nightly\.link/[^"]+/actions/artifacts/\d+\.zip)"[^>]*>\s*` + name,
+		`\[` + name + `\]\((https://nightly\.link/[^)]+/actions/artifacts/\d+\.zip)\)`,
+	} {
+		matches := regexp.MustCompile(pattern).FindAllStringSubmatch(html, -1)
+		if len(matches) > 0 {
+			return matches[len(matches)-1][1]
+		}
+	}
+	return ""
+}
+
+// newestSuccessfulRun returns the most recently created run whose conclusion is
+// "success", or nil if there is none.
+func newestSuccessfulRun(runs []*github.WorkflowRun) *github.WorkflowRun {
+	var best *github.WorkflowRun
+	for _, r := range runs {
+		if r.GetConclusion() != "success" {
+			continue
+		}
+		if best == nil || r.GetCreatedAt().After(best.GetCreatedAt().Time) {
+			best = r
+		}
+	}
+	return best
+}

--- a/pkg/github/artifacts_internal_test.go
+++ b/pkg/github/artifacts_internal_test.go
@@ -1,0 +1,36 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseArtifactURLFromHTML verifies that the nightly.link download URL is
+// extracted from the pr-artifacts-comment bot's rendered link (and its raw
+// Markdown form), and that the last match wins.
+func TestParseArtifactURLFromHTML(t *testing.T) {
+	const linuxURL = "https://nightly.link/ddev/ddev/actions/artifacts/123456789.zip"
+	const macosURL = "https://nightly.link/ddev/ddev/actions/artifacts/999.zip"
+
+	// Rendered anchor form (what GitHub serves for the bot's Markdown link).
+	anchorHTML := `<ul>
+<li><a href="` + linuxURL + `" rel="nofollow">ddev-linux-amd64.zip</a></li>
+<li><a href="` + macosURL + `" rel="nofollow">ddev-macos-arm64.zip</a></li>
+</ul>`
+	require.Equal(t, linuxURL, parseArtifactURLFromHTML(anchorHTML, "ddev-linux-amd64"))
+	require.Equal(t, macosURL, parseArtifactURLFromHTML(anchorHTML, "ddev-macos-arm64"))
+
+	// Raw Markdown form (as embedded in the page's hydration payload).
+	mdHTML := `[ddev-windows-amd64.zip](https://nightly.link/ddev/ddev/actions/artifacts/555.zip)`
+	require.Equal(t, "https://nightly.link/ddev/ddev/actions/artifacts/555.zip",
+		parseArtifactURLFromHTML(mdHTML, "ddev-windows-amd64"))
+
+	// A missing artifact yields an empty string.
+	require.Empty(t, parseArtifactURLFromHTML(anchorHTML, "ddev-windows-arm64"))
+
+	// The bot edits one comment in place, so the last match wins.
+	dup := anchorHTML + `<a href="https://nightly.link/ddev/ddev/actions/artifacts/222.zip" rel="nofollow">ddev-linux-amd64.zip</a>`
+	require.Equal(t, "https://nightly.link/ddev/ddev/actions/artifacts/222.zip",
+		parseArtifactURLFromHTML(dup, "ddev-linux-amd64"))
+}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -56,42 +56,59 @@ func GetGitHubClient(withAuth bool) (context.Context, *Client, error) {
 	return githubContext, githubClientNoAuth, githubClientNoAuthErr
 }
 
-// GetGitHubRelease gets the tarball URL and version for a GitHub repository release
-func GetGitHubRelease(owner, repo, requestedVersion string) (tarballURL, downloadedRelease string, err error) {
+// withAuthFallback runs fn with the authenticated GitHub client and, if that
+// call fails because the configured token is invalid, retries once with the
+// no-auth client. Errors are annotated with GitHub rate-limit details, plus the
+// invalid-token hint when a bad token triggered the fallback.
+func withAuthFallback[T any](fn func(ctx context.Context, client *Client) (T, *github.Response, error)) (T, error) {
+	var zero T
 	ctx, client, clientErr := GetGitHubClient(true)
 	if clientErr != nil {
-		return "", "", clientErr
+		return zero, clientErr
 	}
-
-	releases, resp, err := client.Repositories.ListReleases(ctx, owner, repo, &ListOptions{PerPage: 100})
+	result, resp, err := fn(ctx, client)
 	var tokenErr error
 	if err != nil {
 		if tokenErr = HasInvalidGitHubToken(resp); tokenErr != nil {
-			ctx, client, clientErr = GetGitHubClient(false)
-			if clientErr != nil {
-				return "", "", clientErr
+			if ctx, client, clientErr = GetGitHubClient(false); clientErr != nil {
+				return zero, clientErr
 			}
-			releasesNoAuth, respNoAuth, errNoAuth := client.Repositories.ListReleases(ctx, owner, repo, &ListOptions{PerPage: 100})
-			if errNoAuth == nil {
-				releases = releasesNoAuth
-				resp = respNoAuth
-				err = errNoAuth
-			}
+			result, resp, err = fn(ctx, client)
 		}
 	}
 	if err != nil {
-		errorDetail := ""
-		if resp != nil {
-			rate := resp.Rate
-			if rate.Limit != 0 {
-				resetIn := time.Until(rate.Reset.Time).Round(time.Second)
-				errorDetail += fmt.Sprintf("\nGitHub API Rate Limit: %d/%d remaining (resets in %s)", rate.Remaining, rate.Limit, resetIn)
-			}
-			if tokenErr != nil {
-				errorDetail += "\nError: " + tokenErr.Error()
-			}
+		detail := rateLimitDetail(resp)
+		if tokenErr != nil {
+			detail += "\nError: " + tokenErr.Error()
 		}
-		return "", "", fmt.Errorf("unable to get releases for %v: %w%s", repo, err, errorDetail)
+		return zero, fmt.Errorf("%w%s", err, detail)
+	}
+	return result, nil
+}
+
+// rateLimitDetail returns a human-readable GitHub rate-limit suffix for error
+// messages, or an empty string when no rate information is available. When no
+// token is set it appends a hint, since authenticated requests get a much
+// higher rate limit than anonymous ones.
+func rateLimitDetail(resp *github.Response) string {
+	if resp == nil || resp.Rate.Limit == 0 {
+		return ""
+	}
+	resetIn := time.Until(resp.Rate.Reset.Time).Round(time.Second)
+	detail := fmt.Sprintf("\nGitHub API Rate Limit: %d/%d remaining (resets in %s)", resp.Rate.Remaining, resp.Rate.Limit, resetIn)
+	if !HasGitHubToken() {
+		detail += "\nSet DDEV_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN to raise the rate limit."
+	}
+	return detail
+}
+
+// GetGitHubRelease gets the tarball URL and version for a GitHub repository release
+func GetGitHubRelease(owner, repo, requestedVersion string) (tarballURL, downloadedRelease string, err error) {
+	releases, err := withAuthFallback(func(ctx context.Context, client *Client) ([]*github.RepositoryRelease, *github.Response, error) {
+		return client.Repositories.ListReleases(ctx, owner, repo, &ListOptions{PerPage: 100})
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("unable to get releases for %v: %w", repo, err)
 	}
 	if len(releases) == 0 {
 		return "", "", fmt.Errorf("no releases found for %v", repo)


### PR DESCRIPTION
## The Issue

Testing a specific DDEV build on another machine (e.g. a testbot) is awkward: you have to find the right artifact from the PR comment or nightly.link, download it, unpack it, and put it on your `$PATH` by hand. There is no built-in way to fetch the `ddev`/`ddev-hostname` binaries for a given PR, branch, commit, release tag, latest stable, or `main` HEAD.

## How This PR Solves The Issue

Adds `ddev utility download-ddev`, which downloads the `ddev` and `ddev-hostname` binaries for exactly one source (`--pr`, `--branch`, `--commit`, `--tag`, `--stable`, or `--head`) into a directory and prints how to use them in the current shell or install them permanently. `--os`/`--arch` allow cross-downloading another platform's build.

- `--tag`, `--stable`, `--head` fetch signed builds and need no GitHub token.
- `--pr`, `--branch`, `--commit` fetch CI artifacts and use a GitHub token when set to avoid the anonymous rate limit; `--pr` also falls back to the build links in the PR comment, so it works with no token.

It only downloads binaries; it does not touch your installed DDEV. The `pr-artifacts-comment` bot now also mentions the command.

## Manual Testing Instructions

- https://ddev--8611.org.readthedocs.build/en/8611/users/usage/commands/#utility-download-ddev
- https://ddev--8611.org.readthedocs.build/en/8611/developers/building-contributing/#downloading-a-build-with-ddev-utility-download-ddev
- https://ddev--8611.org.readthedocs.build/en/8611/users/usage/faq/#any-platform

```bash
ddev utility download-ddev --pr 8610
export PATH="$HOME/tmp/ddev-download-ddev/pr-8610:$PATH" 
hash -r

# confirm commit sha from https://github.com/ddev/ddev/pull/8610/commits
ddev --version
```

```bash
ddev utility download-ddev --branch main
export PATH="$HOME/tmp/ddev-download-ddev/main:$PATH" 
hash -r

# confirm commit sha from https://github.com/ddev/ddev/commits/main/
ddev --version
```

```bash
# this is a commit from https://github.com/ddev/ddev/commits/main/
ddev utility download-ddev --commit 4b43e2768cb4a145fcd24bfbdb3cd69e136d8aa0
export PATH="$HOME/tmp/ddev-download-ddev/commit-4b43e27:$PATH" 
hash -r

# confirm commit sha from https://github.com/ddev/ddev/commits/main/
ddev --version
```

```bash
# this is a commit without an artifact from https://github.com/ddev/ddev/commits/main/
ddev utility download-ddev --commit f8357f865ce3da8fdc9b7dd79212d40a3ea48f25

# confirm "commit f8357f8: no successful pr-build.yml run found"
```

```bash
ddev utility download-ddev --tag v1.24.6
export PATH="$HOME/tmp/ddev-download-ddev/v1.24.6:$PATH"
hash -r

# confirm v1.24.6
ddev --version
```

```bash
ddev utility download-ddev --stable
export PATH="$HOME/tmp/ddev-download-ddev/v1.25.3:$PATH"
hash -r

# confirm v1.25.3
ddev --version
```

```bash
ddev utility download-ddev --head
export PATH="$HOME/tmp/ddev-download-ddev/main:$PATH"
hash -r

# confirm latest build commit from https://github.com/ddev/ddev/commits/main/
ddev --version
```

```bash
# cross-download another platform's build:
ddev utility download-ddev --head --os macos --arch amd64

# This is a macos/amd64 build for another machine (linux/amd64); skipping the usage hints.

# confirm "exec format error: ./ddev"
./ddev --version
```

On macOS, for unsigned builds (`--pr`, and non-`main` `--branch`/`--commit`), the command runs the `xattr -r -d com.apple.quarantine ...` commands automatically if the binary is blocked ("cannot be opened" or "killed").

The same is done for Windows.

## Automated Testing Overview

- `pkg/github`: unit test for extracting the artifact URL from the PR-comment HTML.
- `cmd/ddev/cmd`: unit tests for OS/arch resolution, artifact/release naming, URL building, extract+copy, and the mutually-exclusive/one-required source flags.
- A live, opt-in test (`DDEV_RUN_DOWNLOAD_DDEV_TEST=true`, set in the nginx-fpm CI job) runs `--head` end to end and executes the downloaded binary.

## Release/Deployment Notes

New command only; no change to existing behavior. `pkg/github` gained a generic auth-fallback helper that `GetGitHubRelease` now reuses.