### PR TITLE
fix: record last_started_version from every command that starts containers, fixes #8520

### DIFF
--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -31,16 +31,10 @@ ddev restart --all`,
 			instrumentationApp = projects[0]
 		}
 
-		skip, err := cmd.Flags().GetBool("skip-confirmation")
-		if err != nil {
-			util.Failed(err.Error())
-		}
-
 		// Look for version change and opt-in to instrumentation if it has changed.
-		err = checkDdevVersionAndOptInInstrumentation(skip)
-		if err != nil {
-			util.Failed(err.Error())
-		}
+		// Do it here rather than waiting for app.Start() so the poweroff prompt
+		// comes before any of the restart output.
+		ddevapp.RunUpgradeCheck()
 
 		noCache, _ := cmd.Flags().GetBool("no-cache")
 

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +29,8 @@ var (
 	serviceUser        string
 	updateDocURL       = "https://docs.ddev.com/en/stable/users/install/ddev-upgrade/"
 	instrumentationApp *ddevapp.DdevApp
+	// skipConfirmation is the value of the running command's `-y` flag, if it has one.
+	skipConfirmation bool
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -53,6 +56,17 @@ Support: https://docs.ddev.com/en/stable/users/support/`,
 		_ = cmd.Help()
 	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Most commands that can start containers offer `-y`, spelled either
+		// `--skip-confirmation` or `--yes`; honor it for the upgrade prompt
+		// regardless of which command we ended up in.
+		for _, name := range []string{"skip-confirmation", "yes"} {
+			if f := cmd.Flags().Lookup(name); f != nil {
+				if v, err := strconv.ParseBool(f.Value.String()); err == nil && v {
+					skipConfirmation = true
+				}
+			}
+		}
+
 		if len(os.Args) < 2 {
 			return
 		}
@@ -142,6 +156,14 @@ func Execute() {
 }
 
 func init() {
+	// Run the upgrade check from anything that starts containers, not just
+	// `ddev start`. ddevapp calls this at most once per command.
+	ddevapp.UpgradeCheck = func() {
+		if err := checkDdevVersionAndOptInInstrumentation(skipConfirmation); err != nil {
+			util.Warning("Unable to write global config: %v", err)
+		}
+	}
+
 	// This flag represents the output.JSONOutput variable, and parsed very early in pkg/output/output_setup.go
 	RootCmd.PersistentFlags().BoolP("json-output", "j", false, "If true, user-oriented output will be in JSON format.")
 	RootCmd.PersistentFlags().BoolVarP(&ddevapp.SkipHooks, "skip-hooks", "", false, "If true, any hook normally run by the command will be skipped.")
@@ -185,14 +207,18 @@ func init() {
 // from the last saved version. If it is, prompt to request anon DDEV usage stats
 // and update the info.
 func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
-	if !output.JSONOutput && semver.Compare(versionconstants.DdevVersion, globalconfig.DdevGlobalConfig.LastStartedVersion) > 0 && !globalconfig.DdevGlobalConfig.InstrumentationOptIn && !globalconfig.DdevNoInstrumentation && !skipConfirmation {
-		allowStats := util.Confirm("It looks like you have a new DDEV release.\nMay we send anonymous DDEV usage statistics and errors?\nTo know what we will see please take a look at\nhttps://docs.ddev.com/en/stable/users/usage/diagnostics/#opt-in-usage-information\nPermission to beam up?")
-		if allowStats {
-			globalconfig.DdevGlobalConfig.InstrumentationOptIn = true
-		}
+	if globalconfig.DdevGlobalConfig.LastStartedVersion == versionconstants.DdevVersion {
+		return nil
 	}
 
-	if globalconfig.DdevGlobalConfig.LastStartedVersion != versionconstants.DdevVersion && !skipConfirmation {
+	if !skipConfirmation {
+		if !output.JSONOutput && semver.Compare(versionconstants.DdevVersion, globalconfig.DdevGlobalConfig.LastStartedVersion) > 0 && !globalconfig.DdevGlobalConfig.InstrumentationOptIn && !globalconfig.DdevNoInstrumentation {
+			allowStats := util.Confirm("It looks like you have a new DDEV release.\nMay we send anonymous DDEV usage statistics and errors?\nTo know what we will see please take a look at\nhttps://docs.ddev.com/en/stable/users/usage/diagnostics/#opt-in-usage-information\nPermission to beam up?")
+			if allowStats {
+				globalconfig.DdevGlobalConfig.InstrumentationOptIn = true
+			}
+		}
+
 		// If they have a new version (but not first-timer) then prompt to poweroff
 		if globalconfig.DdevGlobalConfig.LastStartedVersion != "v0.0" {
 			// Check if any containers are running before prompting for poweroff
@@ -216,18 +242,13 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 				}
 			}
 		}
-
-		// If they have a new version write the new version into last-started
-		globalconfig.DdevGlobalConfig.LastStartedVersion = versionconstants.DdevVersion
-		err := globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
-		if err != nil {
-			return err
-		}
-
-		return nil
 	}
 
-	return nil
+	// Record the new version even when confirmation was skipped; otherwise `-y`
+	// users are asked about the same upgrade by every later command.
+	globalconfig.DdevGlobalConfig.LastStartedVersion = versionconstants.DdevVersion
+
+	return globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig)
 }
 
 // addCommandIfNotExists adds cmdToAdd to rootCmd if a command with the same name does not already exist.

--- a/cmd/ddev/cmd/root.go
+++ b/cmd/ddev/cmd/root.go
@@ -212,7 +212,7 @@ func checkDdevVersionAndOptInInstrumentation(skipConfirmation bool) error {
 	}
 
 	if !skipConfirmation {
-		if !output.JSONOutput && semver.Compare(versionconstants.DdevVersion, globalconfig.DdevGlobalConfig.LastStartedVersion) > 0 && !globalconfig.DdevGlobalConfig.InstrumentationOptIn && !globalconfig.DdevNoInstrumentation {
+		if !output.JSONOutput && semver.Compare(versionconstants.DdevVersion, globalconfig.DdevGlobalConfig.LastStartedVersion) != 0 && !globalconfig.DdevGlobalConfig.InstrumentationOptIn && !globalconfig.DdevNoInstrumentation {
 			allowStats := util.Confirm("It looks like you have a new DDEV release.\nMay we send anonymous DDEV usage statistics and errors?\nTo know what we will see please take a look at\nhttps://docs.ddev.com/en/stable/users/usage/diagnostics/#opt-in-usage-information\nPermission to beam up?")
 			if allowStats {
 				globalconfig.DdevGlobalConfig.InstrumentationOptIn = true

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -520,6 +520,88 @@ func TestNoPoweroffPromptWhenStopped(t *testing.T) {
 	require.Equal(t, 1, len(apps), "Expected one active project after start")
 }
 
+// TestLastStartedVersionUpdatedByAnyStart checks that last_started_version is recorded
+// by every command that starts containers, not just `ddev start`, and that it is
+// recorded even when confirmation is skipped with `-y`.
+// See https://github.com/ddev/ddev/issues/8520
+func TestLastStartedVersionUpdatedByAnyStart(t *testing.T) {
+	if !nodeps.IsLinux() {
+		t.Skip("No need to test except on Linux")
+	}
+	origDir, _ := os.Getwd()
+
+	tmpXdgConfigHomeDir := testcommon.CopyGlobalDdevDir(t)
+
+	testName := t.Name() + "-testproject"
+	_, _ = exec.RunHostCommand(DdevBin, "delete", "-Oy", testName)
+
+	tmpTestProjectDir := testcommon.CreateTmpDir(testName)
+	err := os.Chdir(tmpTestProjectDir)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+
+		t.Logf("attempting to remove project %s", testName)
+		_, _ = exec.RunHostCommand(DdevBin, "delete", "-Oy", testName)
+
+		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
+
+		// Restart test sites
+		for _, site := range TestSites {
+			_, _ = exec.RunCommand(DdevBin, []string{"start", "-y", site.Name})
+		}
+
+		_ = os.RemoveAll(tmpTestProjectDir)
+	})
+
+	out, err := exec.RunHostCommand(DdevBin, "config", "--project-name", testName, "--project-type", "php")
+	require.NoError(t, err, "out=%s", out)
+
+	// Power off first so that the version checks below never find containers to
+	// offer a poweroff for; this test is about recording, not about the prompt.
+	out, err = exec.RunHostCommand(DdevBin, "poweroff")
+	require.NoError(t, err, "poweroff failed, out='%s'", out)
+
+	// `ddev start -y` has to record the version, otherwise every later command
+	// asks about the same upgrade again.
+	setLastStartedVersion(t, "v0.1")
+	out, err = exec.RunHostCommand(DdevBin, "start", "-y")
+	require.NoError(t, err, "start failed, out='%s'", out)
+	require.NotEqual(t, "v0.1", readLastStartedVersion(t), "`ddev start -y` should have recorded last_started_version")
+
+	// `ddev exec` starts a stopped project, so it has to record the version too.
+	out, err = exec.RunHostCommand(DdevBin, "poweroff")
+	require.NoError(t, err, "poweroff failed, out='%s'", out)
+
+	setLastStartedVersion(t, "v0.1")
+	out, err = exec.RunHostCommand(DdevBin, "exec", "ls")
+	require.NoError(t, err, "exec failed, out='%s'", out)
+	require.NotEqual(t, "v0.1", readLastStartedVersion(t), "`ddev exec` should have recorded last_started_version")
+
+	// The project is running now, so a stale last_started_version would make this
+	// start prompt for (and, non-interactively, do) a poweroff.
+	out, err = exec.RunHostCommand(DdevBin, "start")
+	require.NoError(t, err, "start failed, out='%s'", out)
+	require.NotContains(t, out, "You seem to have a new DDEV version", "Should not report an upgrade already recorded by `ddev exec`")
+	require.NotContains(t, out, "May I do `ddev poweroff`", "Should not prompt for poweroff after `ddev exec` recorded the version")
+}
+
+// setLastStartedVersion writes last_started_version into the global config
+func setLastStartedVersion(t *testing.T, version string) {
+	t.Helper()
+	require.NoError(t, globalconfig.ReadGlobalConfig())
+	globalconfig.DdevGlobalConfig.LastStartedVersion = version
+	require.NoError(t, globalconfig.WriteGlobalConfig(globalconfig.DdevGlobalConfig))
+}
+
+// readLastStartedVersion re-reads last_started_version from the global config
+func readLastStartedVersion(t *testing.T) string {
+	t.Helper()
+	require.NoError(t, globalconfig.ReadGlobalConfig())
+	return globalconfig.DdevGlobalConfig.LastStartedVersion
+}
+
 // addSites runs `ddev start` on the test apps
 func addSites() error {
 	output.UserOut.Debugln("Removing any existing TestSites")

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -72,16 +72,10 @@ ddev start --all`,
 			rc.ShowSponsorshipAppreciation()
 		}
 
-		skip, err := cmd.Flags().GetBool("skip-confirmation")
-		if err != nil {
-			util.Failed(err.Error())
-		}
-
 		// Look for version change and opt-in to instrumentation if it has changed.
-		err = checkDdevVersionAndOptInInstrumentation(skip)
-		if err != nil {
-			util.Failed(err.Error())
-		}
+		// Do it here rather than waiting for app.Start() so the poweroff prompt
+		// comes before any of the start output.
+		ddevapp.RunUpgradeCheck()
 
 		selectFlag, err := cmd.Flags().GetBool("select")
 

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1506,6 +1506,8 @@ func (app *DdevApp) composeBuild(args ...string) (string, error) {
 func (app *DdevApp) Start() error {
 	var err error
 
+	RunUpgradeCheck()
+
 	if _, err := dockerutil.DownloadDockerBuildxIfNeeded(); err != nil {
 		return err
 	}

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -76,6 +76,8 @@ func RemoveRouterContainer() error {
 
 // StartDdevRouter ensures the router is running.
 func StartDdevRouter() error {
+	RunUpgradeCheck()
+
 	// Kill the router if not running or if its image is outdated, so it restarts fresh.
 	// Use HasSuffix to handle registry prefixes (e.g. docker.io/) that Podman includes in image names.
 	router, err := FindDdevRouter()

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -38,6 +38,8 @@ func FullRenderedSSHAuthComposeYAMLPath() string {
 
 // EnsureSSHAgentContainer ensures the ssh-auth container is running.
 func (app *DdevApp) EnsureSSHAgentContainer() error {
+	RunUpgradeCheck()
+
 	util.Debug("Ensuring ddev-ssh-agent container is running with the current image")
 	sshContainer, err := findDdevSSHAuth()
 	if err != nil {

--- a/pkg/ddevapp/upgrade_check.go
+++ b/pkg/ddevapp/upgrade_check.go
@@ -1,0 +1,33 @@
+package ddevapp
+
+import "sync"
+
+// UpgradeCheck is run once per process, immediately before DDEV starts any
+// container. The CLI installs the DDEV version check here: it offers a
+// `ddev poweroff` after an upgrade and records `last_started_version`.
+// It stays a no-op for tests and other library consumers, which must never get
+// a surprise poweroff.
+var UpgradeCheck = func() {}
+
+var (
+	upgradeCheckMu   sync.Mutex
+	upgradeCheckDone bool
+)
+
+// RunUpgradeCheck runs UpgradeCheck at most once per process. It is called from
+// every path that creates containers, not just `ddev start`, so that
+// `last_started_version` is recorded no matter which command did the starting
+// (`ddev pull`, `ddev auth ssh`, `ddev exec`, a custom command, …). Otherwise
+// the upgrade prompt keeps reappearing on the next `ddev start`.
+// See https://github.com/ddev/ddev/issues/8520
+func RunUpgradeCheck() {
+	upgradeCheckMu.Lock()
+	alreadyDone := upgradeCheckDone
+	upgradeCheckDone = true
+	upgradeCheckMu.Unlock()
+
+	if alreadyDone {
+		return
+	}
+	UpgradeCheck()
+}


### PR DESCRIPTION
## The Issue

- Fixes #8520

`last_started_version` was only written by `ddev start` and `ddev restart`, so any other command that creates containers left it pointing at the old version. The next `ddev start` then saw a stale version plus running containers and prompted for a poweroff that was no longer needed.

That covers `ddev pull`, `ddev push`, `ddev auth ssh`, `ddev exec`, `ddev ssh`, `ddev share`, `ddev import-db`, `ddev export-db`, `ddev composer`, `ddev snapshot`, `ddev snapshot restore`, `ddev xhgui`, `ddev delete` (it starts the project to snapshot it), `ddev debug rebuild`, and custom commands.

Separately, `-y` skipped the write as well as the prompt: the write to global config lived inside `if LastStartedVersion != DdevVersion && !skipConfirmation`, so `ddev start -y` never recorded the version and the prompt came back on every later command.

## How This PR Solves The Issue

The check now runs from the places that actually start containers instead of from a hand-maintained list of commands. `app.Start()`, `EnsureSSHAgentContainer()`, and `StartDdevRouter()` call `ddevapp.RunUpgradeCheck()`, which runs the CLI's check at most once per process. Everything that starts a container funnels through one of those three, including commands added later.

`ddevapp.UpgradeCheck` is a hook that stays a no-op for `pkg/` tests and other library consumers, so they never get a surprise poweroff; the CLI installs the real check in `root.go`'s `init()`. The once-guard is a mutex plus a flag set before invoking rather than `sync.Once`, because the callback can call `PowerOff()` and because `StartDdevRouter()` runs on its own goroutine inside `app.Start()`.

`start` and `restart` still call `RunUpgradeCheck()` themselves so the poweroff prompt appears before any start output rather than mid-run; the once-guard keeps `app.Start()` from repeating it.

The version is now recorded even when confirmation was skipped, and `-y` is picked up generically in `PersistentPreRun` from either spelling (`--skip-confirmation` or `--yes`), so it applies to `ddev pull -y`, `ddev delete -y`, and the rest.

## Manual Testing Instructions

Isolate global config so your real `~/.ddev` is untouched, and disable the unrelated instrumentation opt-in prompt so it doesn't muddy the test:

```bash
export DDEV_XDG_CONFIG_HOME=$(mktemp -d)
export DDEV_NO_INSTRUMENTATION=true
```

Create a throwaway project and confirm `-y` now records the version:

```bash
mkdir -p ~/tmp/poweroff-test && cd ~/tmp/poweroff-test
ddev config --project-type=php --docroot=web

ddev start -y
grep last_started_version $DDEV_XDG_CONFIG_HOME/ddev/global_config.yaml   # now set; was not before
ddev poweroff
```

Simulate an upgrade and confirm a non-`start` command records the version too:

```bash
sed -i 's/^last_started_version:.*/last_started_version: v0.1/' $DDEV_XDG_CONFIG_HOME/ddev/global_config.yaml
ddev exec ls
grep last_started_version $DDEV_XDG_CONFIG_HOME/ddev/global_config.yaml   # recorded by exec
ddev start                                                                # no poweroff prompt, version already current
```

Clean up:

```bash
ddev poweroff
cd ~ && rm -rf ~/tmp/poweroff-test
unset DDEV_XDG_CONFIG_HOME DDEV_NO_INSTRUMENTATION
```

Optional — the originally reported scenario, against your real global config (requires two of your own existing DDEV projects; substitute a real pull provider name, or swap in another non-start/restart command like `ddev auth ssh` if you don't have one configured). This should stay quiet throughout, with no repeated poweroff prompt on the second project:

```bash
make && ddev poweroff && ddev auth ssh
cd project1 && ddev pull <provider> -y
cd ../project2 && ddev start
```

## Automated Testing Overview

`TestLastStartedVersionUpdatedByAnyStart` covers both halves: that `ddev start -y` records the version, and that `ddev exec` records it so a following `ddev start` does not prompt. Like its neighbors in `root_test.go` it is Linux-only, so CI is its first real run.

## Release/Deployment Notes

Commands other than `start` and `restart` now also offer the poweroff after an upgrade, rather than starting containers silently and leaving the prompt for a later command.
