### PR TITLE
build(hash-paths): fix hash-paths.sh portability problem on windows (#8714) [skip ci]

### DIFF
--- a/containers/hash-paths.sh
+++ b/containers/hash-paths.sh
@@ -17,9 +17,33 @@ fi
 
 HASH_LEN="${HASH_LEN:-10}"
 
+# Pick a SHA-256 implementation. sha256sum exists on Linux, WSL2, and
+# Git Bash on Windows (which ships GNU coreutils); macOS has shasum instead.
+# All are invoked in binary mode, which avoids the CRLF translation that
+# Cygwin/MSYS coreutils can apply in text mode. Output is normalized below
+# to the classic "<hash>  <path>" form so every tool yields identical bytes.
+if command -v sha256sum >/dev/null 2>&1; then
+  hasher=(sha256sum -b);        stdin_hasher=(sha256sum)
+elif command -v shasum >/dev/null 2>&1; then
+  hasher=(shasum -a 256 -b);    stdin_hasher=(shasum -a 256)
+elif command -v openssl >/dev/null 2>&1; then
+  hasher=(openssl dgst -sha256 -r); stdin_hasher=(openssl dgst -sha256 -r)
+else
+  echo "$0: no SHA-256 tool found (need sha256sum, shasum, or openssl)" >&2
+  exit 1
+fi
+
 cd "$(git rev-parse --show-toplevel)"
 
-{
-  git ls-files -- "$@"
-  git ls-files --others --exclude-standard -- "$@"
-} | LC_ALL=C sort -u | xargs -r sha256sum | LC_ALL=C sort | sha256sum | cut -c1-"${HASH_LEN}"
+files=$(
+  {
+    git ls-files -- "$@"
+    git ls-files --others --exclude-standard -- "$@"
+  } | LC_ALL=C sort -u
+)
+
+# NUL-delimited so paths containing spaces survive; the explicit emptiness
+# check replaces "xargs -r", which is a GNU extension absent on macOS.
+if [ -n "$files" ]; then
+  printf '%s\n' "$files" | tr '\n' '\0' | xargs -0 "${hasher[@]}" | sed 's/ \*/  /'
+fi | LC_ALL=C sort | "${stdin_hasher[@]}" | cut -d' ' -f1 | cut -c1-"${HASH_LEN}"


### PR DESCRIPTION
## Short Summary (TL;DR)

The `hash-paths.sh` we were using resulted in different hashes on Windows than everywhere else. As a result,  all windows builds failed like [this](https://buildkite.com/ddev/ddev-windows-mutagen/builds/6477#01a014f9-6412-4f03-9e7f-8d58d8b3eddc) waiting for a hash that would never appear.

## The Issue

The existing script used particularly cross-os fragile `sha256sum`

## How This PR Solves The Issue

Replace the script with one that is more careful.

## Manual Testing Instructions

`make` on windows of a checked-out PR should not want to touch the versionconstants.go

