### PR TITLE
build(go): modernize for go 1.27, latest golangci-lint (#8722) [skip ci]

### DIFF
--- a/cmd/ddev/cmd/delete-images.go
+++ b/cmd/ddev/cmd/delete-images.go
@@ -246,7 +246,7 @@ func deleteDdevImages(deleteAll, dryRun bool) error {
 		} else if len(img.RepoDigests) > 0 {
 			var names []string
 			for _, digest := range img.RepoDigests {
-				name := strings.SplitN(digest, "@", 2)[0]
+				name, _, _ := strings.Cut(digest, "@")
 				names = append(names, name+":<none>")
 			}
 			imageName = strings.Join(names, ", ")

--- a/cmd/ddev/cmd/exec.go
+++ b/cmd/ddev/cmd/exec.go
@@ -90,8 +90,7 @@ ddev exec -s db -u root ls -la /root`,
 
 		if err != nil {
 			exitCode := 1
-			var statusErr cli.StatusError
-			if errors.As(err, &statusErr) {
+			if statusErr, ok := errors.AsType[cli.StatusError](err); ok {
 				exitCode = statusErr.StatusCode
 			}
 			if !quiet {

--- a/cmd/ddev/cmd/ssh.go
+++ b/cmd/ddev/cmd/ssh.go
@@ -53,8 +53,7 @@ ddev ssh -d /var/www/html`,
 			SkipHooks: true,
 		})
 		if err != nil {
-			var statusErr cli.StatusError
-			if errors.As(err, &statusErr) {
+			if statusErr, ok := errors.AsType[cli.StatusError](err); ok {
 				os.Exit(statusErr.StatusCode)
 			}
 			util.Failed("ddev ssh failed: %v", err)

--- a/cmd/ddev/cmd/utility-addon-update-checker.go
+++ b/cmd/ddev/cmd/utility-addon-update-checker.go
@@ -79,8 +79,7 @@ ddev ut addon-update-checker -d /path/to/my-addons-workspace
 		hostCmd.Dir = rootDir
 
 		if err := hostCmd.Run(); err != nil {
-			var exiterr *osexec.ExitError
-			if errors.As(err, &exiterr) {
+			if exiterr, ok := errors.AsType[*osexec.ExitError](err); ok {
 				output.UserErr.Exit(exiterr.ExitCode())
 			}
 			util.Failed("Unable to run update checker script: %v", err)

--- a/cmd/ddev/cmd/utility-port-diagnose.go
+++ b/cmd/ddev/cmd/utility-port-diagnose.go
@@ -347,8 +347,7 @@ func isPortFree(port string) bool {
 		// EACCES means we can't bind due to permissions (e.g. port < 1024 on
 		// Linux without CAP_NET_BIND_SERVICE). Fall through to the dial check
 		// rather than assuming the port is occupied.
-		var syscallErr *net.OpError
-		if errors.As(err, &syscallErr) {
+		if syscallErr, ok := errors.AsType[*net.OpError](err); ok {
 			if errors.Is(syscallErr.Err, syscall.EACCES) {
 				// Dial to see if anything actually answers.
 				conn, dialErr := net.DialTimeout("tcp", "127.0.0.1:"+port, 250*time.Millisecond)

--- a/pkg/ddevapp/addons.go
+++ b/pkg/ddevapp/addons.go
@@ -248,8 +248,7 @@ func processBashHostAction(action string, installDesc InstallDesc, app *DdevApp,
 	if err != nil {
 		warningCode := GetAddonDdevWarningExitCode(action)
 		if warningCode > 0 {
-			var exitErr *goexec.ExitError
-			if errors.As(err, &exitErr) {
+			if exitErr, ok := errors.AsType[*goexec.ExitError](err); ok {
 				// Get the exit code
 				exitCode := exitErr.ExitCode()
 				if exitCode == warningCode {

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -3503,7 +3503,7 @@ func deleteImages(app *DdevApp) {
 		} else if len(image.RepoDigests) > 0 {
 			var names []string
 			for _, digest := range image.RepoDigests {
-				name := strings.SplitN(digest, "@", 2)[0]
+				name, _, _ := strings.Cut(digest, "@")
 				names = append(names, name+":<none> "+dockerutil.TruncateID(image.ID))
 			}
 			imageName = strings.Join(names, ", ")

--- a/pkg/ddevapp/providerPlatform_test.go
+++ b/pkg/ddevapp/providerPlatform_test.go
@@ -122,7 +122,7 @@ func writePlatformLocalConfig(t *testing.T, app *ddevapp.DdevApp, token string) 
 
 // setupPlatformProject does basic setup, creating project, etc.
 func setupPlatformProject(t *testing.T, environment string) (*ddevapp.DdevApp, *ddevapp.Provider, error) {
-	testName := strings.Split(t.Name(), "/")[0]
+	testName, _, _ := strings.Cut(t.Name(), "/")
 	siteDir := testcommon.CreateTmpDir(testName)
 
 	err := globalconfig.RemoveProjectInfo(testName)
@@ -184,7 +184,7 @@ func startAndCheckPlatformPush(t *testing.T, app *ddevapp.DdevApp, provider *dde
 		require.Equal(t, expectedInfo, provider.GetInfo())
 	}
 
-	testName := strings.Split(t.Name(), "/")[0]
+	testName, _, _ := strings.Cut(t.Name(), "/")
 
 	// Create database and files entries that we can verify after push
 	tval := nodeps.RandomString(10)

--- a/pkg/ddevapp/providerUpsun_test.go
+++ b/pkg/ddevapp/providerUpsun_test.go
@@ -125,7 +125,7 @@ func writeUpsunLocalConfig(t *testing.T, app *ddevapp.DdevApp, token string) err
 
 // setupUpsunProject does basic setup, creating project, etc.
 func setupUpsunProject(t *testing.T, environment string) (*ddevapp.DdevApp, *ddevapp.Provider, error) {
-	testName := strings.Split(t.Name(), "/")[0]
+	testName, _, _ := strings.Cut(t.Name(), "/")
 	siteDir := testcommon.CreateTmpDir(testName)
 
 	err := globalconfig.RemoveProjectInfo(testName)
@@ -187,7 +187,7 @@ func startAndCheckUpsunPush(t *testing.T, app *ddevapp.DdevApp, provider *ddevap
 		require.Equal(t, expectedInfo, provider.GetInfo())
 	}
 
-	testName := strings.Split(t.Name(), "/")[0]
+	testName, _, _ := strings.Cut(t.Name(), "/")
 
 	// Create database and files entries that we can verify after push
 	tval := nodeps.RandomString(10)

--- a/pkg/fileutil/file_hash_test.go
+++ b/pkg/fileutil/file_hash_test.go
@@ -78,6 +78,6 @@ func externalComputeSha1Sum(filePath string) (string, error) {
 		return "", err
 	}
 
-	hash := strings.Split(out, " ")[0]
+	hash, _, _ := strings.Cut(out, " ")
 	return hash, nil
 }


### PR DESCRIPTION

## Short Summary (TL;DR)

go 1.27 came out, and golangci-lint 2.13.1 with it. golangci-lint has some specific new `modernize` recommendations.

## The Issue

Fixup modernize stuff

## How This PR Solves The Issue

golangci-lint --fix

HEAD and updated PRs don't pass static checks until this goes in.