### PR TITLE
fix: reject symlinks with rooted/absolute targets in Untar, for #8213 (#8625) [skip ci]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,14 @@ Examples:
 - `feat(pantheon): use environment variables`
 - `docs: clarify zensical setup`
 
+**ALWAYS write the commit message to a file first and commit with `git commit -F <file>`.**
+This applies to every commit, not just PR-initial commits. Never use
+`git commit -m "$(cat <<'EOF' ... EOF)"` or any other inline-heredoc-in-`$(...)`
+construct — it is unreliable in bash and silently fails or mangles the message
+(missing EOF, stray quotes, chained `&&` breaking mid-heredoc). Write the message
+with the Write tool (or `cat > /tmp/msg.txt <<'EOF' ... EOF` as its own command),
+then run `git commit -F /tmp/msg.txt` as a separate command.
+
 ### Pull Request Template
 
 In the initial commit for a PR, use the format in  `.github/PULL_REQUEST_TEMPLATE.md` with these required sections:

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -306,8 +306,15 @@ func Untar(source string, dest string, extractionDir string) error {
 			// Remove any existing file/symlink at this path
 			_ = os.Remove(fullPath)
 
-			// Create the symlink
-			err = os.Symlink(file.Linkname, fullPath)
+			// Create the symlink using the same target that was validated above.
+			// For absolute targets this is resolvedTarget (rebased under dest), not the
+			// raw file.Linkname, otherwise the symlink would point outside dest on disk
+			// even though the check above validated the rebased path.
+			linkTarget := file.Linkname
+			if filepath.IsAbs(file.Linkname) {
+				linkTarget = resolvedTarget
+			}
+			err = os.Symlink(linkTarget, fullPath)
 			if err != nil {
 				return fmt.Errorf("failed to create symlink %v -> %v, err: %v", fullPath, file.Linkname, err)
 			}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -154,26 +154,13 @@ func UnXz(source string, destDirectory string) error {
 	return nil
 }
 
-// isArchiveAbsolutePath reports whether a tar entry's Linkname should be
-// treated as an absolute path to rebase under dest. Tar Linkname strings are
-// POSIX-style regardless of host OS, so filepath.IsAbs alone is not enough:
-// on Windows it returns false for a leading "/" with no drive letter, even
-// though that is meant to be treated as absolute (rooted) here.
+// isArchiveAbsolutePath reports whether a tar entry's Linkname is an absolute
+// path. Tar Linkname strings are POSIX-style regardless of host OS, so
+// filepath.IsAbs alone is not enough: on Windows it returns false for a
+// leading "/" with no drive letter, even though that is rooted and must be
+// rejected the same as any other absolute form.
 func isArchiveAbsolutePath(p string) bool {
 	return strings.HasPrefix(p, "/") || strings.HasPrefix(p, `\`) || filepath.IsAbs(p)
-}
-
-// rebaseUnderDest rebases an absolute path (POSIX-style or native, e.g. a
-// Windows drive-lettered path) under dest, treating dest as the new root.
-// It strips any volume name and leading slashes from p before joining, so
-// two absolute paths are never naively concatenated (which on Windows would
-// produce an invalid path with an embedded drive letter/colon).
-func rebaseUnderDest(dest string, p string) string {
-	if v := filepath.VolumeName(p); v != "" {
-		p = p[len(v):]
-	}
-	p = strings.TrimLeft(p, `/\`)
-	return filepath.Join(dest, filepath.FromSlash(p))
 }
 
 // Untar accepts a tar, tar.gz, tar.bz2, tar.xz file and extracts the contents to the provided destination path.
@@ -311,24 +298,17 @@ func Untar(source string, dest string, extractionDir string) error {
 				return fmt.Errorf("failed to create the directory %s, err: %v", fullPathDir, err)
 			}
 
-			// Validate symlink target doesn't escape dest.
-			// Absolute targets are rebased against dest (treating dest as root),
-			// so container paths like /var/www/html/... are accepted.
-			// Relative targets are resolved against the symlink's parent directory.
-			//
-			// Tar Linkname strings are POSIX-style regardless of host OS, so
-			// filepath.IsAbs (which is host-OS-dependent) cannot be used to
-			// detect "absolute": on Windows it returns false for a leading
-			// "/" with no drive letter, which would skip rebasing entirely.
-			// isArchiveAbsolutePath/rebaseUnderDest handle both POSIX-style
-			// and native-Windows absolute forms explicitly and portably.
-			var resolvedTarget string
-			absoluteLinkTarget := isArchiveAbsolutePath(file.Linkname)
-			if absoluteLinkTarget {
-				resolvedTarget = rebaseUnderDest(dest, file.Linkname)
-			} else {
-				resolvedTarget = filepath.Join(fullPathDir, file.Linkname)
+			// A dev-environment archive has no legitimate need to plant an
+			// absolute symlink target, and there's no safe general way to
+			// let one through: rebasing it under dest is what caused this
+			// function's history of escape bugs (see GHSA-9hq4-hm3j-jmph).
+			// Reject absolute targets outright; only relative targets,
+			// resolved against and confined to the symlink's parent
+			// directory, are allowed.
+			if isArchiveAbsolutePath(file.Linkname) {
+				return fmt.Errorf("symlink target %q in archive entry %q is absolute, which is not allowed", file.Linkname, file.Name)
 			}
+			resolvedTarget := filepath.Join(fullPathDir, file.Linkname)
 			if !strings.HasPrefix(filepath.Clean(resolvedTarget)+string(os.PathSeparator), filepath.Clean(dest)+string(os.PathSeparator)) {
 				return fmt.Errorf("symlink target %q in archive entry %q escapes destination directory", file.Linkname, file.Name)
 			}
@@ -336,15 +316,7 @@ func Untar(source string, dest string, extractionDir string) error {
 			// Remove any existing file/symlink at this path
 			_ = os.Remove(fullPath)
 
-			// Create the symlink using the same target that was validated above.
-			// For absolute targets this is resolvedTarget (rebased under dest), not the
-			// raw file.Linkname, otherwise the symlink would point outside dest on disk
-			// even though the check above validated the rebased path.
-			linkTarget := file.Linkname
-			if absoluteLinkTarget {
-				linkTarget = resolvedTarget
-			}
-			err = os.Symlink(linkTarget, fullPath)
+			err = os.Symlink(file.Linkname, fullPath)
 			if err != nil {
 				return fmt.Errorf("failed to create symlink %v -> %v, err: %v", fullPath, file.Linkname, err)
 			}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -154,6 +154,28 @@ func UnXz(source string, destDirectory string) error {
 	return nil
 }
 
+// isArchiveAbsolutePath reports whether a tar entry's Linkname should be
+// treated as an absolute path to rebase under dest. Tar Linkname strings are
+// POSIX-style regardless of host OS, so filepath.IsAbs alone is not enough:
+// on Windows it returns false for a leading "/" with no drive letter, even
+// though that is meant to be treated as absolute (rooted) here.
+func isArchiveAbsolutePath(p string) bool {
+	return strings.HasPrefix(p, "/") || strings.HasPrefix(p, `\`) || filepath.IsAbs(p)
+}
+
+// rebaseUnderDest rebases an absolute path (POSIX-style or native, e.g. a
+// Windows drive-lettered path) under dest, treating dest as the new root.
+// It strips any volume name and leading slashes from p before joining, so
+// two absolute paths are never naively concatenated (which on Windows would
+// produce an invalid path with an embedded drive letter/colon).
+func rebaseUnderDest(dest string, p string) string {
+	if v := filepath.VolumeName(p); v != "" {
+		p = p[len(v):]
+	}
+	p = strings.TrimLeft(p, `/\`)
+	return filepath.Join(dest, filepath.FromSlash(p))
+}
+
 // Untar accepts a tar, tar.gz, tar.bz2, tar.xz file and extracts the contents to the provided destination path.
 // extractionDir is the path at which extraction should start; nothing will be extracted except the contents of
 // extractionDir. If extranctionDir is empty, the entire tarball is extracted.
@@ -293,9 +315,17 @@ func Untar(source string, dest string, extractionDir string) error {
 			// Absolute targets are rebased against dest (treating dest as root),
 			// so container paths like /var/www/html/... are accepted.
 			// Relative targets are resolved against the symlink's parent directory.
+			//
+			// Tar Linkname strings are POSIX-style regardless of host OS, so
+			// filepath.IsAbs (which is host-OS-dependent) cannot be used to
+			// detect "absolute": on Windows it returns false for a leading
+			// "/" with no drive letter, which would skip rebasing entirely.
+			// isArchiveAbsolutePath/rebaseUnderDest handle both POSIX-style
+			// and native-Windows absolute forms explicitly and portably.
 			var resolvedTarget string
-			if filepath.IsAbs(file.Linkname) {
-				resolvedTarget = filepath.Join(dest, file.Linkname)
+			absoluteLinkTarget := isArchiveAbsolutePath(file.Linkname)
+			if absoluteLinkTarget {
+				resolvedTarget = rebaseUnderDest(dest, file.Linkname)
 			} else {
 				resolvedTarget = filepath.Join(fullPathDir, file.Linkname)
 			}
@@ -311,7 +341,7 @@ func Untar(source string, dest string, extractionDir string) error {
 			// raw file.Linkname, otherwise the symlink would point outside dest on disk
 			// even though the check above validated the rebased path.
 			linkTarget := file.Linkname
-			if filepath.IsAbs(file.Linkname) {
+			if absoluteLinkTarget {
 				linkTarget = resolvedTarget
 			}
 			err = os.Symlink(linkTarget, fullPath)

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -155,10 +155,14 @@ func UnXz(source string, destDirectory string) error {
 }
 
 // isArchiveAbsolutePath reports whether a tar entry's Linkname is an absolute
-// path. Tar Linkname strings are POSIX-style regardless of host OS, so
-// filepath.IsAbs alone is not enough: on Windows it returns false for a
-// leading "/" with no drive letter, even though that is rooted and must be
-// rejected the same as any other absolute form.
+// path, in any spelling. Linkname comes from the archive being extracted, so
+// it cannot be trusted to follow tar's usual POSIX-style ("/") convention;
+// filepath.IsAbs alone is not enough to catch every case, since its notion
+// of "absolute" is host-OS-dependent: on Windows it returns false for a
+// leading "/" or "\" with no drive letter, even though the resulting symlink
+// still resolves rooted (to the current drive) rather than confined under
+// dest. Checking all three forms explicitly catches an absolute target
+// regardless of which spelling the archive uses or which OS is running.
 func isArchiveAbsolutePath(p string) bool {
 	return strings.HasPrefix(p, "/") || strings.HasPrefix(p, `\`) || filepath.IsAbs(p)
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/archive"
@@ -225,33 +224,27 @@ func TestUntarPathTraversal(t *testing.T) {
 	})
 
 	t.Run("absolute_symlink_target_with_traversal", func(t *testing.T) {
-		// Absolute path with .. traversal that escapes dest even when rebased
 		tarball := buildTar("link.txt", "/../../../etc/passwd", tar.TypeSymlink)
 		err := archive.Untar(tarball, destDir, "")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "escapes destination directory")
+		require.Contains(t, err.Error(), "is absolute, which is not allowed")
 	})
 
-	t.Run("absolute_symlink_container_path_allowed", func(t *testing.T) {
-		// Absolute container paths like /var/www/html/... should be allowed,
-		// but the symlink actually created on disk must be rebased under dest,
-		// not point at the raw absolute path (which would land outside dest).
+	t.Run("absolute_symlink_target_rejected", func(t *testing.T) {
+		// Absolute symlink targets are rejected outright, even ones shaped
+		// like container paths (e.g. /var/www/html/...). There is no safe
+		// general way to let one through: rebasing it under dest is what
+		// caused this function's history of escape bugs, see GHSA-9hq4-hm3j-jmph.
 		tarball := buildTar("link.txt", "/var/www/html/lib/web/underscore.js", tar.TypeSymlink)
 		err := archive.Untar(tarball, destDir, "")
-		require.NoError(t, err)
-
-		linkPath := filepath.Join(destDir, "link.txt")
-		linkTarget, err := os.Readlink(linkPath)
-		require.NoError(t, err)
-		require.True(t, strings.HasPrefix(filepath.Clean(linkTarget), filepath.Clean(destDir)),
-			"symlink target %q must be rebased under dest %q, not point at the raw absolute path", linkTarget, destDir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is absolute, which is not allowed")
 	})
 
 	t.Run("absolute_symlink_write_through_escape", func(t *testing.T) {
 		// Regression test for GHSA-9hq4-hm3j-jmph: an absolute symlink target
-		// passed the (rebased) escape check but was created on disk pointing
-		// at the raw absolute target, so a follow-up regular-file entry that
-		// traversed the symlink could write outside dest.
+		// must be rejected outright, since a follow-up regular-file entry
+		// that traverses it could otherwise write outside dest.
 		victimDir := t.TempDir()
 		victimFile := filepath.Join(victimDir, "pwned.txt")
 		require.NoError(t, os.WriteFile(victimFile, []byte("original"), 0644))
@@ -281,7 +274,9 @@ func TestUntarPathTraversal(t *testing.T) {
 
 		writeThroughDest := testcommon.CreateTmpDir("absolute_symlink_write_through_escape")
 		t.Cleanup(func() { _ = os.RemoveAll(writeThroughDest) })
-		_ = archive.Untar(f.Name(), writeThroughDest, "")
+		err = archive.Untar(f.Name(), writeThroughDest, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is absolute, which is not allowed")
 
 		data, err := os.ReadFile(victimFile)
 		require.NoError(t, err)

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/archive"
@@ -232,10 +233,60 @@ func TestUntarPathTraversal(t *testing.T) {
 	})
 
 	t.Run("absolute_symlink_container_path_allowed", func(t *testing.T) {
-		// Absolute container paths like /var/www/html/... should be allowed
+		// Absolute container paths like /var/www/html/... should be allowed,
+		// but the symlink actually created on disk must be rebased under dest,
+		// not point at the raw absolute path (which would land outside dest).
 		tarball := buildTar("link.txt", "/var/www/html/lib/web/underscore.js", tar.TypeSymlink)
 		err := archive.Untar(tarball, destDir, "")
 		require.NoError(t, err)
+
+		linkPath := filepath.Join(destDir, "link.txt")
+		linkTarget, err := os.Readlink(linkPath)
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(filepath.Clean(linkTarget), filepath.Clean(destDir)),
+			"symlink target %q must be rebased under dest %q, not point at the raw absolute path", linkTarget, destDir)
+	})
+
+	t.Run("absolute_symlink_write_through_escape", func(t *testing.T) {
+		// Regression test for GHSA-9hq4-hm3j-jmph: an absolute symlink target
+		// passed the (rebased) escape check but was created on disk pointing
+		// at the raw absolute target, so a follow-up regular-file entry that
+		// traversed the symlink could write outside dest.
+		victimDir := t.TempDir()
+		victimFile := filepath.Join(victimDir, "pwned.txt")
+		require.NoError(t, os.WriteFile(victimFile, []byte("original"), 0644))
+
+		f, err := os.CreateTemp("", "absolute_symlink_write_through_escape_*.tar")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(f.Name()) })
+
+		tw := tar.NewWriter(f)
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name:     "link",
+			Typeflag: tar.TypeSymlink,
+			Linkname: victimDir,
+			Mode:     0777,
+		}))
+		content := []byte("OWNED-BY-ARCHIVE")
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name:     "link/pwned.txt",
+			Typeflag: tar.TypeReg,
+			Size:     int64(len(content)),
+			Mode:     0644,
+		}))
+		_, err = tw.Write(content)
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+		require.NoError(t, f.Close())
+
+		writeThroughDest := testcommon.CreateTmpDir("absolute_symlink_write_through_escape")
+		t.Cleanup(func() { _ = os.RemoveAll(writeThroughDest) })
+		_ = archive.Untar(f.Name(), writeThroughDest, "")
+
+		data, err := os.ReadFile(victimFile)
+		require.NoError(t, err)
+		require.Equal(t, "original", string(data),
+			"host file outside dest must not be overwritten via a planted symlink")
 	})
 }
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -155,13 +155,13 @@ var (
 		// Full docs and management/upgrade at https://github.com/ddev/test-magento2
 		{
 			Name: "testpkgmagento2",
-			// echo "This is a junk" >pub/junk.txt && tar -czf .tarballs/testpkgmagento2_code_no_media.magento2.4.6-p4.tgz --exclude=.ddev --exclude=var --exclude=pub/media --exclude=.tarballs --exclude=app/etc/env.php .
-			SourceURL:                     "https://github.com/ddev/test-magento2/releases/download/2.4.6-p4/testpkgmagento2_code_no_media.magento2.4.6-p4.tgz",
+			// echo "This is a junk" >pub/junk.txt && tar -czf .tarballs/testpkgmagento2_code_no_media.magento2.4.9.tgz --exclude=.ddev --exclude=var --exclude=pub/media --exclude=.tarballs --exclude=app/etc/env.php .
+			SourceURL:                     "https://github.com/ddev/test-magento2/releases/download/2.4.9/testpkgmagento2_code_no_media.magento2.4.9.tgz",
 			ArchiveInternalExtractionPath: "",
-			// ddev export-db --gzip=false --file=.tarballs/db.sql && tar -czf .tarballs/testpkgmagento2.magento2.4.6-p4.db.tgz -C .tarballs db.sql
-			DBTarURL: "https://github.com/ddev/test-magento2/releases/download/2.4.6-p4/testpkgmagento2.magento2.4.6-p4.db.tgz",
-			// tar -czf .tarballs/testpkgmagento2_files.magento2.4.6-p4.tgz -C pub/media .
-			FilesTarballURL:           "https://github.com/ddev/test-magento2/releases/download/2.4.6-p4/testpkgmagento2_files.magento2.4.6-p4.tgz",
+			// ddev export-db --gzip=false --file=.tarballs/db.sql && tar -czf .tarballs/testpkgmagento2.magento2.4.9.db.tgz -C .tarballs db.sql
+			DBTarURL: "https://github.com/ddev/test-magento2/releases/download/2.4.9/testpkgmagento2.magento2.4.9.db.tgz",
+			// tar -czf .tarballs/testpkgmagento2_files.magento2.4.9.tgz -C pub/media .
+			FilesTarballURL:           "https://github.com/ddev/test-magento2/releases/download/2.4.9/testpkgmagento2_files.magento2.4.9.tgz",
 			FullSiteTarballURL:        "",
 			Docroot:                   "pub",
 			Type:                      nodeps.AppTypeMagento2,

--- a/pkg/ddevapp/magento.go
+++ b/pkg/ddevapp/magento.go
@@ -165,9 +165,9 @@ func setMagento2SiteSettingsPaths(app *DdevApp) {
 //	return nil
 //}
 
-// Magento2 2.4.7 requires php8.2/3 and MariaDB 10.6
+// Magento2 2.4.9 requires PHP 8.4/8.5 and MariaDB 12.3 (recommended) or 11.8
 // https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/system-requirements.html
 func magento2ConfigOverrideAction(app *DdevApp) error {
-	app.Database = DatabaseDesc{Type: nodeps.MariaDB, Version: nodeps.MariaDB106}
+	app.Database = DatabaseDesc{Type: nodeps.MariaDB, Version: nodeps.MariaDB123}
 	return nil
 }


### PR DESCRIPTION
## The Issue

Follow-up to CVE-2026-32885 / GHSA-9hq4-hm3j-jmph.

The ZipSlip fix in 05cbe2997 (#8213) added a symlink-target escape check to `Untar`, but for an absolute (rooted) `Linkname` it validated a copy rebased under `dest` while creating the symlink on disk with the raw, un-rebased target. The value that was validated was not the value that was written: a malicious archive could plant a host-absolute symlink that passed the check, and a follow-up regular-file entry that traversed that symlink could overwrite arbitrary files outside `dest` (e.g. `$HOME` rc-files), reachable via `ddev add-on get <repo|url>` and `ddev import-db`/`import-files`.

Attempting to fix this by rebasing absolute targets under `dest` (rather than rejecting them) turned out to be its own recurring source of bugs: a Windows CI run surfaced a second escape, because `filepath.IsAbs` is host-OS-dependent and doesn't recognize a POSIX-style rooted path (`/var/www/...`) as absolute on Windows, so that rebasing was silently skipped there too.

## How This PR Solves The Issue

Rather than continue trying to safely rebase absolute symlink targets under `dest`, `Untar` now rejects any rooted/absolute `Linkname` outright — a dev-environment archive has no legitimate need to plant one. `isArchiveAbsolutePath` detects a rooted target in any spelling (POSIX `/...`, bare-rooted `\...`, or a native drive-lettered/UNC path), regardless of which OS is running, and `Untar` returns an error for it instead of trying to place it somewhere safe. Only relative symlink targets are extracted, resolved against and confined to the symlink's own parent directory, as before.

## Manual Testing Instructions

1. Build a tar archive containing a `tar.TypeSymlink` entry with a rooted `Linkname` (e.g. an absolute path outside the extraction directory), optionally followed by a `tar.TypeReg` entry whose name traverses that symlink.
2. Run `archive.Untar(tarball, dest, "")`.
3. Before this PR: the symlink is created pointing at the raw absolute target, and a follow-up entry traversing it can write
   outside `dest`. After this PR: `Untar` returns an error for the rooted symlink entry and nothing is written outside `dest`.

## Automated Testing Overview

In `pkg/archive/archive_test.go`, `TestUntarPathTraversal`:

- `absolute_symlink_target_with_traversal` / `absolute_symlink_target_rejected`: any rooted symlink target — including one shaped like a container path (`/var/www/html/...`) that a prior version of this fix special-cased as allowed — is now rejected outright.
- `absolute_symlink_write_through_escape`: regression test reproducing the advisory's PoC (planted rooted symlink + traversing regular-file entry). Verified this fails against the pre-fix code (host file overwritten) and now passes: `Untar` errors out on the rooted symlink entry before the write-through can happen.

`go test ./pkg/archive/...` and `make staticrequired` pass. Cross-compiled and vetted for `GOOS=windows` (no Windows machine available locally); verification of the actual Windows path handling depends on the `ddev-windows-mutagen` Buildkite pipeline.

## Release/Deployment Notes

Security fix for GHSA-9hq4-hm3j-jmph. Behavior change: tar archives containing a symlink with a rooted/absolute target will now fail to extract with an explicit error, instead of being silently rebased under the destination directory. No code elsewhere in the repository was found to depend on absolute symlink targets surviving extraction.

---

Moved from a private fork because merging a security advisory ignores the configured merge strategy and commit message:

- https://github.com/orgs/community/discussions/200267