### PR TITLE
fix(dockerutil): stop hijacking the exec stream in Exec(), avoids a hang on socktainer

### DIFF
--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -3,8 +3,11 @@ package dockerutil
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -1048,28 +1051,87 @@ func Exec(containerID string, command string, uid string) (string, string, error
 		return "", "", err
 	}
 
-	var stdout, stderr bytes.Buffer
-	execAttach, err := apiClient.ExecAttach(ctx, execCreate.ID, client.ExecAttachOptions{})
-	if err != nil {
-		return "", "", err
-	}
-	defer execAttach.Close()
-
-	_, err = stdcopy.StdCopy(&stdout, &stderr, execAttach.Reader)
+	stdout, stderr, err := execStartAndCapture(ctx, apiClient, execCreate.ID)
 	if err != nil {
 		return "", "", err
 	}
 
 	info, err := apiClient.ExecInspect(ctx, execCreate.ID, client.ExecInspectOptions{})
 	if err != nil {
-		return stdout.String(), stderr.String(), err
+		return stdout, stderr, err
 	}
 	var execErr error
 	if info.ExitCode != 0 {
 		execErr = fmt.Errorf("command '%s' returned exit code %v", command, info.ExitCode)
 	}
 
-	return stdout.String(), stderr.String(), execErr
+	return stdout, stderr, execErr
+}
+
+// execStartAndCapture starts an already-created exec and returns its
+// demultiplexed stdout/stderr.
+//
+// This deliberately does not use client.Client.ExecAttach(), which always
+// upgrades the connection to a raw hijacked stream (see its doc comment) and
+// relies on the daemon closing that connection once the exec process exits
+// to signal EOF to stdcopy.StdCopy. Real dockerd does this; socktainer (the
+// Docker-compatible API in front of Apple Container, see #7372) does not -
+// confirmed directly against the API: the hijacked connection still delivers
+// the command's output correctly, but then sits open indefinitely, so
+// ExecAttach+stdcopy.StdCopy hangs forever after the command has already
+// finished and its output has already arrived.
+//
+// POSTing to /exec/{id}/start without asking for the hijack upgrade avoids
+// this: dockerd (and socktainer) then respond with a normal chunked HTTP
+// response carrying the same multiplexed stream format, which every tested
+// provider (real Docker, OrbStack, socktainer) terminates correctly, since
+// this is the same request/response shape used whenever a client doesn't
+// need to attach stdin - which is always true here, as dockerutil.Exec never
+// sends stdin.
+//
+// apiClient is documented as implemented only by *client.Client (its
+// interface embeds unexported methods, so no other type can satisfy it);
+// the type assertion is not expected to fail in practice.
+func execStartAndCapture(ctx context.Context, apiClient client.APIClient, execID string) (stdout, stderr string, err error) {
+	cli, ok := apiClient.(*client.Client)
+	if !ok {
+		return "", "", fmt.Errorf("dockerutil.Exec: unsupported APIClient implementation %T", apiClient)
+	}
+
+	body, err := json.Marshal(container.ExecStartRequest{Detach: false, Tty: false})
+	if err != nil {
+		return "", "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://docker/v"+cli.ClientVersion()+"/exec/"+execID+"/start", bytes.NewReader(body))
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	dial := cli.Dialer()
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return dial(ctx)
+			},
+		},
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		errBody, _ := io.ReadAll(resp.Body)
+		return "", "", fmt.Errorf("exec start on %s failed: status=%d body=%s", execID, resp.StatusCode, errBody)
+	}
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if _, err = stdcopy.StdCopy(&stdoutBuf, &stderrBuf, resp.Body); err != nil {
+		return "", "", err
+	}
+	return stdoutBuf.String(), stderrBuf.String(), nil
 }
 
 // CopyIntoContainer copies a path (file or directory) into a specified container and location

--- a/pkg/dockerutil/containers.go
+++ b/pkg/dockerutil/containers.go
@@ -1110,13 +1110,17 @@ func execStartAndCapture(ctx context.Context, apiClient client.APIClient, execID
 	req.Header.Set("Content-Type", "application/json")
 
 	dial := cli.Dialer()
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return dial(ctx)
-			},
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return dial(ctx)
 		},
+		// A new Transport is created per call and never reused, so keeping its
+		// connection alive in an idle pool only leaks the readLoop/writeLoop
+		// goroutines net/http spawns per connection - nothing will ever reuse
+		// them. Close the connection once this response is done instead.
+		DisableKeepAlives: true,
 	}
+	httpClient := &http.Client{Transport: transport}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
## The Issue

- Related to #7372

`dockerutil.Exec()` hangs indefinitely against socktainer (the
Docker-compatible API in front of Apple Container), even for a trivial
`echo hi` — while `docker exec` on the same container returns in well
under a second. This affects, among other callers, `GetRouterConfigErrors()`.

Traced at the raw HTTP/socket level: `ExecAttach()` (used internally by
`Exec()`) always upgrades the connection to a hijacked raw stream and
relies on the daemon closing that connection once the exec process exits,
which is what lets `stdcopy.StdCopy` see EOF and return. Real `dockerd`
does this; socktainer delivers the command's output correctly over the
hijacked stream (confirmed byte-for-byte, correct multiplexed-stream
framing) but never closes the connection afterward, so `stdcopy.StdCopy`
blocks forever waiting for a close that never comes.

This is arguably a socktainer bug (RFC-wise, a daemon should close a
hijacked exec stream on process exit), but `dockerutil.Exec()` never
attaches stdin and doesn't need the hijacked/bidirectional stream at all —
it only needs to capture output — so avoiding the hijack path entirely is
a reasonable hardening on the DDEV side regardless of which daemon is on
the other end.

## How This PR Solves The Issue

Replaced the `ExecAttach()` + `stdcopy.StdCopy` call with
`execStartAndCapture()`, which POSTs to `/exec/{id}/start` as a plain
(non-upgraded) request instead of requesting the hijack, reusing the
existing client's `Dialer()`/`ClientVersion()` so it still goes through
whatever transport the client was configured with, then demuxes the
chunked response body the same way `stdcopy.StdCopy` always has.
`ExecCreate()` and `ExecInspect()` are untouched — only the start+capture
step changes.

## Manual Testing Instructions

Confirmed against the real API on both providers, including multi-frame
output large enough to need several chunks:

- socktainer: `echo hi` went from hanging (2+ min, killed) to 787ms;
  stdout/stderr separation, non-zero exit codes, and 5000 lines of output
  (23893 bytes) all came back correct and fast.
- OrbStack: identical behavior and timing for the same three cases — this
  isn't a socktainer-only code path, it's how `Exec()` always starts execs
  now.

## Automated Testing Overview

No new test file — the existing `TestDockerExec` in
`pkg/dockerutil/containers_test.go` already exercises both the
success and error-output cases through the public `Exec()` function and
needed no changes; it passed against both providers. Also ran the full
`pkg/dockerutil` suite against OrbStack (clean pass) to check for
regressions beyond `Exec()` itself.

## Release/Deployment Notes

None. Pure `pkg/dockerutil` change, no image dependency.
