### PR TITLE
fix(ci): quote placeholder workflow strings so #8609 isn't parsed as a YAML comment (#8708) [skip ci]

### DIFF
--- a/.github/workflows/image-build-push.yml
+++ b/.github/workflows/image-build-push.yml
@@ -27,8 +27,9 @@ permissions:
 
 jobs:
   placeholder:
-    name: Placeholder (see #8609)
+    name: "Placeholder (see #8609)"
     runs-on: ubuntu-24.04
     steps:
       - name: Do nothing
-        run: echo "Placeholder for #8609 phase 2 - no-op until the real workflow lands."
+        run: |
+          echo "Placeholder for #8609 phase 2 - no-op until the real workflow lands."

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -20,9 +20,10 @@ permissions:
 
 jobs:
   placeholder:
-    name: Placeholder (see #8609)
+    name: "Placeholder (see #8609)"
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
     steps:
       - name: Do nothing
-        run: echo "Placeholder for #8609 phase 2 - no-op until the real workflow lands."
+        run: |
+          echo "Placeholder for #8609 phase 2 - no-op until the real workflow lands."


### PR DESCRIPTION
## Short Summary (TL;DR)

Fixes the "Image build"/"Image push" placeholder jobs (from #8706) failing on every PR touching `containers/**`, e.g. #8705.

## The Issue

Unquoted `#8609` in `name:`/`run:` strings gets parsed as a YAML comment mid-value, truncating `run:` into invalid bash (unterminated quote).

## How This PR Solves The Issue

Quotes `name:`, switches `run:` to a block scalar (`|`), which isn't subject to inline comment stripping. Scanned all other workflow files for the same pattern; nothing else affected.

## Manual Testing Instructions

Open/re-run a PR touching `containers/**`; confirm the placeholder job passes.

## Automated Testing Overview

Verified via `yaml.safe_load` that both values parse intact, and ran the resulting command through bash directly.

## Release/Deployment Notes

Fixes an active CI failure on `main`. No other changes.
