### PR TITLE
test(silverstripe): update fixture to test-silverstripe 6.2.2 (#8626) [skip ci]

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -274,14 +274,14 @@ var (
 		// 14: Silverstripe
 		{
 			Name:                          "TestPkgSilverstripe",
-			SourceURL:                     "https://github.com/ddev/test-silverstripe/releases/download/1.0.0/silverstripe-base.tar.gz",
-			DBTarURL:                      "https://github.com/ddev/test-silverstripe/releases/download/1.0.0/db.tar.gz",
+			SourceURL:                     "https://github.com/ddev/test-silverstripe/releases/download/6.2.2/silverstripe-base.tar.gz",
+			DBTarURL:                      "https://github.com/ddev/test-silverstripe/releases/download/6.2.2/db.tar.gz",
 			ArchiveInternalExtractionPath: "",
 			FullSiteTarballURL:            "",
 			FilesTarballURL:               "",
 			Docroot:                       "public",
 			Type:                          nodeps.AppTypeSilverstripe,
-			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "<meta name=\"generator\" content=\"Silverstripe CMS 5.0\">"},
+			DynamicURI:                    testcommon.URIWithExpect{URI: "/", Expect: "<meta name=\"generator\" content=\"Silverstripe CMS 6.2\">"},
 		},
 		// 15: CakePHP
 		{


### PR DESCRIPTION
## The Issue

The `TestPkgSilverstripe` fixture in `TestDdevFullSiteSetup` still pointed at
the `test-silverstripe` repo's stale `1.0.0` release (from 2023), and the
test's expected generator meta tag (`Silverstripe CMS 5.0`) no longer
matches. The `test-silverstripe` fixture repo has since been upgraded to
Silverstripe CMS 6 and a new `6.2.2` release was cut with fresh
`silverstripe-base.tar.gz`/`db.tar.gz` artifacts (see
https://github.com/ddev/test-silverstripe/releases/tag/6.2.2).

## How This PR Solves The Issue

Updated `pkg/ddevapp/ddevapp_test.go`'s Silverstripe test case to:

- Point `SourceURL` and `DBTarURL` at the `6.2.2` release tag.
- Update the expected `DynamicURI` generator meta tag to
  `Silverstripe CMS 6.2`, matching the `silverstripe/framework` version
  (`6.2.2`) actually locked in the new fixture's `composer.lock` — the CMS
  computes this meta tag at runtime from the installed framework's
  major.minor version.

No changes were needed in `pkg/ddevapp/silverstripe.go`; nothing there is
version-pinned.

## Manual Testing Instructions

1. `GOTEST_SHORT=14 DDEV_RUN_TEST_ANYWAY=true go test -v -run TestDdevFullSiteSetup ./pkg/ddevapp/...`
2. Confirm the Silverstripe fixture downloads, starts, and the homepage
   response contains `<meta name="generator" content="Silverstripe CMS 6.2">`.

## Automated Testing Overview

`TestDdevFullSiteSetup` (case 14, Silverstripe) now runs against the new
fixture artifacts and passes.

## Release/Deployment Notes

Test-only change; no impact on released DDEV behavior.
