### PR TITLE
fix(perf): make the nightly collector resilient to one bad leg [skip ci]

### DIFF
--- a/.buildkite/perf.sh
+++ b/.buildkite/perf.sh
@@ -114,7 +114,25 @@ export DDEV_PERF_SITE_URL="$PROJECT_URL"
 # perf-result*.json artifact from a build, so this doesn't need to match
 # anything on that end.
 RESULT_FILE="perf-result-${DOCKER_PROVIDER_LABEL:-${DOCKER_TYPE:-unknown}}.json"
-"$(dirname "$0")/../perf/run-benchmark.sh" | tee "$RESULT_FILE"
+# run-benchmark.sh's contract is "one JSON result line on stdout" (see its own
+# header comment), and everything else it prints is explicitly redirected to
+# stderr for exactly this reason -- but that contract has already been broken
+# once by a step that forgot to redirect (npm ci's own output). Rather than
+# trust every current and future step in that chain to honor the contract,
+# capture the full output for the Buildkite log (tee, as before) but only
+# take the LAST line for the artifact: the JSON echo is always the final
+# stdout write, so this is safe regardless of what anything upstream prints.
+RAW_OUTPUT="$(mktemp)"
+"$(dirname "$0")/../perf/run-benchmark.sh" | tee "$RAW_OUTPUT"
+tail -n1 "$RAW_OUTPUT" > "$RESULT_FILE"
+
+echo "--- Validating result JSON"
+if ! jq -e . "$RESULT_FILE" >/dev/null 2>&1; then
+  echo "FATAL: $RESULT_FILE is not valid JSON -- failing here instead of" >&2
+  echo "uploading something collect.js can't parse. Full run-benchmark.sh output:" >&2
+  cat "$RAW_OUTPUT" >&2
+  exit 1
+fi
 
 echo "--- Uploading result artifact"
 buildkite-agent artifact upload "$RESULT_FILE"

--- a/.github/workflows/perf-collect.yml
+++ b/.github/workflows/perf-collect.yml
@@ -74,6 +74,7 @@ jobs:
           node-version: '22'
 
       - name: Collect results
+        id: collect
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -106,3 +107,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run docs-publish.yml --repo "$GITHUB_REPOSITORY" --ref main
+
+      # Deliberately last: collect.js exits 0 even when a source failed, so
+      # the commit/push and docs-publish steps above still run and publish
+      # whatever clean results came through. This step turns the run red
+      # anyway, but only after that publishing has already happened -- a
+      # broken source should be visible, not silently swallowed, but it also
+      # shouldn't block the legs that worked.
+      - name: Fail if any source had a collection error
+        if: steps.collect.outputs.had_errors == 'true'
+        run: |
+          echo "One or more sources failed to collect this run -- see the 'Collect results' step's ERROR lines above."
+          exit 1

--- a/perf/collector/collect.js
+++ b/perf/collector/collect.js
@@ -24,15 +24,24 @@ if (!HISTORY_PATH) {
 
 const CONFIG = JSON.parse(fs.readFileSync(path.join(__dirname, 'pipelines.json'), 'utf8'));
 
+// Set whenever any single pipeline/artifact fails to collect, so the run can
+// still finish, commit, and publish whatever DID come through clean -- one
+// broken leg shouldn't blank out the other five -- while still reporting
+// failure at the end (see main()) so a broken leg doesn't go unnoticed the
+// way a fully-silent skip would.
+let hadErrors = false;
+
 async function buildkiteApi(url) {
   const token = process.env.BUILDKITE_API_TOKEN;
   if (!token) throw new Error('BUILDKITE_API_TOKEN must be set');
+  console.log(`  GET ${url}`);
   const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
   if (!res.ok) throw new Error(`Buildkite API error ${res.status} for ${url}`);
   return res.json();
 }
 
 async function latestBuildkiteResults(pipeline) {
+  console.log(`Checking pipeline ${pipeline} for its latest passed build...`);
   const org = CONFIG.buildkiteOrg;
   const builds = await buildkiteApi(
     `https://api.buildkite.com/v2/organizations/${org}/pipelines/${pipeline}/builds?per_page=1&state=passed`
@@ -42,6 +51,7 @@ async function latestBuildkiteResults(pipeline) {
     return [];
   }
   const build = builds[0];
+  console.log(`  Latest passed build: #${build.number} (${build.web_url})`);
 
   const artifacts = await buildkiteApi(
     `https://api.buildkite.com/v2/organizations/${org}/pipelines/${pipeline}/builds/${build.number}/artifacts`
@@ -55,23 +65,34 @@ async function latestBuildkiteResults(pipeline) {
     console.warn(`No perf-result*.json artifact found on latest passed build of ${pipeline}`);
     return [];
   }
+  console.log(`  Found ${matches.length} perf-result*.json artifact(s): ${matches.map((a) => a.filename).join(', ')}`);
 
   const token = process.env.BUILDKITE_API_TOKEN;
   const results = [];
   for (const artifact of matches) {
-    const res = await fetch(artifact.download_url, { headers: { Authorization: `Bearer ${token}` } });
-    if (!res.ok) throw new Error(`Failed to download artifact ${artifact.filename} for ${pipeline}: ${res.status}`);
-    const text = await res.text();
+    // Caught per-artifact, not left to propagate: one bad upload in a build
+    // that holds several (e.g. macos-shared-providers' 6 legs) must not
+    // discard the other, valid ones.
     try {
-      results.push(JSON.parse(text));
+      console.log(`  Downloading ${artifact.filename} from ${artifact.download_url}`);
+      const res = await fetch(artifact.download_url, { headers: { Authorization: `Bearer ${token}` } });
+      if (!res.ok) throw new Error(`download failed: HTTP ${res.status}`);
+      const text = await res.text();
+      try {
+        results.push(JSON.parse(text));
+      } catch (err) {
+        // Bare JSON.parse errors don't say which artifact failed, what it
+        // actually contained, or where it came from -- all three are needed
+        // to tell "wrong scope/HTML error page" apart from "a script wrote
+        // non-JSON to stdout ahead of the result line" (the actual cause the
+        // first time this fired) without pulling raw Buildkite logs by hand.
+        throw new Error(
+          `not valid JSON: ${err.message}\n    URL: ${artifact.download_url}\n    First 200 chars: ${text.slice(0, 200)}`
+        );
+      }
     } catch (err) {
-      // Bare JSON.parse errors don't say which artifact failed or what it
-      // actually contained -- both are needed to tell "wrong scope/HTML
-      // error page" apart from "a script wrote non-JSON to stdout ahead of
-      // the result line" (the actual cause the one time this fired).
-      throw new Error(
-        `${pipeline}'s ${artifact.filename} is not valid JSON: ${err.message}\nFirst 200 chars: ${text.slice(0, 200)}`
-      );
+      console.error(`ERROR collecting ${pipeline}'s ${artifact.filename}: ${err.message}`);
+      hadErrors = true;
     }
   }
   return results;
@@ -80,9 +101,10 @@ async function latestBuildkiteResults(pipeline) {
 function latestLinuxResult() {
   const repo = process.env.GITHUB_REPOSITORY;
   if (!repo) throw new Error('GITHUB_REPOSITORY must be set');
+  console.log('Checking perf-linux.yml for its latest successful run...');
   const runsJson = execFileSync(
     'gh',
-    ['run', 'list', '--repo', repo, '--workflow', 'perf-linux.yml', '--status', 'success', '--limit', '1', '--json', 'databaseId'],
+    ['run', 'list', '--repo', repo, '--workflow', 'perf-linux.yml', '--status', 'success', '--limit', '1', '--json', 'databaseId,url'],
     { encoding: 'utf8' }
   );
   const runs = JSON.parse(runsJson);
@@ -91,6 +113,7 @@ function latestLinuxResult() {
     return null;
   }
   const runId = runs[0].databaseId;
+  console.log(`  Latest successful run: ${runs[0].url}`);
   const tmpDir = fs.mkdtempSync('/tmp/ddev-perf-linux-');
   execFileSync('gh', [
     'run', 'download', String(runId),
@@ -98,7 +121,15 @@ function latestLinuxResult() {
     '-n', 'perf-result-linux-docker-ce',
     '-D', tmpDir,
   ]);
-  return JSON.parse(fs.readFileSync(path.join(tmpDir, 'perf-result.json'), 'utf8'));
+  const resultPath = path.join(tmpDir, 'perf-result.json');
+  const text = fs.readFileSync(resultPath, 'utf8');
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      `perf-result-linux-docker-ce from ${runs[0].url} is not valid JSON: ${err.message}\n  First 200 chars: ${text.slice(0, 200)}`
+    );
+  }
 }
 
 // Identity of one data point, matching dashboard.html's legKey() plus the run's
@@ -129,16 +160,23 @@ async function main() {
 
   // A missing token is the expected, tolerated state before the one-time
   // BUILDKITE_API_TOKEN vault setup (see this file's header comment) --
-  // skip Buildkite entirely and still collect the Linux leg below. Once a
-  // token is present, though, any request failure (wrong scope, revoked,
-  // rate-limited) means the setup is broken, not "not done yet": let it
-  // throw and abort the whole run instead of quietly committing an
-  // empty/partial dataset that overwrites the live dashboard with nothing.
+  // skip Buildkite entirely and still collect the Linux leg below, without
+  // counting it as an error. Once a token is present, a request failure
+  // (wrong scope, revoked, rate-limited) means the setup is broken, not "not
+  // done yet" -- but one pipeline failing that way must not discard the
+  // other pipelines' perfectly good results, so it's caught here (per
+  // pipeline) the same way latestBuildkiteResults() catches per artifact:
+  // logged loudly, counted in hadErrors, and the loop moves on.
   if (!process.env.BUILDKITE_API_TOKEN) {
     console.warn('BUILDKITE_API_TOKEN not set; skipping Buildkite pipelines');
   } else {
     for (const pipeline of CONFIG.pipelines) {
-      results.push(...(await latestBuildkiteResults(pipeline)));
+      try {
+        results.push(...(await latestBuildkiteResults(pipeline)));
+      } catch (err) {
+        console.error(`ERROR collecting ${pipeline}: ${err.message}`);
+        hadErrors = true;
+      }
     }
   }
 
@@ -146,7 +184,8 @@ async function main() {
     const linuxResult = latestLinuxResult();
     if (linuxResult) results.push(linuxResult);
   } catch (err) {
-    console.warn(`Skipping Linux: ${err.message}`);
+    console.error(`ERROR collecting Linux: ${err.message}`);
+    hadErrors = true;
   }
 
   if (!results.length) {
@@ -176,7 +215,29 @@ async function main() {
   console.log(`Appended ${lines.length} new result(s) of ${results.length} collected to ${HISTORY_PATH}`);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+main()
+  .then(() => {
+    // Exit 0 even when hadErrors, so the caller's later workflow steps
+    // (commit/push, docs-publish trigger) still run and publish whatever
+    // clean results came through -- one broken source shouldn't block the
+    // others. Recorded via GITHUB_OUTPUT so a later step in the same
+    // workflow can still fail the run visibly, AFTER publishing, instead of
+    // this going unnoticed the way a fully-silent skip would.
+    if (process.env.GITHUB_OUTPUT) {
+      fs.appendFileSync(process.env.GITHUB_OUTPUT, `had_errors=${hadErrors}\n`);
+    }
+    if (hadErrors) {
+      console.error('Completed with errors on one or more sources (see ERROR lines above). Any clean results were still collected and written; the workflow will report failure after publishing them.');
+    }
+  })
+  .catch((err) => {
+    // A genuine crash (malformed pipelines.json, a required env var missing)
+    // reaches here, distinct from a per-source error, which main() already
+    // caught and logged without letting it propagate. Nothing here is
+    // trustworthy enough to publish, so fail immediately.
+    console.error(err);
+    if (process.env.GITHUB_OUTPUT) {
+      fs.appendFileSync(process.env.GITHUB_OUTPUT, 'had_errors=true\n');
+    }
+    process.exit(1);
+  });

--- a/perf/run-benchmark.sh
+++ b/perf/run-benchmark.sh
@@ -161,7 +161,7 @@ branch="${BUILDKITE_BRANCH:-${GITHUB_REF_NAME:-$(git -C "$DIR" rev-parse --abbre
 # report a real provider too.
 docker_provider="${DOCKER_PROVIDER_LABEL:-${DOCKER_TYPE:-$(jq -r '.raw["docker-platform"] // "unknown"' <<<"$version_json")}}"
 
-result_json=$(jq -n \
+result_json=$(jq -nc \
   --argjson metrics "$metrics_json" \
   --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --arg commit_sha "$commit_sha" \


### PR DESCRIPTION
## The Issue

No tracked issue — a direct follow-up to #8622 (the nightly perf benchmark harness) and #8668 (round 1 of post-merge bugfixes). Round 1's `npm ci` stdout-leak fix landed at `2026-08-06T03:02:12Z`, two minutes after that night's `0 3 * * *` Buildkite cron had already fired, so at least one leg (`ddev-perf-macos-docker-desktop-arm64`) checked out `main` just ahead of the fix and produced an npm-leak-poisoned artifact again — not a new bug, a one-night timing race against the merge. `perf-collect.yml`'s all-or-nothing error handling then let that single bad artifact abort collection of the other five legs' perfectly good results too.

## How This PR Solves The Issue

- **`perf/collector/collect.js`**: errors are now caught per-artifact (a single build can hold several, e.g. `macos-shared-providers`' 6 legs) and per-pipeline, logged loudly with the pipeline, filename, download URL, and a content snippet, then skipped — everything else still gets collected and written. A new `hadErrors` flag is recorded to `GITHUB_OUTPUT` (`had_errors`) instead of exiting non-zero directly, so the workflow can still fail visibly without blocking publication of whatever came through clean. Added progress logging throughout (which pipeline, which build, which artifacts, which URL) so a future failure is diagnosable from the log alone instead of a bare stack trace.
- **`.github/workflows/perf-collect.yml`**: gave the "Collect results" step an `id`, and added a final step, `if: steps.collect.outputs.had_errors == 'true'`, that fails the run — placed after the commit/push and docs-publish-trigger steps so a bad leg is visible without blocking the legs that worked.
- **`.buildkite/perf.sh`**: stopped trusting that nothing upstream will ever print a stray line to stdout again (the exact assumption that broke last time). Captures the full `run-benchmark.sh` output to a temp file (still `tee`'d to the Buildkite log as before), takes only the last line for the actual artifact, then validates it with `jq -e .` before upload — failing the build immediately with the full raw output logged if it's still not valid JSON, instead of silently uploading garbage for the collector to choke on hours later.
- **`perf/run-benchmark.sh`**: the line above assumes the JSON result really is the single last line of stdout, which wasn't true — `result_json` was built with `jq -n` and echoed as-is, producing pretty-printed, multi-line JSON despite this script's own header comment promising "one JSON result line to stdout." Confirmed live: the `perf.sh` change above shipped first, immediately failed a real build (`ddev-perf-macos-docker-desktop-arm64` #11) by extracting only the trailing `}`, which correctly failed `jq -e .` — the validation worked exactly as designed, just against a different bug than the one it was built for. Fixed with `jq -nc`, making the header comment's contract actually true.

## Manual Testing Instructions

Validated locally with a stub-based driver (`fetch`/`execFileSync` stubbed, no network) across three scenarios: healthy, one-artifact-bad-among-several, and one-pipeline-entirely-broken. In all three, everything collectible still gets collected and written, `had_errors` is set correctly, and `collect.js` itself always exits 0 (the workflow's new final step is what fails the run, deliberately after publishing).

Then validated live against this branch via `bk build create --ignore-branch-filters` and `gh workflow run --ref <branch>`:

- All 5 Buildkite perf pipelines passed, producing 10 result artifacts (including `macos-shared-providers`' 6 legs) — every one confirmed valid, single-line JSON built from this branch's `jq -nc` fix.
- `perf-collect.yml` collected all 10 with `had_errors=false`, committed `history.ndjson`, and triggered `docs-publish.yml`.
- `docs-publish.yml` itself hit an unrelated GitHub Pages backend stall (deployment stuck at `deployment_queued` for its full 10-minute timeout, then a retry got immediately `Deployment cancelled` — both against the identical, unchanged `main` SHA, which `docs-publish.yml` always deploys from regardless of which branch triggered it). Not caused by anything in this PR; left for the maintainer to retry once GitHub's side has settled, or let tonight's cron pick it up.

## Automated Testing Overview

None. CI/tooling plumbing (shell + Node scripts), no Go changes.

## Release/Deployment Notes

No user-facing or binary changes. Affects only the `perf/` nightly benchmark harness (#8622, #8668).
