### PR TITLE
fix(dev-tools): put installed tools on PATH and verify they work (#8651) [skip ci]

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -344,6 +344,7 @@ dir
 directory
 disable
 disallowal
+distribution's
 distro
 distros
 dns
@@ -435,6 +436,7 @@ information
 ini
 inotify
 inside
+installer's
 integrations
 internet
 into

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@
 # .spellcheck.yml at all. Prepend the dev-tools directories here so make always
 # gets the ones we installed. Missing directories on PATH are harmless.
 DEV_TOOLS_DIR ?= $(HOME)/.ddev-dev-tools
-export PATH := $(DEV_TOOLS_DIR)/python/bin:$(DEV_TOOLS_DIR)/node/bin:$(EXTRA_PATH):$(PATH)
+DEV_TOOLS_PATH = $(DEV_TOOLS_DIR)/python/bin:$(DEV_TOOLS_DIR)/node/bin
+export PATH := $(DEV_TOOLS_PATH):$(EXTRA_PATH):$(PATH)
 
 BUILD_BASE_DIR ?= $(PWD)
 
@@ -217,11 +218,23 @@ define require_tool
 	}
 endef
 
+# Check for a tool, then run it. The PATH= prefix is not redundant with the
+# export at the top of this file: GNU make 3.81, still /usr/bin/make on macOS,
+# execs a recipe line with no shell metacharacters itself and looks the command
+# up in make's own PATH rather than the exported one, so a bare
+# `pyspelling --config ...` dies with "No such file or directory" even though
+# the `command -v pyspelling` on the line before it just succeeded. The prefix
+# forces the line through $(SHELL), which does have the exported PATH.
+# $(2) must not contain commas; $(call) would split them into further arguments.
+define run_tool
+	$(call require_tool,$(1))
+	@PATH="$(PATH)" $(1) $(2)
+endef
+
 # Best to install markdownlint-cli locally with "npm install -g markdownlint-cli"
 markdownlint:
 	@echo "markdownlint: "
-	$(call require_tool,markdownlint)
-	@markdownlint *.md docs/content 2>&1
+	$(call run_tool,markdownlint,*.md docs/content 2>&1)
 
 # Install zensical locally using
 # https://docs.ddev.com/en/stable/developers/testing-docs/
@@ -245,11 +258,7 @@ zensical:
 # It does require installing zensical: pip install zensical
 # See https://docs.ddev.com/en/stable/developers/testing-docs/
 zensical-serve:
-	@if command -v zensical >/dev/null ; then \
-		zensical serve; \
-	else \
-		echo "zensical is not installed (run scripts/install-dev-tools.sh)" && exit 2; \
-	fi; \
+	$(call run_tool,zensical,serve)
 
 mkdocs: zensical
 mkdocs-serve: zensical-serve
@@ -257,29 +266,20 @@ mkdocs-serve: zensical-serve
 # Install linkspector locally with "sudo npm install -g @umbrelladocs/linkspector"
 linkspector:
 	@echo "linkspector: "
-	@if command -v linkspector >/dev/null 2>&1; then \
-		linkspector check; \
-	else \
-		echo "Not running linkspector because it's not installed (run scripts/install-dev-tools.sh)"; \
-	fi
+	$(call run_tool,linkspector,check)
 
 
 # Best to install pyspelling locally with "sudo -H pip3 install pyspelling pymdown-extensions". Also requires aspell, `sudo apt-get install aspell"
 pyspelling:
 	@echo "pyspelling: "
-	$(call require_tool,pyspelling)
-	@pyspelling --config .spellcheck.yml
+	$(call run_tool,pyspelling,--config .spellcheck.yml)
 
 # Install textlint locally with `npm install -g textlint textlint-filter-rule-comments textlint-rule-no-todo textlint-rule-stop-words textlint-rule-terminology`
 textlint:
 	@echo "textlint: "
-	@CMD="textlint {README.md,version-history.md,docs/**}"; \
-	set -eu -o pipefail; \
-	if command -v textlint >/dev/null 2>&1 ; then \
-		$$CMD; \
-	else \
-		echo "textlint is not installed (run scripts/install-dev-tools.sh)"; \
-	fi
+	$(call require_tool,textlint)
+	@set -eu -o pipefail; \
+	textlint {README.md,version-history.md,docs/**}
 
 darwin_amd64_signed: $(GOTMP)/bin/darwin_amd64/ddev $(GOTMP)/bin/darwin_amd64/ddev-hostname
 	@if [ -z "$(DDEV_MACOS_SIGNING_PASSWORD)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 # Makefile for a standard golang repo with associated container
 
-# Circleci doesn't seem to provide a decent way to add to path, just adding here, for case where
-# linux build and linuxbrew is installed.
-#
 # scripts/install-dev-tools.sh puts the docs tooling in its own venv and npm
 # prefix, and until now only .envrc added those to PATH. direnv covers
 # interactive shells that have it hooked in and nothing else, so a make target
@@ -205,11 +202,8 @@ setup:
 	@mkdir -p $(GOTMP)/{bin/linux_arm64,bin/linux_amd64,bin/darwin_arm64,bin/darwin_amd64,bin/windows_amd64,bin/windows_arm64,src,pkg/mod/cache,.cache}
 	@mkdir -p $(TESTTMP)
 
-# Required static analysis targets used in circleci - these cause fail if they don't work.
-# pyspelling is included because .github/workflows/docs-check.yml enforces it:
-# leaving it out meant the documented pre-commit check could not catch a
-# spelling failure that CI would then reject.
-staticrequired: setup golangci-lint markdownlint pyspelling zensical
+# Required static analysis targets for pre-push.
+staticrequired: setup golangci-lint markdownlint zensical
 
 # Fail rather than skip when a required tool is absent. These targets used to
 # print a note and exit 0, so `make staticrequired` reported success while

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,16 @@
 
 # Circleci doesn't seem to provide a decent way to add to path, just adding here, for case where
 # linux build and linuxbrew is installed.
-export PATH := $(EXTRA_PATH):$(PATH)
+#
+# scripts/install-dev-tools.sh puts the docs tooling in its own venv and npm
+# prefix, and until now only .envrc added those to PATH. direnv covers
+# interactive shells that have it hooked in and nothing else, so a make target
+# could resolve some other copy of a tool instead: a Homebrew pyspelling, for
+# instance, whose Python prefix has no pymdown-extensions and so cannot read
+# .spellcheck.yml at all. Prepend the dev-tools directories here so make always
+# gets the ones we installed. Missing directories on PATH are harmless.
+DEV_TOOLS_DIR ?= $(HOME)/.ddev-dev-tools
+export PATH := $(DEV_TOOLS_DIR)/python/bin:$(DEV_TOOLS_DIR)/node/bin:$(EXTRA_PATH):$(PATH)
 
 BUILD_BASE_DIR ?= $(PWD)
 
@@ -196,29 +205,36 @@ setup:
 	@mkdir -p $(GOTMP)/{bin/linux_arm64,bin/linux_amd64,bin/darwin_arm64,bin/darwin_amd64,bin/windows_amd64,bin/windows_arm64,src,pkg/mod/cache,.cache}
 	@mkdir -p $(TESTTMP)
 
-# Required static analysis targets used in circleci - these cause fail if they don't work
-staticrequired: setup golangci-lint markdownlint zensical
+# Required static analysis targets used in circleci - these cause fail if they don't work.
+# pyspelling is included because .github/workflows/docs-check.yml enforces it:
+# leaving it out meant the documented pre-commit check could not catch a
+# spelling failure that CI would then reject.
+staticrequired: setup golangci-lint markdownlint pyspelling zensical
+
+# Fail rather than skip when a required tool is absent. These targets used to
+# print a note and exit 0, so `make staticrequired` reported success while
+# silently running nothing -- the worst of both worlds, since it looks checked.
+define require_tool
+	@command -v $(1) >/dev/null 2>&1 || { \
+		echo "$(1) is required but was not found on PATH."; \
+		echo "Install the development tools with: scripts/install-dev-tools.sh"; \
+		echo "Expected location: $(DEV_TOOLS_DIR)"; \
+		exit 1; \
+	}
+endef
 
 # Best to install markdownlint-cli locally with "npm install -g markdownlint-cli"
 markdownlint:
 	@echo "markdownlint: "
-	@CMD="markdownlint *.md docs/content 2>&1"; \
-	set -eu -o pipefail; \
-	if command -v markdownlint >/dev/null 2>&1 ; then \
-		$$CMD; \
-	else \
-		echo "Skipping markdownlint as not installed (run scripts/install-dev-tools.sh)"; \
-	fi
+	$(call require_tool,markdownlint)
+	@markdownlint *.md docs/content 2>&1
 
 # Install zensical locally using
 # https://docs.ddev.com/en/stable/developers/testing-docs/
 zensical:
 	@echo "zensical: "
-	@if ! command -v zensical >/dev/null 2>&1; then \
-		echo "Not running zensical because it's not installed (run scripts/install-dev-tools.sh)"; \
-		exit 0; \
-	fi; \
-	for i in 1 2 3; do \
+	$(call require_tool,zensical)
+	@for i in 1 2 3; do \
 		out=$$(zensical build --strict 2>&1); rc=$$?; \
 		echo "$$out"; \
 		if [ $$rc -eq 0 ]; then exit 0; fi; \
@@ -257,13 +273,8 @@ linkspector:
 # Best to install pyspelling locally with "sudo -H pip3 install pyspelling pymdown-extensions". Also requires aspell, `sudo apt-get install aspell"
 pyspelling:
 	@echo "pyspelling: "
-	@CMD="pyspelling --config .spellcheck.yml"; \
-	set -eu -o pipefail; \
-	if command -v pyspelling >/dev/null 2>&1 ; then \
-		$$CMD; \
-	else \
-		echo "Not running pyspelling because it's not installed (run scripts/install-dev-tools.sh)"; \
-	fi
+	$(call require_tool,pyspelling)
+	@pyspelling --config .spellcheck.yml
 
 # Install textlint locally with `npm install -g textlint textlint-filter-rule-comments textlint-rule-no-todo textlint-rule-stop-words textlint-rule-terminology`
 textlint:

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -7,8 +7,11 @@ set -euo pipefail
 INSTALL_DIR="$HOME/.ddev-dev-tools"
 PYTHON_ENV="$INSTALL_DIR/python"
 NODE_ENV="$INSTALL_DIR/node"
+PUPPETEER_CACHE="$INSTALL_DIR/puppeteer"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Colors for output
+DIRENV_RELOAD_NEEDED=false
+
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
@@ -18,7 +21,6 @@ log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
-# Check prerequisites
 check_prerequisites() {
   log_info "Checking prerequisites..."
 
@@ -36,12 +38,11 @@ check_prerequisites() {
   log_info "✓ Node.js: $(node --version)"
 }
 
-# Install system dependencies
 install_system_deps() {
   log_info "Installing system dependencies..."
 
   if command -v aspell >/dev/null 2>&1; then
-    log_info "Installing aspell via Homebrew..."
+    log_info "✓ aspell already installed"
   else
     if command -v brew >/dev/null 2>&1; then
       log_info "Installing aspell via Homebrew..."
@@ -57,11 +58,17 @@ install_system_deps() {
   fi
 }
 
-# Setup Python environment
 setup_python_env() {
   log_info "Setting up Python environment..."
 
   mkdir -p "$INSTALL_DIR"
+
+  # A venv is bound to the interpreter that created it, so a system Python
+  # upgrade leaves it dead. Rebuild rather than fail halfway through pip.
+  if [[ -f "$PYTHON_ENV/bin/activate" ]] && ! "$PYTHON_ENV/bin/python3" -c '' 2>/dev/null; then
+    log_warn "Python virtual environment is broken (system Python changed); recreating"
+    rm -rf "$PYTHON_ENV"
+  fi
 
   if [[ ! -f "$PYTHON_ENV/bin/activate" ]]; then
     log_info "Creating Python virtual environment..."
@@ -70,31 +77,26 @@ setup_python_env() {
     log_info "✓ Python virtual environment already exists"
   fi
 
-  # Activate and upgrade pip
-  source "$PYTHON_ENV/bin/activate"
-  python3 -m pip install --upgrade pip setuptools wheel >/dev/null 2>&1
+  # Not `source bin/activate`: that would put $PYTHON_ENV/bin on PATH for the
+  # rest of this script, so verify_installation would not see the user's PATH.
+  "$PYTHON_ENV/bin/python3" -m pip install --upgrade pip setuptools wheel >/dev/null 2>&1
 }
 
-# Install Python tools
 install_python_tools() {
   log_info "Installing Python tools..."
-
-  source "$PYTHON_ENV/bin/activate"
 
   cat >"$INSTALL_DIR/python-requirements.txt" <<'EOF'
 # Spell checking tools
 pyspelling
 pymdown-extensions
 EOF
-
-  # Append docs requirements
-  cat "$(dirname "$0")/../docs/requirements.txt" >>"$INSTALL_DIR/python-requirements.txt"
+  cat "$REPO_ROOT/docs/requirements.txt" >>"$INSTALL_DIR/python-requirements.txt"
 
   log_info "Installing Python packages (this may take a moment)..."
-  python3 -m pip install -r "$INSTALL_DIR/python-requirements.txt" >/dev/null
+  # --upgrade so re-running updates; without it pip stops at "already satisfied".
+  "$PYTHON_ENV/bin/python3" -m pip install --upgrade -r "$INSTALL_DIR/python-requirements.txt" >/dev/null
 }
 
-# Setup Node environment
 setup_node_env() {
   log_info "Setting up Node.js environment..."
 
@@ -104,15 +106,13 @@ setup_node_env() {
   export npm_config_fund=false
 }
 
-# Install Node tools
 install_node_tools() {
-  log_info "Installing Node.js tools..."
+  log_info "Installing Node.js tools (this may take a moment)..."
 
-  export NPM_CONFIG_PREFIX="$NODE_ENV"
-  export npm_config_update_notifier=false
-  export npm_config_fund=false
-
-  npm install -g \
+  # puppeteer's postinstall downloads linkspector's browser, which npm 12 blocks
+  # unless allowlisted. PUPPETEER_CACHE_DIR keeps it out of ~/.cache/puppeteer.
+  export PUPPETEER_CACHE_DIR="$PUPPETEER_CACHE"
+  npm install -g --allow-scripts=puppeteer \
     markdownlint-cli \
     @umbrelladocs/linkspector \
     textlint \
@@ -120,23 +120,83 @@ install_node_tools() {
     textlint-rule-no-todo \
     textlint-rule-stop-words \
     textlint-rule-terminology >/dev/null
+
+  write_linkspector_shim
+  prune_puppeteer_cache
 }
 
-# Verify installation
-#
-# This deliberately does NOT prepend the install directories to PATH. The
-# previous version did, then looked for the tools it had just installed, so it
-# always succeeded while saying nothing about what the user's shell will run.
-# On a machine with a Homebrew pyspelling ahead of ours on PATH it reported a
-# clean install, and `pyspelling --config .spellcheck.yml` then failed with
-# ModuleNotFoundError: No module named 'pymdownx'.
-#
-# So check two things the old version could not: which copy of each tool the
-# current PATH resolves, and whether that copy actually runs.
+puppeteer_dir() {
+  find "$NODE_ENV/lib/node_modules" -type d -path '*/node_modules/puppeteer' -print -quit 2>/dev/null
+}
+
+# puppeteer adds each browser build it downloads (~650MB) instead of replacing
+# the last one, so drop whatever the installed version no longer resolves to.
+prune_puppeteer_cache() {
+  local pd exe rel keep browser build
+  pd="$(puppeteer_dir)"
+  [[ -n "${pd}" ]] || return 0
+
+  exe="$(cd "${pd}" && PUPPETEER_CACHE_DIR="$PUPPETEER_CACHE" node -e "
+    import('puppeteer').then(async m => console.log(await (m.default ?? m).executablePath()))
+  " 2>/dev/null)" || return 0
+
+  rel="${exe#"$PUPPETEER_CACHE"/}"
+  [[ "${rel}" != "${exe}" ]] || return 0 # resolved outside our cache; leave it alone
+  rel="${rel#*/}"
+  keep="${rel%%/*}"
+
+  # chrome and chrome-headless-shell are fetched together at the same build id.
+  for browser in "$PUPPETEER_CACHE"/*/; do
+    for build in "${browser}"*/; do
+      [[ -d "${build}" ]] || continue
+      if [[ "$(basename "${build}")" == "${keep}" ]]; then continue; fi
+      log_info "Removing stale browser $(basename "${browser%/}")/$(basename "${build}")"
+      rm -rf "${build}"
+    done
+  done
+}
+
+# PUPPETEER_CACHE_DIR has to be set when linkspector runs, not only when it is
+# installed, so carry it in the bin instead of in every caller's environment.
+write_linkspector_shim() {
+  local entry="$NODE_ENV/lib/node_modules/@umbrelladocs/linkspector/index.js"
+  local bin="$NODE_ENV/bin/linkspector"
+
+  if [[ ! -f "${entry}" ]]; then
+    log_warn "linkspector entry point not found at ${entry}"
+    return
+  fi
+
+  # rm first: writing to the symlink npm created would overwrite index.js.
+  rm -f "${bin}"
+  cat >"${bin}" <<EOF
+#!/usr/bin/env bash
+# Generated by ddev scripts/install-dev-tools.sh; rewritten on each install.
+export PUPPETEER_CACHE_DIR="\${PUPPETEER_CACHE_DIR:-${PUPPETEER_CACHE}}"
+exec node "${entry}" "\$@"
+EOF
+  chmod +x "${bin}"
+}
+
+# True when .envrc will put the tool directories on PATH but direnv has not
+# re-evaluated yet, which is always so on a first install: .envrc took its
+# "tools missing" branch before the directories existed.
+direnv_will_cover_path() {
+  [[ -n "${DIRENV_DIR:-}" ]] || return 1
+  command -v direnv >/dev/null 2>&1 || return 1
+  [[ -f "${REPO_ROOT}/.envrc" ]] || return 1
+  grep -q 'ddev-dev-tools' "${REPO_ROOT}/.envrc" || return 1
+  # "allowed 0" is direnv's code for allowed; a blocked .envrc will not reload.
+  (cd "${REPO_ROOT}" && direnv status 2>/dev/null | grep -q '^Found RC allowed 0$')
+}
+
 verify_installation() {
   log_info "Verifying installation..."
 
-  local failures=0 shadowed=0
+  local failures=0 path_issues=0 direnv_covers=false
+  if direnv_will_cover_path; then
+    direnv_covers=true
+  fi
 
   check_tool() {
     local tool="$1" expected_dir="$2"
@@ -145,11 +205,25 @@ verify_installation() {
     resolved="$(command -v "${tool}" 2>/dev/null || true)"
 
     if [[ -z "${resolved}" ]]; then
-      if [[ -x "${expected_dir}/${tool}" ]]; then
-        log_warn "${tool} is installed but not on your PATH (${expected_dir}/${tool})"
-      else
+      if [[ ! -x "${expected_dir}/${tool}" ]]; then
         log_error "${tool} was not installed and is not on your PATH"
         failures=$((failures + 1))
+        return
+      fi
+      # Run it anyway, so a broken install is not hidden behind a PATH message.
+      shift # drop the tool name; call the copy we installed by full path
+      if ! "${expected_dir}/${tool}" "$@" >/dev/null 2>&1; then
+        log_error "${tool} (${expected_dir}/${tool}) failed to run: $*"
+        failures=$((failures + 1))
+        return
+      fi
+
+      if [[ "${direnv_covers}" == true ]]; then
+        DIRENV_RELOAD_NEEDED=true
+        log_info "✓ ${tool} (${expected_dir}/${tool}), on PATH after direnv reloads"
+      else
+        log_warn "${tool} is installed but not on your PATH (${expected_dir}/${tool})"
+        path_issues=$((path_issues + 1))
       fi
       return
     fi
@@ -157,10 +231,9 @@ verify_installation() {
     if [[ "${resolved}" != "${expected_dir}/"* && "${expected_dir}" != "system" ]]; then
       log_warn "${tool} resolves to ${resolved}"
       log_warn "  not the copy installed here (${expected_dir}/${tool})"
-      shadowed=$((shadowed + 1))
+      path_issues=$((path_issues + 1))
     fi
 
-    # Presence is not enough: a tool can be on PATH and still be unusable.
     if ! "$@" >/dev/null 2>&1; then
       log_error "${tool} (${resolved}) is on PATH but failed to run: $*"
       failures=$((failures + 1))
@@ -170,10 +243,9 @@ verify_installation() {
     log_info "✓ ${tool} (${resolved})"
   }
 
-  # pyspelling only breaks when it loads a config that uses pymdown-extensions,
-  # so --version would not catch the failure this is here to detect. Run it
-  # against a throwaway config instead of the repo's, which would spellcheck
-  # every document and could fail for reasons unrelated to the install.
+  # pyspelling only breaks when a config pulls in pymdown-extensions, so
+  # --version misses it. Probe with a throwaway config, not the repo's, which
+  # could fail over document content.
   local probe; probe="$(mktemp -d)"
   printf 'hello\n' > "${probe}/probe.md"
   cat > "${probe}/probe.yml" <<EOF
@@ -197,13 +269,31 @@ EOF
   check_tool aspell       system            aspell --version
   rm -rf "${probe}"
 
-  if [[ ${shadowed} -gt 0 ]]; then
+  # linkspector launches a browser only for links its HTTP pass cannot settle,
+  # so --version passes with no Chrome and a real run dies partway through.
+  local pd; pd="$(puppeteer_dir)"
+  if [[ -z "${pd}" ]]; then
+    log_error "puppeteer is missing; linkspector cannot check links that need a browser"
+    failures=$((failures + 1))
+  elif ! grep -q PUPPETEER_CACHE_DIR "$NODE_ENV/bin/linkspector" 2>/dev/null; then
+    log_error "$NODE_ENV/bin/linkspector is not the wrapper that sets PUPPETEER_CACHE_DIR"
+    failures=$((failures + 1))
+  elif (cd "${pd}" && PUPPETEER_CACHE_DIR="$PUPPETEER_CACHE" node -e "
+    const args = process.getuid && process.getuid() === 0 ? ['--no-sandbox'] : []
+    import('puppeteer').then(p => p.launch({headless: 'new', args})).then(b => b.close())
+  ") >/dev/null 2>&1; then
+    log_info "✓ linkspector browser (Chrome launches from $PUPPETEER_CACHE)"
+  else
+    log_error "linkspector's Chrome will not launch"
+    log_error "  install it with: (cd ${pd} && PUPPETEER_CACHE_DIR=$PUPPETEER_CACHE node install.mjs)"
+    failures=$((failures + 1))
+  fi
+
+  if [[ ${path_issues} -gt 0 ]]; then
     echo
-    log_warn "${shadowed} tool(s) resolve to a different copy than the one installed here."
-    log_warn "That copy may not have the dependencies these checks need."
-    log_warn "make targets are unaffected: the Makefile puts ${INSTALL_DIR} first itself."
-    log_warn "For your shell, put it first too:"
-    log_warn "  export PATH=\"$PYTHON_ENV/bin:$NODE_ENV/bin:\$PATH\""
+    log_warn "${path_issues} tool(s) are off your PATH, or resolve to a copy installed"
+    log_warn "elsewhere that may lack the dependencies we need. make targets are"
+    log_warn "unaffected: the Makefile puts ${INSTALL_DIR} first itself."
   fi
 
   if [[ ${failures} -gt 0 ]]; then
@@ -212,7 +302,6 @@ EOF
   fi
 }
 
-# Main installation
 main() {
   log_info "Installing DDEV development tools to $INSTALL_DIR"
 
@@ -232,6 +321,11 @@ main() {
   echo "• In DDEV projects: added to PATH via .envrc, if you use direnv"
   echo "• In your shell: add to your profile (.bashrc/.bash_profile/.zshrc):"
   echo "  export PATH=\"$PYTHON_ENV/bin:$NODE_ENV/bin:\$PATH\""
+
+  if [[ "${DIRENV_RELOAD_NEEDED}" == true ]]; then
+    echo
+    log_info "This shell predates the install; run 'direnv reload' to pick the tools up."
+  fi
 }
 
 main "$@"

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -123,31 +123,91 @@ install_node_tools() {
 }
 
 # Verify installation
+#
+# This deliberately does NOT prepend the install directories to PATH. The
+# previous version did, then looked for the tools it had just installed, so it
+# always succeeded while saying nothing about what the user's shell will run.
+# On a machine with a Homebrew pyspelling ahead of ours on PATH it reported a
+# clean install, and `pyspelling --config .spellcheck.yml` then failed with
+# ModuleNotFoundError: No module named 'pymdownx'.
+#
+# So check two things the old version could not: which copy of each tool the
+# current PATH resolves, and whether that copy actually runs.
 verify_installation() {
   log_info "Verifying installation..."
 
-  export PATH="$PYTHON_ENV/bin:$NODE_ENV/bin:$PATH"
+  local failures=0 shadowed=0
 
-  local tools=(
-    "zensical"
-    "pyspelling"
-    "markdownlint"
-    "textlint"
-    "linkspector"
-    "aspell"
-  )
+  check_tool() {
+    local tool="$1" expected_dir="$2"
+    shift 2
+    local resolved
+    resolved="$(command -v "${tool}" 2>/dev/null || true)"
 
-  local missing=()
-  for tool in "${tools[@]}"; do
-    if command -v "$tool" >/dev/null 2>&1; then
-      log_info "✓ $tool"
-    else
-      missing+=("$tool")
+    if [[ -z "${resolved}" ]]; then
+      if [[ -x "${expected_dir}/${tool}" ]]; then
+        log_warn "${tool} is installed but not on your PATH (${expected_dir}/${tool})"
+      else
+        log_error "${tool} was not installed and is not on your PATH"
+        failures=$((failures + 1))
+      fi
+      return
     fi
-  done
 
-  if [[ ${#missing[@]} -gt 0 ]]; then
-    log_error "Missing tools: ${missing[*]}"
+    if [[ "${resolved}" != "${expected_dir}/"* && "${expected_dir}" != "system" ]]; then
+      log_warn "${tool} resolves to ${resolved}"
+      log_warn "  not the copy installed here (${expected_dir}/${tool})"
+      shadowed=$((shadowed + 1))
+    fi
+
+    # Presence is not enough: a tool can be on PATH and still be unusable.
+    if ! "$@" >/dev/null 2>&1; then
+      log_error "${tool} (${resolved}) is on PATH but failed to run: $*"
+      failures=$((failures + 1))
+      return
+    fi
+
+    log_info "✓ ${tool} (${resolved})"
+  }
+
+  # pyspelling only breaks when it loads a config that uses pymdown-extensions,
+  # so --version would not catch the failure this is here to detect. Run it
+  # against a throwaway config instead of the repo's, which would spellcheck
+  # every document and could fail for reasons unrelated to the install.
+  local probe; probe="$(mktemp -d)"
+  printf 'hello\n' > "${probe}/probe.md"
+  cat > "${probe}/probe.yml" <<EOF
+matrix:
+- name: probe
+  aspell:
+    lang: en
+  pipeline:
+  - pyspelling.filters.markdown:
+      markdown_extensions:
+      - pymdownx.superfences:
+  sources:
+  - '${probe}/probe.md'
+EOF
+
+  check_tool pyspelling   "$PYTHON_ENV/bin" pyspelling --config "${probe}/probe.yml"
+  check_tool zensical     "$PYTHON_ENV/bin" zensical --version
+  check_tool markdownlint "$NODE_ENV/bin"   markdownlint --version
+  check_tool textlint     "$NODE_ENV/bin"   textlint --version
+  check_tool linkspector  "$NODE_ENV/bin"   linkspector --version
+  check_tool aspell       system            aspell --version
+  rm -rf "${probe}"
+
+  if [[ ${shadowed} -gt 0 ]]; then
+    echo
+    log_warn "${shadowed} tool(s) resolve to a different copy than the one installed here."
+    log_warn "That copy may not have the dependencies these checks need."
+    log_warn "make targets are unaffected: the Makefile puts ${INSTALL_DIR} first itself."
+    log_warn "For your shell, put it first too:"
+    log_warn "  export PATH=\"$PYTHON_ENV/bin:$NODE_ENV/bin:\$PATH\""
+  fi
+
+  if [[ ${failures} -gt 0 ]]; then
+    log_error "${failures} tool(s) missing or not working"
     return 1
   fi
 }
@@ -168,8 +228,9 @@ main() {
   log_info "Installation complete!"
   echo
   echo "The tools are now available:"
-  echo "• In DDEV projects: Automatically added to PATH via .envrc"
-  echo "• Globally: Add to your shell profile (.bashrc/.bash_profile/.zshrc):"
+  echo "• To make: always, the Makefile puts these directories on PATH itself"
+  echo "• In DDEV projects: added to PATH via .envrc, if you use direnv"
+  echo "• In your shell: add to your profile (.bashrc/.bash_profile/.zshrc):"
   echo "  export PATH=\"$PYTHON_ENV/bin:$NODE_ENV/bin:\$PATH\""
 }
 


### PR DESCRIPTION
## The Issue

No GitHub issue. Found while working on #8650, where a docs spellcheck failure reached CI that should have been caught locally.

`scripts/install-dev-tools.sh` installs the right packages — `pyspelling` and `pymdown-extensions` included — into `$HOME/.ddev-dev-tools`. Getting them *used* is the part that does not work, in several ways that compound.

**Only `.envrc` put those directories on PATH.** That covers interactive shells with direnv hooked in and nothing else, so a make target could resolve some other copy of a tool, or none at all. On the machine where this was found:

```text
pyspelling     /home/linuxbrew/.linuxbrew/bin/pyspelling   <- Homebrew, not ours
markdownlint   /home/linuxbrew/.linuxbrew/bin/markdownlint <- Homebrew, not ours
zensical       <not on PATH>
textlint       <not on PATH>
linkspector    <not on PATH>
```

That Homebrew `pyspelling` has no `pymdown-extensions` in its Python prefix, so it cannot read `.spellcheck.yml` at all and dies with `ModuleNotFoundError: No module named 'pymdownx'`. Two working installs, and PATH picked the broken one. Meanwhile `make zensical` reported the tool missing while it sat installed in the venv.

**Missing tools became passing builds.** `markdownlint`, `pyspelling`, `zensical`, `textlint` and `linkspector` each printed a note and exited 0, so a missing tool looked like a clean run — worse than failing, because it looks checked.

**Exporting PATH from the Makefile is not enough on macOS.** GNU make 3.81, which is still `/usr/bin/make` on macOS, execs a recipe line containing no shell metacharacters itself and resolves the command against make's own PATH rather than the one the Makefile exported. So `make pyspelling` died with `pyspelling: No such file or directory` one line after `command -v pyspelling` had succeeded. The other targets were unaffected only by luck: their recipe lines happen to contain a glob, a redirect or a `;`, which sends them through the shell.

**`verify_installation` could not have caught any of it.** It prepended the install directories to PATH and then looked for the tools it had just installed, so it passed by construction and said nothing about what the user's shell resolves. It also only tested that each tool exists, and `command -v pyspelling` succeeds for a copy that explodes on use.

## How This PR Solves The Issue

**The Makefile puts the dev-tools directories on PATH itself** rather than relying on direnv. That fixes both the not-found case and the shadowing case, since the installed copies now come first for every target.

**Missing tools fail instead of skipping.** A `require_tool` helper prints what is missing, where it was expected, and how to install it, then exits nonzero. It is used by `markdownlint`, `pyspelling`, `zensical`, `zensical-serve`, `textlint` and `linkspector`. (`golangci-lint` still skips when absent; `install-dev-tools.sh` does not install it, so requiring it would be a separate decision.)

**Tool invocations go through the shell.** A `run_tool` macro pairs the `require_tool` check with a `PATH=`-prefixed invocation, which forces the recipe line through `$(SHELL)` and so past the make 3.81 behavior above.

**`verify_installation` is rewritten** to check what the user's shell actually resolves, warn when a tool resolves outside the install directory, and run each tool rather than merely locating it. `pyspelling` gets a throwaway config that exercises `pymdown-extensions`, because `--version` would not catch this failure and the repo config would spellcheck every document and could fail for unrelated reasons.

**`staticrequired` is unchanged** and still runs golangci-lint, markdownlint and zensical. Spellcheck stays opt-in via `make pyspelling`: it costs ~30 seconds, which is more than the rest of `staticrequired` put together. Note that spelling *is* enforced in CI — `.github/workflows/docs-check.yml` runs `rojopolis/spellcheck-github-actions`, which is pyspelling reading this repo's `.spellcheck.yml` — it is simply not run through make.

## Manual Testing Instructions

```bash
# 1. The docs gates run rather than skipping, and resolve the installed copies.
#    Before this PR, on macOS, pyspelling failed with "No such file or directory".
make pyspelling
make zensical
make markdownlint
make textlint
make staticrequired

# 2. A missing tool fails loudly instead of passing.
make pyspelling DEV_TOOLS_DIR=/nonexistent PATH=/usr/bin:/bin
#   -> "pyspelling is required but was not found on PATH." and exit 1
#   Same for markdownlint, zensical, zensical-serve, textlint, linkspector.

# 3. Verification reports what your shell resolves, not what the script installed.
scripts/install-dev-tools.sh
```

On a machine with a Homebrew `pyspelling` ahead of the venv, step 3 reports it shadowed and broken, `markdownlint` shadowed but working, `zensical`/`textlint`/`linkspector` installed but off PATH, and exits nonzero. The previous version printed six clean checkmarks for that same state.

## Automated Testing Overview

No new tests: the change is a Makefile and a developer setup script, neither of which has existing test coverage.

Verified locally on macOS: `make pyspelling` passes in ~54s where it previously could not start; `make markdownlint`, `make textlint` and `make staticrequired` all execute their tools; each target with `DEV_TOOLS_DIR=/nonexistent PATH=/usr/bin:/bin` prints the installer hint and exits nonzero; and the rewritten verification was run against a machine exhibiting the shadowing problem and correctly distinguished shadowed-and-broken from shadowed-but-working from installed-but-off-PATH.

## Release/Deployment Notes

No user-facing DDEV changes; this affects the development environment only.

One thing contributors will notice: targets that used to skip a missing tool now fail, which is the intent, but anyone running them without the docs tooling installed will need `scripts/install-dev-tools.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
