### PR TITLE
fix(modx): add missing 403 in nginx, use `ddev php`, for #8560

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -2056,7 +2056,7 @@ DDEV supports both [MODX](https://modx.com/) Revolution 2.x and 3.x.
 DDEV generates a `#ddev-generated` `core/config/config.inc.php` with the DDEV database credentials (database name, user, and password are all `db`; host is `db`). Install MODX with the CLI installer, which performs a fresh install using those credentials:
 
 ```bash
-ddev exec php setup/cli-install.php \
+ddev php setup/cli-install.php \
   --database_server=db --database=db --database_user=db --database_password=db \
   --table_prefix=modx_ --http_host=my-modx-site.ddev.site \
   --cmsadmin=admin --cmspassword=Admin123! --cmsadminemail=admin@example.com --language=en \
@@ -2086,7 +2086,7 @@ ddev launch /manager/
     ddev config --project-type=modx
     ddev start -y
     ddev composer create-project modx/revolution
-    ddev exec php setup/cli-install.php \
+    ddev php setup/cli-install.php \
       --database_server=db --database=db --database_user=db --database_password=db \
       --table_prefix=modx_ --http_host=my-modx-site.ddev.site \
       --cmsadmin=admin --cmspassword=Admin123! --cmsadminemail=admin@example.com --language=en \

--- a/docs/tests/modx.bats
+++ b/docs/tests/modx.bats
@@ -30,7 +30,7 @@ teardown() {
   # Perform a fresh install using the DDEV database credentials. The four
   # --context_* arguments are the installer's own defaults; passing them
   # explicitly keeps the install non-interactive.
-  run ddev exec php setup/cli-install.php \
+  run ddev php setup/cli-install.php \
     --database_server=db --database=db --database_user=db --database_password=db \
     --table_prefix=modx_ --http_host=${PROJNAME}.ddev.site \
     --cmsadmin=admin --cmspassword=Admin123! --cmsadminemail=admin@example.com --language=en \
@@ -96,7 +96,7 @@ teardown() {
   # Perform a fresh install using the DDEV database credentials. The four
   # --context_* arguments are the installer's own defaults; passing them
   # explicitly keeps the install non-interactive.
-  run ddev exec php setup/cli-install.php \
+  run ddev php setup/cli-install.php \
     --database_server=db --database=db --database_user=db --database_password=db \
     --table_prefix=modx_ --http_host=${PROJNAME}.ddev.site \
     --cmsadmin=admin --cmspassword=Admin123! --cmsadminemail=admin@example.com --language=en \

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-modx.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-modx.conf
@@ -17,7 +17,7 @@ server {
 
     include /etc/nginx/monitoring.conf;
 
-    index index.php index.htm index.html;
+    index index.php index.htm index.html /ddev-webserver-403-error;
 
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
     sendfile off;


### PR DESCRIPTION
## The Issue

- For #8560

The rebased PR didn't include nginx changes from #8641

We don't need to use `ddev exec php`

## How This PR Solves The Issue

- Adds `/ddev-webserver-403-error`.
- Uses `ddev php`.

## Manual Testing Instructions

Follow the quickstart steps https://ddev--8687.org.readthedocs.build/en/8687/users/quickstart/#modx-revolution

And run this:

```bash
mv index.php index.php.bak
ddev launch
```

Before: default 403 error.
After: custom 403 error.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
