### PR TITLE
docs: explain how to avoid hard line breaks in gh issue/PR/comment bodies (#8662) [skip ci]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,14 @@ EOF
 gh pr create --title "<type>: <description>" --body-file ~/tmp/pr_body.md
 ```
 
+### Avoiding Hard Line Breaks in Issue/PR/Comment Bodies
+
+GitHub renders issue, PR, and comment bodies (`gh issue create`, `gh pr create`, `gh pr comment`, `gh issue comment`, etc.) with GFM's hard-line-break behavior: a single `\n` inside a paragraph becomes an actual `<br>`. This is different from how GitHub renders committed Markdown files (this file, docs, READMEs), which follow standard CommonMark, where a lone `\n` is just whitespace and the paragraph reflows to the container width.
+
+Hand-wrapping prose to a fixed column width — normal, good practice for a text file or commit message body — produces a ragged, too-short-lined paragraph when posted as an issue/PR/comment body, because each wrapped line becomes its own forced line instead of reflowing.
+
+When writing a `--body-file` for any of these commands, write each paragraph as one continuous line with no embedded newlines. Only use actual blank lines to separate paragraphs, headings, and list items. This does not apply to code blocks, tables, or files meant to be read as source.
+
 ### Pre-Commit Checklist
 
 1. Run appropriate tests: `go test -v -run TestName ./pkg/...`


### PR DESCRIPTION
## The Issue

While filing a GitHub issue via `gh issue create --body-file`, every paragraph rendered as short, ragged lines instead of reflowing to the container width. The body file was written like a normal text file, hand-wrapped to ~80 columns.

## How This PR Solves The Issue

GitHub renders issue/PR/comment bodies with GFM's hard-line-break behavior: a single `\n` inside a paragraph becomes an actual `<br>`. That's different from committed Markdown files (this file, docs, READMEs), which follow CommonMark, where a lone `\n` is just whitespace. Adds a short section to `CLAUDE.md` after "Creating PRs with `gh`" explaining the distinction and the fix: write each paragraph as one continuous line, with blank lines only between paragraphs/headings/list items.

## Manual Testing Instructions

Read the new "Avoiding Hard Line Breaks in Issue/PR/Comment Bodies" section in `CLAUDE.md`.

## Automated Testing Overview

None — documentation only.

## Release/Deployment Notes

None.
