### PR TITLE
ci(buildkite): cap windows-mutagen test timeout at 4h

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -395,7 +395,7 @@ echo "--- Running tests..."
 
 # From here on, cleanup (the EXIT trap) runs testbot_maintenance.sh post-test.
 RAN_TESTS=true
-make ${MAKE_TARGET:-test} TESTARGS="${TESTARGS:-}" TESTPKG="${TESTPKG:-}" TESTFILE="${TESTFILE:-}" | sed -u 's/^--- FAIL:/+++ FAIL:/; /\//!s/^=== RUN /--- RUN /'
+make ${MAKE_TARGET:-test} TESTARGS="${TESTARGS:-}" TESTPKG="${TESTPKG:-}" TESTFILE="${TESTFILE:-}" TEST_TIMEOUT="${TEST_TIMEOUT:-6h}" | sed -u 's/^--- FAIL:/+++ FAIL:/; /\//!s/^=== RUN /--- RUN /'
 RV=$?
 echo "test.sh completed with status=$RV"
 ddev poweroff || true

--- a/.buildkite/windows10dockerforwindows.yml
+++ b/.buildkite/windows10dockerforwindows.yml
@@ -12,6 +12,10 @@
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
       DOCKER_TYPE: dockerforwindows
+      # Normal passing runs finish in ~160-220m; cap well below the default
+      # 6h TEST_TIMEOUT so a hung test fails fast instead of occupying the
+      # runner for the full 6h + cleanup overhead.
+      TEST_TIMEOUT: 4h
       # C:\buildkite-agent\hooks\environment
       # DOCKERHUB_PULL_USERNAME
       # DOCKERHUB_PULL_PASSWORD


### PR DESCRIPTION
## The Issue

No tracked issue — found via ad hoc investigation of `ddev-windows-mutagen` hangs.

The `ddev-windows-mutagen` Buildkite pipeline hung 3 times in the last 30 hours
(builds [6413](https://buildkite.com/ddev/ddev-windows-mutagen/builds/6413),
[6418](https://buildkite.com/ddev/ddev-windows-mutagen/builds/6418),
[6419](https://buildkite.com/ddev/ddev-windows-mutagen/builds/6419)), each time
running the full 6h `go test -timeout` before failing (6h15m-6h22m wall time),
rather than failing in a reasonable amount of time. All three hung in the same
place: `TestRouterNotRebuiltOnHostnameChange`, blocked writing a debug log
line to stdout deep into the run (thousands of lines and hours of successful
container/network/image operations in, not on first Docker use).

Pulling the Docker Desktop version out of each build's log (`docker version`
output near the start of the job) shows this pipeline ran cleanly on Docker
Desktop 4.77.0 → 4.78.0 → 4.79.0 across ~90 prior runs over 4+ months with zero
occurrences of this hang. The runner (`tb-win11-10`, which handles nearly all
`ddev-windows-mutagen` jobs) silently auto-updated to Docker Desktop 4.84.0
between build 6406 (Jul 28, passed, 4.79.0) and 6408 (Jul 29, 4.84.0).
**Every build that has completed since that upgrade has hung — 3 for 3.**

There's a matching, freshly-filed upstream report,
[docker/desktop-feedback#560](https://github.com/docker/desktop-feedback/issues/560)
(filed the same day as build 6419), describing Docker Desktop 4.84.0 on
Windows/WSL2 intermittently reporting its backend VM as reduced/stopped before
recovering minutes later — consistent with the backend appearing to not be
running when the runner was checked manually. No 4.84.x fix is available yet,
so this PR addresses the CI cost rather than the Docker Desktop bug itself.

## How This PR Solves The Issue

Normal passing runs on this pipeline finish in ~160-220 minutes, so the
existing global `TEST_TIMEOUT=6h` (shared by every CI job via the `Makefile`)
gives a hang roughly 2x more runway than it needs before failing.

- `.buildkite/test.sh`: threads `TEST_TIMEOUT` through to the `make` test
  invocation, defaulting to today's `6h` so every other pipeline is unaffected.
- `.buildkite/windows10dockerforwindows.yml`: overrides `TEST_TIMEOUT` to `4h`
  for this pipeline only — comfortable margin above the observed ~220m normal
  max, while cutting wasted runner time on a hang from ~6h15m to ~4h15m.

This is a mitigation for the symptom (CI burning hours on a hang), not a fix
for the underlying Docker Desktop 4.84.0 backend issue, which needs to be
addressed separately (e.g. pinning/downgrading Docker Desktop on the runner
until Docker ships a fix).

## Manual Testing Instructions

This only changes Buildkite CI configuration; there's no local user-facing
behavior to test. To verify:

1. Confirm `.buildkite/test.sh` passes `TEST_TIMEOUT` through to `make` and
   defaults to `6h` when unset (unchanged behavior for every pipeline besides
   `ddev-windows-mutagen`).
2. Confirm `.buildkite/windows10dockerforwindows.yml` sets `TEST_TIMEOUT: 4h`.
3. Watch the next few `ddev-windows-mutagen` runs: passing runs should be
   unaffected (~160-220m), and if the Docker Desktop 4.84.0 hang recurs, the
   job should now fail at ~4h instead of ~6h15m+.

## Automated Testing Overview

No new automated tests — this is a CI configuration change (test-timeout
plumbing), not application logic.

## Release/Deployment Notes

CI-only change; no user-facing impact. Does not fix the underlying Docker
Desktop 4.84.0 backend hang — only limits how much runner time each
occurrence wastes while that's investigated/resolved separately.
