### PR TITLE
docs(quickstart): pin quickstart to Symfony LTS, fixes symfony.bats failures [skip ci]

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2932,10 +2932,10 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev start
     ```
 
-    Install Symfony via Composer:
+    Install Symfony via Composer, pinned to the current [long-term support (LTS) release](https://symfony.com/doc/current/setup.html#symfony-lts-versions):
 
     ```bash
-    ddev composer create-project symfony/skeleton
+    ddev composer create-project symfony/skeleton:"7.4.*"
     ddev composer require webapp
     # When it asks if you want to include docker configuration, say "no" with "x"
     ```
@@ -2956,7 +2956,7 @@ DDEV automatically updates or creates the `.env.local` file with the database in
         mkdir -p my-symfony-composer-site && cd my-symfony-composer-site
         ddev config --project-type=symfony --docroot=public
         ddev start -y
-        ddev composer create-project symfony/skeleton
+        ddev composer create-project symfony/skeleton:"7.4.*"
         ddev composer require webapp
         ddev launch
         EOF
@@ -2971,7 +2971,8 @@ DDEV automatically updates or creates the `.env.local` file with the database in
     ddev config --project-type=symfony --docroot=public
     ddev start
     ddev exec symfony check:requirements
-    ddev exec symfony new temp --webapp
+    # --version=lts always resolves to the current long-term support release
+    ddev exec symfony new temp --webapp --version=lts
     # 'symfony new' can't install in the current directory right away,
     # so we use 'rsync' to move the installed files one level up
     ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'

--- a/docs/tests/symfony.bats
+++ b/docs/tests/symfony.bats
@@ -17,13 +17,16 @@ teardown() {
   run mkdir -p ${PROJNAME} && cd ${PROJNAME}
   assert_success
 
-  run ddev config --project-type=symfony --docroot=public --php-version=8.3
+  run ddev config --project-type=symfony --docroot=public
   assert_success
 
   run ddev start -y
   assert_success
 
-  run ddev composer create-project symfony/skeleton
+  # Composer has no movable "lts" alias (unlike symfony-cli's --version=lts
+  # below), so this pins to the current LTS branch explicitly. See
+  # https://symfony.com/releases for the current LTS when this needs bumping.
+  run ddev composer create-project symfony/skeleton:"7.4.*"
   assert_success
 
   run bash -c 'printf "x\n" | ddev composer require webapp'
@@ -60,7 +63,9 @@ teardown() {
   run ddev exec symfony check:requirements
   assert_success
 
-  run ddev exec symfony new temp --webapp
+  # --version=lts always resolves to the current long-term support release,
+  # see https://symfony.com/doc/current/setup.html#symfony-lts-versions.
+  run ddev exec symfony new temp --webapp --version=lts
   assert_success
 
   run ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'


### PR DESCRIPTION
## Symfony quickstart failure 

Another Symfony release, another quickstart failure.

The Symfony quickstart bats tests began failing in CI, see https://github.com/ddev/ddev/actions/runs/30475681424/job/90656671792

Symfony 8.1 was published (2026-05-29) but parts of its own ecosystem have not caught up, so installing the webapp pack on top of a Symfony 8.1 skeleton fails to resolve:

    symfony/http-kernel v8.1.2 conflicts with symfony/serializer v8.1.1
    symfony/monolog-bundle[v3.11.0, ...] require symfony/config ^6.4 || ^7.0
      -> but the package is fixed to v8.1.2 (lock file version) by a
         partial update

Both quickstart paths hit this once Symfony 8.1 is selected:

- `symfony new temp --webapp` (Symfony CLI) picks the latest release, so it failed outright.
- `ddev composer create-project symfony/skeleton` + `ddev composer require webapp` fails the same way. It was only passing because the test pinned `--php-version=8.3`; Symfony 8's skeleton requires PHP >=8.4, so the PHP pin incidentally forced the 7.4 branch. That pin was a workaround for the same class of breakage at the Symfony 8.0 release (271f5cf49), and its explanatory TODO comment was later dropped, leaving it looking intentional.

Pin both quickstart paths to the current Symfony LTS release, which is Symfony's own documented recommendation for stability (https://symfony.com/doc/current/setup.html#symfony-lts-versions), rather than chasing the latest release:

- Symfony CLI: `symfony new temp --webapp --version=lts`. The `lts` shortcut is resolved by symfony-cli at request time, so it needs no maintenance.
- Composer: `symfony/skeleton:"7.4.*"`. Composer has no movable `lts` alias (per the Symfony docs, the shortcut is symfony-cli only), so this is an explicit version that will need bumping when the next LTS ships in ~2 years. Comments point at https://symfony.com/releases for the current LTS.

The `--php-version=8.3` pin is removed from the Composer test so it now runs on DDEV's default PHP version. The PHP version was never the real lever here: the conflict is in Symfony's package graph, not a PHP compatibility gate.

Waiting for upstream was considered and rejected: the conflicting release has been out ~2 months with no tracking issue on symfony/webapp-pack, and the underlying cause is that the webapp install performs a partial Composer update that won't relax already-locked transitive deps (`composer require webapp -W` does succeed on 8.1), so there is no visible upstream ETA.

Composer path:

```bash
mkdir -p ~/tmp/my-symfony-composer-site && cd ~/tmp/my-symfony-composer-site
ddev config --project-type=symfony --docroot=public
ddev start -y
ddev composer create-project symfony/skeleton:"7.4.*"
printf "x\n" | ddev composer require webapp
curl -sk https://my-symfony-composer-site.ddev.site | grep '<title>'
```

Symfony CLI path:

```bash
mkdir -p ~/tmp/my-symfony-cli-site && cd ~/tmp/my-symfony-cli-site
ddev config --project-type=symfony --docroot=public
ddev start -y
ddev exec symfony check:requirements
ddev exec symfony new temp --webapp --version=lts
ddev exec 'rsync -rltgopD temp/ ./ && rm -rf temp'
curl -sk https://my-symfony-cli-site.ddev.site | grep '<title>'
```

Both should return `<title>Welcome to Symfony!</title>`, and `curl -sfI` should show `server: nginx` with `HTTP/2 404`.

`docs/tests/symfony.bats` covers both quickstart paths and is unchanged apart from the version pins; its existing assertions (launch URL, nginx header, HTTP/2 404, and homepage body strings) still apply. Both tests were run manually end-to-end against Symfony 7.4 on DDEV's default PHP 8.4 and pass.

Documentation and test-only change; no functional change to DDEV itself. Users following the quickstart get Symfony 7.4 LTS instead of the latest release. The Composer version string needs a manual bump when the next Symfony LTS ships.


Claude-Session: https://claude.ai/code/session_016Bdmp6Ta8tCiu5jZjpvTWj

