### PR TITLE
docs(readme): add in-kind sponsors section (#8700) [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ DDEV is free and open source, maintained by the nonprofit [DDEV Foundation](http
 
 ## In-kind sponsors
 
-DDEV depends on products and services provided free of charge by the companies below.
+DDEV depends on products and services provided free of charge by the generous companies below. Thanks!
 
 | Sponsor | Contribution |
 | ------- | ------------ |

--- a/README.md
+++ b/README.md
@@ -25,11 +25,15 @@
 
 ## Get started
 
-1. 💻 **Check that DDEV runs where you work:** macOS, Windows 11, WSL2, Linux, and [GitHub Codespaces](https://github.com/codespaces). See the [system requirements](https://docs.ddev.com/en/stable/#system-requirements).
+The quickest path is the **[Get Started guide](https://ddev.com/get-started/)**: pick your operating system and it gives you the install commands and your first project, on one page.
+
+If you'd rather read the full instructions:
+
+1. 💻 **Check that DDEV runs where you work:** macOS, Windows 11, WSL2, Linux, and GitHub Codespaces. See the [system requirements](https://docs.ddev.com/en/stable/#system-requirements).
 2. 📥 **[Install a Docker provider and DDEV](https://docs.ddev.com/en/stable/users/install/).**
 3. 🏁 **Follow a [quickstart guide](https://docs.ddev.com/en/stable/users/quickstart/)** for your CMS or framework, then run `ddev start`.
 
-[ddev.com/get-started](https://ddev.com/get-started/) is the up-to-date getting-started guide. Or try DDEV without installing anything: <a href="https://github.com/codespaces/new/ddev/ddev"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
+Want to try DDEV first? Run it in your browser, nothing to install: <a href="https://github.com/codespaces/new/ddev/ddev"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
 
 ## Why DDEV?
 
@@ -84,6 +88,16 @@ DDEV is free and open source, maintained by the nonprofit [DDEV Foundation](http
 [![Sponsor DDEV](https://img.shields.io/badge/Sponsor-DDEV-blue?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://ddev.com/sponsor)
 
 </div>
+
+## In-kind sponsors
+
+DDEV depends on products and services provided free of charge by the companies below.
+
+| Sponsor | Contribution |
+| ------- | ------------ |
+| <a href="https://cloudsmith.com"><picture><source media="(prefers-color-scheme: dark)" srcset="https://ddev.com/logos/cloudsmith-dark.svg"><img alt="Cloudsmith" src="https://ddev.com/logos/cloudsmith.svg" height="40"></picture></a> | Linux package repository hosting is graciously provided by [Cloudsmith](https://cloudsmith.com). Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that enables your organization to create, store and share packages in any format, to any place, with total confidence. |
+| <a href="https://www.jetbrains.com"><picture><source media="(prefers-color-scheme: dark)" srcset="https://ddev.com/logos/jetbrains-dark.svg"><img alt="JetBrains" src="https://ddev.com/logos/jetbrains.svg" height="40"></picture></a> | [JetBrains](https://www.jetbrains.com) provides DDEV maintainers with licenses for its IDEs. |
+| <a href="https://www.macstadium.com"><picture><source media="(prefers-color-scheme: dark)" srcset="https://ddev.com/logos/dark-mac-stadium.svg"><img alt="MacStadium" src="https://ddev.com/logos/mac-stadium.svg" height="40"></picture></a> | [MacStadium](https://www.macstadium.com) provides a cloud-hosted Apple silicon machine that DDEV uses for testing. |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@
 
 ## Get started
 
-The quickest path is the **[Get Started guide](https://ddev.com/get-started/)**: pick your operating system and it gives you the install commands and your first project, on one page.
+The quickest path is the [Get Started guide](https://ddev.com/get-started/): pick your operating system and it gives you the install commands and your first project, on one page.
 
 If you'd rather read the full instructions:
 
 1. 💻 **Check that DDEV runs where you work:** macOS, Windows 11, WSL2, Linux, and GitHub Codespaces. See the [system requirements](https://docs.ddev.com/en/stable/#system-requirements).
-2. 📥 **[Install a Docker provider and DDEV](https://docs.ddev.com/en/stable/users/install/).**
-3. 🏁 **Follow a [quickstart guide](https://docs.ddev.com/en/stable/users/quickstart/)** for your CMS or framework, then run `ddev start`.
+2. 📥 **Install a Docker provider and DDEV:** follow the [install instructions](https://docs.ddev.com/en/stable/users/install/).
+3. 🏁 **Start your first project:** pick a [quickstart guide](https://docs.ddev.com/en/stable/users/quickstart/) for your CMS or framework, then run `ddev start`.
 
 Want to try DDEV first? Run it in your browser, nothing to install: <a href="https://github.com/codespaces/new/ddev/ddev"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" style="max-width: 100%; height: 20px;"></a>
 


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev.com/pull/720

Cloudsmith asked for attribution for the free hosting of DDEV's Linux package repositories, and the README had nowhere to credit sponsors who contribute products and services. The Get started section also mentioned the ddev.com guide only after the docs-based steps, which read as an afterthought.

## How This PR Solves The Issue

- Adds an "In-kind sponsors" section before License: a table crediting Cloudsmith (package repository hosting, wording from their open source hosting policy https://docs.cloudsmith.com/resources/open-source-hosting-policy#attribution), JetBrains (IDE licenses), and MacStadium (cloud-hosted Apple silicon machine for testing). Logos use light/dark `<picture>` variants, like the sponsors block above.
- Reworks Get started so the ddev.com Get Started guide comes first and the docs steps follow, and rewrites the Codespaces line.

## Manual Testing Instructions

https://github.com/stasadev/ddev/blob/20260813_stasadev_cloudsmith/README.md#in-kind-sponsors

Preview README.md on GitHub in light and dark themes. Each logo should swap variants with the theme and link to the sponsor's site.

https://github.com/stasadev/ddev/blob/20260813_stasadev_cloudsmith/README.md#get-started

## Automated Testing Overview

None; documentation only. `markdownlint README.md` passes.

## Release/Deployment Notes

None.