### PR TITLE
test(quickstart): statamic output changed, fix assertion

### DIFF
--- a/docs/tests/statamic.bats
+++ b/docs/tests/statamic.bats
@@ -50,7 +50,7 @@ teardown() {
   assert_success
   run curl -sfv https://${PROJNAME}.ddev.site
   assert_output --partial "<title>Home</title>"
-  assert_output --partial "<li><a href=\"https://statamic.dev\">Head to the docs</a> and learn how Statamic&nbsp;works.</li>"
+  assert_output --partial "Welcome to your new Statamic site"
   assert_success
   run curl -sfv https://${PROJNAME}.ddev.site/cp/auth/login
   assert_output --regexp 'component.*auth.*Login'


### PR DESCRIPTION

## The Issue

Statamic quickstart started failing all the time. It was a change in their default page. It's all fancied up.

## How This PR Solves The Issue

Assert on the real behavior.
