### PR TITLE
fix(nginx): remove robots.txt location block, fixes #8607 (#8663) [skip ci]

### DIFF
--- a/pkg/ddevapp/webserver_config_assets/nginx-site-asterios.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-asterios.conf
@@ -35,11 +35,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     error_page 404 /index.php;
 
     location ~ \.php$ {

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-backdrop.conf
@@ -39,11 +39,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For Backdrop CMS: Clean URLs are handled by Backdrop core
         # Pass the original query string to maintain functionality

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-cakephp.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-cakephp.conf
@@ -34,11 +34,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-codeigniter.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-codeigniter.conf
@@ -34,11 +34,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     # Pass PHP scripts to FastCGI server
 
     error_page 404 /index.php;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-craftcms.conf
@@ -44,11 +44,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal.conf
@@ -36,11 +36,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
@@ -35,11 +35,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
@@ -35,11 +35,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal12.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal12.conf
@@ -35,11 +35,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal6.conf
@@ -43,11 +43,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         rewrite ^/(.*)$ /index.php?q=$1;
     }

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal7.conf
@@ -37,11 +37,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal8.conf
@@ -35,11 +35,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal9.conf
@@ -35,11 +35,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-joomla.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-joomla.conf
@@ -34,11 +34,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     # Joomla 4+ REST API endpoint
     location /api/ {
         try_files $uri $uri/ /api/index.php?$query_string;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-laravel.conf
@@ -36,11 +36,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     error_page 404 /index.php;
 
     location ~ \.php$ {

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento.conf
@@ -43,11 +43,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location /api {
         rewrite ^/api/rest /api.php?type=rest last;
     }

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-magento2.conf
@@ -84,11 +84,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location /pub/ {
         location ~ ^/pub/media/(downloadable|customer|import|theme_customization/.*\.xml) {
             deny all;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-maho.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-maho.conf
@@ -42,11 +42,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     # Maho API Platform routing (mirrors public/.htaccess):
     #   /api/rest/v2/*                  -> rest.php (REST API, Symfony API Platform)
     #   /api/rest/*                     -> api.php?type=rest (legacy Magento 1 REST)

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-modx.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-modx.conf
@@ -36,11 +36,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     # Deny direct web access to the MODX core, which is not meant to be served.
     # MODX ships equivalent .htaccess deny rules for Apache.
     location ~ ^/core/ {

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-php.conf
@@ -33,11 +33,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-shopware6.conf
@@ -35,11 +35,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-silverstripe.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-silverstripe.conf
@@ -34,11 +34,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-symfony.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-symfony.conf
@@ -34,11 +34,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     location @rewrite {
         # For D7 and above:
         # Clean URLs are handled in drupal_environment_initialize().

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-typo3.conf
@@ -70,11 +70,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        access_log off;
-        log_not_found off;
-    }
-
     # TYPO3 11 Backend URL rewriting support
     location = /typo3 {
         rewrite ^ /typo3/;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-wordpress.conf
@@ -35,12 +35,6 @@ server {
         log_not_found off;
     }
 
-    location = /robots.txt {
-        allow all;
-        access_log off;
-        log_not_found off;
-    }
-
     # Deny all attempts to access hidden files such as .htaccess, .htpasswd, .DS_Store (Mac).
     # Keep logging the requests to parse later (or to pass to firewall utilities such as fail2ban)
     location ~ /\. {


### PR DESCRIPTION
## The Issue

- Fixes #8607

PR #8461 added a `location = /robots.txt` block to every nginx site template to suppress 404-log noise, mirroring the `favicon.ico` fix from #7010. Unlike `favicon.ico`, that block had no `try_files` fallback, so it shadowed the app's normal routing and broke dynamic robots.txt generation, e.g. Drupal's robotstxt module. The PR author confirmed on the issue that the `robots.txt` condition was added without a clear reason.

## How This PR Solves The Issue

Removes the `location = /robots.txt { ... }` block from all 25 nginx site templates in `pkg/ddevapp/webserver_config_assets/`, restoring pre-#8461 behavior where `/robots.txt` falls through to `try_files`/PHP like any other route. The `favicon.ico` block, which fixes a real double-PHP-invocation bug, is untouched.

## Manual Testing Instructions

```bash
mkdir -p ~/tmp/test-robots/web && cd ~/tmp/test-robots
cat > web/index.php <<'PHP'
<?php
if ($_SERVER['REQUEST_URI'] === '/robots.txt') {
    header('Content-Type: text/plain');
    echo "User-agent: *\nDynamic-Robots: yes\n";
    exit;
}
echo "hello world";
PHP
ddev config --project-type=php --docroot=web
ddev start
curl -sk https://test-robots.ddev.site/robots.txt   # should print the PHP-generated content
curl -sk -o /dev/null -w '%{http_code}\n' https://test-robots.ddev.site/favicon.ico   # still 404, no PHP hit
```

## Automated Testing Overview

No new tests needed - config-only change reverting a prior config-only change.

## Release/Deployment Notes

Only the CLI-embedded `.ddev/nginx_full` templates change; the `ddev-webserver` Docker image is untouched, since it never contained these blocks. Existing projects pick up the fix on `ddev start` after rebuilding/upgrading the `ddev` binary, unless a project has taken ownership of its `.ddev/nginx_full/nginx-site.conf` by removing the `#ddev-generated` marker.
