### PR TITLE
build(public-variables): Add DOCKER_ORG [skip ci]

### DIFF
--- a/.github/public-variables/README.md
+++ b/.github/public-variables/README.md
@@ -20,6 +20,7 @@ Current variables:
   - **Bats tests:** each pattern is matched as a case-sensitive substring against the bats filename (without `.bats`) or the `@test` description. E.g. `sveltekit` skips all tests in `sveltekit.bats`; `Symfony Composer` skips only the Composer-flavored test in `symfony.bats`. Go and bats patterns can be combined: `TestLagoonPull|sveltekit`.
   - `workflow_dispatch` runs skip loading the `public-variables` branch entirely, so maintainers can verify fixes without removing them from the embargo list first.
 - `DDEV_EMBARGO_PHP_VERSIONS` - comma-separated PHP versions to skip in `TestPHPConfig`, e.g. `7.0,7.1`
+- `DOCKER_ORG` - Default `hub.docker.com` organization to use, nearly always `ddev`.
 
 ## Adding a new variable
 


### PR DESCRIPTION

## Short Summary (TL;DR)

Add a new DOCKER_ORG public variable (which is almost always `ddev`

This is for testing of non-default in 
* https://github.com/ddev/ddev/pull/8707

