### PR TITLE
docs(shopware): fix quickstart for php-http/discovery no longer prompting

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2528,7 +2528,9 @@ ddev config --upload-dirs=sites/assets/files && ddev restart
         mkdir -p my-shopware-site && cd my-shopware-site
         ddev config --project-type=shopware6 --docroot=public
         ddev start -y
-        ddev composer create-project shopware/production
+        # Answer `x` to "Do you want to include Docker configuration from recipes?"
+        # so Shopware's Docker recipe is not added (DDEV provides the environment).
+        printf "x\n" | ddev composer create-project shopware/production
         ddev exec console system:install --basic-setup
         ddev launch /admin
         EOF

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -21,13 +21,14 @@ teardown() {
   run ddev start -y
   assert_success
 
-  # 1. Do you trust "php-http/discovery" to execute code and wish to enable it now?
-  #    (writes "allow-plugins" to composer.json) [y,n,d,?]
-  # 2. Do you want to include Docker configuration from recipes?
-  #    [x] No permanently, never ask again for this project
-  run bats_pipe printf "y\nx\n" \| ddev composer create-project shopware/production
+  # shopware/production's composer.json now sets "php-http/discovery": false in
+  # allow-plugins, so Composer no longer prompts to trust that plugin. The only
+  # remaining interactive prompt is:
+  #   Do you want to include Docker configuration from recipes?
+  #   [x] No permanently, never ask again for this project
+  # Answer `x`: DDEV provides the environment, not the recipe's Docker config.
+  run bats_pipe printf "x\n" \| ddev composer create-project shopware/production
   assert_success
-  assert_output --partial "execute code and wish to enable it now?"
   assert_output --partial "Do you want to include Docker configuration from recipes?"
   assert_file_not_exist compose.yaml
   assert_file_not_exist compose.override.yaml


### PR DESCRIPTION
## The Issue

- No existing issue — filing directly for an upstream breakage.

The `Shopware Composer based quickstart` docs test began failing (e.g. [this run](https://github.com/ddev/ddev/actions/runs/30163319226/job/89692055438)). `shopware/production`'s `composer.json` now sets `"php-http/discovery": false` in `config.allow-plugins`, so Composer no longer emits the `Do you trust "php-http/discovery" to execute code and wish to enable it now?` prompt.

That breaks the test two ways:

1. The `assert_output --partial "execute code and wish to enable it now?"` assertion never matches.
2. The piped `printf "y\nx\n"` was `y` for the (now-gone) trust prompt and `x` for the Docker prompt. With the trust prompt gone, `y` now answers the Docker-recipe prompt, pulling in Shopware's Docker recipe and creating `compose.yaml`/`compose.override.yaml` — the opposite of what the quickstart wants (reproduced locally).

## How This PR Solves The Issue

- `docs/tests/shopware.bats`: send only `printf "x\n"` (answering the sole remaining prompt, "Do you want to include Docker configuration from recipes?", with `x`), and drop the stale trust-prompt assertion.
- `docs/content/users/quickstart.md`: the "Prefer to run as a script?" block ran `ddev composer create-project shopware/production` with no input, so the Docker prompt fell through to its `y` default and added the Docker recipe. It now pipes `printf "x\n"` so the non-interactive script declines the Docker recipe.

The interactive block already instructs answering `x` at that prompt and is unchanged.

## Manual Testing Instructions

```bash
mkdir -p my-shopware-site && cd my-shopware-site
ddev config --project-type=shopware6 --docroot=public
ddev start -y
printf "x\n" | ddev composer create-project shopware/production
# no compose.yaml / compose.override.yaml should be created
ddev exec console system:install --basic-setup
ddev launch /admin
```

## Automated Testing Overview

Existing `docs/tests/shopware.bats` covers this. Verified locally:

```
$ bats docs/tests/shopware.bats
ok 1 Shopware Composer based quickstart with ddev version v1.25.3-18-g540808b7b
```

## Release/Deployment Notes

Docs and a docs test only; no effect on DDEV behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
