### PR TITLE
test(db): fix filepath formatting in test [skip github]

### DIFF
--- a/pkg/ddevapp/base_db_seed_test.go
+++ b/pkg/ddevapp/base_db_seed_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/stretchr/testify/require"
@@ -108,7 +109,7 @@ func TestAnnounceBaseDBSeed(t *testing.T) {
 	out := outFunc()
 
 	require.Contains(t, out, "Initializing new database volume from the 'initializer' snapshot")
-	require.Contains(t, out, filepath.ToSlash(initializer))
+	require.Contains(t, out, fileutil.ShortHomeJoin(filepath.ToSlash(initializer)))
 	require.Contains(t, out, "(2.0KB)")
 	require.Contains(t, out, "this may take a long time")
 	require.Contains(t, out, "default_container_timeout")


### PR DESCRIPTION

## The Issue

TestAnnounceBaseDBSeed from 
* https://github.com/ddev/ddev/pull/8608

had a test formatting error:

```
    base_db_seed_test.go:111:
        	Error Trace:	C:/Users/testbot/tmp/buildkite/tb-win11-10-1/ddev/ddev-windows-mutagen/pkg/ddevapp/base_db_seed_test.go:111
        	Error:      	"Initializing new database volume from the 'initializer' snapshot\n~/AppData/Local/Temp/TestAnnounceBaseDBSeed3300031974/001/.ddev/db_snapshots/initializer-mariadb_10.11.zst (2.0KB)...\nWith a large database this may take a long time.\nThis may time out after 600 seconds \nbut you can increase it by changing default_container_timeout.\nYou can follow the progress in another terminal window with `ddev logs -s db -f base-db-seed-test`\n" does not contain "C:/Users/testbot/AppData/Local/Temp/TestAnnounceBaseDBSeed3300031974/001/.ddev/db_snapshots/initializer-mariadb_10.11.zst"
        	Test:       	TestAnnounceBaseDBSeed
```
## How This PR Solves The Issue

Fix the test to use the ShortHomeDir form for the require.