### PR TITLE
docs: note that base_db/initializer seeding doesn't support PostgreSQL (#8690) [skip ci]

### DIFF
--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -264,7 +264,7 @@ With a large database this may take a long time.
 ```
 
 !!!note
-    Not supported on the very old, EOL `mysql:5.5` and `mariadb:5.5` database types.
+    Only supported for `mysql` and `mariadb` database types (excluding the very old, EOL `mysql:5.5` and `mariadb:5.5`). PostgreSQL projects use the stock upstream `postgres` image and its own startup process, which this seeding mechanism doesn't hook into, so a baked-in seed is silently ignored.
 
 ## Adding EOL Versions of PHP
 

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -71,7 +71,7 @@ With a large database this may take a long time.
 ```
 
 !!!note
-    Not supported on the very old, EOL `mysql:5.5` and `mariadb:5.5` database types.
+    Only supported for `mysql` and `mariadb` database types (excluding the very old, EOL `mysql:5.5` and `mariadb:5.5`). PostgreSQL projects use the stock upstream `postgres` image and its own startup process, which this seeding mechanism doesn't hook into, so an `initializer` snapshot is silently ignored.
 
 ## Database Clients
 


### PR DESCRIPTION
## The Issue

While testing #8642 I tried out the database `initializer` feature on postgres:17... It isn't implemented for postgres, because it is built around mariabackup and xtrabackup. I was surprised.

The docs for the `initializer` snapshot / baked-in `base_db` seed feature (added in #8608) only mention that it's unsupported on the EOL `mysql:5.5`/`mariadb:5.5` database types. They don't mention that it doesn't work for PostgreSQL at all: `UsesBaseDBSeed()` in `pkg/ddevapp/base_db_seed.go` gates the whole mechanism to MariaDB/MySQL, so a `.ddev/db_snapshots/initializer-postgres_*` file (or a baked-in `base_db` seed) is silently ignored on a PostgreSQL project, with no warning or error. A user following the docs with a PostgreSQL project has no way to know this before hitting it.

## How This PR Solves The Issue

Updates the `!!!note` in both `docs/content/users/usage/database-management.md` and `docs/content/users/extend/customizing-images.md` to say the feature is only supported for `mysql`/`mariadb` (excluding the EOL 5.5 versions), and explains why: PostgreSQL projects run the stock upstream `postgres` image with its own startup process, which this seeding mechanism (built around `ddev-dbserver`'s own entrypoint and `mariabackup`/`xtrabackup`) doesn't hook into.

## Manual Testing Instructions

