### PR TITLE
fix(webserver): tolerate a stale non-FIFO /var/tmp/logpipe on container start (#8635) [skip ci]

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/pre-start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/pre-start.sh
@@ -11,7 +11,8 @@ set -eu -o pipefail
 
 logpipe=/var/tmp/logpipe
 if [[ ! -p ${logpipe} ]]; then
-    mkfifo ${logpipe}
+    rm -f "${logpipe}"
+    mkfifo "${logpipe}"
 fi
 
 # Kill process 1 + process group if this exist or fails

--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -144,7 +144,8 @@ ddev_custom_init_scripts
 # Make sure /var/tmp/logpipe gets logged; only for standalone non-ddev usages
 logpipe=/var/tmp/logpipe
 if [[ ! -p ${logpipe} ]]; then
-  mkfifo ${logpipe}
+  rm -f "${logpipe}"
+  mkfifo "${logpipe}"
   cat < ${logpipe} >/proc/1/fd/1 &
 fi
 

--- a/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-prod-scripts/start.sh
@@ -136,7 +136,8 @@ ddev_custom_init_scripts
 # Make sure /var/tmp/logpipe gets logged; only for standalone non-ddev usages
 logpipe=/var/tmp/logpipe
 if [[ ! -p ${logpipe} ]]; then
-  mkfifo ${logpipe}
+  rm -f "${logpipe}"
+  mkfifo "${logpipe}"
   cat < ${logpipe} >/proc/1/fd/1 &
 fi
 

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260729_rfay_mysql_97" // Note that this can be overridden by make
+var WebTag = "20260730_rfay_fix_logpipe_race" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- Related CI failure: https://github.com/ddev/ddev/actions/runs/30571913531/job/90970565670

The `all-project-types` job failed in `TestDbServer` with:

```text
+ set -eu -o pipefail
+ logpipe=/var/tmp/logpipe
+ [[ ! -p /var/tmp/logpipe ]]
+ mkfifo /var/tmp/logpipe
mkfifo: cannot create fifo '/var/tmp/logpipe': File exists
```

which made the `ddev-webserver` container exit immediately, so `ddev start`
timed out waiting for it to become healthy. A restart of the job made it
pass.

## How This PR Solves The Issue

The `ddev-webserver` container's actual startup command is `/pre-start.sh`
(set via `command: /pre-start.sh` in `app_compose_template.yaml`). Its only
job is to create a FIFO at `/var/tmp/logpipe` and `cat` it forever as PID 1;
DDEV's Go code later `docker exec`s `/start.sh` into the running container,
redirecting its output into that same pipe so it shows up in `docker logs`.
Both `start.sh` variants use the identical pattern for the same reason
(so `/var/tmp/logpipe` also works for non-DDEV/standalone container usage).

All three copies used a non-atomic check-then-create:

```bash
if [[ ! -p ${logpipe} ]]; then
    mkfifo ${logpipe}
fi
```

In the failing run, the test had just stopped/removed the
`ddev-TestPkgWordpress-web` container (finishing a mariadb 11.8 iteration)
and immediately recreated a brand-new container of the same name a couple
of seconds later for a mariadb 12.3 iteration. `/var/tmp` is only the
container's own writable layer (not a bind mount or named volume), so a
genuinely fresh container should never have anything at that path already.
The fact that something was there — and wasn't recognized as a valid FIFO —
points to a Docker/overlay2 storage-layer race on the GitHub-hosted runner,
where the previous container's writable layer wasn't fully torn down before
the new one (same name) was created, so it inherited stale leftover state.

This doesn't fix that underlying container-runtime race (which is outside
DDEV's control), but it makes the three scripts tolerant of it by removing
any stale non-pipe file before calling `mkfifo`:

```bash
if [[ ! -p ${logpipe} ]]; then
    rm -f "${logpipe}"
    mkfifo "${logpipe}"
fi
```

`WebTag` in `pkg/versionconstants/versionconstants.go` is bumped to match,
since the `ddev-webserver` container scripts changed.

## Manual Testing Instructions

1. `make linux_amd64` (or your platform) and confirm the build succeeds.
2. `ddev start` a project and confirm the web container comes up healthy as
   usual -- this is a defensive fix for a rare race, so normal startup is
   unaffected.
3. To directly exercise the fix, exec into a running web container and
   simulate the stale-file condition before a restart:
   ```
   docker exec ddev-<project>-web sh -c 'rm -f /var/tmp/logpipe && touch /var/tmp/logpipe'
   ddev restart
   ```
   Before this change, the container would fail to become healthy
   (`mkfifo: File exists`). After this change, it starts normally.

## Automated Testing Overview

No new automated test is added -- this addresses a rare Docker
storage-layer race on CI runners that isn't reliably reproducible in a
unit/integration test. Existing `ddevapp` integration tests (e.g.
`TestDbServer`) exercise the affected startup path on every run.

## Release/Deployment Notes

Bumps the `ddev-webserver` image tag (`WebTag`). No user-facing behavior
change under normal conditions; only affects the rare case where a stale
`/var/tmp/logpipe` file exists at container start.
