### PR TITLE
test(router): make TestUseEphemeralPort resilient to host port races, fixes #8293 (#8638) [skip ci]

### DIFF
--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -1,6 +1,7 @@
 package ddevapp_test
 
 import (
+	"fmt"
 	"math/rand"
 	"net"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
@@ -196,6 +198,50 @@ func TestAllocateAvailablePortForRouter(t *testing.T) {
 	require.Equal(t, startPort+3, port)
 }
 
+// isDockerHostPortRaceError detects a Docker-level host port bind collision.
+//
+// The db and web services publish some ports with no fixed host port
+// (for example "127.0.0.1::3306"), so Docker picks a host port from the kernel's
+// local port range (32768-60999 on Linux). Docker does not reserve that port, and
+// under rootless Docker the bind happens later still, in RootlessKit's port
+// manager. So the chosen port can be taken by an unrelated socket, or not yet
+// released by a container that was just removed, by the time the bind runs.
+//
+// This is unrelated to DDEV's own ephemeral router port allocation; it is a
+// property of the environment, so retrying is the appropriate response.
+func isDockerHostPortRaceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	// rootless Docker/Podman via RootlessKit, and rootful Docker, word this differently.
+	return strings.Contains(msg, "address already in use") ||
+		strings.Contains(msg, "port is already allocated")
+}
+
+// startRetryingHostPortRace calls app.Start(), retrying with a short backoff if it
+// hits isDockerHostPortRaceError, since the port holder normally releases within a
+// second or two and the next attempt draws a different random host port.
+//
+// It deliberately does not call app.Stop() between attempts: Stop() clears
+// ddevapp.EphemeralRouterPortsAssigned, which would let a later project be handed
+// an ephemeral router port already bound by the router for an earlier project.
+func startRetryingHostPortRace(t *testing.T, app *ddevapp.DdevApp) error {
+	const attempts = 3
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		err = app.Start()
+		if err == nil || !isDockerHostPortRaceError(err) {
+			return err
+		}
+		if attempt < attempts {
+			t.Logf("app.Start() attempt %d/%d hit a Docker host port collision, retrying: %v", attempt, attempts, err)
+			time.Sleep(2 * time.Second)
+		}
+	}
+	return err
+}
+
 // Test that the app assigns an ephemeral port if the default one is not available.
 func TestUseEphemeralPort(t *testing.T) {
 	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && (dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop()) {
@@ -249,35 +295,42 @@ func TestUseEphemeralPort(t *testing.T) {
 		_ = dockerutil.RemoveContainer(nodeps.RouterContainer)
 	})
 
-	for i, app := range apps {
-		// Predict which ephemeral ports the apps will use by using guess from starting point
-		// This is fragile, only works if no other projects are running and holding open the earlier ports
-		expectedEphemeralHTTPPort := ddevapp.MinEphemeralPort + i*4
-		expectedEphemeralHTTPSPort := ddevapp.MinEphemeralPort + i*4 + 1
+	// Tracks ephemeral ports already handed out, so we can verify each project gets
+	// its own. Maps port number to a description of what claimed it.
+	assignedPorts := map[int]string{}
 
-		err := app.Start()
+	for i, app := range apps {
+		err := startRetryingHostPortRace(t, app)
 		require.NoError(t, err)
 
 		// Get a new copy of the app to make sure we have up-to-date port information
 		app, err = ddevapp.NewApp(app.GetAppRoot(), true)
 		require.NoError(t, err)
 
-		// app1 will not use the configured target ports, uses the assigned ephemeral ports.
+		// The project must not use the configured target ports, since those are occupied.
 		require.NotEqual(t, targetHTTPPort, app.GetPrimaryRouterHTTPPort())
 		require.NotEqual(t, targetHTTPSPort, app.GetPrimaryRouterHTTPSPort())
 
-		// Allow a margin of +2 for ephemeral port checks due to flakiness
-		actualHTTPPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPPort())
-		require.NoError(t, err)
-		require.Condition(t, func() bool {
-			return actualHTTPPort >= expectedEphemeralHTTPPort && actualHTTPPort <= expectedEphemeralHTTPPort+2
-		}, "HTTP port must be between %d and %d, got %d", expectedEphemeralHTTPPort, expectedEphemeralHTTPPort+2, actualHTTPPort)
-
-		actualHTTPSPort, err := strconv.Atoi(app.GetPrimaryRouterHTTPSPort())
-		require.NoError(t, err)
-		require.Condition(t, func() bool {
-			return actualHTTPSPort >= expectedEphemeralHTTPSPort && actualHTTPSPort <= expectedEphemeralHTTPSPort+2
-		}, "HTTPS port must be between %d and %d, got %d", expectedEphemeralHTTPSPort, expectedEphemeralHTTPSPort+2, actualHTTPSPort)
+		// Don't predict the exact port numbers. Which ephemeral port a project lands on
+		// depends on what else on the machine happens to hold ports in the range at that
+		// moment, so all that matters is that each replacement port is in the ephemeral
+		// range and is not one already given to another project. That the port actually
+		// works is proven by the content checks below.
+		for _, p := range []struct{ scheme, port string }{
+			{"HTTP", app.GetPrimaryRouterHTTPPort()},
+			{"HTTPS", app.GetPrimaryRouterHTTPSPort()},
+		} {
+			portNum, err := strconv.Atoi(p.port)
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, portNum, ddevapp.MinEphemeralPort,
+				"app %d (%s) %s port %d is below the ephemeral range", i, app.Name, p.scheme, portNum)
+			require.LessOrEqual(t, portNum, ddevapp.MaxEphemeralPort,
+				"app %d (%s) %s port %d is above the ephemeral range", i, app.Name, p.scheme, portNum)
+			claimant := fmt.Sprintf("app %d (%s) %s", i, app.Name, p.scheme)
+			require.NotContains(t, assignedPorts, portNum,
+				"%s got port %d, which was already assigned to %s", claimant, portNum, assignedPorts[portNum])
+			assignedPorts[portNum] = claimant
+		}
 
 		// Make sure that both http and https URLs have proper content
 		testcommon.AssertLocalHTTPContent(t, app.GetHTTPURL(), testString,


### PR DESCRIPTION
## The Issue

- Fixes #8293

Seen as intermittent CI failures in multiple environments, including GitHub Actions and Buildkite, for example [this run](https://github.com/ddev/ddev/actions/runs/30582029761/job/91004397529):

```text
router_test.go:259:
    Error: Received unexpected error:
    Error response from daemon: failed to set up container networking:
    driver failed programming external connectivity on endpoint
    ddev-TestUseEphemeralPortsite2...-db: error while calling RootlessKit
    PortManager.AddPort(): listen tcp4 127.0.0.1:33336: bind: address
    already in use
```

There are two separate sources of flakiness here:

1. **The failure above is at `app.Start()`, on a host port DDEV never chose.** The db service publishes `{{ .DockerIP }}:$DDEV_HOST_DB_PORT:{{ .DBPort }}` and `host_db_port` is unset in this test, so it renders as `127.0.0.1::3306` and Docker draws the host port from the kernel local range (32768-60999 on Linux). Docker does not reserve its pick, and under rootless Docker the bind happens later still in RootlessKit's port manager, so the port can be held by an unrelated socket or by a just-removed container that has not released it yet. That range overlaps DDEV's 33000-35000 ephemeral router range, which is why the port number looks like a DDEV allocation but is not one.

2. **The port assertions predicted exact port numbers** as `MinEphemeralPort + i*4` with a `+2` margin, which hardcodes both "each project consumes exactly 4 ports" and "nothing else on the machine holds a port in 33000-35000". The original comment already called this fragile.

Loosening the assertions alone would not have fixed the linked run, and retrying alone would not fix (2) — both changes are needed, for different flakes.

## How This PR Solves The Issue

For (1), `startRetryingHostPortRace()` retries `app.Start()` up to 3 times with a 2s backoff, but only for `address already in use` / `port is already allocated`. Every other error still fails immediately.

It deliberately does not call `app.Stop()` between attempts. `Stop()` calls `clear(EphemeralRouterPortsAssigned)`, and with that map cleared `AllocateAvailablePortForRouter` takes its "already bound by router, reusing it" branch and can hand the second project a port already serving the first — which would break the distinctness check below in a way that looks like a product bug but is not.

For (2), the test now asserts what actually matters rather than predicting port numbers:

- the project is pushed off the occupied configured ports (unchanged)
- each port falls within `[MinEphemeralPort, MaxEphemeralPort]`
- each port is distinct from every port already handed out, tracked in an `assignedPorts` map that names the claimant so a collision reports which project took the port
- the port actually works, via the existing HTTP/HTTPS content checks, which were always the assertion carrying the real weight

Distinctness is kept rather than dropped because `AllocateAvailablePortForRouter` tracks `EphemeralRouterPortsAssigned` specifically to avoid reissuing a port, so it is intended behavior. Since Traefik routes by Host header, two projects sharing a router port would still serve correct content, so the content checks alone would not catch that regression.

No non-test code changes.

## Manual Testing Instructions

```bash
DDEV_NO_INSTRUMENTATION=true go test -v -timeout 30m \
  -run 'TestUseEphemeralPort$' ./pkg/ddevapp/
```

To exercise the retry path, hold a port in the range Docker will pick from while the test starts a project, or run the test repeatedly on rootless Docker where the collision occurs naturally.

## Automated Testing Overview

This is a test-only change to an existing test. The test passed locally (`--- PASS: TestUseEphemeralPort (43.43s)`) with both projects exercising the new range and distinctness assertions.

Note that the local run warned `mkcert CA files are not readable from mkcert -CAROOT`, so the HTTPS content assertions were likely skipped locally; CI has a working CAROOT.

`make staticrequired` reports 0 issues.

## Release/Deployment Notes

None. Test-only, no user-visible or runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
