### PR TITLE
test(windows): use forward slashes for paths fed to the db-version bash script on Windows [skip github] (#8701) [skip ci]

### DIFF
--- a/pkg/ddevapp/db.go
+++ b/pkg/ddevapp/db.go
@@ -43,14 +43,14 @@ func (app *DdevApp) GetExistingDBType() (string, error) {
 func getDBVersionFromVolumeScript(mariadbVersionFile, postgresVersionFile, postgresVersionGlob string) string {
 	return fmt.Sprintf(`
 		# Check MySQL/MariaDB version file
-		if [ -f %[1]s ]; then
-			cat %[1]s
+		if [ -f "%[1]s" ]; then
+			cat "%[1]s"
 			exit 0
 		fi
 
 		# Check PostgreSQL version file (pre-18 location)
-		if [ -f %[2]s ]; then
-			cat %[2]s
+		if [ -f "%[2]s" ]; then
+			cat "%[2]s"
 			exit 0
 		fi
 

--- a/pkg/ddevapp/db_internal_test.go
+++ b/pkg/ddevapp/db_internal_test.go
@@ -78,10 +78,13 @@ func TestGetDBVersionFromVolumeScript(t *testing.T) {
 			root := t.TempDir()
 			tt.setup(t, root)
 
+			// The script runs under bash even on Windows (Git Bash), where an
+			// unquoted backslash is an escape character, so paths fed into it
+			// must use forward slashes rather than the native os.PathSeparator.
 			script := getDBVersionFromVolumeScript(
-				filepath.Join(root, "mysql", "db_mariadb_version.txt"),
-				filepath.Join(root, "postgres", "PG_VERSION"),
-				filepath.Join(root, "postgres", "*", "docker", "PG_VERSION"),
+				filepath.ToSlash(filepath.Join(root, "mysql", "db_mariadb_version.txt")),
+				filepath.ToSlash(filepath.Join(root, "postgres", "PG_VERSION")),
+				filepath.ToSlash(filepath.Join(root, "postgres", "*", "docker", "PG_VERSION")),
 			)
 			out, err := exec.Command("bash", "-c", script).CombinedOutput()
 			require.NoError(t, err, "script output: %s", out)


### PR DESCRIPTION

TestGetDBVersionFromVolumeScript failed on Windows CI. `filepath.Join()` builds paths with backslashes on Windows, and those were substituted unquoted into a bash script. In bash, an unquoted backslash outside quotes is an escape character that strips itself and merges with the next character, mangling paths like `C:\Users\testbot\...` so the `[ -f ... ]` checks silently failed.

- `pkg/ddevapp/db_internal_test.go`: wrap the paths passed into `getDBVersionFromVolumeScript` with `filepath.ToSlash()` so bash always sees forward-slash paths, regardless of host OS. `path.Join` alone would not fix this, since it only inserts `/` between elements and does not translate separators already present inside an element such as the `t.TempDir()` root.
- `pkg/ddevapp/db.go`: quote the two flat-file `[ -f ... ]`/`cat` checks in the generated script, hardening against paths containing spaces. The glob check is intentionally left unquoted since it relies on bash word-splitting/glob expansion.

`go test -v -run TestGetDBVersionFromVolumeScript ./pkg/ddevapp/` — all subtests pass.

Existing table-driven unit test in `db_internal_test.go` covers this path; no new tests needed since the failure was in the test's own path construction, not in production behavior (production callers always use hardcoded forward-slash container paths).

None - test-only fix plus a defensive quoting change to the script string with no behavior change on Linux/macOS.
