### PR TITLE
fix(docker): quiet per-layer image pull progress in non-interactive output, fixes #8624

### DIFF
--- a/pkg/dockerutil/docker_compose.go
+++ b/pkg/dockerutil/docker_compose.go
@@ -10,9 +10,11 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/output"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/docker/cli/cli"
@@ -54,14 +56,20 @@ func NewComposeServiceWithStreams(stdout, stderr io.Writer) (context.Context, ap
 		return nil, nil, err
 	}
 	var ep api.EventProcessor
-	if !output.JSONOutput && isatty.IsTerminal(os.Stdout.Fd()) {
+	switch {
+	case !output.JSONOutput && isatty.IsTerminal(os.Stdout.Fd()):
 		ep = display.Full(stdout, stderr, false)
-	} else {
-		progressOut := output.UserErr.Out
-		if output.JSONOutput {
-			progressOut = &output.JSONProgressWriter{}
-		}
-		ep = display.Plain(progressOut)
+	case output.JSONOutput:
+		ep = display.Plain(&output.JSONProgressWriter{})
+	case globalconfig.DdevDebug:
+		// Explicit opt-in to full per-layer progress verbosity even without a terminal.
+		ep = display.Plain(output.UserErr.Out)
+	default:
+		// Non-interactive output (CI, coder.ddev.com, piped output) with display.Plain
+		// echoes every layer download/extract progress tick, flooding logs with
+		// hundreds of lines per image. Report only the final status of each
+		// top-level resource instead.
+		ep = newQuietEventProcessor(output.UserErr.Out)
 	}
 	opts := []compose.Option{
 		compose.WithOutputStream(stdout),
@@ -71,6 +79,42 @@ func NewComposeServiceWithStreams(stdout, stderr io.Writer) (context.Context, ap
 	svc, err := compose.NewComposeService(dm.cli, opts...)
 	return dm.goContext, svc, err
 }
+
+// quietEventProcessor implements api.EventProcessor, reporting only the final
+// Done/Error/Warning status of each top-level resource (an image pull, a
+// container, ...) and suppressing the per-layer sub-events (ParentID set)
+// that account for most of display.Plain's output volume.
+type quietEventProcessor struct {
+	out      io.Writer
+	mu       sync.Mutex
+	reported map[string]bool
+}
+
+func newQuietEventProcessor(out io.Writer) *quietEventProcessor {
+	return &quietEventProcessor{out: out, reported: map[string]bool{}}
+}
+
+func (q *quietEventProcessor) Start(_ context.Context, _ string) {}
+
+func (q *quietEventProcessor) On(events ...api.Resource) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for _, e := range events {
+		if e.ParentID != "" {
+			continue
+		}
+		switch e.Status {
+		case api.Done, api.Error, api.Warning:
+			if q.reported[e.ID] {
+				continue
+			}
+			q.reported[e.ID] = true
+			_, _ = fmt.Fprintln(q.out, e.ID, e.Text, e.Details)
+		}
+	}
+}
+
+func (q *quietEventProcessor) Done(_ string, _ bool) {}
 
 // ExitCodeToError converts the (exitCode, err) return of api.Compose.Exec /
 // RunOneOffContainer into a single error usable with errors.As(&cli.StatusError{}).

--- a/pkg/dockerutil/docker_compose_internal_test.go
+++ b/pkg/dockerutil/docker_compose_internal_test.go
@@ -2,6 +2,7 @@ package dockerutil
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,6 +94,36 @@ func TestProgressOptsPlainWriterRouting(t *testing.T) {
 
 	require.Contains(t, buf.String(), "routing-check",
 		"display.Plain must write events to the writer it was constructed with")
+}
+
+// TestQuietEventProcessorSuppressesSubEvents verifies that quietEventProcessor
+// drops per-layer sub-events (ParentID set) and in-progress top-level events,
+// only reporting a resource's final Done/Error/Warning status once.
+func TestQuietEventProcessorSuppressesSubEvents(t *testing.T) {
+	var buf bytes.Buffer
+	ep := newQuietEventProcessor(&buf)
+
+	ep.On(
+		// Sub-event (layer download progress) must be dropped entirely.
+		api.Resource{ID: "sha256:layer", ParentID: "ddev/ddev-webserver:latest", Status: api.Working, Text: "Downloading", Details: "45%"},
+		// In-progress top-level event must be dropped.
+		api.Resource{ID: "ddev/ddev-webserver:latest", Status: api.Working, Text: "Pulling"},
+		// Final top-level event must be reported.
+		api.Resource{ID: "ddev/ddev-webserver:latest", Status: api.Done, Text: "Pulled"},
+		// A repeat of the same final event must not be reported twice.
+		api.Resource{ID: "ddev/ddev-webserver:latest", Status: api.Done, Text: "Pulled"},
+		// A different top-level resource erroring out must be reported.
+		api.Resource{ID: "ddev/ddev-dbserver:latest", Status: api.Error, Text: "Error", Details: "pull access denied"},
+	)
+
+	out := buf.String()
+	require.NotContains(t, out, "Downloading", "layer sub-events must be suppressed")
+	require.NotContains(t, out, "Pulling", "in-progress top-level events must be suppressed")
+	require.Equal(t, 1, strings.Count(out, "ddev/ddev-webserver:latest"),
+		"expected exactly one reported line for the webserver image")
+	require.Contains(t, out, "ddev/ddev-webserver:latest Pulled")
+	require.Contains(t, out, "ddev/ddev-dbserver:latest Error")
+	require.Contains(t, out, "pull access denied")
 }
 
 // TestSuppressLogrusFormatterDirect exercises the formatter installed at


### PR DESCRIPTION
See https://github.com/ddev/coder-ddev/pull/192 for the motivating case — image pull noise was drowning out useful output there, which is what prompted picking this up now.

## The Issue

- Fixes #8624

`ddev utility download-images` (and any pull that happens outside a real terminal — CI, coder.ddev.com, piped output) is really noisy: it echoes a line for every layer download/extract progress tick, so a single image pull can produce hundreds of useless lines. The only useful information is the overall per-image result and any errors.

## How This PR Solves The Issue

`dockerutil.NewComposeServiceWithStreams` picks the compose `EventProcessor` used for all compose operations (including pulls). It already used `display.Full` (the pretty interactive progress UI) when stdout is a terminal, but fell back to `display.Plain` otherwise, which logs every raw compose event including per-layer sub-progress.

This PR adds a `quietEventProcessor` that drops per-layer sub-events (`ParentID` set) and in-progress top-level events, reporting only each top-level resource's final `Done`/`Error`/`Warning` line once. `NewComposeServiceWithStreams` now uses it by default whenever stdout isn't a terminal:

- Interactive TTY sessions are unaffected — still get `display.Full`.
- `--json-output` mode is unaffected — still `display.Plain` with the JSON writer.
- `DDEV_DEBUG=true` opts back into full `display.Plain` verbosity for troubleshooting.

## Manual Testing Instructions

1. `make` to build `ddev`.
2. Run a pull piped through `cat` to force non-TTY output, e.g.:

   ```bash
   ddev utility download-images --all 2>&1 | cat
   ```

   Output should show only one line per image (`Pulled` or an error), not per-layer progress.
3. Run the same command in an interactive terminal (no pipe) — the existing pretty progress UI should be unchanged.
4. Run with `DDEV_DEBUG=true` piped through `cat` — full per-layer verbose output should return.

## Automated Testing Overview

Added `TestQuietEventProcessorSuppressesSubEvents` in `pkg/dockerutil/docker_compose_internal_test.go`, which feeds `quietEventProcessor` a mix of sub-events, in-progress events, duplicate final events, and an error event, and asserts only the deduplicated final lines are written.

## Release/Deployment Notes

No config or behavior changes for interactive use. Non-interactive/CI users will see much less pull output by default; `DDEV_DEBUG=true` restores the previous verbose behavior if needed.
