### PR TITLE
docs: reorganize README to put getting started first (#8693) [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![documentation](https://img.shields.io/badge/DDEV-Documentation-blue)](https://docs.ddev.com)
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
 [![Discord](https://img.shields.io/discord/664580571770388500?logo=discord&logoColor=%23fff&label=Discord&link=https%3A%2F%2Fddev.com%2Fs%2Fdiscord)](https://ddev.com/s/discord)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ddev/ddev)
 
 DDEV is an open-source tool for running local web development environments for PHP and Node.js, ready in minutes. Its per-project configuration can be extended, version controlled, and shared, so a whole team gets the same workflow without anyone maintaining bespoke setup. It depends on a Docker provider under the hood, but you'll hardly ever know it.
 

--- a/README.md
+++ b/README.md
@@ -1,62 +1,78 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://ddev.com/logos/dark-ddev.svg">
-  <img alt="DDEV logo with light and dark mode variants" src="https://ddev.com/logos/ddev.svg">
-</picture>
+<div align="center">
 
-[![ddev.com](https://img.shields.io/badge/DDEV-Website-blue)](https://ddev.com)
-[![documentation](https://img.shields.io/badge/DDEV-Documentation-blue)](https://docs.ddev.com)
-[![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
+<a href="https://ddev.com">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://ddev.com/logos/dark-ddev.svg">
+    <img alt="DDEV" src="https://ddev.com/logos/ddev.svg" width="320">
+  </picture>
+</a>
+
+### Docker-based local development environments, ready in minutes
+
+**Get the power of Docker without needing to know Docker.** Start PHP and Node.js projects in minutes, run many projects at the same time, and spend less time on setup.
+
+[![Website](https://img.shields.io/badge/website-ddev.com-blue)](https://ddev.com)
+[![Docs](https://img.shields.io/badge/docs-docs.ddev.com-blue)](https://docs.ddev.com)
+[![Add-on registry](https://img.shields.io/badge/add--ons-addons.ddev.com-blue)](https://addons.ddev.com)
 [![Discord](https://img.shields.io/discord/664580571770388500?logo=discord&logoColor=%23fff&label=Discord&link=https%3A%2F%2Fddev.com%2Fs%2Fdiscord)](https://ddev.com/s/discord)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-DDEV is an open-source tool for running local web development environments for PHP and Node.js, ready in minutes. Its per-project configuration can be extended, version controlled, and shared, so a whole team gets the same workflow without anyone maintaining bespoke setup. It depends on a Docker provider under the hood, but you'll hardly ever know it.
+[**Get Started**](https://ddev.com/get-started/) · [**Documentation**](https://docs.ddev.com) · [**Quickstarts**](https://docs.ddev.com/en/stable/users/quickstart/) · [**Add-on Registry**](https://addons.ddev.com) · [**Contributing**](CONTRIBUTING.md) · [**Sponsor**](https://ddev.com/sponsor)
 
-## Get Started
+</div>
 
-1. **Check that DDEV runs where you work:** macOS, Windows 11, WSL2, Linux, and [GitHub Codespaces](https://github.com/codespaces). See [system requirements](https://docs.ddev.com/en/stable/users/install/ddev-installation/).
-2. **Install a [Docker provider and DDEV](https://docs.ddev.com/en/stable/users/install/).**
-3. **Follow a [CMS quick start guide](https://docs.ddev.com/en/stable/users/quickstart/).**
+---
 
-[https://ddev.com/get-started/](https://ddev.com/get-started/) is the up-to-date getting-started guide, and you can try DDEV without installing anything: <a href="https://github.com/codespaces/new/ddev/ddev"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
+## Get started
 
-Each project chooses its own stack: PHP [5.6 through 8.5](https://docs.ddev.com/en/stable/users/configuration/config/#php_version), [Nginx or Apache](https://docs.ddev.com/en/stable/users/configuration/config/#webserver_type), and [MariaDB, MySQL, or PostgreSQL](https://docs.ddev.com/en/stable/users/extend/database-types/).
+1. 💻 **Check that DDEV runs where you work:** macOS, Windows 11, WSL2, Linux, and [GitHub Codespaces](https://github.com/codespaces). See the [system requirements](https://docs.ddev.com/en/stable/users/install/ddev-installation/).
+2. 📥 **[Install a Docker provider and DDEV](https://docs.ddev.com/en/stable/users/install/).**
+3. 🏁 **Follow a [quickstart guide](https://docs.ddev.com/en/stable/users/quickstart/)** for your CMS or framework, then run `ddev start`.
 
-## What DDEV Gives You
+[ddev.com/get-started](https://ddev.com/get-started/) is the up-to-date getting-started guide. Or try DDEV without installing anything: <a href="https://github.com/codespaces/new/ddev/ddev"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
 
-### Environments
+## Why DDEV?
 
-* Create a local environment from a code repository with minimal configuration.
-* Get trusted HTTPS without setting anything up.
-* Extend and customize as much (or as little!) as you need to.
+DDEV takes care of Docker for you, so you and your team can focus on your work. It comes with good defaults for everyday use, and you can change them when you need more.
 
-### Data
+- 🚀 **Ready in minutes:** good defaults and little setup. Just run `ddev start`.
+- 📦 **One setup per project:** keep it in Git and share the same environment with your whole team.
+- 🔧 **Your stack, your choice:** PHP [5.6 through 8.5](https://docs.ddev.com/en/stable/users/configuration/config/#php_version), [Nginx or Apache](https://docs.ddev.com/en/stable/users/configuration/config/#webserver_type), and [MariaDB, MySQL, or PostgreSQL](https://docs.ddev.com/en/stable/users/extend/database-types/), per project.
+- 🧩 **Easy to extend:** a growing set of [add-ons](https://addons.ddev.com) for extra services and integrations, and custom commands are ordinary shell scripts.
+- 🖥️ **Runs everywhere:** macOS, Windows, WSL2, Linux, and GitHub Codespaces, on both ARM64 and AMD64.
+- 🔒 **Included out of the box:** trusted HTTPS, Xdebug, database snapshots, and hosting integrations with [Upsun (formerly Platform.sh)](https://upsun.com), [Pantheon](https://pantheon.io), [Acquia](https://www.acquia.com), and others.
+- 💙 **Run by the community:** free and open source, cared for by the nonprofit [DDEV Foundation](https://ddev.com/foundation/).
 
-* Import a database into any of your local environments.
-* Import upload files to match the project, such as Drupal `sites/default/files` or WordPress `wp-content/uploads`.
-* Snapshot databases with `ddev snapshot`.
-* Integrate with hosting platforms like [Upsun (formerly Platform.sh)](https://upsun.com), [Pantheon](https://pantheon.io), [Acquia](https://www.acquia.com), and others.
+## Everyday commands
 
-### Workflow
+- `ddev start` and `ddev stop`: run or pause a project's containers
+- `ddev import-db` and `ddev import-files`: load a database dump, or user-upload files such as Drupal `sites/default/files` and WordPress `wp-content/uploads`
+- `ddev snapshot`: save and restore database state
+- `ddev exec` and `ddev ssh`: run a command inside the web container, or open a shell in it
+- `ddev logs` and `ddev list`: read container logs, or see every project on the machine
+- `ddev share`: hand someone a temporary public URL for your local site
 
-* Run commands inside the Docker environment with `ddev exec`, or explore it with `ddev ssh`.
-* Read web and database container logs, and list running projects with `ddev list`.
-* Share your development site with others temporarily using `ddev share`.
-* Add custom commands as ordinary shell scripts.
+Run `ddev` for the full [command reference](https://docs.ddev.com/en/stable/users/usage/cli/).
 
-Run `ddev` to see all the [commands](https://docs.ddev.com/en/stable/users/usage/cli/).
+## Community and support
 
-## Documentation and Support
-
-[docs.ddev.com](https://docs.ddev.com) has the full documentation, and [ddev.com](https://ddev.com) has live examples, contributor live training, and guides.
-
-If you need help, our friendly community provides [great support](https://docs.ddev.com/en/stable/users/support/).
+- 💬 [Discord](https://ddev.com/s/discord): the fastest way to get help and talk to the maintainers
+- 🧭 [Support](https://docs.ddev.com/en/stable/users/support/): every place the friendly community answers questions
+- 🐛 [Issues](https://github.com/ddev/ddev/issues): report bugs and ask for new features
+- 📚 [Documentation](https://docs.ddev.com): guides, references, and how-tos
+- 📣 [Blog](https://ddev.com/blog/): news, releases, and community updates
 
 ## Contributing
 
-Start with “How can I contribute to DDEV?” in the [FAQ](https://docs.ddev.com/en/stable/users/usage/faq/) and the [Contributing](CONTRIBUTING.md) page. To build and test the code, see [Building, Testing, and Contributing](docs/content/developers/building-contributing.md).
+- 🙋 “How can I contribute to DDEV?” in the [FAQ](https://docs.ddev.com/en/stable/users/usage/faq/): all the ways to help, code or not
+- 📄 [Contributing](CONTRIBUTING.md): issues, pull requests, and Stack Overflow
+- 🛠️ [Building, Testing, and Contributing](docs/content/developers/building-contributing.md): build the binary and run the tests
 
-## Sponsors
+## Sponsor DDEV
 
-DDEV's ongoing development is made possible entirely by the support of these awesome backers. If you'd like to join them, please consider [sponsoring DDEV development](https://ddev.com/sponsor).
+DDEV is free and open source, maintained by the nonprofit [DDEV Foundation](https://ddev.com/foundation/) and paid for by its community. If DDEV saves you time, please consider [sponsoring the project](https://ddev.com/sponsor). Sponsorships fund the maintainers and infrastructure, and keep DDEV independent.
+
+<div align="center">
 
 <a href="https://ddev.com/#supporters">
   <picture>
@@ -64,6 +80,10 @@ DDEV's ongoing development is made possible entirely by the support of these awe
     <img alt="DDEV featured sponsors" src="https://ddev.com/resources/featured-sponsors.svg">
   </picture>
 </a>
+
+[![Sponsor DDEV](https://img.shields.io/badge/Sponsor-DDEV-blue?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://ddev.com/sponsor)
+
+</div>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Get started
 
-1. 💻 **Check that DDEV runs where you work:** macOS, Windows 11, WSL2, Linux, and [GitHub Codespaces](https://github.com/codespaces). See the [system requirements](https://docs.ddev.com/en/stable/users/install/ddev-installation/).
+1. 💻 **Check that DDEV runs where you work:** macOS, Windows 11, WSL2, Linux, and [GitHub Codespaces](https://github.com/codespaces). See the [system requirements](https://docs.ddev.com/en/stable/#system-requirements).
 2. 📥 **[Install a Docker provider and DDEV](https://docs.ddev.com/en/stable/users/install/).**
 3. 🏁 **Follow a [quickstart guide](https://docs.ddev.com/en/stable/users/quickstart/)** for your CMS or framework, then run `ddev start`.
 
@@ -37,7 +37,7 @@ DDEV takes care of Docker for you, so you and your team can focus on your work. 
 
 - 🚀 **Ready in minutes:** good defaults and little setup. Just run `ddev start`.
 - 📦 **One setup per project:** keep it in Git and share the same environment with your whole team.
-- 🔧 **Your stack, your choice:** PHP [5.6 through 8.5](https://docs.ddev.com/en/stable/users/configuration/config/#php_version), [Nginx or Apache](https://docs.ddev.com/en/stable/users/configuration/config/#webserver_type), and [MariaDB, MySQL, or PostgreSQL](https://docs.ddev.com/en/stable/users/extend/database-types/), per project.
+- 🔧 **Your stack, your choice:** PHP [5.6 through 8.5](https://docs.ddev.com/en/stable/users/configuration/config/#php_version), [Nginx or Apache](https://docs.ddev.com/en/stable/users/configuration/config/#webserver_type), and [MariaDB, MySQL, or PostgreSQL](https://docs.ddev.com/en/stable/users/extend/database-types/), per project. And any version of Node.js you need.
 - 🧩 **Easy to extend:** a growing set of [add-ons](https://addons.ddev.com) for extra services and integrations, and custom commands are ordinary shell scripts.
 - 🖥️ **Runs everywhere:** macOS, Windows, WSL2, Linux, and GitHub Codespaces, on both ARM64 and AMD64.
 - 🔒 **Included out of the box:** trusted HTTPS, Xdebug, database snapshots, and hosting integrations with [Upsun (formerly Platform.sh)](https://upsun.com), [Pantheon](https://pantheon.io), [Acquia](https://www.acquia.com), and others.

--- a/README.md
+++ b/README.md
@@ -3,33 +3,61 @@
   <img alt="DDEV logo with light and dark mode variants" src="https://ddev.com/logos/ddev.svg">
 </picture>
 
----
-
 [![ddev.com](https://img.shields.io/badge/DDEV-Website-blue)](https://ddev.com)
+[![documentation](https://img.shields.io/badge/DDEV-Documentation-blue)](https://docs.ddev.com)
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
-[![last commit](https://img.shields.io/github/last-commit/ddev/ddev)](https://github.com/ddev/ddev/commits)
 [![Discord](https://img.shields.io/discord/664580571770388500?logo=discord&logoColor=%23fff&label=Discord&link=https%3A%2F%2Fddev.com%2Fs%2Fdiscord)](https://ddev.com/s/discord)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ddev/ddev)
-<a href="https://github.com/codespaces/new/ddev/ddev"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
 
-[![Works with Mac | Windows | Linux | Cloud](https://img.shields.io/badge/works%20with-Mac%20%7C%20Windows%20%7C%20Linux%20%7C%20Cloud-blue.svg)](https://docs.ddev.com/en/stable/users/install/ddev-installation/)
-[![Supported PHP 5.6 to 8.5](https://img.shields.io/badge/supported-PHP%208.5%20%7C%208.4%20%7C%208.3%20%7C%208.2%20%7C%208.1%20%7C%208.0%20%7C%207.4%20%7C%207.3%20%7C%207.2%20%7C%207.1%20%7C%207.0%20%7C%205.6-blue.svg)](https://docs.ddev.com/en/stable/users/configuration/config/#php_version)
-[![Supported nginx & apache](https://img.shields.io/badge/supported-Nginx%20%7C%20Apache-blue)](https://docs.ddev.com/en/stable/users/configuration/config/#webserver_type)
-[![Supported MariaDB, MySQL, PostgreSQL](https://img.shields.io/badge/supported-MariaDB%20%7C%20MySQL%20%7C%20PostgreSQL-blue)](https://docs.ddev.com/en/stable/users/extend/database-types/)
+DDEV is an open-source tool for running local web development environments for PHP and Node.js, ready in minutes. Its per-project configuration can be extended, version controlled, and shared, so a whole team gets the same workflow without anyone maintaining bespoke setup. It depends on a Docker provider under the hood, but you'll hardly ever know it.
 
-DDEV is an open-source tool for running local web development environments for PHP and Node.js, ready in minutes. Its powerful, flexible per-project environment configurations can be extended, version controlled, and shared. DDEV allows development teams to adopt a consistent Docker workflow without the complexities of bespoke configuration.
+## Get Started
 
-## Documentation
+1. **Check that DDEV runs where you work:** macOS, Windows 11, WSL2, Linux, and [GitHub Codespaces](https://github.com/codespaces). See [system requirements](https://docs.ddev.com/en/stable/users/install/ddev-installation/).
+2. **Install a [Docker provider and DDEV](https://docs.ddev.com/en/stable/users/install/).**
+3. **Follow a [CMS quick start guide](https://docs.ddev.com/en/stable/users/quickstart/).**
 
-To check out live examples, docs, contributor live training, guides and more visit [ddev.com](https://ddev.com) and [docs.ddev.com](https://docs.ddev.com/en/stable/users/support)
+[https://ddev.com/get-started/](https://ddev.com/get-started/) is the up-to-date getting-started guide, and you can try DDEV without installing anything: <a href="https://github.com/codespaces/new/ddev/ddev"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
 
-## Questions
+Each project chooses its own stack: PHP [5.6 through 8.5](https://docs.ddev.com/en/stable/users/configuration/config/#php_version), [Nginx or Apache](https://docs.ddev.com/en/stable/users/configuration/config/#webserver_type), and [MariaDB, MySQL, or PostgreSQL](https://docs.ddev.com/en/stable/users/extend/database-types/).
+
+## What DDEV Gives You
+
+### Environments
+
+* Create a local environment from a code repository with minimal configuration.
+* Get trusted HTTPS without setting anything up.
+* Extend and customize as much (or as little!) as you need to.
+
+### Data
+
+* Import a database into any of your local environments.
+* Import upload files to match the project, such as Drupal `sites/default/files` or WordPress `wp-content/uploads`.
+* Snapshot databases with `ddev snapshot`.
+* Integrate with hosting platforms like [Upsun (formerly Platform.sh)](https://upsun.com), [Pantheon](https://pantheon.io), [Acquia](https://www.acquia.com), and others.
+
+### Workflow
+
+* Run commands inside the Docker environment with `ddev exec`, or explore it with `ddev ssh`.
+* Read web and database container logs, and list running projects with `ddev list`.
+* Share your development site with others temporarily using `ddev share`.
+* Add custom commands as ordinary shell scripts.
+
+Run `ddev` to see all the [commands](https://docs.ddev.com/en/stable/users/usage/cli/).
+
+## Documentation and Support
+
+[docs.ddev.com](https://docs.ddev.com) has the full documentation, and [ddev.com](https://ddev.com) has live examples, contributor live training, and guides.
 
 If you need help, our friendly community provides [great support](https://docs.ddev.com/en/stable/users/support/).
 
-## Featured Sponsors
+## Contributing
 
-DDEV is an Apache License 2.0 open-source project with its ongoing development made possible entirely by the support of these awesome backers. If you'd like to join them, please consider [sponsoring DDEV development](https://ddev.com/sponsor).
+Start with “How can I contribute to DDEV?” in the [FAQ](https://docs.ddev.com/en/stable/users/usage/faq/) and the [Contributing](CONTRIBUTING.md) page. To build and test the code, see [Building, Testing, and Contributing](docs/content/developers/building-contributing.md).
+
+## Sponsors
+
+DDEV's ongoing development is made possible entirely by the support of these awesome backers. If you'd like to join them, please consider [sponsoring DDEV development](https://ddev.com/sponsor).
 
 <a href="https://ddev.com/#supporters">
   <picture>
@@ -38,34 +66,6 @@ DDEV is an Apache License 2.0 open-source project with its ongoing development m
   </picture>
 </a>
 
-## Contributing
+## License
 
-See “How can I contribute to DDEV?” in the [FAQ](https://docs.ddev.com/en/stable/users/usage/faq/), and the [Contributing](CONTRIBUTING.md) page.
-
-![Overview of GitHub contributions](https://repobeats.axiom.co/api/embed/941b040a17921e974655fc01d7735aa350a53603.svg "Repobeats analytics image")
-
-## Get Started
-
-1. **Check [System Requirements](https://docs.ddev.com/):** macOS (Intel and Apple Silicon), Windows 10/11, WSL2, Linux, and [GitHub Codespaces](https://github.com/codespaces).
-2. **Install a [Docker provider and DDEV](https://docs.ddev.com/en/stable/users/install/)**.
-3. **Try a [CMS Quick Start Guide](https://docs.ddev.com/en/stable/users/quickstart/)**.
-
-Additionally, [https://ddev.com/get-started/](https://ddev.com/get-started/) provides an up-to-date getting-started guide.
-
-## Highlighted Features
-
-* Quickly create local web development environments based on code repositories, with minimal configuration.
-* Import a database to any of your local environments.
-* Import upload files to match the project (e.g. Drupal sites/default/files or WordPress `wp-content/uploads`).
-* Customizable integration with hosting platforms like [Upsun (formerly Platform.sh)](https://upsun.com), [Pantheon](https://pantheon.io), [Acquia](https://www.acquia.com) and others.
-* Run commands within the Docker environment using `ddev exec`.
-* View logs from the web and database containers.
-* Use `ddev ssh` to explore the Linux environment inside the container.
-* List running projects with `ddev list`.
-* Snapshot databases with `ddev snapshot`.
-* Temporarily share your development website with others using `ddev share`.
-* Create custom commands as simple shell scripts.
-* Enjoy effortless, trusted HTTPS support.
-* Extend and customize environments as much (or as little!) as you need to.
-
-Run `ddev` to see all the [commands](https://docs.ddev.com/en/stable/users/usage/cli/).
+DDEV is licensed under the Apache License 2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## The Issue

The README just got too big over time. A first-time visitor met ten badges, then sponsors and a Repobeats contribution graph, before reaching "Get Started" in eighth position.

## How This PR Solves The Issue

Reorders to: logo, badges, description, Get Started, features, docs/support, Contributing, Sponsors, License.

- Badges cut from ten to five. The four static support-matrix badges become one prose line in Get Started, keeping the same doc links; the Codespaces button moves there too.
- Features regrouped under Environments / Data / Workflow.
- Repobeats image removed. Contributing keeps the FAQ and CONTRIBUTING.md links and adds a pointer to `building-contributing.md`.
- Removed deepwiki badge
- "Documentation" and "Questions" merged into one section; a License section added (Apache 2.0 was only mentioned in passing inside the sponsors paragraph).

## Manual Testing Instructions

Read the [rendered README](https://github.com/ddev/ddev/blob/f2460436e28c843438fc1ee20950980187b4050d/README.md). The description and install path should be visible without scrolling; sponsors below the fold.

## Automated Testing Overview

None. `markdownlint` and `textlint` pass; the existing docs-check workflow covers it.

## Release/Deployment Notes

Documentation only.
