### PR TITLE
fix(perf): install drush in the nightly Linux perf project

### DIFF
--- a/.github/workflows/perf-linux.yml
+++ b/.github/workflows/perf-linux.yml
@@ -70,6 +70,11 @@ jobs:
             cd "$PERF_PROJECT_DIR"
             ddev start -y
           fi
+          # drupal/recommended-project doesn't include drush/drush, which
+          # 05-drush-install.sh needs -- same guard perf.sh applies.
+          if ! ddev drush --version >/dev/null 2>&1; then
+            ddev composer require drush/drush
+          fi
           {
             echo "DDEV_PERF_PROJECT_DIR=$PERF_PROJECT_DIR"
             echo "DDEV_PERF_SITE_URL=$(ddev describe -j | jq -r '.raw.primary_url')"


### PR DESCRIPTION
## The Issue

No issue; found in the nightly run [31146029005](https://github.com/ddev/ddev/actions/runs/31146029005/job/92929308173).

`perf-linux.yml` provisioned its benchmark project with `ddev composer create-project drupal/recommended-project` and stopped there. That package doesn't include drush, so `05-drush-install.sh` failed with "drush is not available" and the whole battery aborted with "FATAL: expected a JSON metric line but got: ''".

## How This PR Solves The Issue

Adds the same drush guard `.buildkite/perf.sh` already carries, placed after the provision if/else rather than inside the fresh-provision branch so the two files keep the identical structure that step's comment calls for.

The Buildkite legs were already covered — they all run `perf.sh` (the Windows ones via `perf.cmd`) — so `perf-linux.yml` was the only perf config with its own provisioning logic, and the only one missing this.

## Manual Testing Instructions

Run the workflow via `workflow_dispatch` and check that the "drush si demo_umami (CLI diagnostic)" metric produces a number instead of exiting 1, and that `perf-result.json` parses as JSON.

## Automated Testing Overview

None; the workflow is its own test and runs nightly.

## Release/Deployment Notes

CI-only. No effect on the ddev binary or on users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
