### PR TITLE
feat: Allow worktrees to share DB snapshots

### DIFF
--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -13,9 +13,10 @@ var DdevSnapshotRestoreCommand = &cobra.Command{
 	Use:   "restore [snapshot_name]",
 	Short: "Restore a project's database to the provided snapshot version.",
 	Long: `Uses mariabackup command to restore a project database to a particular snapshot from the .ddev/db_snapshots folder.
+If the current project is part of a git worktree, snapshots from the corresponding project paths in other worktrees are also listed.
 Example: "ddev snapshot restore d8git_20180717203845"`,
 	Run: func(_ *cobra.Command, args []string) {
-		var snapshotName string
+		// snapshotName is declared in cmd/snapshot.go as a package var; do not redeclare it here
 
 		app, err := ddevapp.GetActiveApp("")
 		if err != nil {
@@ -29,45 +30,62 @@ Example: "ddev snapshot restore d8git_20180717203845"`,
 			util.Failed("Failed to start app %s: %v", app.GetName(), err)
 		}
 
+		var restoreTarget *ddevapp.SnapshotRestoreTarget
 		if snapshotRestoreLatest {
-			if snapshotName, err = app.GetLatestSnapshot(); err != nil {
+			restoreTarget, err = app.GetLatestSnapshotRestoreTarget()
+			if err != nil {
 				util.Failed("Failed to get latest snapshot of project %s: %v", app.GetName(), err)
 			}
 		} else {
 			if len(args) != 1 { // If the name of the snapshot isn't provided, do prompted restore
-				snapshots, err := app.ListSnapshotNames()
+				targets, err := app.ListSnapshotRestoreTargets()
 				if err != nil {
-					util.Failed("Cannot list snapshots of project %s: %v", app.GetName(), err)
+				util.Failed("Cannot list snapshots of project %s: %v", app.GetName(), err)
 				}
 
-				if len(snapshots) == 0 {
-					util.Failed("No snapshots found for project %s", app.GetName())
+				if len(targets) == 0 {
+				util.Failed("No snapshots found for project %s", app.GetName())
+				}
+
+				snapshotLabels := make([]string, len(targets))
+				for i, target := range targets {
+				snapshotLabels[i] = target.Label
 				}
 
 				templates := &promptui.SelectTemplates{
-					Label: "{{ . | cyan }}:",
+				Label: "{{ . | cyan }}:",
 				}
 
 				prompt := promptui.Select{
-					Label:     "Snapshot",
-					Items:     snapshots,
-					Templates: templates,
+				Label:     "Snapshot",
+				Items:     snapshotLabels,
+				Templates: templates,
 				}
 
-				_, snapshotName, err = prompt.Run()
-
+				selectedIndex, _, err := prompt.Run()
 				if err != nil {
-					util.Failed("Prompt failed %v", err)
+				util.Failed("Prompt failed %v", err)
 				}
+				restoreTarget = &targets[selectedIndex]
 			} else { // Snapshot name was given on command-line, use it.
-				snapshotName = args[0]
+				targets, err := app.ListSnapshotRestoreTargets()
+				if err != nil {
+				util.Failed("Cannot list snapshots of project %s: %v", app.GetName(), err)
+				}
+				for i := range targets {
+					if targets[i].Name == args[0] {
+						restoreTarget = &targets[i]
+						break
+					}
+				}
+				if restoreTarget == nil || restoreTarget.Name == "" {
+					restoreTarget = &ddevapp.SnapshotRestoreTarget{Name: args[0], SourceRoot: app.AppRoot, Label: args[0]}
+				}
 			}
 		}
 
-		// Normalize the snapshot name
-
-		if err := app.RestoreSnapshot(snapshotName); err != nil {
-			util.Failed("Failed to restore snapshot %s for project %s: %v", snapshotName, app.GetName(), err)
+		if err := app.RestoreSnapshotFromWorktree(restoreTarget.Name, restoreTarget.SourceRoot); err != nil {
+			util.Failed("Failed to restore snapshot %s for project %s: %v", restoreTarget.Name, app.GetName(), err)
 		}
 	},
 }

--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -40,37 +40,37 @@ Example: "ddev snapshot restore d8git_20180717203845"`,
 			if len(args) != 1 { // If the name of the snapshot isn't provided, do prompted restore
 				targets, err := app.ListSnapshotRestoreTargets()
 				if err != nil {
-				util.Failed("Cannot list snapshots of project %s: %v", app.GetName(), err)
+					util.Failed("Cannot list snapshots of project %s: %v", app.GetName(), err)
 				}
 
 				if len(targets) == 0 {
-				util.Failed("No snapshots found for project %s", app.GetName())
+					util.Failed("No snapshots found for project %s", app.GetName())
 				}
 
 				snapshotLabels := make([]string, len(targets))
 				for i, target := range targets {
-				snapshotLabels[i] = target.Label
+					snapshotLabels[i] = target.Label
 				}
 
 				templates := &promptui.SelectTemplates{
-				Label: "{{ . | cyan }}:",
+					Label: "{{ . | cyan }}:",
 				}
 
 				prompt := promptui.Select{
-				Label:     "Snapshot",
-				Items:     snapshotLabels,
-				Templates: templates,
+					Label:     "Snapshot",
+					Items:     snapshotLabels,
+					Templates: templates,
 				}
 
 				selectedIndex, _, err := prompt.Run()
 				if err != nil {
-				util.Failed("Prompt failed %v", err)
+					util.Failed("Prompt failed %v", err)
 				}
 				restoreTarget = &targets[selectedIndex]
 			} else { // Snapshot name was given on command-line, use it.
 				targets, err := app.ListSnapshotRestoreTargets()
 				if err != nil {
-				util.Failed("Cannot list snapshots of project %s: %v", app.GetName(), err)
+					util.Failed("Cannot list snapshots of project %s: %v", app.GetName(), err)
 				}
 				for i := range targets {
 					if targets[i].Name == args[0] {

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -178,9 +178,9 @@ func (app *DdevApp) getGitWorktreePaths() ([]string, error) {
 	}
 
 	var worktreePaths []string
-	for _, line := range strings.Split(strings.TrimSpace(worktreeOutput), "\n") {
-		if strings.HasPrefix(line, "worktree ") {
-			worktreePath := strings.TrimSpace(strings.TrimPrefix(line, "worktree "))
+	for line := range strings.SplitSeq(strings.TrimSpace(worktreeOutput), "\n") {
+		if worktreePath, ok := strings.CutPrefix(line, "worktree "); ok {
+			worktreePath = strings.TrimSpace(worktreePath)
 			absPath, err := filepath.Abs(worktreePath)
 			if err != nil {
 				continue

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -23,6 +24,14 @@ import (
 type Snapshot struct {
 	Name    string
 	Created time.Time
+}
+
+// SnapshotRestoreTarget represents a snapshot that can be restored from a project path.
+type SnapshotRestoreTarget struct {
+	Name       string
+	Created    time.Time
+	SourceRoot string
+	Label      string
 }
 
 // SnapshotRestoreDefaultWaitTime is the max time we'll wait for snapshot restore.
@@ -77,6 +86,144 @@ func (app *DdevApp) GetLatestSnapshot() (string, error) {
 	return snapshots[0], nil
 }
 
+// ListSnapshotRestoreTargets returns restore targets for the current project and any matching
+// project paths in git worktrees.
+func (app *DdevApp) ListSnapshotRestoreTargets() ([]SnapshotRestoreTarget, error) {
+	targets, err := app.getSnapshotRestoreTargetsForRoot(app.AppRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	worktreeRoots, err := app.getGitWorktreePaths()
+	if err != nil {
+		return nil, err
+	}
+	for _, worktreeRoot := range worktreeRoots {
+		if samePath(worktreeRoot, app.AppRoot) {
+			continue
+		}
+		projectRoot, err := app.getProjectRootForWorktree(worktreeRoot)
+		if err != nil || projectRoot == "" {
+			continue
+		}
+		if samePath(projectRoot, app.AppRoot) {
+			continue
+		}
+		otherTargets, err := app.getSnapshotRestoreTargetsForRoot(projectRoot)
+		if err != nil {
+			continue
+		}
+		targets = append(targets, otherTargets...)
+	}
+
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].Created.After(targets[j].Created)
+	})
+
+	return targets, nil
+}
+
+// GetLatestSnapshotRestoreTarget returns the latest snapshot restore target available for the current project's worktree context.
+func (app *DdevApp) GetLatestSnapshotRestoreTarget() (*SnapshotRestoreTarget, error) {
+	targets, err := app.ListSnapshotRestoreTargets()
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("no snapshots found")
+	}
+	return &targets[0], nil
+}
+
+func (app *DdevApp) getSnapshotRestoreTargetsForRoot(root string) ([]SnapshotRestoreTarget, error) {
+	var targets []SnapshotRestoreTarget
+	if root == "" {
+		return targets, nil
+	}
+
+	snapshots, err := listSnapshotsInDir(filepath.Join(root, ".ddev", "db_snapshots"))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, snapshot := range snapshots {
+		label := snapshot.Name
+		if !samePath(root, app.AppRoot) {
+			label = fmt.Sprintf("%s (%s)", snapshot.Name, filepath.Base(root))
+		}
+		targets = append(targets, SnapshotRestoreTarget{
+			Name:       snapshot.Name,
+			Created:    snapshot.Created,
+			SourceRoot: root,
+			Label:      label,
+		})
+	}
+
+	return targets, nil
+}
+
+func (app *DdevApp) getGitWorktreePaths() ([]string, error) {
+	repoRootOutput, err := exec.RunHostCommand("git", "-C", app.AppRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil, nil
+	}
+	repoRoot := strings.TrimSpace(repoRootOutput)
+	if repoRoot == "" {
+		return nil, nil
+	}
+
+	worktreeOutput, err := exec.RunHostCommand("git", "-C", repoRoot, "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, err
+	}
+
+	var worktreePaths []string
+	for _, line := range strings.Split(strings.TrimSpace(worktreeOutput), "\n") {
+		if strings.HasPrefix(line, "worktree ") {
+			worktreePath := strings.TrimSpace(strings.TrimPrefix(line, "worktree "))
+			absPath, err := filepath.Abs(worktreePath)
+			if err != nil {
+				continue
+			}
+			worktreePaths = append(worktreePaths, absPath)
+		}
+	}
+
+	return worktreePaths, nil
+}
+
+func (app *DdevApp) getProjectRootForWorktree(worktreeRoot string) (string, error) {
+	repoRootOutput, err := exec.RunHostCommand("git", "-C", app.AppRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", nil
+	}
+	repoRoot := strings.TrimSpace(repoRootOutput)
+	if repoRoot == "" {
+		return "", nil
+	}
+
+	relPath, err := filepath.Rel(repoRoot, app.AppRoot)
+	if err != nil {
+		return "", err
+	}
+	if relPath == "." {
+		return worktreeRoot, nil
+	}
+	return filepath.Join(worktreeRoot, relPath), nil
+}
+
+func samePath(path1, path2 string) bool {
+	absPath1, err := filepath.Abs(path1)
+	if err != nil {
+		return false
+	}
+	absPath2, err := filepath.Abs(path2)
+	if err != nil {
+		return false
+	}
+	return filepath.Clean(absPath1) == filepath.Clean(absPath2)
+}
+
 // ListSnapshots returns a list of the names of all project snapshots
 func (app *DdevApp) ListSnapshotNames() ([]string, error) {
 	var names []string
@@ -89,12 +236,8 @@ func (app *DdevApp) ListSnapshotNames() ([]string, error) {
 	return names, err
 }
 
-// ListSnapshots returns a list of all project snapshots
-func (app *DdevApp) ListSnapshots() ([]Snapshot, error) {
-	var err error
+func listSnapshotsInDir(snapshotDir string) ([]Snapshot, error) {
 	var snapshots []Snapshot
-
-	snapshotDir := app.GetConfigPath("db_snapshots")
 
 	if !fileutil.FileExists(snapshotDir) {
 		return snapshots, nil
@@ -138,9 +281,24 @@ func (app *DdevApp) ListSnapshots() ([]Snapshot, error) {
 	return snapshots, nil
 }
 
+// ListSnapshots returns a list of all project snapshots
+func (app *DdevApp) ListSnapshots() ([]Snapshot, error) {
+	snapshotDir := app.GetConfigPath("db_snapshots")
+	return listSnapshotsInDir(snapshotDir)
+}
+
 // RestoreSnapshot restores a MariaDB snapshot of the db to be loaded
 // The project must be stopped and Docker volume removed and recreated for this to work.
 func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
+	return app.restoreSnapshot(snapshotName, app.AppRoot)
+}
+
+// RestoreSnapshotFromWorktree restores a snapshot from the specified project root, which may live in another git worktree.
+func (app *DdevApp) RestoreSnapshotFromWorktree(snapshotName, sourceRoot string) error {
+	return app.restoreSnapshot(snapshotName, sourceRoot)
+}
+
+func (app *DdevApp) restoreSnapshot(snapshotName, sourceRoot string) error {
 	var err error
 	err = app.ProcessHooks("pre-restore-snapshot")
 	if err != nil {
@@ -149,13 +307,12 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 
 	currentDBVersion := app.Database.Type + "_" + app.Database.Version
 
-	snapshotFile, err := GetSnapshotFileFromName(snapshotName, app)
+	snapshotFile, err := getSnapshotFileFromNameFromRoot(snapshotName, sourceRoot)
 	if err != nil {
 		return fmt.Errorf("no snapshot found for name %s: %v", snapshotName, err)
 	}
-	snapshotFileOrDir := filepath.Join("db_snapshots", snapshotFile)
-
-	hostSnapshotFileOrDir := app.GetConfigPath(snapshotFileOrDir)
+	snapshotDir := filepath.Join(sourceRoot, ".ddev", "db_snapshots")
+	hostSnapshotFileOrDir := filepath.Join(snapshotDir, snapshotFile)
 
 	if !fileutil.FileExists(hostSnapshotFileOrDir) {
 		return fmt.Errorf("failed to find a snapshot at %s", hostSnapshotFileOrDir)
@@ -194,7 +351,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	}
 
 	if snapshotDBVersion != currentDBVersion {
-		return fmt.Errorf("snapshot '%s' is a DB server '%s' snapshot and is not compatible with the configured DDEV DB server version (%s).  Please restore it using the DB version it was created with, and then you can try upgrading the DDEV DB version", snapshotName, snapshotDBVersion, currentDBVersion)
+		return fmt.Errorf("snapshot '%s' is a DB server '%s' snapshot and is not compatible with the configured DDEV DB server version (%s). Please restore it using the DB version it was created with, and then you can try upgrading the DDEV DB version", snapshotName, snapshotDBVersion, currentDBVersion)
 	}
 
 	status, _ := app.SiteStatus()
@@ -215,8 +372,10 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 		}
 	}
 
-	// If we have no bind mounts, we need to copy our snapshot into the snapshots volme
-	// With bind mounts, they'll already be there in the /mnt/ddev_config/db_snapshots folder
+	// If we have no bind mounts, we need to copy our snapshot into the snapshots volume
+	// With bind mounts, the snapshot must exist under the current project's .ddev/db_snapshots
+	// If the snapshot comes from a different worktree (sourceRoot != app.AppRoot) and
+	// bind mounts are used, copy the snapshot into the current project's .ddev/db_snapshots
 	if globalconfig.DdevGlobalConfig.NoBindMounts {
 		uid, _, _ := dockerutil.GetContainerUser()
 
@@ -227,9 +386,35 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 			subdir = snapshotName
 		}
 
-		err = dockerutil.CopyIntoVolume(filepath.Join(app.GetConfigPath("db_snapshots"), snapshotFile), "ddev-"+app.Name+"-snapshots", subdir, uid, "", true)
+		err = dockerutil.CopyIntoVolume(filepath.Join(snapshotDir, snapshotFile), "ddev-"+app.Name+"-snapshots", subdir, uid, "", true)
 		if err != nil {
 			return err
+		}
+	} else if !samePath(sourceRoot, app.AppRoot) {
+		// Bind mounts are used but the snapshot is in another worktree; copy it into
+		// this project's .ddev/db_snapshots so the bind mount will expose it to the container.
+		destSnapshotsDir := filepath.Join(app.AppRoot, ".ddev", "db_snapshots")
+		if !fileutil.FileExists(destSnapshotsDir) {
+			if err := os.MkdirAll(destSnapshotsDir, 0o755); err != nil {
+				return fmt.Errorf("failed to create snapshots dir %s: %v", destSnapshotsDir, err)
+			}
+		}
+		srcPath := filepath.Join(snapshotDir, snapshotFile)
+		destPath := filepath.Join(destSnapshotsDir, filepath.Base(srcPath))
+		// Remove any existing destination before copying
+		if fileutil.FileExists(destPath) {
+			if err := os.RemoveAll(destPath); err != nil {
+				return fmt.Errorf("failed to remove existing snapshot at %s: %v", destPath, err)
+			}
+		}
+		if fileutil.IsDirectory(srcPath) {
+			if err := fileutil.CopyDir(srcPath, destPath); err != nil {
+				return fmt.Errorf("failed to copy snapshot directory from %s to %s: %v", srcPath, destPath, err)
+			}
+		} else {
+			if err := fileutil.CopyFile(srcPath, destPath); err != nil {
+				return fmt.Errorf("failed to copy snapshot file from %s to %s: %v", srcPath, destPath, err)
+			}
 		}
 	}
 
@@ -315,9 +500,8 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	return nil
 }
 
-// GetSnapshotFileFromName returns the filename corresponding to the snapshot name
-func GetSnapshotFileFromName(name string, app *DdevApp) (string, error) {
-	snapshotsDir := app.GetConfigPath("db_snapshots")
+func getSnapshotFileFromNameFromRoot(name, sourceRoot string) (string, error) {
+	snapshotsDir := filepath.Join(sourceRoot, ".ddev", "db_snapshots")
 	snapshotFullPath := filepath.Join(snapshotsDir, name)
 
 	// If old-style directory-based snapshot, then use the name, no massaging required
@@ -340,4 +524,9 @@ func GetSnapshotFileFromName(name string, app *DdevApp) (string, error) {
 	}
 
 	return "", fmt.Errorf("snapshot %s not found in %s", name, snapshotsDir)
+}
+
+// GetSnapshotFileFromName returns the filename corresponding to the snapshot name
+func GetSnapshotFileFromName(name string, app *DdevApp) (string, error) {
+	return getSnapshotFileFromNameFromRoot(name, app.AppRoot)
 }

--- a/pkg/ddevapp/snapshot_test.go
+++ b/pkg/ddevapp/snapshot_test.go
@@ -3,6 +3,7 @@ package ddevapp_test
 import (
 	"fmt"
 	"os"
+	osexec "os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -154,6 +155,69 @@ func TestGetLatestSnapshot(t *testing.T) {
 }
 
 // TestDdevRestoreSnapshot tests creating a snapshot and reverting to it.
+func TestListSnapshotRestoreTargetsIncludesOtherWorktrees(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoRoot := filepath.Join(tmpDir, "repo")
+	worktreeRoot := filepath.Join(tmpDir, "repo-worktree")
+	projectRoot := filepath.Join(repoRoot, "work", "site")
+	projectWorktreeRoot := filepath.Join(worktreeRoot, "work", "site")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, ".ddev", "db_snapshots"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(projectWorktreeRoot, ".ddev", "db_snapshots"), 0o755))
+
+	_, err := osexec.Command("git", "init", repoRoot).CombinedOutput()
+	require.NoError(t, err)
+	_, err = osexec.Command("git", "-C", repoRoot, "config", "user.name", "Test User").CombinedOutput()
+	require.NoError(t, err)
+	_, err = osexec.Command("git", "-C", repoRoot, "config", "user.email", "test@example.com").CombinedOutput()
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, ".ddev", "db_snapshots", "snapshot-current-mariadb_10.11.1.zst"), []byte("current"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectWorktreeRoot, ".ddev", "db_snapshots", "snapshot-other-mariadb_10.11.1.zst"), []byte("other"), 0o644))
+
+	currentFile := filepath.Join(projectRoot, ".ddev", "db_snapshots", "snapshot-current-mariadb_10.11.1.zst")
+	otherFile := filepath.Join(projectWorktreeRoot, ".ddev", "db_snapshots", "snapshot-other-mariadb_10.11.1.zst")
+	olderTime := time.Now().Add(-2 * time.Hour)
+	newerTime := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(currentFile, olderTime, olderTime))
+	require.NoError(t, os.Chtimes(otherFile, newerTime, newerTime))
+
+	_, err = osexec.Command("git", "-C", repoRoot, "add", ".").CombinedOutput()
+	require.NoError(t, err)
+	_, err = osexec.Command("git", "-C", repoRoot, "commit", "-m", "initial").CombinedOutput()
+	require.NoError(t, err)
+	_, err = osexec.Command("git", "-C", repoRoot, "worktree", "add", "--detach", worktreeRoot, "HEAD").CombinedOutput()
+	require.NoError(t, err)
+
+	app := &ddevapp.DdevApp{AppRoot: projectRoot}
+
+	targets, err := app.ListSnapshotRestoreTargets()
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+
+	foundCurrent := false
+	foundOther := false
+	for _, target := range targets {
+		switch target.Name {
+		case "snapshot-current":
+			foundCurrent = true
+			require.Equal(t, projectRoot, target.SourceRoot)
+		case "snapshot-other":
+			foundOther = true
+			require.Equal(t, projectWorktreeRoot, target.SourceRoot)
+			require.Equal(t, "snapshot-other (repo-worktree)", target.Label)
+		}
+	}
+
+	require.True(t, foundCurrent)
+	require.True(t, foundOther)
+
+	latest, err := app.GetLatestSnapshotRestoreTarget()
+	require.NoError(t, err)
+	require.Equal(t, "snapshot-other", latest.Name)
+	require.Equal(t, projectWorktreeRoot, latest.SourceRoot)
+}
+
 func TestDdevRestoreSnapshot(t *testing.T) {
 	// Don't run this unless GOTEST_SHORT is unset; it doesn't need to be run everywhere.
 	if os.Getenv("GOTEST_SHORT") != "" {


### PR DESCRIPTION
<!--
  PR titles have very precise rules, please read
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
-->

## The Issue

- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER

Recently watched [git-worktree-contributor-training](https://ddev.com/blog/git-worktree-contributor-training/) which uses `ddev export-db` and `ddev import-db` via a top-level .tarballs directory:

```txt
.
├── .tarballs
├── d11simple
└── fancy-feat1
```

While this works, `ddev snapshot restore` can be faster and has a nice TUI to browse snapshots. It would be nice if we could reuse this when using worktree workflow.

## How This PR Solves The Issue

This update enables database snapshots to be shared across git worktrees, allowing users to restore snapshots from corresponding project paths in other worktrees.

It attempts to detect if the project is a worktree and displays snapshots from other worktrees via TUI. Selecting a snapshot from a different worktree, copies the file locally before importing to maintain correct mounting paths.

Projects that are NOT a worktree are unchanged.

## Manual Testing Instructions

### "snapshot restore" lists worktree snapshots

1. Clone a base repository ("d11simple")

```shell
git clone git@github.com:ddev/d11simple
cd d11simple
```

2. Get "d11simple" site to working state

```shell
ddev start
ddev drush si -y
ddev launch
# Confirm Drupal welcome page is displayed.
```

3. Create "d11simple" snapshot

```shell
$ ddev snapshot
...
Restore this snapshot with 'ddev snapshot restore d11simple_20260727184413'
```

4. Create "feat-95" git worktree

```shell
git worktree add ../feat-95
cd ../feat-95
```

5. Confirm "feat-95" worktree does NOT have initialized database

```shell
ddev launch
# Confirm page loads Drupal setup wizard
```

6. Attempt to load "d11simple" snapshot created earlier (d11simple_20260727184413)

```shell
$ ddev snapshot restore
Use the arrow keys to navigate: ↓ ↑ → ←
Snapshot:
  ▸ d11simple_20260727184413
...
Database snapshot d11simple_20260727184413 was restored in 15s
```

7. Confirm "feat-95" now loads with populated database

```shell
ddev launch
# Confirm DDEV welcome screen is displayed
```

1. Confirm worktree in sub-folders work. Eg. `git worktree add ../feat/new-67`

### "snapshot restore" does NOT see non-worktree snapshots at same level

Assuming the following file structure:

```
.
├── d11simple
└── feat-95
```

1. Create clone at same level as "d11simple" (fake)

```shell
$ ls
d11simple  feat-95

$ git clone git@github.com:ddev/d11simple fake
...
Updating files: 100% (25351/25351), done.

$ ls
d11simple  fake  feat-95
```

2. Attempt to load "d11simple" snapshot created earlier (d11simple_20260727184413)

```shell
$ ddev snapshot restore
No snapshots found for project fake
```

3. Create "fake" snapshot

```shell
$ ddev snapshot
...
Restore this snapshot with 'ddev snapshot restore fake_20260727190329'
```

4. Confirm snapshot is not visible from "d11simple"

```shell
cd ../d11simple
ddev snapshot restore
Snapshot:
  ▸ d11simple_20260727184413
```

## Automated Testing Overview

Introduced tests to verify that the snapshot restoration process includes targets from other worktrees.

## Release/Deployment Notes

No additional deployment steps are required, but ensure that users are aware of the new functionality regarding worktree snapshot sharing.
