### PR TITLE
fix(dockerutil): fall back to NetworkSettings.Ports in GetBoundHostPorts (#8657) [skip ci]

### DIFF
--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -913,6 +913,19 @@ func RemoveContainersByLabels(labels map[string]string) error {
 	return nil
 }
 
+// addBoundHostPorts collects the non-empty HostPort values from a
+// network.PortMap into portMap.
+func addBoundHostPorts(portMap map[string]bool, m network.PortMap) {
+	for _, portBindings := range m {
+		for _, binding := range portBindings {
+			// Only include ports with a non-empty HostPort
+			if binding.HostPort != "" {
+				portMap[binding.HostPort] = true
+			}
+		}
+	}
+}
+
 // GetBoundHostPorts takes a container pointer and returns an array
 // of exposed ports (and error)
 func GetBoundHostPorts(containerID string) ([]string, error) {
@@ -928,17 +941,14 @@ func GetBoundHostPorts(containerID string) ([]string, error) {
 
 	portMap := map[string]bool{}
 
-	if inspectInfo.Container.HostConfig != nil && inspectInfo.Container.HostConfig.PortBindings != nil {
-		for _, portBindings := range inspectInfo.Container.HostConfig.PortBindings {
-			if len(portBindings) > 0 {
-				for _, binding := range portBindings {
-					// Only include ports with a non-empty HostPort
-					if binding.HostPort != "" {
-						portMap[binding.HostPort] = true
-					}
-				}
-			}
-		}
+	if inspectInfo.Container.HostConfig != nil {
+		addBoundHostPorts(portMap, inspectInfo.Container.HostConfig.PortBindings)
+	}
+	// HostConfig.PortBindings is the binding that was *requested*; providers that
+	// leave it empty on inspect (seen on socktainer/Apple Container) still report
+	// the ports actually bound in NetworkSettings.Ports, so fall back to that.
+	if len(portMap) == 0 && inspectInfo.Container.NetworkSettings != nil {
+		addBoundHostPorts(portMap, inspectInfo.Container.NetworkSettings.Ports)
 	}
 	var ports []string
 	for k := range portMap {

--- a/pkg/dockerutil/containers_internal_test.go
+++ b/pkg/dockerutil/containers_internal_test.go
@@ -3,7 +3,9 @@ package dockerutil
 import (
 	"testing"
 
+	"github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSanitizeUsername tests the username sanitization logic
@@ -109,6 +111,64 @@ func TestSanitizeUsername(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := sanitizeUsername(tt.input)
 			assert.Equal(t, tt.expected, result, "sanitizeUsername(%q) should return %q, got %q", tt.input, tt.expected, result)
+		})
+	}
+}
+
+// TestAddBoundHostPorts verifies that addBoundHostPorts extracts every non-empty
+// HostPort from a network.PortMap, which is the logic GetBoundHostPorts relies on
+// to fall back from HostConfig.PortBindings to NetworkSettings.Ports. Some
+// providers (e.g. socktainer/Apple Container) report an empty HostConfig on
+// inspect even though the container has ports bound, per NetworkSettings.
+func TestAddBoundHostPorts(t *testing.T) {
+	tests := []struct {
+		name     string
+		portMaps []network.PortMap
+		expected map[string]bool
+	}{
+		{
+			name:     "nil PortMap",
+			portMaps: []network.PortMap{nil},
+			expected: map[string]bool{},
+		},
+		{
+			name: "single PortMap with bound ports",
+			portMaps: []network.PortMap{
+				{
+					network.MustParsePort("80/tcp"): []network.PortBinding{{HostPort: "8080"}},
+				},
+			},
+			expected: map[string]bool{"8080": true},
+		},
+		{
+			name: "PortBinding with empty HostPort is excluded",
+			portMaps: []network.PortMap{
+				{
+					network.MustParsePort("80/tcp"): []network.PortBinding{{HostPort: ""}},
+				},
+			},
+			expected: map[string]bool{},
+		},
+		{
+			name: "merging two PortMaps, as when falling back from HostConfig to NetworkSettings",
+			portMaps: []network.PortMap{
+				{},
+				{
+					network.MustParsePort("80/tcp"):  []network.PortBinding{{HostPort: "8080"}},
+					network.MustParsePort("443/tcp"): []network.PortBinding{{HostPort: "8443"}},
+				},
+			},
+			expected: map[string]bool{"8080": true, "8443": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			portMap := map[string]bool{}
+			for _, m := range tt.portMaps {
+				addBoundHostPorts(portMap, m)
+			}
+			require.Equal(t, tt.expected, portMap)
 		})
 	}
 }


### PR DESCRIPTION
## The Issue

- Related to #7372

`GetBoundHostPorts()` only reads `HostConfig.PortBindings` (the *requested*
port bindings) to figure out which host ports a container has bound. On
socktainer (the Docker-compatible API in front of Apple Container), that
field comes back empty even for containers with real, working port
bindings — only `NetworkSettings.Ports` (the *actual* bindings) is
populated. The practical effect: DDEV thinks the port is free and tries to
reallocate it, when it's actually already in use by the running container.

This is a real (if narrow) DDEV bug independent of Apple Container: the
Docker API documents `HostConfig.PortBindings` and `NetworkSettings.Ports`
as separate, sometimes-divergent fields, and DDEV was only ever reading
one of them.

## How This PR Solves The Issue

`GetBoundHostPorts()` now falls back to `NetworkSettings.Ports` when
`HostConfig.PortBindings` yields no bound ports, via a shared
`addBoundHostPorts()` helper used for both fields.

## Manual Testing Instructions

- `go test -v ./pkg/dockerutil -run TestAddBoundHostPorts`
- On a normal Docker setup this is a no-op (regular `dockerd` populates
  both fields), so existing behavior is unchanged; verified live against
  socktainer where the fallback path is what actually fires.

## Automated Testing Overview

Added `TestAddBoundHostPorts` in `pkg/dockerutil/containers_internal_test.go`
(whitebox, package `dockerutil`), covering both the `PortBindings`-populated
and fallback-to-`NetworkSettings.Ports` cases.

## Release/Deployment Notes

None. Pure `pkg/dockerutil` change, no image dependency.
