### PR TITLE
fix(router): skip TestRouterNotRebuiltOnHostnameChange on Windows, fixes #8644 (#8649) [skip ci]

### DIFF
--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -1004,6 +1004,11 @@ func TestRouterNotRebuiltWithExtraPorts(t *testing.T) {
 // project update the router's network aliases in place rather than recreating
 // the router container.
 func TestRouterNotRebuiltOnHostnameChange(t *testing.T) {
+	// Windows can't handle this test, util.CaptureUserOut() can deadlock around a full app.Start()/Restart(), see #8644
+	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && nodeps.IsWindows() {
+		t.Skip("Skipping TestRouterNotRebuiltOnHostnameChange on Windows")
+	}
+
 	// Start clean.
 	ddevapp.PowerOff()
 


### PR DESCRIPTION
## The Issue

- Fixes #8644

`ddev-windows-mutagen` hung for the full 6h `go test -timeout` in three
consecutive runs (6418, 6419, 6421), always inside
`TestRouterNotRebuiltOnHostnameChange`, blocked writing a debug log line to
stdout. #8644 mitigated the symptom by capping the pipeline's timeout at 4h,
attributing the hangs to a Docker Desktop 4.84.0 backend regression on the
Windows runner.

The test wraps `app2.Start()`/`app2.Restart()` in `util.CaptureUserOut()`.
That helper redirects output to an `os.Pipe()` that isn't drained until
`getOutput()` is called - i.e. only after `Start()`/`Restart()` returns. With
`DDEV_DEBUG=true` (set for all CI runs), a full `app.Start()` can emit enough
debug output to fill that pipe before it returns, deadlocking the write. This
is a known, longstanding Windows limitation of `CaptureUserOut()`:
`TestDdevLogs` has skipped Windows for the identical reason since 2018. The
new test (added in 6e7e41649, merged 2026-07-30) just reintroduced the same
hazard without a Windows guard.

## How This PR Solves The Issue

- `pkg/ddevapp/router_test.go`: skip `TestRouterNotRebuiltOnHostnameChange`
  on Windows, following the same pattern (and referencing the same root
  cause) as the existing `TestDdevLogs` Windows skip.

## Manual Testing Instructions

1. On Windows, run
   `go test -v -run TestRouterNotRebuiltOnHostnameChange ./pkg/ddevapp/...`
   and confirm it's skipped rather than hanging.
2. `make staticrequired` passes.

## Automated Testing Overview

No new tests added; `TestRouterNotRebuiltOnHostnameChange` is now skipped on
Windows where `CaptureUserOut()` remains unsafe around a full
`Start()`/`Restart()`.

## Release/Deployment Notes

No user-facing behavior change; the skip only affects CI.
