### PR TITLE
ci(podman): force k8s-file log driver to avoid conmon journald crash (#8630) [skip ci]

### DIFF
--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -84,10 +84,20 @@ EOF
   # Reload systemd
   systemctl --user daemon-reload
   # Set DNS
+  # Force k8s-file logging instead of the default journald: Homebrew's conmon
+  # bottle is built without journald support, so when podman picks journald
+  # (its default whenever the systemd journal is readable/writable) conmon
+  # fails with "Include journald in compilation path to log to systemd
+  # journal" (containers/conmon#348). Also force the file events logger for
+  # the same reason.
   mkdir -p ~/.config/containers/containers.conf.d
   cat << 'EOF' > ~/.config/containers/containers.conf.d/dns.conf
 [containers]
 dns_servers = ["1.1.1.1", "1.0.0.1"]
+log_driver = "k8s-file"
+
+[engine]
+events_logger = "file"
 EOF
   # https://github.com/containers/podman/blob/main/docs/tutorials/performance.md#choosing-a-storage-driver
   cat << 'EOF' > ~/.config/containers/storage.conf
@@ -167,6 +177,20 @@ EOF
   # Fix for Podman 6: "registries.conf must be in v2 format but is in v1"
   sudo tee /etc/containers/registries.conf > /dev/null <<EOF
 unqualified-search-registries = ["docker.io"]
+EOF
+  # Force k8s-file logging instead of the default journald: Homebrew's conmon
+  # bottle is built without journald support, so when podman picks journald
+  # (its default whenever the systemd journal is readable/writable) conmon
+  # fails with "Include journald in compilation path to log to systemd
+  # journal" (containers/conmon#348). Also force the file events logger for
+  # the same reason.
+  sudo mkdir -p /etc/containers/containers.conf.d
+  sudo tee /etc/containers/containers.conf.d/logging.conf > /dev/null <<EOF
+[containers]
+log_driver = "k8s-file"
+
+[engine]
+events_logger = "file"
 EOF
   # Reload systemd
   sudo systemctl daemon-reload


### PR DESCRIPTION
## The Issue

No tracked issue — found while investigating recurring, intermittent podman-rootless/podman-root CI failures, e.g.:

- https://github.com/ddev/ddev/actions/runs/30494242027/job/90719252589#step:9:330
- https://github.com/ddev/ddev/actions/runs/30494242109/job/90719255716
- https://github.com/ddev/ddev/actions/runs/30495321830/job/90722728846

All three fail at the same spot in `.github/workflows/linux-setup.sh`, on the very first `podman run` after rootless/root setup:

```
[conmon:e]: Include journald in compilation path to log to systemd journal
Error: conmon failed: exit status 1
##[error]Process completed with exit code 126.
```

## How This PR Might Solve The Issue

Podman's container `log_driver` defaults to `journald` only if the systemd journal looks readable/writable *at the moment podman checks* — otherwise it falls back to `k8s-file`. That check runs against the per-user systemd session that was just brought up seconds earlier (`systemctl --user enable --now podman.socket`), so whether the journal looks "ready" is a timing race, not a stable runner property — which is why the failure is intermittent and a re-run sometimes passes.

When podman does pick `journald`, it hands `-l journald` to conmon. The `conmon` binary from the Homebrew bottle installed in CI (`brew install podman`) was built without journald support (`USE_JOURNALD` unset), so it hits `#ifndef USE_JOURNALD` and exits fatally — matching [containers/conmon#348](https://github.com/containers/conmon/issues/348).

Rather than retry the race, this forces `log_driver = "k8s-file"` and `events_logger = "file"` in `containers.conf` for both the rootless and root podman setups, so podman never selects journald in CI.

This is CI/Homebrew-specific: the Linux install docs (`docs/content/users/install/docker-installation.md`) have users install Podman via `apt`/`dnf`, whose distro-built `conmon` packages compile with journald support, so end users following the docs shouldn't hit this. No doc changes included.

## Manual Testing Instructions

Not practically reproducible locally (the failure is a timing race tied to a fresh GitHub Actions runner's systemd user session). Verify via CI:

1. Watch the `Test Podman Rootless` and `Test Podman Root` workflow runs on this PR/branch.
2. Confirm the `Install Docker and deps (Linux)` step passes and `podman info`/`podman version` show `k8s-file` as the log driver.

## Automated Testing Overview

No new tests; this only changes CI environment setup (`.github/workflows/linux-setup.sh`). Confidence comes from the existing podman-rootless/podman-root CI jobs, which exercise the changed code path directly.

## Release/Deployment Notes

CI-only change; no impact on released DDEV behavior or end-user Podman setup.
