### PR TITLE
feat: stream import-db dumps into the db container without extracting to disk, fixes #8692

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -6,12 +6,14 @@ import (
 	"bufio"
 	"compress/bzip2"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -414,6 +416,233 @@ func Unzip(source string, dest string, extractionDir string) error {
 	}
 
 	return nil
+}
+
+// SQLDumpReader returns a reader over the SQL content of source, which may
+// be a plain .sql/.mysql file or one compressed with gzip, bzip2, or xz.
+// The returned reader must be closed when done.
+func SQLDumpReader(source string) (io.ReadCloser, error) {
+	f, err := os.Open(source)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case strings.HasSuffix(source, "sql.gz") || strings.HasSuffix(source, "mysql.gz"):
+		gf, err := gzip.NewReader(f)
+		if err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+		return &readCloser{r: gf, closeFn: func() error { return errors.Join(gf.Close(), f.Close()) }}, nil
+	case strings.HasSuffix(source, "sql.bz2") || strings.HasSuffix(source, "mysql.bz2"):
+		return &readCloser{r: bzip2.NewReader(bufio.NewReader(f)), closeFn: f.Close}, nil
+	case strings.HasSuffix(source, "sql.xz") || strings.HasSuffix(source, "mysql.xz"):
+		xr, err := xz.NewReader(bufio.NewReader(f))
+		if err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+		return &readCloser{r: xr, closeFn: f.Close}, nil
+	default:
+		return f, nil
+	}
+}
+
+// readCloser adapts an io.Reader to an io.ReadCloser with a custom close function.
+type readCloser struct {
+	r       io.Reader
+	closeFn func() error
+}
+
+func (rc *readCloser) Read(p []byte) (int, error) { return rc.r.Read(p) }
+func (rc *readCloser) Close() error               { return rc.closeFn() }
+
+// sqlMemberName reports whether an archive member would be imported into a
+// database: a .sql or .mysql file at the top level of the archive, or of
+// extractionDir when given. It mirrors the extraction logic of Untar/Unzip
+// followed by ImportDB's top-level glob: extractionDir names a prefix within
+// the archive (a directory, or a single file when a member matches it
+// exactly), and the rest of the member's name is considered relative to the
+// top level.
+func sqlMemberName(name, extractionDir string, isDir bool) bool {
+	if !strings.HasPrefix(name, extractionDir) {
+		return false
+	}
+	if name == extractionDir && !isDir {
+		name = filepath.Base(name)
+	} else {
+		// TrimPrefix can leave a leading "/" when extractionDir has none;
+		// filepath.Join in Untar/Unzip cleans that away.
+		name = strings.TrimLeft(strings.TrimPrefix(name, extractionDir), "/")
+	}
+	if name == "" || isDir || strings.Contains(name, "/") {
+		return false
+	}
+	return strings.HasSuffix(name, ".sql") || strings.HasSuffix(name, ".mysql")
+}
+
+// SQLMembersInTar returns the names of the members of the (optionally
+// gzip/bzip2/xz-compressed) tar archive source that a database import would
+// use: .sql and .mysql files at the top level of the archive, or of
+// extractionDir when given. Names are returned sorted. An error is returned
+// when no member matches extractionDir.
+func SQLMembersInTar(source, extractionDir string) ([]string, error) {
+	tf, closeFn, err := newTarReader(source)
+	if err != nil {
+		return nil, err
+	}
+	defer closeFn()
+
+	var names []string
+	foundExtractionPath := false
+	for {
+		hdr, err := tf.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error during read of tar archive %v, err: %v", source, err)
+		}
+		if !strings.HasPrefix(hdr.Name, extractionDir) {
+			continue
+		}
+		foundExtractionPath = true
+		if sqlMemberName(hdr.Name, extractionDir, hdr.Typeflag != tar.TypeReg) {
+			names = append(names, hdr.Name)
+		}
+	}
+	if !foundExtractionPath {
+		return nil, fmt.Errorf("failed to find files in extraction path: %s", extractionDir)
+	}
+	slices.Sort(names)
+	return names, nil
+}
+
+// SQLMembersInZip is the zip analog of SQLMembersInTar.
+func SQLMembersInZip(source, extractionDir string) ([]string, error) {
+	zf, err := zip.OpenReader(source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open zipfile %s, err:%v", source, err)
+	}
+	defer util.CheckClose(zf)
+
+	var names []string
+	foundExtractionPath := false
+	for _, file := range zf.File {
+		if !strings.HasPrefix(file.Name, extractionDir) {
+			continue
+		}
+		foundExtractionPath = true
+		if sqlMemberName(file.Name, extractionDir, file.FileInfo().IsDir()) {
+			names = append(names, file.Name)
+		}
+	}
+	if !foundExtractionPath {
+		return nil, fmt.Errorf("failed to find files in extraction path: %s", extractionDir)
+	}
+	slices.Sort(names)
+	return names, nil
+}
+
+// StreamTarMembers copies the contents of the named members of the
+// (optionally gzip/bzip2/xz-compressed) tar archive source to w, in the
+// order given. names should come from SQLMembersInTar.
+func StreamTarMembers(source string, names []string, w io.Writer) error {
+	for _, name := range names {
+		tf, closeFn, err := newTarReader(source)
+		if err != nil {
+			return err
+		}
+		found := false
+		for {
+			hdr, err := tf.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				closeFn()
+				return err
+			}
+			if hdr.Name == name {
+				if _, err := io.Copy(w, tf); err != nil {
+					closeFn()
+					return err
+				}
+				found = true
+				break
+			}
+		}
+		closeFn()
+		if !found {
+			return fmt.Errorf("archive member %q not found in %s", name, source)
+		}
+	}
+	return nil
+}
+
+// StreamZipMembers copies the contents of the named members of the zip
+// archive source to w, in the order given. names should come from
+// SQLMembersInZip.
+func StreamZipMembers(source string, names []string, w io.Writer) error {
+	zf, err := zip.OpenReader(source)
+	if err != nil {
+		return fmt.Errorf("failed to open zipfile %s, err:%v", source, err)
+	}
+	defer util.CheckClose(zf)
+
+	byName := make(map[string]*zip.File, len(zf.File))
+	for _, file := range zf.File {
+		byName[file.Name] = file
+	}
+	for _, name := range names {
+		file, ok := byName[name]
+		if !ok {
+			return fmt.Errorf("archive member %q not found in %s", name, source)
+		}
+		rc, err := file.Open()
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(w, rc)
+		_ = rc.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// newTarReader opens source and returns a tar.Reader over its contents along
+// with a function that closes the file and any decompressor.
+func newTarReader(source string) (*tar.Reader, func(), error) {
+	f, err := os.Open(source)
+	if err != nil {
+		return nil, nil, err
+	}
+	closeFn := func() { _ = f.Close() }
+	switch {
+	case strings.HasSuffix(source, "gz"):
+		gf, err := gzip.NewReader(f)
+		if err != nil {
+			_ = f.Close()
+			return nil, nil, err
+		}
+		return tar.NewReader(gf), func() {
+			_ = gf.Close()
+			_ = f.Close()
+		}, nil
+	case strings.HasSuffix(source, "xz"):
+		xr, err := xz.NewReader(bufio.NewReader(f))
+		if err != nil {
+			_ = f.Close()
+			return nil, nil, err
+		}
+		return tar.NewReader(xr), closeFn, nil
+	case strings.HasSuffix(source, "bz2"):
+		return tar.NewReader(bzip2.NewReader(bufio.NewReader(f))), closeFn, nil
+	default:
+		return tar.NewReader(f), closeFn, nil
+	}
 }
 
 // Tar takes a source dir and tarballFilePath and a single exclusion path

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -3,12 +3,14 @@ package archive_test
 import (
 	"archive/tar"
 	"archive/zip"
+	"bytes"
 	"compress/gzip"
 	"io"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/archive"
@@ -415,4 +417,151 @@ func TestUntarSymlinks(t *testing.T) {
 	require.NoError(t, err)
 	linkTarget2 = filepath.ToSlash(linkTarget2)
 	assert.Equal("../target.txt", linkTarget2)
+}
+
+// makeTestArchive writes members to a tar and a zip file in the same
+// directory and returns their paths.
+func makeTestArchive(t *testing.T, members map[string]string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	for name, content := range members {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Mode: 0600, Size: int64(len(content)), Typeflag: tar.TypeReg}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	tarPath := filepath.Join(dir, "test.tar")
+	require.NoError(t, os.WriteFile(tarPath, tarBuf.Bytes(), 0644))
+
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	for name, content := range members {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	zipPath := filepath.Join(dir, "test.zip")
+	require.NoError(t, os.WriteFile(zipPath, zipBuf.Bytes(), 0644))
+
+	return tarPath, zipPath
+}
+
+// TestSQLMembers tests that only top-level .sql/.mysql archive members are
+// listed, mirroring ImportDB's extraction-then-glob behavior, and that the
+// named members can be streamed back in order.
+func TestSQLMembers(t *testing.T) {
+	members := map[string]string{
+		"b.sql":        "SELECT 1;\n",
+		"a.sql":        "SELECT 2;\n",
+		"nested/c.sql": "SELECT 3;\n",
+		"x.sql.gz":     "garbage",
+		"notes.txt":    "not sql",
+	}
+	tarPath, zipPath := makeTestArchive(t, members)
+
+	tests := []struct {
+		name          string
+		source        string
+		extractionDir string
+		want          []string
+		wantErr       bool
+	}{
+		{"tar top level", tarPath, "", []string{"a.sql", "b.sql"}, false},
+		{"zip top level", zipPath, "", []string{"a.sql", "b.sql"}, false},
+		{"tar extraction dir", tarPath, "nested/", []string{"nested/c.sql"}, false},
+		{"zip extraction dir", zipPath, "nested/", []string{"nested/c.sql"}, false},
+		{"tar extraction dir without slash", tarPath, "nested", []string{"nested/c.sql"}, false},
+		{"zip extraction dir without slash", zipPath, "nested", []string{"nested/c.sql"}, false},
+		{"tar single file", tarPath, "b.sql", []string{"b.sql"}, false},
+		{"zip single file", zipPath, "b.sql", []string{"b.sql"}, false},
+		{"tar matching dir without sql", tarPath, "notes.txt", nil, false},
+		{"zip matching dir without sql", zipPath, "notes.txt", nil, false},
+		{"tar missing extraction dir", tarPath, "missing/", nil, true},
+		{"zip missing extraction dir", zipPath, "missing/", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []string
+			var err error
+			if strings.HasSuffix(tt.source, ".zip") {
+				got, err = archive.SQLMembersInZip(tt.source, tt.extractionDir)
+			} else {
+				got, err = archive.SQLMembersInTar(tt.source, tt.extractionDir)
+			}
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+
+	// Streaming concatenates the named members in the given order.
+	var buf bytes.Buffer
+	require.NoError(t, archive.StreamTarMembers(tarPath, []string{"a.sql", "b.sql"}, &buf))
+	require.Equal(t, "SELECT 2;\nSELECT 1;\n", buf.String())
+	buf.Reset()
+	require.NoError(t, archive.StreamZipMembers(zipPath, []string{"a.sql", "b.sql"}, &buf))
+	require.Equal(t, "SELECT 2;\nSELECT 1;\n", buf.String())
+
+	// A gzipped tarball streams the same way.
+	dir := t.TempDir()
+	gzPath := filepath.Join(dir, "test.tar.gz")
+	f, err := os.Create(gzPath)
+	require.NoError(t, err)
+	gw := gzip.NewWriter(f)
+	raw, err := os.ReadFile(tarPath)
+	require.NoError(t, err)
+	_, err = gw.Write(raw)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	require.NoError(t, f.Close())
+	buf.Reset()
+	require.NoError(t, archive.StreamTarMembers(gzPath, []string{"a.sql"}, &buf))
+	require.Equal(t, "SELECT 2;\n", buf.String())
+}
+
+// TestSQLDumpReader tests that plain and gzip-compressed SQL files yield
+// their decompressed contents.
+func TestSQLDumpReader(t *testing.T) {
+	content := "SELECT 1;\n"
+	dir := t.TempDir()
+
+	plain := filepath.Join(dir, "db.sql")
+	require.NoError(t, os.WriteFile(plain, []byte(content), 0644))
+	rc, err := archive.SQLDumpReader(plain)
+	require.NoError(t, err)
+	b, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, content, string(b))
+	require.NoError(t, rc.Close())
+
+	gz := filepath.Join(dir, "db.sql.gz")
+	f, err := os.Create(gz)
+	require.NoError(t, err)
+	gw := gzip.NewWriter(f)
+	_, err = gw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	require.NoError(t, f.Close())
+
+	rc, err = archive.SQLDumpReader(gz)
+	require.NoError(t, err)
+	b, err = io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, content, string(b))
+	require.NoError(t, rc.Close())
+
+	// A corrupt gzip stream must be reported, not silently truncated.
+	bad := filepath.Join(dir, "bad.sql.gz")
+	require.NoError(t, os.WriteFile(bad, []byte("not gzip"), 0644))
+	_, err = archive.SQLDumpReader(bad)
+	require.Error(t, err)
 }

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -882,7 +883,10 @@ func (app *DdevApp) GetDBDumpCommand() string {
 	return "mysqldump"
 }
 
-// ImportDB takes a source sql dump and imports it to an active site's database container.
+// ImportDB imports a SQL dump into the active site's database container.
+// The dump can be a plain .sql/.mysql file, one compressed with
+// gzip/bzip2/xz, or a tar/zip archive of SQL files. It is streamed into the
+// container's stdin rather than extracted to disk on the host.
 func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool, noDrop bool, targetDB string) error {
 	_ = app.DockerEnv()
 	if err := dockerutil.CheckAvailableSpace(); err != nil {
@@ -892,21 +896,8 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 	if targetDB == "" {
 		targetDB = "db"
 	}
-	var extPathPrompt bool
-	dbPath, err := os.MkdirTemp(filepath.Dir(app.ConfigPath), ".importdb")
-	if err != nil {
-		return err
-	}
-	err = util.Chmod(dbPath, 0777)
-	if err != nil {
-		return err
-	}
 
-	defer func() {
-		_ = os.RemoveAll(dbPath)
-	}()
-
-	err = app.ProcessHooks("pre-import-db")
+	err := app.ProcessHooks("pre-import-db")
 	if err != nil {
 		return err
 	}
@@ -914,109 +905,77 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 	// If they don't provide an import path and we're not on a tty (piped in stuff)
 	// then prompt for path to db
 	if dumpFile == "" && isatty.IsTerminal(os.Stdin.Fd()) {
-		// ensure we prompt for extraction path if an archive is provided, while still allowing
-		// non-interactive use of --file flag without providing a --extract-path flag.
-		if extractPath == "" {
-			extPathPrompt = true
-		}
 		output.UserOut.Println("Provide the path to the database you want to import.")
 		fmt.Print("Path to file: ")
 
 		dumpFile = util.GetQuotedInput("")
 	}
 
+	// The dump is streamed into the container: importStream is the db
+	// command's stdin, fed by a producer goroutine, and importErr carries
+	// failures from that goroutine (a truncated archive or corrupt compressed
+	// stream) that the exec cannot see. For archives the members to import
+	// are listed first, so we fail with "no .sql files found" before touching
+	// the database.
+	var importStream io.ReadCloser
+	var importErr <-chan error
+	var dumpContent io.Reader
+	var streamArchive func(w io.Writer) error
+	var archiveMembers []string
 	if dumpFile != "" {
-		importPath, isArchive, err := appimport.ValidateAsset(dumpFile, "db")
+		importPath, _, err := appimport.ValidateAsset(dumpFile, "db")
 		if err != nil {
-			if isArchive && extPathPrompt {
-				output.UserOut.Println("You provided an archive. Do you want to extract from a specific path in your archive? You may leave this blank if you wish to use the full archive contents")
-				fmt.Print("Archive extraction path: ")
-
-				extractPath = util.GetQuotedInput("")
-			} else {
-				return fmt.Errorf("unable to validate import asset %s: %s", dumpFile, err)
-			}
+			return fmt.Errorf("unable to validate import asset %s: %s", dumpFile, err)
 		}
 
+		var dumpReader io.ReadCloser
 		switch {
-		case strings.HasSuffix(importPath, "sql.gz") || strings.HasSuffix(importPath, "mysql.gz"):
-			err = archive.Ungzip(importPath, dbPath)
-			if err != nil {
-				return fmt.Errorf("failed to extract provided file: %v", err)
+		case isTar(importPath):
+			archiveMembers, err = archive.SQLMembersInTar(importPath, extractPath)
+			if err == nil {
+				streamArchive = func(w io.Writer) error {
+					return archive.StreamTarMembers(importPath, archiveMembers, w)
+				}
 			}
-
-		case strings.HasSuffix(importPath, "sql.bz2") || strings.HasSuffix(importPath, "mysql.bz2"):
-			err = archive.UnBzip2(importPath, dbPath)
-			if err != nil {
-				return fmt.Errorf("failed to extract file: %v", err)
+		case isZip(importPath):
+			archiveMembers, err = archive.SQLMembersInZip(importPath, extractPath)
+			if err == nil {
+				streamArchive = func(w io.Writer) error {
+					return archive.StreamZipMembers(importPath, archiveMembers, w)
+				}
 			}
-
-		case strings.HasSuffix(importPath, "sql.xz") || strings.HasSuffix(importPath, "mysql.xz"):
-			err = archive.UnXz(importPath, dbPath)
-			if err != nil {
-				return fmt.Errorf("failed to extract file: %v", err)
-			}
-
-		case strings.HasSuffix(importPath, "zip"):
-			err = archive.Unzip(importPath, dbPath, extractPath)
-			if err != nil {
-				return fmt.Errorf("failed to extract provided archive: %v", err)
-			}
-
-		case strings.HasSuffix(importPath, "tar"):
-			fallthrough
-		case strings.HasSuffix(importPath, "tar.gz"):
-			fallthrough
-		case strings.HasSuffix(importPath, "tar.bz2"):
-			fallthrough
-		case strings.HasSuffix(importPath, "tar.xz"):
-			fallthrough
-		case strings.HasSuffix(importPath, "tgz"):
-			err := archive.Untar(importPath, dbPath, extractPath)
-			if err != nil {
-				return fmt.Errorf("failed to extract provided archive: %v", err)
-			}
-
 		default:
-			err = fileutil.CopyFile(importPath, filepath.Join(dbPath, "db.sql"))
-			if err != nil {
-				return err
+			dumpReader, err = archive.SQLDumpReader(importPath)
+			if err == nil {
+				dumpContent = dumpReader
 			}
 		}
-
-		matches, err := filepath.Glob(filepath.Join(dbPath, "*.*sql"))
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to open import asset %s: %v", importPath, err)
 		}
-
-		if len(matches) < 1 {
+		if streamArchive != nil && len(archiveMembers) < 1 {
 			return fmt.Errorf("no .sql or .mysql files found to import")
 		}
-	}
 
-	// Default insideContainerImportPath is the one mounted from .ddev directory
-	insideContainerImportPath := path.Join("/mnt/ddev_config/", filepath.Base(dbPath))
-	// But if we don't have bind mounts, we have to copy dump into the container
-	if globalconfig.DdevGlobalConfig.NoBindMounts {
-		dbContainerName := GetContainerName(app, "db")
-		uid, _, _ := dockerutil.GetContainerUser()
-
-		insideContainerImportPath, _, err = dockerutil.Exec(dbContainerName, "mktemp -d", uid)
-		if err != nil {
-			return err
+		pr, pw := io.Pipe()
+		errCh := make(chan error, 1)
+		go func() {
+			var err error
+			if streamArchive != nil {
+				err = streamArchive(pw)
+			} else {
+				_, err = io.Copy(pw, dumpContent)
+			}
+			_ = pw.CloseWithError(err)
+			errCh <- err
+		}()
+		importStream = pr
+		importErr = errCh
+		if dumpReader != nil {
+			defer dumpReader.Close()
 		}
-		insideContainerImportPath = strings.Trim(insideContainerImportPath, "\n")
-
-		err = dockerutil.CopyIntoContainer(dbPath, dbContainerName, insideContainerImportPath, "")
-		if err != nil {
-			return err
-		}
 	}
 
-	err = app.MutagenSyncFlush()
-	if err != nil {
-		return err
-	}
 	// The Perl manipulation removes statements like CREATE DATABASE and USE, which
 	// throw off imports.
 	// It also removes the new `/*!999999\- enable the sandbox mode */` introduced in
@@ -1041,7 +1000,8 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 			preImportSQL = fmt.Sprintf("DROP DATABASE IF EXISTS %s; ", targetDB) + preImportSQL
 		}
 
-		// Case for reading from file
+		// The dump always arrives on stdin, whether piped by the user or
+		// streamed from a file, so there is a single command form.
 		// The Perl regex does three things:
 		// 1. Strips sandbox mode comments, CREATE DATABASE, and USE statements from the dump
 		// 2. Replaces MariaDB 11.x modern collation (utf8mb4_uca1400_ai_ci) with server's default collation
@@ -1049,19 +1009,7 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 		// The collation replacements skip INSERT and VALUES lines to avoid corrupting data that mentions these collations
 		// The PIPESTATUS check ensures we catch and report errors from the mysql command
 		// DDEV_REPLACED_COLLATION is queried from the server and used via $ENV{DDEV_REPLACED_COLLATION} in Perl
-		inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail; DDEV_REPLACED_COLLATION=$(%[1]s -sN -e "SELECT @@collation_server" </dev/null 2>/dev/null || echo "utf8mb4_unicode_ci"); export DDEV_REPLACED_COLLATION; %[1]s -e "%[2]s"; pv %[3]s/*.*sql | perl -p -e 's/^(\/\*.*999999.*enable the sandbox mode *|CREATE DATABASE \/\*|USE %[4]s)[^;]*(;|\*\/)//; unless (/^\s*(INSERT\s+INTO|VALUES)/i) { s/COLLATE[= ]utf8mb4_uca1400_ai_ci/COLLATE $ENV{DDEV_REPLACED_COLLATION}/gi; s/COLLATE[= ]utf8mb4_0900_ai_ci/COLLATE $ENV{DDEV_REPLACED_COLLATION}/gi; }' | %[1]s %[5]s; status=${PIPESTATUS[2]}; if [ $status -ne 0 ]; then echo "Database import command failed" >&2; exit 1; fi`, dbClientCmd, preImportSQL, insideContainerImportPath, "`", targetDB)}
-
-		// Alternate case where we are reading from stdin
-		// The Perl regex does three things:
-		// 1. Strips CREATE DATABASE and USE statements from the dump
-		// 2. Replaces MariaDB 11.x modern collation (utf8mb4_uca1400_ai_ci) with server's default collation
-		// 3. Replaces MySQL 8.0+ modern collation (utf8mb4_0900_ai_ci) with server's default collation
-		// The collation replacements skip INSERT and VALUES lines to avoid corrupting data that mentions these collations
-		// The PIPESTATUS check ensures we catch and report errors from the mysql command even when reading from stdin
-		// DDEV_REPLACED_COLLATION is queried from the server and used via $ENV{DDEV_REPLACED_COLLATION} in Perl
-		if dumpFile == "" && extractPath == "" {
-			inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail; DDEV_REPLACED_COLLATION=$(%[1]s -sN -e "SELECT @@collation_server" </dev/null 2>/dev/null || echo "utf8mb4_unicode_ci"); export DDEV_REPLACED_COLLATION; %[1]s -e "%[2]s"; perl -p -e 's/^(CREATE DATABASE \/\*|USE %[3]s)[^;]*;//; unless (/^\s*(INSERT\s+INTO|VALUES)/i) { s/COLLATE[= ]utf8mb4_uca1400_ai_ci/COLLATE $ENV{DDEV_REPLACED_COLLATION}/gi; s/COLLATE[= ]utf8mb4_0900_ai_ci/COLLATE $ENV{DDEV_REPLACED_COLLATION}/gi; }' | %[1]s %[4]s; status=${PIPESTATUS[1]}; if [ $status -ne 0 ]; then echo "Database import command failed" >&2; exit 1; fi`, dbClientCmd, preImportSQL, "`", targetDB)}
-		}
+		inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail; DDEV_REPLACED_COLLATION=$(%[1]s -sN -e "SELECT @@collation_server" </dev/null 2>/dev/null || echo "utf8mb4_unicode_ci"); export DDEV_REPLACED_COLLATION; %[1]s -e "%[2]s"; perl -p -e 's/^(\/\*.*999999.*enable the sandbox mode *|CREATE DATABASE \/\*|USE %[3]s)[^;]*(;|\*\/)//; unless (/^\s*(INSERT\s+INTO|VALUES)/i) { s/COLLATE[= ]utf8mb4_uca1400_ai_ci/COLLATE $ENV{DDEV_REPLACED_COLLATION}/gi; s/COLLATE[= ]utf8mb4_0900_ai_ci/COLLATE $ENV{DDEV_REPLACED_COLLATION}/gi; }' | %[1]s %[4]s; status=${PIPESTATUS[1]}; if [ $status -ne 0 ]; then echo "Database import command failed" >&2; exit 1; fi`, dbClientCmd, preImportSQL, "`", targetDB)}
 
 	case nodeps.Postgres:
 		preImportSQL = ""
@@ -1078,18 +1026,33 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 		preImportSQL = preImportSQL + fmt.Sprintf(`
 			GRANT ALL PRIVILEGES ON DATABASE %s TO db;`, targetDB)
 
-		// If there is no import path, we're getting it from stdin
-		if dumpFile == "" && extractPath == "" {
-			inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && (echo '%s' | psql -d postgres) && psql -v ON_ERROR_STOP=1 -d %s`, preImportSQL, targetDB)}
-		} else { // otherwise getting it from mounted file
-			inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && (echo "%s" | psql -q -d postgres -v ON_ERROR_STOP=1) && pv %s/*.*sql | psql -q -v ON_ERROR_STOP=1 %s >/dev/null`, preImportSQL, insideContainerImportPath, targetDB)}
-		}
+		// The dump always arrives on stdin, whether piped by the user or
+		// streamed from a file, so there is a single command form.
+		inContainerCommand = []string{"bash", "-c", fmt.Sprintf(`set -eu -o pipefail && (echo '%s' | psql -d postgres) && psql -v ON_ERROR_STOP=1 -d %s`, preImportSQL, targetDB)}
+	}
+	stopDots := func() {}
+	if progress && importStream != nil {
+		stopDots = util.ShowDots()
 	}
 	stdout, stderr, err := app.Exec(&ExecOpts{
 		Service: "db",
 		RawCmd:  inContainerCommand,
-		Tty:     progress && isatty.IsTerminal(os.Stdin.Fd()),
+		Stdin:   importStream,
+		// A streamed dump arrives on the command's stdin, so no TTY is
+		// allocated; the user-piped case keeps its previous behavior.
+		Tty: importStream == nil && progress && isatty.IsTerminal(os.Stdin.Fd()),
 	})
+	stopDots()
+
+	if importStream != nil {
+		// Unblock the producer if the exec ended before consuming the dump,
+		// then surface producer failures (truncated archive, corrupt
+		// compressed stream) that the exec cannot report.
+		_ = importStream.Close()
+		if streamErr := <-importErr; streamErr != nil && !errors.Is(streamErr, io.ErrClosedPipe) && err == nil {
+			err = fmt.Errorf("failed to stream dump into container: %v", streamErr)
+		}
+	}
 
 	if err != nil {
 		return fmt.Errorf("failed to import database: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
@@ -1104,11 +1067,6 @@ func (app *DdevApp) ImportDB(dumpFile string, extractPath string, progress bool,
 	err = app.PostImportDBAction()
 	if err != nil {
 		return fmt.Errorf("failed to execute PostImportDBAction: %v", err)
-	}
-
-	err = fileutil.PurgeDirectory(dbPath)
-	if err != nil {
-		return fmt.Errorf("failed to clean up %s after import: %v", dbPath, err)
 	}
 
 	err = app.ProcessHooks("post-import-db")
@@ -2536,6 +2494,9 @@ type ExecOpts struct {
 	Stdout *os.File
 	// Stderr can be overridden with a File
 	Stderr *os.File
+	// Stdin is the stream fed to the command's stdin instead of the
+	// process's own stdin. When set, no TTY is allocated.
+	Stdin io.ReadCloser
 	// Detach does docker-compose detach
 	Detach bool
 	// Env is the array of environment variables
@@ -2605,6 +2566,10 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	if opts.Stderr != nil {
 		stderr = opts.Stderr
 	}
+	stdin := opts.Stdin
+	if stdin == nil {
+		stdin = os.Stdin
+	}
 
 	execProject, execLoadErr := dockerutil.LoadComposeProject([]string{app.DockerComposeFullRenderedYAMLPath()}, api.ProjectLoadOptions{
 		ProjectName: app.GetComposeProjectName(),
@@ -2613,8 +2578,9 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		return "", "", execLoadErr
 	}
 
-	// Allocate a TTY only when both stdin and stdout are real terminals.
-	tty := opts.Tty && isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(stdout.Fd())
+	// Allocate a TTY only when both stdin and stdout are real terminals, and
+	// never when the caller feeds the command's stdin itself.
+	tty := opts.Tty && opts.Stdin == nil && isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(stdout.Fd())
 
 	// A session with a TTY gets the terminal of the host, so programs in the
 	// container know how many colors they can use. Without a TTY there is no
@@ -2637,7 +2603,7 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 
 	var stdoutResult, stderrResult string
 	if opts.NoCapture || opts.Tty {
-		restore, stdinErr := dockerutil.SetExecStdin(os.Stdin, tty)
+		restore, stdinErr := dockerutil.SetExecStdin(stdin, tty)
 		if stdinErr != nil {
 			return "", "", stdinErr
 		}
@@ -2648,9 +2614,9 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 		}
 		err = dockerutil.ExitCodeToError(execSvc.Exec(execCtx, execProject.Name, runOpts))
 	} else {
-		if !isatty.IsTerminal(os.Stdin.Fd()) {
+		if opts.Stdin != nil || !isatty.IsTerminal(os.Stdin.Fd()) {
 			// Forward piped stdin so exec commands can read it even without Tty.
-			restore, _ := dockerutil.SetExecStdin(os.Stdin, false)
+			restore, _ := dockerutil.SetExecStdin(stdin, false)
 			defer restore()
 		}
 		captureCtx, _, captureCtxErr := dockerutil.GetDockerClient()


### PR DESCRIPTION
## The Issue

- Fixes #8692

`ddev import-db` decompresses a dump to `.ddev/.importdb*/` on the host before importing it, so a compressed dump requires a full uncompressed copy on disk (plus a `docker cp` into the container when `no_bind_mounts` is set), and the import only starts after the entire file has been extracted.

## How This PR Solves The Issue

The dump is now streamed straight into the database container's stdin instead of being extracted to disk first:

- `ExecOpts` gains a `Stdin io.ReadCloser`; `Exec` feeds it to the container command in both the capture and no-capture paths and never allocates a TTY when it is set.
- `ImportDB` feeds the dump through an `io.Pipe` into the existing container-side `perl ... | mysql`/`psql` pipeline. Gzip/bzip2/xz files are decompressed on the fly; tar and zip archives are enumerated for their top-level `.sql`/`.mysql` members (honoring `--extract-path`, in sorted order, mirroring the old extract-then-glob behavior) and streamed member by member.
- This removes the `.ddev/.importdb*` temp directory, the `no_bind_mounts` `docker cp` into the db container, and the `MutagenSyncFlush` from the import path.
- Archive members are listed before the import starts, so an archive with no SQL files still fails before the database is dropped.
- Errors from the streaming side (truncated archive, corrupt compressed stream) are surfaced after the exec, since the container's client would otherwise just see EOF. As before, a mid-stream failure leaves a partial import behind; the `PIPESTATUS`/`ON_ERROR_STOP` checks in the container still catch SQL errors.
- Progress is shown with the existing dots indicator while a file is being streamed (the container-side `pv` is gone).

New helpers in `pkg/archive`: `SQLDumpReader`, `SQLMembersInTar`/`SQLMembersInZip`, `StreamTarMembers`/`StreamZipMembers`.

One minor behavior change: a symlinked `.sql` member inside a tar archive is now skipped (previously it would be extracted and imported), since symlinked members are already rejected for path-safety reasons in `Untar`.

## Manual Testing Instructions

- `ddev import-db --file=some.sql.gz` and verify the tables are imported correctly
- Repeat with `.sql`, `.sql.bz2`, `.sql.xz`, `.mysql.gz`, a tar/tgz of SQL files, a zip of SQL files, and `--extract-path` pointing at a subdirectory
- `cat db.sql | ddev import-db` (stdin path is unchanged)
- `ddev import-db --file=broken.sql.gz` should fail loudly rather than silently importing a truncated dump
- With `ddev config global --no-bind-mounts`, imports should now skip the `docker cp` step entirely

## Automated Testing Overview

- `TestDdevImportDB` (MariaDB and Postgres) passes unchanged: plain, gz/bz2/xz, tar/tgz/tar.gz/tar.bz2/tar.xz, zip, `--extract-path`, stdin, `--no-drop`, collation replacement, and invalid-SQL cases are all verified against the live database.
- New unit tests in `pkg/archive` cover member listing (top-level, extraction-dir, single-file, missing-dir), sorted streaming order, gzip stream reading, and corrupt-gzip detection.

## Release/Deployment Notes

No config or command-line surface changes. Imports no longer consume disk space for the extracted copy, and `no_bind_mounts` imports no longer copy the dump into the container. The `.ddev/.importdb*` gitignore entry and the mutagen ignore entry for `.importdb*` become vestigial and can be cleaned up later.
