### PR TITLE
docs: sharpen CLAUDE.md guidance on Windows pitfalls and comment length, improve templates, fixes #8255 (#8702) [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,13 @@ name: 🐞 Bug report or Support Request
 description: Create a report to help us improve.
 labels: [bug]
 body:
+  - type: textarea
+    attributes:
+      label: Short summary (TL;DR)
+      description: One or two sentences describing the problem, so anyone reading can tell at a glance what this is about. Details go in the sections below.
+      placeholder: "`ddev start` fails with a port conflict after upgrading, on macOS with OrbStack."
+    validations:
+      required: true
   - type: checkboxes
     attributes:
       label: Preliminary checklist

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,19 +42,19 @@ body:
       required: false
   - type: textarea
     attributes:
-      label: Expected Behavior
-      description: What did you expect to happen?
-    validations:
-      required: true
-  - type: textarea
-    attributes:
       label: Actual Behavior
-      description: What actually happened instead?
+      description: What went wrong?
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Steps To Reproduce
+      label: Expected Behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Reproduction Steps
       description: Specific steps to reproduce the behavior.
       placeholder: |
         1. In this environment... 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,13 @@ name: 🚀 Feature request
 description: Suggest an idea for this project.
 labels: [enhancement]
 body:
+  - type: textarea
+    attributes:
+      label: Short summary (TL;DR)
+      description: One or two sentences describing what you want, so anyone reading can tell at a glance what this is about. Details go in the sections below.
+      placeholder: "Add a `ddev config --router-http-port` flag so projects can pick their own router port without editing config.yaml."
+    validations:
+      required: true
   - type: checkboxes
     attributes:
       label: Is there an existing issue for this?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,10 @@
   https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
 -->
 
+## Short Summary (TL;DR)
+
+<!-- Required. One or two sentences a reviewer can read at a glance: what this changes, and why. Write it last, but put it here first. If it needs a paragraph, the detail belongs in the sections below. -->
+
 ## The Issue
 
 - Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 <!-- 
   PR titles have very precise rules, please read 
   https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
+
+  If this is a nontrivial contribution, please create an issue for discussion first, or discuss it first in Discord, https://ddev.com/s/discord. This will save you time and help direct the feature.
 -->
 
 ## Short Summary (TL;DR)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,18 +127,61 @@ owns its file and won't be touched.
 - Focus on surgical, minimal changes that maintain compatibility
 - Tests should prefer `require` over `assert`
 
+#### Windows Compatibility
+
+The two most common ways Claude-written Go code breaks on Windows, in order
+of frequency:
+
+- **`path` vs `path/filepath`.** Use `filepath` for anything that touches the
+  host filesystem — file paths, directory listings, anything passed to
+  `os.*`. It uses the host's separator. Use `path` only for things that are
+  always forward-slash regardless of host OS: paths inside a Docker
+  container, URLs, embedded/import paths. Using `path` (or manual `"/"`
+  joins) for a host path works fine on macOS/Linux and silently produces a
+  wrong path on Windows.
+- **Line endings.** Don't assume `\n`-only line endings when parsing command
+  output, file contents, or config values — anything written or edited on
+  Windows, or produced by a Windows tool, can be CRLF. Trim `\r` explicitly
+  (`strings.Trim(s, "\r\n")`, not just `"\n"`), and don't hardcode byte/rune
+  offsets, split counts, or substring lengths that assume a fixed
+  line-ending width. `pkg/ddevapp/snapshot.go`, `pkg/ddevapp/addons.go`, and
+  `pkg/nodeps/wsl.go` have the established pattern.
+
+Neither mistake fails on the platform where the change is written and
+tested. Both fail only later, in the Windows CI job or on a Windows user's
+machine, at which point the original diff is old news and the failure looks
+unrelated. When a change builds a path or parses text with positional
+assumptions, check it against both rules before moving on — passing tests
+on macOS/Linux is not evidence it works on Windows.
+
 #### Comments
 
-Keep comments short. A comment earns its place only by saying something the code
+Keep comments short enough that a reviewer skimming the diff does not feel
+compelled to stop and parse them — that feeling is the failure mode, not a
+matter of taste. A comment earns its place only by saying something the code
 does not already say — why a directive is ordered that way, why a workaround
 exists, a non-obvious consequence.
 
 - Do not restate the code, the function name, or the config directive below it
 - Do not explain standard behavior of the language, webserver, or tooling
-- Do not write multi-paragraph rationale essays; one to three lines is usually enough
-- Do not repeat the same explanation in several files — explain it once and point
-  to that file
+- One short paragraph, one to three lines, full stop — not "usually", always.
+  No blank line inside a comment block: a second paragraph means the comment
+  is doing too much. Cut it to the one sentence that matters, or drop the
+  rest — a commit message or PR description is where extended rationale
+  belongs, not the source file
+- Do not repeat the same explanation at more than one call site, even within
+  a single file. If two functions share a reason, put it in one place (a doc
+  comment on the shared helper or constant) and let the other site rely on
+  it instead of restating it
 - Never re-describe in comments what a linked issue or commit message already covers
+- Test doc comments: the test name plus its assertions already say what is
+  being tested. Comment only what is not obvious from those — a non-obvious
+  setup step, or why the test skips under some condition
+
+Before finishing a change, reread every comment you just wrote or edited
+against these rules and cut anything that fails, the same way you'd fix a
+lint error before considering the change done — these have been ignored in
+past PRs even though they were already written down.
 
 ### English Language Usage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,41 +147,75 @@ of frequency:
   line-ending width. `pkg/ddevapp/snapshot.go`, `pkg/ddevapp/addons.go`, and
   `pkg/nodeps/wsl.go` have the established pattern.
 
-Neither mistake fails on the platform where the change is written and
-tested. Both fail only later, in the Windows CI job or on a Windows user's
-machine, at which point the original diff is old news and the failure looks
-unrelated. When a change builds a path or parses text with positional
-assumptions, check it against both rules before moving on — passing tests
-on macOS/Linux is not evidence it works on Windows.
+Neither shows up on the machine where the change is written, so when a change
+builds a host path or parses text by offset, check it against these rules
+before moving on. Passing tests on macOS/Linux is not evidence either way.
 
 #### Comments
 
-Keep comments short enough that a reviewer skimming the diff does not feel
-compelled to stop and parse them — that feeling is the failure mode, not a
-matter of taste. A comment earns its place only by saying something the code
-does not already say — why a directive is ordered that way, why a workaround
-exists, a non-obvious consequence.
+If a reviewer skimming the diff stops to parse your comment, it is too long.
+A comment earns its place only by saying something the code does not already
+say — why a directive is ordered that way, why a workaround exists, a
+non-obvious consequence.
+
+Budget: **three lines** for a comment inside a function, **eight** for a doc
+comment on an exported identifier. Past that, the comment is carrying
+rationale that belongs in the commit message or PR description.
 
 - Do not restate the code, the function name, or the config directive below it
 - Do not explain standard behavior of the language, webserver, or tooling
-- One short paragraph, one to three lines, full stop — not "usually", always.
-  No blank line inside a comment block: a second paragraph means the comment
-  is doing too much. Cut it to the one sentence that matters, or drop the
-  rest — a commit message or PR description is where extended rationale
-  belongs, not the source file
 - Do not repeat the same explanation at more than one call site, even within
   a single file. If two functions share a reason, put it in one place (a doc
-  comment on the shared helper or constant) and let the other site rely on
-  it instead of restating it
+  comment on the shared helper or constant) and let the other site point to it
 - Never re-describe in comments what a linked issue or commit message already covers
 - Test doc comments: the test name plus its assertions already say what is
   being tested. Comment only what is not obvious from those — a non-obvious
   setup step, or why the test skips under some condition
 
-Before finishing a change, reread every comment you just wrote or edited
-against these rules and cut anything that fails, the same way you'd fix a
-lint error before considering the change done — these have been ignored in
-past PRs even though they were already written down.
+Blank lines inside a doc comment are fine when it documents an API for its
+callers, and are the normal way to keep a long one readable. They are not a
+license to exceed the budget.
+
+Before finishing a change, reread every comment you wrote or edited and cut
+anything that fails these rules.
+
+##### Example
+
+Too long — three paragraphs of background where one sentence and a pointer
+would do:
+
+```go
+// RouterPortSubstitutionsLabel is the name of a Docker label set on the
+// ddev-router container recording which ephemeral host port was substituted
+// for each standard (proposed) router port, in the form "80=33000,443=33001".
+// The router binds ephemeral substitutes as <port>:<port>, so without this
+// label the container carries no trace of which standard port an ephemeral
+// port stands in for. Storing the record on the router container gives it
+// exactly the router's lifetime: it survives across ddev invocations and
+// disappears when the router is recreated or removed.
+//
+// It closes a race: when a standard port (say 80) is busy at router creation
+// time, the router is created bound to an ephemeral substitute. If the
+// original occupant of port 80 then goes away, a later project would see
+// port 80 as free and expect the router to bind it directly - a port the
+// running router does not have - forcing an unnecessary router recreation.
+// See GetAvailableRouterPort().
+```
+
+Right — what it holds, the one fact that isn't obvious, and who to read next:
+
+```go
+// RouterPortSubstitutionsLabel records which ephemeral port stands in for
+// which standard router port, as "80=33000,443=33001".
+//
+// The router binds ephemeral substitutes as <port>:<port>, so nothing else on
+// the container says that 33000 is really port 80. Used by
+// GetAvailableRouterPort() to keep a substitute after the process occupying
+// the standard port goes away.
+```
+
+The race, the reasoning, and the alternatives considered belong in the commit
+message, where they are searchable and don't age into the source file.
 
 ### English Language Usage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,11 +321,20 @@ a reviewer who will read the diff anyway:
 
 In the initial commit for a PR, use the format in  `.github/PULL_REQUEST_TEMPLATE.md` with these required sections:
 
+- **Short Summary (TL;DR):** One or two sentences, first, always
 - **The Issue:** Reference issue with `#<number>`
 - **How This PR Solves The Issue:** Technical explanation
 - **Manual Testing Instructions:** Step-by-step testing guide
 - **Automated Testing Overview:** Test coverage explanation
 - **Release/Deployment Notes:** Impact assessment
+
+The TL;DR is what a reviewer reads before deciding how closely to read the
+rest, so write it for someone who has not seen the issue. Say what changes and
+why in plain terms; skip the mechanism, which the next two sections cover. If
+it runs past two sentences, it has stopped being a summary.
+
+The same applies to issues you file: lead with a one-or-two-sentence summary,
+matching the "Short summary (TL;DR)" field in `.github/ISSUE_TEMPLATE/`.
 
 ### Creating Commits with PR Template
 
@@ -334,6 +343,10 @@ When creating the initial commit for a PR, use `git commit -F -` to read from st
 ```bash
 cat <<'EOF' | git commit -F -
 <type>: <description>
+
+## Short Summary (TL;DR)
+
+[One or two sentences: what changes and why]
 
 ## The Issue
 
@@ -369,6 +382,10 @@ When creating or editing PRs with `gh pr create` or `gh pr edit`, use the same t
 
 ```bash
 cat > ~/tmp/pr_body.md <<'EOF'
+## Short Summary (TL;DR)
+
+[One or two sentences: what changes and why]
+
 ## The Issue
 
 - Fixes #<issue_number>


### PR DESCRIPTION
## Short Summary (TL;DR)

* Improve CLAUDE.me comment length with a concrete budget and a before/after example instead of more prose 
* Add a Windows-portability section for the two mistakes that only surface in Windows CI
*  Make a short TL;DR the required first section of issues and PRs.
* Issue/PR templates reversed the order of "What went wrong" and "What was expected"

## The Issue

Prompted by [review feedback on #8653](https://github.com/ddev/ddev/pull/8653#pullrequestreview-4929999348): wall-of-text comments, and CLAUDE.md's existing comment-length rules being ignored.

- Fixes #8255

## How This PR Solves The Issue

Documentation and templates only, no code changes.

**Comments section.** The first pass tried "no blank line inside a comment block". That was wrong: it condemns roughly two dozen existing multi-paragraph comments, including the `dupStdin` doc in `pkg/dockerutil/stdin_dup.go` and the `pkg/config/state` package doc, and it contradicts Go convention for exported doc comments. The #8653 comments were bad because of length, not paragraph structure — blank lines are what makes a long doc comment skimmable. Replaced with an explicit budget: three lines for a comment inside a function, eight for a doc comment on an exported identifier.

The section also now carries a before/after example taken from the #8653 comment that prompted the review. It was previously all abstract prose, which is exactly what was already being ignored; an example is far more likely to be matched against than another rule. Dropped "these have been ignored in past PRs" and "full stop — not 'usually', always" — emphasis is not a mechanism.

**Windows Compatibility section.** `path` vs `path/filepath`, and CRLF-unaware line/offset parsing: the two recurring ways Claude-written Go breaks only in the Windows CI job, long after the change lands. Cites the established pattern in `pkg/ddevapp/snapshot.go`, `pkg/ddevapp/addons.go`, and `pkg/nodeps/wsl.go`.

**TL;DR first.** `.github/PULL_REQUEST_TEMPLATE.md` gains a "Short Summary (TL;DR)" section ahead of "The Issue"; both issue templates gain a required "Short summary (TL;DR)" textarea as their first body element. CLAUDE.md lists it among the required PR sections and includes it in both worked examples, so generated PRs carry it. This helps human readers and gives Claude a slot it has to fill rather than burying the point in five sections of detail.

## Manual Testing Instructions

Read the diff. `markdownlint CLAUDE.md .github/PULL_REQUEST_TEMPLATE.md` passes, and both issue-template YAML files parse with the new field first and `required: true`:

```bash
for f in .github/ISSUE_TEMPLATE/*.yml; do yq -r '.body[0].attributes.label' "$f"; done
```

The real test is the next Claude-authored PR — whether the comment budget and the TL;DR slot survive contact.

