### PR TITLE
fix(ddevapp): attach command output to failing provider and hook commands (#8672) [skip ci]

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -2532,10 +2533,11 @@ type ExecOpts struct {
 	NoCapture bool
 	// Tty if true causes a tty to be allocated
 	Tty bool
-	// Stdout can be overridden with a File
-	Stdout *os.File
-	// Stderr can be overridden with a File
-	Stderr *os.File
+	// Stdout can be overridden with a Writer; a caller that also wants a
+	// captured copy (see errorWithOutput) can pass an io.MultiWriter.
+	Stdout io.Writer
+	// Stderr can be overridden with a Writer; see Stdout.
+	Stderr io.Writer
 	// Detach does docker-compose detach
 	Detach bool
 	// Env is the array of environment variables
@@ -2597,8 +2599,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		opts.RawCmd = []string{shell, "-c", errcheck + ` && ( ` + opts.Cmd + `)`}
 	}
 
-	stdout := os.Stdout
-	stderr := os.Stderr
+	var stdout, stderr io.Writer = os.Stdout, os.Stderr
 	if opts.Stdout != nil {
 		stdout = opts.Stdout
 	}
@@ -2614,7 +2615,13 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	}
 
 	// Allocate a TTY only when both stdin and stdout are real terminals.
-	tty := opts.Tty && isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(stdout.Fd())
+	// A non-*os.File stdout (e.g. an io.MultiWriter teeing to a capture
+	// buffer) is never a terminal.
+	stdoutIsTerminal := false
+	if f, ok := stdout.(*os.File); ok {
+		stdoutIsTerminal = isatty.IsTerminal(f.Fd())
+	}
+	tty := opts.Tty && isatty.IsTerminal(os.Stdin.Fd()) && stdoutIsTerminal
 
 	// A session with a TTY gets the terminal of the host, so programs in the
 	// container know how many colors they can use. Without a TTY there is no
@@ -2673,41 +2680,45 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	return stdoutResult, stderrResult, err
 }
 
+// runHostCommandWithCapturedOutput runs cmd via bash in app's root, keeping
+// stdin and the terminal connected, and attaches captured output to a
+// failure the same way errorWithOutput does elsewhere. Shared by
+// ExecOnHostOrService's host branch and the exec-host hook task, which need
+// identical behavior on the host.
+func runHostCommandWithCapturedOutput(app *DdevApp, cmd string) error {
+	cwd, _ := os.Getwd()
+	appRoot := app.GetAppRoot()
+	if err := os.Chdir(appRoot); err != nil {
+		return fmt.Errorf("unable to chdir to %s: %v", appRoot, err)
+	}
+	defer func() {
+		_ = os.Chdir(cwd)
+	}()
+	bashPath := "bash"
+	if nodeps.IsWindows() {
+		bashPath = util.FindBashPath()
+		if bashPath == "" {
+			return fmt.Errorf("unable to find bash.exe on Windows")
+		}
+	}
+
+	_ = app.DockerEnv()
+	// Interactive: these commands prompt for ssh passphrases and print
+	// transfer progress, so they keep stdin and a live terminal.
+	out, err := exec.RunInteractiveCommandWithCapture(bashPath, []string{"-c", cmd})
+	if err != nil {
+		return errorWithOutput(err, out)
+	}
+	return nil
+}
+
 // ExecOnHostOrService runs cmd on the host or in the named service.
 // A failure carries the command's output, which is otherwise lost in logs
 // far from the error that mentions it.
 func (app *DdevApp) ExecOnHostOrService(service string, cmd string) error {
 	// Handle case on host
 	if service == "host" {
-		cwd, _ := os.Getwd()
-		appRoot := app.GetAppRoot()
-		if err := os.Chdir(appRoot); err != nil {
-			return fmt.Errorf("unable to chdir to %s: %v", appRoot, err)
-		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
-		bashPath := "bash"
-		if nodeps.IsWindows() {
-			bashPath = util.FindBashPath()
-			if bashPath == "" {
-				return fmt.Errorf("unable to find bash.exe on Windows")
-			}
-		}
-
-		args := []string{
-			"-c",
-			cmd,
-		}
-
-		_ = app.DockerEnv()
-		// Interactive: these commands prompt for ssh passphrases and print
-		// transfer progress, so they keep stdin and a live terminal.
-		out, err := exec.RunInteractiveCommandWithCapture(bashPath, args)
-		if err != nil {
-			return errorWithOutput(err, out)
-		}
-		return nil
+		return runHostCommandWithCapturedOutput(app, cmd)
 	}
 	// handle case in container
 	// Tty must require stdout too, not just stdin: app.Exec() skips capture

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2710,11 +2710,14 @@ func (app *DdevApp) ExecOnHostOrService(service string, cmd string) error {
 		return nil
 	}
 	// handle case in container
+	// Tty must require stdout too, not just stdin: app.Exec() skips capture
+	// whenever Tty is true, so gating on stdin alone left errorWithOutput()
+	// below with nothing to attach whenever only stdout was redirected.
 	stdout, stderr, err := app.Exec(
 		&ExecOpts{
 			Service: service,
 			Cmd:     cmd,
-			Tty:     isatty.IsTerminal(os.Stdin.Fd()),
+			Tty:     isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd()),
 		})
 	if err != nil {
 		return errorWithOutput(err, stdout+"\n"+stderr)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2673,15 +2673,20 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	return stdoutResult, stderrResult, err
 }
 
+// ExecOnHostOrService runs cmd on the host or in the named service.
+// A failure carries the command's output, which is otherwise lost in logs
+// far from the error that mentions it.
 func (app *DdevApp) ExecOnHostOrService(service string, cmd string) error {
-	var err error
 	// Handle case on host
 	if service == "host" {
 		cwd, _ := os.Getwd()
-		err = os.Chdir(app.GetAppRoot())
-		if err != nil {
-			return fmt.Errorf("unable to GetAppRoot: %v", err)
+		appRoot := app.GetAppRoot()
+		if err := os.Chdir(appRoot); err != nil {
+			return fmt.Errorf("unable to chdir to %s: %v", appRoot, err)
 		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
 		bashPath := "bash"
 		if nodeps.IsWindows() {
 			bashPath = util.FindBashPath()
@@ -2696,17 +2701,35 @@ func (app *DdevApp) ExecOnHostOrService(service string, cmd string) error {
 		}
 
 		_ = app.DockerEnv()
-		err = exec.RunInteractiveCommand(bashPath, args)
-		_ = os.Chdir(cwd)
-	} else { // handle case in container
-		_, _, err = app.Exec(
-			&ExecOpts{
-				Service: service,
-				Cmd:     cmd,
-				Tty:     isatty.IsTerminal(os.Stdin.Fd()),
-			})
+		// Interactive: these commands prompt for ssh passphrases and print
+		// transfer progress, so they keep stdin and a live terminal.
+		out, err := exec.RunInteractiveCommandWithCapture(bashPath, args)
+		if err != nil {
+			return errorWithOutput(err, out)
+		}
+		return nil
 	}
-	return err
+	// handle case in container
+	stdout, stderr, err := app.Exec(
+		&ExecOpts{
+			Service: service,
+			Cmd:     cmd,
+			Tty:     isatty.IsTerminal(os.Stdin.Fd()),
+		})
+	if err != nil {
+		return errorWithOutput(err, stdout+"\n"+stderr)
+	}
+	return nil
+}
+
+// errorWithOutput attaches command output to err, skipping it when there is
+// none to attach or when the user has already watched it go by on a terminal.
+func errorWithOutput(err error, out string) error {
+	out = strings.TrimSpace(out)
+	if out == "" || isatty.IsTerminal(os.Stdout.Fd()) {
+		return err
+	}
+	return fmt.Errorf("%v\noutput: %s", err, out)
 }
 
 // Logs returns logs for a site's given container.

--- a/pkg/ddevapp/execOnHostOrService_test.go
+++ b/pkg/ddevapp/execOnHostOrService_test.go
@@ -1,0 +1,55 @@
+package ddevapp_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecOnHostOrServiceContainerOutput ensures a failing container-service
+// command (the branch used by provider examples like acquia.yaml, which
+// don't set `service: host`) has its output attached to the returned error
+// when stdout is not a terminal, same as the host branch already does.
+// Forcing stdout non-tty makes this deterministic regardless of whether the
+// test itself runs at an interactive terminal; only stdin's ttyness varies
+// by environment, and app.Exec() requires both to skip capture.
+func TestExecOnHostOrServiceContainerOutput(t *testing.T) {
+	if nodeps.IsWindows() {
+		t.Skip("util.CaptureStdOut() doesn't work on Windows")
+	}
+
+	origDir, _ := os.Getwd()
+	tmpDir := testcommon.CreateTmpDir(t.Name())
+
+	err := os.Chdir(tmpDir)
+	require.NoError(t, err)
+
+	app, err := ddevapp.NewApp(tmpDir, true)
+	require.NoError(t, err)
+	app.Name = t.Name()
+	app.Type = nodeps.AppTypePHP
+	err = app.WriteConfig()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = app.Stop(true, false)
+		require.NoError(t, err)
+		_ = os.Chdir(origDir)
+		_ = os.RemoveAll(tmpDir)
+	})
+
+	err = app.Start()
+	require.NoError(t, err)
+
+	restoreStdout := util.CaptureStdOut()
+	err = app.ExecOnHostOrService("web", `echo "boom-output-marker-web" >&2; exit 7`)
+	_ = restoreStdout()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "boom-output-marker-web")
+}

--- a/pkg/ddevapp/hooks_test.go
+++ b/pkg/ddevapp/hooks_test.go
@@ -167,6 +167,37 @@ func TestProcessHooks(t *testing.T) {
 		})
 	})
 
+	// A failing exec/exec-host hook's output is teed live (unchanged) and
+	// also attached to the logged failure, the same way ExecOnHostOrService
+	// attaches output for a failing provider command.
+	t.Run("failing hook output is attached to the error", func(t *testing.T) {
+		t.Run("exec", func(t *testing.T) {
+			app.Hooks = map[string][]ddevapp.YAMLTask{
+				"hook-test": {
+					{"exec": `echo "boom-output-marker-web" >&2; exit 7`},
+				},
+			}
+			getUserOut := util.CaptureUserOut()
+			err = app.ProcessHooks("hook-test")
+			userOut := getUserOut()
+			require.NoError(t, err)
+			require.Contains(t, userOut, "boom-output-marker-web")
+		})
+
+		t.Run("exec-host", func(t *testing.T) {
+			app.Hooks = map[string][]ddevapp.YAMLTask{
+				"hook-test": {
+					{"exec-host": `echo "boom-output-marker-host" >&2; exit 7`},
+				},
+			}
+			getUserOut := util.CaptureUserOut()
+			err = app.ProcessHooks("hook-test")
+			userOut := getUserOut()
+			require.NoError(t, err)
+			require.Contains(t, userOut, "boom-output-marker-host")
+		})
+	})
+
 	t.Run("pre-share and post-share hooks", func(t *testing.T) {
 		app.Hooks = map[string][]ddevapp.YAMLTask{
 			"pre-share": {

--- a/pkg/ddevapp/task.go
+++ b/pkg/ddevapp/task.go
@@ -1,11 +1,12 @@
 package ddevapp
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
-	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/mattn/go-isatty"
@@ -44,8 +45,11 @@ type ComposerTask struct {
 	app     *DdevApp
 }
 
-// Execute executes an ExecTask
+// Execute executes an ExecTask. Output is teed to a buffer so a failure's
+// error can carry it, the same way ExecOnHostOrService's does for providers;
+// the command still streams live exactly as before.
 func (c ExecTask) Execute() error {
+	var captured bytes.Buffer
 	opts := &ExecOpts{
 		Service:   c.service,
 		User:      c.user,
@@ -53,10 +57,14 @@ func (c ExecTask) Execute() error {
 		RawCmd:    c.execRaw,
 		Tty:       isatty.IsTerminal(os.Stdin.Fd()),
 		NoCapture: true,
+		Stdout:    io.MultiWriter(os.Stdout, &captured),
+		Stderr:    io.MultiWriter(os.Stderr, &captured),
 	}
 	_, _, err := c.app.Exec(opts)
-
-	return err
+	if err != nil {
+		return errorWithOutput(err, captured.String())
+	}
+	return nil
 }
 
 // GetDescription returns a human-readable description of the task
@@ -75,30 +83,11 @@ func (c ExecHostTask) GetDescription() string {
 	return fmt.Sprintf("Exec command '%s' on the host (%s)", c.exec, hostname)
 }
 
-// Execute (HostTask) executes a command in a container, by default the web container,
-// and returns stdout, stderr, err
+// Execute (HostTask) executes a command on the host, keeping stdin and the
+// terminal connected, and attaches captured output to a failure the same
+// way ExecOnHostOrService's host branch does for providers.
 func (c ExecHostTask) Execute() error {
-	cwd, _ := os.Getwd()
-	err := os.Chdir(c.app.GetAppRoot())
-	if err != nil {
-		return err
-	}
-
-	bashPath := "bash"
-	if nodeps.IsWindows() {
-		bashPath = util.FindBashPath()
-	}
-
-	args := []string{
-		"-c",
-		c.exec,
-	}
-
-	err = exec.RunInteractiveCommand(bashPath, args)
-
-	_ = os.Chdir(cwd)
-
-	return err
+	return runHostCommandWithCapturedOutput(c.app, c.exec)
 }
 
 // Execute (ComposerTask) runs a Composer command in the web container

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -96,19 +96,20 @@ func RunInteractiveCommand(command string, args []string) error {
 // RunInteractiveCommandWithCapture runs a command interactively like
 // RunInteractiveCommand(), but also returns a copy of what it printed, so a
 // failure can be reported with its output attached. stdout and stderr are
-// combined and share one writer, so os/exec copies them from a single
-// goroutine and the capture stays race-free.
+// captured into separate buffers, each written by its own os/exec copy
+// goroutine, so callers that rely on stderr staying off stdout (exec-host
+// hooks piping DDEV's stderr, for instance) see the same separation as
+// RunInteractiveCommand().
 func RunInteractiveCommandWithCapture(command string, args []string) (string, error) {
-	var captured bytes.Buffer
+	var capturedStdout, capturedStderr bytes.Buffer
 	cmd := HostCommand(command, args...)
 	cmd.Stdin = os.Stdin
 	// Byte-for-byte tee, unlike RunInteractiveCommandWithOutput(), so progress
 	// output and colors reach the terminal unchanged.
-	tee := io.MultiWriter(os.Stdout, &captured)
-	cmd.Stdout = tee
-	cmd.Stderr = tee
+	cmd.Stdout = io.MultiWriter(os.Stdout, &capturedStdout)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &capturedStderr)
 	err := cmd.Run()
-	return captured.String(), err
+	return capturedStdout.String() + "\n" + capturedStderr.String(), err
 }
 
 // RunInteractiveCommandWithOutput connects stdin and writes the command's

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -93,8 +93,27 @@ func RunInteractiveCommand(command string, args []string) error {
 	return err
 }
 
-// RunInteractiveCommandWithOutput writes to the host and
-// also to the passed io.Writer
+// RunInteractiveCommandWithCapture runs a command interactively like
+// RunInteractiveCommand(), but also returns a copy of what it printed, so a
+// failure can be reported with its output attached. stdout and stderr are
+// combined and share one writer, so os/exec copies them from a single
+// goroutine and the capture stays race-free.
+func RunInteractiveCommandWithCapture(command string, args []string) (string, error) {
+	var captured bytes.Buffer
+	cmd := HostCommand(command, args...)
+	cmd.Stdin = os.Stdin
+	// Byte-for-byte tee, unlike RunInteractiveCommandWithOutput(), so progress
+	// output and colors reach the terminal unchanged.
+	tee := io.MultiWriter(os.Stdout, &captured)
+	cmd.Stdout = tee
+	cmd.Stderr = tee
+	err := cmd.Run()
+	return captured.String(), err
+}
+
+// RunInteractiveCommandWithOutput connects stdin and writes the command's
+// combined output to the passed io.Writer, line by line with ANSI color
+// codes removed. Nothing goes to the terminal unless out writes there.
 func RunInteractiveCommandWithOutput(command string, args []string, out io.Writer) error {
 	cmd := HostCommand(command, args...)
 	cmd.Stdin = os.Stdin

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -104,3 +104,38 @@ func TestRunHostCommandWithOptions(t *testing.T) {
 		assert.Equal(t, "", output)
 	})
 }
+
+// TestRunInteractiveCommandWithCapture verifies that the command's output both
+// reaches the terminal and comes back to the caller, unmodified.
+func TestRunInteractiveCommandWithCapture(t *testing.T) {
+	bashPath := util.FindBashPath()
+
+	t.Run("captures stdout and stderr", func(t *testing.T) {
+		restoreOutput := util.CaptureStdOut()
+		captured, err := exec.RunInteractiveCommandWithCapture(bashPath, []string{"-c", `echo to-stdout; echo to-stderr >&2`})
+		printed := restoreOutput()
+		require.NoError(t, err)
+		require.Contains(t, captured, "to-stdout")
+		require.Contains(t, captured, "to-stderr")
+		// The user still sees it happen; capturing is not a substitute for that.
+		require.Contains(t, printed, "to-stdout")
+		require.Contains(t, printed, "to-stderr")
+	})
+
+	t.Run("returns output along with the error", func(t *testing.T) {
+		restoreOutput := util.CaptureStdOut()
+		captured, err := exec.RunInteractiveCommandWithCapture(bashPath, []string{"-c", `echo why-it-failed >&2; exit 3`})
+		_ = restoreOutput()
+		require.Error(t, err)
+		require.Contains(t, captured, "why-it-failed")
+	})
+
+	t.Run("passes bytes through unchanged", func(t *testing.T) {
+		restoreOutput := util.CaptureStdOut()
+		captured, err := exec.RunInteractiveCommandWithCapture(bashPath, []string{"-c", `printf '\033[31mred\033[0m\rprogress'`})
+		_ = restoreOutput()
+		require.NoError(t, err)
+		// Unlike RunInteractiveCommandWithOutput(), colors and carriage returns survive.
+		require.Equal(t, "\x1b[31mred\x1b[0m\rprogress", captured)
+	})
+}

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -1,6 +1,8 @@
 package exec_test
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -105,37 +107,67 @@ func TestRunHostCommandWithOptions(t *testing.T) {
 	})
 }
 
+// captureStdErr is CaptureStdOut's os.Stderr counterpart; pkg/util has no
+// public equivalent since nothing else needs one.
+func captureStdErr() func() string {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	return func() string {
+		outC := make(chan string)
+		go func() {
+			var buf bytes.Buffer
+			_, err := io.Copy(&buf, r)
+			util.CheckErr(err)
+			outC <- buf.String()
+		}()
+		util.CheckClose(w)
+		os.Stderr = old
+		return <-outC
+	}
+}
+
 // TestRunInteractiveCommandWithCapture verifies that the command's output both
 // reaches the terminal and comes back to the caller, unmodified.
 func TestRunInteractiveCommandWithCapture(t *testing.T) {
 	bashPath := util.FindBashPath()
 
-	t.Run("captures stdout and stderr", func(t *testing.T) {
-		restoreOutput := util.CaptureStdOut()
+	t.Run("captures stdout and stderr, keeping them separate on the terminal", func(t *testing.T) {
+		restoreStdout := util.CaptureStdOut()
+		restoreStderr := captureStdErr()
 		captured, err := exec.RunInteractiveCommandWithCapture(bashPath, []string{"-c", `echo to-stdout; echo to-stderr >&2`})
-		printed := restoreOutput()
+		printedStdout := restoreStdout()
+		printedStderr := restoreStderr()
 		require.NoError(t, err)
 		require.Contains(t, captured, "to-stdout")
 		require.Contains(t, captured, "to-stderr")
-		// The user still sees it happen; capturing is not a substitute for that.
-		require.Contains(t, printed, "to-stdout")
-		require.Contains(t, printed, "to-stderr")
+		// The user still sees it happen, on the same stream as always;
+		// capturing is not a substitute for that, and must not merge streams.
+		require.Contains(t, printedStdout, "to-stdout")
+		require.NotContains(t, printedStdout, "to-stderr")
+		require.Contains(t, printedStderr, "to-stderr")
 	})
 
 	t.Run("returns output along with the error", func(t *testing.T) {
-		restoreOutput := util.CaptureStdOut()
+		restoreStdout := util.CaptureStdOut()
+		restoreStderr := captureStdErr()
 		captured, err := exec.RunInteractiveCommandWithCapture(bashPath, []string{"-c", `echo why-it-failed >&2; exit 3`})
-		_ = restoreOutput()
+		_ = restoreStdout()
+		_ = restoreStderr()
 		require.Error(t, err)
 		require.Contains(t, captured, "why-it-failed")
 	})
 
 	t.Run("passes bytes through unchanged", func(t *testing.T) {
-		restoreOutput := util.CaptureStdOut()
+		restoreStdout := util.CaptureStdOut()
+		restoreStderr := captureStdErr()
 		captured, err := exec.RunInteractiveCommandWithCapture(bashPath, []string{"-c", `printf '\033[31mred\033[0m\rprogress'`})
-		_ = restoreOutput()
+		_ = restoreStdout()
+		_ = restoreStderr()
 		require.NoError(t, err)
 		// Unlike RunInteractiveCommandWithOutput(), colors and carriage returns survive.
-		require.Equal(t, "\x1b[31mred\x1b[0m\rprogress", captured)
+		// stdout-only command: captured is "<stdout>\n<empty stderr>".
+		require.Equal(t, "\x1b[31mred\x1b[0m\rprogress\n", captured)
 	})
 }


### PR DESCRIPTION
## The Issue

Sorry, this ended up a bit more ambitious than intended, but the fix will certainly help our reading of CI logs, and it will help people in failure situations as well.

`ExecOnHostOrService()` returned bare errors like `exit status 1`. The output explaining the failure went to the terminal, far from the error, and in CI logs often nowhere near the test that reported it.

Raised by review of #8643, which addressed this by switching the host branch to `exec.RunCommand()`. That captures output but also drops stdin and live output for every host-service provider command — `git clone` in the `git` example can no longer prompt for an SSH passphrase, and rsync-style pulls go silent for the length of the transfer.

The `exec` and `exec-host` hook tasks (`.ddev/config.yaml`'s `hooks:`) have the exact same shape of problem: their commands stream live, but the "Task failed" line `ProcessHooks()` logs afterward is a bare error, so anyone reading just that line — a CI summary, a status bar, a wrapped error surfaced somewhere else — doesn't see why without hunting back through the full log.

## How This PR Solves The Issue

Adds `exec.RunInteractiveCommandWithCapture()`, which keeps stdin and the terminal connected exactly as `RunInteractiveCommand()` does while teeing a copy of the output to a buffer. `ExecOnHostOrService()` uses it for the host branch, and attaches that copy to the error via `errorWithOutput()`.

Output is attached only when stdout is not a terminal, so an interactive user does not read the same output twice. The container branch does the same with what `app.Exec()` captured — which requires passing `Tty` based on both stdin and stdout being terminals, not stdin alone, since `app.Exec()` skips capture whenever `Tty` is true. Gating on stdin only left the common case of an interactive shell with redirected stdout uncaptured, so the attached-error branch never had anything to attach for container-service providers (Acquia, Pantheon, Upsun, Lagoon).

The `exec`/`exec-host` hook tasks (`task.go`) get the same treatment:

- `ExecHostTask.Execute()` (the `exec-host` hook) now calls the same `runHostCommandWithCapturedOutput()` helper extracted from `ExecOnHostOrService()`'s host branch, instead of its own bare call to the older `exec.RunInteractiveCommand()`.
- `ExecTask.Execute()` (the `exec` hook, running in a container) tees its output to a buffer with `io.MultiWriter` so the command still streams live exactly as before, then attaches the captured copy to the error on failure the same way.
- That tee requires `ExecOpts.Stdout`/`Stderr` to accept any `io.Writer`, not just `*os.File`. `app.Exec()`'s terminal detection now type-asserts to `*os.File` first: a plain `os.Stdout`/`os.Stderr` or a caller-supplied file (e.g. `ExportDB`'s dump-to-file target) still checks `isatty` exactly as before, and a non-file writer like the new tee is simply treated as non-terminal — matching how a redirected file already behaved, so no existing caller's behavior changes.

Also restores the working directory with `defer`, drops the shadowed `err` that made the trailing return unreachable in practice, and corrects the "unable to GetAppRoot" message on what is really a `chdir` failure.

## Manual Testing Instructions

**Providers** — the `git`/`localfile`/`acquia` examples depend on network, SSH, or account state that varies by machine, so exercise both branches of `ExecOnHostOrService()` with one provider that fails deterministically. `auth_command` runs on the host; `db_pull_command` runs in the `web` container (the default service when none is given, same as `acquia.yaml` and friends):

```yaml
# .ddev/providers/failtest.yaml
environment_variables:
  target: web

auth_command:
  service: host
  command: |
    if [ "${target}" = "host" ]; then
      echo "boom-output-marker-host" >&2
      exit 7
    fi

db_pull_command:
  command: |
    echo "boom-output-marker-web" >&2
    exit 7
```

`auth_command` runs on every `ddev pull`, so pick which branch to exercise with `--environment` and `--skip-db`/`--skip-files`:

- Container branch — `ddev pull failtest -y >/tmp/out.log`: with stdout redirected but stdin still a terminal (the common case of running interactively and piping to a file), the terminal shows `output: boom-output-marker-web` attached to `Pull failed: ...`, instead of losing it in `/tmp/out.log`.
- Host branch — `ddev pull failtest -y --environment="target=host" --skip-db --skip-files >/tmp/out.log`: same redirected-stdout check, `output: boom-output-marker-host` shows attached to the error.
- Either branch run in a plain interactive terminal (no redirection) shows its marker live and ends with a bare `Pull failed: ...` — unchanged from before this PR.
- With the `git` example, point `project_url` at a nonexistent repository over SSH: an SSH passphrase prompt from `git clone` still appears and accepts input, confirming stdin stays connected.

**Hooks** — add an auxiliary config file (any `.ddev/config.*.yaml` merges into `config.yaml`, so it's easy to drop in and delete after) with one failing `exec` hook and one failing `exec-host` hook:

```yaml
# .ddev/config.test.yaml
# fail_on_hook_fail:false makes sure exec-host still runs even if your
# project already sets fail_on_hook_fail/FailOnHookFailGlobal true.
fail_on_hook_fail: false
hooks:
  post-start:
    - exec: 'echo "boom-output-marker-web" >&2; exit 7'
    - exec-host: 'echo "boom-output-marker-host" >&2; exit 7'
```

Run `ddev restart -y >/tmp/out.log 2>&1`, then look at `/tmp/out.log` (both hook tasks' own logger writes to stdout, so nothing appears on the terminal itself here — that's expected, unlike the provider case above): each marker appears twice — once streamed live as the hook ran, and again attached directly to its `Task failed: ...` line right below (`... exit status 7\noutput: boom-output-marker-web`). Before this PR, that second line was bare, with no repeated output, so finding out why required scrolling back up to the live transcript.

## Automated Testing Overview

`TestRunInteractiveCommandWithCapture` covers the new helper: output reaches both the terminal and the caller, a failing command returns its output with the error, and bytes pass through unaltered (colors and carriage returns survive, unlike `RunInteractiveCommandWithOutput()`). `TestGitPull` and `TestLocalfilePull` exercise `ExecOnHostOrService()`'s host branch end to end. `TestExecOnHostOrServiceContainerOutput` is new and covers the container branch the same way: a failing `service: web` command has its output attached to the error, with stdout forced non-tty via `util.CaptureStdOut()` so the assertion is deterministic. That capture-forcing only fixes stdout; it can't fake stdin as a terminal without a real pty, so this test doesn't reproduce the exact stdin-tty/stdout-redirected regression in a headless CI runner (stdin is already non-tty there) — it does reproduce it when run at an interactive terminal, and either way it closes a real gap: the container branch previously had no coverage at all for this behavior.

`TestProcessHooks` gets two new subtests, `failing hook output is attached to the error/exec` and `.../exec-host`, covering the same behavior for both hook task types via `ProcessHooks()` directly — deterministic in any environment, since the tee capture there is unconditional rather than tty-gated.

## Release/Deployment Notes

No user-visible change on success. Failures from provider commands and `exec`/`exec-host` hooks now include the output when DDEV's stdout is redirected.
