### PR TITLE
fix(webserver): don't let a failing global-cache chown kill the container

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
+++ b/containers/ddev-webserver/ddev-webserver-base-scripts/start.sh
@@ -101,7 +101,14 @@ ls /var/www/html >/dev/null || (echo "/var/www/html does not seem to be healthy/
 sudo mkdir -p ${TERMINUS_CACHE_DIR}
 
 sudo mkdir -p /mnt/ddev-global-cache/{bashhistory/${HOSTNAME},mysqlhistory/${HOSTNAME},n_prefix/${HOSTNAME},npm,yarn/classic,yarn/berry,corepack}
-sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ /var/lib/php
+sudo chown -R "$(id -u):$(id -g)" /var/lib/php
+
+# The global cache is already chowned by a privileged utility container in
+# app.Start() before this container ever starts (see chownCmd in ddevapp.go),
+# so this is normally a no-op. On some bind-mounted filesystems (e.g. virtiofs
+# on Apple Container/socktainer) chown fails even when ownership already
+# matches, which would otherwise kill this container outright under `set -e`.
+sudo chown -R "$(id -u):$(id -g)" /mnt/ddev-global-cache/ || true
 
 # The following ensures a persistent and shared "global" cache for
 # yarn classic (frozen v1) and yarn berry (active). In the case of berry, the global cache

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,7 +20,7 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260716_stasadev_webserver_403_message" // Note that this can be overridden by make
+var WebTag = "20260802_rfay_global_cache_chown_non_fatal" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"


### PR DESCRIPTION
## The Issue

- Related to #7372

`start.sh` chowns `/mnt/ddev-global-cache/` and `/var/lib/php` in one
`chown -R` call under `set -e`. The global cache is already chowned by a
privileged utility container earlier in `app.Start()`, so this is normally
a no-op — but on some bind-mounted filesystems (observed with virtiofs on
Apple Container/socktainer) `chown` fails even when ownership already
matches, which kills the whole container on start since the combined
command is one `set -e` unit with the unrelated (and required) `/var/lib/php`
chown.

This is a real DDEV bug: `start.sh` treats a redundant, best-effort chown
as fatal alongside one that genuinely must succeed, on a filesystem type
that isn't unique to Apple Container.

## How This PR Solves The Issue

Split the combined chown into two: the `/var/lib/php` chown stays fatal,
and the global-cache chown (already redundant in the common case) is now
`|| true` so a spurious failure on this filesystem no longer takes the
container down.

## Manual Testing Instructions

- Reproduced independently of DDEV/socktainer using the native `container`
  CLI directly, confirming the chown failure and container death without
  this fix.
- `ddev start` on affected filesystems now succeeds; unaffected filesystems
  (normal Docker/OrbStack) are unchanged since the chown there just
  succeeds as before.

## Automated Testing Overview

No new automated test — this is a shell-script change in the webserver
image whose failure mode only reproduces on affected bind-mount
filesystems; covered by manual reproduction described above.

## Release/Deployment Notes

Changes `containers/ddev-webserver/ddev-webserver-base-scripts/start.sh`,
so `WebTag` in `pkg/versionconstants/versionconstants.go` is bumped to this
branch name. The corresponding `ddev-webserver` image has been built and
pushed under that tag.
