### PR TITLE
ci(podman): enable lingering session for rootless podman to fix buildx cgroup failure [skip buildkite]

### DIFF
--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -43,6 +43,20 @@ if [[ ${DDEV_TEST_PODMAN_ROOTLESS:-} == "true" ]]; then
   sudo mkdir -p /etc/sysctl.d
   echo 'net.ipv4.ip_unprivileged_port_start=0' | sudo tee -a /etc/sysctl.d/60-rootless.conf
   sudo sysctl -p /etc/sysctl.d/60-rootless.conf
+  # Without a genuine lingering session, systemd --user has no D-Bus session
+  # bus to manage cgroups through, so podman silently falls back to
+  # --cgroup-manager=cgroupfs. buildx then pins its buildkit container to the
+  # "/docker/buildx" cgroup parent whenever podman reports "cgroupfs" as its
+  # driver, which a rootless user can't create outside its own delegated
+  # subtree, and every docker-compose build fails with:
+  #   crun: create `/sys/fs/cgroup/docker`: Permission denied: OCI permission denied
+  # See https://github.com/containers/podman/issues/5443 and
+  # https://github.com/containers/podman/pull/29303.
+  sudo loginctl enable-linger "$(whoami)"
+  for _ in $(seq 1 10); do
+    [ -S "/run/user/$(id -u)/bus" ] && break
+    sleep 1
+  done
   # Create systemd unit files
   mkdir -p ~/.config/systemd/user
   # Create podman.socket


### PR DESCRIPTION
## The Issue

`test-podman-rootless.yml` intermittently fails every `docker-compose build` step with:

`
docker-compose build failed: Error response from daemon: crun: create `/sys/fs/cgroup/docker`: Permission denied: OCI permission denied
`

Failing run/job: <https://github.com/ddev/ddev/actions/runs/30559267112/job/90927788110>
(hit while retesting #8633, but it's an unrelated, separate bug from that PR's
netavark firewall-backend fix — that fix is confirmed working in this same job's
log, no firewall error at all; the cgroup failure below is what's left.)

## How This PR Solves The Issue

`podman info` in the failing job's log shows `cgroupManager: cgroupfs`. That's
the trigger. Rootless podman falls back to `cgroupfs` whenever it can't reach
a systemd user D-Bus session bus to manage cgroups through systemd — and
`linux-setup.sh` starts podman's `systemd --user` units without ever
establishing a real lingering session for the runner user first, so there's
no session bus for it to find.

When podman reports `"cgroupfs"` as its cgroup driver over the Docker-compat
API, `buildx` pins its buildkit container to the `/docker/buildx` cgroup
parent, which a rootless user can't create outside its own delegated cgroup
subtree — hence the `Permission denied`.

Fix: run `sudo loginctl enable-linger "$(whoami)"` before podman's
`systemd --user` units start, and poll briefly for `/run/user/<uid>/bus` to
appear. That gives podman a genuine session bus so it picks
`--cgroup-manager=systemd` instead of falling back to `cgroupfs`.

### Where this fix came from

- [`containers/podman` troubleshooting.md](https://github.com/containers/podman/blob/main/troubleshooting.md) explicitly recommends `loginctl enable-linger <username>` before invoking podman in exactly this kind of non-interactive/headless session scenario.
- [containers/podman#5443](https://github.com/containers/podman/issues/5443), "podman warnings while rootless, falling back to `--cgroup-manager=cgroupfs`" — same fallback behavior, same underlying cause (no reachable session bus).
- [containers/podman#29303](https://github.com/containers/podman/pull/29303) — an **open, unmerged** upstream PR that would make podman report `"none"` instead of `"cgroupfs"` in this situation, which is what buildx's own compat-API check is actually tripping over (buildx pins to `/docker/buildx` only when it sees `"cgroupfs"`). Since it isn't merged, we can't rely on it and need our own fix.

## Manual Testing Instructions

CI-runner-setup only, can't be exercised outside CI:

1. Push this branch and let `test-podman-rootless.yml` run.
2. Confirm `podman info` in the job log now shows `cgroupManager: systemd`.
3. Confirm none of the `docker-compose build` steps hit `crun: create \`/sys/fs/cgroup/docker\`: Permission denied`.

## Automated Testing Overview

No new automated tests; this is a CI runner configuration fix. Confidence
comes from the `test-podman-rootless.yml` run on this PR no longer hitting
the failure.

## Release/Deployment Notes

CI-only change (`.github/workflows/linux-setup.sh`, rootless podman branch
only). No impact on DDEV itself or on users.
