### PR TITLE
feat(add-on): add `ddev add-on update` to update all installed add-ons, fixes #4979 (#8717) [skip ci]

### DIFF
--- a/cmd/ddev/cmd/addon-update.go
+++ b/cmd/ddev/cmd/addon-update.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// addonUpdateResult describes the outcome of checking/updating a single add-on,
+// used to build the `raw` JSON output.
+type addonUpdateResult struct {
+	Name       string `json:"name"`
+	Repository string `json:"repository"`
+	OldVersion string `json:"old_version"`
+	NewVersion string `json:"new_version,omitempty"`
+	Status     string `json:"status"`
+	Error      string `json:"error,omitempty"`
+}
+
+// AddonUpdateCmd is the "ddev add-on update" command
+var AddonUpdateCmd = &cobra.Command{
+	Use:   "update [addonName...]",
+	Args:  cobra.ArbitraryArgs,
+	Short: "Update installed add-ons to their latest available version",
+	Long: `Check installed add-ons for a newer release and install it. If no add-on names
+are provided, all installed add-ons are checked.
+
+Only add-ons installed from a GitHub repository can be checked automatically; add-ons
+installed from a local directory or from a non-GitHub tarball URL are skipped.
+
+Use '--dry-run' to see what would be updated without installing anything.`,
+	Example: `ddev add-on update
+ddev add-on update redis
+ddev add-on update ddev/ddev-redis
+ddev add-on update --dry-run
+ddev add-on update --project my-project
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		verbose, _ := cmd.Flags().GetBool("verbose")
+
+		app, err := ddevapp.GetActiveApp(cmd.Flag("project").Value.String())
+		if err != nil {
+			util.Failed("Unable to get project %v: %v", cmd.Flag("project").Value.String(), err)
+		}
+		err = os.Chdir(app.AppRoot)
+		if err != nil {
+			util.Failed("Unable to change directory to project root %s: %v", app.AppRoot, err)
+		}
+		_ = app.DockerEnv()
+
+		manifests := ddevapp.GetInstalledAddons(app)
+		if len(manifests) == 0 {
+			util.Warning("No add-ons are installed in project '%s'.", app.Name)
+			return
+		}
+
+		if len(args) > 0 {
+			allManifests, err := ddevapp.GatherAllManifests(app)
+			if err != nil {
+				util.Failed("Unable to gather add-on manifests: %v", err)
+			}
+			seen := map[string]bool{}
+			var filtered []ddevapp.AddonManifest
+			for _, arg := range args {
+				manifest, ok := allManifests[arg]
+				if !ok {
+					util.Warning("Add-on '%s' is not installed in project '%s'", arg, app.Name)
+					continue
+				}
+				if !seen[manifest.Name] {
+					seen[manifest.Name] = true
+					filtered = append(filtered, manifest)
+				}
+			}
+			manifests = filtered
+		}
+
+		var results []addonUpdateResult
+		var toUpdate []addonUpdateResult
+
+		for _, manifest := range manifests {
+			result := addonUpdateResult{Name: manifest.Name, Repository: manifest.Repository, OldVersion: manifest.Version}
+
+			if !ddevapp.IsGithubRef(manifest.Repository) {
+				util.Warning("Skipping '%s': not installed from a GitHub repository, cannot check for updates", manifest.Name)
+				result.Status = "skipped"
+				results = append(results, result)
+				continue
+			}
+
+			_, latestVersion, err := ddevapp.GetAddonTarballURL(manifest.Repository, "", false, 0)
+			if err != nil {
+				util.Warning("Skipping '%s': unable to determine the latest version: %v", manifest.Name, err)
+				result.Status = "skipped"
+				result.Error = err.Error()
+				results = append(results, result)
+				continue
+			}
+
+			result.NewVersion = latestVersion
+			if latestVersion == manifest.Version {
+				if verbose {
+					util.Success("'%s' is already up to date (%s)", manifest.Name, manifest.Version)
+				}
+				result.Status = "up-to-date"
+				results = append(results, result)
+				continue
+			}
+
+			result.Status = "outdated"
+			toUpdate = append(toUpdate, result)
+		}
+
+		if len(toUpdate) == 0 {
+			output.UserOut.WithField("raw", results).Println("All add-ons are up to date.")
+			return
+		}
+
+		if dryRun {
+			for _, r := range toUpdate {
+				util.Success("'%s' can be updated: %s -> %s", r.Name, r.OldVersion, r.NewVersion)
+			}
+			results = append(results, toUpdate...)
+			output.UserOut.WithField("raw", results).Printf("%d add-on(s) can be updated.", len(toUpdate))
+			return
+		}
+
+		var updatedNames []string
+		var failedNames []string
+		for _, r := range toUpdate {
+			util.Success("\nUpdating '%s': %s -> %s", r.Name, r.OldVersion, r.NewVersion)
+			err := ddevapp.InstallAddonFromGitHub(app, r.Repository, "", verbose)
+			if err != nil {
+				util.Warning("Unable to update '%s': %v", r.Name, err)
+				r.Status = "failed"
+				r.Error = err.Error()
+				failedNames = append(failedNames, r.Name)
+				results = append(results, r)
+				continue
+			}
+
+			err = ddevapp.ProcessRuntimeDependencies(app, r.Name, verbose)
+			if err != nil {
+				util.Warning("Unable to process runtime dependencies for '%s': %v", r.Name, err)
+			}
+
+			r.Status = "updated"
+			updatedNames = append(updatedNames, r.Name)
+			results = append(results, r)
+		}
+
+		err = app.CleanupConfigurationFiles()
+		if err != nil {
+			util.Warning("Unable to clean up temporary configuration files: %v", err)
+		}
+
+		if len(updatedNames) > 0 {
+			output.UserOut.WithField("raw", results).Printf("\nUpdated %d add-on(s): %s\nUse `ddev restart` to enable updates.", len(updatedNames), strings.Join(updatedNames, ", "))
+		}
+		if len(failedNames) > 0 {
+			util.Failed("Failed to update %d add-on(s): %s", len(failedNames), strings.Join(failedNames, ", "))
+		}
+	},
+}
+
+func init() {
+	AddonUpdateCmd.Flags().Bool("dry-run", false, "Show which add-ons would be updated without installing anything")
+	_ = AddonUpdateCmd.RegisterFlagCompletionFunc("dry-run", configCompletionFunc([]string{"true", "false"}))
+	AddonUpdateCmd.Flags().BoolP("verbose", "v", false, "Extended/verbose output")
+	_ = AddonUpdateCmd.RegisterFlagCompletionFunc("verbose", configCompletionFunc([]string{"true", "false"}))
+	AddonUpdateCmd.Flags().String("project", "", "Name of the project to update the add-ons for")
+	_ = AddonUpdateCmd.RegisterFlagCompletionFunc("project", ddevapp.GetProjectNamesFunc("all", 0))
+
+	AddonCmd.AddCommand(AddonUpdateCmd)
+}

--- a/cmd/ddev/cmd/addon-update.go
+++ b/cmd/ddev/cmd/addon-update.go
@@ -32,11 +32,15 @@ are provided, all installed add-ons are checked.
 Only add-ons installed from a GitHub repository can be checked automatically; add-ons
 installed from a local directory or from a non-GitHub tarball URL are skipped.
 
-Use '--dry-run' to see what would be updated without installing anything.`,
+Use '--dry-run' to see what would be updated without installing anything.
+
+You'll be asked to confirm before any add-on is updated; use '--yes' to skip
+the prompt.`,
 	Example: `ddev add-on update
 ddev add-on update redis
 ddev add-on update ddev/ddev-redis
 ddev add-on update --dry-run
+ddev add-on update --yes
 ddev add-on update --project my-project
 `,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -130,6 +134,16 @@ ddev add-on update --project my-project
 			return
 		}
 
+		yes, _ := cmd.Flags().GetBool("yes")
+		if !yes {
+			for _, r := range toUpdate {
+				util.Warning("'%s' can be updated: %s -> %s", r.Name, r.OldVersion, r.NewVersion)
+			}
+			if !util.Confirm("Update these add-on(s)?") {
+				util.Failed("Update cancelled")
+			}
+		}
+
 		var updatedNames []string
 		var failedNames []string
 		for _, r := range toUpdate {
@@ -152,6 +166,7 @@ ddev add-on update --project my-project
 			r.Status = "updated"
 			updatedNames = append(updatedNames, r.Name)
 			results = append(results, r)
+			util.Warning("If '%s' causes problems, revert with: ddev add-on get %s --version %s", r.Name, r.Repository, r.OldVersion)
 		}
 
 		err = app.CleanupConfigurationFiles()
@@ -175,6 +190,8 @@ func init() {
 	_ = AddonUpdateCmd.RegisterFlagCompletionFunc("verbose", configCompletionFunc([]string{"true", "false"}))
 	AddonUpdateCmd.Flags().String("project", "", "Name of the project to update the add-ons for")
 	_ = AddonUpdateCmd.RegisterFlagCompletionFunc("project", ddevapp.GetProjectNamesFunc("all", 0))
+	AddonUpdateCmd.Flags().BoolP("yes", "y", false, "Yes - skip confirmation prompt")
+	_ = AddonUpdateCmd.RegisterFlagCompletionFunc("yes", configCompletionFunc([]string{"true", "false"}))
 
 	AddonCmd.AddCommand(AddonUpdateCmd)
 }

--- a/cmd/ddev/cmd/addon-update.go
+++ b/cmd/ddev/cmd/addon-update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -146,6 +147,7 @@ ddev add-on update --project my-project
 
 		var updatedNames []string
 		var failedNames []string
+		var rollbackHints []string
 		for _, r := range toUpdate {
 			util.Success("\nUpdating '%s': %s -> %s", r.Name, r.OldVersion, r.NewVersion)
 			err := ddevapp.InstallAddonFromGitHub(app, r.Repository, "", verbose)
@@ -166,7 +168,7 @@ ddev add-on update --project my-project
 			r.Status = "updated"
 			updatedNames = append(updatedNames, r.Name)
 			results = append(results, r)
-			util.Warning("If '%s' causes problems, revert with: ddev add-on get %s --version %s", r.Name, r.Repository, r.OldVersion)
+			rollbackHints = append(rollbackHints, fmt.Sprintf("ddev add-on get %s --version %s  # downgrade '%s'", r.Repository, r.OldVersion, r.Name))
 		}
 
 		err = app.CleanupConfigurationFiles()
@@ -176,6 +178,7 @@ ddev add-on update --project my-project
 
 		if len(updatedNames) > 0 {
 			output.UserOut.WithField("raw", results).Printf("\nUpdated %d add-on(s): %s\nUse `ddev restart` to enable updates.", len(updatedNames), strings.Join(updatedNames, ", "))
+			util.Warning("\nTo downgrade again:\n%s", strings.Join(rollbackHints, "\n"))
 		}
 		if len(failedNames) > 0 {
 			util.Failed("Failed to update %d add-on(s): %s", len(failedNames), strings.Join(failedNames, ", "))

--- a/cmd/ddev/cmd/addon-update.go
+++ b/cmd/ddev/cmd/addon-update.go
@@ -178,7 +178,7 @@ ddev add-on update --project my-project
 
 		if len(updatedNames) > 0 {
 			output.UserOut.WithField("raw", results).Printf("\nUpdated %d add-on(s): %s\nUse `ddev restart` to enable updates.", len(updatedNames), strings.Join(updatedNames, ", "))
-			util.Warning("\nTo downgrade again:\n%s", strings.Join(rollbackHints, "\n"))
+			util.Warning("\nIf you want to go back to the original versions:\n%s", strings.Join(rollbackHints, "\n"))
 		}
 		if len(failedNames) > 0 {
 			util.Failed("Failed to update %d add-on(s): %s", len(failedNames), strings.Join(failedNames, ", "))

--- a/cmd/ddev/cmd/addon-update_test.go
+++ b/cmd/ddev/cmd/addon-update_test.go
@@ -72,7 +72,7 @@ func TestCmdAddonUpdate(t *testing.T) {
 	out, err = exec.RunHostCommand(DdevBin, "add-on", "update", "--yes")
 	require.NoError(t, err, "output=%s", out)
 	assert.Contains(out, "Updated 1 add-on(s): redis")
-	assert.Contains(out, "To downgrade again:")
+	assert.Contains(out, "If you want to go back to the original versions:")
 	assert.Contains(out, "ddev add-on get ddev/ddev-redis --version v0.0.1-fake-old-for-testing")
 
 	content, err = os.ReadFile(manifestFile)

--- a/cmd/ddev/cmd/addon-update_test.go
+++ b/cmd/ddev/cmd/addon-update_test.go
@@ -72,7 +72,8 @@ func TestCmdAddonUpdate(t *testing.T) {
 	out, err = exec.RunHostCommand(DdevBin, "add-on", "update", "--yes")
 	require.NoError(t, err, "output=%s", out)
 	assert.Contains(out, "Updated 1 add-on(s): redis")
-	assert.Contains(out, "revert with: ddev add-on get ddev/ddev-redis --version v0.0.1-fake-old-for-testing")
+	assert.Contains(out, "To downgrade again:")
+	assert.Contains(out, "ddev add-on get ddev/ddev-redis --version v0.0.1-fake-old-for-testing")
 
 	content, err = os.ReadFile(manifestFile)
 	require.NoError(t, err)

--- a/cmd/ddev/cmd/addon-update_test.go
+++ b/cmd/ddev/cmd/addon-update_test.go
@@ -68,9 +68,11 @@ func TestCmdAddonUpdate(t *testing.T) {
 	assert.Contains(string(content), "v0.0.1-fake-old-for-testing")
 
 	// A real update should install the latest release and rewrite the manifest.
-	out, err = exec.RunHostCommand(DdevBin, "add-on", "update")
+	// --yes skips the confirmation prompt.
+	out, err = exec.RunHostCommand(DdevBin, "add-on", "update", "--yes")
 	require.NoError(t, err, "output=%s", out)
 	assert.Contains(out, "Updated 1 add-on(s): redis")
+	assert.Contains(out, "revert with: ddev add-on get ddev/ddev-redis --version v0.0.1-fake-old-for-testing")
 
 	content, err = os.ReadFile(manifestFile)
 	require.NoError(t, err)

--- a/cmd/ddev/cmd/addon-update_test.go
+++ b/cmd/ddev/cmd/addon-update_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/github"
+	asrt "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// versionLineRegex matches the "version: ..." line in an add-on manifest.yaml
+var versionLineRegex = regexp.MustCompile(`(?m)^version:.*$`)
+
+// TestCmdAddonUpdate tests `ddev add-on update`
+func TestCmdAddonUpdate(t *testing.T) {
+	if !github.HasGitHubToken() {
+		t.Skip("Skipping because DDEV_GITHUB_TOKEN is not set")
+	}
+	assert := asrt.New(t)
+
+	origDir, _ := os.Getwd()
+	site := TestSites[0]
+	err := os.Chdir(site.Dir)
+	require.NoError(t, err)
+	app, err := ddevapp.GetActiveApp("")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = exec.RunHostCommand(DdevBin, "add-on", "remove", "redis")
+		_, _ = exec.RunHostCommand(DdevBin, "add-on", "remove", "example")
+		err = os.Chdir(origDir)
+		assert.NoError(err)
+	})
+
+	out, err := exec.RunHostCommand(DdevBin, "add-on", "get", "ddev/ddev-redis")
+	require.NoError(t, err, "output=%s", out)
+
+	// Install a directory-based addon too; it can't be checked for updates.
+	exampleDir := filepath.Join(origDir, "testdata", "TestCmdAddon", "example-repo")
+	out, err = exec.RunHostCommand(DdevBin, "add-on", "get", exampleDir)
+	require.NoError(t, err, "output=%s", out)
+
+	// Fake an outdated version so 'update' has something to do, without
+	// depending on a specific historical redis release.
+	manifestFile := app.GetConfigPath("addon-metadata/redis/manifest.yaml")
+	require.FileExists(t, manifestFile)
+	content, err := os.ReadFile(manifestFile)
+	require.NoError(t, err)
+	fakeContent := versionLineRegex.ReplaceAll(content, []byte("version: v0.0.1-fake-old-for-testing"))
+	err = os.WriteFile(manifestFile, fakeContent, 0644)
+	require.NoError(t, err)
+
+	// Dry run should report redis as updatable and skip the directory-based addon,
+	// without changing anything.
+	out, err = exec.RunHostCommand(DdevBin, "add-on", "update", "--dry-run")
+	require.NoError(t, err, "output=%s", out)
+	assert.Contains(out, "redis")
+	assert.Contains(out, "can be updated")
+	assert.Contains(out, "Skipping 'example'")
+
+	content, err = os.ReadFile(manifestFile)
+	require.NoError(t, err)
+	assert.Contains(string(content), "v0.0.1-fake-old-for-testing")
+
+	// A real update should install the latest release and rewrite the manifest.
+	out, err = exec.RunHostCommand(DdevBin, "add-on", "update")
+	require.NoError(t, err, "output=%s", out)
+	assert.Contains(out, "Updated 1 add-on(s): redis")
+
+	content, err = os.ReadFile(manifestFile)
+	require.NoError(t, err)
+	assert.NotContains(string(content), "v0.0.1-fake-old-for-testing")
+
+	// Running again should find nothing to update.
+	out, err = exec.RunHostCommand(DdevBin, "add-on", "update")
+	require.NoError(t, err, "output=%s", out)
+	assert.Contains(out, "All add-ons are up to date.")
+}

--- a/cmd/ddev/cmd/addon.go
+++ b/cmd/ddev/cmd/addon.go
@@ -10,6 +10,7 @@ var AddonCmd = &cobra.Command{
 	Aliases: []string{"addon", "add-ons", "addons"},
 	Short:   "A collection of commands for managing installed 3rd party add-ons",
 	Example: `ddev add-on get ddev/ddev-redis
+ddev add-on update
 ddev add-on remove someaddonname
 ddev add-on list
 ddev add-on list --installed

--- a/docs/content/users/extend/using-add-ons.md
+++ b/docs/content/users/extend/using-add-ons.md
@@ -142,6 +142,14 @@ ddev add-on get <owner>/<repo>
 
 This updates to the latest version while preserving your customizations.
 
+To check and update every installed add-on at once:
+
+```bash
+ddev add-on update
+```
+
+Add `--dry-run` to see what would be updated without installing anything.
+
 ### Remove an Add-on
 
 ```bash

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -155,10 +155,37 @@ When an add-on declares dependencies in its `install.yaml`, DDEV will automatica
 
 DDEV will detect and prevent circular dependencies with clear error messages.
 
-In general, you can run `ddev add-on get` multiple times without doing any damage. Updating an add-on can be done by running `ddev add-on get <add-on-name>`. If you have changed an add-on file and removed the `#ddev-generated` marker in the file, that file will not be touched and DDEV will let you know about it.
+In general, you can run `ddev add-on get` multiple times without doing any damage. Updating an add-on can be done by running `ddev add-on get <add-on-name>`, or use `ddev add-on update` to update every installed add-on at once. If you have changed an add-on file and removed the `#ddev-generated` marker in the file, that file will not be touched and DDEV will let you know about it.
 
 !!!tip "How to install add-ons from private repositories?"
     See [Private Add-ons](../extend/using-add-ons.md#private-add-ons) for details.
+
+### `add-on update`
+
+Check installed add-ons for a newer release and install it. If no add-on names are provided, all installed add-ons are checked. Add-ons installed from a local directory or from a non-GitHub tarball URL can't be checked automatically and are skipped.
+
+Flags:
+
+* `--dry-run`: Show which add-ons would be updated without installing anything (default `false`)
+* `--project <projectName>`: Specify a project to update the add-ons for. Defaults to checking for a project in the current directory.
+* `--verbose`, `-v`: Output verbose error information with Bash `set -x` (default `false`)
+
+Example:
+
+```shell
+# Check and update all installed add-ons
+ddev add-on update
+
+# Update a single installed add-on
+ddev add-on update redis
+ddev add-on update ddev/ddev-redis
+
+# See what would be updated without installing anything
+ddev add-on update --dry-run
+
+# Update add-ons for a specific project
+ddev add-on update --project my-project
+```
 
 ### `add-on remove`
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -169,6 +169,7 @@ Flags:
 * `--dry-run`: Show which add-ons would be updated without installing anything (default `false`)
 * `--project <projectName>`: Specify a project to update the add-ons for. Defaults to checking for a project in the current directory.
 * `--verbose`, `-v`: Output verbose error information with Bash `set -x` (default `false`)
+* `--yes`, `-y`: Skip confirmation prompt.
 
 Example:
 


### PR DESCRIPTION
## Short Summary (TL;DR)

Adds `ddev add-on update` to check installed add-ons for newer releases and update them, instead of running `ddev add-on get` by hand for each one.

## The Issue

- Fixes #4979

## How This PR Solves The Issue

`ddev add-on update [addonName...]` compares each installed add-on's manifest version against its latest GitHub release and reinstalls the ones that are outdated (reusing the existing `InstallAddonFromGitHub` install path). Add-ons installed from a local directory or non-GitHub tarball are skipped with a warning. `--dry-run` reports what would change without installing anything.

## Manual Testing Instructions

```
ddev add-on get ddev/ddev-adminer
ddev add-on update            # reports up to date
# edit .ddev/addon-metadata/adminer/manifest.yaml, set version to something older
ddev add-on update --dry-run  # reports adminer as updatable
ddev add-on update            # reinstalls and updates the manifest
```

## Automated Testing Overview

`TestCmdAddonUpdate` in `cmd/ddev/cmd/addon-update_test.go`, gated on `DDEV_GITHUB_TOKEN` like the other add-on integration tests.

## Release/Deployment Notes

New subcommand only; no changes to existing add-on commands.
