### PR TITLE
feat(database): add --seed-snapshot and --reset-database, rename 'initializer' to 'seed', fixes #8661, fixes #8322

### DIFF
--- a/cmd/ddev/cmd/config.go
+++ b/cmd/ddev/cmd/config.go
@@ -737,10 +737,16 @@ func handleMainConfigArgs(cmd *cobra.Command, _ []string, app *ddevapp.DdevApp) 
 		return fmt.Errorf("failed to validate config: %v", err)
 	}
 
-	// If the database already exists in volume and is not of this type, then throw an error
+	// Configuring a database the existing volume doesn't hold is allowed, since
+	// writing config.yaml destroys nothing, but `ddev start` will refuse until
+	// it's resolved one way or the other.
 	if !nodeps.ArrayContainsString(app.GetOmittedContainers(), "db") {
-		if dbType, err := app.GetExistingDBType(); err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
-			return fmt.Errorf("unable to configure project %s with database type %s because that database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s', and you can try a migration with 'ddev utility migrate-database %s' see docs at %s", app.Name, app.Database.Type+":"+app.Database.Version, dbType, dbType, app.Database.Type+":"+app.Database.Version, "https://docs.ddev.com/en/stable/users/extend/database-types/")
+		dbType, err := app.GetExistingDBType()
+		if err != nil {
+			return err
+		}
+		if dbType != "" && dbType != app.Database.Type+":"+app.Database.Version {
+			util.Warning("This %s", app.DatabaseMismatchMessage(dbType))
 		}
 	}
 

--- a/cmd/ddev/cmd/delete.go
+++ b/cmd/ddev/cmd/delete.go
@@ -73,16 +73,8 @@ ddev delete --all`,
 			// Delete database
 			// Delete any other associated volumes
 
-			// We do the snapshot UNLESS omit-snapshot is set; the project may have to be
-			// started to do the snapshot.
-			status, _ := project.SiteStatus()
-			if status != ddevapp.SiteRunning && !deleteOmitSnapshot {
-				util.Warning("project must be started to do the snapshot")
-				err = project.Start()
-				if err != nil {
-					util.Failed("Failed to start project %s: %v", project.Name, err)
-				}
-			}
+			// Stop() does the snapshot UNLESS omit-snapshot is set, starting the
+			// project first if it has to.
 			if err := project.Stop(true, !deleteOmitSnapshot); err != nil {
 				util.Failed("Failed to remove project %s: \n%v", project.GetName(), err)
 			}

--- a/cmd/ddev/cmd/restart.go
+++ b/cmd/ddev/cmd/restart.go
@@ -18,7 +18,8 @@ var RestartCmd = &cobra.Command{
 	Long:              `Stops named projects and then starts them back up again.`,
 	Example: `ddev restart
 ddev restart <project1> <project2>
-ddev restart --all`,
+ddev restart --all
+ddev restart --reset-database`,
 	PreRun: func(_ *cobra.Command, _ []string) {
 		dockerutil.EnsureDdevNetwork()
 	},
@@ -37,9 +38,22 @@ ddev restart --all`,
 		ddevapp.RunUpgradeCheck()
 
 		noCache, _ := cmd.Flags().GetBool("no-cache")
+		seedSnapshot, _ := cmd.Flags().GetString("seed-snapshot")
+		resetDatabase, _ := cmd.Flags().GetBool("reset-database")
+		omitSnapshot, _ := cmd.Flags().GetBool("omit-snapshot")
+		skipConfirmation, _ := cmd.Flags().GetBool("skip-confirmation")
+		checkResetDatabaseFlags(resetDatabase, omitSnapshot, restartAll)
 
 		for _, app := range projects {
 			app.NoCache = noCache
+			app.SeedSnapshot = seedSnapshot
+
+			if resetDatabase {
+				if err := resetProjectDatabase(app, omitSnapshot, skipConfirmation); err != nil {
+					util.Failed("Failed to reset the database of %s: %v", app.GetName(), err)
+				}
+			}
+
 			output.UserOut.Printf("Restarting project %s...", app.GetName())
 			err = app.Restart()
 			if err != nil {
@@ -56,5 +70,6 @@ func init() {
 	RestartCmd.Flags().BoolP("skip-confirmation", "y", false, "Skip any confirmation steps")
 	RestartCmd.Flags().BoolP("no-cache", "", false, "Rebuild custom Docker image layers without cache")
 	RestartCmd.Flags().BoolVarP(&restartAll, "all", "a", false, "Restart all projects")
+	addResetDatabaseFlags(RestartCmd)
 	RootCmd.AddCommand(RestartCmd)
 }

--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -21,6 +21,7 @@ var snapshotList bool
 var snapshotName string
 var snapshotRestoreLatest bool
 var snapshotUncompressed bool
+var snapshotRestoreForce bool
 
 // noConfirm: If true, --yes, we won't stop and prompt before each deletion
 var snapshotCleanupNoConfirm bool

--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -12,10 +12,10 @@ import (
 var DdevSnapshotRestoreCommand = &cobra.Command{
 	Use:   "restore [snapshot_name]",
 	Short: "Restore a project's database to the provided snapshot version.",
-	Long:  `Uses mariabackup command to restore a project database to a particular snapshot from the .ddev/db_snapshots folder.`,
+	Long:  `Uses mariabackup or xtrabackup command to restore a project database to a particular snapshot from the .ddev/db_snapshots folder.`,
 	Example: `ddev snapshot restore d8git_20180717203845
 ddev snapshot restore --latest
-ddev snapshot restore --force d8git_20180717203845`,
+ddev snapshot restore --force t3v14-latest`,
 	Run: func(_ *cobra.Command, args []string) {
 		var snapshotName string
 

--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -12,8 +12,10 @@ import (
 var DdevSnapshotRestoreCommand = &cobra.Command{
 	Use:   "restore [snapshot_name]",
 	Short: "Restore a project's database to the provided snapshot version.",
-	Long: `Uses mariabackup command to restore a project database to a particular snapshot from the .ddev/db_snapshots folder.
-Example: "ddev snapshot restore d8git_20180717203845"`,
+	Long:  `Uses mariabackup command to restore a project database to a particular snapshot from the .ddev/db_snapshots folder.`,
+	Example: `ddev snapshot restore d8git_20180717203845
+ddev snapshot restore --latest
+ddev snapshot restore --force d8git_20180717203845`,
 	Run: func(_ *cobra.Command, args []string) {
 		var snapshotName string
 
@@ -66,7 +68,7 @@ Example: "ddev snapshot restore d8git_20180717203845"`,
 
 		// Normalize the snapshot name
 
-		if err := app.RestoreSnapshot(snapshotName); err != nil {
+		if err := app.RestoreSnapshot(snapshotName, snapshotRestoreForce); err != nil {
 			util.Failed("Failed to restore snapshot %s for project %s: %v", snapshotName, app.GetName(), err)
 		}
 	},
@@ -74,5 +76,6 @@ Example: "ddev snapshot restore d8git_20180717203845"`,
 
 func init() {
 	DdevSnapshotRestoreCommand.Flags().BoolVarP(&snapshotRestoreLatest, "latest", "", false, "use latest snapshot")
+	DdevSnapshotRestoreCommand.Flags().BoolVarP(&snapshotRestoreForce, "force", "f", false, "Restore a snapshot made by a different version of the same database server, which may not come up")
 	DdevSnapshotCommand.AddCommand(DdevSnapshotRestoreCommand)
 }

--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -10,12 +10,13 @@ import (
 
 // DdevSnapshotRestoreCommand handles ddev snapshot restore
 var DdevSnapshotRestoreCommand = &cobra.Command{
-	Use:   "restore [snapshot_name]",
+	Use:   "restore [snapshot_name|path]",
 	Short: "Restore a project's database to the provided snapshot version.",
-	Long:  `Uses mariabackup or xtrabackup command to restore a project database to a particular snapshot from the .ddev/db_snapshots folder.`,
+	Long:  `Uses mariabackup or xtrabackup command to restore a project database to a particular snapshot, either by name from the .ddev/db_snapshots folder or by the path to a snapshot file elsewhere.`,
 	Example: `ddev snapshot restore d8git_20180717203845
 ddev snapshot restore --latest
-ddev snapshot restore --force t3v14-latest`,
+ddev snapshot restore --force t3v14-latest
+ddev snapshot restore $HOME/tmp/mysnapshot-mariadb_11.8.zst`,
 	Run: func(_ *cobra.Command, args []string) {
 		var snapshotName string
 

--- a/cmd/ddev/cmd/snapshot_restore_test.go
+++ b/cmd/ddev/cmd/snapshot_restore_test.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/testcommon"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,4 +50,58 @@ func TestCmdSnapshotRestore(t *testing.T) {
 	assert.NoError(err)
 	assert.Contains(out, "Database snapshot test-snapshot was restored")
 	testcommon.CheckGoroutineOutput(t, out)
+}
+
+// TestCmdSnapshotRestoreFile covers `ddev snapshot restore` pointed at a snapshot
+// file outside the project, which the db container can only reach through a mount
+// added for that restore.
+func TestCmdSnapshotRestoreFile(t *testing.T) {
+	origDir, _ := os.Getwd()
+	site := TestSites[0]
+	require.NoError(t, os.Chdir(site.Dir))
+	app, err := ddevapp.NewApp(site.Dir, false)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, app.Stop(true, false))
+		_ = os.RemoveAll(app.GetConfigPath("db_snapshots"))
+		require.NoError(t, os.Chdir(origDir))
+		require.NoError(t, app.Start())
+	})
+
+	require.NoError(t, app.Restart())
+
+	tableExists := func() bool {
+		out, _, execErr := app.Exec(&ddevapp.ExecOpts{
+			Service: "db",
+			Cmd:     dbListTablesCommand(app),
+		})
+		require.NoError(t, execErr)
+		return len(out) > 0
+	}
+
+	// Snapshot before the marker table exists, so a successful restore removes it.
+	snapshotName, err := app.Snapshot("outside-restore")
+	require.NoError(t, err)
+	snapshotFile, err := ddevapp.GetSnapshotFileFromName(snapshotName, app)
+	require.NoError(t, err)
+
+	createMarkerTable(t, app)
+	require.True(t, tableExists())
+
+	// Move the snapshot out of the project, where only a mount can reach it.
+	// CreateTmpDir keeps it under the home directory, which Docker can bind-mount.
+	outsideDir := testcommon.CreateTmpDir(t.Name())
+	t.Cleanup(func() {
+		_ = os.RemoveAll(outsideDir)
+	})
+	outside := filepath.Join(outsideDir, snapshotFile)
+	inProject := app.GetConfigPath(filepath.Join("db_snapshots", snapshotFile))
+	require.NoError(t, fileutil.CopyFile(inProject, outside))
+	require.NoError(t, os.Remove(inProject))
+
+	out, err := exec.RunHostCommand(DdevBin, "snapshot", "restore", outside)
+	require.NoError(t, err, "output=%s", out)
+	require.Contains(t, out, "was restored")
+	require.False(t, tableExists(), "the out-of-project snapshot should have restored the database to its pre-marker state")
 }

--- a/cmd/ddev/cmd/snapshot_restore_test.go
+++ b/cmd/ddev/cmd/snapshot_restore_test.go
@@ -81,7 +81,7 @@ func TestCmdSnapshotRestoreFile(t *testing.T) {
 	}
 
 	// Snapshot before the marker table exists, so a successful restore removes it.
-	snapshotName, err := app.Snapshot("outside-restore")
+	snapshotName, err := app.Snapshot("outside-restore", false)
 	require.NoError(t, err)
 	snapshotFile, err := ddevapp.GetSnapshotFileFromName(snapshotName, app)
 	require.NoError(t, err)

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -31,7 +32,9 @@ project directory to start that project, or you can start stopped projects in
 any directory by running 'ddev start projectname [projectname ...]'`,
 	Example: `ddev start
 ddev start <project1> <project2>
-ddev start --all`,
+ddev start --all
+ddev start --seed-snapshot=mysnapshot
+ddev start --reset-database`,
 	PreRun: func(_ *cobra.Command, _ []string) {
 		dockerutil.EnsureDdevNetwork()
 	},
@@ -127,12 +130,24 @@ ddev start --all`,
 		}
 
 		noCache, _ := cmd.Flags().GetBool("no-cache")
+		seedSnapshot, _ := cmd.Flags().GetString("seed-snapshot")
+		resetDatabase, _ := cmd.Flags().GetBool("reset-database")
+		omitSnapshot, _ := cmd.Flags().GetBool("omit-snapshot")
+		skipConfirmation, _ := cmd.Flags().GetBool("skip-confirmation")
+		checkResetDatabaseFlags(resetDatabase, omitSnapshot, startAll)
 
 		for _, project := range projects {
 			if err := ddevapp.CheckForMissingProjectFiles(project); err != nil {
 				util.Failed("Failed to start %s: %v", project.GetName(), err)
 			}
 			project.NoCache = noCache
+			project.SeedSnapshot = seedSnapshot
+
+			if resetDatabase {
+				if err := resetProjectDatabase(project, omitSnapshot, skipConfirmation); err != nil {
+					util.Failed("Failed to reset the database of %s: %v", project.GetName(), err)
+				}
+			}
 
 			output.UserOut.Printf("Starting %s...", project.GetName())
 
@@ -162,10 +177,48 @@ func emitReachProjectMessage(project *ddevapp.DdevApp) {
 	}
 }
 
+// checkResetDatabaseFlags rejects flag combinations that don't make sense with
+// --reset-database, which throws a database away.
+func checkResetDatabaseFlags(resetDatabase bool, omitSnapshot bool, allProjects bool) {
+	if !resetDatabase {
+		if omitSnapshot {
+			util.Failed("--omit-snapshot only means something together with --reset-database")
+		}
+		return
+	}
+	if allProjects {
+		util.Failed("--reset-database removes a project's database, so it can't be combined with --all")
+	}
+}
+
+// resetProjectDatabase removes a project's database volume so the next start
+// creates a new one, after confirming with the user.
+func resetProjectDatabase(project *ddevapp.DdevApp, omitSnapshot bool, skipConfirmation bool) error {
+	if !skipConfirmation {
+		prompt := fmt.Sprintf("OK to remove the database of project %s and start over with a new one?\nA database snapshot will be made first.\n", project.GetName())
+		if omitSnapshot {
+			prompt = fmt.Sprintf("OK to remove the database of project %s and start over with a new one?\nNo snapshot will be made, so the existing database will be gone for good.\n", project.GetName())
+		}
+		if !util.Confirm(prompt + "Continue?") {
+			return fmt.Errorf("database reset cancelled")
+		}
+	}
+	return project.ResetDatabaseVolume(omitSnapshot)
+}
+
+// addResetDatabaseFlags adds the flags that seed or throw away a project's
+// database, shared by `ddev start` and `ddev restart`.
+func addResetDatabaseFlags(cmd *cobra.Command) {
+	cmd.Flags().String("seed-snapshot", "", "Seed a brand-new database volume from this snapshot name or file, instead of the stock starter database")
+	cmd.Flags().Bool("reset-database", false, "Remove the project's existing database and start over with a new one")
+	cmd.Flags().BoolP("omit-snapshot", "O", false, "With --reset-database, skip the snapshot of the database being removed")
+}
+
 func init() {
 	StartCmd.Flags().BoolVarP(&startAll, "all", "a", false, "Start all projects")
 	StartCmd.Flags().BoolP("skip-confirmation", "y", false, "Skip any confirmation steps")
 	StartCmd.Flags().BoolP("no-cache", "", false, "Rebuild custom Docker image layers without cache")
+	addResetDatabaseFlags(StartCmd)
 	StartCmd.Flags().String("profiles", "", "Start optional comma-separated docker compose profiles")
 	StartCmd.Flags().BoolP("select", "s", false, "Interactively select a project to start")
 	err := StartCmd.Flags().MarkHidden("select")

--- a/cmd/ddev/cmd/start.go
+++ b/cmd/ddev/cmd/start.go
@@ -34,7 +34,9 @@ any directory by running 'ddev start projectname [projectname ...]'`,
 ddev start <project1> <project2>
 ddev start --all
 ddev start --seed-snapshot=mysnapshot
-ddev start --reset-database`,
+ddev start --seed-snapshot=$HOME/tmp/mysnapshot-mariadb_11.8.zst --reset-database -y
+ddev start --reset-database
+ddev start --reset-database -y`,
 	PreRun: func(_ *cobra.Command, _ []string) {
 		dockerutil.EnsureDdevNetwork()
 	},

--- a/cmd/ddev/cmd/start_reset_database_test.go
+++ b/cmd/ddev/cmd/start_reset_database_test.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCmdStartResetDatabase covers `ddev start --reset-database` and
+// `--seed-snapshot`: throwing the database away and starting over, seeding the
+// new volume from a named snapshot, and the flag combinations that are refused.
+func TestCmdStartResetDatabase(t *testing.T) {
+	origDir, _ := os.Getwd()
+	site := TestSites[0]
+	require.NoError(t, os.Chdir(site.Dir))
+	app, err := ddevapp.NewApp(site.Dir, false)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, app.Stop(true, false))
+		_ = os.RemoveAll(app.GetConfigPath("db_snapshots"))
+		require.NoError(t, os.Chdir(origDir))
+		require.NoError(t, app.Start())
+	})
+
+	require.NoError(t, app.Restart())
+
+	tableExists := func() bool {
+		out, _, execErr := app.Exec(&ddevapp.ExecOpts{
+			Service: "db",
+			Cmd:     dbListTablesCommand(app),
+		})
+		require.NoError(t, execErr)
+		return len(out) > 0
+	}
+
+	createMarkerTable(t, app)
+	require.True(t, tableExists())
+
+	// A snapshot of the marker table, to seed a new volume with further down.
+	_, err = app.Snapshot("reset-test-seed")
+	require.NoError(t, err)
+
+	// --omit-snapshot means nothing on its own.
+	out, err := exec.RunHostCommand(DdevBin, "start", "--omit-snapshot", "-y")
+	require.Error(t, err, "output=%s", out)
+	require.Contains(t, out, "--reset-database")
+
+	// --reset-database throws a database away, so it can't apply to every project.
+	out, err = exec.RunHostCommand(DdevBin, "start", "--all", "--reset-database", "-y")
+	require.Error(t, err, "output=%s", out)
+	require.Contains(t, out, "--all")
+
+	// The reset itself: the marker table is gone, and a snapshot was taken.
+	out, err = exec.RunHostCommand(DdevBin, "start", "--reset-database", "-y")
+	require.NoError(t, err, "output=%s", out)
+	require.Contains(t, out, "Removed database volume")
+	require.False(t, tableExists(), "the database should be back to the stock starter database")
+
+	snapshots, err := app.ListSnapshotNames()
+	require.NoError(t, err)
+	require.Greater(t, len(snapshots), 1, "the removed database should have been snapshotted: %v", snapshots)
+
+	// --seed-snapshot on a project that already has a database is refused rather
+	// than silently ignored.
+	out, err = exec.RunHostCommand(DdevBin, "start", "--seed-snapshot=reset-test-seed")
+	require.Error(t, err, "output=%s", out)
+	require.Contains(t, out, "brand-new database volume")
+
+	// Reset and seed in one command: the marker table comes back.
+	out, err = exec.RunHostCommand(DdevBin, "start", "--reset-database", "--omit-snapshot", "--seed-snapshot=reset-test-seed", "-y")
+	require.NoError(t, err, "output=%s", out)
+	require.Contains(t, out, "Initializing new database volume from snapshot 'reset-test-seed'")
+	require.True(t, tableExists(), "the seed snapshot should have populated the new database volume")
+}
+
+// dbListTablesCommand returns a command listing the marker table if it's there.
+func dbListTablesCommand(app *ddevapp.DdevApp) string {
+	if app.Database.Type == nodeps.Postgres {
+		return `psql -t -c "SELECT tablename FROM pg_tables WHERE tablename='reset_marker';"`
+	}
+	return `echo "SHOW TABLES LIKE 'reset_marker';" | ` + app.GetDBClientCommand() + ` -N`
+}
+
+// createMarkerTable puts a table in the database that survives only if the
+// database itself does.
+func createMarkerTable(t *testing.T, app *ddevapp.DdevApp) {
+	t.Helper()
+	cmd := `echo "CREATE TABLE reset_marker (id INT);" | ` + app.GetDBClientCommand()
+	if app.Database.Type == nodeps.Postgres {
+		cmd = `psql -c "CREATE TABLE reset_marker (id INT);"`
+	}
+	_, _, err := app.Exec(&ddevapp.ExecOpts{Service: "db", Cmd: cmd})
+	require.NoError(t, err)
+}
+
+// TestCmdStartSeedSnapshotFile covers `--seed-snapshot` pointed at a snapshot
+// file outside the project, which the db container can only reach through a
+// mount added for that start.
+func TestCmdStartSeedSnapshotFile(t *testing.T) {
+	origDir, _ := os.Getwd()
+	site := TestSites[0]
+	require.NoError(t, os.Chdir(site.Dir))
+	app, err := ddevapp.NewApp(site.Dir, false)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, app.Stop(true, false))
+		_ = os.RemoveAll(app.GetConfigPath("db_snapshots"))
+		require.NoError(t, os.Chdir(origDir))
+		require.NoError(t, app.Start())
+	})
+
+	require.NoError(t, app.Restart())
+	createMarkerTable(t, app)
+
+	snapshotName, err := app.Snapshot("outside-seed")
+	require.NoError(t, err)
+	snapshotFile, err := ddevapp.GetSnapshotFileFromName(snapshotName, app)
+	require.NoError(t, err)
+
+	// Move the snapshot out of the project, where only a mount can reach it.
+	// CreateTmpDir keeps it under the home directory, which Docker can bind-mount.
+	outsideDir := testcommon.CreateTmpDir(t.Name())
+	t.Cleanup(func() {
+		_ = os.RemoveAll(outsideDir)
+	})
+	outside := filepath.Join(outsideDir, snapshotFile)
+	inProject := app.GetConfigPath(filepath.Join("db_snapshots", snapshotFile))
+	require.NoError(t, fileutil.CopyFile(inProject, outside))
+	require.NoError(t, os.Remove(inProject))
+
+	out, err := exec.RunHostCommand(DdevBin, "start", "--reset-database", "--omit-snapshot", "--seed-snapshot="+outside, "-y")
+	require.NoError(t, err, "output=%s", out)
+
+	tables, _, err := app.Exec(&ddevapp.ExecOpts{Service: "db", Cmd: dbListTablesCommand(app)})
+	require.NoError(t, err)
+	require.NotEmpty(t, tables, "the out-of-project seed snapshot should have populated the new database volume")
+}

--- a/cmd/ddev/cmd/start_reset_database_test.go
+++ b/cmd/ddev/cmd/start_reset_database_test.go
@@ -144,3 +144,72 @@ func TestCmdStartSeedSnapshotFile(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, tables, "the out-of-project seed snapshot should have populated the new database volume")
 }
+
+// TestCmdStartResetDatabaseTypeMismatch covers `ddev start --reset-database` after
+// `ddev config --database=...` has changed the configured database type/version
+// away from what the existing volume actually holds: the pre-reset snapshot must
+// run against the database that actually created the data, not the newly
+// configured one, per SnapshotAtExistingDBVersion.
+func TestCmdStartResetDatabaseTypeMismatch(t *testing.T) {
+	origDir, _ := os.Getwd()
+	site := TestSites[0]
+	require.NoError(t, os.Chdir(site.Dir))
+	app, err := ddevapp.NewApp(site.Dir, false)
+	require.NoError(t, err)
+	origDatabase := app.Database
+
+	t.Cleanup(func() {
+		app.Database = origDatabase
+		require.NoError(t, app.WriteConfig())
+		require.NoError(t, app.Stop(true, false))
+		_ = os.RemoveAll(app.GetConfigPath("db_snapshots"))
+		require.NoError(t, os.Chdir(origDir))
+		require.NoError(t, app.Start())
+	})
+
+	require.NoError(t, app.Restart())
+
+	tableExists := func() bool {
+		out, _, execErr := app.Exec(&ddevapp.ExecOpts{
+			Service: "db",
+			Cmd:     dbListTablesCommand(app),
+		})
+		require.NoError(t, execErr)
+		return len(out) > 0
+	}
+
+	createMarkerTable(t, app)
+	require.True(t, tableExists())
+
+	existingSnapshots, err := app.ListSnapshotNames()
+	require.NoError(t, err)
+
+	// Reconfigure to a different MariaDB version than the one that actually
+	// created the volume; this only warns, it doesn't touch the existing database.
+	mismatchedVersion := nodeps.MariaDB1011
+	require.NotEqual(t, mismatchedVersion, app.Database.Version, "test fixture needs a version different from the default")
+	out, err := exec.RunHostCommand(DdevBin, "config", "--database=mariadb:"+mismatchedVersion)
+	require.NoError(t, err, "output=%s", out)
+	require.Contains(t, out, "its database volume holds")
+
+	app, err = ddevapp.NewApp(site.Dir, false)
+	require.NoError(t, err)
+	require.Equal(t, mismatchedVersion, app.Database.Version)
+
+	// The reset must snapshot the OLD (actual) database, then start fresh as the
+	// newly configured version.
+	out, err = exec.RunHostCommand(DdevBin, "start", "--reset-database", "-y")
+	require.NoError(t, err, "output=%s", out)
+	require.Contains(t, out, "Starting the database as")
+	require.Contains(t, out, "Removed database volume")
+	require.Contains(t, out, "Snapshotted the existing database")
+	require.False(t, tableExists(), "the database should be back to the stock starter database")
+
+	snapshots, err := app.ListSnapshotNames()
+	require.NoError(t, err)
+	require.Greater(t, len(snapshots), len(existingSnapshots), "the removed database should have been snapshotted: %v", snapshots)
+
+	existingType, err := app.GetExistingDBType()
+	require.NoError(t, err)
+	require.Equal(t, "mariadb:"+mismatchedVersion, existingType, "the project should now be running the newly configured database type")
+}

--- a/cmd/ddev/cmd/start_reset_database_test.go
+++ b/cmd/ddev/cmd/start_reset_database_test.go
@@ -45,7 +45,7 @@ func TestCmdStartResetDatabase(t *testing.T) {
 	require.True(t, tableExists())
 
 	// A snapshot of the marker table, to seed a new volume with further down.
-	_, err = app.Snapshot("reset-test-seed")
+	_, err = app.Snapshot("reset-test-seed", false)
 	require.NoError(t, err)
 
 	// --omit-snapshot means nothing on its own.
@@ -121,7 +121,7 @@ func TestCmdStartSeedSnapshotFile(t *testing.T) {
 	require.NoError(t, app.Restart())
 	createMarkerTable(t, app)
 
-	snapshotName, err := app.Snapshot("outside-seed")
+	snapshotName, err := app.Snapshot("outside-seed", false)
 	require.NoError(t, err)
 	snapshotFile, err := ddevapp.GetSnapshotFileFromName(snapshotName, app)
 	require.NoError(t, err)

--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
@@ -326,23 +327,23 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 		require.Contains(t, out, "/mysqlbase/custom/base_db.* baked into dbimage (seeds a new database volume)")
 	})
 
-	// An `initializer` snapshot seeds a fresh database volume, so it's reported
-	// even though it isn't an ordinary config file.
-	t.Run("initializer snapshot", func(t *testing.T) {
+	// A `seed` snapshot seeds a fresh database volume, so it's reported even
+	// though it isn't an ordinary config file.
+	t.Run("seed snapshot", func(t *testing.T) {
 		snapshotDir := filepath.Join(tmpdir, ".ddev", "db_snapshots")
 		err := os.MkdirAll(snapshotDir, 0755)
 		require.NoError(t, err)
-		initializer := filepath.Join(snapshotDir, "initializer-"+nodeps.MariaDB+"_"+nodeps.MariaDBDefaultVersion+".zst")
-		err = os.WriteFile(initializer, []byte("not really a snapshot\n"), 0644)
+		seedSnapshot := filepath.Join(snapshotDir, ddevapp.SeedSnapshotName+"-"+nodeps.MariaDB+"_"+nodeps.MariaDBDefaultVersion+".zst")
+		err = os.WriteFile(seedSnapshot, []byte("not really a snapshot\n"), 0644)
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			_ = os.Remove(initializer)
+			_ = os.Remove(seedSnapshot)
 		})
 
 		out, err := exec.RunCommand(DdevBin, []string{"utility", "check-custom-config"})
 		require.NoError(t, err)
 		require.Contains(t, out, "Custom configuration detected in project '"+projectName+"':")
-		require.Contains(t, out, "initializer-"+nodeps.MariaDB+"_"+nodeps.MariaDBDefaultVersion+".zst (seeds a new database volume)")
+		require.Contains(t, out, ddevapp.SeedSnapshotName+"-"+nodeps.MariaDB+"_"+nodeps.MariaDBDefaultVersion+".zst (seeds a new database volume)")
 	})
 
 	// Test mutagen (conditional: only when mutagen is enabled)

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -172,8 +172,6 @@ if [ ! -f "${DATADIR}/db_mariadb_version.txt" ]; then
 
       snapshot=""
       for candidate in \
-        "/mnt/snapshots/initializer-${server_db_version}.mbstream" \
-        "/mnt/snapshots/initializer-${server_db_version}.xbstream" \
         "/mysqlbase/custom/base_db.zst" \
         "/mysqlbase/custom/base_db.gz" \
         "/mysqlbase/custom/base_db.mbstream" \

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -44,7 +44,14 @@ fi
 # otherwise, fail and abort startup
 if [ $# = "2" ] && [ "${1:-}" = "restore_snapshot" ] ; then
   snapshot_basename=${2:-nothingthere}
-  snapshot="/mnt/snapshots/${snapshot_basename}"
+  # An absolute path lets ddev point at a snapshot mounted somewhere other than
+  # /mnt/snapshots, as `ddev start --seed-snapshot` does with a file outside the
+  # project.
+  case "${snapshot_basename}" in
+    /*) snapshot="${snapshot_basename}" ;;
+    *)  snapshot="/mnt/snapshots/${snapshot_basename}" ;;
+  esac
+  snapshot_basename=$(basename "${snapshot_basename}")
   # If a compressed snapshot file is passed in, decompress and extract stream
   if [ -f "$snapshot" ]; then
     echo "Restoring from snapshot file $snapshot"
@@ -144,14 +151,15 @@ fi
 # If mariadb has not been initialized, copy in the base image from a base_db
 # seed or from a provided $snapshot_dir. The base_db seed is looked up in
 # priority order:
-#   1. /mnt/snapshots/initializer-<db_type>_<db_version>.*  - project-supplied,
-#      living alongside regular snapshots in .ddev/db_snapshots
-#   2. /mysqlbase/custom/base_db.*                          - baked into a derived image
-#   3. /mysqlbase/base_db.*                                 - the stock DDEV starter database
+#   1. /mysqlbase/custom/base_db.*  - baked into a derived image
+#   2. /mysqlbase/base_db.*         - the stock DDEV starter database
 # At each location, a .zst seed is preferred over .gz; .gz only exists at all
 # for db versions (e.g. MariaDB 5.5) whose base image lacks zstd. .mbstream/
 # .xbstream are uncompressed raw backup-tool streams, checked last so an
 # existing compressed seed still wins if one happens to also be present.
+
+# A project-level seed snapshot doesn't appear here: ddev hands it over as a
+# restore_snapshot argument, which works the same way on an empty datadir.
 if [ ! -f "${DATADIR}/db_mariadb_version.txt" ]; then
     # If snapshot_dir is not set, this is a normal startup, so
     # tell healthcheck to wait by touching /tmp/initializing
@@ -164,8 +172,6 @@ if [ ! -f "${DATADIR}/db_mariadb_version.txt" ]; then
 
       snapshot=""
       for candidate in \
-        "/mnt/snapshots/initializer-${server_db_version}.zst" \
-        "/mnt/snapshots/initializer-${server_db_version}.gz" \
         "/mnt/snapshots/initializer-${server_db_version}.mbstream" \
         "/mnt/snapshots/initializer-${server_db_version}.xbstream" \
         "/mysqlbase/custom/base_db.zst" \
@@ -183,7 +189,7 @@ if [ ! -f "${DATADIR}/db_mariadb_version.txt" ]; then
         fi
       done
       if [ -z "${snapshot}" ]; then
-        echo "No base_db seed found in /mnt/snapshots, /mysqlbase/custom, or /mysqlbase"
+        echo "No base_db seed found in /mysqlbase/custom or /mysqlbase"
         exit 102
       fi
       case "${snapshot}" in

--- a/containers/ddev-dbserver/test/base_db_seed.bats
+++ b/containers/ddev-dbserver/test/base_db_seed.bats
@@ -3,24 +3,6 @@
 # Run these tests from the repo root directory, for example
 # ./test/bats tests
 #
-# Exercises the base_db seed lookup in docker-entrypoint.sh, which is
-# checked in priority order:
-#   1. /mnt/snapshots/initializer-<db_type>_<db_version>.*  - project-supplied,
-#      living alongside regular snapshots in .ddev/db_snapshots
-#   2. /mysqlbase/custom/base_db.*                          - baked into a derived image
-#   3. /mysqlbase/base_db.*                                 - the stock DDEV starter database
-# A .zst seed is preferred over .gz at each location; .gz is exercised too,
-# since db versions without zstd (e.g. MariaDB 5.5) still produce it.
-# Exercises the base_db seed lookup in docker-entrypoint.sh, which is
-# checked in priority order:
-#   1. /mnt/snapshots/initializer-<db_type>_<db_version>.*  - project-supplied,
-#      living alongside regular snapshots in .ddev/db_snapshots
-#   2. /mysqlbase/custom/base_db.*                          - baked into a derived image
-#   3. /mysqlbase/base_db.*                                 - the stock DDEV starter database
-# A .zst seed is preferred over .gz at each location; .gz is exercised too,
-# since db versions without zstd (e.g. MariaDB 5.5) still produce it. An
-# uncompressed .mbstream/.xbstream seed (the raw backup-tool stream, no
-# compression stage) is exercised too.
 # Exercises the two ways docker-entrypoint.sh fills a brand-new datadir:
 #   - the base_db seed lookup, checked in priority order:
 #       1. /mysqlbase/custom/base_db.*  - baked into a derived image
@@ -70,7 +52,7 @@ function setup_file {
   # The snapshot naming ddev's Snapshot() uses, e.g. seed-mariadb_11.8.zst
   export SEED_SNAPSHOT_NAME="seed-${DB_TYPE}_${DB_VERSION}.${SEED_EXT}"
 
-  export UNCOMPRESSED_INITIALIZER_NAME="initializer-${DB_TYPE}_${DB_VERSION}.${STREAM_EXT}"
+  export UNCOMPRESSED_SEED_SNAPSHOT_NAME="seed-${DB_TYPE}_${DB_VERSION}.${STREAM_EXT}"
 
   make_seed "marker_seed_a" "${SEED_DIR}/seed_a.${SEED_EXT}" "${SEED_COMPRESS}"
   make_seed "marker_seed_b" "${SEED_DIR}/seed_b.${SEED_EXT}" "${SEED_COMPRESS}"
@@ -140,17 +122,13 @@ function setup {
   [[ "$output" == *"marker_seed_b"* ]]
 }
 
-@test "uncompressed initializer seed overrides the stock seed for ${DB_TYPE} ${DB_VERSION}" {
-@test "restore_snapshot seeds an empty datadir from /mnt/snapshots for ${DB_TYPE} ${DB_VERSION}" {
+@test "restore_snapshot seeds an empty datadir from an uncompressed snapshot for ${DB_TYPE} ${DB_VERSION}" {
   docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy \
-    -v "${SEED_DIR}/seed_a.${SEED_EXT}:/mnt/snapshots/${SEED_SNAPSHOT_NAME}:ro" \
-    -v "${SEED_DIR}/seed_b.${SEED_EXT}:/mysqlbase/custom/base_db.${SEED_EXT}:ro" \
-    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE restore_snapshot "${SEED_SNAPSHOT_NAME}"
+    -v "${SEED_DIR}/seed_c.${STREAM_EXT}:/mnt/snapshots/${UNCOMPRESSED_SEED_SNAPSHOT_NAME}:ro" \
+    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE restore_snapshot "${UNCOMPRESSED_SEED_SNAPSHOT_NAME}"
   containercheck
   run mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
-  # The seed wins over the derived-image base_db mounted alongside it.
-  [[ "$output" == *"marker_seed_a"* ]]
-  [[ "$output" != *"marker_seed_b"* ]]
+  [[ "$output" == *"marker_seed_c"* ]]
 }
 
 @test "restore_snapshot seeds an empty datadir from /mnt/snapshots for ${DB_TYPE} ${DB_VERSION}" {

--- a/containers/ddev-dbserver/test/base_db_seed.bats
+++ b/containers/ddev-dbserver/test/base_db_seed.bats
@@ -10,9 +10,26 @@
 #   2. /mysqlbase/custom/base_db.*                          - baked into a derived image
 #   3. /mysqlbase/base_db.*                                 - the stock DDEV starter database
 # A .zst seed is preferred over .gz at each location; .gz is exercised too,
+# since db versions without zstd (e.g. MariaDB 5.5) still produce it.
+# Exercises the base_db seed lookup in docker-entrypoint.sh, which is
+# checked in priority order:
+#   1. /mnt/snapshots/initializer-<db_type>_<db_version>.*  - project-supplied,
+#      living alongside regular snapshots in .ddev/db_snapshots
+#   2. /mysqlbase/custom/base_db.*                          - baked into a derived image
+#   3. /mysqlbase/base_db.*                                 - the stock DDEV starter database
+# A .zst seed is preferred over .gz at each location; .gz is exercised too,
 # since db versions without zstd (e.g. MariaDB 5.5) still produce it. An
 # uncompressed .mbstream/.xbstream seed (the raw backup-tool stream, no
 # compression stage) is exercised too.
+# Exercises the two ways docker-entrypoint.sh fills a brand-new datadir:
+#   - the base_db seed lookup, checked in priority order:
+#       1. /mysqlbase/custom/base_db.*  - baked into a derived image
+#       2. /mysqlbase/base_db.*         - the stock DDEV starter database
+#   - a `restore_snapshot` argument, which ddev uses for
+#     `ddev start --seed-snapshot` and takes either a name in /mnt/snapshots or
+#     an absolute path to a snapshot mounted anywhere.
+# A .zst seed is preferred over .gz; .gz is exercised too, since db versions
+# without zstd (e.g. MariaDB 5.5) still produce it.
 
 load functions.sh
 
@@ -50,9 +67,9 @@ function setup_file {
   else
     export STREAM_EXT="mbstream"
   fi
+  # The snapshot naming ddev's Snapshot() uses, e.g. seed-mariadb_11.8.zst
+  export SEED_SNAPSHOT_NAME="seed-${DB_TYPE}_${DB_VERSION}.${SEED_EXT}"
 
-  # Matches the server_db_version computed by docker-entrypoint.sh, e.g. mariadb_11.8
-  export INITIALIZER_NAME="initializer-${DB_TYPE}_${DB_VERSION}.${SEED_EXT}"
   export UNCOMPRESSED_INITIALIZER_NAME="initializer-${DB_TYPE}_${DB_VERSION}.${STREAM_EXT}"
 
   make_seed "marker_seed_a" "${SEED_DIR}/seed_a.${SEED_EXT}" "${SEED_COMPRESS}"
@@ -112,28 +129,6 @@ function setup {
   mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
 }
 
-@test "project-mounted initializer seed overrides the stock seed for ${DB_TYPE} ${DB_VERSION}" {
-  docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy \
-    -v "${SEED_DIR}/seed_a.${SEED_EXT}:/mnt/snapshots/${INITIALIZER_NAME}:ro" \
-    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
-  containercheck
-  run docker logs $CONTAINER_NAME
-  [[ "$output" == *"snapshot=/mnt/snapshots/${INITIALIZER_NAME}"* ]]
-  run mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
-  [[ "$output" == *"marker_seed_a"* ]]
-}
-
-@test "uncompressed initializer seed overrides the stock seed for ${DB_TYPE} ${DB_VERSION}" {
-  docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy \
-    -v "${SEED_DIR}/seed_c.${STREAM_EXT}:/mnt/snapshots/${UNCOMPRESSED_INITIALIZER_NAME}:ro" \
-    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
-  containercheck
-  run docker logs $CONTAINER_NAME
-  [[ "$output" == *"snapshot=/mnt/snapshots/${UNCOMPRESSED_INITIALIZER_NAME}"* ]]
-  run mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
-  [[ "$output" == *"marker_seed_c"* ]]
-}
-
 @test "derived-image custom base_db seed overrides the stock seed for ${DB_TYPE} ${DB_VERSION}" {
   docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy \
     -v "${SEED_DIR}/seed_b.${SEED_EXT}:/mysqlbase/custom/base_db.${SEED_EXT}:ro" \
@@ -145,14 +140,36 @@ function setup {
   [[ "$output" == *"marker_seed_b"* ]]
 }
 
-@test "project-mounted initializer seed takes precedence over derived-image seed for ${DB_TYPE} ${DB_VERSION}" {
+@test "uncompressed initializer seed overrides the stock seed for ${DB_TYPE} ${DB_VERSION}" {
+@test "restore_snapshot seeds an empty datadir from /mnt/snapshots for ${DB_TYPE} ${DB_VERSION}" {
   docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy \
-    -v "${SEED_DIR}/seed_a.${SEED_EXT}:/mnt/snapshots/${INITIALIZER_NAME}:ro" \
+    -v "${SEED_DIR}/seed_a.${SEED_EXT}:/mnt/snapshots/${SEED_SNAPSHOT_NAME}:ro" \
     -v "${SEED_DIR}/seed_b.${SEED_EXT}:/mysqlbase/custom/base_db.${SEED_EXT}:ro" \
-    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE
+    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE restore_snapshot "${SEED_SNAPSHOT_NAME}"
   containercheck
-  run docker logs $CONTAINER_NAME
-  [[ "$output" == *"snapshot=/mnt/snapshots/${INITIALIZER_NAME}"* ]]
+  run mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
+  # The seed wins over the derived-image base_db mounted alongside it.
+  [[ "$output" == *"marker_seed_a"* ]]
+  [[ "$output" != *"marker_seed_b"* ]]
+}
+
+@test "restore_snapshot seeds an empty datadir from /mnt/snapshots for ${DB_TYPE} ${DB_VERSION}" {
+  docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy \
+    -v "${SEED_DIR}/seed_a.${SEED_EXT}:/mnt/snapshots/${SEED_SNAPSHOT_NAME}:ro" \
+    -v "${SEED_DIR}/seed_b.${SEED_EXT}:/mysqlbase/custom/base_db.${SEED_EXT}:ro" \
+    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE restore_snapshot "${SEED_SNAPSHOT_NAME}"
+  containercheck
+  run mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
+  # The seed wins over the derived-image base_db mounted alongside it.
+  [[ "$output" == *"marker_seed_a"* ]]
+  [[ "$output" != *"marker_seed_b"* ]]
+}
+
+@test "restore_snapshot accepts an absolute path outside /mnt/snapshots for ${DB_TYPE} ${DB_VERSION}" {
+  docker run -u "$MOUNTUID:$MOUNTGID" -v $VOLUME:/var/lib/mysql:nocopy \
+    -v "${SEED_DIR}:/mnt/seed:ro" \
+    --name=$CONTAINER_NAME -p $HOSTPORT:3306 -d $IMAGE restore_snapshot "/mnt/seed/seed_a.${SEED_EXT}"
+  containercheck
   run mysql ${SKIP_SSL:-} -udb -pdb --database=db --host=127.0.0.1 --port=$HOSTPORT -e "SHOW TABLES;"
   [[ "$output" == *"marker_seed_a"* ]]
 }

--- a/docs/content/users/extend/customizing-images.md
+++ b/docs/content/users/extend/customizing-images.md
@@ -265,7 +265,7 @@ If you publish a derived `dbimage` (for example a CI-built image with your produ
 COPY base_db.zst /mysqlbase/custom/base_db.zst
 ```
 
-The database container uses this seed the first time its data volume is created (a brand-new project, or after `ddev delete` and `ddev start`), instead of the stock DDEV starter database. It's checked ahead of the stock seed but _after_ any project-level [`initializer` snapshot](../usage/database-management.md#snapshots) — so a teammate can still override your baked-in seed for their own project just by dropping an `initializer` snapshot into `.ddev/db_snapshots`, without rebuilding the image.
+The database container uses this seed the first time its data volume is created (a brand-new project, or after `ddev delete` and `ddev start`), instead of the stock DDEV starter database. A project-level [seed snapshot](../usage/database-management.md#seeding-a-fresh-database-from-a-snapshot) wins over it — so a teammate can still override your baked-in seed for their own project just by dropping a `seed` snapshot into `.ddev/db_snapshots`, without rebuilding the image.
 
 A seed can also be baked in uncompressed, as `base_db.mbstream` (MariaDB) or `base_db.xbstream` (MySQL, or MariaDB 5.5/10.0) — the raw `mariabackup`/`xtrabackup` stream with no compression stage. This is an unusual, deliberate tradeoff (see [Uncompressed Snapshots](../usage/database-management.md#uncompressed-snapshots)): it trades a much larger image layer for zero first-boot decompression cost, and only makes sense if you've already decided that tradeoff is worth it.
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1238,6 +1238,7 @@ Flags:
 * `--omit-snapshot`, `-O`: With `--reset-database`, skip the snapshot of the database being removed.
 * `--reset-database`: Remove the project's existing database and start over with a new one.
 * `--seed-snapshot`: Seed a brand-new database volume from this snapshot name or file, instead of the stock starter database.
+* `--skip-confirmation`, `-y`: Skip any confirmation steps.
 
 Example:
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1235,6 +1235,9 @@ Flags:
 
 * `--all`, `-a`: Restart all projects.
 * `--no-cache`: Rebuild custom Docker image layers without cache.
+* `--omit-snapshot`, `-O`: With `--reset-database`, skip the snapshot of the database being removed.
+* `--reset-database`: Remove the project's existing database and start over with a new one.
+* `--seed-snapshot`: Seed a brand-new database volume from this snapshot name or file, instead of the stock starter database.
 
 Example:
 
@@ -1250,6 +1253,9 @@ ddev restart my-project my-other-project
 
 # Restart all projects
 ddev restart --all
+
+# Throw away the current database and restart with a new, empty one
+ddev restart --reset-database
 ```
 
 ## `sake`
@@ -1381,6 +1387,7 @@ Restores a database snapshot from the `.ddev/db_snapshots` directory.
 
 Flags:
 
+* `--force`, `-f`: Restore a snapshot made by a different version of the same database server, which may not come up.
 * `--latest`: Use the latest snapshot.
 
 Example:
@@ -1391,7 +1398,12 @@ ddev snapshot restore --latest
 
 # Restore the previously-taken `my_snapshot_name` snapshot
 ddev snapshot restore my_snapshot_name
+
+# Restore a snapshot taken on an older version of the same database server
+ddev snapshot restore --force my_snapshot_name
 ```
+
+A snapshot normally has to match the project's configured database type and version exactly. `--force` lifts that for a different version of the same server, which the underlying restore doesn't itself check for; the database may fail to come up, in which case [`ddev start --reset-database`](../usage/database-management.md#starting-over-with-a-new-database) starts over. Restoring across database types (a MySQL snapshot into MariaDB, say) is still refused.
 
 ## `spark`
 
@@ -1441,7 +1453,10 @@ Flags:
 
 * `--all`, `-a`: Start all projects.
 * `--no-cache`: Rebuild custom Docker image layers without cache.
+* `--omit-snapshot`, `-O`: With `--reset-database`, skip the snapshot of the database being removed.
 * `--profiles=<optional-compose-profile-list>`: Start services labeled with the Docker Compose profiles in comma-separated list of profiles.
+* `--reset-database`: Remove the project's existing database and start over with a new one.
+* `--seed-snapshot`: Seed a brand-new database volume from this snapshot name or file, instead of the stock starter database.
 * `--skip-confirmation`, `-y`: Skip any confirmation steps.
 
 Example:
@@ -1458,7 +1473,15 @@ ddev start my-project my-other-project
 
 # Start all projects
 ddev start --all
+
+# Throw away the current database and start over with a new, empty one
+ddev start --reset-database
+
+# Start over with a database seeded from a snapshot instead
+ddev start --reset-database --seed-snapshot=my_snapshot_name
 ```
+
+See [Seeding a Fresh Database from a Snapshot](../usage/database-management.md#seeding-a-fresh-database-from-a-snapshot) and [Starting Over with a New Database](../usage/database-management.md#starting-over-with-a-new-database).
 
 ## `stop`
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1386,7 +1386,8 @@ ddev snapshot --uncompressed
 
 ### `snapshot restore`
 
-Restores a database snapshot from the `.ddev/db_snapshots` directory.
+Restores a database snapshot, either by name from the `.ddev/db_snapshots` directory or
+by the path to a snapshot file elsewhere on disk.
 
 Flags:
 
@@ -1404,6 +1405,9 @@ ddev snapshot restore my_snapshot_name
 
 # Restore a snapshot taken on an older version of the same database server
 ddev snapshot restore --force my_snapshot_name
+
+# Restore a snapshot file from outside the project
+ddev snapshot restore ~/tmp/mysnapshot-mariadb_11.8.zst
 ```
 
 A snapshot normally has to match the project's configured database type and version exactly. `--force` lifts that for a different version of the same server, which the underlying restore doesn't itself check for; the database may fail to come up, in which case [`ddev start --reset-database`](../usage/database-management.md#starting-over-with-a-new-database) starts over. Restoring across database types (a MySQL snapshot into MariaDB, say) is still refused.

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1256,6 +1256,9 @@ ddev restart --all
 
 # Throw away the current database and restart with a new, empty one
 ddev restart --reset-database
+
+# Reset and initialize with external snapshot without confirmation
+ddev restart --reset-database --seed-snapshot=/tmp/newsnapshot-mariadb_11.8.zst -y
 ```
 
 ## `sake`
@@ -1387,7 +1390,7 @@ Restores a database snapshot from the `.ddev/db_snapshots` directory.
 
 Flags:
 
-* `--force`, `-f`: Restore a snapshot made by a different version of the same database server, which may not come up.
+* `--force`, `-f`: Restore a snapshot made by a different version of the same database server, which may not succeed.
 * `--latest`: Use the latest snapshot.
 
 Example:

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -86,7 +86,7 @@ ddev start --seed-snapshot=~/datasets/production-mariadb_11.8.zst
 
 A snapshot can only seed the database type and version it was made from, which is why the standard `-<type>_<version>.{zst,gz}` suffix `ddev snapshot` gives it has to stay on the filename.
 
-Unlike other snapshots, `seed` isn't meant to be restored with `ddev snapshot restore` — it's only consulted for an uninitialized database. You can choose to commit the resulting `seed-*` file in `.ddev/db_snapshots` to your repository if you want teammates and CI to get the same starting dataset on their first `ddev start`, but it may be large and you may want to use another distribution technique.
+You can choose to commit the resulting `seed-*` file in `.ddev/db_snapshots` to your repository if you want teammates and CI to get the same starting dataset on their first `ddev start`, but it may be large and you may want to use another distribution technique.
 
 A `seed` snapshot is listed as [custom configuration](../extend/customization-extendibility.md), so `ddev start` and [`ddev utility check-custom-config`](../usage/commands.md#utility-check-custom-config) both show it. When `ddev start` actually seeds a fresh database volume, it says so, naming the snapshot and its size and warning that a large one may take a while:
 

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -53,7 +53,7 @@ Snapshots are stored as compressed (zstd, or gzip on very old database versions)
 
 ### Uncompressed Snapshots
 
-`ddev snapshot`, `ddev snapshot restore`, and the `initializer` seed all compress the database backup by default, which is the right tradeoff for almost everyone. Decompression still costs real time, though — routinely 30-40% of a restore or first `ddev start`, and it competes for the same CPU cores the database restore itself needs right after. `--uncompressed` skips it:
+`ddev snapshot`, `ddev snapshot restore`, and the reserved `seed` snapshot all compress the database backup by default, which is the right tradeoff for almost everyone. Decompression still costs real time, though — routinely 30-40% of a restore or first `ddev start`, and it competes for the same CPU cores the database restore itself needs right after. `--uncompressed` skips it:
 
 ```bash
 ddev snapshot --uncompressed
@@ -61,7 +61,7 @@ ddev snapshot --uncompressed
 
 This is an unusual, deliberate tradeoff, not a general recommendation: an uncompressed snapshot can be roughly as large as the database's uncompressed datadir — many times bigger than the same snapshot compressed with zstd. It's worth it mainly when disk space is cheap relative to CPU time, for example a low-core-count host, or a seed that's read straight off fast local disk and never crosses a network (so compression buys nothing on the transfer side either). `ddev snapshot --list` shows each snapshot's compression (`zstd`, `gzip`, or `none`) so you can tell which kind you're looking at. Restoring an uncompressed snapshot with `ddev snapshot restore` needs no extra flag — the file's extension (`.mbstream`/`.xbstream` instead of `.zst`/`.gz`) already tells DDEV there's nothing to decompress. Not available for PostgreSQL projects.
 
-An `initializer` snapshot honors the same flag, and a `dbimage` built with a baked-in seed (see [Seeding a Custom Starter Database](../extend/customizing-images.md#seeding-a-custom-starter-database-in-dbimage)) can use an uncompressed seed the same way.
+The reserved `seed` snapshot honors the same flag, and a `dbimage` built with a baked-in seed (see [Seeding a Custom Starter Database](../extend/customizing-images.md#seeding-a-custom-starter-database-in-dbimage)) can use an uncompressed seed the same way.
 
 ### Seeding a Fresh Database from a Snapshot
 

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -47,7 +47,7 @@ Snapshots let you easily save the entire status of all of your databases, which 
 
 Snapshots can be named for easier reference later on. For example, [`ddev snapshot --name=two-dbs`](../usage/commands.md#snapshot) would make a snapshot named `two-dbs` in the `.ddev/db_snapshots` directory. It includes the entire state of the db server, so in the case of our two databases above, both databases and the system level `mysql` or `postgres` database will all be snapshotted. Then if you want to delete everything with `ddev delete -O` (omitting the snapshot since we have one already), and then [`ddev start`](../usage/commands.md#start) again, we can `ddev snapshot restore two-dbs` and we’ll be right back where we were.
 
-Use the [`ddev snapshot restore`](../usage/commands.md#snapshot-restore) command to interactively choose among snapshots, or append `--latest` to restore the most recent snapshot: `ddev snapshot restore --latest`.
+Use the [`ddev snapshot restore`](../usage/commands.md#snapshot-restore) command to interactively choose among snapshots, or append `--latest` to restore the most recent snapshot: `ddev snapshot restore --latest`. It also accepts the path to a snapshot file outside the project: `ddev snapshot restore ~/tmp/mysnapshot-mariadb_11.8.zst`.
 
 Snapshots are stored as compressed (zstd, or gzip on very old database versions) files in the project's `.ddev/db_snapshots` directory, and any or all snapshots can be removed with the `ddev snapshot --cleanup` command or by manually deleting the files when you want to save disk space or have no further use for them.
 

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -99,7 +99,7 @@ With a large database this may take a long time.
 
 `ddev start --reset-database` removes the project's database and starts over with a new one. It snapshots the existing database first, unless you add `--omit-snapshot`/`-O`, and asks for confirmation unless you add `--skip-confirmation`/`-y`. The same flags work on [`ddev restart`](../usage/commands.md#restart).
 
-Use it when you want a clean database, or when you've changed `database:` in `config.yaml` and `ddev start` refuses because the existing database was created by a different database server. The snapshot it takes is made with the database version that's actually in the volume, so it stays restorable after you put the configuration back.
+Use it when you want a clean database, or when you've changed `database:` in `config.yaml` and `ddev start` refuses because the existing database was created by a different database server. The snapshot it takes is made with the database version that's actually in the volume, so you can still restore it after you put the configuration back.
 
 ```bash
 ddev config --database=postgres:17

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -53,7 +53,7 @@ Snapshots are stored as compressed (zstd, or gzip on very old database versions)
 
 ### Uncompressed Snapshots
 
-`ddev snapshot`, `ddev snapshot restore`, and the reserved `seed` snapshot all compress the database backup by default, which is the right tradeoff for almost everyone. Decompression still costs real time, though — routinely 30-40% of a restore or first `ddev start`, and it competes for the same CPU cores the database restore itself needs right after. `--uncompressed` skips it:
+`ddev snapshot`, `ddev snapshot restore`, and the reserved `seed` snapshot all compress the database backup by default, which is the right trade-off for almost everyone. Decompression still costs real time, though — routinely 30-40% of a restore or first `ddev start`, and it competes for the same CPU cores the database restore itself needs right after. `--uncompressed` skips it:
 
 ```bash
 ddev snapshot --uncompressed

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -63,27 +63,54 @@ This is an unusual, deliberate tradeoff, not a general recommendation: an uncomp
 
 An `initializer` snapshot honors the same flag, and a `dbimage` built with a baked-in seed (see [Seeding a Custom Starter Database](../extend/customizing-images.md#seeding-a-custom-starter-database-in-dbimage)) can use an uncompressed seed the same way.
 
-### Seeding a Fresh Database with an `initializer` Snapshot
+### Seeding a Fresh Database from a Snapshot
 
-`initializer` is a reserved snapshot name. If a snapshot named `initializer` exists in `.ddev/db_snapshots`, it's used automatically the first time a project's database volume is created — a brand-new project, or after `ddev delete` and [`ddev start`](../usage/commands.md#start) — instead of DDEV's normal empty starter database. This is a fast, direct restore of the database files, much quicker than importing a SQL dump on every fresh start.
+The first time a project's database volume is created — a brand-new project, or after `ddev delete` and [`ddev start`](../usage/commands.md#start) — DDEV can restore a snapshot into it instead of using its normal empty starter database. This is a direct restore of the database files, much quicker than importing a SQL dump on every fresh start.
 
-Create one from a running project's current database with:
+`seed` is a reserved snapshot name used for this. If a snapshot named `seed` exists in `.ddev/db_snapshots`, it's used automatically, with nothing to remember at start time:
 
 ```bash
-ddev snapshot --name=initializer
+ddev snapshot --name=seed
+ddev delete -Oy
+ddev start
 ```
 
-Unlike other snapshots, `initializer` isn't meant to be restored with `ddev snapshot restore` — it's only consulted for an uninitialized database. You can choose to commit the resulting `initializer-*` file in `.ddev/db_snapshots` to your repository if you want teammates and CI to get the same starting dataset on their first `ddev start`, but it may be large and you may want to use another distribution technique.
+To use a different snapshot for one start, name it with `--seed-snapshot`, which takes either a snapshot name from `.ddev/db_snapshots` or the path to a snapshot file elsewhere on disk:
 
-An `initializer` snapshot is listed as [custom configuration](../extend/customization-extendibility.md), so `ddev start` and [`ddev utility check-custom-config`](../usage/commands.md#utility-check-custom-config) both show it. When `ddev start` actually seeds a fresh database volume from it, it says so, naming the snapshot and its size and warning that a large one may take a while:
+```bash
+ddev start --seed-snapshot=large-dataset
+ddev start --seed-snapshot=~/datasets/production-mariadb_11.8.zst
+```
+
+`--seed-snapshot` applies to that command only and is never written to `config.yaml`. It only seeds a brand-new database volume; if the project already has a database, DDEV says so rather than silently ignoring the flag. Use [`ddev start --reset-database`](#starting-over-with-a-new-database) to throw the existing database away first, or [`ddev snapshot restore`](../usage/commands.md#snapshot-restore) to restore over it.
+
+A snapshot can only seed the database type and version it was made from, which is why the standard `-<type>_<version>.{zst,gz}` suffix `ddev snapshot` gives it has to stay on the filename.
+
+Unlike other snapshots, `seed` isn't meant to be restored with `ddev snapshot restore` — it's only consulted for an uninitialized database. You can choose to commit the resulting `seed-*` file in `.ddev/db_snapshots` to your repository if you want teammates and CI to get the same starting dataset on their first `ddev start`, but it may be large and you may want to use another distribution technique.
+
+A `seed` snapshot is listed as [custom configuration](../extend/customization-extendibility.md), so `ddev start` and [`ddev utility check-custom-config`](../usage/commands.md#utility-check-custom-config) both show it. When `ddev start` actually seeds a fresh database volume, it says so, naming the snapshot and its size and warning that a large one may take a while:
 
 ```
-Initializing new database volume from the 'initializer' snapshot /path/to/project/.ddev/db_snapshots/initializer-mariadb_11.8.zst (2.2 GiB)...
+Initializing new database volume from the 'seed' snapshot /path/to/project/.ddev/db_snapshots/seed-mariadb_11.8.zst (2.2 GiB)...
 With a large database this may take a long time.
 ```
 
-!!!note
-    Only supported for `mysql` and `mariadb` database types (excluding the very old, EOL `mysql:5.5` and `mariadb:5.5`). PostgreSQL projects use the stock upstream `postgres` image and its own startup process, which this seeding mechanism doesn't hook into, so an `initializer` snapshot is silently ignored.
+### Starting Over with a New Database
+
+`ddev start --reset-database` removes the project's database and starts over with a new one. It snapshots the existing database first, unless you add `--omit-snapshot`/`-O`, and asks for confirmation unless you add `--skip-confirmation`/`-y`. The same flags work on [`ddev restart`](../usage/commands.md#restart).
+
+Use it when you want a clean database, or when you've changed `database:` in `config.yaml` and `ddev start` refuses because the existing database was created by a different database server. The snapshot it takes is made with the database version that's actually in the volume, so it stays restorable after you put the configuration back.
+
+```bash
+ddev config --database=postgres:17
+ddev start --reset-database
+```
+
+To combine it with a seed, so the new database starts out with a dataset of your choosing rather than empty:
+
+```bash
+ddev start --reset-database --seed-snapshot=large-dataset
+```
 
 ## Database Clients
 

--- a/pkg/ddevapp/app_compose_template.yaml
+++ b/pkg/ddevapp/app_compose_template.yaml
@@ -30,6 +30,9 @@ services:
       - .:/mnt/ddev_config
       - ./db_snapshots:/mnt/snapshots
       {{ end }} {{/* end if .NoBindMounts */}}
+      {{ if .SeedSnapshotMountDir }}
+      - {{ .SeedSnapshotMountDir }}:{{ .SeedSnapshotMountTarget }}:ro
+      {{ end }}
       - ddev-global-cache:/mnt/ddev-global-cache
     restart: "no"
 

--- a/pkg/ddevapp/base_db_seed.go
+++ b/pkg/ddevapp/base_db_seed.go
@@ -87,7 +87,7 @@ func (s *SeedSnapshot) ContainerPath() string {
 //
 // The flag takes either a snapshot name resolved inside .ddev/db_snapshots, or a
 // path to a snapshot file elsewhere. Either way the file has to keep the standard
-// `-<type>_<version>.{zst,gz}` suffix, so a snapshot from a different database
+// `-<type>_<version>.<ext>` suffix, so a snapshot from a different database
 // can't be dropped into a fresh volume it will not work in.
 func (app *DdevApp) ResolveSeedSnapshot() (*SeedSnapshot, error) {
 	if app.IsDBOmitted() {

--- a/pkg/ddevapp/base_db_seed.go
+++ b/pkg/ddevapp/base_db_seed.go
@@ -104,27 +104,9 @@ func (app *DdevApp) ResolveSeedSnapshot() (*SeedSnapshot, error) {
 		return nil, nil
 	}
 
-	hostPath := app.SeedSnapshot
-	mountDir := ""
-	if filepath.IsAbs(hostPath) || strings.ContainsAny(hostPath, `/\`) {
-		var err error
-		if hostPath, err = filepath.Abs(hostPath); err != nil {
-			return nil, fmt.Errorf("unable to resolve --seed-snapshot=%s: %v", app.SeedSnapshot, err)
-		}
-		if !fileutil.FileExists(hostPath) || fileutil.IsDirectory(hostPath) {
-			return nil, fmt.Errorf("--seed-snapshot=%s is not an existing snapshot file", app.SeedSnapshot)
-		}
-		// A snapshot already in .ddev/db_snapshots needs no mount of its own, and
-		// with no_bind_mounts prepareSeedSnapshot copies it in rather than mounting.
-		if dir := filepath.Dir(hostPath); dir != app.GetConfigPath("db_snapshots") && !globalconfig.DdevGlobalConfig.NoBindMounts {
-			mountDir = dir
-		}
-	} else {
-		snapshotFile, err := GetSnapshotFileFromName(app.SeedSnapshot, app)
-		if err != nil {
-			return nil, fmt.Errorf("unable to use --seed-snapshot=%s: %v", app.SeedSnapshot, err)
-		}
-		hostPath = app.GetConfigPath(filepath.Join("db_snapshots", snapshotFile))
+	hostPath, mountDir, err := resolveSnapshotSource(app.SeedSnapshot, app)
+	if err != nil {
+		return nil, fmt.Errorf("unable to use --seed-snapshot=%s: %v", app.SeedSnapshot, err)
 	}
 
 	snapshotDBVersion, err := snapshotDBVersionFromFilename(filepath.Base(hostPath))

--- a/pkg/ddevapp/base_db_seed.go
+++ b/pkg/ddevapp/base_db_seed.go
@@ -114,8 +114,9 @@ func (app *DdevApp) ResolveSeedSnapshot() (*SeedSnapshot, error) {
 		if !fileutil.FileExists(hostPath) || fileutil.IsDirectory(hostPath) {
 			return nil, fmt.Errorf("--seed-snapshot=%s is not an existing snapshot file", app.SeedSnapshot)
 		}
-		// A snapshot already in .ddev/db_snapshots needs no mount of its own.
-		if dir := filepath.Dir(hostPath); dir != app.GetConfigPath("db_snapshots") {
+		// A snapshot already in .ddev/db_snapshots needs no mount of its own, and
+		// with no_bind_mounts prepareSeedSnapshot copies it in rather than mounting.
+		if dir := filepath.Dir(hostPath); dir != app.GetConfigPath("db_snapshots") && !globalconfig.DdevGlobalConfig.NoBindMounts {
 			mountDir = dir
 		}
 	} else {
@@ -240,20 +241,18 @@ func (app *DdevApp) getDerivedDBImageSeed() (seedPath string, size int64) {
 
 // prepareSeedSnapshot makes a seed snapshot reachable by the db container.
 // With bind mounts it's already visible, either in .ddev/db_snapshots or
-// through the mount RenderComposeYAML adds for SeedSnapshotMountDir.
+// through the mount RenderComposeYAML adds for SeedSnapshotMountDir. With
+// no_bind_mounts the db container sees /mnt/snapshots as a Docker volume
+// instead, so wherever the snapshot came from it has to be copied in.
+// Must run after the snapshots volume is created, so it gets the usual labels.
 func (app *DdevApp) prepareSeedSnapshot(seed *SeedSnapshot) error {
-	if !globalconfig.DdevGlobalConfig.NoBindMounts || seed.MountDir == "" {
+	if !globalconfig.DdevGlobalConfig.NoBindMounts {
 		return nil
 	}
-	// With no_bind_mounts the db container sees /mnt/snapshots as a Docker volume
-	// rather than .ddev/db_snapshots, and there is no mount to add, so an
-	// out-of-project snapshot has to be copied into that volume instead.
 	uid, _, _ := dockerutil.GetContainerUser()
 	if err := dockerutil.CopyIntoVolume(seed.HostPath, "ddev-"+app.Name+"-snapshots", "", uid, "", false); err != nil {
 		return fmt.Errorf("failed to copy %s into the snapshots volume: %v", seed.HostPath, err)
 	}
-	seed.MountDir = ""
-	app.SeedSnapshotMountDir = ""
 	return nil
 }
 

--- a/pkg/ddevapp/base_db_seed.go
+++ b/pkg/ddevapp/base_db_seed.go
@@ -3,6 +3,7 @@ package ddevapp
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -17,10 +18,15 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 )
 
-// InitializerSnapshotName is the reserved snapshot name that ddev-dbserver uses
-// to seed a brand-new database volume instead of the stock starter database.
-// See containers/ddev-dbserver/files/docker-entrypoint.sh
-const InitializerSnapshotName = "initializer"
+// SeedSnapshotName is the reserved snapshot name that seeds a brand-new
+// database volume instead of the stock starter database, used when
+// `ddev start --seed-snapshot` names nothing else.
+const SeedSnapshotName = "seed"
+
+// SeedSnapshotMountDir is where the directory holding a seed snapshot from
+// outside the project gets mounted in the db container. Snapshots living in
+// .ddev/db_snapshots are already visible to it at /mnt/snapshots.
+const SeedSnapshotMountDir = "/mnt/seed"
 
 // CustomBaseDBSeedPathPrefix is where a derived dbimage bakes in its own
 // base_db seed; ddev-dbserver checks it ahead of the stock /mysqlbase/base_db.*
@@ -39,21 +45,96 @@ func (app *DdevApp) UsesBaseDBSeed() bool {
 	return !app.IsDBOmitted() && slices.Contains([]string{nodeps.MariaDB, nodeps.MySQL}, app.Database.Type)
 }
 
-// GetInitializerSnapshotFile returns the host path of the project's reserved
-// `initializer` snapshot for the configured database type/version, or an empty
-// string if there isn't one. ddev-dbserver looks for
-// /mnt/snapshots/initializer-<type>_<version>.{zst,gz}, preferring .zst.
-func (app *DdevApp) GetInitializerSnapshotFile() string {
-	if !app.UsesBaseDBSeed() {
+// GetSeedSnapshotFile returns the host path of the project's reserved `seed`
+// snapshot for the configured database type/version, or an empty string if
+// there isn't one. Unlike a base_db seed baked into the dbimage, this works for
+// every database type, because it's restored through the same container command
+// `ddev snapshot restore` uses.
+func (app *DdevApp) GetSeedSnapshotFile() string {
+	if app.IsDBOmitted() {
 		return ""
 	}
 	for _, ext := range baseDBSeedExtensions {
-		f := app.GetConfigPath(filepath.Join("db_snapshots", fmt.Sprintf("%s-%s_%s.%s", InitializerSnapshotName, app.Database.Type, app.Database.Version, ext)))
+		f := app.GetConfigPath(filepath.Join("db_snapshots", fmt.Sprintf("%s-%s_%s.%s", SeedSnapshotName, app.Database.Type, app.Database.Version, ext)))
 		if fileutil.FileExists(f) {
 			return f
 		}
 	}
 	return ""
+}
+
+// SeedSnapshot describes the snapshot a brand-new database volume gets seeded
+// from, resolved from `--seed-snapshot` or from the reserved `seed` snapshot.
+type SeedSnapshot struct {
+	// HostPath is the absolute path of the snapshot file on the host.
+	HostPath string
+	// MountDir is the host directory to mount into the db container, empty when
+	// the snapshot is already in .ddev/db_snapshots.
+	MountDir string
+}
+
+// ContainerPath returns the snapshot file as the db container sees it.
+func (s *SeedSnapshot) ContainerPath() string {
+	if s.MountDir != "" {
+		return path.Join(SeedSnapshotMountDir, filepath.Base(s.HostPath))
+	}
+	return path.Join("/mnt/snapshots", filepath.Base(s.HostPath))
+}
+
+// ResolveSeedSnapshot works out which snapshot should seed a brand-new database
+// volume: the one named by `--seed-snapshot`, or the reserved `seed` snapshot if
+// the flag wasn't used. It returns nil when there is nothing to seed from.
+//
+// The flag takes either a snapshot name resolved inside .ddev/db_snapshots, or a
+// path to a snapshot file elsewhere. Either way the file has to keep the standard
+// `-<type>_<version>.{zst,gz}` suffix, so a snapshot from a different database
+// can't be dropped into a fresh volume it will not work in.
+func (app *DdevApp) ResolveSeedSnapshot() (*SeedSnapshot, error) {
+	if app.IsDBOmitted() {
+		if app.SeedSnapshot != "" {
+			return nil, fmt.Errorf("--seed-snapshot is not usable on project %s because its database is omitted", app.Name)
+		}
+		return nil, nil
+	}
+
+	if app.SeedSnapshot == "" {
+		if f := app.GetSeedSnapshotFile(); f != "" {
+			return &SeedSnapshot{HostPath: f}, nil
+		}
+		return nil, nil
+	}
+
+	hostPath := app.SeedSnapshot
+	mountDir := ""
+	if filepath.IsAbs(hostPath) || strings.ContainsAny(hostPath, `/\`) {
+		var err error
+		if hostPath, err = filepath.Abs(hostPath); err != nil {
+			return nil, fmt.Errorf("unable to resolve --seed-snapshot=%s: %v", app.SeedSnapshot, err)
+		}
+		if !fileutil.FileExists(hostPath) || fileutil.IsDirectory(hostPath) {
+			return nil, fmt.Errorf("--seed-snapshot=%s is not an existing snapshot file", app.SeedSnapshot)
+		}
+		// A snapshot already in .ddev/db_snapshots needs no mount of its own.
+		if dir := filepath.Dir(hostPath); dir != app.GetConfigPath("db_snapshots") {
+			mountDir = dir
+		}
+	} else {
+		snapshotFile, err := GetSnapshotFileFromName(app.SeedSnapshot, app)
+		if err != nil {
+			return nil, fmt.Errorf("unable to use --seed-snapshot=%s: %v", app.SeedSnapshot, err)
+		}
+		hostPath = app.GetConfigPath(filepath.Join("db_snapshots", snapshotFile))
+	}
+
+	snapshotDBVersion, err := snapshotDBVersionFromFilename(filepath.Base(hostPath))
+	if err != nil {
+		return nil, fmt.Errorf("unable to use --seed-snapshot=%s: %v", app.SeedSnapshot, err)
+	}
+	if currentDBVersion := app.Database.Type + "_" + app.Database.Version; snapshotDBVersion != currentDBVersion {
+		return nil, fmt.Errorf("--seed-snapshot=%s is a '%s' snapshot, which cannot seed a '%s' database", app.SeedSnapshot, snapshotDBVersion, currentDBVersion)
+	}
+
+	return &SeedSnapshot{HostPath: hostPath, MountDir: mountDir}, nil
 }
 
 // GetDBBuildDockerfiles returns the global and project db-build Dockerfiles.
@@ -111,10 +192,10 @@ func derivedBuiltImageRef(baseImage, appName string) string {
 }
 
 // getDerivedDBImageSeed returns the in-image path and byte size of a base_db
-// seed baked into the built dbimage. path is empty if there is none; size is
-// -1 if it could not be determined. This runs a container against the image,
+// seed baked into the built dbimage. seedPath is empty if there is none; size
+// is -1 if it could not be determined. This runs a container against the image,
 // so callers gate it on mayHaveDerivedDBImageSeed().
-func (app *DdevApp) getDerivedDBImageSeed() (path string, size int64) {
+func (app *DdevApp) getDerivedDBImageSeed() (seedPath string, size int64) {
 	var candidates []string
 	for _, ext := range baseDBSeedExtensions {
 		candidates = append(candidates, CustomBaseDBSeedPathPrefix+"."+ext)
@@ -157,23 +238,40 @@ func (app *DdevApp) getDerivedDBImageSeed() (path string, size int64) {
 	return "", -1
 }
 
-// BaseDBSeedDescription returns a human-readable description of what a
-// brand-new database volume will be seeded from (an initializer snapshot, or
-// a seed baked into a derived dbimage), or an empty string if it'll just be
-// the stock starter database. Callers use this to decide whether to warn
-// about a long first-boot restore and extend the container-ready timeout
-// accordingly.
-func (app *DdevApp) BaseDBSeedDescription() string {
-	if !app.UsesBaseDBSeed() {
-		return ""
+// prepareSeedSnapshot makes a seed snapshot reachable by the db container.
+// With bind mounts it's already visible, either in .ddev/db_snapshots or
+// through the mount RenderComposeYAML adds for SeedSnapshotMountDir.
+func (app *DdevApp) prepareSeedSnapshot(seed *SeedSnapshot) error {
+	if !globalconfig.DdevGlobalConfig.NoBindMounts || seed.MountDir == "" {
+		return nil
 	}
+	// With no_bind_mounts the db container sees /mnt/snapshots as a Docker volume
+	// rather than .ddev/db_snapshots, and there is no mount to add, so an
+	// out-of-project snapshot has to be copied into that volume instead.
+	uid, _, _ := dockerutil.GetContainerUser()
+	if err := dockerutil.CopyIntoVolume(seed.HostPath, "ddev-"+app.Name+"-snapshots", "", uid, "", false); err != nil {
+		return fmt.Errorf("failed to copy %s into the snapshots volume: %v", seed.HostPath, err)
+	}
+	seed.MountDir = ""
+	app.SeedSnapshotMountDir = ""
+	return nil
+}
 
-	if initializer := app.GetInitializerSnapshotFile(); initializer != "" {
-		return fmt.Sprintf("the '%s' snapshot\n%s%s", InitializerSnapshotName, fileutil.ShortHomeJoin(initializer), fileSizeSuffix(initializer))
+// SeedDescription returns a human-readable description of what a brand-new
+// database volume will be seeded from, or an empty string if it'll just be the
+// stock starter database. Callers use this to decide whether to warn about a
+// long first-boot restore and extend the container-ready timeout accordingly.
+func (app *DdevApp) SeedDescription(seed *SeedSnapshot) string {
+	if seed != nil {
+		description := fmt.Sprintf("the '%s' snapshot", SeedSnapshotName)
+		if app.SeedSnapshot != "" {
+			description = fmt.Sprintf("snapshot '%s'", app.SeedSnapshot)
+		}
+		return fmt.Sprintf("%s\n%s%s", description, fileutil.ShortHomeJoin(seed.HostPath), fileSizeSuffix(seed.HostPath))
 	}
-	if app.mayHaveDerivedDBImageSeed() {
-		if seed, size := app.getDerivedDBImageSeed(); seed != "" {
-			return fmt.Sprintf("%s%s baked into dbimage %s", seed, byteSizeSuffix(size), app.GetDBImage())
+	if app.UsesBaseDBSeed() && app.mayHaveDerivedDBImageSeed() {
+		if baseDBSeed, size := app.getDerivedDBImageSeed(); baseDBSeed != "" {
+			return fmt.Sprintf("%s%s baked into dbimage %s", baseDBSeed, byteSizeSuffix(size), app.GetDBImage())
 		}
 	}
 	return ""
@@ -192,8 +290,8 @@ func (app *DdevApp) announceBaseDBSeed(description string, maxWaitTime int) {
 
 // fileSizeSuffix returns a " (2.3GB)" style suffix for a file, or an empty
 // string if the size can't be determined.
-func fileSizeSuffix(path string) string {
-	fi, err := os.Stat(path)
+func fileSizeSuffix(filePath string) string {
+	fi, err := os.Stat(filePath)
 	if err != nil || fi.IsDir() {
 		return ""
 	}

--- a/pkg/ddevapp/base_db_seed_test.go
+++ b/pkg/ddevapp/base_db_seed_test.go
@@ -38,19 +38,18 @@ func writeBaseDBSeedTestFile(t *testing.T, app *DdevApp, relPath, content string
 	return fullPath
 }
 
-// TestGetInitializerSnapshotFile verifies the host-side lookup of the reserved
-// `initializer` snapshot, which must match ddev-dbserver's docker-entrypoint.sh:
+// TestGetSeedSnapshotFile verifies the lookup of the reserved `seed` snapshot:
 // named for the exact db type/version, preferring .zst over .gz.
-func TestGetInitializerSnapshotFile(t *testing.T) {
+func TestGetSeedSnapshotFile(t *testing.T) {
 	app := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
-	require.Empty(t, app.GetInitializerSnapshotFile())
+	require.Empty(t, app.GetSeedSnapshotFile())
 
-	gz := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "initializer-mariadb_10.11.gz"), "seed")
-	require.Equal(t, gz, app.GetInitializerSnapshotFile())
+	gz := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "seed-mariadb_10.11.gz"), "seed")
+	require.Equal(t, gz, app.GetSeedSnapshotFile())
 
 	// .zst wins over .gz when both are present.
-	zst := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "initializer-mariadb_10.11.zst"), "seed")
-	require.Equal(t, zst, app.GetInitializerSnapshotFile())
+	zst := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "seed-mariadb_10.11.zst"), "seed")
+	require.Equal(t, zst, app.GetSeedSnapshotFile())
 
 	// An uncompressed .mbstream seed is recognized, but a compressed seed
 	// still wins if one is also present.
@@ -64,19 +63,72 @@ func TestGetInitializerSnapshotFile(t *testing.T) {
 
 	// A snapshot for a different db version is not this project's initializer.
 	other := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB106)
-	writeBaseDBSeedTestFile(t, other, filepath.Join("db_snapshots", "initializer-mariadb_10.11.zst"), "seed")
-	require.Empty(t, other.GetInitializerSnapshotFile())
+	writeBaseDBSeedTestFile(t, other, filepath.Join("db_snapshots", "seed-mariadb_10.11.zst"), "seed")
+	require.Empty(t, other.GetSeedSnapshotFile())
 
-	// PostgreSQL doesn't use base_db seeding at all.
+	// Unlike a base_db seed baked into the dbimage, this works for PostgreSQL.
 	pg := newBaseDBSeedTestApp(t, nodeps.Postgres, nodeps.Postgres17)
-	writeBaseDBSeedTestFile(t, pg, filepath.Join("db_snapshots", "initializer-postgres_17.zst"), "seed")
-	require.Empty(t, pg.GetInitializerSnapshotFile())
+	pgSeed := writeBaseDBSeedTestFile(t, pg, filepath.Join("db_snapshots", "seed-postgres_17.zst"), "seed")
+	require.Equal(t, pgSeed, pg.GetSeedSnapshotFile())
 
-	// Neither does a project with no db container.
+	// A project with no db container has nothing to seed.
 	omitted := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
 	omitted.OmitContainers = []string{"db"}
-	writeBaseDBSeedTestFile(t, omitted, filepath.Join("db_snapshots", "initializer-mariadb_10.11.zst"), "seed")
-	require.Empty(t, omitted.GetInitializerSnapshotFile())
+	writeBaseDBSeedTestFile(t, omitted, filepath.Join("db_snapshots", "seed-mariadb_10.11.zst"), "seed")
+	require.Empty(t, omitted.GetSeedSnapshotFile())
+}
+
+// TestResolveSeedSnapshot covers what `--seed-snapshot` accepts: nothing (the
+// reserved `seed` snapshot), a snapshot name in .ddev/db_snapshots, and a path
+// to a snapshot elsewhere, which needs a mount of its own.
+func TestResolveSeedSnapshot(t *testing.T) {
+	app := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
+
+	seed, err := app.ResolveSeedSnapshot()
+	require.NoError(t, err)
+	require.Nil(t, seed, "nothing to seed from without a flag or a reserved snapshot")
+
+	reserved := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "seed-mariadb_10.11.zst"), "seed")
+	seed, err = app.ResolveSeedSnapshot()
+	require.NoError(t, err)
+	require.Equal(t, reserved, seed.HostPath)
+	require.Empty(t, seed.MountDir, "a snapshot in the project needs no mount of its own")
+	require.Equal(t, "/mnt/snapshots/seed-mariadb_10.11.zst", seed.ContainerPath())
+
+	// A bare name resolves inside .ddev/db_snapshots, the same way
+	// `ddev snapshot restore <name>` resolves it.
+	inProject := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "mydata-mariadb_10.11.zst"), "seed")
+	app.SeedSnapshot = "mydata"
+	seed, err = app.ResolveSeedSnapshot()
+	require.NoError(t, err)
+	require.Equal(t, inProject, seed.HostPath)
+	require.Empty(t, seed.MountDir)
+
+	// A path outside the project is mounted into the db container.
+	outsideDir := t.TempDir()
+	outside := filepath.Join(outsideDir, "elsewhere-mariadb_10.11.zst")
+	require.NoError(t, os.WriteFile(outside, []byte("seed"), 0644))
+	app.SeedSnapshot = outside
+	seed, err = app.ResolveSeedSnapshot()
+	require.NoError(t, err)
+	require.Equal(t, outside, seed.HostPath)
+	require.Equal(t, outsideDir, seed.MountDir)
+	require.Equal(t, SeedSnapshotMountDir+"/elsewhere-mariadb_10.11.zst", seed.ContainerPath())
+
+	// A snapshot from another database can't seed this one.
+	wrongVersion := filepath.Join(outsideDir, "elsewhere-mariadb_10.6.zst")
+	require.NoError(t, os.WriteFile(wrongVersion, []byte("seed"), 0644))
+	app.SeedSnapshot = wrongVersion
+	_, err = app.ResolveSeedSnapshot()
+	require.ErrorContains(t, err, "mariadb_10.6")
+
+	app.SeedSnapshot = filepath.Join(outsideDir, "no-such-snapshot.zst")
+	_, err = app.ResolveSeedSnapshot()
+	require.ErrorContains(t, err, "not an existing snapshot file")
+
+	app.SeedSnapshot = "nonexistent"
+	_, err = app.ResolveSeedSnapshot()
+	require.ErrorContains(t, err, "nonexistent")
 }
 
 // TestGetDBBuildSeedDockerfiles verifies that only db-build Dockerfiles that
@@ -101,25 +153,27 @@ func TestGetDBBuildSeedDockerfiles(t *testing.T) {
 }
 
 // TestAnnounceBaseDBSeed verifies that seeding a fresh database volume from a
-// project `initializer` snapshot is announced with what it's doing, which
-// snapshot, and that it may take a while — and that the stock starter database
-// (no initializer, no derived image) stays quiet.
+// project `seed` snapshot is announced with what it's doing, which snapshot, and
+// that it may take a while — and that the stock starter database (no seed
+// snapshot, no derived image) stays quiet.
 func TestAnnounceBaseDBSeed(t *testing.T) {
 	app := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
 	app.DefaultContainerTimeout = nodeps.DefaultDefaultContainerTimeout
 
-	require.Empty(t, app.BaseDBSeedDescription(), "stock starter database should not be announced")
+	require.Empty(t, app.SeedDescription(nil), "stock starter database should not be announced")
 
-	initializer := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "initializer-mariadb_10.11.zst"), strings.Repeat("x", 2048))
-	description := app.BaseDBSeedDescription()
+	seedFile := writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "seed-mariadb_10.11.zst"), strings.Repeat("x", 2048))
+	seed, err := app.ResolveSeedSnapshot()
+	require.NoError(t, err)
+	description := app.SeedDescription(seed)
 	require.NotEmpty(t, description)
 
 	outFunc := util.CaptureUserOut()
 	app.announceBaseDBSeed(description, SnapshotRestoreDefaultWaitTime)
 	out := outFunc()
 
-	require.Contains(t, out, "Initializing new database volume from the 'initializer' snapshot")
-	require.Contains(t, out, fileutil.ShortHomeJoin(filepath.ToSlash(initializer)))
+	require.Contains(t, out, "Initializing new database volume from the 'seed' snapshot")
+	require.Contains(t, out, fileutil.ShortHomeJoin(filepath.ToSlash(seedFile)))
 	require.Contains(t, out, "(2.0KB)")
 	require.Contains(t, out, "this may take a long time")
 	require.Contains(t, out, "default_container_timeout")
@@ -145,7 +199,7 @@ func TestDerivedBuiltImageRef(t *testing.T) {
 }
 
 // TestFileSizeSuffix verifies the human-readable size suffix used when
-// announcing an `initializer` snapshot restore.
+// announcing a seed snapshot restore.
 func TestFileSizeSuffix(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/pkg/ddevapp/base_db_seed_test.go
+++ b/pkg/ddevapp/base_db_seed_test.go
@@ -54,13 +54,13 @@ func TestGetSeedSnapshotFile(t *testing.T) {
 
 	// An uncompressed .mbstream seed is recognized, but a compressed seed
 	// still wins if one is also present.
-	writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "initializer-mariadb_10.11.mbstream"), "seed")
-	require.Equal(t, zst, app.GetInitializerSnapshotFile())
+	writeBaseDBSeedTestFile(t, app, filepath.Join("db_snapshots", "seed-mariadb_10.11.mbstream"), "seed")
+	require.Equal(t, zst, app.GetSeedSnapshotFile())
 
 	// With no compressed seed, the uncompressed one is used.
 	uncompressed := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
-	mbstream := writeBaseDBSeedTestFile(t, uncompressed, filepath.Join("db_snapshots", "initializer-mariadb_10.11.mbstream"), "seed")
-	require.Equal(t, mbstream, uncompressed.GetInitializerSnapshotFile())
+	mbstream := writeBaseDBSeedTestFile(t, uncompressed, filepath.Join("db_snapshots", "seed-mariadb_10.11.mbstream"), "seed")
+	require.Equal(t, mbstream, uncompressed.GetSeedSnapshotFile())
 
 	// A snapshot for a different db version is not this project's initializer.
 	other := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB106)

--- a/pkg/ddevapp/base_db_seed_test.go
+++ b/pkg/ddevapp/base_db_seed_test.go
@@ -62,7 +62,7 @@ func TestGetSeedSnapshotFile(t *testing.T) {
 	mbstream := writeBaseDBSeedTestFile(t, uncompressed, filepath.Join("db_snapshots", "seed-mariadb_10.11.mbstream"), "seed")
 	require.Equal(t, mbstream, uncompressed.GetSeedSnapshotFile())
 
-	// A snapshot for a different db version is not this project's initializer.
+	// A snapshot for a different db version is not this project's seed.
 	other := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB106)
 	writeBaseDBSeedTestFile(t, other, filepath.Join("db_snapshots", "seed-mariadb_10.11.zst"), "seed")
 	require.Empty(t, other.GetSeedSnapshotFile())

--- a/pkg/ddevapp/base_db_seed_test.go
+++ b/pkg/ddevapp/base_db_seed_test.go
@@ -130,6 +130,14 @@ func TestResolveSeedSnapshot(t *testing.T) {
 	require.Equal(t, "/mnt/snapshots/elsewhere-mariadb_10.11.zst", seed.ContainerPath())
 	globalconfig.DdevGlobalConfig.NoBindMounts = false
 
+	// An uncompressed snapshot outside the project is accepted too.
+	uncompressed := filepath.Join(outsideDir, "elsewhere-mariadb_10.11.mbstream")
+	require.NoError(t, os.WriteFile(uncompressed, []byte("seed"), 0644))
+	app.SeedSnapshot = uncompressed
+	seed, err = app.ResolveSeedSnapshot()
+	require.NoError(t, err)
+	require.Equal(t, uncompressed, seed.HostPath)
+
 	// A snapshot from another database can't seed this one.
 	wrongVersion := filepath.Join(outsideDir, "elsewhere-mariadb_10.6.zst")
 	require.NoError(t, os.WriteFile(wrongVersion, []byte("seed"), 0644))

--- a/pkg/ddevapp/base_db_seed_test.go
+++ b/pkg/ddevapp/base_db_seed_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ddev/ddev/pkg/fileutil"
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/stretchr/testify/require"
@@ -84,6 +85,10 @@ func TestGetSeedSnapshotFile(t *testing.T) {
 func TestResolveSeedSnapshot(t *testing.T) {
 	app := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDB1011)
 
+	origNoBindMounts := globalconfig.DdevGlobalConfig.NoBindMounts
+	globalconfig.DdevGlobalConfig.NoBindMounts = false
+	t.Cleanup(func() { globalconfig.DdevGlobalConfig.NoBindMounts = origNoBindMounts })
+
 	seed, err := app.ResolveSeedSnapshot()
 	require.NoError(t, err)
 	require.Nil(t, seed, "nothing to seed from without a flag or a reserved snapshot")
@@ -114,6 +119,16 @@ func TestResolveSeedSnapshot(t *testing.T) {
 	require.Equal(t, outside, seed.HostPath)
 	require.Equal(t, outsideDir, seed.MountDir)
 	require.Equal(t, SeedSnapshotMountDir+"/elsewhere-mariadb_10.11.zst", seed.ContainerPath())
+
+	// With no_bind_mounts there is nothing to mount; prepareSeedSnapshot copies
+	// the snapshot into the snapshots volume, so the container path is the usual one.
+	globalconfig.DdevGlobalConfig.NoBindMounts = true
+	seed, err = app.ResolveSeedSnapshot()
+	require.NoError(t, err)
+	require.Equal(t, outside, seed.HostPath)
+	require.Empty(t, seed.MountDir)
+	require.Equal(t, "/mnt/snapshots/elsewhere-mariadb_10.11.zst", seed.ContainerPath())
+	globalconfig.DdevGlobalConfig.NoBindMounts = false
 
 	// A snapshot from another database can't seed this one.
 	wrongVersion := filepath.Join(outsideDir, "elsewhere-mariadb_10.6.zst")

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -875,6 +875,8 @@ type composeYAMLVars struct {
 	HostXHGuiPort             string
 	XhguiImage                string
 	XHProfMode                types.XHProfMode
+	SeedSnapshotMountDir      string
+	SeedSnapshotMountTarget   string
 }
 
 // RenderComposeYAML renders the contents of .ddev/.ddev-docker-compose*.
@@ -963,6 +965,8 @@ func (app *DdevApp) RenderComposeYAML() (string, error) {
 		XhguiImage:              docker.GetXhguiImage(),
 		XHProfMode:              app.GetXHProfMode(),
 		UseHardenedImages:       globalconfig.DdevGlobalConfig.UseHardenedImages,
+		SeedSnapshotMountDir:    app.SeedSnapshotMountDir,
+		SeedSnapshotMountTarget: SeedSnapshotMountDir,
 	}
 	// We don't want to bind-mount Git directory if it doesn't exist
 	if fileutil.IsDirectory(filepath.Join(app.AppRoot, ".git")) {

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -441,13 +441,13 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 		})
 	}
 
-	// An `initializer` snapshot or a base_db seed baked into a derived dbimage
-	// replaces the stock starter database when a fresh database volume is created,
-	// so report them even though neither is an ordinary config file.
-	if initializer := app.GetInitializerSnapshotFile(); initializer != "" {
+	// A `seed` snapshot or a base_db seed baked into a derived dbimage replaces the
+	// stock starter database when a fresh database volume is created, so report
+	// them even though neither is an ordinary config file.
+	if seed := app.GetSeedSnapshotFile(); seed != "" {
 		findings = append(findings, finding{
 			category: "Database",
-			files:    []fileInfo{{path: fmt.Sprintf("%s (seeds a new database volume)", fileutil.ShortHomeJoin(initializer))}},
+			files:    []fileInfo{{path: fmt.Sprintf("%s (seeds a new database volume)", fileutil.ShortHomeJoin(seed))}},
 		})
 	}
 	// The db-build Dockerfile itself is already listed by the check above, so

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -2081,7 +2081,7 @@ func TestConfigDefaultContainerTimeout(t *testing.T) {
 		require.Equal(t, expectedWaitTime, int(c.Config.Healthcheck.StartPeriod.Seconds()), "db container healthcheck should have been %v with default_container_timeout set to %v", maxWaitTime, app.DefaultContainerTimeout)
 		_, err = app.Snapshot(t.Name()+maxWaitTime, false)
 		require.NoError(t, err)
-		err = app.RestoreSnapshot(t.Name() + maxWaitTime)
+		err = app.RestoreSnapshot(t.Name()+maxWaitTime, false)
 		require.NoError(t, err)
 
 		// Inspect container that results from snapshot restore

--- a/pkg/ddevapp/db.go
+++ b/pkg/ddevapp/db.go
@@ -107,7 +107,7 @@ func (app *DdevApp) SnapshotAtExistingDBVersion(snapshotName string) (string, er
 			return "", err
 		}
 	}
-	return app.Snapshot(snapshotName)
+	return app.Snapshot(snapshotName, false)
 }
 
 // GetExistingDBType returns type/version like mariadb:10.11 or postgres:13 or "" if no existing volume

--- a/pkg/ddevapp/db.go
+++ b/pkg/ddevapp/db.go
@@ -13,6 +13,103 @@ import (
 	"github.com/ddev/ddev/pkg/versionconstants"
 )
 
+// DatabaseMismatchMessage describes a project configured for one database while
+// its database volume holds another, and spells out the two ways forward: put
+// the configuration back, or throw the existing database away. Both `ddev start`
+// (which refuses) and `ddev config` (which only warns) report it.
+func (app *DdevApp) DatabaseMismatchMessage(existingDBType string) string {
+	configuredDBType := app.Database.Type + ":" + app.Database.Version
+	message := fmt.Sprintf("project %s is configured for database %s, but its database volume holds %s.\nTo keep the existing database, put the configuration back with 'ddev config --database=%s'.", app.Name, configuredDBType, existingDBType, existingDBType)
+
+	// `ddev utility migrate-database` only converts between MariaDB and MySQL.
+	convertible := true
+	for _, dbType := range []string{existingDBType, configuredDBType} {
+		if !slices.Contains([]string{nodeps.MariaDB, nodeps.MySQL}, strings.Split(dbType, ":")[0]) {
+			convertible = false
+		}
+	}
+	if convertible {
+		message += fmt.Sprintf("\nTo convert the existing database to %s, put the configuration back and then run 'ddev utility migrate-database %s'.", configuredDBType, configuredDBType)
+	}
+
+	return message + fmt.Sprintf("\nTo throw the existing database away and start over with %s, use 'ddev start --reset-database', which snapshots it first unless you add --omit-snapshot.\nSee %s", configuredDBType, "https://docs.ddev.com/en/stable/users/extend/database-types/")
+}
+
+// ResetDatabaseVolume removes the project's database volumes so that the next
+// start creates and seeds a new one. Unless omitSnapshot, the existing database
+// is snapshotted first, at the database version that actually created it, which
+// is not necessarily the version the project is now configured for.
+func (app *DdevApp) ResetDatabaseVolume(omitSnapshot bool) error {
+	volumes := []string{}
+	for _, volume := range []string{app.GetMariaDBVolumeName(), app.GetPostgresVolumeName()} {
+		if dockerutil.VolumeExists(volume) {
+			volumes = append(volumes, volume)
+		}
+	}
+	if len(volumes) == 0 {
+		return nil
+	}
+
+	if !omitSnapshot {
+		snapshotName, err := app.SnapshotAtExistingDBVersion("")
+		if err != nil {
+			return fmt.Errorf("unable to snapshot the existing database before removing it: %v\nUse --omit-snapshot to remove it without a snapshot", err)
+		}
+		if snapshotName != "" {
+			util.Success("Snapshotted the existing database as '%s' before removing it", snapshotName)
+		}
+	}
+
+	// The volume can't be removed while the db container has it mounted.
+	if dbContainer, err := GetContainer(app, "db"); err == nil && dbContainer != nil {
+		if err = dockerutil.RemoveContainer(dbContainer.ID); err != nil {
+			return fmt.Errorf("failed to remove db container: %v", err)
+		}
+	}
+	for _, volume := range volumes {
+		if err := dockerutil.RemoveVolume(volume); err != nil {
+			return fmt.Errorf("failed to remove database volume %s: %v", volume, err)
+		}
+		util.Success("Removed database volume %s", volume)
+	}
+	return nil
+}
+
+// SnapshotAtExistingDBVersion snapshots the database that is in the database
+// volume using the database type/version that created it, which can differ from
+// the project's configured one after a `database:` change in config.yaml. It
+// returns the snapshot name, or an empty string if there is no database to
+// snapshot.
+func (app *DdevApp) SnapshotAtExistingDBVersion(snapshotName string) (string, error) {
+	existingDBType, err := app.GetExistingDBType()
+	if err != nil {
+		return "", err
+	}
+	if existingDBType == "" {
+		return "", nil
+	}
+
+	// Starting the project with the configured version would refuse outright, so
+	// stand the db up as whatever the volume actually holds, just long enough to
+	// snapshot it.
+	if existingDBType != app.Database.Type+":"+app.Database.Version {
+		configuredDatabase := app.Database
+		dbType, dbVersion, _ := strings.Cut(existingDBType, ":")
+		app.Database = DatabaseDesc{Type: dbType, Version: dbVersion}
+		defer func() {
+			app.Database = configuredDatabase
+		}()
+		util.Warning("Starting the database as %s to snapshot it, because that is what its volume holds", existingDBType)
+	}
+
+	if status, _ := app.SiteStatus(); status != SiteRunning {
+		if err = app.Start(); err != nil {
+			return "", err
+		}
+	}
+	return app.Snapshot(snapshotName)
+}
+
 // GetExistingDBType returns type/version like mariadb:10.11 or postgres:13 or "" if no existing volume
 // This has to make a Docker container run so is fairly costly.
 func (app *DdevApp) GetExistingDBType() (string, error) {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -152,6 +152,13 @@ type DdevApp struct {
 	XHProfMode                types.XHProfMode      `yaml:"xhprof_mode,omitempty"`
 	ComposeYaml               *composeTypes.Project `yaml:"-"`
 	NoCache                   bool                  `yaml:"-"`
+	// SeedSnapshot is the `ddev start --seed-snapshot` value, a snapshot name or
+	// path used to seed a brand-new database volume. It applies to one start only
+	// and is never written to config.yaml.
+	SeedSnapshot string `yaml:"-"`
+	// SeedSnapshotMountDir is the host directory holding a seed snapshot from
+	// outside the project, bind-mounted into the db container for that start.
+	SeedSnapshotMountDir string `yaml:"-"`
 }
 
 // SkipHooks Global variable that's set from --skip-hooks global flag.
@@ -1536,6 +1543,48 @@ func (app *DdevApp) Start() error {
 
 	SyncGenericWebserverPortsWithRouterPorts(app)
 
+	// dbNeedsInitialization means the database volume has no database in it yet,
+	// so the db container will seed it during this start. Seeding contributes a
+	// container command and a mount, so it has to settle before compose renders.
+	dbNeedsInitialization := false
+	var seedSnapshot *SeedSnapshot
+	app.SeedSnapshotMountDir = ""
+	if !app.IsDBOmitted() {
+		dbType, err := app.GetExistingDBType()
+		if err != nil {
+			return err
+		}
+		if dbType != "" && dbType != app.Database.Type+":"+app.Database.Version {
+			return fmt.Errorf("unable to start: %s", app.DatabaseMismatchMessage(dbType))
+		}
+		// A snapshot restore hands the db container its own restore target, so it
+		// never consults a seed even with an empty volume.
+		dbNeedsInitialization = dbType == "" && !strings.HasPrefix(os.Getenv("DDEV_DB_CONTAINER_COMMAND"), RestoreSnapshotCommand)
+
+		if seedSnapshot, err = app.ResolveSeedSnapshot(); err != nil {
+			return err
+		}
+		if seedSnapshot != nil && !dbNeedsInitialization {
+			if app.SeedSnapshot != "" {
+				return fmt.Errorf("--seed-snapshot only applies to a brand-new database volume, and project %s already has a database.\nUse 'ddev start --reset-database --seed-snapshot=%s' to throw the existing database away first, or 'ddev snapshot restore' to restore over it", app.Name, app.SeedSnapshot)
+			}
+			// The reserved seed snapshot is picked up without being asked for, so
+			// leaving it in place once the volume is populated has to stay harmless.
+			seedSnapshot = nil
+		}
+		if seedSnapshot != nil {
+			// prepareSeedSnapshot can move the snapshot, so it settles where the
+			// container will find it before the command naming that path is built.
+			if err = app.prepareSeedSnapshot(seedSnapshot); err != nil {
+				return err
+			}
+			app.SeedSnapshotMountDir = seedSnapshot.MountDir
+			_ = os.Setenv("DDEV_DB_CONTAINER_COMMAND", app.snapshotRestoreContainerCommand(seedSnapshot.ContainerPath()))
+			// nolint: errcheck
+			defer os.Unsetenv("DDEV_DB_CONTAINER_COMMAND")
+		}
+	}
+
 	_ = app.DockerEnv()
 	dockerutil.EnsureDdevNetwork()
 	// The project network may have duplicates, we can remove them here.
@@ -1565,20 +1614,6 @@ func (app *DdevApp) Start() error {
 
 	if pullErr := PullBaseContainerImages(additionalImages, app.NoCache); pullErr != nil {
 		util.Warning("Unable to pull Docker images: %v", pullErr)
-	}
-
-	// dbNeedsInitialization means the database volume has no database in it yet,
-	// so the db container will seed it from a base_db seed during this start.
-	dbNeedsInitialization := false
-	if !app.IsDBOmitted() {
-		// OK to start if dbType is empty (nonexistent) or if it matches
-		dbType, err := app.GetExistingDBType()
-		if err != nil || (dbType != "" && dbType != app.Database.Type+":"+app.Database.Version) {
-			return fmt.Errorf("unable to start project %s because the configured database type does not match the current actual database. Please change your database type back to %s and start again, export, delete, and then change configuration and start. To get back to existing type use 'ddev config --database=%s' and then you might want to try 'ddev utility migrate-database %s', see docs at %s", app.Name, dbType, dbType, app.Database.Type+":"+app.Database.Version, "https://docs.ddev.com/en/stable/users/extend/database-types/")
-		}
-		// A snapshot restore hands the db container its own restore target, so it
-		// never consults a base_db seed even with an empty volume.
-		dbNeedsInitialization = dbType == "" && !strings.HasPrefix(os.Getenv("DDEV_DB_CONTAINER_COMMAND"), RestoreSnapshotCommand)
 	}
 
 	app.CreateUploadDirsIfNecessary()
@@ -1814,18 +1849,6 @@ func (app *DdevApp) Start() error {
 		return err
 	}
 
-	// With no_bind_mounts the db container sees /mnt/snapshots as a Docker volume
-	// instead of .ddev/db_snapshots, so an `initializer` snapshot has to be copied
-	// in for the db container to find it when it seeds a fresh database volume.
-	if globalconfig.DdevGlobalConfig.NoBindMounts && dbNeedsInitialization {
-		if initializer := app.GetInitializerSnapshotFile(); initializer != "" {
-			err = dockerutil.CopyIntoVolume(initializer, "ddev-"+app.Name+"-snapshots", "", uid, "", false)
-			if err != nil {
-				return fmt.Errorf("failed to copy %s into the snapshots volume: %v", initializer, err)
-			}
-		}
-	}
-
 	// Wait for background chown to finish before proceeding.
 	// SSH agent runs after chown (needs volumes ready) and after WriteDockerComposeYAML
 	// (reads app.ComposeYaml) — so it runs sequentially here to avoid a data race.
@@ -1893,7 +1916,7 @@ func (app *DdevApp) Start() error {
 	// seed baked into a derived image can be seen.
 	origDefaultContainerTimeout := app.DefaultContainerTimeout
 	if dbNeedsInitialization {
-		if description := app.BaseDBSeedDescription(); description != "" {
+		if description := app.SeedDescription(seedSnapshot); description != "" {
 			if t, _ := strconv.Atoi(app.DefaultContainerTimeout); t <= SnapshotRestoreDefaultWaitTime {
 				app.DefaultContainerTimeout = strconv.Itoa(SnapshotRestoreDefaultWaitTime)
 			}
@@ -3381,13 +3404,11 @@ func (app *DdevApp) Stop(removeData bool, createSnapshot bool) error {
 	if createSnapshot {
 		if status != SiteRunning {
 			util.Warning("Must start non-running project to do database snapshot")
-			err = app.Start()
-			if err != nil {
-				return fmt.Errorf("failed to start project to perform database snapshot")
-			}
 		}
 		t := time.Now()
-		_, err = app.Snapshot(app.Name+"_remove_data_snapshot_"+t.Format("20060102150405"), false)
+		// The database version in the volume can differ from the configured one,
+		// in which case starting the project normally would refuse.
+		_, err = app.SnapshotAtExistingDBVersion(app.Name + "_remove_data_snapshot_" + t.Format("20060102150405"))
 		if err != nil {
 			return err
 		}

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1573,11 +1573,6 @@ func (app *DdevApp) Start() error {
 			seedSnapshot = nil
 		}
 		if seedSnapshot != nil {
-			// prepareSeedSnapshot can move the snapshot, so it settles where the
-			// container will find it before the command naming that path is built.
-			if err = app.prepareSeedSnapshot(seedSnapshot); err != nil {
-				return err
-			}
 			app.SeedSnapshotMountDir = seedSnapshot.MountDir
 			_ = os.Setenv("DDEV_DB_CONTAINER_COMMAND", app.snapshotRestoreContainerCommand(seedSnapshot.ContainerPath()))
 			// nolint: errcheck
@@ -1847,6 +1842,12 @@ func (app *DdevApp) Start() error {
 	err = util.Chmod(app.GetConfigPath("db_snapshots"), 0777)
 	if err != nil {
 		return err
+	}
+
+	if seedSnapshot != nil {
+		if err = app.prepareSeedSnapshot(seedSnapshot); err != nil {
+			return err
+		}
 	}
 
 	// Wait for background chown to finish before proceeding.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -159,6 +159,9 @@ type DdevApp struct {
 	// SeedSnapshotMountDir is the host directory holding a seed snapshot from
 	// outside the project, bind-mounted into the db container for that start.
 	SeedSnapshotMountDir string `yaml:"-"`
+	// restoreSnapshotMountDir is set by RestoreSnapshot() when the snapshot being
+	// restored lives outside the project, for the one Start() call it triggers.
+	restoreSnapshotMountDir string
 }
 
 // SkipHooks Global variable that's set from --skip-hooks global flag.
@@ -1577,6 +1580,12 @@ func (app *DdevApp) Start() error {
 			_ = os.Setenv("DDEV_DB_CONTAINER_COMMAND", app.snapshotRestoreContainerCommand(seedSnapshot.ContainerPath()))
 			// nolint: errcheck
 			defer os.Unsetenv("DDEV_DB_CONTAINER_COMMAND")
+		} else if app.restoreSnapshotMountDir != "" {
+			// RestoreSnapshot() sets DDEV_DB_CONTAINER_COMMAND to a restore_snapshot
+			// command itself, so dbNeedsInitialization above is false and seedSnapshot
+			// stays nil - but a restore onto an already-populated volume still needs
+			// its external snapshot mounted.
+			app.SeedSnapshotMountDir = app.restoreSnapshotMountDir
 		}
 	}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1966,7 +1966,7 @@ func TestDdevAllDatabases(t *testing.T) {
 			// above. Snapshotting it and then wiping the db volume and restarting
 			// should bring the same data back, ahead of the empty starter database.
 			for _, seedName := range []string{ddevapp.SeedSnapshotName, "explicit-seed"} {
-				_, err = app.Snapshot(seedName)
+				_, err = app.Snapshot(seedName, false)
 				require.NoError(t, err, "could not create '%s' snapshot for %s", seedName, dbTypeVersion)
 			}
 

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1902,7 +1902,7 @@ func TestDdevAllDatabases(t *testing.T) {
 		})
 		assert.NoError(err)
 
-		err = app.RestoreSnapshot(fullSnapshotName)
+		err = app.RestoreSnapshot(fullSnapshotName, false)
 		assert.NoError(err, "could not restore snapshot %s for %s: %v", fullSnapshotName, dbTypeVersion, err)
 		if err != nil {
 			_ = app.Stop(true, false)
@@ -1958,32 +1958,36 @@ func TestDdevAllDatabases(t *testing.T) {
 		out = strings.Trim(out, "\n\r ")
 		assert.Equal("2", out)
 
-		// base_db "initializer" seeding is only wired up for MariaDB/MySQL
-		// (containers/ddev-dbserver); PostgreSQL uses a different image/entrypoint.
-		// Not supported on the very old, EOL 5.5 versions of either.
-		isVeryOldDB := dbVersion == "5.5"
-		if (dbType == nodeps.MariaDB || dbType == nodeps.MySQL) && !isVeryOldDB {
-			// db currently has the 2-row "users" table from the snapshot restore above.
-			// Snapshotting it as "initializer" and then wiping the db volume and
-			// restarting should restore this same data automatically, ahead of the
-			// normal empty starter database.
-			_, err = app.Snapshot("initializer", false)
-			require.NoError(t, err, "could not create initializer snapshot for %s", dbTypeVersion)
+		// Seeding a fresh database volume from a snapshot, both from the reserved
+		// `seed` name and from an explicitly named one. MariaDB/MySQL 5.5 can't
+		// make the zstd snapshots this relies on.
+		if dbVersion != "5.5" {
+			// db currently has the 2-row "users" table from the snapshot restore
+			// above. Snapshotting it and then wiping the db volume and restarting
+			// should bring the same data back, ahead of the empty starter database.
+			for _, seedName := range []string{ddevapp.SeedSnapshotName, "explicit-seed"} {
+				_, err = app.Snapshot(seedName)
+				require.NoError(t, err, "could not create '%s' snapshot for %s", seedName, dbTypeVersion)
+			}
 
-			err = app.Stop(true, false)
-			require.NoError(t, err)
-			err = app.Start()
-			require.NoError(t, err, "failed to start %s after seeding from initializer snapshot", dbTypeVersion)
+			for _, seedFlag := range []string{"", "explicit-seed"} {
+				err = app.Stop(true, false)
+				require.NoError(t, err)
+				app.SeedSnapshot = seedFlag
+				err = app.Start()
+				require.NoError(t, err, "failed to start %s with --seed-snapshot=%s", dbTypeVersion, seedFlag)
 
-			out, _, err = app.Exec(&ddevapp.ExecOpts{
-				Service: "db",
-				Cmd:     c[dbType],
-			})
-			assert.NoError(err)
-			out = strings.Trim(out, "\n\r ")
-			assert.Equal("2", out, "initializer snapshot did not seed a fresh db volume for %s", dbTypeVersion)
+				out, _, err = app.Exec(&ddevapp.ExecOpts{
+					Service: "db",
+					Cmd:     c[dbType],
+				})
+				assert.NoError(err)
+				out = strings.Trim(out, "\n\r ")
+				assert.Equal("2", out, "--seed-snapshot=%s did not seed a fresh db volume for %s", seedFlag, dbTypeVersion)
+			}
+			app.SeedSnapshot = ""
 
-			// "initializer" is a reserved name; clear it so the next dbTypeVersion
+			// `seed` is a reserved name; clear it so the next dbTypeVersion
 			// iteration can create its own.
 			err = os.RemoveAll(app.GetConfigPath("db_snapshots"))
 			assert.NoError(err)

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -205,9 +205,9 @@ func (app *DdevApp) ListSnapshots() ([]Snapshot, error) {
 
 // snapshotDBVersionFromFilename returns the db type/version a snapshot file
 // name encodes, like "mariadb_11.8". Snapshot files are always named
-// <name>-<type>_<version>.{gz,zst} by Snapshot().
+// <name>-<type>_<version>.<ext> by Snapshot(), for any of snapshotExtensions.
 func snapshotDBVersionFromFilename(snapshotFile string) (string, error) {
-	matches := regexp.MustCompile(`((mysql|mariadb|postgres)_[0-9.]+)\.(gz|zst)$`).FindStringSubmatch(snapshotFile)
+	matches := regexp.MustCompile(`((mysql|mariadb|postgres)_[0-9.]+)\.` + snapshotExtensionPattern + `$`).FindStringSubmatch(snapshotFile)
 	if len(matches) < 2 {
 		return "", fmt.Errorf("unable to determine database type/version from snapshot %s", snapshotFile)
 	}

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -234,17 +234,11 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string, force bool) error {
 
 	currentDBVersion := app.Database.Type + "_" + app.Database.Version
 
-	snapshotFile, err := GetSnapshotFileFromName(snapshotName, app)
+	hostSnapshotFileOrDir, mountDir, err := resolveSnapshotSource(snapshotName, app)
 	if err != nil {
-		return fmt.Errorf("no snapshot found for name %s: %v", snapshotName, err)
+		return fmt.Errorf("unable to resolve snapshot %s: %v", snapshotName, err)
 	}
-	snapshotFileOrDir := filepath.Join("db_snapshots", snapshotFile)
-
-	hostSnapshotFileOrDir := app.GetConfigPath(snapshotFileOrDir)
-
-	if !fileutil.FileExists(hostSnapshotFileOrDir) {
-		return fmt.Errorf("failed to find a snapshot at %s", hostSnapshotFileOrDir)
-	}
+	snapshotFile := filepath.Base(hostSnapshotFileOrDir)
 
 	snapshotDBVersion := ""
 
@@ -318,7 +312,7 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string, force bool) error {
 			subdir = snapshotName
 		}
 
-		err = dockerutil.CopyIntoVolume(filepath.Join(app.GetConfigPath("db_snapshots"), snapshotFile), "ddev-"+app.Name+"-snapshots", subdir, uid, "", true)
+		err = dockerutil.CopyIntoVolume(hostSnapshotFileOrDir, "ddev-"+app.Name+"-snapshots", subdir, uid, "", true)
 		if err != nil {
 			return err
 		}
@@ -329,7 +323,14 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string, force bool) error {
 		util.Warning("This snapshot uses gzip compression. Creating a new snapshot will automatically use faster zstd compression.")
 	}
 
-	_ = os.Setenv("DDEV_DB_CONTAINER_COMMAND", app.snapshotRestoreContainerCommand(snapshotFile))
+	containerPath := snapshotFile
+	if mountDir != "" {
+		containerPath = path.Join(SeedSnapshotMountDir, snapshotFile)
+	}
+	app.restoreSnapshotMountDir = mountDir
+	defer func() { app.restoreSnapshotMountDir = "" }()
+
+	_ = os.Setenv("DDEV_DB_CONTAINER_COMMAND", app.snapshotRestoreContainerCommand(containerPath))
 	// nolint: errcheck
 	defer os.Unsetenv("DDEV_DB_CONTAINER_COMMAND")
 	// If the default_container_timeout does not already specify a longer period
@@ -417,6 +418,37 @@ func (app *DdevApp) snapshotRestoreContainerCommand(snapshotPath string) string 
 		targetConfName = path.Join(nodeps.PostgresConfigDir, "recovery.conf")
 	}
 	return fmt.Sprintf(`bash -c '%s && echo "restore_command = 'true'" >>%s && %s'`, prepare, targetConfName, serve)
+}
+
+// resolveSnapshotSource resolves a snapshot name or host path to its absolute
+// file on disk and, if it lives outside .ddev/db_snapshots, the directory that
+// needs to be bind-mounted into the db container so the container can reach it.
+//
+// A path (absolute, or containing a slash) must already exist as a file, not a
+// directory. A bare name is resolved inside .ddev/db_snapshots via
+// GetSnapshotFileFromName, which also supports old-style directory snapshots -
+// something an external path does not.
+func resolveSnapshotSource(nameOrPath string, app *DdevApp) (hostPath string, mountDir string, err error) {
+	if filepath.IsAbs(nameOrPath) || strings.ContainsAny(nameOrPath, `/\`) {
+		if hostPath, err = filepath.Abs(nameOrPath); err != nil {
+			return "", "", fmt.Errorf("unable to resolve %s: %v", nameOrPath, err)
+		}
+		if !fileutil.FileExists(hostPath) || fileutil.IsDirectory(hostPath) {
+			return "", "", fmt.Errorf("%s is not an existing snapshot file", nameOrPath)
+		}
+		// A snapshot already in .ddev/db_snapshots needs no mount of its own, and
+		// with no_bind_mounts the caller copies it in rather than mounting.
+		if dir := filepath.Dir(hostPath); dir != app.GetConfigPath("db_snapshots") && !globalconfig.DdevGlobalConfig.NoBindMounts {
+			mountDir = dir
+		}
+		return hostPath, mountDir, nil
+	}
+
+	snapshotFile, err := GetSnapshotFileFromName(nameOrPath, app)
+	if err != nil {
+		return "", "", err
+	}
+	return app.GetConfigPath(filepath.Join("db_snapshots", snapshotFile)), "", nil
 }
 
 // GetSnapshotFileFromName returns the filename corresponding to the snapshot name

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -203,9 +203,29 @@ func (app *DdevApp) ListSnapshots() ([]Snapshot, error) {
 	return snapshots, nil
 }
 
+// snapshotDBVersionFromFilename returns the db type/version a snapshot file
+// name encodes, like "mariadb_11.8". Snapshot files are always named
+// <name>-<type>_<version>.{gz,zst} by Snapshot().
+func snapshotDBVersionFromFilename(snapshotFile string) (string, error) {
+	matches := regexp.MustCompile(`((mysql|mariadb|postgres)_[0-9.]+)\.(gz|zst)$`).FindStringSubmatch(snapshotFile)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("unable to determine database type/version from snapshot %s", snapshotFile)
+	}
+	return matches[1], nil
+}
+
+// dbTypeFromVersion returns the "mariadb" of a "mariadb_11.8".
+func dbTypeFromVersion(dbVersion string) string {
+	dbType, _, _ := strings.Cut(dbVersion, "_")
+	return dbType
+}
+
 // RestoreSnapshot restores a MariaDB snapshot of the db to be loaded
 // The project must be stopped and Docker volume removed and recreated for this to work.
-func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
+//
+// force allows restoring a snapshot taken on a different version of the same
+// database server, which the underlying restore does not itself check for.
+func (app *DdevApp) RestoreSnapshot(snapshotName string, force bool) error {
 	var err error
 	err = app.ProcessHooks("pre-restore-snapshot")
 	if err != nil {
@@ -259,7 +279,13 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 	}
 
 	if snapshotDBVersion != currentDBVersion {
-		return fmt.Errorf("snapshot '%s' is a DB server '%s' snapshot and is not compatible with the configured DDEV DB server version (%s).  Please restore it using the DB version it was created with, and then you can try upgrading the DDEV DB version", snapshotName, snapshotDBVersion, currentDBVersion)
+		if !force {
+			return fmt.Errorf("snapshot '%s' is a DB server '%s' snapshot and is not compatible with the configured DDEV DB server version (%s).  Please restore it using the DB version it was created with, and then you can try upgrading the DDEV DB version, or use --force to attempt the restore anyway", snapshotName, snapshotDBVersion, currentDBVersion)
+		}
+		if dbTypeFromVersion(snapshotDBVersion) != app.Database.Type {
+			return fmt.Errorf("snapshot '%s' is a '%s' snapshot, which cannot be restored into a '%s' database even with --force", snapshotName, snapshotDBVersion, currentDBVersion)
+		}
+		util.Warning("Restoring a '%s' snapshot into a '%s' database because --force was used.\nThe database may fail to come up, in which case you can start over with `ddev start --reset-database`.", snapshotDBVersion, currentDBVersion)
 	}
 
 	status, _ := app.SiteStatus()
@@ -298,40 +324,12 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 		}
 	}
 
-	restoreCmd := RestoreSnapshotCommand + " " + snapshotFile
-	// Determine compression type for potential conditional restore handling
-	isGzip := strings.HasSuffix(snapshotFile, ".gz")
-	isZstd := strings.HasSuffix(snapshotFile, ".zst")
-	if isGzip {
-		// MariaDB 5.5 does not support zstd compression
-		isMariaDB55 := app.Database.Type == nodeps.MariaDB && app.Database.Version == nodeps.MariaDB55
-		if !isMariaDB55 {
-			util.Warning("This snapshot uses gzip compression. Creating a new snapshot will automatically use faster zstd compression.")
-		}
+	if strings.HasSuffix(snapshotFile, ".gz") && !(app.Database.Type == nodeps.MariaDB && app.Database.Version == nodeps.MariaDB55) {
+		// MariaDB 5.5 is the only db version that can't make a zstd snapshot
+		util.Warning("This snapshot uses gzip compression. Creating a new snapshot will automatically use faster zstd compression.")
 	}
-	if app.Database.Type == nodeps.Postgres {
-		postgresDataDir := app.GetPostgresDataDir()
-		postgresDataPath := app.GetPostgresDataPath()
-		confdDir := path.Join(nodeps.PostgresConfigDir, "conf.d")
-		v, _ := strconv.Atoi(app.Database.Version)
-		// Choose proper tar flags based on compression
-		tarExtract := "-zxf" // gzip default
-		if isZstd {
-			tarExtract = fmt.Sprintf(`-I "%s" -xf`, app.GetDBCompressionCommand())
-		}
-		// PostgreSQL 18+ requires restore_command parameter, older versions use recovery.conf
-		if v >= 18 {
-			restoreCmd = fmt.Sprintf(`bash -c 'chmod 700 %s && mkdir -p %s && rm -rf %s/* && tar -C %s %s /mnt/snapshots/%s && chmod 700 %s && touch %s/recovery.signal && postgres -c config_file=%s/postgresql.conf -c hba_file=%s/pg_hba.conf -c restore_command=true'`, postgresDataDir, confdDir, postgresDataDir, postgresDataDir, tarExtract, snapshotFile, postgresDataPath, postgresDataPath, nodeps.PostgresConfigDir, nodeps.PostgresConfigDir)
-		} else {
-			targetConfName := path.Join(confdDir, "recovery.conf")
-			// Before PostgreSQL v12 the recovery info went into its own file
-			if v < 12 {
-				targetConfName = path.Join(nodeps.PostgresConfigDir, "recovery.conf")
-			}
-			restoreCmd = fmt.Sprintf(`bash -c 'chmod 700 %s && mkdir -p %s && rm -rf %s/* && tar -C %s %s /mnt/snapshots/%s && chmod 700 %s && touch %s/recovery.signal && echo "restore_command = 'true'" >>%s && postgres -c config_file=%s/postgresql.conf -c hba_file=%s/pg_hba.conf'`, postgresDataDir, confdDir, postgresDataDir, postgresDataDir, tarExtract, snapshotFile, postgresDataPath, postgresDataPath, targetConfName, nodeps.PostgresConfigDir, nodeps.PostgresConfigDir)
-		}
-	}
-	_ = os.Setenv("DDEV_DB_CONTAINER_COMMAND", restoreCmd)
+
+	_ = os.Setenv("DDEV_DB_CONTAINER_COMMAND", app.snapshotRestoreContainerCommand(snapshotFile))
 	// nolint: errcheck
 	defer os.Unsetenv("DDEV_DB_CONTAINER_COMMAND")
 	// If the default_container_timeout does not already specify a longer period
@@ -378,6 +376,47 @@ func (app *DdevApp) RestoreSnapshot(snapshotName string) error {
 		return fmt.Errorf("failed to process post-restore-snapshot hooks: %v", err)
 	}
 	return nil
+}
+
+// snapshotRestoreContainerCommand returns the db container command that restores
+// a snapshot into the data directory, replacing whatever is there. snapshotPath
+// is the snapshot as the db container sees it: either a bare file/directory name
+// found in /mnt/snapshots, or an absolute path such as a seed snapshot mounted at
+// SeedSnapshotMountDir.
+//
+// The command runs before the database server starts, so it works the same on an
+// empty data directory (seeding a brand-new volume) as on a populated one.
+func (app *DdevApp) snapshotRestoreContainerCommand(snapshotPath string) string {
+	if app.Database.Type != nodeps.Postgres {
+		return RestoreSnapshotCommand + " " + snapshotPath
+	}
+
+	if !path.IsAbs(snapshotPath) {
+		snapshotPath = path.Join("/mnt/snapshots", snapshotPath)
+	}
+	tarExtract := "-zxf"
+	if strings.HasSuffix(snapshotPath, ".zst") {
+		tarExtract = fmt.Sprintf(`-I "%s" -xf`, app.GetDBCompressionCommand())
+	}
+	dataDir := app.GetPostgresDataDir()
+	dataPath := app.GetPostgresDataPath()
+	confdDir := path.Join(nodeps.PostgresConfigDir, "conf.d")
+	// mkdir of the data directory matters on a brand-new volume, where PostgreSQL
+	// 18+ mounts the volume a level above a data directory that doesn't exist yet.
+	prepare := fmt.Sprintf(`mkdir -p %s %s && chmod 700 %s && rm -rf %s/* && tar -C %s %s %s && chmod 700 %s && touch %s/recovery.signal`, dataDir, confdDir, dataDir, dataDir, dataDir, tarExtract, snapshotPath, dataPath, dataPath)
+	serve := fmt.Sprintf(`postgres -c config_file=%s/postgresql.conf -c hba_file=%s/pg_hba.conf`, nodeps.PostgresConfigDir, nodeps.PostgresConfigDir)
+
+	v, _ := strconv.Atoi(app.Database.Version)
+	// PostgreSQL 18+ takes restore_command as a server parameter; before that it
+	// goes in recovery.conf, which moved into conf.d in v12.
+	if v >= 18 {
+		return fmt.Sprintf(`bash -c '%s && %s -c restore_command=true'`, prepare, serve)
+	}
+	targetConfName := path.Join(confdDir, "recovery.conf")
+	if v < 12 {
+		targetConfName = path.Join(nodeps.PostgresConfigDir, "recovery.conf")
+	}
+	return fmt.Sprintf(`bash -c '%s && echo "restore_command = 'true'" >>%s && %s'`, prepare, targetConfName, serve)
 }
 
 // GetSnapshotFileFromName returns the filename corresponding to the snapshot name

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -430,7 +430,12 @@ func (app *DdevApp) snapshotRestoreContainerCommand(snapshotPath string) string 
 // something an external path does not.
 func resolveSnapshotSource(nameOrPath string, app *DdevApp) (hostPath string, mountDir string, err error) {
 	if filepath.IsAbs(nameOrPath) || strings.ContainsAny(nameOrPath, `/\`) {
-		if hostPath, err = filepath.Abs(nameOrPath); err != nil {
+		// Shell doesn't expand ~ inside --flag=value, so it reaches us literally.
+		expanded, err := util.ExpandHomedir(nameOrPath)
+		if err != nil {
+			return "", "", fmt.Errorf("unable to resolve %s: %v", nameOrPath, err)
+		}
+		if hostPath, err = filepath.Abs(expanded); err != nil {
 			return "", "", fmt.Errorf("unable to resolve %s: %v", nameOrPath, err)
 		}
 		if !fileutil.FileExists(hostPath) || fileutil.IsDirectory(hostPath) {

--- a/pkg/ddevapp/snapshot_restore_command_test.go
+++ b/pkg/ddevapp/snapshot_restore_command_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/stretchr/testify/require"
 )
@@ -61,6 +62,10 @@ func TestSnapshotRestoreContainerCommand(t *testing.T) {
 // argument, not for the value of a `--flag=~/...` (used by both --seed-snapshot
 // and `ddev snapshot restore`).
 func TestResolveSnapshotSourceTilde(t *testing.T) {
+	origNoBindMounts := globalconfig.DdevGlobalConfig.NoBindMounts
+	globalconfig.DdevGlobalConfig.NoBindMounts = false
+	t.Cleanup(func() { globalconfig.DdevGlobalConfig.NoBindMounts = origNoBindMounts })
+
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 

--- a/pkg/ddevapp/snapshot_restore_command_test.go
+++ b/pkg/ddevapp/snapshot_restore_command_test.go
@@ -1,0 +1,55 @@
+package ddevapp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotDBVersionFromFilename verifies the db type/version parsed out of a
+// snapshot file name, which is what stops a snapshot from being restored into,
+// or seeded into, a database it was not made from.
+func TestSnapshotDBVersionFromFilename(t *testing.T) {
+	for filename, expected := range map[string]string{
+		"mysnapshot-mariadb_11.8.zst":               "mariadb_11.8",
+		"mysnapshot-mysql_8.0.gz":                   "mysql_8.0",
+		"seed-postgres_17.zst":                      "postgres_17",
+		"name-with-mariadb_10.11-mariadb_10.11.zst": "mariadb_10.11",
+	} {
+		dbVersion, err := snapshotDBVersionFromFilename(filename)
+		require.NoError(t, err, filename)
+		require.Equal(t, expected, dbVersion, filename)
+	}
+
+	for _, filename := range []string{"mysnapshot.zst", "mysnapshot-mariadb_11.8.tar", "mariadb_11.8"} {
+		_, err := snapshotDBVersionFromFilename(filename)
+		require.Error(t, err, filename)
+	}
+
+	require.Equal(t, "mariadb", dbTypeFromVersion("mariadb_11.8"))
+	require.Equal(t, "postgres", dbTypeFromVersion("postgres_17"))
+}
+
+// TestSnapshotRestoreContainerCommand verifies the db container command used
+// both by `ddev snapshot restore` and by seeding a brand-new database volume.
+// The PostgreSQL command has to create its data directory, which does not exist
+// yet on a brand-new volume under PostgreSQL 18+.
+func TestSnapshotRestoreContainerCommand(t *testing.T) {
+	mariadb := &DdevApp{Name: "test"}
+	mariadb.Database = DatabaseDesc{Type: nodeps.MariaDB, Version: nodeps.MariaDB1011}
+	require.Equal(t, RestoreSnapshotCommand+" mysnapshot-mariadb_10.11.zst", mariadb.snapshotRestoreContainerCommand("mysnapshot-mariadb_10.11.zst"))
+	// An absolute path is passed through, for a seed snapshot mounted outside
+	// /mnt/snapshots.
+	require.Equal(t, RestoreSnapshotCommand+" /mnt/seed/outside-mariadb_10.11.zst", mariadb.snapshotRestoreContainerCommand("/mnt/seed/outside-mariadb_10.11.zst"))
+
+	for _, pgVersion := range []string{nodeps.Postgres14, nodeps.Postgres18} {
+		pg := &DdevApp{Name: "test"}
+		pg.Database = DatabaseDesc{Type: nodeps.Postgres, Version: pgVersion}
+		command := pg.snapshotRestoreContainerCommand("seed-postgres_" + pgVersion + ".zst")
+		require.Contains(t, command, "mkdir -p "+pg.GetPostgresDataDir(), "PostgreSQL %s must create its data directory to seed an empty volume", pgVersion)
+		require.Contains(t, command, "/mnt/snapshots/seed-postgres_"+pgVersion+".zst")
+		require.True(t, strings.Index(command, "mkdir -p") < strings.Index(command, "chmod 700"), "the data directory has to exist before it can be chmodded")
+	}
+}

--- a/pkg/ddevapp/snapshot_restore_command_test.go
+++ b/pkg/ddevapp/snapshot_restore_command_test.go
@@ -1,6 +1,8 @@
 package ddevapp
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -52,4 +54,30 @@ func TestSnapshotRestoreContainerCommand(t *testing.T) {
 		require.Contains(t, command, "/mnt/snapshots/seed-postgres_"+pgVersion+".zst")
 		require.True(t, strings.Index(command, "mkdir -p") < strings.Index(command, "chmod 700"), "the data directory has to exist before it can be chmodded")
 	}
+}
+
+// TestResolveSnapshotSourceTilde verifies that a `~`-prefixed path is expanded
+// against the home directory, since a shell only does that for a bare
+// argument, not for the value of a `--flag=~/...` (used by both --seed-snapshot
+// and `ddev snapshot restore`).
+func TestResolveSnapshotSourceTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	outsideDir, err := os.MkdirTemp(home, "ddev-resolve-snapshot-source-test-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(outsideDir) })
+
+	snapshotFile := filepath.Join(outsideDir, "outside-mariadb_11.8.zst")
+	require.NoError(t, os.WriteFile(snapshotFile, []byte("fake snapshot"), 0644))
+
+	rel, err := filepath.Rel(home, snapshotFile)
+	require.NoError(t, err)
+	tildePath := filepath.Join("~", rel)
+
+	app := &DdevApp{Name: "test", AppRoot: t.TempDir()}
+	hostPath, mountDir, err := resolveSnapshotSource(tildePath, app)
+	require.NoError(t, err)
+	require.Equal(t, snapshotFile, hostPath)
+	require.Equal(t, outsideDir, mountDir)
 }

--- a/pkg/ddevapp/snapshot_restore_command_test.go
+++ b/pkg/ddevapp/snapshot_restore_command_test.go
@@ -20,6 +20,8 @@ func TestSnapshotDBVersionFromFilename(t *testing.T) {
 		"mysnapshot-mysql_8.0.gz":                   "mysql_8.0",
 		"seed-postgres_17.zst":                      "postgres_17",
 		"name-with-mariadb_10.11-mariadb_10.11.zst": "mariadb_10.11",
+		"mysnapshot-mariadb_11.8.mbstream":          "mariadb_11.8",
+		"mysnapshot-mysql_8.0.xbstream":             "mysql_8.0",
 	} {
 		dbVersion, err := snapshotDBVersionFromFilename(filename)
 		require.NoError(t, err, filename)

--- a/pkg/ddevapp/snapshot_test.go
+++ b/pkg/ddevapp/snapshot_test.go
@@ -337,7 +337,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	// Sleep to let sync happen if needed (M1 failure)
 	time.Sleep(2 * time.Second)
 
-	err = app.RestoreSnapshot(tester1Snapshot)
+	err = app.RestoreSnapshot(tester1Snapshot, false)
 	assert.NoError(err)
 
 	assert.FileExists("hello-pre-restore-snapshot-" + app.Name)
@@ -354,7 +354,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	assert.NoError(err)
 	assert.Contains(stdout, "d7 tester test 1 has 1 node")
 
-	err = app.RestoreSnapshot(tester2Snapshot)
+	err = app.RestoreSnapshot(tester2Snapshot, false)
 	assert.NoError(err)
 
 	stdout, _, err = app.Exec(&ddevapp.ExecOpts{
@@ -371,7 +371,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 	err = archive.Untar(oldSnapshotTarball, app.GetConfigPath("db_snapshots"), "")
 	assert.NoError(err)
 
-	err = app.RestoreSnapshot("d7tester_test_1.snapshot_mariadb_10.1")
+	err = app.RestoreSnapshot("d7tester_test_1.snapshot_mariadb_10.1", false)
 	assert.Error(err)
 	assert.Contains(err.Error(), "is not compatible")
 
@@ -431,7 +431,7 @@ func TestDdevRestoreSnapshot(t *testing.T) {
 		})
 		assert.NoError(err)
 
-		err = app.RestoreSnapshot(dirSnapshot)
+		err = app.RestoreSnapshot(dirSnapshot, false)
 		if err != nil {
 			assert.NoError(err, "Failed to restore dirSnapshot '%s': %v, continuing", dirSnapshot, err)
 			continue

--- a/pkg/ddevapp/snapshot_test.go
+++ b/pkg/ddevapp/snapshot_test.go
@@ -218,7 +218,7 @@ func TestSnapshotUncompressed(t *testing.T) {
 	}
 	assert.True(found, "expected to find snapshot %s in ListSnapshots()", snapshotName)
 
-	err = app.RestoreSnapshot(snapshotName)
+	err = app.RestoreSnapshot(snapshotName, false)
 	assert.NoError(err)
 
 	runTime()

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -37,7 +37,7 @@ var WebTagBranch = "20260814_rfay_docker_update_phase_2"
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "71f82087a2" // 20260814_rfay_seed_snapshot_reset_database-71f82087a2
+var BaseDBTag = "90077a0a84" // 20260814_rfay_seed_snapshot_reset_database-90077a0a84
 
 // BaseDBTagBranch is the branch BaseDBTag's content was built from.
 var BaseDBTagBranch = "20260814_rfay_seed_snapshot_reset_database"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -37,10 +37,11 @@ var WebTagBranch = "20260814_rfay_docker_update_phase_2"
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "7b74988035" // 20260814_rfay_uncompressed_snapshot-7b74988035
+var BaseDBTag = "20260814_rfay_seed_snapshot_reset_database-7365c52c34"
 
 // BaseDBTagBranch is the branch BaseDBTag's content was built from.
 var BaseDBTagBranch = "20260814_rfay_uncompressed_snapshot"
+
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -37,7 +37,7 @@ var WebTagBranch = "20260814_rfay_docker_update_phase_2"
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "90077a0a84" // 20260814_rfay_seed_snapshot_reset_database-90077a0a84
+var BaseDBTag = "f57cd53429" // 20260814_rfay_seed_snapshot_reset_database-f57cd53429
 
 // BaseDBTagBranch is the branch BaseDBTag's content was built from.
 var BaseDBTagBranch = "20260814_rfay_seed_snapshot_reset_database"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -37,11 +37,10 @@ var WebTagBranch = "20260814_rfay_docker_update_phase_2"
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "20260814_rfay_seed_snapshot_reset_database-7365c52c34"
+var BaseDBTag = "71f82087a2" // 20260814_rfay_seed_snapshot_reset_database-71f82087a2
 
 // BaseDBTagBranch is the branch BaseDBTag's content was built from.
-var BaseDBTagBranch = "20260814_rfay_uncompressed_snapshot"
-
+var BaseDBTagBranch = "20260814_rfay_seed_snapshot_reset_database"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION
## Short Summary (TL;DR)

* `seed` replaces `initializer` as the reserved snapshot name that fills a brand-new database volume, and it now works for PostgreSQL too.
* `ddev start/restart --seed-snapshot=<name-or-path>` fills a brand-new database volume from any snapshot, including one outside the project.
* `ddev start/restart --reset-database` throws the existing database away and starts over. It snapshots first unless you add `-O`.
* `ddev snapshot restore --force` restores a snapshot made by a different version of the same database server.

## The Issue

- Fixes #8661
- Fixes #8322

The seed mechanism in #8608 was keyed on one filename, `initializer-<type>_<version>.*`. You had to learn that name from the docs, you could not point at a different snapshot, and PostgreSQL was not supported.

Separately, there was no way to say "wipe the database and start over" when `ddev start` refused because the volume was made by a different database server. The error pointed at `ddev utility migrate-database`, which only converts between MariaDB and MySQL. `ddev delete` was no way out either: it started the project to take its pre-delete snapshot, hit the same refusal, and gave up unless you passed `-O`. That is why the workaround in #8322 starts with putting the `config.yaml` change back.

## How This PR Solves The Issue

Seeding now uses the db container's existing `restore_snapshot` command instead of a filename the entrypoint looks for. On an empty data directory that command does exactly what the old seed lookup did, so one path covers the reserved name, the flag, and every database type. The `/mnt/snapshots/initializer-*` tier is gone from the entrypoint; the two `base_db` tiers baked into images are unchanged.

* `seed` is picked up automatically on a fresh database volume, as `initializer` was, and PostgreSQL gets it now as well.
* `--seed-snapshot` takes a snapshot name from `.ddev/db_snapshots` or a path to a file elsewhere. A file outside the project is bind-mounted into the db container rather than copied, so a multi-GB snapshot is not duplicated. The entrypoint learned to accept an absolute path for this.
* Asking to seed a volume that already has a database is an error that says what to do instead, not a silent no-op.

`--reset-database` removes the database volume so the next start makes a new one. The snapshot it takes first is made with the database version that is actually in the volume, not the configured one, which is what makes it work after a `database:` change. `Stop()` uses the same helper, so `ddev delete` stops giving up on a mismatched project.

Two smaller changes were needed to make the above usable:

* `ddev config --database=` now warns instead of failing. Writing `config.yaml` destroys nothing and `ddev start` still refuses until you resolve it, but while `ddev config` refused there was no way to reach `--reset-database` short of hand-editing `config.yaml`.
* The PostgreSQL restore command chmodded its data directory before creating it. That could not be reached before, since only a populated volume was ever restored into, but it is fatal when seeding a brand-new PostgreSQL 18+ volume.

## Manual Testing Instructions

```bash
mkdir ~/tmp/seedtest && cd ~/tmp/seedtest && ddev config --project-type=php
ddev start
echo "CREATE TABLE marker (id INT);" | ddev mysql db
ddev snapshot --name=seed

# Reserved name: the marker table comes back on a brand-new volume
ddev start --reset-database -O -y
echo "SHOW TABLES;" | ddev mysql db

# A named snapshot, then the same snapshot from outside the project
ddev snapshot --name=other
ddev start --reset-database -O --seed-snapshot=other -y
mv .ddev/db_snapshots/other-mariadb_11.8.zst ~/tmp/
ddev start --reset-database -O --seed-snapshot=~/tmp/other-mariadb_11.8.zst -y

# #8322: change database type with data in the volume
ddev config --database=postgres:17   # warns
ddev start                           # refuses, and says both ways out
ddev start --reset-database -y       # snapshots as mariadb_11.8, then starts postgres 17
```

## Automated Testing Overview

* `TestResolveSeedSnapshot`, `TestGetSeedSnapshotFile`, `TestSnapshotDBVersionFromFilename` and `TestSnapshotRestoreContainerCommand` cover flag resolution, version matching and the container command, including the PostgreSQL 18+ `mkdir`.
* `TestCmdStartResetDatabase` and `TestCmdStartSeedSnapshotFile` cover reset with and without a seed, a seed file outside the project, and the flag combinations that are refused.
* `TestDdevAllDatabases` now seeds from both the reserved name and an explicit one, for every supported database version.
* `base_db_seed.bats` covers `restore_snapshot` seeding an empty data directory from both a `/mnt/snapshots` name and an absolute path.

Checked by hand against MariaDB 11.8, PostgreSQL 17 and PostgreSQL 18, including the cross-type reset and `ddev delete` on a mismatched project.

## Release/Deployment Notes

`initializer` snapshots are no longer recognized. Rename the file to `seed-<type>_<version>.<ext>`. That name only ever existed in main and was never in a release, so nothing shipped depends on it, but this needs to land before v1.25.4 for that to stay true.

This needs a `ddev-dbserver` image push. `--seed-snapshot` with a file outside the project relies on the entrypoint accepting an absolute `restore_snapshot` path.
