### PR TITLE
docs(quickstart): work around Drush/Guzzle 8 conflict in Drupal 12 install (#8618) [skip buildkite]

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -891,9 +891,12 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
     Install Drupal via Composer:
 
+    !!!warning "Temporary Drush workaround"
+        Drupal 12 requires `guzzlehttp/guzzle` `^8.0`, but every current Drush release still requires `^7.0`, so a plain `ddev composer require drush/drush` cannot be resolved. Guzzle 8 works with Drush at runtime, so the command below installs Drush with an inline alias that presents the installed Guzzle 8 as a 7.x version. Once [drush-ops/drush#6602](https://github.com/drush-ops/drush/pull/6602) is released, use `ddev composer require drush/drush` instead.
+
     ```bash
     ddev composer create-project drupal/recommended-project:main-dev@dev
-    ddev composer require drush/drush
+    ddev composer require "guzzlehttp/guzzle:8.0.0 as 7.99.0" drush/drush -W
     ```
 
     Run Drupal installation and launch:
@@ -918,7 +921,10 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
         ddev config --project-type=drupal12 --docroot=web
         ddev start -y
         ddev composer create-project drupal/recommended-project:main-dev@dev
-        ddev composer require drush/drush
+        # Temporary: Drupal 12 requires guzzlehttp/guzzle ^8.0 while Drush still requires
+        # ^7.0, so Drush is installed with an inline alias of the installed Guzzle 8.
+        # Use `ddev composer require drush/drush` once drush-ops/drush#6602 is released.
+        ddev composer require "guzzlehttp/guzzle:8.0.0 as 7.99.0" drush/drush -W
         ddev drush site:install --account-name=admin --account-pass=admin -y
         ddev launch
         EOF

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -26,7 +26,15 @@ teardown() {
   run ddev composer create-project drupal/recommended-project:main-dev@dev
   assert_success
 
-  run ddev composer require drush/drush
+  # Temporary: Drupal 12 requires guzzlehttp/guzzle ^8.0 while every Drush release
+  # still requires ^7.0, so `ddev composer require drush/drush` cannot resolve.
+  # Guzzle 8 works with Drush at runtime, so alias the installed Guzzle 8 as a 7.x
+  # version. Composer only accepts an exact version as an alias source, so this
+  # matches the version documented in quickstart.md — keep the two in sync, so
+  # this test fails if the documented command stops resolving. Revert to a plain
+  # `ddev composer require drush/drush` once
+  # https://github.com/drush-ops/drush/pull/6602 is released.
+  run ddev composer require "guzzlehttp/guzzle:8.0.0 as 7.99.0" drush/drush -W
   assert_success
 
   run ddev drush site:install --account-name=admin --account-pass=admin -y


### PR DESCRIPTION
## The Issue

No existing issue — filing this directly, since it's an upstream breakage that showed up in the last day.

Drupal core `main` moved to `guzzlehttp/guzzle: "^8.0"` on 2026-07-24 ([drupal.org #3612544](https://www.drupal.org/project/drupal/issues/3612544), core commit `6e1efec8a`, following Guzzle 8.0.0's release on 2026-07-20). Every current Drush version — 12.x, 13.x and 14.x-dev — still requires `^7.0`.

That makes the `ddev composer require drush/drush` step of the Drupal 12 (HEAD) quickstart unresolvable, so anyone following those instructions today gets:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - drupal/core 12.x-dev requires guzzlehttp/guzzle ^8.0 -> satisfiable by guzzlehttp/guzzle[8.0.0, 8.0.x-dev].
    - drush/drush[... 12.4.3, ..., 12.x-dev, 13.0.0-beta1, ..., 13.x-dev, 14.x-dev] require guzzlehttp/guzzle ^7.0 -> satisfiable by guzzlehttp/guzzle[7.5.x-dev, ..., 7.15.x-dev].
    - You can only install one version of a package, so only one of these can be installed: guzzlehttp/guzzle[5.3.x-dev, 6.5.x-dev, 7.5.x-dev, ..., 7.15.x-dev, 8.0.0, 8.0.x-dev].
```

The `Drupal 12 quickstart` docs test fails for the same reason. Nothing in DDEV is at fault; the conflict reproduces from a bare `composer.json` requiring `drupal/core:12.x-dev` and `drush/drush`, with no DDEV involved.

## How This PR Solves The Issue

Guzzle 8 works with Drush at runtime — the fix upstream is a one-line constraint change ([drush-ops/drush#6602](https://github.com/drush-ops/drush/pull/6602)) — so the Drupal 12 quickstart now installs Drush with a Composer inline alias presenting the installed Guzzle 8 as a 7.x version:

```bash
ddev composer require "guzzlehttp/guzzle:8.0.0 as 7.99.0" drush/drush -W
```

- `docs/content/users/quickstart.md`: updated in the Drupal 12 (HEAD) tab only, in both the interactive block and the "Prefer to run as a script?" block, with a `!!!warning` admonition explaining the conflict and pointing at drush#6602 for when to switch back to the plain command.
- `docs/tests/drupal.bats`: the Drupal 12 test uses the documented command **verbatim** rather than looking the Guzzle version up itself, so the test fails if the copy-pasteable command ever stops resolving.

The version is literal because Composer rejects a range as an alias source (`Invalid version string "^8.0" in "^8.0 as 7.99.0", the alias source must be an exact version`). `drupal/core-recommended` doesn't pin Guzzle, so this keeps resolving if Guzzle 8.0.1 appears — it would just pin the older patch until this is reverted.

Drupal 11, 10, the Drupal 11 git-based quickstart, and Drupal CMS are untouched; they all still resolve `guzzlehttp/guzzle ^7.0`.

## Manual Testing Instructions

```bash
mkdir -p my-drupal12-site && cd my-drupal12-site
ddev config --project-type=drupal12 --docroot=web
ddev start -y
ddev composer create-project drupal/recommended-project:main-dev@dev
ddev composer require drush/drush                                   # fails: Guzzle conflict
ddev composer require "guzzlehttp/guzzle:8.0.0 as 7.99.0" drush/drush -W   # succeeds
ddev drush site:install --account-name=admin --account-pass=admin -y
ddev launch
```

## Automated Testing Overview

No new tests — the existing `Drupal 12 quickstart` test in `docs/tests/drupal.bats` is what covers this, and it was failing before this change.

```
$ bats docs/tests/drupal.bats --filter "Drupal 12"
ok 1 Drupal 12 quickstart with ddev version v1.25.3-18-g540808b7b
```

That exercises the whole documented flow through `drush site:install`, `ddev launch`, and the `x-generator: Drupal 12` / `HTTP/2 200` assertions. `make markdownlint` and `make textlint` are also clean.

## Release/Deployment Notes

**This is a temporary workaround and should be reverted.** Once [drush-ops/drush#6602](https://github.com/drush-ops/drush/pull/6602) is released, both hunks go back to a plain `ddev composer require drush/drush`. Its CI is currently red on the `test-*-functional` jobs; I confirmed which jobs failed but did not read the CircleCI logs, so I can't say whether that reflects real Guzzle 8 breakage in paths beyond the three commands exercised here (`status`, `site:install`, `cache:rebuild`).

No effect on released Drupal versions or on DDEV behavior — docs and a docs test only.
