### PR TITLE
feat(snapshot): support uncompressed mariabackup/xtrabackup snapshots and seeds

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -411,6 +411,7 @@ goland
 golang
 gsudo
 gz
+gzip
 gzipped
 h
 harm
@@ -716,6 +717,7 @@ tlsverify
 tmp
 to
 toc
+tradeoff
 trainings
 transactional
 true
@@ -798,4 +800,5 @@ zip
 zscaler
 zsh
 zshrc
+zstd
 zxf

--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -20,6 +20,7 @@ var snapshotCleanup bool
 var snapshotList bool
 var snapshotName string
 var snapshotRestoreLatest bool
+var snapshotUncompressed bool
 
 // noConfirm: If true, --yes, we won't stop and prompt before each deletion
 var snapshotCleanupNoConfirm bool
@@ -36,7 +37,8 @@ ddev snapshot --cleanup
 ddev snapshot --cleanup --name my_snapshot_name
 ddev snapshot --cleanup -y
 ddev snapshot --list
-ddev snapshot --all`,
+ddev snapshot --all
+ddev snapshot --uncompressed`,
 	Run: func(_ *cobra.Command, args []string) {
 		apps, err := getRequestedProjects(args, snapshotAll)
 		if err != nil {
@@ -72,7 +74,7 @@ func listSnapshots(apps []*ddevapp.DdevApp) {
 	if len(apps) > 1 {
 		columns = append(columns, "Project")
 	}
-	columns = append(columns, "Snapshot", "Created", "Size", "DB Version")
+	columns = append(columns, "Snapshot", "Created", "Size", "DB Version", "Compression")
 
 	if !globalconfig.DdevGlobalConfig.SimpleFormatting {
 		var colConfig []table.ColumnConfig
@@ -94,16 +96,16 @@ func listSnapshots(apps []*ddevapp.DdevApp) {
 			if len(snapshots) > 0 {
 				for _, snapshot := range snapshots {
 					if len(apps) > 1 {
-						t.AppendRow(table.Row{app.GetName(), snapshot.Name, snapshot.Created.Format("2006-01-02"), util.FormatBytes(snapshot.Size), snapshot.DBVersion})
+						t.AppendRow(table.Row{app.GetName(), snapshot.Name, snapshot.Created.Format("2006-01-02"), util.FormatBytes(snapshot.Size), snapshot.DBVersion, snapshot.Compression})
 					} else {
-						t.AppendRow(table.Row{snapshot.Name, snapshot.Created.Format("2006-01-02"), util.FormatBytes(snapshot.Size), snapshot.DBVersion})
+						t.AppendRow(table.Row{snapshot.Name, snapshot.Created.Format("2006-01-02"), util.FormatBytes(snapshot.Size), snapshot.DBVersion, snapshot.Compression})
 					}
 				}
 			} else {
 				if len(apps) > 1 {
-					t.AppendRow(table.Row{app.GetName(), text.Italic.Sprint("No snapshots"), "", "", ""})
+					t.AppendRow(table.Row{app.GetName(), text.Italic.Sprint("No snapshots"), "", "", "", ""})
 				} else {
-					t.AppendRow(table.Row{text.Italic.Sprint("No snapshots"), "", "", ""})
+					t.AppendRow(table.Row{text.Italic.Sprint("No snapshots"), "", "", "", ""})
 				}
 			}
 		}
@@ -131,7 +133,7 @@ func createAppSnapshot(app *ddevapp.DdevApp) {
 	}
 	// If there is an error from Snapshot, show a warning message
 	// allow the command to continue, there may be other snapshots needed
-	if snapshotNameOutput, err := app.Snapshot(snapshotName); err != nil {
+	if snapshotNameOutput, err := app.Snapshot(snapshotName, snapshotUncompressed); err != nil {
 		errorMsg := util.ColorizeText("Failed to snapshot %s: %v", "red")
 		util.Warning(errorMsg, app.GetName(), err)
 	} else {
@@ -189,5 +191,6 @@ func init() {
 	DdevSnapshotCommand.Flags().BoolVarP(&snapshotCleanup, "cleanup", "C", false, "Cleanup snapshots")
 	DdevSnapshotCommand.Flags().BoolVarP(&snapshotCleanupNoConfirm, "yes", "y", false, "Yes - skip confirmation prompt")
 	DdevSnapshotCommand.Flags().StringVarP(&snapshotName, "name", "n", "", "provide a name for the snapshot")
+	DdevSnapshotCommand.Flags().BoolVar(&snapshotUncompressed, "uncompressed", false, "Write the snapshot as an uncompressed mariabackup/xtrabackup stream instead of compressing it. This skips decompression on restore, but the file can be roughly as large as the database's datadir, many times bigger than a compressed snapshot. Not available for PostgreSQL projects.")
 	RootCmd.AddCommand(DdevSnapshotCommand)
 }

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -131,7 +131,11 @@ RUN if ! id mysql &>/dev/null ; then useradd -u 112 mysql; fi
 # Install MySQL compatibility wrappers for MariaDB 11.x+ (needed by create_base_db.sh and at runtime)
 RUN /mariadb-compat-install.sh
 
-# Build a starter base db
+# Build a starter base db. BASE_DB_UNCOMPRESSED=true bakes in an uncompressed
+# base_db instead, for a from-source build trading image size for zero
+# first-boot decompression cost - see https://github.com/ddev/ddev/issues/8665.
+ARG BASE_DB_UNCOMPRESSED=false
+ENV BASE_DB_UNCOMPRESSED=${BASE_DB_UNCOMPRESSED}
 RUN /create_base_db.sh
 
 RUN chmod ugo+x /healthcheck.sh

--- a/containers/ddev-dbserver/files/create_base_db.sh
+++ b/containers/ddev-dbserver/files/create_base_db.sh
@@ -112,7 +112,12 @@ server_db_version=$(awk -F- '{ sub( /\.[0-9]+(-.*)?$/, "", $1); server_type="mys
 echo ${server_db_version} >${DATADIR:-/var/lib/mysql}/db_mariadb_version.txt
 # Prefer zstd (parallel decompression, smaller archive); fall back to gzip
 # for base images that lack zstd (e.g. MariaDB 5.5 on Ubuntu 14.04).
-if command -v zstdmt >/dev/null 2>&1 || command -v zstd >/dev/null 2>&1; then
+# BASE_DB_UNCOMPRESSED=true skips compression entirely and writes the raw
+# backup-tool stream instead, trading a larger base_db for zero first-boot
+# decompression cost - see https://github.com/ddev/ddev/issues/8665.
+if [ "${BASE_DB_UNCOMPRESSED:-false}" = "true" ]; then
+  ${backuptool} --backup --stream=${streamtool} --user=root --password=root --socket=${MYSQL_UNIX_PORT} >${OUTDIR}/base_db.${streamtool}
+elif command -v zstdmt >/dev/null 2>&1 || command -v zstd >/dev/null 2>&1; then
   ${backuptool} --backup --stream=${streamtool} --user=root --password=root --socket=${MYSQL_UNIX_PORT} | "$(command -v zstdmt 2>/dev/null || echo zstd)" --quiet >${OUTDIR}/base_db.zst
 else
   ${backuptool} --backup --stream=${streamtool} --user=root --password=root --socket=${MYSQL_UNIX_PORT} | gzip >${OUTDIR}/base_db.gz

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -60,6 +60,10 @@ if [ $# = "2" ] && [ "${1:-}" = "restore_snapshot" ] ; then
       gz)
         gunzip -c "${snapshot}" | ${STREAMTOOL} -x
         ;;
+      mbstream|xbstream)
+        # Uncompressed raw backup-tool stream, no decompressor needed.
+        ${STREAMTOOL} -x < "${snapshot}"
+        ;;
       *)
         echo "Unknown snapshot compression: .$ext"
         exit 101
@@ -145,7 +149,9 @@ fi
 #   2. /mysqlbase/custom/base_db.*                          - baked into a derived image
 #   3. /mysqlbase/base_db.*                                 - the stock DDEV starter database
 # At each location, a .zst seed is preferred over .gz; .gz only exists at all
-# for db versions (e.g. MariaDB 5.5) whose base image lacks zstd.
+# for db versions (e.g. MariaDB 5.5) whose base image lacks zstd. .mbstream/
+# .xbstream are uncompressed raw backup-tool streams, checked last so an
+# existing compressed seed still wins if one happens to also be present.
 if [ ! -f "${DATADIR}/db_mariadb_version.txt" ]; then
     # If snapshot_dir is not set, this is a normal startup, so
     # tell healthcheck to wait by touching /tmp/initializing
@@ -160,10 +166,16 @@ if [ ! -f "${DATADIR}/db_mariadb_version.txt" ]; then
       for candidate in \
         "/mnt/snapshots/initializer-${server_db_version}.zst" \
         "/mnt/snapshots/initializer-${server_db_version}.gz" \
+        "/mnt/snapshots/initializer-${server_db_version}.mbstream" \
+        "/mnt/snapshots/initializer-${server_db_version}.xbstream" \
         "/mysqlbase/custom/base_db.zst" \
         "/mysqlbase/custom/base_db.gz" \
+        "/mysqlbase/custom/base_db.mbstream" \
+        "/mysqlbase/custom/base_db.xbstream" \
         "/mysqlbase/base_db.zst" \
         "/mysqlbase/base_db.gz" \
+        "/mysqlbase/base_db.mbstream" \
+        "/mysqlbase/base_db.xbstream" \
       ; do
         if [ -f "${candidate}" ]; then
           snapshot="${candidate}"
@@ -181,6 +193,10 @@ if [ ! -f "${DATADIR}/db_mariadb_version.txt" ]; then
           ;;
         *.gz)
           gunzip -c "${snapshot}" | ${STREAMTOOL} -x
+          ;;
+        *.mbstream|*.xbstream)
+          # Uncompressed raw backup-tool stream, no decompressor needed.
+          ${STREAMTOOL} -x < "${snapshot}"
           ;;
       esac
     fi

--- a/containers/ddev-dbserver/test/base_db_seed.bats
+++ b/containers/ddev-dbserver/test/base_db_seed.bats
@@ -10,7 +10,9 @@
 #   2. /mysqlbase/custom/base_db.*                          - baked into a derived image
 #   3. /mysqlbase/base_db.*                                 - the stock DDEV starter database
 # A .zst seed is preferred over .gz at each location; .gz is exercised too,
-# since db versions without zstd (e.g. MariaDB 5.5) still produce it.
+# since db versions without zstd (e.g. MariaDB 5.5) still produce it. An
+# uncompressed .mbstream/.xbstream seed (the raw backup-tool stream, no
+# compression stage) is exercised too.
 
 load functions.sh
 
@@ -41,18 +43,30 @@ function setup_file {
     export SEED_COMPRESS="gzip"
   fi
 
+  # Matches the extension docker-entrypoint.sh's own BACKUPTOOL/STREAMTOOL
+  # detection produces for an uncompressed seed on this image.
+  if docker run --rm --entrypoint bash "${IMAGE}" -c 'command -v xtrabackup' >/dev/null 2>&1; then
+    export STREAM_EXT="xbstream"
+  else
+    export STREAM_EXT="mbstream"
+  fi
+
   # Matches the server_db_version computed by docker-entrypoint.sh, e.g. mariadb_11.8
   export INITIALIZER_NAME="initializer-${DB_TYPE}_${DB_VERSION}.${SEED_EXT}"
+  export UNCOMPRESSED_INITIALIZER_NAME="initializer-${DB_TYPE}_${DB_VERSION}.${STREAM_EXT}"
 
-  make_seed "marker_seed_a" "${SEED_DIR}/seed_a.${SEED_EXT}"
-  make_seed "marker_seed_b" "${SEED_DIR}/seed_b.${SEED_EXT}"
+  make_seed "marker_seed_a" "${SEED_DIR}/seed_a.${SEED_EXT}" "${SEED_COMPRESS}"
+  make_seed "marker_seed_b" "${SEED_DIR}/seed_b.${SEED_EXT}" "${SEED_COMPRESS}"
+  make_seed "marker_seed_c" "${SEED_DIR}/seed_c.${STREAM_EXT}" ""
 }
 
 # Build a base_db seed containing a single marker table, using the same
 # backup tool (mariabackup/xtrabackup via xbstream) the entrypoint expects.
+# An empty compress_cmd writes the raw, uncompressed backup-tool stream.
 function make_seed {
   local marker_table=$1
   local outfile=$2
+  local compress_cmd=$3
   local name="seedbuilder-$$-${RANDOM}"
   local vol="seedbuilder-vol-$$-${RANDOM}"
 
@@ -72,10 +86,14 @@ function make_seed {
   docker exec "${name}" mysql -udb -pdb --database=db -e "CREATE TABLE ${marker_table} (id INT);"
   # mariabackup/mbstream on MariaDB, xtrabackup/xbstream on MySQL (and some
   # older MariaDB) -- same detection docker-entrypoint.sh itself uses.
+  local pipe_to_compressor=""
+  if [ -n "${compress_cmd}" ]; then
+    pipe_to_compressor="| ${compress_cmd}"
+  fi
   docker exec "${name}" bash -c "
     backuptool=mariabackup; streamtool=mbstream
     if command -v xtrabackup >/dev/null 2>&1; then backuptool=xtrabackup; streamtool=xbstream; fi
-    \${backuptool} --backup --stream=\${streamtool} --user=root --password=root --socket=/var/tmp/mysql.sock 2>/tmp/seed.log | ${SEED_COMPRESS}
+    \${backuptool} --backup --stream=\${streamtool} --user=root --password=root --socket=/var/tmp/mysql.sock 2>/tmp/seed.log ${pipe_to_compressor}
   " >"${outfile}"
 
   docker rm -f "${name}" >/dev/null
@@ -103,6 +121,17 @@ function setup {
   [[ "$output" == *"snapshot=/mnt/snapshots/${INITIALIZER_NAME}"* ]]
   run mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
   [[ "$output" == *"marker_seed_a"* ]]
+}
+
+@test "uncompressed initializer seed overrides the stock seed for ${DB_TYPE} ${DB_VERSION}" {
+  docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy \
+    -v "${SEED_DIR}/seed_c.${STREAM_EXT}:/mnt/snapshots/${UNCOMPRESSED_INITIALIZER_NAME}:ro" \
+    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
+  containercheck
+  run docker logs $CONTAINER_NAME
+  [[ "$output" == *"snapshot=/mnt/snapshots/${UNCOMPRESSED_INITIALIZER_NAME}"* ]]
+  run mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
+  [[ "$output" == *"marker_seed_c"* ]]
 }
 
 @test "derived-image custom base_db seed overrides the stock seed for ${DB_TYPE} ${DB_VERSION}" {

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -267,6 +267,8 @@ COPY base_db.zst /mysqlbase/custom/base_db.zst
 
 The database container uses this seed the first time its data volume is created (a brand-new project, or after `ddev delete` and `ddev start`), instead of the stock DDEV starter database. It's checked ahead of the stock seed but _after_ any project-level [`initializer` snapshot](../usage/database-management.md#snapshots) — so a teammate can still override your baked-in seed for their own project just by dropping an `initializer` snapshot into `.ddev/db_snapshots`, without rebuilding the image.
 
+A seed can also be baked in uncompressed, as `base_db.mbstream` (MariaDB) or `base_db.xbstream` (MySQL, or MariaDB 5.5/10.0) — the raw `mariabackup`/`xtrabackup` stream with no compression stage. This is an unusual, deliberate tradeoff (see [Uncompressed Snapshots](../usage/database-management.md#uncompressed-snapshots)): it trades a much larger image layer for zero first-boot decompression cost, and only makes sense if you've already decided that tradeoff is worth it.
+
 When `ddev start` seeds a fresh database volume from a baked-in seed, it says so and warns that a large one may take a while:
 
 ```

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1342,7 +1342,10 @@ Flags:
 * `--cleanup`, `-C`: Cleanup snapshots.
 * `--list`, `-l`: List snapshots.
 * `--name`, `-n`: Provide a name for the snapshot.
+* `--uncompressed`: Write the snapshot as an uncompressed mariabackup/xtrabackup stream instead of compressing it. This skips decompression on restore, but the file can be roughly as large as the database's datadir, many times bigger than a compressed snapshot. Not available for PostgreSQL projects. See [Snapshots](../usage/database-management.md#snapshots) for when this unusual tradeoff makes sense.
 * `--yes`, `-y`: Skip confirmation prompt.
+
+`ddev snapshot --list` also shows each snapshot's compression: `zstd`, `gzip`, or `none` for an uncompressed snapshot.
 
 Example:
 
@@ -1367,6 +1370,9 @@ ddev snapshot --list
 
 # Take a snapshot for each project
 ddev snapshot --all
+
+# Take an uncompressed snapshot, trading disk space for a faster restore
+ddev snapshot --uncompressed
 ```
 
 ### `snapshot restore`

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -49,7 +49,19 @@ Snapshots can be named for easier reference later on. For example, [`ddev snapsh
 
 Use the [`ddev snapshot restore`](../usage/commands.md#snapshot-restore) command to interactively choose among snapshots, or append `--latest` to restore the most recent snapshot: `ddev snapshot restore --latest`.
 
-Snapshots are stored as simple gzipped files in the project's `.ddev/db_snapshots` directory, and any or all snapshots can be removed with the `ddev snapshot --cleanup` command or by manually deleting the files when you want to save disk space or have no further use for them.
+Snapshots are stored as compressed (zstd, or gzip on very old database versions) files in the project's `.ddev/db_snapshots` directory, and any or all snapshots can be removed with the `ddev snapshot --cleanup` command or by manually deleting the files when you want to save disk space or have no further use for them.
+
+### Uncompressed Snapshots
+
+`ddev snapshot`, `ddev snapshot restore`, and the `initializer` seed all compress the database backup by default, which is the right tradeoff for almost everyone. Decompression still costs real time, though — routinely 30-40% of a restore or first `ddev start`, and it competes for the same CPU cores the database restore itself needs right after. `--uncompressed` skips it:
+
+```bash
+ddev snapshot --uncompressed
+```
+
+This is an unusual, deliberate tradeoff, not a general recommendation: an uncompressed snapshot can be roughly as large as the database's uncompressed datadir — many times bigger than the same snapshot compressed with zstd. It's worth it mainly when disk space is cheap relative to CPU time, for example a low-core-count host, or a seed that's read straight off fast local disk and never crosses a network (so compression buys nothing on the transfer side either). `ddev snapshot --list` shows each snapshot's compression (`zstd`, `gzip`, or `none`) so you can tell which kind you're looking at. Restoring an uncompressed snapshot with `ddev snapshot restore` needs no extra flag — the file's extension (`.mbstream`/`.xbstream` instead of `.zst`/`.gz`) already tells DDEV there's nothing to decompress. Not available for PostgreSQL projects.
+
+An `initializer` snapshot honors the same flag, and a `dbimage` built with a baked-in seed (see [Seeding a Custom Starter Database](../extend/customizing-images.md#seeding-a-custom-starter-database-in-dbimage)) can use an uncompressed seed the same way.
 
 ### Seeding a Fresh Database with an `initializer` Snapshot
 

--- a/pkg/ddevapp/base_db_seed.go
+++ b/pkg/ddevapp/base_db_seed.go
@@ -27,8 +27,10 @@ const InitializerSnapshotName = "initializer"
 const CustomBaseDBSeedPathPrefix = "/mysqlbase/custom/base_db"
 
 // baseDBSeedExtensions lists the base_db seed compression suffixes in the same
-// preference order that ddev-dbserver's docker-entrypoint.sh uses.
-var baseDBSeedExtensions = []string{"zst", "gz"}
+// preference order that ddev-dbserver's docker-entrypoint.sh uses: the
+// compressed formats first, then the uncompressed raw stream formats
+// (mbstream from mariabackup, xbstream from xtrabackup).
+var baseDBSeedExtensions = []string{"zst", "gz", "mbstream", "xbstream"}
 
 // UsesBaseDBSeed reports whether this project's database volume gets initialized
 // from a base_db seed. Only MariaDB/MySQL do; PostgreSQL uses the upstream

--- a/pkg/ddevapp/base_db_seed_test.go
+++ b/pkg/ddevapp/base_db_seed_test.go
@@ -52,6 +52,16 @@ func TestGetInitializerSnapshotFile(t *testing.T) {
 	zst := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "initializer-mariadb_10.11.zst"), "seed")
 	require.Equal(t, zst, app.GetInitializerSnapshotFile())
 
+	// An uncompressed .mbstream seed is recognized, but a compressed seed
+	// still wins if one is also present.
+	writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "initializer-mariadb_10.11.mbstream"), "seed")
+	require.Equal(t, zst, app.GetInitializerSnapshotFile())
+
+	// With no compressed seed, the uncompressed one is used.
+	uncompressed := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
+	mbstream := writeBaseDBSeedTestFile(t, uncompressed, filepath.Join("db_snapshots", "initializer-mariadb_10.11.mbstream"), "seed")
+	require.Equal(t, mbstream, uncompressed.GetInitializerSnapshotFile())
+
 	// A snapshot for a different db version is not this project's initializer.
 	other := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB106)
 	writeBaseDBSeedTestFile(t, other, filepath.Join("db_snapshots", "initializer-mariadb_10.11.zst"), "seed")

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -2079,7 +2079,7 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 		require.NotEqual(t, container.InspectResponse{}, c)
 		expectedWaitTime, _ := strconv.Atoi(maxWaitTime)
 		require.Equal(t, expectedWaitTime, int(c.Config.Healthcheck.StartPeriod.Seconds()), "db container healthcheck should have been %v with default_container_timeout set to %v", maxWaitTime, app.DefaultContainerTimeout)
-		_, err = app.Snapshot(t.Name() + maxWaitTime)
+		_, err = app.Snapshot(t.Name()+maxWaitTime, false)
 		require.NoError(t, err)
 		err = app.RestoreSnapshot(t.Name() + maxWaitTime)
 		require.NoError(t, err)

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -3182,8 +3182,12 @@ func (app *DdevApp) DetermineSettingsPathLocation() (string, error) {
 
 // Snapshot causes a snapshot of the db to be written into the snapshots volume
 // Returns the name of the snapshot and err
-func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
+func (app *DdevApp) Snapshot(snapshotName string, uncompressed bool) (string, error) {
 	containerSnapshotDirBase := "/var/tmp"
+
+	if uncompressed && app.Database.Type == nodeps.Postgres {
+		return "", fmt.Errorf("uncompressed snapshots are not supported for PostgreSQL projects")
+	}
 
 	err := app.ProcessHooks("pre-snapshot")
 	if err != nil {
@@ -3200,8 +3204,15 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 	}
 
 	suffix := ".zst"
+	switch {
+	// An uncompressed snapshot is stored as the raw mariabackup/xtrabackup
+	// stream, named for the stream format that produced it.
+	case uncompressed && app.usesXtrabackup():
+		suffix = ".xbstream"
+	case uncompressed:
+		suffix = ".mbstream"
 	// MariaDB 5.5 is based on Ubuntu 14.04 which lacks zstd support
-	if app.Database.Type == nodeps.MariaDB && app.Database.Version == nodeps.MariaDB55 {
+	case app.Database.Type == nodeps.MariaDB && app.Database.Version == nodeps.MariaDB55:
 		suffix = ".gz"
 	}
 	snapshotFile := snapshotName + "-" + app.Database.Type + "_" + app.Database.Version + suffix
@@ -3226,7 +3237,7 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 
 	util.Success("Creating database snapshot %s", snapshotName)
 
-	c := getBackupCommand(app, path.Join(containerSnapshotDir, snapshotFile))
+	c := getBackupCommand(app, path.Join(containerSnapshotDir, snapshotFile), uncompressed)
 	stdout, stderr, err := app.Exec(&ExecOpts{
 		Service: "db",
 		Cmd:     fmt.Sprintf(`set -eu -o pipefail; %s `, c),
@@ -3275,20 +3286,32 @@ func (app *DdevApp) Snapshot(snapshotName string) (string, error) {
 	return snapshotName, nil
 }
 
+// oldMariaVersions are MariaDB versions that predate mariabackup, so they use
+// xtrabackup instead, the same as MySQL.
+var oldMariaVersions = []string{"5.5", "10.0"}
+
+// usesXtrabackup reports whether Snapshot()/getBackupCommand() will invoke
+// xtrabackup (MySQL, or ancient MariaDB predating mariabackup) rather than
+// mariabackup.
+func (app *DdevApp) usesXtrabackup() bool {
+	return app.Database.Type == nodeps.MySQL ||
+		(app.Database.Type == nodeps.MariaDB && nodeps.ArrayContainsString(oldMariaVersions, app.Database.Version))
+}
+
 // getBackupCommand returns the command to dump the entire db system for the various databases
-func getBackupCommand(app *DdevApp, targetFile string) string {
+func getBackupCommand(app *DdevApp, targetFile string, uncompressed bool) string {
 	compressionCommand := app.GetDBCompressionCommand()
+	redirect := fmt.Sprintf(`| %[1]s > "%[2]s"`, compressionCommand, targetFile)
+	if uncompressed {
+		redirect = fmt.Sprintf(`> "%s"`, targetFile)
+	}
 
-	c := fmt.Sprintf(`mariabackup --backup --stream=mbstream --user=root --password=root --socket=/var/tmp/mysql.sock 2>/tmp/snapshot_%[1]s.log | %[2]s > "%[3]s"`, path.Base(targetFile), compressionCommand, targetFile)
-
-	oldMariaVersions := []string{"5.5", "10.0"}
+	c := fmt.Sprintf(`mariabackup --backup --stream=mbstream --user=root --password=root --socket=/var/tmp/mysql.sock 2>/tmp/snapshot_%[1]s.log %[2]s`, path.Base(targetFile), redirect)
 
 	switch {
 	// Old MariaDB versions don't have mariabackup, use xtrabackup for them as well as MySQL
-	case app.Database.Type == nodeps.MariaDB && nodeps.ArrayContainsString(oldMariaVersions, app.Database.Version):
-		fallthrough
-	case app.Database.Type == nodeps.MySQL:
-		c = fmt.Sprintf(`xtrabackup --backup --stream=xbstream --user=root --password=root --socket=/var/tmp/mysql.sock 2>/tmp/snapshot_%[1]s.log | %[2]s > "%[3]s"`, path.Base(targetFile), compressionCommand, targetFile)
+	case app.usesXtrabackup():
+		c = fmt.Sprintf(`xtrabackup --backup --stream=xbstream --user=root --password=root --socket=/var/tmp/mysql.sock 2>/tmp/snapshot_%[1]s.log %[2]s`, path.Base(targetFile), redirect)
 	case app.Database.Type == nodeps.Postgres:
 		postgresDataPath := app.GetPostgresDataPath()
 		postgresDataDir := app.GetPostgresDataDir()
@@ -3364,7 +3387,7 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 			}
 		}
 		t := time.Now()
-		_, err = app.Snapshot(app.Name + "_remove_data_snapshot_" + t.Format("20060102150405"))
+		_, err = app.Snapshot(app.Name+"_remove_data_snapshot_"+t.Format("20060102150405"), false)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1875,7 +1875,7 @@ func TestDdevAllDatabases(t *testing.T) {
 		}
 
 		snapshotName := dbType + "_" + dbVersion + "_" + fileutil.RandomFilenameBase()
-		fullSnapshotName, err := app.Snapshot(snapshotName)
+		fullSnapshotName, err := app.Snapshot(snapshotName, false)
 		if err != nil {
 			dumpDir := fmt.Sprintf("~/%s-broken-%s", t.Name(), util.RandString(5))
 			_, _ = exec.RunHostCommand(`bash`, `-c`, fmt.Sprintf("cp -r %s %s", app.AppRoot, dumpDir))
@@ -1967,7 +1967,7 @@ func TestDdevAllDatabases(t *testing.T) {
 			// Snapshotting it as "initializer" and then wiping the db volume and
 			// restarting should restore this same data automatically, ahead of the
 			// normal empty starter database.
-			_, err = app.Snapshot("initializer")
+			_, err = app.Snapshot("initializer", false)
 			require.NoError(t, err, "could not create initializer snapshot for %s", dbTypeVersion)
 
 			err = app.Stop(true, false)

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -21,10 +21,43 @@ import (
 )
 
 type Snapshot struct {
-	Name      string
-	Created   time.Time
-	Size      int64
-	DBVersion string
+	Name        string
+	Created     time.Time
+	Size        int64
+	DBVersion   string
+	Compression string
+}
+
+// snapshotExtensions lists recognized snapshot file suffixes: the compressed
+// formats (zst, gz) followed by the uncompressed raw stream formats
+// (mbstream from mariabackup, xbstream from xtrabackup).
+var snapshotExtensions = []string{"zst", "gz", "mbstream", "xbstream"}
+
+// snapshotExtensionPattern is the `(zst|gz|mbstream|xbstream)`-style
+// alternation used to recognize a snapshot filename's extension.
+var snapshotExtensionPattern = "(" + strings.Join(snapshotExtensions, "|") + ")"
+
+// hasSnapshotExtension reports whether name ends in one of snapshotExtensions.
+func hasSnapshotExtension(name string) bool {
+	for _, ext := range snapshotExtensions {
+		if strings.HasSuffix(name, "."+ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// snapshotCompressionLabel returns the human-readable compression type for a
+// snapshot file extension, for display in `ddev snapshot --list`.
+func snapshotCompressionLabel(ext string) string {
+	switch ext {
+	case "zst":
+		return "zstd"
+	case "gz":
+		return "gzip"
+	default:
+		return "none"
+	}
 }
 
 // SnapshotRestoreDefaultWaitTime is the max time we'll wait for snapshot restore.
@@ -128,14 +161,16 @@ func (app *DdevApp) ListSnapshots() ([]Snapshot, error) {
 		return files[i].ModTime().After(files[j].ModTime())
 	})
 
-	// Match snapshot files created with gzip (.gz) or zstd (.zst)
-	m := regexp.MustCompile(`-(mariadb|mysql|postgres)_([0-9.]*)\.(gz|zst)$`)
+	// Match snapshot files, capturing the DB type/version and the extension
+	// that identifies the compression (or lack of it).
+	m := regexp.MustCompile(`-(mariadb|mysql|postgres)_([0-9.]*)\.` + snapshotExtensionPattern + `$`)
 
 	for _, f := range files {
-		if f.IsDir() || strings.HasSuffix(f.Name(), ".gz") || strings.HasSuffix(f.Name(), ".zst") {
+		if f.IsDir() || hasSnapshotExtension(f.Name()) {
 			n := m.ReplaceAll([]byte(f.Name()), []byte(""))
 			size := f.Size()
 			dbVersion := "unknown"
+			compression := "none"
 			if f.IsDir() {
 				var err error
 				size, err = fileutil.DirSize(filepath.Join(snapshotDir, f.Name()))
@@ -150,14 +185,16 @@ func (app *DdevApp) ListSnapshots() ([]Snapshot, error) {
 						}
 					}
 				}
-			} else if matches := m.FindStringSubmatch(f.Name()); len(matches) > 2 {
+			} else if matches := m.FindStringSubmatch(f.Name()); len(matches) > 3 {
 				dbVersion = matches[1] + "_" + matches[2]
+				compression = snapshotCompressionLabel(matches[3])
 			}
 			snapshot := Snapshot{
-				Name:      string(n),
-				Created:   f.ModTime(),
-				Size:      size,
-				DBVersion: dbVersion,
+				Name:        string(n),
+				Created:     f.ModTime(),
+				Size:        size,
+				DBVersion:   dbVersion,
+				Compression: compression,
 			}
 			snapshots = append(snapshots, snapshot)
 		}
@@ -207,8 +244,8 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 			snapshotDBVersion = "unknown"
 		}
 	} else {
-		// Extract the DB type/version from the filename, supporting both .gz and .zst
-		m1 := regexp.MustCompile(`((mysql|mariadb|postgres)_[0-9.]+)\.(gz|zst)$`)
+		// Extract the DB type/version from the filename
+		m1 := regexp.MustCompile(`((mysql|mariadb|postgres)_[0-9.]+)\.` + snapshotExtensionPattern + `$`)
 		matches := m1.FindStringSubmatch(snapshotFile)
 		if len(matches) > 2 {
 			snapshotDBVersion = matches[1]
@@ -359,7 +396,7 @@ func GetSnapshotFileFromName(name string, app *DdevApp) (string, error) {
 		return "", err
 	}
 
-	m := regexp.MustCompile("^" + regexp.QuoteMeta(name) + `-(mariadb|mysql|postgres)_[0-9.]*\.(gz|zst)$`)
+	m := regexp.MustCompile("^" + regexp.QuoteMeta(name) + `-(mariadb|mysql|postgres)_[0-9.]*\.` + snapshotExtensionPattern + `$`)
 
 	for _, file := range files {
 		if m.MatchString(file) {

--- a/pkg/ddevapp/snapshot_test.go
+++ b/pkg/ddevapp/snapshot_test.go
@@ -42,11 +42,11 @@ func TestDdevSnapshotCleanup(t *testing.T) {
 	assert.NoError(err)
 
 	// Make a snapshot of d7 tester test 1
-	snapshotName, err := app.Snapshot(t.Name() + "_1")
+	snapshotName, err := app.Snapshot(t.Name()+"_1", false)
 	assert.NoError(err)
 
 	// Provide a second snapshot that should not be deleted and whose filename will be lexicographically earlier (See https://github.com/ddev/ddev/issues/6694).
-	_, err = app.Snapshot(t.Name() + "_1-a")
+	_, err = app.Snapshot(t.Name()+"_1-a", false)
 	assert.NoError(err)
 
 	err = app.Init(site.Dir)
@@ -93,11 +93,11 @@ func TestGetLatestSnapshot(t *testing.T) {
 
 	snapshots := []string{t.Name() + "_1", t.Name() + "_2", t.Name() + "_3"}
 	// Make three snapshots and compare the last
-	s1Name, err := app.Snapshot(snapshots[0])
+	s1Name, err := app.Snapshot(snapshots[0], false)
 	assert.NoError(err)
-	s2Name, err := app.Snapshot(snapshots[1])
+	s2Name, err := app.Snapshot(snapshots[1], false)
 	assert.NoError(err)
-	s3Name, err := app.Snapshot(snapshots[2]) // last = latest
+	s3Name, err := app.Snapshot(snapshots[2], false) // last = latest
 	assert.NoError(err)
 
 	// Verify the snapshot files exist and have .zst extension
@@ -149,6 +149,77 @@ func TestGetLatestSnapshot(t *testing.T) {
 	assert.NoError(err)
 	latestSnapshot, _ = app.GetLatestSnapshot()
 	assert.Equal("", latestSnapshot)
+
+	runTime()
+}
+
+// TestSnapshotUncompressedPostgresError verifies that --uncompressed is
+// rejected for PostgreSQL projects: only mariabackup/xtrabackup produce a raw
+// stream that can be stored uncompressed, and Postgres snapshots use
+// pg_basebackup/tar instead.
+func TestSnapshotUncompressedPostgresError(t *testing.T) {
+	app := &ddevapp.DdevApp{}
+	app.Database.Type = nodeps.Postgres
+	app.Database.Version = nodeps.PostgresDefaultVersion
+	_, err := app.Snapshot("irrelevant", true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not supported for PostgreSQL")
+}
+
+// TestSnapshotUncompressed tests that app.Snapshot(name, true) writes an
+// uncompressed mariabackup/xtrabackup stream (.mbstream/.xbstream), that
+// ListSnapshots() reports its compression as "none", and that it restores
+// correctly.
+func TestSnapshotUncompressed(t *testing.T) {
+	// Don't run this unless GOTEST_SHORT is unset; it doesn't need to be run everywhere.
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skip because GOTEST_SHORT is set")
+	}
+
+	assert := assert2.New(t)
+	app := &ddevapp.DdevApp{}
+	site := TestSites[0]
+	origDir, _ := os.Getwd()
+	err := os.Chdir(site.Dir)
+	assert.NoError(err)
+
+	runTime := util.TimeTrackC(t.Name())
+
+	testcommon.ClearDockerEnv()
+	err = app.Init(site.Dir)
+	assert.NoError(err)
+
+	t.Cleanup(func() {
+		err = app.Stop(true, false)
+		assert.NoError(err)
+		_ = os.RemoveAll(app.GetConfigPath("db_snapshots"))
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+	})
+
+	err = app.Start()
+	require.NoError(t, err)
+
+	snapshotName, err := app.Snapshot(t.Name(), true)
+	require.NoError(t, err)
+
+	snapshotFile, err := ddevapp.GetSnapshotFileFromName(snapshotName, app)
+	require.NoError(t, err)
+	assert.True(strings.HasSuffix(snapshotFile, ".mbstream") || strings.HasSuffix(snapshotFile, ".xbstream"), "expected an uncompressed snapshot extension, got %s", snapshotFile)
+
+	snapshots, err := app.ListSnapshots()
+	require.NoError(t, err)
+	found := false
+	for _, s := range snapshots {
+		if s.Name == snapshotName {
+			found = true
+			assert.Equal("none", s.Compression)
+		}
+	}
+	assert.True(found, "expected to find snapshot %s in ListSnapshots()", snapshotName)
+
+	err = app.RestoreSnapshot(snapshotName)
+	assert.NoError(err)
 
 	runTime()
 }
@@ -211,7 +282,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	assert.Contains(stdout, "d7 tester test 1 has 1 node")
 
 	// Make a snapshot of d7 tester test 1
-	tester1Snapshot, err := app.Snapshot("d7testerTest1")
+	tester1Snapshot, err := app.Snapshot("d7testerTest1", false)
 	assert.NoError(err)
 
 	assert.Contains(tester1Snapshot, "d7testerTest1")
@@ -227,19 +298,19 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	assert.NoError(err)
 
 	// Make sure duplicate snapshot name gives an error
-	_, err = app.Snapshot("d7testerTest1")
+	_, err = app.Snapshot("d7testerTest1", false)
 	assert.Error(err)
 
 	// Name should contain only allowed characters
-	_, err = app.Snapshot(`name with spaces`)
+	_, err = app.Snapshot(`name with spaces`, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid snapshot name")
 
-	_, err = app.Snapshot(`single'quotes`)
+	_, err = app.Snapshot(`single'quotes`, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid snapshot name")
 
-	_, err = app.Snapshot(`double"quotes`)
+	_, err = app.Snapshot(`double"quotes`, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid snapshot name")
 
@@ -253,7 +324,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	assert.NoError(err)
 	assert.Contains(stdout, "d7 tester test 2 has 2 nodes")
 
-	tester2Snapshot, err := app.Snapshot("d7testerTest2")
+	tester2Snapshot, err := app.Snapshot("d7testerTest2", false)
 	assert.NoError(err)
 	assert.Contains(tester2Snapshot, "d7testerTest2")
 	latest, err = app.GetLatestSnapshot()

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -37,11 +37,10 @@ var WebTagBranch = "20260814_rfay_docker_update_phase_2"
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20260814_rfay_uncompressed_snapshot-2bfcd888e6"
+var BaseDBTag = "7b74988035" // 20260814_rfay_uncompressed_snapshot-7b74988035
 
 // BaseDBTagBranch is the branch BaseDBTag's content was built from.
-var BaseDBTagBranch = "20260814_rfay_docker_update_phase_2"
-
+var BaseDBTagBranch = "20260814_rfay_uncompressed_snapshot"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -37,10 +37,11 @@ var WebTagBranch = "20260814_rfay_docker_update_phase_2"
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "5a7c45ddbf" // 20260814_rfay_docker_update_phase_2-5a7c45ddbf
+var BaseDBTag = "20260814_rfay_uncompressed_snapshot-2bfcd888e6"
 
 // BaseDBTagBranch is the branch BaseDBTag's content was built from.
 var BaseDBTagBranch = "20260814_rfay_docker_update_phase_2"
+
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION
## Short Summary (TL;DR)

Adds a `--uncompressed` option so `ddev snapshot`, `ddev snapshot restore`, and the first-boot `base_db` seed can skip compression. This uses more disk space but restores faster since there's nothing to decompress. Nothing changes unless you use the new option.

## The Issue

- Fixes #8665

Snapshots and the first-boot database seed are always compressed today (zstd, or gzip on very old databases). Decompressing them takes real time, often 30-40% of a restore, and it competes for CPU with the restore step that runs right after it. On a host with plenty of disk space, or a seed that never travels over a network, that CPU cost buys nothing.

## How This PR Solves The Issue

- `ddev snapshot --uncompressed` writes the raw mariabackup/xtrabackup stream instead of piping it through a compressor. The file gets a `.mbstream` or `.xbstream` extension instead of `.zst`/`.gz`.
- `ddev snapshot restore` and the `base_db` seed lookup (project `initializer`, custom dbimage seed, and stock seed) recognize these new extensions and skip decompression when they see them.
- `ddev snapshot --list` now shows a Compression column (`zstd`, `gzip`, or `none`) so you can tell which kind of snapshot you're looking at.
- A new `BASE_DB_UNCOMPRESSED` build arg lets someone building the `ddev-dbserver` image from source bake in an uncompressed stock seed too.
- PostgreSQL isn't supported for `--uncompressed` (its backup pipeline is different) and gives a clear error if you try.

Nothing here changes any default. You only get an uncompressed file if you explicitly ask for one.

## Manual Testing Instructions

1. In a project: `ddev snapshot --uncompressed --name=test1`
2. `ddev snapshot --list` - the new snapshot should show extension `.mbstream`/`.xbstream`, a much bigger size than a normal snapshot, and `none` in the Compression column
3. `ddev snapshot restore test1` - should restore successfully
4. Try `ddev snapshot --uncompressed` on a PostgreSQL project - should fail with a clear error message

## Automated Testing Overview

- `pkg/ddevapp/snapshot_test.go`: a full create/list/restore round trip for an uncompressed snapshot, plus a test that PostgreSQL rejects the option
- `pkg/ddevapp/base_db_seed_test.go`: extended to cover the new seed extensions
- `containers/ddev-dbserver/test/base_db_seed.bats`: a new test for an uncompressed initializer seed

## Release/Deployment Notes

None. Every new code path only runs if someone uses the new `--uncompressed` flag, an extension nobody has today, or the new `BASE_DB_UNCOMPRESSED` build arg.
