### PR TITLE
fix(router): only trust router's bound ports when it is actually running, fixes #8293

### DIFF
--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -649,9 +649,14 @@ func CheckRouterPorts(activeApps []*DdevApp) error {
 // Returns the port found, and a boolean that determines if the
 // port is valid (true) or not (false), and the port is marked as allocated
 func AllocateAvailablePortForRouter(start, upTo int) (int, bool) {
-	// Get ports already bound by the router - these can be reused
+	// Get ports already bound by the router - these can be reused.
+	// Only trust these bindings when the router is actually running: a
+	// container that failed to start (for example one that lost a port-bind
+	// race) still reports the port it tried to bind in its HostConfig, and
+	// treating that as a legitimate binding would keep reoffering the same
+	// never-actually-bound port on every subsequent call.
 	var routerBoundPorts []string
-	if router, err := FindDdevRouter(); err == nil && router != nil {
+	if router, err := FindDdevRouter(); err == nil && router != nil && router.State == "running" {
 		routerBoundPorts, _ = dockerutil.GetBoundHostPorts(router.ID)
 	}
 
@@ -691,11 +696,15 @@ func GetAvailableRouterPort(proposedPort string, minPort, maxPort int) (string, 
 	if proposedPort == "" {
 		return proposedPort, "", false
 	}
-	// If the router exists, check if it's already handling the proposedPort
+	// If the router is running, check if it's already handling the proposedPort
 	// regardless of its health status. This prevents allocating ephemeral ports
 	// when the router is running but unhealthy (e.g., broken Traefik config).
+	// A router container that exists but isn't running (for example one that
+	// failed to start because it lost a port-bind race) still reports the
+	// port it tried to bind in its HostConfig, so its bindings are only
+	// trustworthy while it's actually running.
 	r, err := FindDdevRouter()
-	if r != nil && err == nil {
+	if r != nil && err == nil && r.State == "running" {
 		util.Debug("GetAvailableRouterPort(): Router exists, checking bound ports")
 		// Check if the proposedPort is already being handled by the router.
 		routerPortsAlreadyBound, err := dockerutil.GetBoundHostPorts(r.ID)


### PR DESCRIPTION
## The Issue

- Fixes #8293 (follow-up to #8638, which did not fully resolve it)

#8638 added a retry loop to `TestUseEphemeralPort` for the case where the db/web container's host port (drawn fresh from the kernel by Docker on every `docker-compose up`, since it's published with no fixed host port) loses a bind race. That retry helps there because each attempt draws a different port.

CI kept failing anyway, on a different race, in a way the retry loop cannot help with: [this run](https://github.com/ddev/ddev/actions/runs/30709764475/job/91395069771)

```text
router_test.go:304:
    Error: Received unexpected error:
    failed to start ddev-router: Error response from daemon: failed to
    set up container networking: driver failed programming external
    connectivity on endpoint ddev-router: failed to bind host port for
    127.0.0.1:33004:172.18.0.7:33004/tcp: address already in use
```

With `DDEV_DEBUG` on, the log shows what happened:

1. DDEV's own router-port allocator (`GetAvailableRouterPort` in `pkg/ddevapp/router.go`) checks port 33004, finds it free, and assigns it.
2. Roughly 10s later, the actual `docker-compose up` for `ddev-router` fails to bind 33004: something else grabbed it in that window. This part is a genuine, unavoidable TOCTOU race, just like the one #8638 fixed for the db/web port, except here it's on DDEV's own dynamically-chosen router port.
3. Every retry after that logs `proposedPort 33004 already bound on ddev-router, accepting it` and hands back the exact same port. The retry loop never actually tries a different port, so it fails identically three times in a row.

The reason for (3): `GetBoundHostPorts()` reads a container's *configured* `HostConfig.PortBindings` (the port it asked Docker to bind), not what it actually succeeded in binding. `FindDdevRouter()` looks up containers with `ContainerList(All: true)`, so it finds the leftover `ddev-router` container from the failed attempt even though it's not running. `GetAvailableRouterPort` and `AllocateAvailablePortForRouter` treat that stale HostConfig entry as proof the router legitimately owns the port, and keep re-offering it forever.

`StartDdevRouter()` already has the right instinct for this (`router.State != "running"` triggers removal and recreation), but that check only runs later in `app.Start()`, after the port has already been poisoned.

## How This PR Solves The Issue

`GetAvailableRouterPort()` and `AllocateAvailablePortForRouter()` now only trust the router's existing port bindings when the router container's state is `"running"`. A container that merely attempted (and failed) to bind a port no longer poisons subsequent allocations with the same broken port.

This preserves the existing "trust the router regardless of health status" behavior for a router that's running but unhealthy (e.g. broken Traefik config) — only containers that aren't running at all are now excluded.

No test changes; #8638 already fixed the retry loop and port assertions, and this closes the remaining gap the retries couldn't cover.

## Manual Testing Instructions

```bash
DDEV_NO_INSTRUMENTATION=true go test -v -timeout 15m \
  -run 'TestGlobalPortOverride|TestProjectPortOverride|TestRouterConfigOverride|TestAllocateAvailablePortForRouter|TestUseEphemeralPort' \
  ./pkg/ddevapp/
```

To exercise the fix directly: start a project so `ddev-router` binds an ephemeral port, then kill the router container without going through `ddev stop` so it's left in an `exited` state while still holding that port in its config, then start another project needing an ephemeral port and confirm it picks a fresh one instead of reusing the dead container's port.

## Automated Testing Overview

Ran the full `router_test.go` suite locally: `TestGlobalPortOverride`, `TestProjectPortOverride`, `TestRouterConfigOverride`, `TestAllocateAvailablePortForRouter`, and `TestUseEphemeralPort` all pass. `make staticrequired` reports 0 issues.

## Release/Deployment Notes

None. Internal port-allocation logic only; no user-visible or config changes.
