### PR TITLE
fix(docker): restore /usr/local/n and make /var/log group-0-writable, fixes #8640, fixes #8574

### DIFF
--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -117,11 +117,36 @@ RUN curl -L --fail -o /usr/local/bin/n -sSL https://raw.githubusercontent.com/tj
 RUN N_PREFIX=/usr/local/n n install --cleanup "${NODE_VERSION}"
 RUN npm install --unsafe-perm=true --global gulp-cli yarn
 
+# Make /usr/local/n writable here, once, for any container user, instead of
+# recursively chgrp/chmod'ing it on every project's web image build (which was
+# slow, see https://github.com/ddev/ddev/issues/8600): use the "arbitrary UID"
+# technique of owning it by the root group (gid 0) and making it group-writable,
+# so any per-project user just needs to be a member of group 0 (added in
+# WriteBuildDockerfile in pkg/ddevapp/config.go) to get write access, with no
+# per-project recursive walk of this directory needed. See
+# https://developers.redhat.com/blog/2020/10/26/adapting-docker-and-kubernetes-containers-to-run-on-red-hat-openshift-container-platform
+RUN chgrp -R 0 /usr/local/n && chmod -R g+rwX,o-w /usr/local/n
+
 # Loop through $PHP_VERSIONS, selecting packages for the target architecture.
 RUN for v in ${PHP_VERSIONS}; do \
     /usr/local/bin/install_php_extensions.sh "$v" "${TARGETPLATFORM#linux/}"; \
 done
 RUN update-alternatives --set php /usr/bin/php${PHP_DEFAULT_VERSION}
+
+# Same "arbitrary UID" technique for /var/log itself: some setups (custom
+# supervisord daemons, app loggers) write files directly into /var/log, which
+# relied on /var/log being world-writable before #8379 hardened it. Rather
+# than reverting to world-writable, make the top-level directory group-0
+# writable so any per-project user (a group-0 member) can create files there,
+# without loosening perms on subdirectories that already have narrower,
+# explicit permissions (e.g. /var/log/nginx, /var/log/apache2 below).
+# This must run after the PHP-FPM installs above: installing php-fpm pulls in
+# the `systemd` package for the first time, and systemd's postinst runs a
+# global `systemd-tmpfiles --create`, which resets /var/log back to its
+# packaged 0755 root:root default (see /usr/lib/tmpfiles.d/var.conf) and
+# would silently undo this fix if applied any earlier.
+# See https://github.com/ddev/ddev/issues/8574
+RUN chgrp 0 /var/log && chmod g+rwX,o-w /var/log
 RUN mkdir -p /etc/nginx/sites-enabled /var/lock/apache2 /var/log/apache2 /var/run/apache2 /var/lib/apache2/module/enabled_by_admin /var/lib/apache2/module/disabled_by_admin && \
     touch /var/log/php-fpm.log && \
     chmod ugo+rw /var/log/php-fpm.log && \
@@ -482,6 +507,11 @@ RUN mkdir -p /mnt/ddev-global-cache/mkcert /run/php /run/blackfire /var/run/ngin
 RUN chgrp -R www-data /etc/alternatives /var/lib/dpkg/alternatives && \
     chmod -R g+rwX,o-w /etc/alternatives /var/lib/dpkg/alternatives
 
+# Reapply the /var/log group-0-writable fix (see the comment near its first
+# application in the ddev-php-base stage above): further package installs in
+# this stage may pull in `systemd` for the first time and reset it again.
+RUN chgrp 0 /var/log && chmod g+rwX,o-w /var/log
+
 RUN chmod -fR ugo+w /etc/nginx /var/cache/nginx /var/lib/nginx /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/php /etc/apache2 /var/lib/apache2 /mnt/ddev-global-cache/*
 
 RUN mkdir -p /var/xhprof && curl --fail -o /tmp/xhprof.tgz -sSL https://pecl.php.net/get/xhprof && tar -zxf /tmp/xhprof.tgz --strip-components=1 -C /var/xhprof && chmod ugo+rwX /var/xhprof/xhprof_html && rm /tmp/xhprof.tgz
@@ -580,6 +610,11 @@ RUN mkdir -p /mnt/ddev-global-cache/mkcert /run/php /var/run/nginx /var/run/supe
 
 RUN chgrp -R www-data /etc/alternatives /var/lib/dpkg/alternatives && \
     chmod -R g+rwX,o-w /etc/alternatives /var/lib/dpkg/alternatives
+
+# Reapply the /var/log group-0-writable fix (see the comment near its first
+# application in the ddev-php-base stage above): further package installs in
+# this stage may pull in `systemd` for the first time and reset it again.
+RUN chgrp 0 /var/log && chmod g+rwX,o-w /var/log
 
 RUN chmod -fR ugo+w /etc/nginx /var/cache/nginx /var/lib/nginx /var/www /etc/php/*/*/conf.d/ /var/lib/php/modules /etc/php /etc/apache2 /var/lib/apache2 /mnt/ddev-global-cache/*
 

--- a/containers/ddev-webserver/tests/ddev-webserver/general.bats
+++ b/containers/ddev-webserver/tests/ddev-webserver/general.bats
@@ -69,6 +69,29 @@ setup() {
   assert_equal "${output}" "$noninteractive_path"
 }
 
+@test "Verify /usr/local/n and /var/log are baked group-0-writable but not world-writable" {
+  # Regression guard for https://github.com/ddev/ddev/issues/8640: these
+  # directories must be owned by group 0 (root) and group-writable, so a
+  # per-project user (added to group 0 by WriteBuildDockerfile) can write
+  # into them (e.g. `npm install -g`, or an app logging to /var/log)
+  # without either directory being world-writable (see #8379).
+  for dir in /usr/local/n /var/log; do
+    run docker exec "$CONTAINER_NAME" stat -c '%g %A' "$dir"
+    assert_success
+    assert_output --regexp "^0 .{5}w.{2}[^w].\$"
+  done
+}
+
+@test "Verify a group-0 member (not the file owner) can write into /usr/local/n and /var/log" {
+  # Simulates the supplementary-group-0 membership that WriteBuildDockerfile
+  # adds for every project user (useradd -G tty,0), which is how a non-root,
+  # non-www-data user gets write access to these directories.
+  for dir in /usr/local/n /var/log; do
+    run docker run --rm -u "$MOUNTUID:$MOUNTGID" --group-add 0 "$DOCKER_IMAGE" bash -c "touch '$dir/ddev-group0-write-test' && rm -f '$dir/ddev-group0-write-test'"
+    assert_success
+  done
+}
+
 @test "verify that xdebug is disabled by default when using start.sh to start" {
   run docker exec "$CONTAINER_NAME" php --version
   assert_success

--- a/containers/ddev-webserver/tests/ddev-webserver/test.sh
+++ b/containers/ddev-webserver/tests/ddev-webserver/test.sh
@@ -24,8 +24,8 @@ export CONTAINER_NAME=webserver-test
 export PHP_VERSION=8.4
 export WEBSERVER_TYPE=nginx-fpm
 
-MOUNTUID=33
-MOUNTGID=33
+export MOUNTUID=33
+export MOUNTGID=33
 # /usr/local/bin is added for git-bash, where it may not be in the $PATH.
 export PATH="/usr/local/bin:$PATH"
 

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -1065,7 +1065,7 @@ if [ -n "$INSTALL_PKGS" ]; then
 fi
 cd /tmp && rm -rf /tmp/n-version-files
 # n installs by overwriting the files baked into the base image (see
-# containers/ddev-php-base/Dockerfile), which resets them to root-only
+# containers/ddev-webserver/Dockerfile), which resets them to root-only
 # permissions, so group-writability by root (gid 0) has to be reapplied here.
 # Only needed on this non-default Node.js version path; the common case
 # (default Node.js version) is already handled once in the base image.
@@ -1298,9 +1298,9 @@ ARG DDEV_PHP_VERSION
 ARG DDEV_DATABASE
 RUN getent group tty || groupadd tty
 # Group 0 (root) is added here so this user can read/write directories that are
-# baked group-writable-by-root in the base image (e.g. /usr/local/n, see
-# containers/ddev-php-base/Dockerfile) without a per-project chgrp/chmod of
-# those directories. See the note near the chmod -R below, and
+# baked group-writable-by-root in the base image (e.g. /usr/local/n, /var/log,
+# see containers/ddev-webserver/Dockerfile) without a per-project chgrp/chmod
+# of those directories. See the note near the chmod -R below, and
 # https://developers.redhat.com/blog/2020/10/26/adapting-docker-and-kubernetes-containers-to-run-on-red-hat-openshift-container-platform
 RUN (groupadd --gid "$gid" "$username" || groupadd "$username" || true) && \
     (useradd -G tty,0 -l -m -s "/bin/bash" --gid "$username" --comment '' --uid "$uid" "$username" || \

--- a/pkg/ddevapp/nodejs_test.go
+++ b/pkg/ddevapp/nodejs_test.go
@@ -156,3 +156,39 @@ func TestCorepackEnable(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(out, "4."))
 }
+
+// TestNpmGlobalInstall tests that `npm install -g` works for the project
+// user, who is not the file owner of /usr/local/n but a member of its
+// group (0/root) - regression test for
+// https://github.com/ddev/ddev/issues/8640
+func TestNpmGlobalInstall(t *testing.T) {
+	site := TestSites[0]
+	origDir, _ := os.Getwd()
+	_ = os.Chdir(site.Dir)
+
+	runTime := util.TimeTrackC(t.Name())
+
+	testcommon.ClearDockerEnv()
+	app, err := ddevapp.NewApp(site.Dir, true)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		runTime()
+		_ = os.Chdir(origDir)
+		_ = app.Stop(true, false)
+	})
+
+	err = app.Start()
+	require.NoError(t, err)
+
+	out, _, err := app.Exec(&ddevapp.ExecOpts{
+		Cmd: `npm install -g npm@latest`,
+	})
+	require.NoError(t, err, "npm install -g failed, output: %s", out)
+	require.NotContains(t, out, "EACCES")
+
+	out, _, err = app.Exec(&ddevapp.ExecOpts{
+		Cmd: `npm --version`,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, strings.TrimSpace(out))
+}

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260730_rfay_fix_logpipe_race" // Note that this can be overridden by make
+var WebTag = "20260801_rfay_global_npm" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- Fixes #8640
- Fixes #8574

#8640: `npm install -g <pkg>` regressed back to `EACCES` on `/usr/local/n`. #8603
fixed this by baking `chgrp -R 0 /usr/local/n && chmod -R g+rwX,o-w /usr/local/n`
into what was then `containers/ddev-php-base/Dockerfile`, and adding the
per-project container user to group 0 (`useradd -G tty,0` in
`WriteBuildDockerfile`). #8604 (consolidating `ddev-php-base` into
`ddev-webserver`) silently dropped that `chgrp`/`chmod` line during the merge,
so the fix from #8603 stopped shipping even though the code around it
(group 0 membership, etc.) was still intact.

#8574: some add-ons/apps write log files directly into `/var/log` (custom
supervisord daemons, app loggers), which worked when `/var/log` was
world-writable pre-v1.25.3, and broke when #8379 hardened it to `root:root
0755`. #8379's hardening was correct and shouldn't be reverted, but the same
group-0 technique already used for `/usr/local/n` closes this gap without
reintroducing world-writability.

## How This PR Solves The Issue

- `containers/ddev-webserver/Dockerfile`: restores the `/usr/local/n`
  `chgrp -R 0 && chmod -R g+rwX,o-w` line in the `ddev-php-base` stage.
- Same Dockerfile: adds `chgrp 0 /var/log && chmod g+rwX,o-w /var/log` -
  only the top-level directory, not its subdirectories
  (`/var/log/nginx`, `/var/log/apache2`, etc.), which already have their own
  narrower, explicit permissions elsewhere in the Dockerfile and are
  untouched by this change. Since the per-project user is already a
  supplementary member of group 0 (unchanged from #8603), this "just works"
  for every project without any per-project Dockerfile changes.
- The `/var/log` fix has to run **after** the PHP-FPM installs: installing
  php-fpm pulls in the `systemd` package for the first time, and systemd's
  postinst runs a global `systemd-tmpfiles --create`, which resets
  `/var/log` back to its packaged `0755 root:root` default per
  `/usr/lib/tmpfiles.d/var.conf` - silently undoing the fix if applied any
  earlier in the build. It's placed right after that install, and reapplied
  once more at the tail of both the dev-base and prod-base stages (mirroring
  the existing `/etc/alternatives` reapplication pattern already in this
  Dockerfile) as defense-in-depth against any later stage pulling in
  `systemd` for the first time instead.
- `pkg/ddevapp/config.go`: fixes two comments that still referenced the
  now-removed `containers/ddev-php-base/Dockerfile` path.
- `pkg/ddevapp/nodejs_test.go`: adds `TestNpmGlobalInstall`, the
  `ddev npm install -g ...` test @stasadev asked for on #8603 that never
  landed - part of why this regression went unnoticed for as long as it did.
- `containers/ddev-webserver/tests/ddev-webserver/general.bats` +
  `test.sh`: adds two image-level regression tests - one asserting the baked
  permissions on `/usr/local/n` and `/var/log` (group 0, group-writable,
  not world-writable), and one that actually writes into both as a
  non-owner, group-0-only user (`docker run --group-add 0`), simulating the
  real per-project user.
- `pkg/versionconstants/versionconstants.go`: bumps `WebTag` for the new
  image.

This does **not** touch `/usr/local/bin`, `/run`, `/var/run`, or the
update-alternatives directories - the other paths #8379 hardened remain
exactly as locked-down as before. Only `/var/log`'s own top-level directory
gets the same group-0 (not world-writable) carve-out already accepted for
`/usr/local/n`.

## Manual Testing Instructions

1. Build the image locally:
   ```
   cd containers/ddev-webserver && docker buildx build --platform linux/arm64 --target=ddev-webserver -t ddev/ddev-webserver:test --load .
   ```
2. Confirm the baked permissions:
   ```
   docker run --rm ddev/ddev-webserver:test stat -c "%g %A" /usr/local/n /var/log
   ```
   Both should show group `0` and a group-writable, non-world-writable mode
   (e.g. `drwxrwxr-x`).
3. Confirm a real per-project user (group-0 member, not the file owner) can
   write to both, and that `npm install -g` succeeds:
   ```
   docker run --rm -u 12345:12345 --group-add 0 -e HOME=/tmp ddev/ddev-webserver:test bash -c \
     'export PATH=/usr/local/n/bin:$PATH; npm install -g pnpm && pnpm --version && touch /var/log/x && rm /var/log/x'
   ```
4. Confirm an unrelated user with no group-0 membership is still denied
   (no regression of #8379):
   ```
   docker run --rm -u 54321:54321 ddev/ddev-webserver:test bash -c \
     'touch /var/log/x; touch /usr/local/n/x'
   ```
   Both `touch` calls should fail with `Permission denied`.
5. `go test -v -run TestNpmGlobalInstall ./pkg/ddevapp/` against a built
   image, once published.
6. `make test` in `containers/ddev-webserver` (or
   `tests/ddev-webserver/test.sh <image>`) to run the full bats suite,
   including the two new regression tests.

## Automated Testing Overview

- `pkg/ddevapp/nodejs_test.go`: `TestNpmGlobalInstall` runs
  `npm install -g npm@latest` against a real DDEV project and confirms it
  succeeds with no `EACCES`.
- `containers/ddev-webserver/tests/ddev-webserver/general.bats`: two new
  tests cover the baked permissions and actual group-0 write access
  described above, for both the dev and prod image variants (via the
  existing `test.sh` loop over `DEFAULT_IMAGES`).
- Manually verified end-to-end per the steps above, including confirming
  the `systemd`-triggered reset without the fix, and that it stays fixed
  with the fix in place.

## Release/Deployment Notes

- Requires publishing a new `ddev-webserver` image (this branch bumps
  `WebTag` to `20260801_rfay_global_npm`; a maintainer needs to push that
  tag via `push-tagged-image.yml` before/at merge).
- Projects built with the old image will get the corrected permissions the
  next time their web image is rebuilt.
