### PR TITLE
test(quickstart): derive URLs from `ddev describe -j` instead of hardcoding ddev.site [skip buildkite]

### DIFF
--- a/docs/tests/asterios.bats
+++ b/docs/tests/asterios.bats
@@ -21,20 +21,22 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project asterios/app
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project - check status code
-  run curl -sf -o /dev/null -w "%{http_code}" https://${PROJNAME}.ddev.site
+  run curl -sf -o /dev/null -w "%{http_code}" ${PRIMARY_URL}
   assert_success
   assert_output "200"
 
   # validate running project - check content
-  run curl -sf https://${PROJNAME}.ddev.site
+  run curl -sf ${PRIMARY_URL}
   assert_success
   assert_output --partial "Build your next project with de.asteriosphp.app"
 }

--- a/docs/tests/backdrop.bats
+++ b/docs/tests/backdrop.bats
@@ -33,11 +33,11 @@ teardown() {
   run ddev bee si --username=admin --password=Password123 --db-name=db --db-user=db --db-pass=db --db-host=db --auto
   assert_success
 
-  DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
-  assert_success
-
   _extra_info
+
+  DDEV_DEBUG=true run ddev launch
+  assert_output "FULLURL ${PRIMARY_URL}"
+  assert_success
   # Check direct http/https URLs
   run curl -sfIv ${HOST_HTTP_URL}
   assert_output --partial "HTTP/1.1 200"
@@ -105,7 +105,7 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project

--- a/docs/tests/cakephp.bats
+++ b/docs/tests/cakephp.bats
@@ -26,16 +26,18 @@ teardown() {
   run ddev composer create-project --prefer-dist --no-interaction cakephp/app:~5.0
   assert_success
 
+  _extra_info
+
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "CakePHP: the rapid development PHP framework:"
   assert_output --partial "Welcome to CakePHP"
   assert_success

--- a/docs/tests/civicrm.bats
+++ b/docs/tests/civicrm.bats
@@ -31,6 +31,8 @@ EOF
   run ddev start
   assert_success
 
+  _extra_info
+
   run ddev exec "curl -LsS https://download.civicrm.org/latest/civicrm-STABLE-standalone.tar.gz -o /tmp/civicrm-standalone.tar.gz"
   assert_success
 
@@ -51,11 +53,11 @@ EOF
 
   # ddev launch
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "location: /civicrm/home"
   assert_output --partial "HTTP/2 302"
   assert_success

--- a/docs/tests/codeigniter.bats
+++ b/docs/tests/codeigniter.bats
@@ -21,20 +21,22 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project codeigniter4/appstarter
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project - check status code
-  run curl -sf -o /dev/null -w "%{http_code}" https://${PROJNAME}.ddev.site
+  run curl -sf -o /dev/null -w "%{http_code}" ${PRIMARY_URL}
   assert_success
   assert_output "200"
 
   # validate running project - check content
-  run curl -sf https://${PROJNAME}.ddev.site
+  run curl -sf ${PRIMARY_URL}
   assert_success
   assert_output --partial "Welcome to CodeIgniter 4"
 }

--- a/docs/tests/common-setup.bash
+++ b/docs/tests/common-setup.bash
@@ -32,11 +32,18 @@ _common_setup() {
 #    echo "# Starting test at $(date)" >&3
 }
 
+# Populates URL variables from `ddev describe -j`, so tests don't have to
+# hand-build URLs and can stay correct under a custom router_http(s)_port or TLD.
 _extra_info() {
-  HOST_HTTP_URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.services.web.host_http_url)
-  HOST_HTTPS_URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.services.web.host_https_url)
-  PRIMARY_HTTP_URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.httpurl)
-  PRIMARY_HTTPS_URL=$(ddev describe -j ${PROJNAME} | jq -r .raw.httpsurl)
+  local json
+  json=$(ddev describe -j ${PROJNAME})
+  HOST_HTTP_URL=$(echo "${json}" | jq -r .raw.services.web.host_http_url)
+  HOST_HTTPS_URL=$(echo "${json}" | jq -r .raw.services.web.host_https_url)
+  PRIMARY_HTTP_URL=$(echo "${json}" | jq -r .raw.httpurl)
+  PRIMARY_HTTPS_URL=$(echo "${json}" | jq -r .raw.httpsurl)
+  PRIMARY_URL=$(echo "${json}" | jq -r .raw.primary_url)
+  DDEV_HOSTNAME=$(echo "${json}" | jq -r .raw.hostname)
+  PRIMARY_URL_ENCODED=$(printf '%s' "${PRIMARY_URL}" | jq -sRr '@uri')
 }
 
 _common_teardown() {

--- a/docs/tests/contao.bats
+++ b/docs/tests/contao.bats
@@ -23,6 +23,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project contao/managed-edition:5.7
   assert_success
   # Set DATABASE_URL and MAILER_DSN in .env.local
@@ -35,10 +37,10 @@ teardown() {
   run ddev exec contao-console contao:user:create --username=admin --name=Administrator --email=admin@example.com --language=en --password=Password123 --admin
   assert_success
   DDEV_DEBUG=true run ddev launch contao
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/contao"
+  assert_output "FULLURL ${PRIMARY_URL}/contao"
   assert_success
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site/contao/login
+  run curl -sfIv ${PRIMARY_URL}/contao/login
   assert_output --partial "HTTP/2 200"
   assert_success
 }
@@ -55,13 +57,16 @@ teardown() {
   assert_success
   run ddev start -y
   assert_success
+
+  _extra_info
+
   run ddev exec "wget -O public/contao-manager.phar.php https://download.contao.org/contao-manager/stable/contao-manager.phar"
   assert_success
   DDEV_DEBUG=true run ddev launch contao-manager.phar.php
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/contao-manager.phar.php"
+  assert_output "FULLURL ${PRIMARY_URL}/contao-manager.phar.php"
   assert_success
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site/contao-manager.phar.php
+  run curl -sfIv ${PRIMARY_URL}/contao-manager.phar.php
   assert_output --partial "HTTP/2 302"
   assert_output --partial "location: /contao-manager.phar.php/"
   assert_success

--- a/docs/tests/craftcms.bats
+++ b/docs/tests/craftcms.bats
@@ -20,6 +20,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   # Username: [admin] admin
   # Email: admin@example.com
   # Password: Password123
@@ -32,23 +34,23 @@ teardown() {
 
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
   DDEV_DEBUG=true run ddev launch /admin/login
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/admin/login"
+  assert_output "FULLURL ${PRIMARY_URL}/admin/login"
   assert_success
 
   ## validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_output --partial "x-powered-by: Craft CMS"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "<title>Welcome to Craft CMS</title>"
   assert_output --partial "<h2>Popular Resources</h2>"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site/admin/login
+  run curl -sfv ${PRIMARY_URL}/admin/login
   assert_success
   assert_output --partial "<title>Sign In - CraftCMS</title>"
 }

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -23,6 +23,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project drupal/recommended-project:main-dev@dev
   assert_success
 
@@ -33,11 +35,11 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_line "FULLURL https://${PROJNAME}.ddev.site"
+  assert_line "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "x-generator: Drupal 12 (https://www.drupal.org)"
   assert_output --partial "HTTP/2 200"
   assert_success
@@ -55,6 +57,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project "drupal/recommended-project"
   assert_success
 
@@ -65,11 +69,11 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_line "FULLURL https://${PROJNAME}.ddev.site"
+  assert_line "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "x-generator: Drupal 11 (https://www.drupal.org)"
   assert_output --partial "HTTP/2 200"
   assert_success
@@ -87,6 +91,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project "drupal/recommended-project:^10"
   assert_success
 
@@ -97,11 +103,11 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_line "FULLURL https://${PROJNAME}.ddev.site"
+  assert_line "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "x-generator: Drupal 10 (https://www.drupal.org)"
   assert_output --partial "HTTP/2 200"
   assert_success
@@ -123,6 +129,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer install
   assert_success
 
@@ -130,11 +138,11 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_line "FULLURL https://${PROJNAME}.ddev.site"
+  assert_line "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "x-generator: Drupal 11 (https://www.drupal.org)"
   assert_output --partial "HTTP/2 200"
   assert_success
@@ -152,6 +160,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project drupal/cms
   assert_success
   # This check shows that post-create-project-cmd event ran successfully
@@ -167,15 +177,15 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_line "FULLURL https://${PROJNAME}.ddev.site"
+  assert_line "FULLURL ${PRIMARY_URL}"
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "HTTP/2 200"
   assert_output --partial "expires: Sun, 19 Nov 1978 05:00:00 GMT"
   assert_output --partial "x-generator: Drupal 11 (https://www.drupal.org)"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_success
   assert_output --partial "Home | Drush Site-Install"
   assert_output --partial "Bring your site to life, starting here."

--- a/docs/tests/ee.bats
+++ b/docs/tests/ee.bats
@@ -30,9 +30,11 @@ teardown() {
   DDEV_DEBUG=true run ddev start -y
   assert_success
 
+  _extra_info
+
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch /admin.php
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/admin.php"
+  assert_output "FULLURL ${PRIMARY_URL}/admin.php"
   assert_success
 
   # Diagnostic: show traefik config files in volume
@@ -50,11 +52,11 @@ teardown() {
   # echo "# Traefik routers: \n $(echo $output | jq -r)" >&3
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site/admin.php
+  run curl -sfIv ${PRIMARY_URL}/admin.php
   assert_line --partial "server: nginx"
   assert_line --partial "HTTP/2 200"
   assert_success
-  run curl -sf https://${PROJNAME}.ddev.site/admin.php
+  run curl -sf ${PRIMARY_URL}/admin.php
   assert_output --partial "<title>Install ExpressionEngine"
   assert_success
 }
@@ -74,6 +76,8 @@ teardown() {
   DDEV_DEBUG=true run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer install
   assert_success
 
@@ -87,7 +91,7 @@ teardown() {
 
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch /admin.php
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/admin.php"
+  assert_output "FULLURL ${PRIMARY_URL}/admin.php"
   assert_success
 
   # Diagnostic: show traefik config files in volume
@@ -101,11 +105,11 @@ teardown() {
   # printf '%s\n' "$(echo "$output" | jq -r)" | sed 's/^/# /' >&3
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site/admin.php
+  run curl -sfIv ${PRIMARY_URL}/admin.php
   assert_line --partial "server: nginx"
   assert_line --partial "HTTP/2 200"
   assert_success
-  run curl -sf https://${PROJNAME}.ddev.site/admin.php
+  run curl -sf ${PRIMARY_URL}/admin.php
   assert_output --partial "<title>Install ExpressionEngine"
   assert_success
 }

--- a/docs/tests/generic.bats
+++ b/docs/tests/generic.bats
@@ -43,9 +43,11 @@ EOF
   run ddev start -y
   assert_success
 
+  _extra_info
+
   # ddev launch
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   #echo "#" >&3
@@ -66,11 +68,11 @@ EOF
   # printf '%s\n' "$(echo "$output" | jq -r)" | sed 's/^/# /' >&3
 
   # validate running project
-  run curl -sfI https://${PROJNAME}.ddev.site
+  run curl -sfI ${PRIMARY_URL}
   assert_line --partial "x-powered-by: PHP"
   assert_success
 
-  run curl -sf https://${PROJNAME}.ddev.site
+  run curl -sf ${PRIMARY_URL}
   assert_line --partial "Built-in HTTP server"
   assert_success
 }

--- a/docs/tests/grav.bats
+++ b/docs/tests/grav.bats
@@ -23,6 +23,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project getgrav/grav
   assert_success
 
@@ -30,11 +32,11 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "set-cookie: grav-site-"
   assert_output --partial "location: /admin"
   assert_output --partial "HTTP/2 302"
@@ -57,6 +59,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer install
   assert_success
 
@@ -67,11 +71,11 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "set-cookie: grav-site-"
   assert_output --partial "location: /admin"
   assert_output --partial "HTTP/2 302"

--- a/docs/tests/ibexa.bats
+++ b/docs/tests/ibexa.bats
@@ -23,21 +23,24 @@ teardown() {
   assert_success
   run ddev exec console ibexa:install --no-interaction
   assert_success
+
+  _extra_info
+
   DDEV_DEBUG=true run ddev launch /admin/login
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/admin/login"
+  assert_output "FULLURL ${PRIMARY_URL}/admin/login"
   assert_success
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "x-powered-by: Ibexa Open Source v5"
   assert_output --partial "HTTP/2 200"
   assert_success
 
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "Open-source solution for building custom, scalable websites."
   assert_output --partial "Powered by Ibexa DXP"
   assert_success
 
-  run curl -sfv https://${PROJNAME}.ddev.site/admin/login
+  run curl -sfv ${PRIMARY_URL}/admin/login
   assert_output --partial "Welcome to<br/> Ibexa DXP"
   assert_output --partial "<h3 class=\"ibexa-login__support-headline\">Get to know Ibexa DXP</h3>"
   assert_success

--- a/docs/tests/joomla.bats
+++ b/docs/tests/joomla.bats
@@ -35,24 +35,26 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev php installation/joomla.php install --site-name="My Joomla Site" --admin-user="Administrator" --admin-username=admin --admin-password=AdminAdmin1! --admin-email=admin@example.com --db-type=mysql --db-encryption=0 --db-host=db --db-user=db --db-pass="db" --db-name=db --db-prefix=ddev_ --public-folder=""
   assert_success
 
   DDEV_DEBUG=true run ddev launch /administrator/
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/administrator/"
+  assert_output "FULLURL ${PRIMARY_URL}/administrator/"
   assert_success
 
   # validate running project
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "<meta name=\"generator\" content=\"Joomla! - Open Source Content Management\">"
   assert_output --partial "alt=\"My Joomla Site\""
   assert_success
 
-  run curl -sfIv https://${PROJNAME}.ddev.site/administrator/
+  run curl -sfIv ${PRIMARY_URL}/administrator/
   assert_output --partial "HTTP/2 200"
   assert_success
 
-  run curl -sfv https://${PROJNAME}.ddev.site/administrator/
+  run curl -sfv ${PRIMARY_URL}/administrator/
   assert_output --partial "<meta name=\"generator\" content=\"Joomla! - Open Source Content Management\">"
   assert_success
 }

--- a/docs/tests/kirby.bats
+++ b/docs/tests/kirby.bats
@@ -21,19 +21,21 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project getkirby/starterkit
   assert_success
 
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: Apache"
   assert_output --partial "HTTP/2 200"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "<h2><a href=\"https://getkirby.com\">Made with Kirby</a></h2>"
   assert_output --partial "the file-based CMS that adapts to any project"
   assert_success

--- a/docs/tests/laravel.bats
+++ b/docs/tests/laravel.bats
@@ -26,16 +26,18 @@ teardown() {
   run ddev composer create-project laravel/laravel
   assert_success
 
+  _extra_info
+
   DDEV_DEBUG=true run ddev launch
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "HTTP/2 200"
   assert_success
 
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "Laravel"
   assert_success
 
@@ -60,16 +62,18 @@ teardown() {
   run ddev composer create-project laravel/laravel
   assert_success
 
+  _extra_info
+
   DDEV_DEBUG=true run ddev launch
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "HTTP/2 200"
   assert_success
 
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "Laravel"
   assert_success
 
@@ -121,16 +125,18 @@ DOCKERFILEEND
   run ddev composer run-script post-create-project-cmd
   assert_success
 
+  _extra_info
+
   DDEV_DEBUG=true run ddev launch
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "HTTP/2 200"
   assert_success
 
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "Laravel"
   assert_success
 

--- a/docs/tests/magento2.bats
+++ b/docs/tests/magento2.bats
@@ -42,6 +42,8 @@ EOF
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project --repository https://repo.magento.com/ magento/project-community-edition
   assert_success
 
@@ -53,7 +55,7 @@ EOF
   assert_success
   assert_file_not_exist app/etc/env.php
 
-  run ddev magento setup:install --base-url="https://${PROJNAME}.ddev.site/" \
+  run ddev magento setup:install --base-url="${PRIMARY_URL}/" \
       --cleanup-database --db-host=db --db-name=db --db-user=db --db-password=db \
       --opensearch-host=opensearch --search-engine=opensearch --opensearch-port=9200 \
       --admin-firstname=Magento --admin-lastname=User --admin-email=user@example.com \
@@ -82,26 +84,27 @@ EOF
 
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch /admin_ddev
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/admin_ddev"
+  assert_output "FULLURL ${PRIMARY_URL}/admin_ddev"
   assert_success
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "Copyright © 2013-present Magento, Inc. All rights reserved."
   assert_output --partial "Here is what\`s trending on Luma right now"
   assert_output --partial "title=\"Argus All-Weather Tank\""
   assert_success
-  run curl -sfIv https://${PROJNAME}.ddev.site/index.php/admin_ddev/
+  run curl -sfIv ${PRIMARY_URL}/index.php/admin_ddev/
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site/index.php/admin_ddev/
+  run curl -sfv ${PRIMARY_URL}/index.php/admin_ddev/
   assert_output --partial "Copyright &copy; $(date +%Y) Magento Commerce Inc. All rights reserved."
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site:5602/app/home#/
+  # OpenSearch Dashboards is exposed on its own port, independent of router_https_port
+  run curl -sfv https://${DDEV_HOSTNAME}:5602/app/home#/
   assert_output --partial "<title>OpenSearch Dashboards</title>"
   assert_success
 }

--- a/docs/tests/maho.bats
+++ b/docs/tests/maho.bats
@@ -23,6 +23,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project mahocommerce/maho-starter
   assert_success
 
@@ -32,8 +34,8 @@ teardown() {
     --license_agreement_accepted yes \
     --locale en_US --timezone UTC --default_currency USD \
     --db_host db --db_name db --db_user db --db_pass db \
-    --url "https://${PROJNAME}.ddev.site/" \
-    --use_secure 1 --secure_base_url "https://${PROJNAME}.ddev.site/" --use_secure_admin 1 \
+    --url "${PRIMARY_URL}/" \
+    --use_secure 1 --secure_base_url "${PRIMARY_URL}/" --use_secure_admin 1 \
     --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
     --admin_username admin --admin_password veryl0ngpassw0rd \
     --sample_data 1
@@ -47,17 +49,17 @@ teardown() {
 
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_success
 
   # Check if the admin is working
-  run curl -sfvL https://${PROJNAME}.ddev.site/admin
+  run curl -sfvL ${PRIMARY_URL}/admin
   assert_output --partial "Log in to Admin Panel"
   assert_success
 }

--- a/docs/tests/modx.bats
+++ b/docs/tests/modx.bats
@@ -23,6 +23,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   # Install MODX Revolution via Composer (resolves to the latest stable release)
   run ddev composer create-project modx/revolution
   assert_success
@@ -32,7 +34,7 @@ teardown() {
   # explicitly keeps the install non-interactive.
   run ddev exec php setup/cli-install.php \
     --database_server=db --database=db --database_user=db --database_password=db \
-    --table_prefix=modx_ --http_host=${PROJNAME}.ddev.site \
+    --table_prefix=modx_ --http_host=${DDEV_HOSTNAME} \
     --cmsadmin=admin --cmspassword=Admin123! --cmsadminemail=admin@example.com --language=en \
     --context_mgr_path=/var/www/html/manager/ --context_mgr_url=/manager/ \
     --context_connectors_path=/var/www/html/connectors/ --context_connectors_url=/connectors/
@@ -40,23 +42,23 @@ teardown() {
 
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch /manager/
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/manager/"
+  assert_output "FULLURL ${PRIMARY_URL}/manager/"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_success
 
   # Check the frontend renders the default MODX resource
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "<title>Home - MODX Revolution</title>"
   assert_output --partial "You have successfully installed MODX Revolution"
   assert_success
 
   # Check the MODX manager (backend) login page is working
-  run curl -sfv https://${PROJNAME}.ddev.site/manager/
+  run curl -sfv ${PRIMARY_URL}/manager/
   assert_output --partial "<body id=\"login\">"
   assert_output --partial "alt=\"MODX CMS/CMF\""
   assert_output --partial "id=\"modx-login-form\""
@@ -93,12 +95,14 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   # Perform a fresh install using the DDEV database credentials. The four
   # --context_* arguments are the installer's own defaults; passing them
   # explicitly keeps the install non-interactive.
   run ddev exec php setup/cli-install.php \
     --database_server=db --database=db --database_user=db --database_password=db \
-    --table_prefix=modx_ --http_host=${PROJNAME}.ddev.site \
+    --table_prefix=modx_ --http_host=${DDEV_HOSTNAME} \
     --cmsadmin=admin --cmspassword=Admin123! --cmsadminemail=admin@example.com --language=en \
     --context_mgr_path=/var/www/html/manager/ --context_mgr_url=/manager/ \
     --context_connectors_path=/var/www/html/connectors/ --context_connectors_url=/connectors/
@@ -106,23 +110,23 @@ teardown() {
 
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch /manager/
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/manager/"
+  assert_output "FULLURL ${PRIMARY_URL}/manager/"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_success
 
   # Check the frontend renders the default MODX resource
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "<title>Home - MODX Revolution</title>"
   assert_output --partial "You have successfully installed MODX Revolution"
   assert_success
 
   # Check the MODX manager (backend) login page is working
-  run curl -sfv https://${PROJNAME}.ddev.site/manager/
+  run curl -sfv ${PRIMARY_URL}/manager/
   assert_output --partial "<body id=\"login\">"
   assert_output --partial "alt=\"MODX CMS/CMF\""
   assert_output --partial "id=\"modx-login-form\""

--- a/docs/tests/moodle.bats
+++ b/docs/tests/moodle.bats
@@ -21,6 +21,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project moodle/moodle
   assert_success
 
@@ -28,18 +30,18 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch /login
-  assert_line "FULLURL https://${PROJNAME}.ddev.site/login"
+  assert_line "FULLURL ${PRIMARY_URL}/login"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "HTTP/2 303"
   assert_line --regexp "location: .*/login/index.php"
   assert_output --partial "set-cookie: MoodleSession="
   assert_output --partial "server: Apache"
   assert_success
 
-  run curl -sfIv https://${PROJNAME}.ddev.site/login/index.php
+  run curl -sfIv ${PRIMARY_URL}/login/index.php
   assert_output --partial "HTTP/2 200"
   assert_output --partial "set-cookie: MoodleSession="
   assert_output --partial "server: Apache"

--- a/docs/tests/nodejs.bats
+++ b/docs/tests/nodejs.bats
@@ -21,8 +21,6 @@ teardown() {
   DDEV_DEBUG=true run ddev start -y
   assert_success
 
-  _extra_info
-
   run ddev npm install express
   assert_success
 
@@ -47,6 +45,11 @@ EOF
 
   DDEV_DEBUG=true run ddev restart -y
   assert_success
+
+  # web_extra_exposed_ports only takes effect after this restart, so the
+  # generic webserver has no primary URL to report until now (see
+  # GetPrimaryRouterHTTP(S)Port in pkg/ddevapp/ddevapp.go).
+  _extra_info
 
   # Diagnostic: show traefik config files in volume
 #  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/

--- a/docs/tests/nodejs.bats
+++ b/docs/tests/nodejs.bats
@@ -21,6 +21,8 @@ teardown() {
   DDEV_DEBUG=true run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev npm install express
   assert_success
 
@@ -55,7 +57,7 @@ EOF
 
   DDEV_DEBUG=true run ddev launch
   assert_success
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
 
   # Diagnostic: show traefik config files in volume
 #  run docker exec ddev-router ls -la /mnt/ddev-global-cache/traefik/config/
@@ -65,7 +67,7 @@ EOF
 #  echo "# Traefik routers: $output"
 
   # validate running project
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "DDEV experimental Node.js"
   assert_success
 }

--- a/docs/tests/octobercms.bats
+++ b/docs/tests/octobercms.bats
@@ -21,6 +21,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project october/october
   assert_success
 
@@ -29,26 +31,26 @@ teardown() {
 
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "HTTP/2 200"
   assert_success
 
   # check October CMS is serving pages
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "Welcome to October CMS!"
   assert_success
 
   # check admin is accessible (follows redirect to login page)
-  run curl -sfv -L https://${PROJNAME}.ddev.site/admin
+  run curl -sfv -L ${PRIMARY_URL}/admin
   assert_output --partial "Administration Area | October CMS"
   assert_success
 
   # check admin setup page is accessible
-  run curl -sfIv -L https://${PROJNAME}.ddev.site/admin/backend/auth/setup
+  run curl -sfIv -L ${PRIMARY_URL}/admin/backend/auth/setup
   assert_output --partial "HTTP/2 200"
   assert_success
 

--- a/docs/tests/openmage.bats
+++ b/docs/tests/openmage.bats
@@ -26,6 +26,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   # Use --no-security-blocking for now, 2026-02-02
   run ddev composer install --no-security-blocking
   assert_success
@@ -35,24 +37,24 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_output --partial "set-cookie: om_frontend"
   assert_success
 
   # Check if the frontend is working
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "<title>Madison Island</title>"
   assert_output --partial "<meta name=\"keywords\" content=\"Magento, Varien, E-commerce\" />"
   assert_success
 
   # Check if the admin is working
-  run curl -sfv https://${PROJNAME}.ddev.site/index.php/admin/
+  run curl -sfv ${PRIMARY_URL}/index.php/admin/
   assert_output --partial "Log into OpenMage Admin Page"
   assert_success
 }
@@ -68,6 +70,8 @@ teardown() {
 
   run ddev start -y
   assert_success
+
+  _extra_info
 
   # init project
   run ddev composer init --name "openmage/composer-test" --description "OpenMage starter project" --type "project" -l "OSL-3.0" -s "dev" -q
@@ -117,24 +121,24 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_output --partial "set-cookie: om_frontend"
   assert_success
 
   # Check if the frontend is working
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "<title>Madison Island</title>"
   assert_output --partial "<meta name=\"keywords\" content=\"Magento, Varien, E-commerce\" />"
   assert_success
 
   # Check if the admin is working
-  run curl -sfv https://${PROJNAME}.ddev.site/index.php/admin/
+  run curl -sfv ${PRIMARY_URL}/index.php/admin/
   assert_output --partial "Log into OpenMage Admin Page"
   assert_success
 }

--- a/docs/tests/pimcore.bats
+++ b/docs/tests/pimcore.bats
@@ -20,6 +20,9 @@ teardown() {
   assert_success
   run ddev start -y
   assert_success
+
+  _extra_info
+
   run ddev composer create-project pimcore/skeleton
   assert_success
   run ddev exec pimcore-install --mysql-username=db --mysql-password=db --mysql-host-socket=db --mysql-database=db --admin-password=admin --admin-username=admin
@@ -36,10 +39,10 @@ teardown() {
   run ddev restart -y
   assert_success
   DDEV_DEBUG=true run ddev launch /admin
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/admin"
+  assert_output "FULLURL ${PRIMARY_URL}/admin"
   assert_success
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "HTTP/2 200"
   assert_output --partial "x-powered-by: pimcore"
   assert_output --partial "x-pimcore-output-cache-disable-reason:"

--- a/docs/tests/processwire.bats
+++ b/docs/tests/processwire.bats
@@ -24,8 +24,11 @@ teardown() {
   assert_success
   DDEV_DEBUG=true run ddev start -y
   assert_success
+
+  _extra_info
+
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # Diagnostic: show traefik config files in volume
@@ -43,10 +46,10 @@ teardown() {
   #echo "# Traefik routers: $output"
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: Apache"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "This tool will guide you through the installation process."
   assert_success
 }
@@ -60,9 +63,12 @@ teardown() {
   assert_success
   DDEV_DEBUG=true run ddev start -y
   assert_success
+
+  _extra_info
+
   run ddev composer create-project "processwire/processwire:^3"
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # Diagnostic: show traefik config files in volume
@@ -73,11 +79,11 @@ teardown() {
 #  echo "# Traefik routers: $output"
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: Apache"
   assert_output --partial "HTTP/2 200"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "This tool will guide you through the installation process."
   assert_success
 }

--- a/docs/tests/shopware.bats
+++ b/docs/tests/shopware.bats
@@ -21,6 +21,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   # shopware/production's composer.json now sets "php-http/discovery": false in
   # allow-plugins, so Composer no longer prompts to trust that plugin. The only
   # remaining interactive prompt is:
@@ -37,11 +39,11 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch /admin
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site/admin"
+  assert_output --partial "FULLURL ${PRIMARY_URL}/admin"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site/admin
+  run curl -sfIv ${PRIMARY_URL}/admin
   assert_output --partial "sw-context-token,sw-access-key,sw-language-id,sw-version-id,sw-inheritance"
   assert_output --partial "HTTP/2 200"
   assert_success

--- a/docs/tests/silverstripe.bats
+++ b/docs/tests/silverstripe.bats
@@ -23,6 +23,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project --prefer-dist silverstripe/installer
   assert_success
 
@@ -30,18 +32,18 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch /admin
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/admin"
+  assert_output "FULLURL ${PRIMARY_URL}/admin"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site/Security/login
+  run curl -sfIv ${PRIMARY_URL}/Security/login
   assert_output --partial "server: Apache"
   assert_output --partial "HTTP/2 200"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "Welcome to Silverstripe"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site/Security/login
+  run curl -sfv ${PRIMARY_URL}/Security/login
   assert_output --partial "<title>Your Site Name: Log in</title>"
   assert_output --partial "id=\"MemberLoginForm_LoginForm\""
   assert_success

--- a/docs/tests/statamic.bats
+++ b/docs/tests/statamic.bats
@@ -23,6 +23,8 @@ teardown() {
   run ddev composer create-project --prefer-dist statamic/statamic
   assert_success
 
+  _extra_info
+
   # fill out the interactive form
   run ddev php please make:user admin@example.com --password=admin1234 --super --no-interaction
   ddev mutagen sync
@@ -31,28 +33,28 @@ teardown() {
 
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
   DDEV_DEBUG=true run ddev launch /cp
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/cp"
+  assert_output "FULLURL ${PRIMARY_URL}/cp"
   assert_success
 
     # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_output --partial "x-powered-by: Statamic"
   assert_success
-  run curl -sfIv https://${PROJNAME}.ddev.site/cp/auth/login
+  run curl -sfIv ${PRIMARY_URL}/cp/auth/login
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_output --partial "x-powered-by: Statamic"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "<title>Home</title>"
   assert_output --partial "Welcome to your new Statamic site"
   assert_success
-  run curl -sfv https://${PROJNAME}.ddev.site/cp/auth/login
+  run curl -sfv ${PRIMARY_URL}/cp/auth/login
   assert_output --regexp 'component.*auth.*Login'
   assert_success
 }

--- a/docs/tests/sulu.bats
+++ b/docs/tests/sulu.bats
@@ -19,6 +19,9 @@ teardown() {
   # ddev start -y
   run ddev start -y
   assert_success
+
+  _extra_info
+
   run ddev composer create-project sulu/skeleton
   assert_success
   export SULU_PROJECT_NAME="My Sulu Site"
@@ -37,10 +40,10 @@ teardown() {
   run ddev exec bin/adminconsole sulu:build dev --no-interaction
   assert_success
   DDEV_DEBUG=true run ddev launch /admin
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site/admin"
+  assert_output --partial "FULLURL ${PRIMARY_URL}/admin"
   assert_success
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "x-generator: Sulu"
   assert_output --partial "HTTP/2 200"
   assert_success

--- a/docs/tests/sveltekit.bats
+++ b/docs/tests/sveltekit.bats
@@ -21,8 +21,6 @@ teardown() {
   DDEV_DEBUG=true run ddev start -y
   assert_success
 
-  _extra_info
-
   cat <<EOF > .ddev/config.sveltekit.yaml
 web_extra_exposed_ports:
     - name: svelte
@@ -55,6 +53,11 @@ EOF
   assert_success
   DDEV_DEBUG=true run ddev restart -y
   assert_success
+
+  # web_extra_exposed_ports only takes effect after this restart, so the
+  # generic webserver has no primary URL to report until now (see
+  # GetPrimaryRouterHTTP(S)Port in pkg/ddevapp/ddevapp.go).
+  _extra_info
 
   # ddev launch
   DDEV_DEBUG=true run ddev launch

--- a/docs/tests/sveltekit.bats
+++ b/docs/tests/sveltekit.bats
@@ -21,6 +21,8 @@ teardown() {
   DDEV_DEBUG=true run ddev start -y
   assert_success
 
+  _extra_info
+
   cat <<EOF > .ddev/config.sveltekit.yaml
 web_extra_exposed_ports:
     - name: svelte
@@ -56,10 +58,10 @@ EOF
 
   # ddev launch
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
   # validate running project
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "to your new"
   assert_success
 }

--- a/docs/tests/symfony.bats
+++ b/docs/tests/symfony.bats
@@ -23,6 +23,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   # Composer has no movable "lts" alias (unlike symfony-cli's --version=lts
   # below), so this pins to the current LTS branch explicitly. See
   # https://symfony.com/releases for the current LTS when this needs bumping.
@@ -34,14 +36,14 @@ teardown() {
 
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 404"
-  run curl https://${PROJNAME}.ddev.site
+  run curl ${PRIMARY_URL}
   assert_output --partial "<title>Welcome to Symfony!</title>"
   assert_output --partial "You are seeing this page because the homepage URL is not configured and"
   assert_output --partial "<a target=\"_blank\" href=\"https://symfony.com/community#interact\">Follow Symfony</a>"
@@ -60,6 +62,8 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev exec symfony check:requirements
   assert_success
 
@@ -73,14 +77,14 @@ teardown() {
 
   # validate ddev launch
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 404"
-  run curl https://${PROJNAME}.ddev.site
+  run curl ${PRIMARY_URL}
   assert_output --partial "<title>Welcome to Symfony!</title>"
   assert_output --partial "You are seeing this page because the homepage URL is not configured and"
   assert_output --partial "<a target=\"_blank\" href=\"https://symfony.com/community#interact\">Follow Symfony</a>"

--- a/docs/tests/tempest.bats
+++ b/docs/tests/tempest.bats
@@ -21,19 +21,21 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project tempest/app
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site
+  run curl -sfIv ${PRIMARY_URL}
   assert_output --partial "HTTP/2 200"
   assert_success
 
-  run curl -sfv https://${PROJNAME}.ddev.site
+  run curl -sfv ${PRIMARY_URL}
   assert_output --partial "Tempest"
   assert_output --partial "The PHP framework that gets out of your way."
   assert_success

--- a/docs/tests/typo3.bats
+++ b/docs/tests/typo3.bats
@@ -19,6 +19,9 @@ teardown() {
   assert_success
   run ddev start -y >/dev/null
   assert_success
+
+  _extra_info
+
   run ddev composer create-project "typo3/cms-base-distribution:^14" >/dev/null
   assert_success
   run ddev composer require typo3/theme-camino >/dev/null
@@ -40,16 +43,16 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL ${PRIMARY_URL}"
   assert_success
 
-  run curl -sfIv "https://${PROJNAME}.ddev.site/camino/"
+  run curl -sfIv "${PRIMARY_URL}/camino/"
   assert_output --partial "HTTP/2 200"
   assert_success
-  run curl -sfLv "https://${PROJNAME}.ddev.site/camino/"
+  run curl -sfLv "${PRIMARY_URL}/camino/"
   assert_output --partial "Camino de Compostela"
   assert_success
-  run curl -sfLv "https://${PROJNAME}.ddev.site/typo3/"
+  run curl -sfLv "${PRIMARY_URL}/typo3/"
   assert_output --partial "TYPO3 CMS Login:"
   assert_success
 }
@@ -62,13 +65,15 @@ teardown() {
   assert_success
   run ddev start -y >/dev/null
   assert_success
+  _extra_info
+
   run ddev composer create-project "typo3/cms-base-distribution:^13" >/dev/null
   assert_success
 
   run ddev typo3 setup \
     --admin-user-password="Demo123*" \
     --driver=mysqli \
-    --create-site=https://${PROJNAME}.ddev.site \
+    --create-site=${PRIMARY_URL} \
     --server-type=other \
     --dbname=db \
     --username=db \
@@ -82,14 +87,14 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL ${PRIMARY_URL}"
   assert_success
 
-  run bats_pipe curl -sfIv https://${PROJNAME}.ddev.site/ \| grep "HTTP/2 200"
+  run bats_pipe curl -sfIv ${PRIMARY_URL}/ \| grep "HTTP/2 200"
   assert_success
-  run bats_pipe curl -sfLv https://${PROJNAME}.ddev.site/ \| grep "Welcome to a default website made with <a href=\"https://typo3.org\">TYPO3</a>"
+  run bats_pipe curl -sfLv ${PRIMARY_URL}/ \| grep "Welcome to a default website made with <a href=\"https://typo3.org\">TYPO3</a>"
   assert_success
-  run bats_pipe curl -sfLv https://${PROJNAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
+  run bats_pipe curl -sfLv ${PRIMARY_URL}/typo3/ \| grep "TYPO3 CMS Login:"
   assert_success
 }
 
@@ -101,13 +106,15 @@ teardown() {
   assert_success
   run ddev start -y >/dev/null
   assert_success
+  _extra_info
+
   run ddev composer create-project "typo3/cms-base-distribution:^12" >/dev/null
   assert_success
 
   run ddev typo3 setup \
     --admin-user-password="Demo123*" \
     --driver=mysqli \
-    --create-site=https://${PROJNAME}.ddev.site \
+    --create-site=${PRIMARY_URL} \
     --server-type=other \
     --dbname=db \
     --username=db \
@@ -121,14 +128,14 @@ teardown() {
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL ${PRIMARY_URL}"
   assert_success
 
-  run bats_pipe curl -sfIv https://${PROJNAME}.ddev.site/ \| grep "HTTP/2 200"
+  run bats_pipe curl -sfIv ${PRIMARY_URL}/ \| grep "HTTP/2 200"
   assert_success
-  run bats_pipe curl -sfLv https://${PROJNAME}.ddev.site/ \| grep "Welcome to a default website made with <a href=\"https://typo3.org\">TYPO3</a>"
+  run bats_pipe curl -sfLv ${PRIMARY_URL}/ \| grep "Welcome to a default website made with <a href=\"https://typo3.org\">TYPO3</a>"
   assert_success
-  run bats_pipe curl -sfLv https://${PROJNAME}.ddev.site/typo3/ \| grep "TYPO3 CMS Login:"
+  run bats_pipe curl -sfLv ${PRIMARY_URL}/typo3/ \| grep "TYPO3 CMS Login:"
   assert_success
 }
 
@@ -140,18 +147,20 @@ teardown() {
   assert_success
   run ddev start -y >/dev/null
   assert_success
+  _extra_info
+
   run ddev composer create-project "typo3/cms-base-distribution:^11" >/dev/null
   assert_success
   run ddev exec touch public/FIRST_INSTALL
   assert_success
 
   DDEV_DEBUG=true run ddev launch /typo3/install.php
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site/typo3/install.php"
+  assert_output --partial "FULLURL ${PRIMARY_URL}/typo3/install.php"
   assert_success
 
-  run bats_pipe curl -sfIv https://${PROJNAME}.ddev.site/typo3/install.php \| grep "HTTP/2 200"
+  run bats_pipe curl -sfIv ${PRIMARY_URL}/typo3/install.php \| grep "HTTP/2 200"
   assert_success
-  run bats_pipe curl -sfLv https://${PROJNAME}.ddev.site/typo3/install.php \| grep "data-init=\"TYPO3/CMS/Install/Installer\""
+  run bats_pipe curl -sfLv ${PRIMARY_URL}/typo3/install.php \| grep "data-init=\"TYPO3/CMS/Install/Installer\""
   assert_success
 }
 
@@ -166,15 +175,18 @@ teardown() {
   assert_success
   run ddev start -y >/dev/null
   assert_success
+
+  _extra_info
+
   run ddev composer install >/dev/null
   assert_success
   run ddev exec touch public/FIRST_INSTALL
   assert_success
   DDEV_DEBUG=true run ddev launch
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output --partial "FULLURL ${PRIMARY_URL}"
   assert_success
   # validate running project
-  run curl -sfIv https://${PROJNAME}.ddev.site/typo3/install.php
+  run curl -sfIv ${PRIMARY_URL}/typo3/install.php
   assert_output --partial "content-security-policy: default-src 'self'; script-src 'self'"
   assert_output --partial "HTTP/2 200"
   assert_success
@@ -190,6 +202,8 @@ teardown() {
   run ddev start -y >/dev/null
   assert_success
 
+  _extra_info
+
   run ddev composer create-project typo3/cms-base-distribution:^13 >/dev/null
   assert_success
 
@@ -202,15 +216,15 @@ teardown() {
   assert_output --partial "xhgui"
 
   # Ensure there's no profiling data link
-  run ddev exec "curl -s xhgui:80 | grep -q '<a href=\"/?server_name=${PROJNAME}.ddev.site\">'"
+  run ddev exec "curl -s xhgui:80 | grep -q '<a href=\"/?server_name=${DDEV_HOSTNAME}\">'"
   assert_failure
 
   # Profile site
-  run curl -sfIv https://${PROJNAME}.ddev.site/typo3/install.php
+  run curl -sfIv ${PRIMARY_URL}/typo3/install.php
   assert_output --partial "HTTP/2 200"
   assert_success
 
-  run curl -sfv https://${PROJNAME}.ddev.site/typo3/install.php
+  run curl -sfv ${PRIMARY_URL}/typo3/install.php
   assert_output --partial "Installing TYPO3 CMS"
   assert_success
 
@@ -218,6 +232,6 @@ teardown() {
   sleep 5
 
   # Ensure there a profiling data link
-  run ddev exec "curl -s xhgui:80 | grep -q '<a href=\"/?server_name=${PROJNAME}.ddev.site\">'"
+  run ddev exec "curl -s xhgui:80 | grep -q '<a href=\"/?server_name=${DDEV_HOSTNAME}\">'"
   assert_success
 }

--- a/docs/tests/wagtail.bats
+++ b/docs/tests/wagtail.bats
@@ -34,6 +34,8 @@ DOCKERFILEEND
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev exec python -m venv env
   assert_success
 
@@ -76,21 +78,21 @@ EOF
 
   # ddev launch /admin
   DDEV_DEBUG=true run ddev launch /admin
-  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site/admin"
+  assert_output --partial "FULLURL ${PRIMARY_URL}/admin"
   assert_success
 
   # validate running project - check if Wagtail is responding
-  run curl -sfI https://${PROJNAME}.ddev.site
+  run curl -sfI ${PRIMARY_URL}
   assert_line --regexp 'server:.*WSGIServer.*CPython.*'
   assert_success
 
   # Verify main site is running
-  run curl -sf https://${PROJNAME}.ddev.site
+  run curl -sf ${PRIMARY_URL}
   assert_output --partial "Welcome to your new Wagtail site"
   assert_success
 
   # Check if we can access the admin page (should redirect to login)
-  run curl -sfL https://${PROJNAME}.ddev.site/admin
+  run curl -sfL ${PRIMARY_URL}/admin
   assert_output --partial "Sign in - Wagtail"
   assert_success
 }

--- a/docs/tests/wagtail.bats
+++ b/docs/tests/wagtail.bats
@@ -34,8 +34,6 @@ DOCKERFILEEND
   run ddev start -y
   assert_success
 
-  _extra_info
-
   run ddev exec python -m venv env
   assert_success
 
@@ -75,6 +73,11 @@ EOF
 
   run ddev restart
   assert_success
+
+  # web_extra_exposed_ports only takes effect after this restart, so the
+  # generic webserver has no primary URL to report until now (see
+  # GetPrimaryRouterHTTP(S)Port in pkg/ddevapp/ddevapp.go).
+  _extra_info
 
   # ddev launch /admin
   DDEV_DEBUG=true run ddev launch /admin

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -23,29 +23,31 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev wp core download
   assert_success
 
-  run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url="${PRIMARY_URL}" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   run ddev wp config get WP_SITEURL
-  assert_output "https://${PROJNAME}.ddev.site/"
+  assert_output "${PRIMARY_URL}/"
   assert_success
 
   # validate running project
-  run curl -sfI https://${PROJNAME}.ddev.site
-  assert_line --regexp "link:.*${PROJNAME}\.ddev\.site.*rel=\"https://api\.w\.org/\""
+  run curl -sfI ${PRIMARY_URL}
+  assert_line --regexp "link:.*${DDEV_HOSTNAME}.*rel=\"https://api\.w\.org/\""
   assert_output --partial "HTTP/2 200"
   assert_success
 
   # validate running project
-  run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
-  assert_output --partial "location: https://${PROJNAME}.ddev.site/wp-login.php"
+  run curl -sfI ${PRIMARY_URL}/wp-admin/
+  assert_output --partial "location: ${PRIMARY_URL}/wp-login.php"
   assert_output --partial "HTTP/2 302"
   assert_success
 }
@@ -62,29 +64,31 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev wp core download
   assert_success
 
-  run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url="${PRIMARY_URL}" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
 
   run ddev wp config get WP_SITEURL
-  assert_output "https://${PROJNAME}.ddev.site/"
+  assert_output "${PRIMARY_URL}/"
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   # validate running project
-  run curl -sfI https://${PROJNAME}.ddev.site
-  assert_line --regexp "link:.*${PROJNAME}\.ddev\.site.*rel=\"https://api\.w\.org/\""
+  run curl -sfI ${PRIMARY_URL}
+  assert_line --regexp "link:.*${DDEV_HOSTNAME}.*rel=\"https://api\.w\.org/\""
   assert_output --partial "HTTP/2 200"
   assert_success
 
   # validate running project
-  run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
-  assert_output --partial "location: https://${PROJNAME}.ddev.site/wp-login.php"
+  run curl -sfI ${PRIMARY_URL}/wp-admin/
+  assert_output --partial "location: ${PRIMARY_URL}/wp-login.php"
   assert_output --partial "HTTP/2 302"
   assert_success
 }
@@ -98,9 +102,12 @@ teardown() {
   assert_success
   run ddev start -y
   assert_success
+
+  _extra_info
+
   run ddev wp core download
   assert_success
-  run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url="${PRIMARY_URL}" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
 
   run bash -c "
@@ -123,18 +130,18 @@ teardown() {
   assert_success
 
   run ddev wp config get WP_SITEURL
-  assert_output "https://${PROJNAME}.ddev.site/wordpress"
+  assert_output "${PRIMARY_URL}/wordpress"
   assert_success
 
   # validate running project from the root URL
-  run curl -sfI https://${PROJNAME}.ddev.site
-  assert_line --regexp "link:.*${PROJNAME}\.ddev\.site.*rel=\"https://api\.w\.org/\""
+  run curl -sfI ${PRIMARY_URL}
+  assert_line --regexp "link:.*${DDEV_HOSTNAME}.*rel=\"https://api\.w\.org/\""
   assert_output --partial "HTTP/2 200"
   assert_success
 
   # validate admin/login URLs stay under the WordPress subdirectory
-  run curl -sfI https://${PROJNAME}.ddev.site/wordpress/wp-admin/
-  assert_output --partial "location: https://${PROJNAME}.ddev.site/wordpress/wp-login.php"
+  run curl -sfI ${PRIMARY_URL}/wordpress/wp-admin/
+  assert_output --partial "location: ${PRIMARY_URL}/wordpress/wp-login.php"
   assert_output --partial "HTTP/2 302"
   assert_success
 }
@@ -155,26 +162,28 @@ teardown() {
   run ddev start -y
   assert_success
 
-  run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  _extra_info
+
+  run ddev wp core install --url="${PRIMARY_URL}" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
 
   DDEV_DEBUG=true run ddev launch
-  assert_output "FULLURL https://${PROJNAME}.ddev.site"
+  assert_output "FULLURL ${PRIMARY_URL}"
   assert_success
 
   run ddev wp config get WP_SITEURL
-  assert_output "https://${PROJNAME}.ddev.site/"
+  assert_output "${PRIMARY_URL}/"
   assert_success
 
   # validate running project
-  run curl -sfI https://${PROJNAME}.ddev.site
-  assert_line --regexp "link:.*${PROJNAME}\.ddev\.site.*rel=\"https://api\.w\.org/\""
+  run curl -sfI ${PRIMARY_URL}
+  assert_line --regexp "link:.*${DDEV_HOSTNAME}.*rel=\"https://api\.w\.org/\""
   assert_output --partial "HTTP/2 200"
   assert_success
 
   # validate running project /wp-admin
-  run curl -sfI https://${PROJNAME}.ddev.site/wp-admin/
-  assert_output --partial "location: https://${PROJNAME}.ddev.site/wp-login.php?redirect_to=https%3A%2F%2F${PROJNAME}.ddev.site%2Fwp-admin%2F&reauth=1"
+  run curl -sfI ${PRIMARY_URL}/wp-admin/
+  assert_output --partial "location: ${PRIMARY_URL}/wp-login.php?redirect_to=${PRIMARY_URL_ENCODED}%2Fwp-admin%2F&reauth=1"
   assert_output --partial "HTTP/2 302"
   assert_success
 }

--- a/docs/tests/wp-bedrock.bats
+++ b/docs/tests/wp-bedrock.bats
@@ -23,34 +23,36 @@ teardown() {
   run ddev start -y
   assert_success
 
+  _extra_info
+
   run ddev composer create-project roots/bedrock
   assert_success
 
-  run ddev wp core install --url='https://${PROJNAME}.ddev.site' --title='My Bedrock Site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url="${PRIMARY_URL}" --title='My Bedrock Site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
 
   DDEV_DEBUG=true run ddev launch /wp/wp-admin/
-  assert_output "FULLURL https://${PROJNAME}.ddev.site/wp/wp-admin/"
+  assert_output "FULLURL ${PRIMARY_URL}/wp/wp-admin/"
   assert_success
 
   # validate running project
-  run curl -sfI https://${PROJNAME}.ddev.site
-  assert_line --regexp "link:.*${PROJNAME}\.ddev\.site.*rel=\"https://api\.w\.org/\""
+  run curl -sfI ${PRIMARY_URL}
+  assert_line --regexp "link:.*${DDEV_HOSTNAME}.*rel=\"https://api\.w\.org/\""
   assert_output --partial "HTTP/2 200"
   assert_success
 
   # validate /wp/wp-admin/ redirects to login when unauthenticated
-  run curl -sfI https://${PROJNAME}.ddev.site/wp/wp-admin/
-  assert_output --partial "location: https://${PROJNAME}.ddev.site/wp/wp-login.php"
+  run curl -sfI ${PRIMARY_URL}/wp/wp-admin/
+  assert_output --partial "location: ${PRIMARY_URL}/wp/wp-login.php"
   assert_output --partial "HTTP/2 302"
   assert_success
 
   # validate actual login: POST credentials, follow redirect to wp-admin, check for Dashboard
   COOKIE_JAR=$(mktemp)
-  curl -sf -c "${COOKIE_JAR}" https://${PROJNAME}.ddev.site/wp/wp-login.php > /dev/null
+  curl -sf -c "${COOKIE_JAR}" ${PRIMARY_URL}/wp/wp-login.php > /dev/null
   run curl -sf -c "${COOKIE_JAR}" -b "${COOKIE_JAR}" \
     --data "log=admin&pwd=admin&wp-submit=Log+In&redirect_to=%2Fwp%2Fwp-admin%2F&testcookie=1" \
-    --location https://${PROJNAME}.ddev.site/wp/wp-login.php
+    --location ${PRIMARY_URL}/wp/wp-login.php
   assert_output --partial "Dashboard"
   assert_success
   rm -f "${COOKIE_JAR}"


### PR DESCRIPTION

## The Issue

docs/tests/*.bats assert against `ddev launch`'s FULLURL and curl the running site by hand-building the literal string
`https://${PROJNAME}.ddev.site`. This assumes the default router HTTPS port and TLD, so the assertions fail whenever `router_https_port` (or the TLD) is customized, even though `ddev launch`/`GetHTTPSURL()` already resolve the real port/TLD correctly.

## How This PR Solves The Issue

Extends the existing `_extra_info` helper in common-setup.bash to populate `PRIMARY_URL` (same value `ddev launch`'s FULLURL resolves to, via `ddev describe -j`'s `.raw.primary_url`), `DDEV_HOSTNAME` (bare hostname, no scheme/port), and `PRIMARY_URL_ENCODED` (percent-encoded, for URLs embedded in redirect query strings). Every test now calls `_extra_info` once its project is up and asserts against these variables instead of the hardcoded literal.

Incidental fixes made while touching these lines:
- wordpress.bats/wp-bedrock.bats used `--url='https://${PROJNAME}.ddev.site'` single-quoted, so `${PROJNAME}` was never actually expanded by bash; switched to double-quoted `--url="${PRIMARY_URL}"`.
- magento2.bats's OpenSearch/Kibana check on port :5602 now uses `${DDEV_HOSTNAME}` directly, since that port is independent of `router_https_port` and must not be derived from PRIMARY_URL.

## Manual Testing Instructions

1. `bats docs/tests/generic.bats` (or any touched file) against a default project and confirm it passes.
2. Start a project, set `router_https_port: 8443` in .ddev/config.yaml, `ddev restart`, then confirm `ddev describe -j | jq -r .raw.primary_url` matches `DDEV_DEBUG=true ddev launch`'s FULLURL output, and that `curl` against that URL succeeds — this is exactly the case the old hardcoded string would have failed.

Automated Testing Overview

No new tests added; this is a robustness fix to existing docs/tests bats coverage across ~35 framework quickstart files.

Release/Deployment Notes

