### PR TITLE
fix(router): record ephemeral port substitutions on the ddev-router container, fixes #8644

### DIFF
--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -60,10 +60,10 @@ If you're experiencing issues with Vite development servers (like "Bad Gateway" 
 On `ddev start` you may see a message like this:
 
 ```bash
-Port 443 is busy, using 33001 instead, see https://ddev.com/s/port-conflict
+Port 443 is not available, using 33001 instead, see https://ddev.com/s/port-conflict
 ```
 
-This means that DDEV has detected that it can't use the expected port (`443`) in this example, because another application is using it. If this is OK, you don't need to take any action. Most users want to use the default ports though (`80` and `443`) so you may want to figure out what the conflict is and solve it (usually by stopping the competing application).
+This means that DDEV has detected that it can't use the expected port (`443`) in this example, usually because another application is using it. (It can also mean the port was occupied when the `ddev-router` container was created, and DDEV keeps using the substitute port until the router is recreated, for example by `ddev poweroff && ddev start`.) If this is OK, you don't need to take any action. Most users want to use the default ports though (`80` and `443`) so you may want to figure out what the conflict is and solve it (usually by stopping the competing application).
 
 `ddev utility port-diagnose`, run from your project directory, can likely explain what's going on. It checks each port your project needs, identifies the blocking process by name and PID, and suggests how to stop it:
 

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -3,6 +3,7 @@ package ddevapp
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -35,6 +36,29 @@ const (
 // but it may not yet be occupied. A map is used just to make it easy
 // to detect if it's there, the value in the map is not used.
 var EphemeralRouterPortsAssigned = make(map[int]bool)
+
+// RouterPortSubstitutionsLabel is the name of a Docker label set on the
+// ddev-router container recording which ephemeral host port was substituted
+// for each standard (proposed) router port, in the form "80=33000,443=33001".
+// The router binds ephemeral substitutes as <port>:<port>, so without this
+// label the container carries no trace of which standard port an ephemeral
+// port stands in for. Storing the record on the router container gives it
+// exactly the router's lifetime: it survives across ddev invocations and
+// disappears when the router is recreated or removed.
+//
+// It closes a race: when a standard port (say 80) is busy at router creation
+// time, the router is created bound to an ephemeral substitute. If the
+// original occupant of port 80 then goes away, a later project would see
+// port 80 as free and expect the router to bind it directly - a port the
+// running router does not have - forcing an unnecessary router recreation.
+// See GetAvailableRouterPort().
+const RouterPortSubstitutionsLabel = "com.ddev.router-port-substitutions"
+
+// routerPortEphemeralSubstitutions remembers substitutions decided by this
+// process that may not yet have been written to the router's
+// RouterPortSubstitutionsLabel; the label is only written when the router
+// container is created or recreated.
+var routerPortEphemeralSubstitutions = make(map[string]string)
 
 // RouterComposeYAMLPath returns the full filepath to the routers docker-compose yaml file.
 func RouterComposeYAMLPath() string {
@@ -234,6 +258,18 @@ func generateRouterCompose(activeApps []*DdevApp) (string, error) {
 	uid, gid, username := dockerutil.GetContainerUser()
 	timezone, _ := util.GetLocalTimezone()
 
+	// Carry forward the port substitutions recorded on the existing router
+	// (if any) plus those decided by this process, dropping entries whose
+	// ephemeral port the new router will no longer bind because no active
+	// project uses it anymore.
+	oldRouter, _ := FindDdevRouter()
+	portSubstitutions := knownRouterPortSubstitutions(oldRouter)
+	for proposed, ephemeral := range portSubstitutions {
+		if !nodeps.ArrayContainsString(exposedPorts, ephemeral) {
+			delete(portSubstitutions, proposed)
+		}
+	}
+
 	templateVars := map[string]any{
 		"Username":                   username,
 		"UID":                        uid,
@@ -251,6 +287,8 @@ func generateRouterCompose(activeApps []*DdevApp) (string, error) {
 		"IsPodman":                   dockerutil.IsPodman(),
 		"IsRootless":                 dockerutil.IsRootless(),
 		"UseKeepID":                  dockerutil.UseKeepID(),
+		"PortSubstitutionsLabel":     RouterPortSubstitutionsLabel,
+		"PortSubstitutions":          formatRouterPortSubstitutions(portSubstitutions),
 	}
 
 	t, err := template.New("router_compose_template.yaml").Funcs(getTemplateFuncMap()).ParseFS(bundledAssets, "router_compose_template.yaml")
@@ -679,6 +717,41 @@ func AllocateAvailablePortForRouter(start, upTo int) (int, bool) {
 	return 0, false
 }
 
+// parseRouterPortSubstitutions parses a RouterPortSubstitutionsLabel value of
+// the form "80=33000,443=33001" into a proposedPort → ephemeralPort map.
+func parseRouterPortSubstitutions(labelValue string) map[string]string {
+	subs := make(map[string]string)
+	for pair := range strings.SplitSeq(labelValue, ",") {
+		if proposed, ephemeral, found := strings.Cut(pair, "="); found && proposed != "" && ephemeral != "" {
+			subs[proposed] = ephemeral
+		}
+	}
+	return subs
+}
+
+// formatRouterPortSubstitutions is the inverse of parseRouterPortSubstitutions,
+// producing a deterministic (sorted) label value.
+func formatRouterPortSubstitutions(subs map[string]string) string {
+	pairs := make([]string, 0, len(subs))
+	for proposed, ephemeral := range subs {
+		pairs = append(pairs, proposed+"="+ephemeral)
+	}
+	slices.Sort(pairs)
+	return strings.Join(pairs, ",")
+}
+
+// knownRouterPortSubstitutions returns the substitutions recorded on the
+// given router container's RouterPortSubstitutionsLabel, overlaid with any
+// made by this process that the label may not have yet.
+func knownRouterPortSubstitutions(router *container.Summary) map[string]string {
+	subs := make(map[string]string)
+	if router != nil {
+		subs = parseRouterPortSubstitutions(router.Labels[RouterPortSubstitutionsLabel])
+	}
+	maps.Copy(subs, routerPortEphemeralSubstitutions)
+	return subs
+}
+
 // GetAvailableRouterPort gets an ephemeral replacement port when the
 // proposedPort is not available.
 //
@@ -696,11 +769,12 @@ func GetAvailableRouterPort(proposedPort string, minPort, maxPort int) (string, 
 	// If the router exists, check if it's already handling the proposedPort
 	// regardless of its health status. This prevents allocating ephemeral ports
 	// when the router is running but unhealthy (e.g., broken Traefik config).
+	var routerPortsAlreadyBound []string
 	r, err := FindDdevRouter()
 	if r != nil && err == nil {
 		util.Debug("GetAvailableRouterPort(): Router exists, checking bound ports")
 		// Check if the proposedPort is already being handled by the router.
-		routerPortsAlreadyBound, err := dockerutil.GetBoundHostPorts(r.ID)
+		routerPortsAlreadyBound, err = dockerutil.GetBoundHostPorts(r.ID)
 		if err != nil {
 			util.Debug("GetAvailableRouterPort(): Error getting bound ports: %v", err)
 			// Continue to port availability check below
@@ -715,6 +789,16 @@ func GetAvailableRouterPort(proposedPort string, minPort, maxPort int) (string, 
 	// At this point, the router may or may not be running, but we
 	// have not found it already having the proposedPort bound
 	if !netutil.IsPortActive(proposedPort) {
+		// The proposedPort looks free on the host, but if it was previously
+		// substituted with an ephemeral port that the running router still has
+		// bound, keep the substitution. Whatever occupied the proposedPort at
+		// substitution time may simply have gone away since; handing out the
+		// now-free proposedPort would expect a port the running router does not
+		// actually have bound, forcing an unnecessary router recreation.
+		if ephemeralPort, ok := knownRouterPortSubstitutions(r)[proposedPort]; ok && nodeps.ArrayContainsString(routerPortsAlreadyBound, ephemeralPort) {
+			util.Debug("GetAvailableRouterPort(): proposedPort %s is available, but was previously substituted with ephemeralPort=%s, which ddev-router still has bound, keep using it", proposedPort, ephemeralPort)
+			return proposedPort, ephemeralPort, true
+		}
 		// If the proposedPort is available (not active) for use, just have the router use it
 		util.Debug("GetAvailableRouterPort(): proposedPort %s is available, use proposedPort=%s", proposedPort, proposedPort)
 		return proposedPort, "", false
@@ -729,7 +813,12 @@ func GetAvailableRouterPort(proposedPort string, minPort, maxPort int) (string, 
 
 	util.Debug("GetAvailableRouterPort(): proposedPort %s is not available, ephemeralPort=%d is available, use it", proposedPort, ephemeralPort)
 
-	return proposedPort, strconv.Itoa(ephemeralPort), true
+	ephemeralPortStr := strconv.Itoa(ephemeralPort)
+	// Remember the substitution so it can be written to the router's
+	// RouterPortSubstitutionsLabel when the router is (re)created.
+	routerPortEphemeralSubstitutions[proposedPort] = ephemeralPortStr
+
+	return proposedPort, ephemeralPortStr, true
 }
 
 // GetEphemeralPortsIfNeeded replaces the provided ports with an ephemeral version if they need it.
@@ -739,7 +828,7 @@ func GetEphemeralPortsIfNeeded(ports []*string, verbose bool) {
 		if portChangeRequired {
 			*port = replacementPort
 			if verbose {
-				output.UserOut.Printf("Port %s is busy, using %s instead, see %s", proposedPort, replacementPort, "https://ddev.com/s/port-conflict")
+				output.UserOut.Printf("Port %s is not available, using %s instead, see %s", proposedPort, replacementPort, "https://ddev.com/s/port-conflict")
 			}
 		}
 	}

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -690,9 +690,14 @@ func CheckRouterPorts(activeApps []*DdevApp) error {
 // Returns the port found, and a boolean that determines if the
 // port is valid (true) or not (false), and the port is marked as allocated
 func AllocateAvailablePortForRouter(start, upTo int) (int, bool) {
-	// Get ports already bound by the router - these can be reused
+	// Get ports already bound by the router - these can be reused.
+	// Only trust these bindings when the router is actually running: a
+	// container that failed to start (for example one that lost a port-bind
+	// race) still reports the port it tried to bind in its HostConfig, and
+	// treating that as a legitimate binding would keep reoffering the same
+	// never-actually-bound port on every subsequent call.
 	var routerBoundPorts []string
-	if router, err := FindDdevRouter(); err == nil && router != nil {
+	if router, err := FindDdevRouter(); err == nil && router != nil && router.State == "running" {
 		routerBoundPorts, _ = dockerutil.GetBoundHostPorts(router.ID)
 	}
 
@@ -767,12 +772,17 @@ func GetAvailableRouterPort(proposedPort string, minPort, maxPort int) (string, 
 	if proposedPort == "" {
 		return proposedPort, "", false
 	}
-	// If the router exists, check if it's already handling the proposedPort
+	// If the router is running, check if it's already handling the proposedPort
 	// regardless of its health status. This prevents allocating ephemeral ports
 	// when the router is running but unhealthy (e.g., broken Traefik config).
+	// A router container that exists but isn't running (for example one that
+	// failed to start because it lost a port-bind race) still reports the
+	// port it tried to bind in its HostConfig, so its bindings - and the
+	// substitutions recorded on its RouterPortSubstitutionsLabel, checked
+	// below - are only trustworthy while it's actually running.
 	var routerPortsAlreadyBound []string
 	r, err := FindDdevRouter()
-	if r != nil && err == nil {
+	if r != nil && err == nil && r.State == "running" {
 		util.Debug("GetAvailableRouterPort(): Router exists, checking bound ports")
 		// Check if the proposedPort is already being handled by the router.
 		routerPortsAlreadyBound, err = dockerutil.GetBoundHostPorts(r.ID)

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -54,11 +54,12 @@ var EphemeralRouterPortsAssigned = make(map[int]bool)
 // See GetAvailableRouterPort().
 const RouterPortSubstitutionsLabel = "com.ddev.router-port-substitutions"
 
-// routerPortEphemeralSubstitutions remembers substitutions decided by this
+// RouterPortEphemeralSubstitutions remembers substitutions decided by this
 // process that may not yet have been written to the router's
 // RouterPortSubstitutionsLabel; the label is only written when the router
-// container is created or recreated.
-var routerPortEphemeralSubstitutions = make(map[string]string)
+// container is created or recreated. Exported so tests can reset it to
+// simulate a fresh ddev process, the same way EphemeralRouterPortsAssigned is.
+var RouterPortEphemeralSubstitutions = make(map[string]string)
 
 // RouterComposeYAMLPath returns the full filepath to the routers docker-compose yaml file.
 func RouterComposeYAMLPath() string {
@@ -748,7 +749,7 @@ func knownRouterPortSubstitutions(router *container.Summary) map[string]string {
 	if router != nil {
 		subs = parseRouterPortSubstitutions(router.Labels[RouterPortSubstitutionsLabel])
 	}
-	maps.Copy(subs, routerPortEphemeralSubstitutions)
+	maps.Copy(subs, RouterPortEphemeralSubstitutions)
 	return subs
 }
 
@@ -816,7 +817,7 @@ func GetAvailableRouterPort(proposedPort string, minPort, maxPort int) (string, 
 	ephemeralPortStr := strconv.Itoa(ephemeralPort)
 	// Remember the substitution so it can be written to the router's
 	// RouterPortSubstitutionsLabel when the router is (re)created.
-	routerPortEphemeralSubstitutions[proposedPort] = ephemeralPortStr
+	RouterPortEphemeralSubstitutions[proposedPort] = ephemeralPortStr
 
 	return proposedPort, ephemeralPortStr, true
 }

--- a/pkg/ddevapp/router_compose_template.yaml
+++ b/pkg/ddevapp/router_compose_template.yaml
@@ -10,6 +10,13 @@ services:
     init: true
     user: {{ .UID }}:{{ .GID }}
 
+    {{ if .PortSubstitutions }}
+    labels:
+      # Which ephemeral host port stands in for each standard router port,
+      # see RouterPortSubstitutionsLabel in pkg/ddevapp/router.go
+      {{ .PortSubstitutionsLabel }}: "{{ .PortSubstitutions }}"
+    {{ end }}
+
     {{ if .UseKeepID }}
     userns_mode: keep-id
     {{ end }}

--- a/pkg/ddevapp/router_substitutions_test.go
+++ b/pkg/ddevapp/router_substitutions_test.go
@@ -27,9 +27,9 @@ func TestParseFormatRouterPortSubstitutions(t *testing.T) {
 // TestKnownRouterPortSubstitutions checks that the router label and the
 // in-process map are merged, with the in-process map winning on conflict.
 func TestKnownRouterPortSubstitutions(t *testing.T) {
-	origSubstitutions := routerPortEphemeralSubstitutions
+	origSubstitutions := RouterPortEphemeralSubstitutions
 	t.Cleanup(func() {
-		routerPortEphemeralSubstitutions = origSubstitutions
+		RouterPortEphemeralSubstitutions = origSubstitutions
 	})
 
 	router := &container.Summary{
@@ -38,18 +38,18 @@ func TestKnownRouterPortSubstitutions(t *testing.T) {
 		},
 	}
 
-	routerPortEphemeralSubstitutions = map[string]string{}
+	RouterPortEphemeralSubstitutions = map[string]string{}
 	require.Equal(t, map[string]string{"80": "33000", "443": "33001"}, knownRouterPortSubstitutions(router))
 
 	// nil router yields only the in-process entries
-	routerPortEphemeralSubstitutions = map[string]string{"8025": "33002"}
+	RouterPortEphemeralSubstitutions = map[string]string{"8025": "33002"}
 	require.Equal(t, map[string]string{"8025": "33002"}, knownRouterPortSubstitutions(nil))
 
 	// In-process entries overlay the label and win on conflict
-	routerPortEphemeralSubstitutions = map[string]string{"80": "33005", "8025": "33002"}
+	RouterPortEphemeralSubstitutions = map[string]string{"80": "33005", "8025": "33002"}
 	require.Equal(t, map[string]string{"80": "33005", "443": "33001", "8025": "33002"}, knownRouterPortSubstitutions(router))
 
 	// Router without the label contributes nothing
-	routerPortEphemeralSubstitutions = map[string]string{}
+	RouterPortEphemeralSubstitutions = map[string]string{}
 	require.Equal(t, map[string]string{}, knownRouterPortSubstitutions(&container.Summary{Labels: map[string]string{}}))
 }

--- a/pkg/ddevapp/router_substitutions_test.go
+++ b/pkg/ddevapp/router_substitutions_test.go
@@ -1,0 +1,55 @@
+package ddevapp
+
+import (
+	"testing"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseFormatRouterPortSubstitutions checks the round-trip and
+// malformed-input behavior of the RouterPortSubstitutionsLabel serialization.
+func TestParseFormatRouterPortSubstitutions(t *testing.T) {
+	require.Equal(t, map[string]string{}, parseRouterPortSubstitutions(""))
+	require.Equal(t, map[string]string{"80": "33000"}, parseRouterPortSubstitutions("80=33000"))
+	require.Equal(t, map[string]string{"80": "33000", "443": "33001"}, parseRouterPortSubstitutions("80=33000,443=33001"))
+	// Malformed pairs are skipped rather than breaking the whole label
+	require.Equal(t, map[string]string{"80": "33000"}, parseRouterPortSubstitutions("80=33000,junk,=1,2="))
+
+	require.Equal(t, "", formatRouterPortSubstitutions(map[string]string{}))
+	// Output is sorted for determinism
+	require.Equal(t, "443=33001,80=33000", formatRouterPortSubstitutions(map[string]string{"80": "33000", "443": "33001"}))
+
+	roundTrip := parseRouterPortSubstitutions(formatRouterPortSubstitutions(map[string]string{"80": "33000", "443": "33001", "8025": "33002"}))
+	require.Equal(t, map[string]string{"80": "33000", "443": "33001", "8025": "33002"}, roundTrip)
+}
+
+// TestKnownRouterPortSubstitutions checks that the router label and the
+// in-process map are merged, with the in-process map winning on conflict.
+func TestKnownRouterPortSubstitutions(t *testing.T) {
+	origSubstitutions := routerPortEphemeralSubstitutions
+	t.Cleanup(func() {
+		routerPortEphemeralSubstitutions = origSubstitutions
+	})
+
+	router := &container.Summary{
+		Labels: map[string]string{
+			RouterPortSubstitutionsLabel: "80=33000,443=33001",
+		},
+	}
+
+	routerPortEphemeralSubstitutions = map[string]string{}
+	require.Equal(t, map[string]string{"80": "33000", "443": "33001"}, knownRouterPortSubstitutions(router))
+
+	// nil router yields only the in-process entries
+	routerPortEphemeralSubstitutions = map[string]string{"8025": "33002"}
+	require.Equal(t, map[string]string{"8025": "33002"}, knownRouterPortSubstitutions(nil))
+
+	// In-process entries overlay the label and win on conflict
+	routerPortEphemeralSubstitutions = map[string]string{"80": "33005", "8025": "33002"}
+	require.Equal(t, map[string]string{"80": "33005", "443": "33001", "8025": "33002"}, knownRouterPortSubstitutions(router))
+
+	// Router without the label contributes nothing
+	routerPortEphemeralSubstitutions = map[string]string{}
+	require.Equal(t, map[string]string{}, knownRouterPortSubstitutions(&container.Summary{Labels: map[string]string{}}))
+}

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -434,6 +434,129 @@ func TestEphemeralPortsReusedOnRestart(t *testing.T) {
 	require.Equal(t, originalRouterID, router.ID, "Router should not be recreated when ephemeral ports are reused")
 }
 
+// TestRouterPortSubstitutionPersistsAcrossProjects tests that when a router port
+// is substituted with an ephemeral port because the standard port was busy when
+// the router was created, a later, different project still adopts the same
+// substitute after the original conflict clears - recovered from the router's
+// RouterPortSubstitutionsLabel - instead of expecting the router to bind the
+// now-free standard port and forcing an unnecessary router recreation.
+func TestRouterPortSubstitutionPersistsAcrossProjects(t *testing.T) {
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skipping because GOTEST_SHORT is set")
+	}
+	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && (dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop()) {
+		t.Skip("Skipping on Lima/Colima/Rancher as ports don't seem to be released properly in a timely fashion")
+	}
+
+	// Stop all projects and the router first so we can occupy the ports they would normally use
+	ddevapp.PowerOff()
+	ddevapp.EphemeralRouterPortsAssigned = make(map[int]bool)
+	ddevapp.RouterPortEphemeralSubstitutions = make(map[string]string)
+
+	targetHTTPPort, targetHTTPSPort := "39080", "39443"
+
+	site1 := filepath.Join(testcommon.CreateTmpDir(t.Name() + "-project1"))
+	_ = os.MkdirAll(site1, 0755)
+	err := fileutil.TemplateStringToFile("Hello from project1", nil, filepath.Join(site1, "index.html"))
+	require.NoError(t, err)
+	app1, err := ddevapp.NewApp(site1, false)
+	require.NoError(t, err)
+	app1.Name = t.Name() + "-project1"
+	app1.RouterHTTPPort, app1.RouterHTTPSPort = targetHTTPPort, targetHTTPSPort
+	require.NoError(t, app1.WriteConfig())
+
+	site2 := filepath.Join(testcommon.CreateTmpDir(t.Name() + "-project2"))
+	_ = os.MkdirAll(site2, 0755)
+	err = fileutil.TemplateStringToFile("Hello from project2", nil, filepath.Join(site2, "index.html"))
+	require.NoError(t, err)
+	app2, err := ddevapp.NewApp(site2, false)
+	require.NoError(t, err)
+	app2.Name = t.Name() + "-project2"
+	app2.RouterHTTPPort, app2.RouterHTTPSPort = targetHTTPPort, targetHTTPSPort
+	require.NoError(t, app2.WriteConfig())
+
+	// Occupy the target ports so project1 is forced onto ephemeral substitutes
+	var listeners []net.Listener
+	for _, p := range []string{targetHTTPPort, targetHTTPSPort} {
+		listener, err := net.Listen("tcp", "127.0.0.1:"+p)
+		require.NoError(t, err)
+		listeners = append(listeners, listener)
+	}
+	listenersClosed := false
+	closeListeners := func() {
+		if listenersClosed {
+			return
+		}
+		for _, l := range listeners {
+			_ = l.Close()
+		}
+		listenersClosed = true
+	}
+
+	t.Cleanup(func() {
+		closeListeners()
+		_ = app1.Stop(true, false)
+		_ = app2.Stop(true, false)
+		_ = os.RemoveAll(site1)
+		_ = os.RemoveAll(site2)
+		_ = dockerutil.RemoveContainer(nodeps.RouterContainer)
+	})
+
+	// Start project1 while the target ports are busy - it should be forced onto
+	// ephemeral substitutes, and the router should record the substitution.
+	require.NoError(t, app1.Start())
+
+	app1, err = ddevapp.NewApp(app1.GetAppRoot(), true)
+	require.NoError(t, err)
+	substituteHTTPPort := app1.GetPrimaryRouterHTTPPort()
+	substituteHTTPSPort := app1.GetPrimaryRouterHTTPSPort()
+	require.NotEqual(t, targetHTTPPort, substituteHTTPPort, "HTTP port should be ephemeral")
+	require.NotEqual(t, targetHTTPSPort, substituteHTTPSPort, "HTTPS port should be ephemeral")
+
+	router, err := ddevapp.FindDdevRouter()
+	require.NoError(t, err)
+	originalRouterID := router.ID
+
+	labelValue := router.Labels[ddevapp.RouterPortSubstitutionsLabel]
+	require.Contains(t, labelValue, targetHTTPPort+"="+substituteHTTPPort,
+		"router label should record the HTTP port substitution, got %q", labelValue)
+	require.Contains(t, labelValue, targetHTTPSPort+"="+substituteHTTPSPort,
+		"router label should record the HTTPS port substitution, got %q", labelValue)
+
+	// Release the target ports: whatever was occupying them is gone now, so a
+	// fresh negotiation would see them as free.
+	closeListeners()
+
+	// Simulate project2 starting from a brand-new ddev process: clear the
+	// in-process substitution cache so the router's label is the only place
+	// left the substitution could be recovered from.
+	ddevapp.RouterPortEphemeralSubstitutions = make(map[string]string)
+
+	reuseMessage := nodeps.RouterContainer + " already running, pushing new config"
+	recreateMessage := "Starting " + nodeps.RouterContainer + ", pushing config"
+
+	getOutput := util.CaptureUserOut()
+	err = app2.Start()
+	startOutput := getOutput()
+	require.NoError(t, err)
+
+	require.Contains(t, startOutput, reuseMessage,
+		"project2 should reuse the running router, output: %s", startOutput)
+	require.NotContains(t, startOutput, recreateMessage,
+		"project2 should NOT recreate the router just because the standard port freed up, output: %s", startOutput)
+
+	app2, err = ddevapp.NewApp(app2.GetAppRoot(), true)
+	require.NoError(t, err)
+	require.Equal(t, substituteHTTPPort, app2.GetPrimaryRouterHTTPPort(),
+		"project2 should adopt the same ephemeral substitute recorded on the router, not the now-free standard port")
+	require.Equal(t, substituteHTTPSPort, app2.GetPrimaryRouterHTTPSPort())
+
+	router, err = ddevapp.FindDdevRouter()
+	require.NoError(t, err)
+	require.Equal(t, originalRouterID, router.ID,
+		"router should not be recreated when a later project's proposed port frees up but was previously substituted")
+}
+
 // TestProcessExposePorts tests the ProcessExposePorts function for various input scenarios
 func TestProcessExposePorts(t *testing.T) {
 	type testCase struct {

--- a/pkg/ddevapp/router_test.go
+++ b/pkg/ddevapp/router_test.go
@@ -447,6 +447,15 @@ func TestRouterPortSubstitutionPersistsAcrossProjects(t *testing.T) {
 	if nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") && (dockerutil.IsColima() || dockerutil.IsLima() || dockerutil.IsRancherDesktop()) {
 		t.Skip("Skipping on Lima/Colima/Rancher as ports don't seem to be released properly in a timely fashion")
 	}
+	// util.CaptureUserOut() below redirects output to an os.Pipe() that isn't
+	// drained until getOutput() is called, i.e. only after app2.Start()
+	// returns. With DDEV_DEBUG=true a full Start() can emit enough debug
+	// output to fill that pipe before it returns, deadlocking the write on
+	// Windows. Same root cause as the TestDdevLogs and
+	// TestRouterNotRebuiltOnHostnameChange Windows skips.
+	if nodeps.IsWindows() {
+		t.Skip("Skipping on Windows because CaptureUserOut() can hang around a full app.Start()")
+	}
 
 	// Stop all projects and the router first so we can occupy the ports they would normally use
 	ddevapp.PowerOff()


### PR DESCRIPTION
## TL;DR

When `ddev-router` has to fall back to an ephemeral port because a standard port was busy, record that substitution as a Docker label on the router container. That way a later `ddev start` — in a different process, after the port conflict has cleared — keeps using the substitute instead of recreating the router.

## The Issue

- Fixes #8644

When a standard router port (say 443) is busy at `ddev-router` creation time, the router is created bound to an ephemeral substitute (say 33000). The router binds substitutes as `33000:33000`, so the container carries no trace of which standard port the ephemeral port stands in for. If the original occupant of 443 then goes away, a later `ddev start` of a different project sees 443 as free and expects the router to bind it directly — a port the running router does not have — so `PortsMatch()` fails and the router is recreated unnecessarily. That recreation churn is what made `TestRouterNotRebuiltOnHostnameChange` (added in #8561) fail intermittently in CI.

This supersedes the router-port-race portion of #8649 with a different mechanism (see below); the Windows `CaptureUserOut()` test-skip portion of that work is unrelated and stays in its own PR.

## How This PR Solves The Issue

Record the substitution decision on the object whose lifetime bounds its validity: the router container itself, rather than in an in-process map that dies with the `ddev` process (and the router routinely outlives any single `ddev` invocation).

- `generateRouterCompose()` writes a `com.ddev.router-port-substitutions` Docker label (e.g. `443=33000`) onto the router, merging the previous router's label with substitutions decided by the current process and dropping entries whose ephemeral port the new router no longer binds.
- `GetAvailableRouterPort()` consults the label (plus a small in-process cache bridging the gap until the label is written) when the proposed port looks free: if the running router still has the previously-substituted ephemeral port bound, it keeps using the substitute instead of handing out the now-free standard port, avoiding the spurious recreation.
- Both `GetAvailableRouterPort()` and `AllocateAvailablePortForRouter()` now only trust the router's bound-port data (and, by extension, its substitution label) when `router.State == "running"`. A router container that exists but isn't running — for example one that lost a TOCTOU port-bind race — still reports the port it *tried* to bind in its stale `HostConfig`, and would otherwise poison later allocations with a port that was never actually bound. This is the same fix applied in #8648 (open, targets `main` directly, fixes #8293); it's included here because the new substitution-reuse check above sits on the exact same `FindDdevRouter()` result and inherits the identical vulnerability.

Also rewords the "Port X is busy" message to "Port X is not available", since the substitute can now be reported when the port is no longer busy, and updates the matching troubleshooting docs example.

## Manual Testing Instructions

1. Configure two projects with the same non-default, unprivileged router ports so no `sudo` is needed, e.g. `ddev config --router-http-port=28080 --router-https-port=28443` in each.
2. Occupy those ports (`nc -l -k 28080 &` / `nc -l -k 28443 &`, or any listener).
3. `ddev start` project1. Expect `Port 28080 is not available, using <N> instead`, and `docker inspect ddev-router --format '{{index .Config.Labels "com.ddev.router-port-substitutions"}}'` to show `28080=<N>,28443=<M>`.
4. Kill the listeners so the standard ports look free again.
5. `ddev start` project2 in a **separate terminal/process**. Expect `ddev-router already running, pushing new config...` (not `Starting ddev-router...`), the router container ID unchanged (`docker inspect ddev-router --format '{{.Id}}'`), and project2 to land on the same substitute ports as project1.
6. `ddev poweroff && ddev start` project1: it returns directly to 28080/28443, and the label is gone.

Step 5 is the case the old in-process-map approach could not pass, since a fresh process starts with an empty map.

## Automated Testing Overview

- `TestParseFormatRouterPortSubstitutions` / `TestKnownRouterPortSubstitutions`: unit tests for the label serialization and label/in-process merge logic.
- `TestRouterPortSubstitutionPersistsAcrossProjects`: integration test reproducing the cross-process race end-to-end — project1 gets a substitute under port contention, the conflict clears, the in-process cache is explicitly reset to simulate a new `ddev` process, and project2 must still adopt the same substitute from the router's label without a recreation. Gated on `GOTEST_SHORT` and the existing Lima/Colima/Rancher skip used by its sibling tests in this file.
- Re-ran `TestGlobalPortOverride`, `TestProjectPortOverride`, `TestRouterConfigOverride`, `TestAllocateAvailablePortForRouter`, and `TestUseEphemeralPort` after the `router.State == "running"` guard; all pass.
- `make staticrequired` reports 0 issues.

## Release/Deployment Notes

Ephemeral port substitutions become sticky for the life of the router container: once a project is substituted onto an ephemeral port, it keeps that port even after the conflicting process goes away, until the router is recreated (e.g. `ddev poweroff`). Routers created by earlier DDEV versions have no label, so the first start after upgrade behaves as before; the label appears at the next router recreation.
