### PR TITLE
fix(settings): close file handles in TYPO3/Drupal settings writers (Traditional Windows test failures), for #8582 (#8632) [skip ci]

### DIFF
--- a/pkg/ddevapp/drupal.go
+++ b/pkg/ddevapp/drupal.go
@@ -209,11 +209,11 @@ func writeDrupalSettingsDdevPhp(settings *DrupalSettings, filePath string, app *
 	if err != nil {
 		return err
 	}
+	defer util.CheckClose(file)
 	err = t.Execute(file, settings)
 	if err != nil {
 		return err
 	}
-	util.CheckClose(file)
 	return nil
 }
 

--- a/pkg/ddevapp/typo3.go
+++ b/pkg/ddevapp/typo3.go
@@ -101,6 +101,7 @@ func writeTypo3SettingsFile(app *DdevApp) error {
 	if err != nil {
 		return err
 	}
+	defer util.CheckClose(f)
 
 	t, err := template.New("AdditionalConfiguration.php").ParseFS(bundledAssets, "typo3/AdditionalConfiguration.php")
 	if err != nil {


### PR DESCRIPTION
## The Issue

- Surfaced by the test added in #8594 (for #8582), but not caused by it

`writeTypo3SettingsFile()` in `typo3.go` opens `additional.php` with
`os.Create` and never closes the handle. That's from f1c406eed3 ("Add full
support for Postgresql, fixes #2187 (#3557)", 2022-02-07). #8594 didn't
touch the file-handle code — it only changed how the `settings` map is
built.

Linux/macOS allow deleting an open file, so the leak is invisible there. On
traditional Windows/NTFS the handle keeps the file locked, and
`t.TempDir()`'s cleanup hard-fails:

```text
=== RUN   TestWriteTypo3SettingsFileDBConfig/db_container_present
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat C:\Users\testbot\AppData\Local\Temp\TestWriteTypo3SettingsFileDBConfigdb_container_present156302439\001\config\system\additional.php: The process cannot access the file because it is being used by another process.
FAIL: TestWriteTypo3SettingsFileDBConfig (6.76s)
    --- FAIL: TestWriteTypo3SettingsFileDBConfig/db_container_present (1.94s)
    --- FAIL: TestWriteTypo3SettingsFileDBConfig/postgres_db_container (1.38s)
    --- FAIL: TestWriteTypo3SettingsFileDBConfig/db_container_omitted_in_project_config (1.98s)
    --- FAIL: TestWriteTypo3SettingsFileDBConfig/db_container_omitted_in_global_config (1.47s)
```

<https://buildkite.com/ddev/ddev-windows-mutagen/builds/6409#019fb070-a777-4ea0-868f-2d6b584669fd>

It stayed dormant for four years because nothing ever tried to delete the
file while the process still held it open — in normal use DDEV writes
`additional.php` and exits, and the OS reaps the handle. #8594 added
`TestWriteTypo3SettingsFileDBConfig`, the first test to call
`writeTypo3SettingsFile()` at all, and `t.TempDir()` cleanup does exactly
that. PRs also aren't currently tested against traditional Windows (NTFS).

## How This PR Solves The Issue

- `typo3.go`: add `defer util.CheckClose(f)` right after `os.Create`,
  matching every other settings writer (`wordpress.go`, `backdrop.go`, …).
- `drupal.go`: `writeDrupalSettingsDdevPhp` closes its handle only on the
  success path — if `t.Execute` fails, it leaks. From de3d471e5 (2018).
  Moved the close to a `defer`.

Checked every other `os.Create`/`os.OpenFile`/`os.Open` reachable from a
`t.TempDir()`-based test; all close correctly, so this is contained to
these two spots.

No test changes needed — closing the handles is the fix, and `t.TempDir()`
cleanup succeeds once nothing holds the file open. Leaving it as a hard
failure is what caught this in the first place.

## Manual Testing Instructions

1. Manually run the buildkite windows pipeline against this branch.

## Automated Testing Overview

No new tests — this is a resource-leak fix, not a behavior change. The
existing tests in `settings_omitdb_test.go` added by #8594 cover this code
path and now pass on Windows.

## Release/Deployment Notes

No user-facing impact. Fixes a Windows CI test failure.
