### PR TITLE
fix(perf): fix bugs found validating the nightly benchmark harness end-to-end (#8668) [skip ci]

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -141,3 +141,11 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v5
         id: deployment
+
+      - name: Report deployed URLs
+        run: |
+          {
+            echo "### Deployed"
+            echo "- Docs: ${{ steps.deployment.outputs.page_url }}"
+            echo "- Perf dashboard: ${{ steps.deployment.outputs.page_url }}perf/"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/perf/README.md
+++ b/perf/README.md
@@ -33,14 +33,17 @@ One JSON result object per run per leg (platform + Docker provider combination):
 
 | Metric | What it measures | Why it's here |
 |---|---|---|
-| `ddev_rebuild_s` | `ddev utility rebuild` (forced no-cache image build + restart) | Image-build-layer cost -- catches regressions like #8600, where a recursive chgrp/chmod added 90s+ to every project build without any existing metric noticing. `ddev_start_cold_s` below starts from an already-built image, so it can't see this class of regression |
-| `ddev_start_cold_s` | `ddev poweroff` + prune, then `ddev start` to ready | Docker-provider/container startup cost, independent of any CMS |
+| `ddev_rebuild_s` | `ddev utility rebuild` (forced no-cache image build + restart), single sample | Image-build-layer cost -- catches regressions like #8600, where a recursive chgrp/chmod added 90s+ to every project build without any existing metric noticing. `ddev_start_cold_s` below starts from an already-built image, so it can't see this class of regression |
+| `ddev_start_cold_s` | `ddev poweroff`, then `ddev start` to ready | Docker-provider/container startup cost, independent of any CMS |
 | `mutagen_settle_s` | Copy a ~5000-file tree in, time `ddev mutagen sync` (blocking flush) to settle | Isolates file-sync mechanics (bind mount vs. Mutagen vs. NFS) from any app's install logic. `null` when Mutagen isn't enabled on the project |
 | `drupal_install_s` | Puppeteer drives the Drupal `demo_umami` web install wizard end-to-end | The flagship "realistic app" metric — parallels normal browser-based DDEV usage, exercising the DDEV router, webserver, and PHP-FPM on every step |
 | `drush_install_s` | `ddev drush si demo_umami -y` (CLI, non-interactive) | Cheap diagnostic, not a replacement for `drupal_install_s` — see below |
 | `ddev_stop_s` | `ddev poweroff` | Teardown cost |
 
-Each metric script repeats noisy operations `DDEV_PERF_REPEAT` times (default 3) and reports the median, in seconds to one decimal place.
+Each metric script repeats noisy operations `DDEV_PERF_REPEAT` times (default 3) and reports the
+median, in seconds to one decimal place. `ddev_rebuild_s` is the exception: it always runs once --
+a no-cache rebuild is expensive, and each repeat busts its own image-layer cache, so repeating it
+doesn't average out noise the way repeating a plain start or install does.
 
 ### Why both `drupal_install_s` and `drush_install_s`?
 
@@ -132,9 +135,9 @@ revisit — at that point one of them should go.
 ## Assumption: one Buildkite agent per testbot
 
 The `perf-*.yml` pipelines reuse the same `agents:` tags as the correctness pipelines, and
-`01-ddev-start.sh` runs `ddev poweroff` + `docker system prune -f` before each timed sample. That
-is only safe because each testbot machine runs a single `buildkite-agent` slot, so a perf job and a
-test job are never in flight on the same machine at once. `.buildkite/test.sh` already relies on
+`01-ddev-start.sh` runs `ddev poweroff` before each timed sample -- which stops every DDEV project
+on the machine, not just this one. That is only safe because each testbot machine runs a single
+`buildkite-agent` slot, so a perf job and a test job are never in flight on the same machine at once. `.buildkite/test.sh` already relies on
 the same exclusivity (it does `ddev poweroff` and `docker rm -f` against every container on the
 machine), so this adds no new assumption — but if a testbot is ever given more than one agent slot,
 both suites break, not just this one. `perf-macos-shared-providers.yml` handles the related but

--- a/perf/collector/collect.js
+++ b/perf/collector/collect.js
@@ -116,11 +116,18 @@ function existingPointKeys(historyPath) {
 async function main() {
   const results = [];
 
-  for (const pipeline of CONFIG.pipelines) {
-    try {
+  // A missing token is the expected, tolerated state before the one-time
+  // BUILDKITE_API_TOKEN vault setup (see this file's header comment) --
+  // skip Buildkite entirely and still collect the Linux leg below. Once a
+  // token is present, though, any request failure (wrong scope, revoked,
+  // rate-limited) means the setup is broken, not "not done yet": let it
+  // throw and abort the whole run instead of quietly committing an
+  // empty/partial dataset that overwrites the live dashboard with nothing.
+  if (!process.env.BUILDKITE_API_TOKEN) {
+    console.warn('BUILDKITE_API_TOKEN not set; skipping Buildkite pipelines');
+  } else {
+    for (const pipeline of CONFIG.pipelines) {
       results.push(...(await latestBuildkiteResults(pipeline)));
-    } catch (err) {
-      console.warn(`Skipping ${pipeline}: ${err.message}`);
     }
   }
 

--- a/perf/collector/collect.js
+++ b/perf/collector/collect.js
@@ -61,7 +61,18 @@ async function latestBuildkiteResults(pipeline) {
   for (const artifact of matches) {
     const res = await fetch(artifact.download_url, { headers: { Authorization: `Bearer ${token}` } });
     if (!res.ok) throw new Error(`Failed to download artifact ${artifact.filename} for ${pipeline}: ${res.status}`);
-    results.push(JSON.parse(await res.text()));
+    const text = await res.text();
+    try {
+      results.push(JSON.parse(text));
+    } catch (err) {
+      // Bare JSON.parse errors don't say which artifact failed or what it
+      // actually contained -- both are needed to tell "wrong scope/HTML
+      // error page" apart from "a script wrote non-JSON to stdout ahead of
+      // the result line" (the actual cause the one time this fired).
+      throw new Error(
+        `${pipeline}'s ${artifact.filename} is not valid JSON: ${err.message}\nFirst 200 chars: ${text.slice(0, 200)}`
+      );
+    }
   }
   return results;
 }

--- a/perf/metrics/00-ddev-rebuild.sh
+++ b/perf/metrics/00-ddev-rebuild.sh
@@ -14,7 +14,11 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$DIR/../lib/common.sh"
 
 : "${DDEV_PERF_PROJECT_DIR:?DDEV_PERF_PROJECT_DIR must be set}"
-REPEAT="${DDEV_PERF_REPEAT:-3}"
+# Deliberately not DDEV_PERF_REPEAT (3): a no-cache rebuild is expensive and
+# each repeat busts its own image-layer cache, so repeating it doesn't average
+# out noise the way repeating a plain start/install does -- it just triples
+# the cost for no real benefit.
+REPEAT=1
 
 cd "$DDEV_PERF_PROJECT_DIR"
 

--- a/perf/metrics/01-ddev-start.sh
+++ b/perf/metrics/01-ddev-start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Times a cold `ddev start`: power off, prune, then start-to-ready.
+# Times a cold `ddev start`: power off, then start-to-ready.
 # Prints one JSON metric line: {"metric":"ddev_start_cold_s","value_s":N}
 set -euo pipefail
 
@@ -15,7 +15,6 @@ cd "$DDEV_PERF_PROJECT_DIR"
 samples=()
 for _ in $(seq 1 "$REPEAT"); do
   ddev poweroff >/dev/null 2>&1 || true
-  docker system prune -f >/dev/null 2>&1 || true
 
   start=$(now_ms)
   run_quiet "ddev start" ddev start -y

--- a/perf/metrics/03-drupal-install/install-timer.js
+++ b/perf/metrics/03-drupal-install/install-timer.js
@@ -48,14 +48,15 @@ function sleep(ms) {
     // stuck immediately instead of going silent for the full 10 minutes.
     const stage = (s) => console.error(`[install-timer] ${s}`);
 
-    // The final submit triggers Drupal's install batch, which redirects through
-    // one or more intermediate progress pages before landing on the site
-    // homepage. Seen in the field: Puppeteer's navigation tracking occasionally
-    // desyncs partway through that redirect chain and never notices the final
-    // page actually loaded (confirmed once by checking the site directly -- the
-    // install itself had finished, only this wait was stuck). A reload against
-    // the current URL re-fetches whatever page is actually live now, sidestepping
-    // the stuck navigation state instead of waiting on it indefinitely.
+    // Every step below clicks a submit-like control that triggers a full page
+    // navigation (not just a DOM update), and each one of those has now been
+    // caught -- on different runs -- with Puppeteer's navigation tracking
+    // desynced afterward: the wait never resolves even though the site has
+    // actually moved on (confirmed twice by checking the site directly while a
+    // wait was stuck). A reload against the current URL re-fetches whatever
+    // page is actually live now, sidestepping the stuck navigation state
+    // instead of waiting on it indefinitely. Applied to every post-click wait
+    // in this script, not just the ones that have hung so far.
     const waitForSelectorWithReload = async (selector, { attempts = 5, timeoutMs = 60000 } = {}) => {
       for (let i = 1; i <= attempts; i++) {
         try {
@@ -88,7 +89,7 @@ function sleep(ms) {
     await page.click('#edit-submit');
 
     stage('waiting for profile-demo-umami selector');
-    await page.waitForSelector('#edit-profile-demo-umami');
+    await waitForSelectorWithReload('#edit-profile-demo-umami');
     await page.click('#edit-profile-demo-umami');
     await page.click('#edit-submit');
 
@@ -96,6 +97,11 @@ function sleep(ms) {
     // (e.g. a missing recommended PHP extension); on a clean environment it's
     // skipped straight through to the configure-site form, so don't wait on
     // #edit-save unconditionally.
+    // Plain waitForSelector, not the reload-retry helper: whichever of these
+    // two loses the race is left pending in the background (harmless -- it
+    // never resolves, nothing awaits it) once the other wins. A reload from
+    // the loser would yank the page out from under whichever form the winner
+    // is about to type into.
     stage('waiting for requirements or configure-site form');
     await Promise.race([
       page.waitForSelector('#edit-save'),
@@ -109,7 +115,7 @@ function sleep(ms) {
 
     // Final "configure site" form, shown once the install batch finishes.
     stage('waiting for configure-site form');
-    await page.waitForSelector('#edit-site-name');
+    await waitForSelectorWithReload('#edit-site-name');
     await page.type('#edit-site-mail', 'admin@example.com');
     await page.type('#edit-account-name', 'admin');
     await page.type('#edit-account-pass-pass1', 'admin');

--- a/perf/metrics/03-drupal-install/install-timer.js
+++ b/perf/metrics/03-drupal-install/install-timer.js
@@ -47,6 +47,29 @@ function sleep(ms) {
     // 10 minutes. Stage markers on stderr mean a hung run says where it's
     // stuck immediately instead of going silent for the full 10 minutes.
     const stage = (s) => console.error(`[install-timer] ${s}`);
+
+    // The final submit triggers Drupal's install batch, which redirects through
+    // one or more intermediate progress pages before landing on the site
+    // homepage. Seen in the field: Puppeteer's navigation tracking occasionally
+    // desyncs partway through that redirect chain and never notices the final
+    // page actually loaded (confirmed once by checking the site directly -- the
+    // install itself had finished, only this wait was stuck). A reload against
+    // the current URL re-fetches whatever page is actually live now, sidestepping
+    // the stuck navigation state instead of waiting on it indefinitely.
+    const waitForSelectorWithReload = async (selector, { attempts = 5, timeoutMs = 60000 } = {}) => {
+      for (let i = 1; i <= attempts; i++) {
+        try {
+          await page.waitForSelector(selector, { timeout: timeoutMs });
+          return;
+        } catch (err) {
+          if (i === attempts) throw err;
+          stage(`${selector} not found after ${timeoutMs}ms (attempt ${i}/${attempts}), reloading`);
+          await page.reload({ waitUntil: 'domcontentloaded' }).catch((reloadErr) => {
+            stage(`reload failed, will retry anyway: ${reloadErr.message}`);
+          });
+        }
+      }
+    };
     page.on('console', (msg) => console.error(`[install-timer] page console: ${msg.text()}`));
     page.on('pageerror', (err) => console.error(`[install-timer] page error: ${err}`));
     browser.on('disconnected', () => console.error('[install-timer] browser disconnected'));
@@ -94,7 +117,7 @@ function sleep(ms) {
     await page.click('#edit-submit');
 
     stage('waiting for post-install account menu');
-    await page.waitForSelector('#block-umami-account-menu');
+    await waitForSelectorWithReload('#block-umami-account-menu');
     stage('done');
 
     const durationS = Math.round((Date.now() - start) / 100) / 10;

--- a/perf/metrics/03-drupal-install/install-timer.js
+++ b/perf/metrics/03-drupal-install/install-timer.js
@@ -42,6 +42,15 @@ function sleep(ms) {
     const page = await browser.newPage();
     page.setDefaultTimeout(0);
 
+    // waitForSelector/goto have no per-call timeout (see setDefaultTimeout(0)
+    // above), so the only backstop against a genuine hang is protocolTimeout,
+    // 10 minutes. Stage markers on stderr mean a hung run says where it's
+    // stuck immediately instead of going silent for the full 10 minutes.
+    const stage = (s) => console.error(`[install-timer] ${s}`);
+    page.on('console', (msg) => console.error(`[install-timer] page console: ${msg.text()}`));
+    page.on('pageerror', (err) => console.error(`[install-timer] page error: ${err}`));
+    browser.on('disconnected', () => console.error('[install-timer] browser disconnected'));
+
     // Give any post-reset background work (php-fpm restart, Mutagen settle) a moment.
     await sleep(2000);
 
@@ -49,10 +58,13 @@ function sleep(ms) {
 
     const start = Date.now();
 
+    stage(`navigating to ${installUrl}`);
     await page.goto(installUrl);
+    stage('waiting for langcode selector');
     await page.waitForSelector('#edit-langcode');
     await page.click('#edit-submit');
 
+    stage('waiting for profile-demo-umami selector');
     await page.waitForSelector('#edit-profile-demo-umami');
     await page.click('#edit-profile-demo-umami');
     await page.click('#edit-submit');
@@ -61,16 +73,19 @@ function sleep(ms) {
     // (e.g. a missing recommended PHP extension); on a clean environment it's
     // skipped straight through to the configure-site form, so don't wait on
     // #edit-save unconditionally.
+    stage('waiting for requirements or configure-site form');
     await Promise.race([
       page.waitForSelector('#edit-save'),
       page.waitForSelector('#edit-site-name'),
     ]);
     const requirementsPage = await page.$('#edit-save');
     if (requirementsPage) {
+      stage('acknowledging requirements warning');
       await requirementsPage.click();
     }
 
     // Final "configure site" form, shown once the install batch finishes.
+    stage('waiting for configure-site form');
     await page.waitForSelector('#edit-site-name');
     await page.type('#edit-site-mail', 'admin@example.com');
     await page.type('#edit-account-name', 'admin');
@@ -78,7 +93,9 @@ function sleep(ms) {
     await page.type('#edit-account-pass-pass2', 'admin');
     await page.click('#edit-submit');
 
+    stage('waiting for post-install account menu');
     await page.waitForSelector('#block-umami-account-menu');
+    stage('done');
 
     const durationS = Math.round((Date.now() - start) / 100) / 10;
     console.log(JSON.stringify({ metric: 'drupal_install_s', value_s: durationS }));

--- a/perf/run-benchmark.sh
+++ b/perf/run-benchmark.sh
@@ -130,7 +130,10 @@ add_metric "$(bash "$DIR/metrics/02-mutagen-sync-settle.sh")"
 
 echo "--- Drupal demo_umami web install (Puppeteer)" >&2
 bash "$DIR/lib/reset-drupal.sh"
-( cd "$DIR/metrics/03-drupal-install" && npm ci --no-progress )
+# Redirected to stderr: this script's stdout contract is "one JSON result
+# line," and npm's own chatter here would otherwise land in perf.sh's
+# perf-result*.json artifact ahead of that line, breaking collect.js's parse.
+( cd "$DIR/metrics/03-drupal-install" && npm ci --no-progress ) >&2
 add_metric "$(cd "$DIR/metrics/03-drupal-install" && DDEV_PERF_SITE_URL="$DDEV_PERF_SITE_URL" node install-timer.js)"
 
 echo "--- drush si demo_umami (CLI diagnostic)" >&2


### PR DESCRIPTION
## The Issue

No tracked issue — this is a direct follow-up to #8622 (the nightly perf benchmark harness, already merged to `main`). None of these bugs were visible until the harness was exercised against real Buildkite pipelines and real GitHub Actions runs for the first time; each was found, root-caused, and fixed in that order this session.

## How This PR Solves The Issue

- **`perf/collector/collect.js`**: a `BUILDKITE_API_TOKEN` with the wrong scope (auths fine, 403s on artifacts) was treated identically to "token not configured yet," so it silently collected zero results and still let the workflow commit/push an empty `history.ndjson` — which still counted as "changed" and triggered a live dashboard deploy with nothing in it. Now only a genuinely absent token degrades gracefully; a present-but-broken one aborts the run before anything gets committed. Also improved the JSON-parse failure message to name the pipeline and artifact and show a content snippet, instead of a bare `SyntaxError`.
- **`perf/run-benchmark.sh`**: `npm ci`'s own stdout (`added 27 packages...`) was landing in the `perf-result*.json` artifact ahead of the actual JSON line, since it wasn't redirected like every other diagnostic line in this script. That's what the improved `collect.js` error message above caught in practice.
- **`perf/metrics/03-drupal-install/install-timer.js`**: found a real, reproducible Puppeteer bug on a WSL2 testbot — after several of the submit-triggered page navigations in the Drupal install flow, Puppeteer's navigation tracking occasionally desyncs and never notices the next page actually loaded, so the script hangs until its 600s protocol timeout, even though (confirmed directly against the running site, twice) the install had already finished. Added stage-by-stage debug logging so a hang says where it's stuck instead of going silent for 10 minutes, and a bounded reload-retry helper on every post-click wait that's susceptible (deliberately not on the one `Promise.race` step, where reloading the loser would yank the page out from under the winner).
- **`perf/metrics/00-ddev-rebuild.sh`** / **`perf/metrics/01-ddev-start.sh`**: `ddev_rebuild_s` repeated a forced no-cache rebuild 3 times and `ddev_start_cold_s` ran a full `docker system prune -f` before each of 3 samples — neither reflects anything a real DDEV workflow does, and both add real cost without averaging out any noise (a no-cache rebuild has no cache left to average against; the prune doesn't remove tagged images without `-a`, so it wasn't losing images, just burning time on a scan that serves no comparison purpose). Rebuild is now a single sample; the prune is gone.
- **`.github/workflows/docs-publish.yml`**: prints the deployed docs/dashboard URL from `actions/deploy-pages`'s own `page_url` output, instead of requiring it to be worked out by hand afterward.

Combined effect, same WSL2 leg, same machine, before vs. after all of the above:

| metric | before | after |
|---|---|---|
| `ddev_rebuild_s` | 84.1s | 29.5s |
| `ddev_start_cold_s` | 79.3s | 38.8s |
| `drupal_install_s` | 91.1s | 31.6s |
| `drush_install_s` | 79.9s | 24.6s |
| `ddev_stop_s` | 17.9s | 8.5s |

## Manual Testing Instructions

Each fix was validated locally first, without needing a live run:

- `collect.js`'s degrade-vs-fail behavior: a driver script stubs `fetch`/`execFileSync` to simulate no-token, broken-token, healthy-token, and bad-JSON-artifact scenarios and asserts exit code and whether `history.ndjson` changed.
- `install-timer.js`'s reload-retry helper: exercised in isolation with stub `page` objects (succeeds after N retries, throws cleanly once exhausted, doesn't reload on immediate success) — no browser needed.

Then validated live, end-to-end, against this branch (not `main`) via `bk build create --ignore-branch-filters` and `gh workflow run --ref <branch>`:

- All 6 Buildkite perf pipelines passed with clean, valid-JSON artifacts.
- `perf-collect.yml` collected all of them into `history.ndjson` with correct values (including `mutagen_settle_s: null` where Mutagen is disabled).
- `docs-publish.yml` deployed successfully; dashboard live at <https://ddev.github.io/ddev/perf/>.
- The WSL2 testbot that originally hung was retried repeatedly (forcing it via the Buildkite agent pause/resume API) until the fix was confirmed clearing the hang for real, not just no longer hitting it by luck.

## Automated Testing Overview

None. This is CI/tooling plumbing (shell + Node scripts) with no Go changes. `shellcheck`, `node --check`, YAML parsing, and `make markdownlint` are all clean.

## Release/Deployment Notes

No user-facing or binary changes — nothing in `pkg/`, `cmd/`, `containers/`, or the `Makefile`. Affects only the `perf/` nightly benchmark harness added in #8622.
