### PR TITLE
ci(github): pin setup-homebrew, drop dead setup-sandbox input (#8667) [skip ci]

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -54,10 +54,9 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@2026.08.03.2
         with:
           brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
-          setup-sandbox: true
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -50,10 +50,9 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@2026.08.03.2
         with:
           brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
-          setup-sandbox: true
 
       - name: Install Docker and deps
         run: ./.github/workflows/linux-setup.sh

--- a/.github/workflows/perf-start-time.yml
+++ b/.github/workflows/perf-start-time.yml
@@ -64,10 +64,9 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@2026.08.03.2
         with:
           brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
-          setup-sandbox: true
 
       - name: Remove unnecessary items on disk
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -54,10 +54,9 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@2026.08.03.2
         with:
           brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
-          setup-sandbox: true
 
       - name: Remove unnecessary items on disk
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -183,10 +183,9 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@2026.08.03.2
         with:
           brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
-          setup-sandbox: true
 
       - name: Remove unnecessary items on disk
         uses: jlumbroso/free-disk-space@main


### PR DESCRIPTION
## The Issue

CI runs (e.g. [Quickstart test](https://github.com/ddev/ddev/actions/runs/31003578687)) have been logging annotation warnings: `Unexpected input(s) 'setup-sandbox'`, plus `bubblewrap test probe failed` / `Sandbox unavailable: building without sandboxing!`.

`Homebrew/actions/setup-homebrew` is pinned to `@main` in five workflows. On 2026-08-04, Homebrew removed the `setup-sandbox` input from that action ([`Homebrew/actions@23156a3`](https://github.com/Homebrew/actions/commit/23156a3d9674d7f52f74f1a58979ec4d77847166)), moving Linux sandboxing to Landlock, so every run since has passed an input the action no longer recognizes.

## How This PR Solves The Issue

- Pins `Homebrew/actions/setup-homebrew` to the `2026.08.03.2` release tag instead of `@main`, matching how every other third-party action in these workflows is already version-pinned rather than tracking a branch.
- Drops the `setup-sandbox: true` input. It defaults to `false` and only ever drove Bubblewrap-based sandboxing, which already failed its own probe on these runners (unprivileged user namespaces are locked down here) — so it wasn't providing working sandboxing either way. Homebrew's own fix is Landlock, which needs no opt-in input, but it isn't in a stable release yet.

This only quiets the `Unexpected input(s)` annotation and removes a no-op input; it does not and cannot fix the underlying "no sandboxing" condition, which is an upstream limitation until Homebrew ships Landlock in a stable release.

## Manual Testing Instructions

Run `.github/workflows/quickstart.yml` (or any of the other four touched workflows) and confirm the "Set up Homebrew" step no longer logs an `Unexpected input(s) 'setup-sandbox'` annotation.

## Automated Testing Overview

None — this only changes CI workflow configuration, no application code.

## Release/Deployment Notes

None. CI-only change.
