### PR TITLE
ci: add placeholder image-build/image-push workflows for #8609 (#8706) [skip ci]

### DIFF
--- a/.github/workflows/image-build-push.yml
+++ b/.github/workflows/image-build-push.yml
@@ -1,0 +1,34 @@
+name: Image build
+defaults:
+  run:
+    shell: bash
+
+# Placeholder for #8609 phase 2 (fork-safe automatic image build/push). This
+# do-nothing stub exists only so the workflow name/triggers are registered on
+# the default branch before the real detect/approval/build logic lands - see
+# the phase 2 PR, which will replace this file's contents via rebase.
+# image-push.yml's `workflow_run` trigger only fires for a listener that
+# exists on the default branch, so this stub unblocks testing that dependency
+# ahead of the full PR.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "containers/**"
+      - ".github/workflows/image-build-push.yml"
+  push:
+    branches: [main]
+    paths:
+      - "containers/**"
+      - ".github/workflows/image-build-push.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    name: Placeholder (see #8609)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Do nothing
+        run: echo "Placeholder for #8609 phase 2 - no-op until the real workflow lands."

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -1,0 +1,28 @@
+name: Image push
+defaults:
+  run:
+    shell: bash
+
+# Placeholder for #8609 phase 2 (fork-safe automatic image build/push). This
+# do-nothing stub exists only so `workflow_run` below has a registered
+# listener on the default branch before the real load/validate/push logic
+# lands - see the phase 2 PR, which will replace this file's contents via
+# rebase. `workflow_run` only fires for a listener that already exists on the
+# default branch, so this stub unblocks testing that dependency ahead of the
+# full PR.
+on:
+  workflow_run:
+    workflows: ["Image build"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    name: Placeholder (see #8609)
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Do nothing
+        run: echo "Placeholder for #8609 phase 2 - no-op until the real workflow lands."


### PR DESCRIPTION
## Short Summary (TL;DR)

Do-nothing placeholder versions of two upcoming #8609 phase 2 workflows, so their names/triggers exist on `main` before that larger PR lands.

## The Issue

Related to #8609 (phase 2). `workflow_run` only fires for a listener workflow already on the default branch, so testing the real `image-push.yml` is blocked until something with that name exists on `main`.

## How This PR Solves The Issue

Adds `image-build-push.yml` ("Image build") and `image-push.yml` ("Image push") with the real triggers but a single echo step each. No secrets, no build/push logic. The phase 2 branch will be rebased onto this, replacing the stub bodies under the same names.

## Manual Testing Instructions

Open a PR touching `containers/**`; confirm both workflows run their placeholder step.

## Automated Testing Overview

None - inert placeholder.

## Release/Deployment Notes

No functional change. Safe to merge independently of phase 2.
