### PR TITLE
feat(images): record image tag in a com.ddev.version label and warn when a pinned image is stale

### DIFF
--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,6 +75,37 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 		require.Contains(t, out, "webimage: custom-web-image:latest")
 		require.Contains(t, out, "Database")
 		require.Contains(t, out, "dbimage: custom-db-image:latest")
+		// These images don't exist locally, so there is no com.ddev.version
+		// label to read and no staleness note should be invented.
+		require.NotContains(t, out, "but this DDEV expects")
+	})
+
+	// A pinned image carrying a com.ddev.version label from a different DDEV
+	// image generation is reported as stale.
+	t.Run("dbimage built for a different DDEV version", func(t *testing.T) {
+		staleImage := "ddev-test-stale-dbimage:latest"
+		buildDir := testcommon.CreateTmpDir(t.Name())
+		t.Cleanup(func() { testcommon.CleanupDir(buildDir) })
+		err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"),
+			[]byte("FROM busybox\nLABEL com.ddev.version=some-older-ddev-tag\n"), 0644)
+		require.NoError(t, err)
+		_, err = exec.RunHostCommand("docker", "build", "-t", staleImage, buildDir)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, _ = exec.RunHostCommand("docker", "rmi", "-f", staleImage)
+		})
+
+		_, err = exec.RunCommand(DdevBin, []string{"config", "--db-image=" + staleImage})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, _ = exec.RunCommand(DdevBin, []string{"config", "--db-image-default"})
+		})
+
+		out, err := exec.RunCommand(DdevBin, []string{"utility", "check-custom-config"})
+		require.NoError(t, err)
+		require.Contains(t, out, "dbimage: "+staleImage)
+		require.Contains(t, out, "built for DDEV images some-older-ddev-tag")
+		require.Contains(t, out, "but this DDEV expects "+versionconstants.BaseDBTag)
 	})
 
 	// GLOBAL CHECKS (matching order in CheckCustomConfig)

--- a/containers/containers_shared.mk
+++ b/containers/containers_shared.mk
@@ -29,5 +29,6 @@ push:
 			$${tags} \
 			--label "build-info=$(DOCKER_ORG)/$${item}:$(VERSION) commit=$(shell git describe --tags --always) built $$(date) by $$(id -un) on $$(hostname)" \
 			--label "maintainer=DDEV <support@ddev.com>" \
+			--label "com.ddev.version=$(VERSION)" \
 			$(DOCKER_ARGS) . ; \
 	done

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -156,6 +156,12 @@ RUN /sbin/mkhomedir_helper www-data
 # (The DHI mysql base already creates it, so use mkdir -p.)
 RUN mkdir -p /home/mysql && chown mysql:mysql /home/mysql
 
+# Records the image tag this image was built as, so DDEV can tell which of its
+# image generations an image belongs to even after the tag is lost - for
+# example in a derived image built FROM this one and pinned via `dbimage`.
+ARG DDEV_IMAGE_TAG="unknown"
+LABEL com.ddev.version="${DDEV_IMAGE_TAG}"
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 3306

--- a/containers/ddev-dbserver/build_image.sh
+++ b/containers/ddev-dbserver/build_image.sh
@@ -135,7 +135,7 @@ fi
 if [ ! -z ${PUSH:-} ]; then
   echo "building/pushing ddev/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
   set -x
-  docker buildx build --push --platform ${ARCHS} ${DOCKER_ARGS} --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" ${tag_directive}  .
+  docker buildx build --push --platform ${ARCHS} ${DOCKER_ARGS} --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" --build-arg="DDEV_IMAGE_TAG=${IMAGE_TAG}" ${tag_directive}  .
   set +x
 fi
 
@@ -143,5 +143,5 @@ fi
 set -x
 if [ -z "${PUSH:-}" ]; then
     echo "Loading to local docker ddev/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
-    docker buildx build --load ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" ${tag_directive} .
+    docker buildx build --load ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DDEV_IMAGE_TAG=${IMAGE_TAG}" ${tag_directive} .
 fi

--- a/containers/ddev-webserver/Makefile
+++ b/containers/ddev-webserver/Makefile
@@ -16,7 +16,7 @@ DOCKER_REPO ?= $(DOCKER_ORG)/ddev-webserver
 images: $(DEFAULT_IMAGES)
 
 $(DEFAULT_IMAGES):
-	docker build --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
+	docker build --label com.ddev.buildhost=${shell hostname} --label com.ddev.version=$(VERSION) --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 
 test: images

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -169,6 +169,8 @@ The Docker image to use for the database server.
 | -- | -- | --
 | :octicons-file-directory-16: project | [`ddev/ddev-dbserver`](https://hub.docker.com/u/ddev) | Specify your own image based on the [ddev-dbserver](https://github.com/ddev/ddev/tree/main/containers/ddev-dbserver) image matching your project's `database` type and version.
 
+DDEV images carry a `com.ddev.version` label recording the image tag they were built as, and a derived image inherits it. When a pinned image was built from a different generation of DDEV images than the running DDEV expects, `ddev start` reports it as custom configuration, along with a note showing both tags. That's the signal to rebuild your derived image against the current DDEV images. Images built before the label existed are not reported.
+
 ## `dbimage_extra_packages`
 
 Extra Debian packages for the project’s database container. (This is rarely used.)

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/docker"
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/ddev/ddev/pkg/versionconstants"
 )
 
 // customConfigCheck defines a custom configuration check.
@@ -61,6 +63,22 @@ func addPathToAddonMap(fullPath string, addonName string, addonFileMap map[strin
 		return
 	}
 	addonFileMap[fullPath] = addonName
+}
+
+// imageVersionMismatch returns a parenthetical note when a pinned image was
+// built as a different DDEV image generation than this DDEV expects, which is
+// the way a pinned webimage/dbimage goes stale: it keeps working until DDEV
+// changes something the image is expected to provide.
+//
+// It returns an empty string when the image can't be inspected (not pulled
+// yet, no Docker) or carries no com.ddev.version label, so images built before
+// the label existed never produce a false alarm.
+func imageVersionMismatch(imageName string, expectedTag string) string {
+	builtTag, err := dockerutil.ImageLabel(imageName, docker.DdevVersionLabel)
+	if err != nil || builtTag == "" || builtTag == expectedTag {
+		return ""
+	}
+	return fmt.Sprintf(", built for DDEV images %s but this DDEV expects %s", builtTag, expectedTag)
 }
 
 // CheckCustomConfig checks for custom configuration files and returns a message.
@@ -411,13 +429,15 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 	if app.WebImage != "" && app.WebImage != docker.GetWebImage() {
 		findings = append(findings, finding{
 			category: "Web server",
-			files:    []fileInfo{{path: fmt.Sprintf("webimage: %s (non-default)", app.WebImage)}},
+			files: []fileInfo{{path: fmt.Sprintf("webimage: %s (non-default%s)",
+				app.WebImage, imageVersionMismatch(app.WebImage, versionconstants.WebTag))}},
 		})
 	}
 	if app.DBImage != "" && app.DBImage != docker.GetDBImage(app.Database.Type, app.Database.Version) {
 		findings = append(findings, finding{
 			category: "Database",
-			files:    []fileInfo{{path: fmt.Sprintf("dbimage: %s (non-default)", app.DBImage)}},
+			files: []fileInfo{{path: fmt.Sprintf("dbimage: %s (non-default%s)",
+				app.DBImage, imageVersionMismatch(app.DBImage, versionconstants.BaseDBTag))}},
 		})
 	}
 

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -8,6 +8,11 @@ import (
 	"github.com/ddev/ddev/pkg/versionconstants"
 )
 
+// DdevVersionLabel is the image label recording the tag an image was built as.
+// The tag is otherwise lost in a derived image, so this is what lets DDEV tell
+// which of its image generations a pinned webimage/dbimage came from.
+const DdevVersionLabel = "com.ddev.version"
+
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {
 	fullWebImg := versionconstants.WebImg

--- a/pkg/dockerutil/images.go
+++ b/pkg/dockerutil/images.go
@@ -8,6 +8,25 @@ import (
 	"github.com/moby/moby/client"
 )
 
+// ImageLabel returns the value of a label on a local image. It returns an
+// empty string (and no error) when the image has no such label, and an error
+// only when the image can't be inspected at all, for example because it hasn't
+// been pulled yet.
+func ImageLabel(imageName string, label string) (string, error) {
+	ctx, apiClient, err := GetDockerClient()
+	if err != nil {
+		return "", err
+	}
+	inspect, err := apiClient.ImageInspect(ctx, imageName)
+	if err != nil {
+		return "", err
+	}
+	if inspect.Config == nil {
+		return "", nil
+	}
+	return inspect.Config.Labels[label], nil
+}
+
 // ImageExistsLocally determines if an image is available locally.
 func ImageExistsLocally(imageName string) (bool, error) {
 	ctx, apiClient, err := GetDockerClient()


### PR DESCRIPTION
## The Issue

There is no linked issue. This came out of using the `dbimage` option restored in #8610 to pin a derived database image (a CI-built image with production data baked in, per the `base_db` seeding added in #8608).

Both `webimage` and `dbimage` are documented as "not recommended… can break on DDEV upgrades if the pinned image diverges from what DDEV expects." That risk is real but currently invisible: a derived image is built `FROM` a DDEV image and then retagged, so the DDEV image generation it came from is lost. Nothing in the image records it, and nothing in DDEV can check it.

The failure mode is silent. A pinned image keeps working after a DDEV upgrade right up until DDEV changes something the image is expected to provide, and then it fails in a way that gives no hint the pin is the cause.

## How This PR Solves The Issue

- Adds a `com.ddev.version` image label recording the tag an image was built as, to the dbserver (`build_image.sh` → `DDEV_IMAGE_TAG` build arg → `LABEL`) and webserver images (local `images` target plus the shared `push` target in `containers_shared.mk`, which also covers the other containers built there). A derived image inherits the label, which is the whole point — it survives the retagging.
- Adds `dockerutil.ImageLabel()` to read a label from a local image.
- `CheckCustomConfig()` already reports non-default `webimage`/`dbimage` (from #8610) and already runs on `ddev start`. It now appends a note to those existing findings when the pinned image's label doesn't match the tag this DDEV expects (`versionconstants.WebTag` / `versionconstants.BaseDBTag`):

  ```
  dbimage: ghcr.io/example/database:mytag (non-default, built for DDEV images v1.25.3 but this DDEV expects 20260720_weitzman_zstd_base_db)
  ```

Deliberately conservative: it stays silent when the image carries no label or can't be inspected, so images built before this label existed — i.e. every image in the wild today — never produce a false alarm. It also only inspects when the image is already non-default, so there's no added work in the common case.

I wasn't sure whether you'd prefer the label named `com.ddev.version` or something more literal like `com.ddev.image-tag`, since the value is the image tag (which is a release version like `v1.25.3` only at release time). Happy to rename.

## Manual Testing Instructions

1. Build a dbserver image so it carries the new label: `cd containers/ddev-dbserver && make mysql_8.0_$(../get_arch.sh) VERSION=testtag`
2. Confirm the label: `docker image inspect ddev/ddev-dbserver-mysql-8.0:testtag --format '{{index .Config.Labels "com.ddev.version"}}'` → `testtag`
3. In a project, pin it: `ddev config --db-image=ddev/ddev-dbserver-mysql-8.0:testtag`
4. `ddev utility check-custom-config` (or `ddev start`) reports the override with `built for DDEV images testtag but this DDEV expects <BaseDBTag>`.
5. Pin an image with no such label (`ddev config --db-image=busybox`) and confirm the override is still reported but with no staleness note.
6. `ddev config --db-image-default` to restore.

## Automated Testing Overview

`cmd/ddev/cmd/utility-check-custom-config_test.go` gains a subtest that builds a throwaway image labeled with a bogus tag, pins it via `--db-image`, and asserts the staleness note names both tags. The existing webimage/dbimage subtest gains a `NotContains` assertion that images which can't be inspected produce no note.

I verified `dockerutil.ImageLabel()` directly against a running daemon for all three cases (labeled image returns the tag; unlabeled image returns empty with no error; missing image returns an error), and confirmed `go build` and `go vet` are clean for the changed packages. I was not able to run the `cmd` test suite locally, so that subtest is unproven — CI will be its first real run.

## Release/Deployment Notes

Additive and backward compatible. The label only appears on images built after this merges, and the check is silent without it, so nothing changes for existing images or for users who don't pin `webimage`/`dbimage`.

One consequence worth noting: once images carry the label, anyone pinning an image built before this change will start seeing the note the first time they rebuild their derived image from a labeled base — which is the intended signal, but it will look new.
