### PR TITLE
feat(images): record image tag in a com.ddev.image-tag label and warn when a pinned image is stale

### DIFF
--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -97,7 +97,7 @@ jobs:
           if [ "${{ steps.meta.outputs.multi_arch }}" = "true" ]; then
             version="${version}-${{ matrix.arch }}"
           fi
-          make $target PUSH=true VERSION="${version}"
+          make $target PUSH=true VERSION="${version}" DDEV_IMAGE_TAG="${TAG}"
       - name: Record image information
         id: image-info
         run: |

--- a/.github/workflows/push-tagged-image.yml
+++ b/.github/workflows/push-tagged-image.yml
@@ -88,7 +88,7 @@ jobs:
           if [ "${{ steps.meta.outputs.multi_arch }}" = "true" ]; then
             version="${version}-${{ matrix.arch }}"
           fi
-          make push VERSION="${version}"
+          make push VERSION="${version}" DDEV_IMAGE_TAG="${TAG}"
       - name: Record image information
         id: image-info
         run: |

--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,6 +75,37 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 		require.Contains(t, out, "webimage: custom-web-image:latest")
 		require.Contains(t, out, "Database")
 		require.Contains(t, out, "dbimage: custom-db-image:latest")
+		// These images don't exist locally, so there is no com.ddev.version
+		// label to read and no staleness note should be invented.
+		require.NotContains(t, out, "but this DDEV expects")
+	})
+
+	// A pinned image carrying a com.ddev.version label from a different DDEV
+	// image generation is reported as stale.
+	t.Run("dbimage built for a different DDEV version", func(t *testing.T) {
+		staleImage := "ddev-test-stale-dbimage:latest"
+		buildDir := testcommon.CreateTmpDir(t.Name())
+		t.Cleanup(func() { testcommon.CleanupDir(buildDir) })
+		err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"),
+			[]byte("FROM busybox\nLABEL com.ddev.version=some-older-ddev-tag\n"), 0644)
+		require.NoError(t, err)
+		_, err = exec.RunHostCommand("docker", "build", "-t", staleImage, buildDir)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, _ = exec.RunHostCommand("docker", "rmi", "-f", staleImage)
+		})
+
+		_, err = exec.RunCommand(DdevBin, []string{"config", "--db-image=" + staleImage})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, _ = exec.RunCommand(DdevBin, []string{"config", "--db-image-default"})
+		})
+
+		out, err := exec.RunCommand(DdevBin, []string{"utility", "check-custom-config"})
+		require.NoError(t, err)
+		require.Contains(t, out, "dbimage: "+staleImage)
+		require.Contains(t, out, "built for DDEV images some-older-ddev-tag")
+		require.Contains(t, out, "but this DDEV expects "+versionconstants.BaseDBTag)
 	})
 
 	// GLOBAL CHECKS (matching order in CheckCustomConfig)

--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -75,19 +75,20 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 		require.Contains(t, out, "webimage: custom-web-image:latest")
 		require.Contains(t, out, "Database")
 		require.Contains(t, out, "dbimage: custom-db-image:latest")
-		// These images don't exist locally, so there is no com.ddev.version
+		// These images don't exist locally, so there is no com.ddev.image-tag
 		// label to read and no staleness note should be invented.
 		require.NotContains(t, out, "but this DDEV expects")
 	})
 
-	// A pinned image carrying a com.ddev.version label from a different DDEV
+	// A pinned image carrying a com.ddev.image-tag label from a different DDEV
 	// image generation is reported as stale.
 	t.Run("dbimage built for a different DDEV version", func(t *testing.T) {
 		staleImage := "ddev-test-stale-dbimage:latest"
-		buildDir := testcommon.CreateTmpDir(t.Name())
+		// t.Name() in a subtest contains a "/", which os.MkdirTemp rejects.
+		buildDir := testcommon.CreateTmpDir(strings.ReplaceAll(t.Name(), "/", "_"))
 		t.Cleanup(func() { testcommon.CleanupDir(buildDir) })
 		err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"),
-			[]byte("FROM busybox\nLABEL com.ddev.version=some-older-ddev-tag\n"), 0644)
+			[]byte("FROM busybox\nLABEL com.ddev.image-tag=some-older-ddev-tag\n"), 0644)
 		require.NoError(t, err)
 		_, err = exec.RunHostCommand("docker", "build", "-t", staleImage, buildDir)
 		require.NoError(t, err)

--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -83,6 +84,14 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 	// A pinned image carrying a com.ddev.image-tag label from a different DDEV
 	// image generation is reported as stale.
 	t.Run("dbimage built for a different DDEV version", func(t *testing.T) {
+		if dockerutil.IsPodman() {
+			// Podman stores a locally built image as `localhost/<name>`, so
+			// inspecting the unqualified name the project pins finds nothing.
+			// The check then correctly degrades to reporting the override with
+			// no staleness note, which is what this subtest is trying to
+			// distinguish from a genuine match.
+			t.Skip("Skipping: podman qualifies locally built image names with localhost/")
+		}
 		staleImage := "ddev-test-stale-dbimage:latest"
 		// t.Name() in a subtest contains a "/", which os.MkdirTemp rejects.
 		buildDir := testcommon.CreateTmpDir(strings.ReplaceAll(t.Name(), "/", "_"))

--- a/containers/containers_shared.mk
+++ b/containers/containers_shared.mk
@@ -29,5 +29,6 @@ push:
 			$${tags} \
 			--label "build-info=$(DOCKER_ORG)/$${item}:$(VERSION) commit=$(shell git describe --tags --always) built $$(date) by $$(id -un) on $$(hostname)" \
 			--label "maintainer=DDEV <support@ddev.com>" \
+			--label "com.ddev.version=$(VERSION)" \
 			$(DOCKER_ARGS) . ; \
 	done

--- a/containers/containers_shared.mk
+++ b/containers/containers_shared.mk
@@ -16,7 +16,7 @@ DOTFILE_IMAGE = $(subst /,_,$(IMAGE))-$(VERSION)
 .PHONY: container push
 
 container: container-name
-	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) --label "build-info=$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)" .
+	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) --label "build-info=$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)" --label "com.ddev.version=$(DDEV_IMAGE_TAG)" .
 
 container-name:
 	@echo "container: $(DOCKER_REPO):$(VERSION)"

--- a/containers/containers_shared.mk
+++ b/containers/containers_shared.mk
@@ -5,6 +5,12 @@ SHELL = /bin/bash
 
 SANITIZED_DOCKER_REPO = $(subst /,_,$(DOCKER_REPO))
 
+# Value for the com.ddev.version label. Separate from VERSION because a
+# multi-arch push builds each arch under an intermediate `<tag>-<arch>` tag that
+# is combined into the manifest and then deleted; the label has to record the
+# tag people actually pull.
+DDEV_IMAGE_TAG ?= $(VERSION)
+
 DOTFILE_IMAGE = $(subst /,_,$(IMAGE))-$(VERSION)
 
 .PHONY: container push
@@ -29,6 +35,6 @@ push:
 			$${tags} \
 			--label "build-info=$(DOCKER_ORG)/$${item}:$(VERSION) commit=$(shell git describe --tags --always) built $$(date) by $$(id -un) on $$(hostname)" \
 			--label "maintainer=DDEV <support@ddev.com>" \
-			--label "com.ddev.version=$(VERSION)" \
+			--label "com.ddev.version=$(DDEV_IMAGE_TAG)" \
 			$(DOCKER_ARGS) . ; \
 	done

--- a/containers/containers_shared.mk
+++ b/containers/containers_shared.mk
@@ -5,7 +5,7 @@ SHELL = /bin/bash
 
 SANITIZED_DOCKER_REPO = $(subst /,_,$(DOCKER_REPO))
 
-# Value for the com.ddev.version label. Separate from VERSION because a
+# Value for the com.ddev.image-tag label. Separate from VERSION because a
 # multi-arch push builds each arch under an intermediate `<tag>-<arch>` tag that
 # is combined into the manifest and then deleted; the label has to record the
 # tag people actually pull.
@@ -16,7 +16,7 @@ DOTFILE_IMAGE = $(subst /,_,$(IMAGE))-$(VERSION)
 .PHONY: container push
 
 container: container-name
-	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) --label "build-info=$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)" --label "com.ddev.version=$(DDEV_IMAGE_TAG)" .
+	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) --label "build-info=$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)" --label "com.ddev.image-tag=$(DDEV_IMAGE_TAG)" .
 
 container-name:
 	@echo "container: $(DOCKER_REPO):$(VERSION)"
@@ -35,6 +35,6 @@ push:
 			$${tags} \
 			--label "build-info=$(DOCKER_ORG)/$${item}:$(VERSION) commit=$(shell git describe --tags --always) built $$(date) by $$(id -un) on $$(hostname)" \
 			--label "maintainer=DDEV <support@ddev.com>" \
-			--label "com.ddev.version=$(DDEV_IMAGE_TAG)" \
+			--label "com.ddev.image-tag=$(DDEV_IMAGE_TAG)" \
 			$(DOCKER_ARGS) . ; \
 	done

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -156,6 +156,12 @@ RUN /sbin/mkhomedir_helper www-data
 # (The DHI mysql base already creates it, so use mkdir -p.)
 RUN mkdir -p /home/mysql && chown mysql:mysql /home/mysql
 
+# Records the image tag this image was built as, so DDEV can tell which of its
+# image generations an image belongs to even after the tag is lost - for
+# example in a derived image built FROM this one and pinned via `dbimage`.
+ARG DDEV_IMAGE_TAG="unknown"
+LABEL com.ddev.version="${DDEV_IMAGE_TAG}"
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 3306

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -160,7 +160,7 @@ RUN mkdir -p /home/mysql && chown mysql:mysql /home/mysql
 # image generations an image belongs to even after the tag is lost - for
 # example in a derived image built FROM this one and pinned via `dbimage`.
 ARG DDEV_IMAGE_TAG="unknown"
-LABEL com.ddev.version="${DDEV_IMAGE_TAG}"
+LABEL com.ddev.image-tag="${DDEV_IMAGE_TAG}"
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -5,7 +5,7 @@ export DOCKER_REPO
 
 VERSION := $(shell git describe --tags --always --dirty)
 
-# Value for the com.ddev.version label. Separate from VERSION because a
+# Value for the com.ddev.image-tag label. Separate from VERSION because a
 # multi-arch push builds each arch under an intermediate `<tag>-<arch>` tag that
 # is combined into the manifest and then deleted; the label has to record the
 # tag people actually pull.

--- a/containers/ddev-dbserver/Makefile
+++ b/containers/ddev-dbserver/Makefile
@@ -5,6 +5,12 @@ export DOCKER_REPO
 
 VERSION := $(shell git describe --tags --always --dirty)
 
+# Value for the com.ddev.version label. Separate from VERSION because a
+# multi-arch push builds each arch under an intermediate `<tag>-<arch>` tag that
+# is combined into the manifest and then deleted; the label has to record the
+# tag people actually pull.
+DDEV_IMAGE_TAG ?= $(VERSION)
+
 .PHONY: build clean test
 
 CURRENT_ARCH=$(shell ../get_arch.sh)
@@ -70,7 +76,7 @@ $(BUILD_TARGETS) $(SINGLE_ARCH_TARGETS):
 	    ARCHS="linux/$${ARCH}"; \
 	    ;; \
 	esac; \
-	cmd="./build_image.sh --db-type=$${DB_TYPE} --db-major-version=$${DB_MAJOR_VERSION} --archs=$${ARCHS} --tag=$(VERSION) --docker-org=$(DOCKER_ORG) --docker-args=$(DOCKER_ARGS)" && \
+	cmd="./build_image.sh --db-type=$${DB_TYPE} --db-major-version=$${DB_MAJOR_VERSION} --archs=$${ARCHS} --tag=$(VERSION) --ddev-image-tag=$(DDEV_IMAGE_TAG) --docker-org=$(DOCKER_ORG) --docker-args=$(DOCKER_ARGS)" && \
 	if [ ! -z $${PUSH} ]; then cmd="$$cmd --push"; fi && \
 	if [ ! -z $${DB_PINNED_VERSION} ]; then cmd="$$cmd --db-pinned-version=$${DB_PINNED_VERSION}"; fi && \
 	echo $${cmd} && \

--- a/containers/ddev-dbserver/build_image.sh
+++ b/containers/ddev-dbserver/build_image.sh
@@ -135,7 +135,7 @@ fi
 if [ ! -z ${PUSH:-} ]; then
   echo "building/pushing ddev/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
   set -x
-  docker buildx build --push --platform ${ARCHS} ${DOCKER_ARGS} --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" ${tag_directive}  .
+  docker buildx build --push --platform ${ARCHS} ${DOCKER_ARGS} --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" --build-arg="DDEV_IMAGE_TAG=${IMAGE_TAG}" ${tag_directive}  .
   set +x
 fi
 
@@ -143,5 +143,5 @@ fi
 set -x
 if [ -z "${PUSH:-}" ]; then
     echo "Loading to local docker ddev/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
-    docker buildx build --load ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" ${tag_directive} .
+    docker buildx build --load ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DDEV_IMAGE_TAG=${IMAGE_TAG}" ${tag_directive} .
 fi

--- a/containers/ddev-dbserver/build_image.sh
+++ b/containers/ddev-dbserver/build_image.sh
@@ -27,7 +27,7 @@ if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
 fi
 
 OPTS=-h,-v:,-d:
-LONGOPTS=archs:,db-type:,db-major-version:,db-pinned-version:,docker-args:,docker-org:,tag:,push,help
+LONGOPTS=archs:,db-type:,db-major-version:,db-pinned-version:,ddev-image-tag:,docker-args:,docker-org:,tag:,push,help
 
 ! PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "$0" -- "$@")
 if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
@@ -83,6 +83,10 @@ while true; do
     IMAGE_TAG=$2
     shift 2
     ;;
+  --ddev-image-tag)
+    DDEV_IMAGE_TAG=$2
+    shift 2
+    ;;
   --docker-org)
     DOCKER_ORG=$2
     shift 2
@@ -100,6 +104,10 @@ while true; do
 done
 
 set -o nounset
+
+# Defaults to IMAGE_TAG, and differs only for a multi-arch push, where
+# IMAGE_TAG carries an intermediate -<arch> suffix that must not reach the label.
+DDEV_IMAGE_TAG=${DDEV_IMAGE_TAG:-${IMAGE_TAG}}
 
 if [ -z ${DB_PINNED_VERSION:-} ]; then
   DB_PINNED_VERSION=${DB_MAJOR_VERSION}
@@ -135,7 +143,7 @@ fi
 if [ ! -z ${PUSH:-} ]; then
   echo "building/pushing ddev/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
   set -x
-  docker buildx build --push --platform ${ARCHS} ${DOCKER_ARGS} --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" --build-arg="DDEV_IMAGE_TAG=${IMAGE_TAG}" ${tag_directive}  .
+  docker buildx build --push --platform ${ARCHS} ${DOCKER_ARGS} --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" --build-arg="DDEV_IMAGE_TAG=${DDEV_IMAGE_TAG}" ${tag_directive}  .
   set +x
 fi
 
@@ -143,5 +151,5 @@ fi
 set -x
 if [ -z "${PUSH:-}" ]; then
     echo "Loading to local docker ddev/ddev-dbserver-${DB_TYPE}-${DB_MAJOR_VERSION}:${IMAGE_TAG}"
-    docker buildx build --load ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DDEV_IMAGE_TAG=${IMAGE_TAG}" ${tag_directive} .
+    docker buildx build --load ${DOCKER_ARGS} --build-arg="DB_TYPE=${DB_TYPE}" --build-arg="DB_MAJOR_VERSION=${DB_MAJOR_VERSION}" --build-arg="BASE_IMAGE=${BASE_IMAGE}" --build-arg="DB_PINNED_VERSION=${DB_PINNED_VERSION}" --build-arg="DDEV_IMAGE_TAG=${DDEV_IMAGE_TAG}" ${tag_directive} .
 fi

--- a/containers/ddev-traefik-router/Makefile
+++ b/containers/ddev-traefik-router/Makefile
@@ -13,5 +13,5 @@ test: container
 	test/test.sh $(DOCKER_REPO):$(VERSION)
 
 multi-arch:
-	docker buildx build --platform $(BUILD_ARCHS) -t $(DOCKER_REPO):$(VERSION) --label "com.ddev.version=$(DDEV_IMAGE_TAG)" $(DOCKER_ARGS) .; \
+	docker buildx build --platform $(BUILD_ARCHS) -t $(DOCKER_REPO):$(VERSION) --label "com.ddev.image-tag=$(DDEV_IMAGE_TAG)" $(DOCKER_ARGS) .; \
 	echo "created multi-arch builds $(BUILD_ARCHS) for $(DOCKER_REPO)";

--- a/containers/ddev-traefik-router/Makefile
+++ b/containers/ddev-traefik-router/Makefile
@@ -13,5 +13,5 @@ test: container
 	test/test.sh $(DOCKER_REPO):$(VERSION)
 
 multi-arch:
-	docker buildx build --platform $(BUILD_ARCHS) -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) .; \
+	docker buildx build --platform $(BUILD_ARCHS) -t $(DOCKER_REPO):$(VERSION) --label "com.ddev.version=$(DDEV_IMAGE_TAG)" $(DOCKER_ARGS) .; \
 	echo "created multi-arch builds $(BUILD_ARCHS) for $(DOCKER_REPO)";

--- a/containers/ddev-webserver/Makefile
+++ b/containers/ddev-webserver/Makefile
@@ -16,7 +16,7 @@ DOCKER_REPO ?= $(DOCKER_ORG)/ddev-webserver
 images: $(DEFAULT_IMAGES)
 
 $(DEFAULT_IMAGES):
-	docker build --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
+	docker build --label com.ddev.buildhost=${shell hostname} --label com.ddev.version=$(VERSION) --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 
 test: images

--- a/containers/ddev-webserver/Makefile
+++ b/containers/ddev-webserver/Makefile
@@ -16,7 +16,7 @@ DOCKER_REPO ?= $(DOCKER_ORG)/ddev-webserver
 images: $(DEFAULT_IMAGES)
 
 $(DEFAULT_IMAGES):
-	docker build --label com.ddev.buildhost=${shell hostname} --label com.ddev.version=$(VERSION) --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
+	docker build --label com.ddev.buildhost=${shell hostname} --label com.ddev.version=$(DDEV_IMAGE_TAG) --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 
 test: images

--- a/containers/ddev-webserver/Makefile
+++ b/containers/ddev-webserver/Makefile
@@ -16,7 +16,7 @@ DOCKER_REPO ?= $(DOCKER_ORG)/ddev-webserver
 images: $(DEFAULT_IMAGES)
 
 $(DEFAULT_IMAGES):
-	docker build --label com.ddev.buildhost=${shell hostname} --label com.ddev.version=$(DDEV_IMAGE_TAG) --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
+	docker build --label com.ddev.buildhost=${shell hostname} --label com.ddev.image-tag=$(DDEV_IMAGE_TAG) --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 
 test: images

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -169,6 +169,8 @@ The Docker image to use for the database server.
 | -- | -- | --
 | :octicons-file-directory-16: project | [`ddev/ddev-dbserver`](https://hub.docker.com/u/ddev) | Specify your own image based on the [ddev-dbserver](https://github.com/ddev/ddev/tree/main/containers/ddev-dbserver) image matching your project's `database` type and version.
 
+DDEV images carry a `com.ddev.version` label recording the image tag they were built as, and a derived image inherits it. When a pinned image was built from a different generation of DDEV images than the running DDEV expects, `ddev start` reports it as custom configuration, along with a note showing both tags. That's the signal to rebuild your derived image against the current DDEV images. Images built before the label existed are not reported.
+
 ## `dbimage_extra_packages`
 
 Extra Debian packages for the project’s database container. (This is rarely used.)

--- a/docs/content/users/configuration/config.md
+++ b/docs/content/users/configuration/config.md
@@ -169,7 +169,7 @@ The Docker image to use for the database server.
 | -- | -- | --
 | :octicons-file-directory-16: project | [`ddev/ddev-dbserver`](https://hub.docker.com/u/ddev) | Specify your own image based on the [ddev-dbserver](https://github.com/ddev/ddev/tree/main/containers/ddev-dbserver) image matching your project's `database` type and version.
 
-DDEV images carry a `com.ddev.version` label recording the image tag they were built as, and a derived image inherits it. When a pinned image was built from a different generation of DDEV images than the running DDEV expects, `ddev start` reports it as custom configuration, along with a note showing both tags. That's the signal to rebuild your derived image against the current DDEV images. Images built before the label existed are not reported.
+DDEV images carry a `com.ddev.image-tag` label recording the image tag they were built as, and a derived image inherits it. When a pinned image was built from a different generation of DDEV images than the running DDEV expects, `ddev start` reports it as custom configuration, along with a note showing both tags. That's the signal to rebuild your derived image against the current DDEV images. Images built before the label existed are not reported. See [DDEV Labels on Images](../extend/customizing-images.md#ddev-labels-on-images) for how this differs from `com.ddev.webtag`.
 
 ## `dbimage_extra_packages`
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -253,7 +253,7 @@ A DDEV image can carry two labels that look similar and mean different things. `
 | Label | Set by | Means |
 | -- | -- | -- |
 | `com.ddev.image-tag` | baked in when the image is built | The tag this image was published as. Inherited through `FROM`, so a derived image keeps the tag of the DDEV image it descends from, even after it is given its own name and tag. |
-| `com.ddev.webtag` | the running DDEV CLI, at build/run time | Which DDEV built or started this resource. Applied to containers, networks, and the build sections DDEV generates, so it always reflects the DDEV you are running rather than the image's origin. |
+| `com.ddev.webtag` | the running DDEV CLI | Which DDEV built or started this resource. Applied to containers, networks, and the build sections DDEV generates, so it always reflects the DDEV you are running rather than the image's origin. |
 
 So a project's own web image, built from `.ddev/web-build`, inherits `com.ddev.image-tag` from the `ddev-webserver` base it was built on, and gets `com.ddev.webtag` from whichever DDEV built it. When you pin a [`webimage`](../configuration/config.md#webimage) or [`dbimage`](../configuration/config.md#dbimage), only `com.ddev.image-tag` tells you which generation of DDEV images it came from, which is what DDEV checks to warn you that a pinned image has gone stale.
 

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -248,11 +248,11 @@ RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/la
 
 ## DDEV Labels on Images
 
-A DDEV image can carry two version-ish labels that look similar and mean different things. `docker inspect` on a locally built web image will show both, usually with different values, which is expected:
+A DDEV image can carry two labels that look similar and mean different things. `docker inspect` on a locally built web image will show both, usually with different values, which is expected:
 
 | Label | Set by | Means |
 | -- | -- | -- |
-| `com.ddev.image-tag` | baked in when the image is built | The tag this image was published as. Inherited through `FROM`, so a derived image keeps the tag of the DDEV image it descends from, even after you retag it. |
+| `com.ddev.image-tag` | baked in when the image is built | The tag this image was published as. Inherited through `FROM`, so a derived image keeps the tag of the DDEV image it descends from, even after it is given its own name and tag. |
 | `com.ddev.webtag` | the running DDEV CLI, at build/run time | Which DDEV built or started this resource. Applied to containers, networks, and the build sections DDEV generates, so it always reflects the DDEV you are running rather than the image's origin. |
 
 So a project's own web image, built from `.ddev/web-build`, inherits `com.ddev.image-tag` from the `ddev-webserver` base it was built on, and gets `com.ddev.webtag` from whichever DDEV built it. When you pin a [`webimage`](../configuration/config.md#webimage) or [`dbimage`](../configuration/config.md#dbimage), only `com.ddev.image-tag` tells you which generation of DDEV images it came from, which is what DDEV checks to warn you that a pinned image has gone stale.

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -246,6 +246,17 @@ An example of using `$TARGETARCH` would be:
 RUN curl --fail -JL -s -o /usr/local/bin/mkcert "https://dl.filippo.io/mkcert/latest?for=linux/${TARGETARCH}"
 ```
 
+## DDEV Labels on Images
+
+A DDEV image can carry two version-ish labels that look similar and mean different things. `docker inspect` on a locally built web image will show both, usually with different values, which is expected:
+
+| Label | Set by | Means |
+| -- | -- | -- |
+| `com.ddev.image-tag` | baked in when the image is built | The tag this image was published as. Inherited through `FROM`, so a derived image keeps the tag of the DDEV image it descends from, even after you retag it. |
+| `com.ddev.webtag` | the running DDEV CLI, at build/run time | Which DDEV built or started this resource. Applied to containers, networks, and the build sections DDEV generates, so it always reflects the DDEV you are running rather than the image's origin. |
+
+So a project's own web image, built from `.ddev/web-build`, inherits `com.ddev.image-tag` from the `ddev-webserver` base it was built on, and gets `com.ddev.webtag` from whichever DDEV built it. When you pin a [`webimage`](../configuration/config.md#webimage) or [`dbimage`](../configuration/config.md#dbimage), only `com.ddev.image-tag` tells you which generation of DDEV images it came from, which is what DDEV checks to warn you that a pinned image has gone stale.
+
 ## Seeding a Custom Starter Database in `dbimage`
 
 If you publish a derived `dbimage` (for example a CI-built image with your production dataset baked in, so teammates or preview environments get a ready-to-use database with no import step), bake it in as `/mysqlbase/custom/base_db.zst` using a `.ddev/db-build/Dockerfile`:

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/docker"
+	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
+	"github.com/ddev/ddev/pkg/versionconstants"
 )
 
 // customConfigCheck defines a custom configuration check.
@@ -61,6 +63,22 @@ func addPathToAddonMap(fullPath string, addonName string, addonFileMap map[strin
 		return
 	}
 	addonFileMap[fullPath] = addonName
+}
+
+// imageVersionMismatch returns a parenthetical note when a pinned image was
+// built as a different DDEV image generation than this DDEV expects, which is
+// the way a pinned webimage/dbimage goes stale: it keeps working until DDEV
+// changes something the image is expected to provide.
+//
+// It returns an empty string when the image can't be inspected (not pulled
+// yet, no Docker) or carries no com.ddev.version label, so images built before
+// the label existed never produce a false alarm.
+func imageVersionMismatch(imageName string, expectedTag string) string {
+	builtTag, err := dockerutil.ImageLabel(imageName, docker.DdevVersionLabel)
+	if err != nil || builtTag == "" || builtTag == expectedTag {
+		return ""
+	}
+	return fmt.Sprintf(", built for DDEV images %s but this DDEV expects %s", builtTag, expectedTag)
 }
 
 // CheckCustomConfig checks for custom configuration files and returns a message.
@@ -411,13 +429,15 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 	if app.WebImage != "" && app.WebImage != docker.GetWebImage() {
 		findings = append(findings, finding{
 			category: "Web server",
-			files:    []fileInfo{{path: fmt.Sprintf("webimage: %s (non-default)", app.WebImage)}},
+			files: []fileInfo{{path: fmt.Sprintf("webimage: %s (non-default%s)",
+				app.WebImage, imageVersionMismatch(app.WebImage, versionconstants.WebTag))}},
 		})
 	}
 	if app.DBImage != "" && app.DBImage != docker.GetDBImage(app.Database.Type, app.Database.Version) {
 		findings = append(findings, finding{
 			category: "Database",
-			files:    []fileInfo{{path: fmt.Sprintf("dbimage: %s (non-default)", app.DBImage)}},
+			files: []fileInfo{{path: fmt.Sprintf("dbimage: %s (non-default%s)",
+				app.DBImage, imageVersionMismatch(app.DBImage, versionconstants.BaseDBTag))}},
 		})
 	}
 

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -71,10 +71,10 @@ func addPathToAddonMap(fullPath string, addonName string, addonFileMap map[strin
 // changes something the image is expected to provide.
 //
 // It returns an empty string when the image can't be inspected (not pulled
-// yet, no Docker) or carries no com.ddev.version label, so images built before
+// yet, no Docker) or carries no com.ddev.image-tag label, so images built before
 // the label existed never produce a false alarm.
 func imageVersionMismatch(imageName string, expectedTag string) string {
-	builtTag, err := dockerutil.ImageLabel(imageName, docker.DdevVersionLabel)
+	builtTag, err := dockerutil.ImageLabel(imageName, docker.DdevImageTagLabel)
 	if err != nil || builtTag == "" || builtTag == expectedTag {
 		return ""
 	}

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -8,6 +8,11 @@ import (
 	"github.com/ddev/ddev/pkg/versionconstants"
 )
 
+// DdevVersionLabel is the image label recording the tag an image was built as.
+// The tag is otherwise lost in a derived image, so this is what lets DDEV tell
+// which of its image generations a pinned webimage/dbimage came from.
+const DdevVersionLabel = "com.ddev.version"
+
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {
 	fullWebImg := versionconstants.WebImg

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ddev/ddev/pkg/versionconstants"
 )
 
-// DdevVersionLabel is the image label recording the tag an image was built as.
+// DdevImageTagLabel is the image label recording the tag an image was built as.
 // The tag is otherwise lost in a derived image, so this is what lets DDEV tell
 // which of its image generations a pinned webimage/dbimage came from.
-const DdevVersionLabel = "com.ddev.version"
+const DdevImageTagLabel = "com.ddev.image-tag"
 
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {

--- a/pkg/dockerutil/images.go
+++ b/pkg/dockerutil/images.go
@@ -8,6 +8,25 @@ import (
 	"github.com/moby/moby/client"
 )
 
+// ImageLabel returns the value of a label on a local image. It returns an
+// empty string (and no error) when the image has no such label, and an error
+// only when the image can't be inspected at all, for example because it hasn't
+// been pulled yet.
+func ImageLabel(imageName string, label string) (string, error) {
+	ctx, apiClient, err := GetDockerClient()
+	if err != nil {
+		return "", err
+	}
+	inspect, err := apiClient.ImageInspect(ctx, imageName)
+	if err != nil {
+		return "", err
+	}
+	if inspect.Config == nil {
+		return "", nil
+	}
+	return inspect.Config.Labels[label], nil
+}
+
 // ImageExistsLocally determines if an image is available locally.
 func ImageExistsLocally(imageName string) (bool, error) {
 	ctx, apiClient, err := GetDockerClient()

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -32,19 +32,19 @@ var BaseDBTag = "20260808_weitzman_ddev_version_label"
 var TraefikRouterImage = "ddev/ddev-traefik-router"
 
 // TraefikRouterTag is traefik router tag
-var TraefikRouterTag = "20260716_stasadev_webserver_403_message"
+var TraefikRouterTag = "20260808_weitzman_ddev_version_label"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "v1.25.3"
+var SSHAuthTag = "20260808_weitzman_ddev_version_label"
 
 // XhguiImage is image for xhgui
 var XhguiImage = "ddev/ddev-xhgui"
 
 // XhguiTag is xhgui tag
-var XhguiTag = "v1.25.3"
+var XhguiTag = "20260808_weitzman_ddev_version_label"
 
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities:latest"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -20,13 +20,13 @@ var AmplitudeAPIKey = ""
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "20260802_rfay_global_cache_chown_non_fatal" // Note that this can be overridden by make
+var WebTag = "20260808_weitzman_ddev_version_label" // Note that this can be overridden by make
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20260720_weitzman_zstd_base_db"
+var BaseDBTag = "20260808_weitzman_ddev_version_label"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION
**TL;DR**: When building official images labels they each get labeled with `com.ddev.image-tag`. Then, if somebody is using a custom derived dbimage, and it is not built from the expected current dbimage, the user gets a warning about this at start time.

Continuation of @weitzman's work in #8680 (fork-based) and #8681 (branch-based). #8681 was closed automatically when its head branch `feat/ddev-version-label` was renamed to `20260808_weitzman_ddev_version_label` to match DDEV's branch-naming convention; GitHub cannot repoint an existing PR's head branch, so this PR replaces it. All authorship is preserved in the commits — `8a4f9f55b` is authored and committed by Moshe Weitzman. Please merge with rebase or a merge commit rather than squash so that attribution survives.

The original PR body from #8681 follows, updated as review feedback landed.

---

## The Issue

There is no linked issue. This came out of using the `dbimage` option restored in #8610 to pin a derived database image (a CI-built image with production data baked in, via the `base_db` seeding from #8608).

Both `webimage` and `dbimage` are documented as "not recommended… can break on DDEV upgrades if the pinned image diverges from what DDEV expects." That risk is real but currently invisible: a derived image is built `FROM` a DDEV image and then retagged, so the DDEV image generation it came from is lost. Nothing in the image records it, and nothing in DDEV can check it.

The failure mode is silent. A pinned image keeps working after a DDEV upgrade right up until DDEV changes something the image is expected to provide, and then it fails in a way that gives no hint the pin is the cause.

### Relationship to #8312

#8312 centralized DDEV labels and stamps `com.ddev.webtag` (= `versionconstants.WebTag`) on containers, networks, and build sections, noting it is "not actively used yet, but intended to allow pruning stale resources or triggering rebuilds when switching to a different DDEV version."

That is the same *motivation* but the opposite direction of travel, and the two don't overlap:

- **#8312** records *which DDEV created this resource*. The running DDEV stamps its own version onto containers/networks it creates — the value is the same no matter which image was used, so it says nothing about a pinned image's provenance.
- **This PR** records *what an image was built as*, baked into the image at build time in the Dockerfile/Makefiles. It's inherited by derived images, which is the whole point: it survives the retagging that makes a pinned image anonymous.

So this fills exactly the gap #8312 left open, and is the missing half of "triggering rebuilds on DDEV version changes." It deliberately does not touch #8312's Go-side label injection, which is a different mechanism (compose labels vs. image labels).

**Naming — resolved.** The label started out as `com.ddev.version` and is now `com.ddev.image-tag`, per review. Next to #8312's `com.ddev.webtag`, the old name read like "the DDEV version" when it actually means "the tag this image was published as"; the new name is unambiguous and matches the `DDEV_IMAGE_TAG` build arg and make variable that supply the value. Because the two labels can legitimately appear on the same image with different values, they are now documented side by side (see below).

## How This PR Solves The Issue

- Adds a `com.ddev.image-tag` image label recording the tag an image was built as:
    - **dbserver** via an `ARG DDEV_IMAGE_TAG` in its `Dockerfile`, supplied by `build_image.sh`, which covers both its push and local-load paths.
    - **webserver and the other shared containers** via `containers_shared.mk` (both the `container:` and `push:` targets), the webserver `images` target, and the traefik-router build.
    - `DDEV_IMAGE_TAG` is deliberately separate from `VERSION`, because a multi-arch push builds each arch under an intermediate `<tag>-<arch>` tag that is later combined into the manifest and deleted. Without the split, the label recorded `…-arm64` and every image derived from a current base looked stale.
- Adds `dockerutil.ImageLabel()` to read a label from a local image.
- `CheckCustomConfig()` already reports non-default `webimage`/`dbimage` (#8610) and already runs on `ddev start`. It now appends a note to those existing findings when the pinned image's label doesn't match the tag this DDEV expects (`versionconstants.WebTag` / `versionconstants.BaseDBTag`):

  ```
  dbimage: derived-stale:prod (non-default, built for DDEV images 20260720_weitzman_zstd_base_db but this DDEV expects 20260808_weitzman_ddev_version_label)
  ```

Deliberately conservative: silent when the image carries no label or can't be inspected, so images built before this label existed — every image in the wild today — never produce a false alarm. It also only inspects when the image is already non-default, so there's no added work in the common case.

Docs: a new "DDEV Labels on Images" section in `customizing-images.md` contrasts `com.ddev.image-tag` (baked in at image build, inherited through `FROM`, tells you the image's origin) with `com.ddev.webtag` (applied by the running CLI, tells you what built or started the resource), and notes that a locally built web image legitimately carries both with different values. The `dbimage` entry in `config.md` links to it.

## Manual Testing Instructions

Web and db images for `20260808_weitzman_ddev_version_label` are already pushed and carry the label, so no image building is involved. Set up a scratch project and two derived images:

```bash
mkdir ~/tmp/labeltest && cd ~/tmp/labeltest && ddev config --project-type=php --docroot=.

# derived from the current base
printf 'FROM ddev/ddev-dbserver-mariadb-11.8:20260808_weitzman_ddev_version_label\nRUN touch /tmp/prod-data\n' \
  | docker build -q -t derived-current:prod -

# derived, but labeled as an older generation
printf 'FROM ddev/ddev-dbserver-mariadb-11.8:20260808_weitzman_ddev_version_label\nLABEL com.ddev.image-tag=20260720_weitzman_zstd_base_db\n' \
  | docker build -q -t derived-stale:prod -
```

**1. Published images carry the tag as their label, on both arches, with no `-amd64`/`-arm64` suffix.** This is what the workflow change fixes; a suffix here makes every current image look stale.

```bash
docker buildx imagetools inspect ddev/ddev-webserver:20260808_weitzman_ddev_version_label \
  --format '{{json .Image}}' | jq -r 'to_entries[]|.key+" = "+.value.config.Labels["com.ddev.image-tag"]'
```

Both arches print `20260808_weitzman_ddev_version_label`. Repeat for `ddev-webserver-prod` and `ddev-dbserver-mariadb-11.8`.

**2. The label survives derivation and retagging** — the property everything else depends on.

```bash
docker image inspect derived-current:prod --format '{{index .Config.Labels "com.ddev.image-tag"}}'
```

Prints the base image's tag despite the new name and tag.

**3. An image derived from the current base is silent.** `ddev config --db-image=derived-current:prod && ddev utility check-custom-config` reports `dbimage: derived-current:prod (non-default)` with no staleness note.

**4. An image derived from an older generation is reported.** `ddev config --db-image=derived-stale:prod && ddev start` prints `built for DDEV images 20260720_weitzman_zstd_base_db but this DDEV expects 20260808_weitzman_ddev_version_label`, and the project still starts. Confirms the note reaches `ddev start`, not just the utility command.

**5. Images from before the label existed produce no false alarm.** Pin real pre-label images with `ddev config --db-image=ddev/ddev-dbserver-mariadb-11.8:20260720_weitzman_zstd_base_db --web-image=ddev/ddev-webserver:20260802_rfay_global_cache_chown_non_fatal`. Both are reported non-default with no note. This also exercises the `WebTag` path, which step 4 doesn't cover.

**6. An image that isn't pulled locally doesn't error.** `docker rmi -f derived-stale:prod`, pin it again, run `ddev utility check-custom-config`: reported non-default, no note, no Docker error, no delay.

**7. Default images are unaffected.** `ddev config --db-image-default --web-image-default && ddev start` produces no web/db finding at all.

Clean up with `ddev delete -Oy labeltest` and `docker rmi -f derived-current:prod derived-stale:prod`.

Steps 1-7 were run on arm64 and all behaved as described. That run predates the rename, so it exercised `com.ddev.version` against images published under the old key; the images have since been republished under `com.ddev.image-tag`, and the logic either side of the label name is unchanged. Also not covered: the comparison on amd64 (step 1 verifies the amd64 label in the registry, but the string compare itself only ran on arm64), and Docker being entirely unreachable rather than merely missing the image.

## Automated Testing Overview

`cmd/ddev/cmd/utility-check-custom-config_test.go` gains a subtest that builds a throwaway image labeled with a bogus tag, pins it via `--db-image`, and asserts the staleness note names both tags. The existing webimage/dbimage subtest gains a `NotContains` assertion that images which can't be inspected produce no note.

The subtest is skipped under `dockerutil.IsPodman()`: podman stores a locally built image as `localhost/<name>`, so inspecting the unqualified name the project pins finds nothing, and the check then correctly degrades to reporting the override with no staleness note — which is exactly the outcome the subtest exists to tell apart from a genuine match. The graceful degradation is the desired behavior; it is the test that isn't portable.

`dockerutil.ImageLabel()` was also verified directly against a running daemon for all three cases: labeled image returns the tag, unlabeled image returns empty with no error, missing image returns an error. `go build` and `go vet` are clean for the changed packages (the two `unreachable code` warnings in `pkg/dockerutil/containers.go` are pre-existing). The docs checks — `pyspelling`, `make markdownlint`, `textlint` — were run locally on this branch and pass.

## Release/Deployment Notes

Additive and backward compatible. The label only appears on images built after this merges, and the check is silent without it, so nothing changes for existing images or for users who don't pin `webimage`/`dbimage`.

One consequence worth noting: once images carry the label, anyone pinning an image built before this change will start seeing the note the first time they rebuild their derived image from a labeled base — which is the intended signal, but it will look new.
