### PR TITLE
fix(ddevapp): read db version from a running container via exec, not a second volume mount (#8658) [skip ci]

### DIFF
--- a/pkg/ddevapp/db.go
+++ b/pkg/ddevapp/db.go
@@ -1,6 +1,7 @@
 package ddevapp
 
 import (
+	"fmt"
 	"regexp"
 	"slices"
 	"strconv"
@@ -27,28 +28,34 @@ func (app *DdevApp) GetExistingDBType() (string, error) {
 	return GetDBTypeVersionFromString(dbVersionInfo), nil
 }
 
-// getDBVersionFromVolume inspects the database volume to determine version info
-// Returns the raw version string found in the volume, or empty string if none found
-func (app *DdevApp) getDBVersionFromVolume() (string, error) {
-	// Command to check for database version files:
-	// 1. MySQL/MariaDB: /var/tmp/mysql/db_mariadb_version.txt
-	// 2. PostgreSQL <=17: /var/tmp/postgres/PG_VERSION
-	// 3. PostgreSQL 18+: /var/tmp/postgres/[version]/docker/PG_VERSION (check common versions)
-	cmd := []string{"sh", "-c", `
+// getDBVersionFromVolumeScript returns a shell script that finds and prints
+// whichever known database version file exists:
+//   - mariadbVersionFile: MySQL/MariaDB's db_mariadb_version.txt
+//   - postgresVersionFile: PostgreSQL <=17's PG_VERSION, sitting directly at the
+//     volume root
+//   - postgresVersionGlob: PostgreSQL 18+'s PG_VERSION, one level down in a
+//     version-specific directory (e.g. .../18/docker/PG_VERSION) - see
+//     GetPostgresDataDir/GetPostgresDataPath, since 18+ mounts the volume one
+//     level higher than earlier versions did
+//
+// Callers pass either the utility-container mount points below, or the real
+// in-container paths used when reading directly from a running db container.
+func getDBVersionFromVolumeScript(mariadbVersionFile, postgresVersionFile, postgresVersionGlob string) string {
+	return fmt.Sprintf(`
 		# Check MySQL/MariaDB version file
-		if [ -f /var/tmp/mysql/db_mariadb_version.txt ]; then
-			cat /var/tmp/mysql/db_mariadb_version.txt
+		if [ -f %[1]s ]; then
+			cat %[1]s
 			exit 0
 		fi
 
 		# Check PostgreSQL version file (pre-18 location)
-		if [ -f /var/tmp/postgres/PG_VERSION ]; then
-			cat /var/tmp/postgres/PG_VERSION
+		if [ -f %[2]s ]; then
+			cat %[2]s
 			exit 0
 		fi
 
 		# Check PostgreSQL 18+ version files in version-specific directories
-		for version_file in /var/tmp/postgres/*/docker/PG_VERSION; do
+		for version_file in %[3]s; do
 			if [ -f "$version_file" ]; then
 				cat "$version_file"
 				exit 0
@@ -57,7 +64,42 @@ func (app *DdevApp) getDBVersionFromVolume() (string, error) {
 
 		# No version file found
 		exit 0
-	`}
+	`, mariadbVersionFile, postgresVersionFile, postgresVersionGlob)
+}
+
+// getDBVersionFromVolume inspects the database volume to determine version info
+// Returns the raw version string found in the volume, or empty string if none found
+func (app *DdevApp) getDBVersionFromVolume() (string, error) {
+	// If the db service is already running, read its version file directly via
+	// exec instead of mounting the db volume into a separate utility container.
+	// This is both cheaper (no extra container to create/pull/remove) and, on
+	// providers where a volume can only be attached read-write by one container
+	// at a time (Apple Container/socktainer), the only way this can succeed at
+	// all: the running db container already holds the volume read-write, so a
+	// second attach - read-only or not - fails outright. See #7372.
+	dbContainerName := GetContainerName(app, "db")
+	if state, err := dockerutil.GetContainerStateByName(dbContainerName); err == nil && state == "running" {
+		script := getDBVersionFromVolumeScript(
+			"/var/lib/mysql/db_mariadb_version.txt",
+			"/var/lib/postgresql/data/PG_VERSION",
+			"/var/lib/postgresql/*/docker/PG_VERSION",
+		)
+		out, stderr, err := dockerutil.Exec(dbContainerName, script, "")
+		if err != nil {
+			return "", fmt.Errorf("unable to inspect database version/type on running container %s: %v, stderr=%s", dbContainerName, err, stderr)
+		}
+		return strings.TrimSpace(out), nil
+	}
+
+	// Command to check for database version files:
+	// 1. MySQL/MariaDB: /var/tmp/mysql/db_mariadb_version.txt
+	// 2. PostgreSQL <=17: /var/tmp/postgres/PG_VERSION
+	// 3. PostgreSQL 18+: /var/tmp/postgres/[version]/docker/PG_VERSION (check common versions)
+	cmd := []string{"sh", "-c", getDBVersionFromVolumeScript(
+		"/var/tmp/mysql/db_mariadb_version.txt",
+		"/var/tmp/postgres/PG_VERSION",
+		"/var/tmp/postgres/*/docker/PG_VERSION",
+	)}
 
 	var volumesNeeded []string
 	if dockerutil.VolumeExists(app.GetMariaDBVolumeName()) {

--- a/pkg/ddevapp/db_internal_test.go
+++ b/pkg/ddevapp/db_internal_test.go
@@ -1,0 +1,91 @@
+package ddevapp
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetDBVersionFromVolumeScript verifies the shell script shared by both
+// getDBVersionFromVolume() code paths - the utility-container mount case and
+// the exec-into-the-running-db-container case added for #7372 - against
+// arbitrary file locations, run locally with no Docker involved. It exercises
+// the script's own logic (check order, glob handling, "nothing found" case)
+// independent of which literal paths either caller passes in.
+func TestGetDBVersionFromVolumeScript(t *testing.T) {
+	tests := []struct {
+		name           string
+		setup          func(t *testing.T, root string)
+		expectedOutput string
+	}{
+		{
+			name: "MariaDB version file present",
+			setup: func(t *testing.T, root string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(root, "mysql"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(root, "mysql", "db_mariadb_version.txt"), []byte("mariadb_10.11"), 0644))
+			},
+			expectedOutput: "mariadb_10.11",
+		},
+		{
+			name: "PostgreSQL pre-18 flat PG_VERSION",
+			setup: func(t *testing.T, root string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(root, "postgres"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(root, "postgres", "PG_VERSION"), []byte("17"), 0644))
+			},
+			expectedOutput: "17",
+		},
+		{
+			name: "PostgreSQL 18+ version-specific directory",
+			setup: func(t *testing.T, root string) {
+				dir := filepath.Join(root, "postgres", "18", "docker")
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "PG_VERSION"), []byte("18"), 0644))
+			},
+			expectedOutput: "18",
+		},
+		{
+			name: "PostgreSQL future version-specific directory",
+			setup: func(t *testing.T, root string) {
+				dir := filepath.Join(root, "postgres", "19", "docker")
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "PG_VERSION"), []byte("19"), 0644))
+			},
+			expectedOutput: "19",
+		},
+		{
+			name: "MariaDB file takes precedence when both exist",
+			setup: func(t *testing.T, root string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(root, "mysql"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(root, "mysql", "db_mariadb_version.txt"), []byte("mariadb_10.11"), 0644))
+				require.NoError(t, os.MkdirAll(filepath.Join(root, "postgres"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(root, "postgres", "PG_VERSION"), []byte("17"), 0644))
+			},
+			expectedOutput: "mariadb_10.11",
+		},
+		{
+			name:           "no version files found",
+			setup:          func(t *testing.T, root string) {},
+			expectedOutput: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			tt.setup(t, root)
+
+			script := getDBVersionFromVolumeScript(
+				filepath.Join(root, "mysql", "db_mariadb_version.txt"),
+				filepath.Join(root, "postgres", "PG_VERSION"),
+				filepath.Join(root, "postgres", "*", "docker", "PG_VERSION"),
+			)
+			out, err := exec.Command("bash", "-c", script).CombinedOutput()
+			require.NoError(t, err, "script output: %s", out)
+			require.Equal(t, tt.expectedOutput, strings.TrimSpace(string(out)))
+		})
+	}
+}


### PR DESCRIPTION
## The Issue

- Related to #7372

`GetExistingDBType()` determines the running project's db type/version by
mounting the db volume into a throwaway utility container and reading a
version file from it. If the real `db` container is already running, that
volume is already attached read-write, and Apple Container's volume
semantics only allow one read-write attacher (or many read-only) at a
time — so the utility-container mount fails and the command errors out.

This is a genuine DDEV bug: any provider that enforces stricter (and
more standard) volume-exclusivity semantics than a permissive Docker
Engine will hit it, so it isn't Apple-Container-specific in principle,
just newly exposed by it.

## How This PR Solves The Issue

When the `db` container is already running, `getDBVersionFromVolume()` now
execs directly into it to read the version file instead of mounting the
volume into a separate utility container. The version-detection script is
shared (parameterized by explicit file/glob paths) between this fast path
and the original utility-container fallback used when `db` isn't running,
so MariaDB and both pre-18 and 18+ PostgreSQL data layouts are handled the
same way in either case.

## Manual Testing Instructions

- `go test -v ./pkg/ddevapp -run TestGetDBVersionFromVolumeScript`
- Start a project (`ddev start`), then run a command that calls
  `GetExistingDBType()` (e.g. `ddev config` again, or `ddev describe`)
  while the db container is already running — should succeed instead of
  erroring on the volume mount.

## Automated Testing Overview

Added `TestGetDBVersionFromVolumeScript` in
`pkg/ddevapp/db_internal_test.go` (whitebox, package `ddevapp`), covering
MariaDB, pre-18 Postgres, 18+/nested Postgres, precedence between them,
and the not-found case, by running the generated script locally via bash
against a temp directory (no Docker required). The existing
Docker-integration test of the same name in `pkg/ddevapp/db_test.go` is
unchanged and still passes.

## Release/Deployment Notes

None. Pure `pkg/ddevapp` change, no image dependency.
