### PR TITLE
test: skip tests that don't need to repeat across every CI wrapper workflow, for #8696 (#8725) [skip ci]

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -23,6 +23,7 @@ import (
 
 // TestCustomCommands does basic checks to make sure custom commands work OK.
 func TestCustomCommands(t *testing.T) {
+	testcommon.SkipUnlessDefaultEnvironment(t)
 	assert := asrt.New(t)
 	runTime := util.TimeTrackC(t.Name())
 

--- a/cmd/ddev/cmd/debug-test_test.go
+++ b/cmd/ddev/cmd/debug-test_test.go
@@ -6,11 +6,13 @@ import (
 
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/stretchr/testify/require"
 )
 
 // TestCmdDebugTest ensures that `ddev utility test` has basic functionality
 func TestCmdDebugTest(t *testing.T) {
+	testcommon.SkipUnlessDefaultEnvironment(t)
 	origDir, _ := os.Getwd()
 	site := TestSites[0]
 	_ = os.Chdir(site.Dir)

--- a/cmd/ddev/cmd/delete_test.go
+++ b/cmd/ddev/cmd/delete_test.go
@@ -83,6 +83,7 @@ func TestDeleteCmd(t *testing.T) {
 // TestOmitSnapshotOnDeleteGlobal tests the omit_snapshot_on_delete global config option
 // and its interaction with the --omit-snapshot flag on 'ddev delete'.
 func TestOmitSnapshotOnDeleteGlobal(t *testing.T) {
+	testcommon.SkipUnlessDefaultEnvironment(t)
 	origDir, _ := os.Getwd()
 	site := TestSites[0]
 	err := os.Chdir(site.Dir)

--- a/cmd/ddev/cmd/root_test.go
+++ b/cmd/ddev/cmd/root_test.go
@@ -380,6 +380,10 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 	_, err = exec.RunHostCommand(DdevBin, "start", "-y")
 	assert.NoError(err)
 
+	// Captured below, before the poweroff, so cleanup can restart exactly the
+	// projects that were running rather than every entry in TestSites.
+	var apps []*ddevapp.DdevApp
+
 	t.Cleanup(func() {
 		err = os.Chdir(origDir)
 		assert.NoError(err)
@@ -392,9 +396,12 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 		testcommon.ResetGlobalDdevDir(t, tmpXdgConfigHomeDir)
 
 		// Because the start has done a poweroff (new DDEV version),
-		// make sure sites are running again.
-		for _, site := range TestSites {
-			_, _ = exec.RunCommand(DdevBin, []string{"start", "-y", site.Name})
+		// make sure the projects that were running before are running again.
+		for _, app := range apps {
+			if app.Name == junkName {
+				continue
+			}
+			_, _ = exec.RunCommand(DdevBin, []string{"start", "-y", app.Name})
 		}
 
 		t.Logf("attempting to remove project files in %s", tmpJunkProjectDir)
@@ -404,7 +411,7 @@ func TestPoweroffOnNewVersion(t *testing.T) {
 		}
 	})
 
-	apps := ddevapp.GetActiveProjects()
+	apps = ddevapp.GetActiveProjects()
 	activeCount := len(apps)
 	assert.GreaterOrEqual(activeCount, 2)
 

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -1122,6 +1122,7 @@ func TestPHPConfig(t *testing.T) {
 	if nodeps.IsAppleSilicon() && dockerutil.IsDockerDesktop() && nodeps.IsEnvFalse("DDEV_RUN_TEST_ANYWAY") {
 		t.Skip("Skipping on Docker Desktop/Apple Silicon to ignore problems with 'connection reset by peer'")
 	}
+	testcommon.SkipUnlessDefaultEnvironment(t)
 	assert := asrt.New(t)
 	origDir, _ := os.Getwd()
 	app := &ddevapp.DdevApp{}

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -2347,6 +2347,7 @@ func TestWebserverMariaMySQLDBClient(t *testing.T) {
 // TestWebserverPostgresDBClient tests functionality of Postgres
 // database clients in the ddev-webserver
 func TestWebserverPostgresDBClient(t *testing.T) {
+	testcommon.SkipUnlessDefaultEnvironment(t)
 	assert := asrt.New(t)
 
 	serverVersions := []string{"postgres:18", "postgres:17", "postgres:16"}
@@ -3661,6 +3662,7 @@ func TestHttpsRedirection(t *testing.T) {
 	if globalconfig.GetCAROOT() == "" {
 		t.Skip("Skipping because MkcertCARoot is not set, no https")
 	}
+	testcommon.SkipUnlessDefaultEnvironment(t)
 
 	assert := asrt.New(t)
 	testcommon.ClearDockerEnv()

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/testcommon"
 	"github.com/ddev/ddev/pkg/util"
 	asrt "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,9 +30,7 @@ func TestMutagenSimple(t *testing.T) {
 	if nodeps.IsWSL2MirroredMode() {
 		t.Skip("Skipping TestMutagenSimple in WSL2 mirrored mode; It can fail randomly on the 'composer install' step due to network issues, unable to download random dependencies from either dist or source.")
 	}
-	if nodeps.PerformanceModeDefault != types.PerformanceModeMutagen && !nodeps.NoBindMountsDefault {
-		t.Skip("forces Mutagen mode itself; only runs in a Mutagen-flavored workflow to avoid testing the same thing redundantly, see ddev/ddev#8696")
-	}
+	testcommon.SkipUnlessDefaultEnvironment(t)
 	assert := asrt.New(t)
 
 	// Make sure there's not an existing Mutagen running, perhaps in wrong directory
@@ -195,9 +194,7 @@ func TestMutagenConfigChange(t *testing.T) {
 	if !nodeps.IsMacOS() {
 		t.Skip("TestMutagenConfigChange runs only on macOS (without Colima), skipping")
 	}
-	if nodeps.PerformanceModeDefault != types.PerformanceModeMutagen && !nodeps.NoBindMountsDefault {
-		t.Skip("forces Mutagen mode itself; only runs in a Mutagen-flavored workflow to avoid testing the same thing redundantly, see ddev/ddev#8696")
-	}
+	testcommon.SkipUnlessDefaultEnvironment(t)
 	assert := asrt.New(t)
 
 	// Make sure there's not an existing Mutagen running, perhaps in wrong directory
@@ -283,9 +280,7 @@ func TestMutagenDiagnose(t *testing.T) {
 	if nodeps.IsWindows() {
 		t.Skip("TestMutagenDiagnose skipped on Windows")
 	}
-	if nodeps.PerformanceModeDefault != types.PerformanceModeMutagen && !nodeps.NoBindMountsDefault {
-		t.Skip("forces Mutagen mode itself; only runs in a Mutagen-flavored workflow to avoid testing the same thing redundantly, see ddev/ddev#8696")
-	}
+	testcommon.SkipUnlessDefaultEnvironment(t)
 	assert := asrt.New(t)
 
 	// Make sure there's not an existing Mutagen running

--- a/pkg/ddevapp/mutagen_test.go
+++ b/pkg/ddevapp/mutagen_test.go
@@ -29,6 +29,9 @@ func TestMutagenSimple(t *testing.T) {
 	if nodeps.IsWSL2MirroredMode() {
 		t.Skip("Skipping TestMutagenSimple in WSL2 mirrored mode; It can fail randomly on the 'composer install' step due to network issues, unable to download random dependencies from either dist or source.")
 	}
+	if nodeps.PerformanceModeDefault != types.PerformanceModeMutagen && !nodeps.NoBindMountsDefault {
+		t.Skip("forces Mutagen mode itself; only runs in a Mutagen-flavored workflow to avoid testing the same thing redundantly, see ddev/ddev#8696")
+	}
 	assert := asrt.New(t)
 
 	// Make sure there's not an existing Mutagen running, perhaps in wrong directory
@@ -192,6 +195,9 @@ func TestMutagenConfigChange(t *testing.T) {
 	if !nodeps.IsMacOS() {
 		t.Skip("TestMutagenConfigChange runs only on macOS (without Colima), skipping")
 	}
+	if nodeps.PerformanceModeDefault != types.PerformanceModeMutagen && !nodeps.NoBindMountsDefault {
+		t.Skip("forces Mutagen mode itself; only runs in a Mutagen-flavored workflow to avoid testing the same thing redundantly, see ddev/ddev#8696")
+	}
 	assert := asrt.New(t)
 
 	// Make sure there's not an existing Mutagen running, perhaps in wrong directory
@@ -276,6 +282,9 @@ func TestMutagenConfigChange(t *testing.T) {
 func TestMutagenDiagnose(t *testing.T) {
 	if nodeps.IsWindows() {
 		t.Skip("TestMutagenDiagnose skipped on Windows")
+	}
+	if nodeps.PerformanceModeDefault != types.PerformanceModeMutagen && !nodeps.NoBindMountsDefault {
+		t.Skip("forces Mutagen mode itself; only runs in a Mutagen-flavored workflow to avoid testing the same thing redundantly, see ddev/ddev#8696")
 	}
 	assert := asrt.New(t)
 

--- a/pkg/testcommon/testcommon.go
+++ b/pkg/testcommon/testcommon.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/ddev/ddev/pkg/archive"
+	"github.com/ddev/ddev/pkg/config/types"
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/fileutil"
@@ -460,6 +461,21 @@ func CheckGoroutineOutput(t *testing.T, out string) {
 	num, err := strconv.Atoi(matches[0][1])
 	require.NoError(t, err, "can't convert %s to number: %v", matches[0][1])
 	require.LessOrEqual(t, num, goroutineLimit, "number of goroutines=%v, higher than limit=%d", num, goroutineLimit)
+}
+
+// SkipUnlessDefaultEnvironment skips t unless the test is running with the
+// plain default settings: nginx webserver, Mutagen off, bind mounts on,
+// normal (non-rootless) Docker. Use it for tests that don't actually check
+// webserver type, Mutagen, or rootless Docker - running them again under each
+// of those special setups just repeats the same check with nothing new to
+// show for it. See ddev/ddev#8696.
+func SkipUnlessDefaultEnvironment(t *testing.T) {
+	if nodeps.WebserverDefault != nodeps.WebserverNginxFPM ||
+		nodeps.PerformanceModeDefault == types.PerformanceModeMutagen ||
+		nodeps.NoBindMountsDefault ||
+		dockerutil.IsPodman() || dockerutil.IsDockerRootless() {
+		t.Skip("skipping: this test doesn't depend on webserver type, Mutagen, or rootless Docker, so it only needs to run once, under the plain default setup; see ddev/ddev#8696")
+	}
 }
 
 // PortPair is for tests to use naming portsets for tests


### PR DESCRIPTION
## Short Summary (TL;DR)

Several of the slowest tests in the Go suite don't actually depend on webserver type, Mutagen, or rootless Docker, yet they run in all 8 CI wrapper workflows that vary those settings; this PR skips them everywhere except the one workflow where they add real coverage, and fixes a related cleanup bug that restarts every test site instead of just the ones a test touched.

## The Issue

- Part of #8696

Issue #8696 found that 601 of 615 top-level Go tests run nearly identically across all 8 Linux CI wrapper workflows (apache-fpm, nginx-fpm, mutagen, podman-rootless, race-detection, no-bind-mounts, docker-rootless, podman-rootless-mutagen), which differ only in environment flags. The issue's own conclusion is that eliminating this redundant execution is worth far more than optimizing any single slow test. This PR is a first, mechanical installment against that finding, targeting the highest-cost tests confirmed to be independent of what those wrapper workflows actually vary.

## How This PR Solves The Issue

Adds `testcommon.SkipUnlessDefaultEnvironment(t)`, a helper that skips a test unless it's running with the plain default settings (nginx webserver, Mutagen off, bind mounts on, non-rootless Docker), using the same skip-gate pattern already established elsewhere in the suite (`nodeps.WebserverDefault`, `nodeps.PerformanceModeDefault`, `dockerutil.IsPodman()/IsDockerRootless()` checks). Applies it to six tests confirmed to test things unrelated to webserver/Mutagen/rootless: `TestOmitSnapshotOnDeleteGlobal`, `TestCmdDebugTest`, `TestCustomCommands`, `TestWebserverPostgresDBClient`, `TestPHPConfig`, and `TestHttpsRedirection` (the last of which already tests both nginx and apache internally in a single run, so pinning it to one wrapper loses no webserver coverage).

Separately gates `TestMutagenSimple`, `TestMutagenConfigChange`, and `TestMutagenDiagnose` to only run in Mutagen-flavored workflows. Each of these forces Mutagen mode on its own app object regardless of the ambient environment, so they were previously paying their full cost (up to ~200s for `TestMutagenSimple`) in workflows that add no coverage beyond the dedicated Mutagen/no-bind-mounts workflows.

Also fixes `TestPoweroffOnNewVersion`'s cleanup, which restarted every entry in the global `TestSites` fixture instead of just the projects it actually stopped before the test's simulated poweroff. It now restarts exactly the projects it captured as active beforehand.

## Manual Testing Instructions

Run the gated tests locally (default environment, so they should behave exactly as before):

```
go test -v -run 'TestOmitSnapshotOnDeleteGlobal|TestCmdDebugTest|TestCustomCommands|TestPoweroffOnNewVersion' ./cmd/ddev/cmd/
go test -v -run 'TestWebserverPostgresDBClient|TestPHPConfig|TestHttpsRedirection' ./pkg/ddevapp/
```

Confirm the Mutagen family skips under the default environment and runs under a Mutagen environment:

```
go test -v -run 'TestMutagenSimple|TestMutagenConfigChange|TestMutagenDiagnose' ./pkg/ddevapp/
DDEV_TEST_USE_MUTAGEN=true go test -v -run TestMutagenDiagnose ./pkg/ddevapp/
```

The actual multi-workflow effect (each gated test running once instead of up to 8 times) can only be observed on a real CI push, since it depends on which of the 8 wrapper workflows sets which environment variable.

