### PR TITLE
docs: expand CLAUDE.md language rules to curb AI-nonsense words and ego-stroking [skip ci]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,8 +140,20 @@ files); a project that already took ownership of the file (removed the
 
 ### English Language Usage
 
+These rules apply everywhere: conversation, commit messages, PR text, code, and comments.
+
 - Never use the words `comprehensive` or `seamless`
-- Avoid flowery or flattering usage in conversation, code, or comments
+- Avoid credibility-filler that asserts sincerity: `honest`, `honestly`, `genuine`,
+  `genuinely`, `truly`, `really` (as an intensifier), `to be honest`, `in all honesty`,
+  `for real`. State the claim directly instead.
+- Avoid empty intensifiers and hype: `perfect`/`perfectly`, `works perfectly`,
+  `production-ready`, `robust`, `powerful`, `effortless`, `delve`, `elevate`, `unleash`.
+- Do not compliment, flatter, or validate the user (`You're absolutely right`,
+  `Great question`, `Perfect`, `Excellent`). Skip the preamble and answer.
+- Do not open a reply by praising the request or restating how good the idea is.
+  Lead with the substance.
+- Report results plainly. If something failed, was skipped, or is unverified, say so;
+  do not paper over it with confident-sounding language.
 
 ### Testing Philosophy
 


### PR DESCRIPTION
## The Issue

- CLAUDE.md's language rules only banned `comprehensive`/`seamless` and "flowery or flattering usage." That left a lot of common AI-nonsense filler and ego-stroking uncovered.

## How This PR Solves The Issue

Expands the **English Language Usage** section so the rules apply everywhere (conversation, commit messages, PR text, code, comments) and adds:

- A ban on credibility-filler that asserts sincerity: `honest`, `honestly`, `genuine`, `genuinely`, `truly`, `really` (as an intensifier), `to be honest`, etc.
- A ban on empty intensifiers/hype: `perfect`/`perfectly`, `works perfectly`, `production-ready`, `robust`, `powerful`, `delve`, `elevate`, `unleash`.
- Explicit rules against complimenting/validating the user (`You're absolutely right`, `Great question`) and against opening replies with praise.
- A rule to report results plainly, including failures and unverified steps.

## Manual Testing Instructions

Documentation-only change. Review the diff in `CLAUDE.md`.

## Automated Testing Overview

No automated tests; docs-only.

## Release/Deployment Notes

No user-facing or runtime impact. Affects Claude Code behavior for contributors working in this repo.
