### PR TITLE
docs(quickstart): revert Drush/Guzzle 8 workaround for Drupal 12

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -891,12 +891,9 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
 
     Install Drupal via Composer:
 
-    !!!warning "Temporary Drush workaround"
-        Drupal 12 requires `guzzlehttp/guzzle` `^8.0`, but every current Drush release still requires `^7.0`, so a plain `ddev composer require drush/drush` cannot be resolved. Guzzle 8 works with Drush at runtime, so the command below installs Drush with an inline alias that presents the installed Guzzle 8 as a 7.x version. Once [drush-ops/drush#6602](https://github.com/drush-ops/drush/pull/6602) is released, use `ddev composer require drush/drush` instead.
-
     ```bash
     ddev composer create-project drupal/recommended-project:main-dev@dev
-    ddev composer require "guzzlehttp/guzzle:8.0.0 as 7.99.0" drush/drush -W
+    ddev composer require drush/drush
     ```
 
     Run Drupal installation and launch:
@@ -921,10 +918,7 @@ Set [`composer_root`](./configuration/config.md#composer_root) to the subdirecto
         ddev config --project-type=drupal12 --docroot=web
         ddev start -y
         ddev composer create-project drupal/recommended-project:main-dev@dev
-        # Temporary: Drupal 12 requires guzzlehttp/guzzle ^8.0 while Drush still requires
-        # ^7.0, so Drush is installed with an inline alias of the installed Guzzle 8.
-        # Use `ddev composer require drush/drush` once drush-ops/drush#6602 is released.
-        ddev composer require "guzzlehttp/guzzle:8.0.0 as 7.99.0" drush/drush -W
+        ddev composer require drush/drush
         ddev drush site:install --account-name=admin --account-pass=admin -y
         ddev launch
         EOF

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -26,15 +26,7 @@ teardown() {
   run ddev composer create-project drupal/recommended-project:main-dev@dev
   assert_success
 
-  # Temporary: Drupal 12 requires guzzlehttp/guzzle ^8.0 while every Drush release
-  # still requires ^7.0, so `ddev composer require drush/drush` cannot resolve.
-  # Guzzle 8 works with Drush at runtime, so alias the installed Guzzle 8 as a 7.x
-  # version. Composer only accepts an exact version as an alias source, so this
-  # matches the version documented in quickstart.md — keep the two in sync, so
-  # this test fails if the documented command stops resolving. Revert to a plain
-  # `ddev composer require drush/drush` once
-  # https://github.com/drush-ops/drush/pull/6602 is released.
-  run ddev composer require "guzzlehttp/guzzle:8.0.0 as 7.99.0" drush/drush -W
+  run ddev composer require drush/drush
   assert_success
 
   run ddev drush site:install --account-name=admin --account-pass=admin -y


### PR DESCRIPTION
## The Issue

- Reverts #8618

Drush released a fix (drush-ops/drush#6602) allowing `drush/drush` to resolve against `guzzlehttp/guzzle` `^8.0`, so the Guzzle-8-alias workaround documented in #8618 for Drupal 12 quickstart installs is no longer needed.

## How This PR Solves The Issue

Reverts the workaround added in #8618:

- `docs/content/users/quickstart.md`: removes the "Temporary Drush workaround" warning box and restores the plain `ddev composer require drush/drush` command in both the manual steps and the one-liner script.
- `docs/tests/drupal.bats`: restores the plain `ddev composer require drush/drush` in the Drupal quickstart test.

## Manual Testing Instructions

1. `ddev config --project-type=drupal12 --docroot=web`
2. `ddev start -y`
3. `ddev composer create-project drupal/recommended-project:main-dev@dev`
4. `ddev composer require drush/drush` — should resolve cleanly with `guzzlehttp/guzzle` `8.0.0` and no alias needed
5. `ddev drush site:install --account-name=admin --account-pass=admin -y` — should complete successfully
6. `ddev launch`

Verified locally: `composer require drush/drush` resolved `drush/drush 14.x-dev` alongside `guzzlehttp/guzzle 8.0.0` directly, and `ddev drush site:install` completed successfully.

## Automated Testing Overview

`docs/tests/drupal.bats` is restored to its pre-#8618 form and exercises the plain `ddev composer require drush/drush` command as part of the Drupal quickstart Bats test.

## Release/Deployment Notes

Documentation-only change; no code or release impact.
