### PR TITLE
fix(ci): wait for pushed images reliably, fixes #8609

### DIFF
--- a/.buildkite/installer-test.sh
+++ b/.buildkite/installer-test.sh
@@ -74,6 +74,9 @@ while IFS= read -r varname; do
 done < <(MSYS_NO_PATHCONV=1 git ls-tree --name-only refs/public-variables-tmp:.github/public-variables/)
 git update-ref -d refs/public-variables-tmp
 
+# A changed image may still be waiting on image-push.yml's approval
+"$(dirname "$0")/../containers/wait-for-images.sh"
+
 export PATH=$PATH:/home/linuxbrew/.linuxbrew/bin
 
 export DDEV_NONINTERACTIVE=true

--- a/.github/workflows/perf-linux.yml
+++ b/.github/workflows/perf-linux.yml
@@ -44,6 +44,11 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Wait for pushed images
+        # This runner holds no push credentials, so it can race
+        # image-push.yml's approval/build/push - see containers/wait-for-images.sh.
+        run: containers/wait-for-images.sh
+
       - name: Build ddev
         run: |
           make build

--- a/.github/workflows/perf-start-time.yml
+++ b/.github/workflows/perf-start-time.yml
@@ -87,6 +87,11 @@ jobs:
           go-version: '>=1.23'
           check-latest: true
 
+      - name: Wait for pushed images
+        # This runner holds no push credentials, so it can race
+        # image-push.yml's approval/build/push - see containers/wait-for-images.sh.
+        run: containers/wait-for-images.sh
+
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         with:

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -52,6 +52,11 @@ jobs:
           done < <(git ls-tree --name-only refs/public-variables-tmp:.github/public-variables/)
           git update-ref -d refs/public-variables-tmp
 
+      - name: Wait for pushed images
+        # This runner holds no push credentials, so it can race
+        # image-push.yml's approval/build/push - see containers/wait-for-images.sh.
+        run: containers/wait-for-images.sh
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@2026.08.03.2

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -34,7 +34,10 @@ jobs:
   build:
     name: Docs Quickstart test
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    # 90 was already tight for the quickstart-test suite alone; the "Wait for
+    # pushed images" step can now add up to ~40 more minutes (see
+    # containers/wait-for-images.sh) before the suite even starts.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v7
         with:

--- a/containers/wait-for-images.sh
+++ b/containers/wait-for-images.sh
@@ -22,10 +22,14 @@
 # no wait.
 #
 # Env:
-#   WAIT_FOR_IMAGES_ATTEMPTS - poll attempts before giving up (default 40)
+#   WAIT_FOR_IMAGES_ATTEMPTS - poll attempts before giving up (default 80)
 #   WAIT_FOR_IMAGES_SLEEP    - seconds between attempts (default 30)
 #
-# Defaults give ~20 minutes - ddev-webserver alone takes ~6-8 minutes to build.
+# Defaults give ~40 minutes. image-build-push.yml's own build fan-out alone
+# regularly takes ~17 minutes before image-push.yml even starts, and a large
+# image's push (e.g. ddev-dbserver-mysql-9.7) adds a few more on top of a
+# maintainer's approval - a 20-minute budget left ~0 margin and timed out
+# waiting on PR #8705 with an otherwise-prompt approval. See #8609.
 
 set -eu -o pipefail
 
@@ -34,7 +38,7 @@ REGISTRY_TAG_EXISTS="$SCRIPT_DIR/registry-tag-exists.sh"
 REQUIRED_IMAGE_TAG="$SCRIPT_DIR/required-image-tag.sh"
 DOCKER_ORG="${DOCKER_ORG:-ddev}"
 
-ATTEMPTS="${WAIT_FOR_IMAGES_ATTEMPTS:-40}"
+ATTEMPTS="${WAIT_FOR_IMAGES_ATTEMPTS:-80}"
 SLEEP_SECONDS="${WAIT_FOR_IMAGES_SLEEP:-30}"
 
 # shellcheck source=containers/image-configs.sh


### PR DESCRIPTION
## Short Summary (TL;DR)

Several CI workflows (quickstart, perf-start-time, perf-linux, the Windows installer pipeline) never got the `wait-for-images.sh` step added by #8707, so they can race image-push.yml's async push.

## The Issue

- Fixes #8609

Multiple checks on #8705 failed after #8707 merged to main:

- `quickstart.yml` and `perf-start-time.yml` (and `perf-linux.yml`, the Windows installer pipeline) build/start DDEV without waiting for `image-push.yml`'s async push, so they raced a content-tagged image that hadn't landed on Docker Hub yet (`ddev-dbserver-mariadb-11.8:... not found`).
- Increased the possible wait time.

## How This PR Solves The Issue

- Added missing `Wait for pushed images` step
- Doubled `wait-for-images.sh`'s default budget from 20 to 40 minutes, and bumped `quickstart.yml`'s job `timeout-minutes` from 90 to 150 so the longer wait doesn't crowd out the quickstart-test suite that follows it.

**This PR does not exercise the real failure mode it fixes.** None of the paths this PR touches are inputs to any image's content hash, so every image in this PR's own CI run hits the fast path (tag already exists, no wait, no cross-platform hash comparison). Passing CI here confirms the containerized hashing reproduces today's committed tags and that the added wait steps don't break anything - it does **not** confirm the Windows hash-divergence bug is actually fixed, or that 40 minutes is enough headroom. That only gets a real test the next time a PR changes `containers/ddev-dbserver` (or another hashed image directory) and pushes through `ddev-windows-mutagen` and the GitHub image-consuming workflows for real - please watch the next such PR/push to main to confirm before considering this closed.

## Manual Testing Instructions

- The real test: watch the next PR/push that actually changes `containers/ddev-dbserver` (or webserver/traefik/ssh-agent/xhgui) all the way through `ddev-windows-mutagen` on Buildkite and the GitHub image-consuming workflows, and confirm no image-not-found or false-timeout failures.

