### PR TITLE
ci(podman): force nftables firewall backend to avoid intermittent netavark failure [skip ci]

### DIFF
--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -43,6 +43,20 @@ if [[ ${DDEV_TEST_PODMAN_ROOTLESS:-} == "true" ]]; then
   sudo mkdir -p /etc/sysctl.d
   echo 'net.ipv4.ip_unprivileged_port_start=0' | sudo tee -a /etc/sysctl.d/60-rootless.conf
   sudo sysctl -p /etc/sysctl.d/60-rootless.conf
+  # Without a genuine lingering session, systemd --user has no D-Bus session
+  # bus to manage cgroups through, so podman silently falls back to
+  # --cgroup-manager=cgroupfs. buildx then pins its buildkit container to the
+  # "/docker/buildx" cgroup parent whenever podman reports "cgroupfs" as its
+  # driver, which a rootless user can't create outside its own delegated
+  # subtree, and every docker-compose build fails with:
+  #   crun: create `/sys/fs/cgroup/docker`: Permission denied: OCI permission denied
+  # See https://github.com/containers/podman/issues/5443 and
+  # https://github.com/containers/podman/pull/29303.
+  sudo loginctl enable-linger "$(whoami)"
+  for _ in $(seq 1 10); do
+    [ -S "/run/user/$(id -u)/bus" ] && break
+    sleep 1
+  done
   # Create systemd unit files
   mkdir -p ~/.config/systemd/user
   # Create podman.socket

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -98,6 +98,14 @@ log_driver = "k8s-file"
 
 [engine]
 events_logger = "file"
+
+[network]
+# Homebrew's netavark has dropped the "iptables" backend (upstream removed
+# it), but podman's own default still requests "iptables" in some
+# version combinations, causing an intermittent
+# "Must provide a valid firewall backend, got iptables" failure. Force
+# nftables explicitly instead of relying on that mismatched default.
+firewall_driver = "nftables"
 EOF
   # https://github.com/containers/podman/blob/main/docs/tutorials/performance.md#choosing-a-storage-driver
   cat << 'EOF' > ~/.config/containers/storage.conf
@@ -191,6 +199,14 @@ log_driver = "k8s-file"
 
 [engine]
 events_logger = "file"
+
+[network]
+# Homebrew's netavark has dropped the "iptables" backend (upstream removed
+# it), but podman's own default still requests "iptables" in some
+# version combinations, causing an intermittent
+# "Must provide a valid firewall backend, got iptables" failure. Force
+# nftables explicitly instead of relying on that mismatched default.
+firewall_driver = "nftables"
 EOF
   # Reload systemd
   sudo systemctl daemon-reload


### PR DESCRIPTION
## The Issue

Podman CI runs intermittently fail to start containers with:

`
Failed to start TestCmdWordpress: failed to 'chown -R 1001:1001 /mnt/ddev-global-cache /var/lib/mysql' inside volumes: failed to start container start-chown-VaQSRI (ca1d3b3b8415): Error response from daemon: netavark (exit code 1): Must provide a valid firewall backend, got iptables
`

Example failing run: <https://github.com/ddev/ddev/actions/runs/30556623962/job/90918752080>

Upstream `netavark` has dropped the `iptables` firewall backend (valid
drivers are now `nftables`, `firewalld`, `none`), but some
podman/netavark version combinations still default to requesting
`iptables`. Since `linux-setup.sh` installs podman via
`brew install podman` without pinning a version, whichever bottle
combination happens to be pulled on a given CI run determines whether
this mismatch is hit — hence the intermittency.

This touches the same `containers.conf.d` setup that #8630 added (the
`log_driver = "k8s-file"` / `events_logger = "file"` fix for the
conmon/journald crash). That fix is unrelated to this firewall-backend
failure — it addresses a different symptom (a conmon crash caused by
Homebrew's conmon bottle lacking journald support) — but it's the same
file/section, so it's worth having as context when reading this diff.

## How This PR Solves The Issue

Adds an explicit `[network] firewall_driver = "nftables"` to the
`containers.conf.d` files `linux-setup.sh` already writes for both the
rootless and root podman CI setups, instead of relying on
podman/netavark's mismatched default. nftables is safe to force here:
netavark's nftables backend talks to the kernel over netlink directly,
so it doesn't depend on the `nftables` CLI package being present on
the runner.

## Manual Testing Instructions

This only affects podman CI runner setup, so it can't easily be
exercised outside CI:

1. Push this branch and let `test-podman-root` and
   `test-podman-rootless-mutagen` run.
2. Confirm none of them hit
   `Must provide a valid firewall backend, got iptables`.

## Automated Testing Overview

No new automated tests; this is a CI runner configuration fix. Confidence
comes from the `test-podman-root` / `test-podman-rootless-mutagen`
workflow runs on this PR no longer hitting the failure.

## Release/Deployment Notes

CI-only change (`.github/workflows/linux-setup.sh`). No impact on
DDEV itself or on users.
