### PR TITLE
fix(provider): run import hooks for custom db/files import commands (#8671) [skip ci]

### DIFF
--- a/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
+++ b/pkg/ddevapp/dotddev_assets/providers/git.yaml.example
@@ -30,11 +30,16 @@ db_import_command:
   command: |
     set -eu -o pipefail
     # set -x
-    ddev import-db --file="${checkout_dir}/db.sql.gz"
+    # Import directly rather than via `ddev import-db`, which fires pre/post-import-db
+    # hooks itself and would run them twice alongside this command's own hooks.
+    gzip -dc ${checkout_dir}/db.sql.gz | ddev mysql db
 
 files_import_command:
   service: host
   command: |
     set -eu -o pipefail
     # set -x
-    ddev import-files --source="${checkout_dir}/files"
+    # Import directly rather than via `ddev import-files`, for the same reason as
+    # db_import_command above.
+    mkdir -p web/sites/default/files
+    cp -r ${checkout_dir}/files/. web/sites/default/files/

--- a/pkg/ddevapp/provider.go
+++ b/pkg/ddevapp/provider.go
@@ -107,7 +107,11 @@ func (app *DdevApp) Pull(provider *Provider, skipDBArg bool, skipFilesArg bool, 
 			if err != nil {
 				return err
 			}
-			output.UserOut.Printf("Importing databases %v", fileLocation)
+			// With a db_import_command and no db_pull_command there's nothing downloaded to name here,
+			// and importDatabaseBackup() announces itself.
+			if len(fileLocation) > 0 {
+				output.UserOut.Printf("Importing databases %v", fileLocation)
+			}
 			err = provider.importDatabaseBackup(fileLocation, importPath)
 			if err != nil {
 				return err
@@ -347,7 +351,10 @@ func (p *Provider) getDatabaseBackups() ([]string, error) {
 	}
 
 	if p.DBPullCommand.Command == "" {
-		util.Warning("No db_pull_command provided, so skipping database pull")
+		// A db_import_command may do the downloading itself, so there's nothing to warn about.
+		if p.DBImportCommand.Command == "" {
+			util.Warning("No db_pull_command provided, so skipping database pull")
+		}
 		return nil, nil
 	}
 
@@ -396,7 +403,17 @@ func (p *Provider) importDatabaseBackup(fileLocation []string, importPath []stri
 			s = "web"
 		}
 		output.UserOut.Printf("Importing database via custom db_import_command")
+		// app.ImportDB() runs these itself, so the custom command has to do it here.
+		if err := p.app.ProcessHooks("pre-import-db"); err != nil {
+			return err
+		}
 		err = p.app.ExecOnHostOrService(s, p.injectedEnvironment()+"; "+p.DBImportCommand.Command)
+		if err != nil {
+			return err
+		}
+		if err := p.app.ProcessHooks("post-import-db"); err != nil {
+			return err
+		}
 	}
 	return err
 }
@@ -418,7 +435,17 @@ func (p *Provider) doFilesImport(fileLocation string, importPath string) error {
 			s = "web"
 		}
 		output.UserOut.Printf("Importing files via custom files_import_command...")
+		// See the db_import_command note in importDatabaseBackup().
+		if err := p.app.ProcessHooks("pre-import-files"); err != nil {
+			return err
+		}
 		err = p.app.ExecOnHostOrService(s, p.injectedEnvironment()+"; "+p.FilesImportCommand.Command)
+		if err != nil {
+			return err
+		}
+		if err := p.app.ProcessHooks("post-import-files"); err != nil {
+			return err
+		}
 	}
 	return err
 }

--- a/pkg/ddevapp/providerLocalfile_test.go
+++ b/pkg/ddevapp/providerLocalfile_test.go
@@ -43,6 +43,14 @@ func TestLocalfilePull(t *testing.T) {
 	app.Name = t.Name()
 	app.Type = nodeps.AppTypeDrupal11
 	app.Docroot = "web"
+	// localfile.yaml.example uses db_import_command and files_import_command, so this
+	// verifies the import hooks fire for custom import commands, not just for the built-in importers.
+	app.Hooks = map[string][]ddevapp.YAMLTask{
+		"pre-import-db":     {{"exec-host": "touch hello-pre-import-db-" + app.Name}},
+		"post-import-db":    {{"exec-host": "touch hello-post-import-db-" + app.Name}},
+		"pre-import-files":  {{"exec-host": "touch hello-pre-import-files-" + app.Name}},
+		"post-import-files": {{"exec-host": "touch hello-post-import-files-" + app.Name}},
+	}
 	err = app.Stop(true, false)
 	require.NoError(t, err)
 	err = app.WriteConfig()
@@ -82,10 +90,18 @@ func TestLocalfilePull(t *testing.T) {
 
 	err = app.Start()
 	require.NoError(t, err)
+	// localfile.yaml has a db_import_command and no db_pull_command, which must not warn.
+	getWarnings := util.CaptureUserErr()
 	err = app.Pull(provider, false, false, false)
+	warnings := getWarnings()
 	require.NoError(t, err)
+	t.Logf("warnings during pull: %s", warnings)
+	require.NotContains(t, warnings, "No db_pull_command provided")
 
 	assert.FileExists(filepath.Join(app.GetHostUploadDirFullPath(), "docs/developers/building-contributing.md"))
+	for _, hook := range []string{"pre-import-db", "post-import-db", "pre-import-files", "post-import-files"} {
+		require.FileExists(t, filepath.Join(app.GetAppRoot(), "hello-"+hook+"-"+app.Name), "%s hook did not run", hook)
+	}
 	out, _, err = app.Exec(&ddevapp.ExecOpts{
 		Cmd:     fmt.Sprintf(`echo 'select COUNT(*) from users_field_data where mail="margaret.hopper@example.com";' | %s -N`, app.GetDBClientCommand()),
 		Service: "db",


### PR DESCRIPTION
## The Issue

Providers that use `db_import_command`/`files_import_command` instead of the built-in importers have two problems, both visible today in `ddev pull lagoon` and in the `git`/`localfile` provider examples:

- `pre-import-db`, `post-import-db`, `pre-import-files` and `post-import-files` never fire. Those hooks live inside `app.ImportDB()`/`app.ImportFiles()`, which the custom-command branches bypass. A Drupal project with `post-import-db: drush cr` silently gets nothing.
- Every pull warns `No db_pull_command provided, so skipping database pull` and then prints `Importing databases []`, even though the import is about to happen via the custom command. `doFilesPullCommand()` already guards against this on the files side; the db side did not.

Surfaced by review of #8643, which moves the Acquia provider onto `db_import_command` and would inherit both.

## How This PR Solves The Issue

Fire the pre/post import hooks around the custom import commands in `importDatabaseBackup()` and `doFilesImport()`, suppress the `db_pull_command` warning when a `db_import_command` exists, and only print the downloaded-file list when there is one.

`git.yaml.example`'s `db_import_command`/`files_import_command` used to shell out to `ddev import-db`/`ddev import-files`, which fire the same pre/post-import hooks internally. With the provider-level wrapping added here, that recipe would run each hook twice. Changed it to import the dump/files directly, the same technique `localfile.yaml.example` already uses, so the provider-level wrapping is the only place those hooks fire from.

## Manual Testing Instructions

This uses [d11simple](https://github.com/ddev/d11simple), a real Drupal 11 codebase, and [d11simple-artifacts](https://github.com/ddev/d11simple-artifacts), a `db.sql.gz`/`files.tgz` pair, to exercise the actual custom-command import path end to end rather than a synthetic hook.

1. 
   ```
   git clone https://github.com/ddev/d11simple.git ~/tmp/d11simple && cd ~/tmp/d11simple
   ddev start
   ```
2. Write `.ddev/providers/pulltest.yaml`:

   ```yaml
   environment_variables:
     project_url: https://github.com/ddev/d11simple-artifacts
     checkout_dir: ~/tmp/d11simple-artifacts

   auth_command:
     service: host
     command: |
       set -eu -o pipefail
       if [ ! -d ${checkout_dir}/.git ]; then
           git clone -q ${project_url} ${checkout_dir}
       else
           cd ${checkout_dir} && git pull -q
       fi

   db_import_command:
     service: host
     command: |
       set -eu -o pipefail
       gzip -dc ${checkout_dir}/db.sql.gz | ddev mysql db

   files_import_command:
     service: host
     command: |
       set -eu -o pipefail
       mkdir -p web/sites/default/files
       tar -zxf ${checkout_dir}/files.tgz -C web/sites/default/files
   ```

4. Add  `.ddev/config.test.yaml`:

   ```yaml
   # .ddev/config.test.yaml
   hooks:
     pre-import-db:
       - exec-host: echo PRE-IMPORT-DB
     post-import-db:
       - exec-host: echo POST-IMPORT-DB
     pre-import-files:
       - exec-host: echo PRE-IMPORT-FILES
     post-import-files:
       - exec-host: echo POST-IMPORT-FILES
   ```

5. `ddev pull pulltest`

Expect each of the four echoes exactly once, in pre/post order around each import, and no `No db_pull_command provided` or `Importing databases []` lines. Confirm the import itself worked with `echo 'select mail from users_field_data where uid=3;' | ddev mysql db -N` (returns `margaret.hopper@example.com`) and `ddev exec "ls web/sites/default/files"` (populated with image files).

On `main`, before this fix, the four hook echoes are absent and the `No db_pull_command provided`/`Importing databases []` lines appear even though the custom commands are doing the work. I ran both versions against this recipe while preparing this PR: the `main` behavior above, and a version of this fix without the `git.yaml.example` change, which printed each of the four hook echoes twice.

## Automated Testing Overview

`TestLocalfilePull` now sets all four import hooks and requires that each one ran, and captures UserErr during the pull to require that the `db_pull_command` warning is gone. It uses `localfile.yaml.example`, which supplies both custom import commands, so it covers the db and files paths together, needs no provider credentials, and runs in the ordinary PR test matrix rather than only in the pull/push provider workflow. `TestGitPull` continues to pass against the updated `git.yaml.example`.

## Release/Deployment Notes

Projects using a provider with custom import commands will start running their `*-import-db`/`*-import-files` hooks on pull. That is the documented behavior, but it is a change from what those projects do today. Projects whose custom import command itself shells out to `ddev import-db`/`ddev import-files` (as the old `git.yaml.example` did) would have seen those hooks fire twice; anyone who copied that pattern should switch to importing the dump/files directly, as the updated example and `localfile.yaml.example` do.
