### PR TITLE
ci(perf): track total CI runtime per test type across GitHub Actions and Buildkite

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -131,6 +131,9 @@ jobs:
             if [ -f checkout-perf-data/history.ndjson ]; then
               cp -v checkout-perf-data/history.ndjson combined-site/perf/history.ndjson
             fi
+            if [ -f checkout-perf-data/test-runtime-history.ndjson ]; then
+              cp -v checkout-perf-data/test-runtime-history.ndjson combined-site/perf/test-runtime-history.ndjson
+            fi
           fi
 
       - name: Upload pages artifact

--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -107,7 +107,7 @@ source ~/.bashrc
 
 brew trust bats-core/bats-core
 
-for item in bats-core bats-core/bats-core/bats-assert bats-core/bats-core/bats-file bats-core/bats-core/bats-support ddev/ddev/ddev golangci-lint; do
+for item in bats-core bats-core/bats-core/bats-assert bats-core/bats-core/bats-file bats-core/bats-core/bats-support ddev/ddev/ddev golangci-lint gotestsum; do
   brew install $item >/dev/null || brew upgrade -y $item >/dev/null
 done
 

--- a/.github/workflows/perf-collect.yml
+++ b/.github/workflows/perf-collect.yml
@@ -19,7 +19,18 @@ name: Collect and publish nightly performance results
 on:
   schedule:
     - cron: '0 6 * * *'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      fresh:
+        description: 'Wipe test-runtime-history.ndjson and rebuild it from scratch instead of appending (use after a schema change to the row format, so old rows do not miss new fields)'
+        required: false
+        type: boolean
+        default: false
+      since:
+        description: 'Override --since for this run (YYYY-MM-DD). Mainly useful with fresh=true, to pull back further than the default 7-day backfill window.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -90,8 +101,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if [ "${{ inputs.fresh }}" = "true" ]; then
+            echo "fresh=true: rebuilding test-runtime-history.ndjson from scratch"
+            rm -f ../performance-data/test-runtime-history.ndjson
+          fi
           touch ../performance-data/test-runtime-history.ndjson
-          node perf/collector/collect-test-runtime.js ../performance-data/test-runtime-history.ndjson
+          node perf/collector/collect-test-runtime.js ../performance-data/test-runtime-history.ndjson ${{ inputs.since != '' && format('--since={0}', inputs.since) || '' }}
 
       - name: Commit and push results
         id: commit

--- a/.github/workflows/perf-collect.yml
+++ b/.github/workflows/perf-collect.yml
@@ -82,13 +82,24 @@ jobs:
           node perf/collector/collect.js ../performance-data/history.ndjson
           cp perf/collector/dashboard.html ../performance-data/index.html
 
+      # Separate dataset from the nightly perf benchmarks above: total
+      # runtime per CI test workflow (golang-nginx-fpm, quickstart, etc.),
+      # not narrow synthetic metrics. See perf/collector/README.md.
+      - name: Collect test-runtime results
+        id: collect-test-runtime
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          touch ../performance-data/test-runtime-history.ndjson
+          node perf/collector/collect-test-runtime.js ../performance-data/test-runtime-history.ndjson
+
       - name: Commit and push results
         id: commit
         run: |
           cd ../performance-data
           git config user.name "ddev-perf-bot"
           git config user.email "actions@github.com"
-          git add history.ndjson index.html
+          git add history.ndjson index.html test-runtime-history.ndjson
           if git diff --cached --quiet; then
             echo "No new results to commit"
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -115,7 +126,7 @@ jobs:
       # broken source should be visible, not silently swallowed, but it also
       # shouldn't block the legs that worked.
       - name: Fail if any source had a collection error
-        if: steps.collect.outputs.had_errors == 'true'
+        if: steps.collect.outputs.had_errors == 'true' || steps.collect-test-runtime.outputs.test_runtime_had_errors == 'true'
         run: |
-          echo "One or more sources failed to collect this run -- see the 'Collect results' step's ERROR lines above."
+          echo "One or more sources failed to collect this run -- see the 'Collect results' / 'Collect test-runtime results' step's ERROR lines above."
           exit 1

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -211,7 +211,7 @@ jobs:
           check-latest: true
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.12.1
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Load 1password secret(s) for pull-push-providers
         if: ${{ inputs.pull_push_providers == 'true' && env.OP_SERVICE_ACCOUNT_TOKEN != '' }}

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -210,9 +210,6 @@ jobs:
           go-version: '>=1.23'
           check-latest: true
 
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
-
       - name: Load 1password secret(s) for pull-push-providers
         if: ${{ inputs.pull_push_providers == 'true' && env.OP_SERVICE_ACCOUNT_TOKEN != '' }}
         uses: 1password/load-secrets-action@v5

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -134,6 +134,10 @@ jobs:
       DDEV_TEST_NO_BIND_MOUNTS: ${{ inputs.ddev_test_no_bind_mounts }}
       DDEV_TEST_PODMAN_ROOTLESS: ${{ inputs.ddev_test_podman_rootless }}
       DDEV_TEST_DOCKER_ROOTLESS: ${{ inputs.ddev_test_docker_rootless }}
+      # Picked up by the Makefile's gotest macro (see Makefile) so `make test`
+      # runs through gotestsum and writes per-test JSON events here, for the
+      # CI test-runtime collector (perf/collector/README.md).
+      GOTESTSUM_JSONFILE_DIR: test-results
 
     steps:
       - uses: actions/checkout@v7
@@ -206,6 +210,9 @@ jobs:
           go-version: '>=1.23'
           check-latest: true
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.12.1
+
       - name: Load 1password secret(s) for pull-push-providers
         if: ${{ inputs.pull_push_providers == 'true' && env.OP_SERVICE_ACCOUNT_TOKEN != '' }}
         uses: 1password/load-secrets-action@v5
@@ -253,6 +260,21 @@ jobs:
             echo "CGO_ENABLED=${CGO_ENABLED} but built cgo=${cgo}" && exit 5
           fi
           make CGO_ENABLED="${CGO_ENABLED}" BUILDARGS="${BUILDARGS}" TESTARGS="${TESTARGS}" ${MAKE_TARGET} ${MAKEARGS}
+
+      # Consumed by perf/collector/'s nightly test-runtime rollup, not by
+      # anyone reading this run directly -- see perf/collector/README.md.
+      # Named per (run, attempt, make_target) because some callers (podman
+      # rootless, podman rootless mutagen, WSL2 NAT) invoke this reusable
+      # workflow twice in the same run, once per make_target, which would
+      # otherwise collide on upload.
+      - name: Upload gotestsum results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.MAKE_TARGET }}
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 90
 
       - name: Clean up Homebrew
         continue-on-error: true

--- a/.github/workflows/test-wsl2-reusable.yml
+++ b/.github/workflows/test-wsl2-reusable.yml
@@ -196,3 +196,32 @@ jobs:
           $skip_nodejs = "${{ env.DDEV_SKIP_NODEJS_TEST }}"
           $docker_org = "${{ env.DOCKER_ORG }}"
           wsl -u testuser -- bash -exc "export GOTEST_SHORT='$gotest_short' TESTARGS='$testargs' MAKE_TARGET='$make_target' MAKEARGS='$makeargs' DDEV_EMBARGO_TESTS='$embargo' DDEV_EMBARGO_PHP_VERSIONS='$embargo_php' DDEV_SKIP_NODEJS_TEST='$skip_nodejs' DOCKER_ORG='$docker_org' && cd ~/workspace/ddev && bash -e .github/workflows/wsl2-test.sh"
+
+      # wsl2-test.sh writes gotestsum's per-test JSON inside the WSL2 VM's
+      # filesystem, invisible to actions/upload-artifact on the Windows host
+      # runner -- copy it out via the \\wsl$ UNC path first. Distro name
+      # "DDEV" matches the `wsl --install --name DDEV` step above.
+      - name: Copy gotestsum results out of WSL2
+        if: always()
+        shell: pwsh
+        run: |
+          $src = "\\wsl$\DDEV\home\testuser\workspace\ddev\test-results"
+          if (Test-Path $src) {
+            New-Item -ItemType Directory -Force -Path test-results | Out-Null
+            Copy-Item -Path "$src\*" -Destination test-results -Recurse -Force
+            Write-Host "Copied gotestsum results from WSL2:"
+            Get-ChildItem test-results
+          } else {
+            Write-Host "No gotestsum results found in WSL2 at $src -- nothing to copy"
+          }
+
+      # Consumed by perf/collector/'s nightly test-runtime rollup, not by
+      # anyone reading this run directly -- see perf/collector/README.md.
+      - name: Upload gotestsum results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ github.run_id }}-${{ github.run_attempt }}-wsl2-${{ inputs.networking }}-${{ inputs.make_target }}
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 90

--- a/.github/workflows/wsl2-setup.sh
+++ b/.github/workflows/wsl2-setup.sh
@@ -55,7 +55,7 @@ ln -sf /usr/local/go/bin/go /usr/local/bin/go
 ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 echo "=== Installing gotestsum ==="
-GOBIN=/usr/local/bin go install gotest.tools/gotestsum@v1.12.1
+GOBIN=/usr/local/bin go install gotest.tools/gotestsum@v1.13.0
 
 echo "=== Installing mkcert ==="
 MKCERT_VERSION="v1.4.4"

--- a/.github/workflows/wsl2-setup.sh
+++ b/.github/workflows/wsl2-setup.sh
@@ -54,6 +54,9 @@ rm /tmp/go.tar.gz
 ln -sf /usr/local/go/bin/go /usr/local/bin/go
 ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
+echo "=== Installing gotestsum ==="
+GOBIN=/usr/local/bin go install gotest.tools/gotestsum@v1.12.1
+
 echo "=== Installing mkcert ==="
 MKCERT_VERSION="v1.4.4"
 curl -fsSL "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64" -o /usr/local/bin/mkcert
@@ -99,5 +102,6 @@ go version
 docker version
 mkcert --version || true
 git --version
+gotestsum --version
 
 echo "=== WSL2 setup complete ==="

--- a/.github/workflows/wsl2-setup.sh
+++ b/.github/workflows/wsl2-setup.sh
@@ -55,7 +55,10 @@ ln -sf /usr/local/go/bin/go /usr/local/bin/go
 ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 echo "=== Installing gotestsum ==="
-GOBIN=/usr/local/bin go install gotest.tools/gotestsum@v1.13.0
+GOTESTSUM_VERSION="1.13.0"
+curl -fsSL "https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" -o /tmp/gotestsum.tar.gz
+tar -C /usr/local/bin -xzf /tmp/gotestsum.tar.gz gotestsum
+rm /tmp/gotestsum.tar.gz
 
 echo "=== Installing mkcert ==="
 MKCERT_VERSION="v1.4.4"

--- a/.github/workflows/wsl2-test.sh
+++ b/.github/workflows/wsl2-test.sh
@@ -24,6 +24,11 @@ export TESTARGS="${TESTARGS:-}"
 export MAKEARGS="${MAKEARGS:-}"
 export MAKE_TARGET="${MAKE_TARGET:-test}"
 export PATH="/usr/local/go/bin:$PATH"
+# Picked up by the Makefile's gotest macro (see Makefile) so `make test` runs
+# through gotestsum and writes per-test JSON events here, relative to the repo
+# root this script runs from. The caller workflow copies this dir out of WSL2
+# and uploads it for the CI test-runtime collector (perf/collector/README.md).
+export GOTESTSUM_JSONFILE_DIR=test-results
 
 echo "=== Environment ==="
 echo "GOTEST_SHORT=${GOTEST_SHORT}"

--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,16 @@ DDEV_BINARY_FULLPATH=$(DDEV_PATH)/$(DDEVNAME)
 # tests are skipped at the framework level without requiring per-test code.
 EMBARGO_SKIP_FLAG := $(if $(DDEV_EMBARGO_TESTS),-skip "$(DDEV_EMBARGO_TESTS)",)
 
+# When GOTESTSUM_JSONFILE_DIR is set, tests run through gotestsum instead of
+# `go test` directly, additionally writing structured per-test JSON events to
+# <dir>/<name>.ndjson for the CI test-runtime collector (see
+# perf/collector/README.md). --format=standard-verbose mirrors plain
+# `go test -v` console output, including full failure detail, so CI log
+# review is unaffected. Unset by default, so local `make test` needs no
+# gotestsum install and behaves exactly as before.
+GOTESTSUM_JSONFILE_DIR ?=
+gotest = $(if $(GOTESTSUM_JSONFILE_DIR),gotestsum --format=standard-verbose --jsonfile=$(GOTESTSUM_JSONFILE_DIR)/$(1).ndjson --,go test)
+
 # Override test section with tests specific to ddev
 test: testpkg testcmd
 
@@ -195,19 +205,19 @@ testcmd: $(DEFAULT_BUILD) setup
 	@echo DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH)
 	@echo "Running ddev version check..."
 	@$(DDEV_BINARY_FULLPATH) version
-	export PATH="$(DDEV_PATH):$$PATH" DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=$(CGO_ENABLED) DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH); go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags " $(LDFLAGS) " ./cmd/... $(EMBARGO_SKIP_FLAG) $(TESTARGS)
+	export PATH="$(DDEV_PATH):$$PATH" DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=$(CGO_ENABLED) DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH); $(call gotest,testcmd) $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags " $(LDFLAGS) " ./cmd/... $(EMBARGO_SKIP_FLAG) $(TESTARGS)
 
 testpkg: testnotddevapp testddevapp
 
 testddevapp: $(DEFAULT_BUILD) setup
 	@echo "Running ddev version check..."
 	@$(DDEV_BINARY_FULLPATH) version
-	export PATH="$(DDEV_PATH):$$PATH" DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=$(CGO_ENABLED) DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH); go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags " $(LDFLAGS) " ./pkg/ddevapp $(EMBARGO_SKIP_FLAG) $(TESTARGS)
+	export PATH="$(DDEV_PATH):$$PATH" DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=$(CGO_ENABLED) DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH); $(call gotest,testddevapp) $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags " $(LDFLAGS) " ./pkg/ddevapp $(EMBARGO_SKIP_FLAG) $(TESTARGS)
 
 testnotddevapp: $(DEFAULT_BUILD) setup
 	@echo "Running ddev version check..."
 	@$(DDEV_BINARY_FULLPATH) version
-	export PATH="$(DDEV_PATH):$$PATH" DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=$(CGO_ENABLED) DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH); go test $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags " $(LDFLAGS) " $(shell find ./pkg -maxdepth 1 -type d ! -name ddevapp ! -name pkg) $(EMBARGO_SKIP_FLAG) $(TESTARGS)
+	export PATH="$(DDEV_PATH):$$PATH" DDEV_NO_INSTRUMENTATION=true CGO_ENABLED=$(CGO_ENABLED) DDEV_BINARY_FULLPATH=$(DDEV_BINARY_FULLPATH); $(call gotest,testnotddevapp) $(USEMODVENDOR) -p 1 -timeout $(TEST_TIMEOUT) -v -installsuffix static -ldflags " $(LDFLAGS) " $(shell find ./pkg -maxdepth 1 -type d ! -name ddevapp ! -name pkg) $(EMBARGO_SKIP_FLAG) $(TESTARGS)
 
 testfullsitesetup: $(DEFAULT_BUILD) setup
 	@echo "Running ddev version check..."
@@ -242,6 +252,7 @@ testwsl2scripts:
 setup:
 	@mkdir -p $(GOTMP)/{bin/linux_arm64,bin/linux_amd64,bin/darwin_arm64,bin/darwin_amd64,bin/windows_amd64,bin/windows_arm64,src,pkg/mod/cache,.cache}
 	@mkdir -p $(TESTTMP)
+	@if [ -n "$(GOTESTSUM_JSONFILE_DIR)" ]; then mkdir -p "$(GOTESTSUM_JSONFILE_DIR)"; fi
 
 # Required static analysis targets for pre-push.
 staticrequired: setup golangci-lint markdownlint zensical check-image-tags

--- a/perf/collector/README.md
+++ b/perf/collector/README.md
@@ -38,6 +38,15 @@ should have finished.
   live (`bk pipeline list --org ddev`) against several retired/legacy
   pipelines the Buildkite API still returns -- see #8695.
 
+  `perf-collect.yml`'s `workflow_dispatch` has a `fresh` input (wipes
+  test-runtime-history.ndjson before collecting, instead of appending) and a
+  `since` input (overrides the default 7-day backfill window). Since the
+  collector dedupes by run/build identity, adding a field to the row schema
+  only appears on rows collected *after* that change -- `fresh=true` (with
+  `since` set far enough back) re-derives every existing row from GitHub's
+  and Buildkite's own retained history, rather than leaving old rows
+  permanently missing the new field until enough new data dilutes them.
+
   For GitHub Actions runs GitHub itself marked `failure`, the collector also
   downloads that run's gotestsum artifact and checks which of
   `testnotddevapp.ndjson`/`testddevapp.ndjson`/`testcmd.ndjson` exist, adding

--- a/perf/collector/README.md
+++ b/perf/collector/README.md
@@ -10,6 +10,33 @@ should have finished.
   separate jobs in the same build), plus the latest successful `perf-linux.yml`
   run's artifact, and appends one line per leg to `history.ndjson` on the
   `performance-data` branch.
+- `collect-test-runtime.js` is a separate dataset: total runtime per CI test
+  type (`golang-nginx-fpm`, `macos-lima`, `quickstart`, etc.), not narrow
+  synthetic benchmarks. It pulls completed `main`-branch runs for every
+  GitHub Actions workflow in `test-workflows.json` via `gh api`, plus finished
+  `main`-branch builds for every Buildkite pipeline in `test-pipelines.json`
+  (the actual Go-test-suite pipelines -- `macos-lima`, `wsl2-mirrored`, etc. --
+  not the nightly `ddev-perf-*` benchmarks in `pipelines.json`). No test
+  instrumentation required for this dataset. It appends one row per run/build
+  to `test-runtime-history.ndjson`, with `wall_clock_s` (queue-excluded
+  duration) and `compute_s` (summed job duration, so a run split into more
+  than one job -- podman-rootless's testpkg/testcmd, WSL2 NAT -- reports real
+  CPU-minutes, not just the longest job) plus a `jobs[]` breakdown with each
+  job's runner labels (GitHub Actions labels or Buildkite agent `meta_data`
+  tags, e.g. `os=macos`, `lima=true`). Incremental by default (derives
+  `--since` from the newest timestamp already in the history file, with a
+  1-day overlap); pass `--since=YYYY-MM-DD` to backfill further back. Reruns
+  are recorded as distinct points (keyed on source + workflow + run/build
+  number + attempt), not deduped away, since a flaky-test rerun is itself a
+  real measurement. `BUILDKITE_API_TOKEN` is the same one `collect.js` uses;
+  if unset, the Buildkite side is skipped (not an error), same tolerance.
+  Complements the per-test data gotestsum writes when `GOTESTSUM_JSONFILE_DIR`
+  is set (see `Makefile`) -- that's per-Go-test detail uploaded as a build
+  artifact by the workflows that run `make test`; this script is the
+  per-test-type total that also covers non-Go workflows like Quickstart.
+  `test-pipelines.json`'s comment explains how its 12 slugs were confirmed
+  live (`bk pipeline list --org ddev`) against several retired/legacy
+  pipelines the Buildkite API still returns -- see #8695.
 - `dashboard.html` is a dependency-free static page: it `fetch()`es
   `history.ndjson` client-side, filterable by metric and by leg
   (platform/arch/docker provider). Two views: a per-metric trend line over

--- a/perf/collector/README.md
+++ b/perf/collector/README.md
@@ -37,6 +37,25 @@ should have finished.
   `test-pipelines.json`'s comment explains how its 12 slugs were confirmed
   live (`bk pipeline list --org ddev`) against several retired/legacy
   pipelines the Buildkite API still returns -- see #8695.
+
+  For GitHub Actions runs GitHub itself marked `failure`, the collector also
+  downloads that run's gotestsum artifact and checks which of
+  `testnotddevapp.ndjson`/`testddevapp.ndjson`/`testcmd.ndjson` exist, adding
+  a `stage_analysis` object to the matching job in `jobs[]`. The Makefile's
+  target chain (`test: testpkg testcmd`; `testpkg: testnotddevapp
+  testddevapp`) means a failure in an earlier target aborts the rest --
+  GNU Make's default behavior on a non-zero recipe -- so a target whose
+  jsonfile never got written never ran. `stage_analysis.truncated` is true
+  when that happened (the run's `wall_clock_s`/`compute_s` reflect only part
+  of a full run, not a real completion -- exclude these from duration trends
+  the same way cancelled runs already are); `failed_at_stage` names the
+  target that never ran; `failing_tests` lists the actual failing test names
+  from whichever stage did run last. No artifact match (the common case
+  before this was added, and always true for Buildkite, which has no
+  gotestsum wiring) just means no `stage_analysis` -- not an error.
+  `makeTargetFromArtifactName`/`analyzeStageDir` in the script are pure
+  functions verified against fixture data (no jest/mocha dependency here, so
+  ad hoc rather than a committed test file -- same as `collect.js`).
 - `dashboard.html` is a dependency-free static page: it `fetch()`es
   `history.ndjson` client-side, filterable by metric and by leg
   (platform/arch/docker provider). Two views: a per-metric trend line over

--- a/perf/collector/collect-test-runtime.js
+++ b/perf/collector/collect-test-runtime.js
@@ -166,7 +166,7 @@ function analyzeStageArtifact(repo, runId, artifactName) {
   return analyzeStageDir(makeTarget, tmpDir);
 }
 
-module.exports = { makeTargetFromArtifactName, analyzeStageDir, MAKE_TARGET_STAGES };
+module.exports = { makeTargetFromArtifactName, analyzeStageDir, MAKE_TARGET_STAGES, hasSkipMarker };
 
 async function buildkiteApiPaginated(urlPath, params) {
   const token = process.env.BUILDKITE_API_TOKEN;
@@ -206,6 +206,23 @@ function durationSeconds(startIso, endIso) {
   return Number.isFinite(ms) ? Math.round(ms / 1000) : null;
 }
 
+// [skip buildkite]/[skip ci] (checked by .buildkite/test.sh, before any real
+// setup) and [skip github] (checked by test-reusable.yml's check-skip job)
+// all make the run/build exit almost instantly while still recording a
+// success conclusion -- Buildkite has no separate "skipped" state the way a
+// GitHub job does, so without this tag these near-zero-duration runs mix
+// into the same success bucket as a real multi-hour run, producing the
+// "vast swings" the dashboard showed before this was added. Checked against
+// all three markers on both sources rather than just the one each side's
+// own script looks for, since what matters here is "was this run real,"
+// not which specific tool would have honored the marker.
+const SKIP_MARKERS = ['[skip ci]', '[skip buildkite]', '[skip github]'];
+function hasSkipMarker(message) {
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  return SKIP_MARKERS.some((marker) => lower.includes(marker));
+}
+
 function toRow(run, jobs) {
   const jobRows = jobs.map((j) => ({
     name: j.name,
@@ -220,6 +237,7 @@ function toRow(run, jobs) {
     workflow: run.name,
     workflow_file: path.basename(run.path || ''),
     conclusion: run.conclusion,
+    skip_marker: hasSkipMarker(run.head_commit && run.head_commit.message),
     // Wall-clock: when the run actually started executing (post-queue) to
     // completion. What "total runtime for golang-nginx-fpm" means day to
     // day -- queue time is infra noise, not the thing #8695/#8696 restructure.
@@ -256,6 +274,7 @@ function toBuildkiteRow(pipeline, build) {
     workflow: pipeline,
     workflow_file: null,
     conclusion: build.state,
+    skip_marker: hasSkipMarker(build.message),
     wall_clock_s: durationSeconds(build.started_at, build.finished_at),
     compute_s: jobRows.reduce((sum, j) => sum + (j.duration_s || 0), 0),
     commit_sha: build.commit,

--- a/perf/collector/collect-test-runtime.js
+++ b/perf/collector/collect-test-runtime.js
@@ -268,6 +268,21 @@ function toBuildkiteRow(pipeline, build) {
     conclusion: j.state,
     duration_s: durationSeconds(j.started_at, j.finished_at),
   }));
+  const computeS = jobRows.reduce((sum, j) => sum + (j.duration_s || 0), 0);
+  // build.started_at fires the moment the build is created (confirmed
+  // against real data -- always within a second or two), so
+  // build.started_at..build.finished_at is NOT "post-queue" the way GitHub's
+  // run.run_started_at is. These pipelines' script jobs run sequentially on
+  // one scarce self-hosted agent (not the genuinely-parallel case GitHub's
+  // podman-rootless split is), and a job's own started_at can trail its
+  // runnable_at by hours waiting for that agent -- confirmed on a real build
+  // where the actual test job waited 5.4h for a colima_vz/arm64 agent but
+  // only ran for 65 minutes once it got one. So unlike the GitHub side,
+  // wall_clock_s here means the same thing compute_s does: real execution
+  // time, queue wait excluded. The excluded time isn't discarded, just
+  // labeled honestly as queue_wait_s -- itself a useful signal for the
+  // scarce-self-hosted-capacity story in #8695.
+  const totalElapsedS = durationSeconds(build.started_at, build.finished_at);
   return {
     timestamp: build.started_at || build.created_at,
     source: 'buildkite',
@@ -275,8 +290,9 @@ function toBuildkiteRow(pipeline, build) {
     workflow_file: null,
     conclusion: build.state,
     skip_marker: hasSkipMarker(build.message),
-    wall_clock_s: durationSeconds(build.started_at, build.finished_at),
-    compute_s: jobRows.reduce((sum, j) => sum + (j.duration_s || 0), 0),
+    wall_clock_s: computeS,
+    compute_s: computeS,
+    queue_wait_s: totalElapsedS != null ? Math.max(0, totalElapsedS - computeS) : null,
     commit_sha: build.commit,
     branch: build.branch,
     // Buildkite build numbers are only unique per pipeline (unlike GH's

--- a/perf/collector/collect-test-runtime.js
+++ b/perf/collector/collect-test-runtime.js
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+// Pulls completed `main`-branch runs for each workflow in test-workflows.json
+// via `gh api`, plus finished `main`-branch builds for each Buildkite Test-*
+// pipeline in test-pipelines.json, and appends one row per run/build (with a
+// per-job breakdown) to test-runtime-history.ndjson on the performance-data
+// branch. This is the "total runtime per test type" (golang-nginx-fpm,
+// macos-lima, quickstart, etc.) dataset -- see perf/collector/README.md.
+// Companion to collect.js, which tracks the narrower nightly perf-benchmark
+// metrics.
+//
+// Required env:
+//   GITHUB_TOKEN         - for `gh` CLI calls against this repo's Actions runs
+//   GITHUB_REPOSITORY    - owner/repo, set automatically in GitHub Actions
+//   BUILDKITE_API_TOKEN  - read access to builds; if unset, the Buildkite
+//                          pipelines are skipped (not an error) -- same
+//                          tolerance as collect.js, for the pre-setup state.
+//
+// Usage: node perf/collector/collect-test-runtime.js <path-to-test-runtime-history.ndjson> [--since=YYYY-MM-DD]
+//
+// --since is normally omitted: the incremental (nightly) run derives it from
+// the newest timestamp already in the history file, with a 1-day overlap to
+// tolerate any run that was still in progress the last time this collected.
+// Pass --since explicitly to backfill further back than the existing history
+// -- e.g. to seed the dataset for the first time, or to re-pull a known gap.
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const args = process.argv.slice(2);
+const HISTORY_PATH = args.find((a) => !a.startsWith('--'));
+const sinceArg = args.find((a) => a.startsWith('--since='));
+if (!HISTORY_PATH) {
+  console.error('Usage: collect-test-runtime.js <path-to-history.ndjson> [--since=YYYY-MM-DD]');
+  process.exit(1);
+}
+
+const CONFIG = JSON.parse(fs.readFileSync(path.join(__dirname, 'test-workflows.json'), 'utf8'));
+const BK_CONFIG = JSON.parse(fs.readFileSync(path.join(__dirname, 'test-pipelines.json'), 'utf8'));
+
+// Set whenever any single workflow fails to collect, so the run can still
+// finish, commit, and publish whatever DID come through clean -- mirrors
+// collect.js's per-source error tolerance (see its header comment for why).
+let hadErrors = false;
+
+const DEFAULT_BACKFILL_DAYS = 7;
+const OVERLAP_DAYS = 1;
+
+function ghApiPages(urlPath, params) {
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!repo) throw new Error('GITHUB_REPOSITORY must be set');
+  const fArgs = params.flatMap((p) => ['-f', p]);
+  // --method GET is not optional here: gh api silently switches to POST as
+  // soon as any -f flag is present unless the method is given explicitly,
+  // and POST against these (GET-only) endpoints fails as a plain 404 rather
+  // than a method-not-allowed error -- easy to misread as a bad path/token.
+  const out = execFileSync(
+    'gh',
+    ['api', '--method', 'GET', '--paginate', '--slurp', `repos/${repo}${urlPath}`, ...fArgs],
+    { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 }
+  );
+  return JSON.parse(out);
+}
+
+function fetchRuns(workflowFile, since) {
+  console.log(`Fetching ${workflowFile} runs on main since ${since}...`);
+  const pages = ghApiPages(`/actions/workflows/${workflowFile}/runs`, [
+    'branch=main',
+    'status=completed',
+    'per_page=100',
+    `created=>=${since}`,
+  ]);
+  const runs = pages.flatMap((p) => p.workflow_runs || []);
+  console.log(`  Found ${runs.length} completed run(s)`);
+  return runs;
+}
+
+function fetchJobs(runId) {
+  const pages = ghApiPages(`/actions/runs/${runId}/jobs`, ['per_page=100']);
+  return pages.flatMap((p) => p.jobs || []);
+}
+
+async function buildkiteApiPaginated(urlPath, params) {
+  const token = process.env.BUILDKITE_API_TOKEN;
+  if (!token) throw new Error('BUILDKITE_API_TOKEN must be set');
+  const perPage = 100;
+  let page = 1;
+  const all = [];
+  for (;;) {
+    const qs = new URLSearchParams({ ...params, page: String(page), per_page: String(perPage) });
+    const url = `https://api.buildkite.com/v2/${urlPath}?${qs}`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok) throw new Error(`Buildkite API error ${res.status} for ${url}`);
+    const batch = await res.json();
+    all.push(...batch);
+    if (batch.length < perPage) break;
+    page++;
+  }
+  return all;
+}
+
+async function fetchBuildkiteBuilds(pipeline, since) {
+  console.log(`Fetching Buildkite pipeline ${pipeline} builds on main since ${since}...`);
+  const builds = await buildkiteApiPaginated(
+    `organizations/${BK_CONFIG.buildkiteOrg}/pipelines/${pipeline}/builds`,
+    { branch: 'main', created_from: `${since}T00:00:00Z` }
+  );
+  // Buildkite has no "status=completed" filter -- exclude builds still in
+  // flight (no finished_at yet) client-side instead.
+  const finished = builds.filter((b) => b.finished_at);
+  console.log(`  Found ${finished.length} finished build(s) of ${builds.length} total`);
+  return finished;
+}
+
+function durationSeconds(startIso, endIso) {
+  if (!startIso || !endIso) return null;
+  const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
+  return Number.isFinite(ms) ? Math.round(ms / 1000) : null;
+}
+
+function toRow(run, jobs) {
+  const jobRows = jobs.map((j) => ({
+    name: j.name,
+    labels: j.labels || [],
+    runner_name: j.runner_name || null,
+    conclusion: j.conclusion,
+    duration_s: durationSeconds(j.started_at, j.completed_at),
+  }));
+  return {
+    timestamp: run.run_started_at || run.created_at,
+    source: 'github',
+    workflow: run.name,
+    workflow_file: path.basename(run.path || ''),
+    conclusion: run.conclusion,
+    // Wall-clock: when the run actually started executing (post-queue) to
+    // completion. What "total runtime for golang-nginx-fpm" means day to
+    // day -- queue time is infra noise, not the thing #8695/#8696 restructure.
+    wall_clock_s: durationSeconds(run.run_started_at, run.updated_at),
+    // Compute cost: sum of every job's own duration, so workflows split into
+    // more than one job (podman-rootless's testpkg/testcmd, WSL2 NAT) still
+    // report the real CPU-minutes spent, not just the wall-clock of whichever
+    // job happened to run longest.
+    compute_s: jobRows.reduce((sum, j) => sum + (j.duration_s || 0), 0),
+    commit_sha: run.head_sha,
+    branch: run.head_branch,
+    run_id: run.id,
+    run_attempt: run.run_attempt,
+    html_url: run.html_url,
+    jobs: jobRows,
+  };
+}
+
+function toBuildkiteRow(pipeline, build) {
+  // Only "script" jobs (Buildkite's term for an actual command step) have
+  // real runtime -- "waiter"/"trigger"/"manual" job types are structural and
+  // would otherwise dilute compute_s with near-zero entries.
+  const scriptJobs = (build.jobs || []).filter((j) => j.type === 'script');
+  const jobRows = scriptJobs.map((j) => ({
+    name: j.name || j.step_key || null,
+    labels: (j.agent && j.agent.meta_data) || [],
+    runner_name: (j.agent && j.agent.name) || null,
+    conclusion: j.state,
+    duration_s: durationSeconds(j.started_at, j.finished_at),
+  }));
+  return {
+    timestamp: build.started_at || build.created_at,
+    source: 'buildkite',
+    workflow: pipeline,
+    workflow_file: null,
+    conclusion: build.state,
+    wall_clock_s: durationSeconds(build.started_at, build.finished_at),
+    compute_s: jobRows.reduce((sum, j) => sum + (j.duration_s || 0), 0),
+    commit_sha: build.commit,
+    branch: build.branch,
+    // Buildkite build numbers are only unique per pipeline (unlike GH's
+    // repo-wide run ids) -- see pointKey(), which folds `workflow` in too.
+    run_id: build.number,
+    run_attempt: 1,
+    html_url: build.web_url,
+    jobs: jobRows,
+  };
+}
+
+// Identity of one data point. For GitHub, a specific attempt of a specific
+// run -- run_attempt increments on a manual rerun, which is a distinct, real
+// measurement, not a duplicate (flaky-test reruns are exactly the kind of
+// thing this dataset should be able to show). `workflow` is folded in because
+// Buildkite build numbers (run_id here) are unique only within their own
+// pipeline, not across the dataset the way GitHub's run ids are.
+function pointKey(row) {
+  return `${row.source}:${row.workflow}:${row.run_id}|${row.run_attempt}`;
+}
+
+function existingPointKeys(historyPath) {
+  if (!fs.existsSync(historyPath)) return new Set();
+  const keys = new Set();
+  for (const line of fs.readFileSync(historyPath, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      keys.add(pointKey(JSON.parse(line)));
+    } catch (err) {
+      console.warn(`Ignoring unparseable history line: ${err.message}`);
+    }
+  }
+  return keys;
+}
+
+function latestTimestamp(historyPath) {
+  if (!fs.existsSync(historyPath)) return null;
+  let latest = null;
+  for (const line of fs.readFileSync(historyPath, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const ts = JSON.parse(line).timestamp;
+      if (ts && (!latest || ts > latest)) latest = ts;
+    } catch {
+      // already warned about in existingPointKeys; ignore here
+    }
+  }
+  return latest;
+}
+
+function computeSince(historyPath) {
+  if (sinceArg) return sinceArg.slice('--since='.length);
+  const latest = latestTimestamp(historyPath);
+  if (!latest) {
+    const d = new Date(Date.now() - DEFAULT_BACKFILL_DAYS * 86400 * 1000);
+    return d.toISOString().slice(0, 10);
+  }
+  const d = new Date(new Date(latest).getTime() - OVERLAP_DAYS * 86400 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+async function main() {
+  const since = computeSince(HISTORY_PATH);
+  const results = [];
+
+  for (const workflowFile of CONFIG.workflows) {
+    try {
+      const runs = fetchRuns(workflowFile, since);
+      for (const run of runs) {
+        try {
+          const jobs = fetchJobs(run.id);
+          results.push(toRow(run, jobs));
+        } catch (err) {
+          console.error(`ERROR fetching jobs for ${workflowFile} run ${run.id}: ${err.message}`);
+          hadErrors = true;
+        }
+      }
+    } catch (err) {
+      console.error(`ERROR collecting ${workflowFile}: ${err.message}`);
+      hadErrors = true;
+    }
+  }
+
+  // A missing token is the expected, tolerated state before the one-time
+  // BUILDKITE_API_TOKEN vault setup (shared with collect.js's perf-* legs) --
+  // skip Buildkite entirely and still keep whatever GitHub Actions rows came
+  // through above, without counting it as an error.
+  if (!process.env.BUILDKITE_API_TOKEN) {
+    console.warn('BUILDKITE_API_TOKEN not set; skipping Buildkite pipelines');
+  } else {
+    for (const pipeline of BK_CONFIG.pipelines) {
+      try {
+        const builds = await fetchBuildkiteBuilds(pipeline, since);
+        for (const build of builds) {
+          results.push(toBuildkiteRow(pipeline, build));
+        }
+      } catch (err) {
+        console.error(`ERROR collecting Buildkite pipeline ${pipeline}: ${err.message}`);
+        hadErrors = true;
+      }
+    }
+  }
+
+  if (!results.length) {
+    console.warn('No results collected this run; leaving test-runtime-history.ndjson unchanged');
+    return;
+  }
+
+  const seen = existingPointKeys(HISTORY_PATH);
+  const fresh = [];
+  for (const row of results) {
+    const key = pointKey(row);
+    if (seen.has(key)) {
+      console.log(`Skipping already-recorded run: ${key}`);
+      continue;
+    }
+    seen.add(key);
+    fresh.push(row);
+  }
+
+  if (!fresh.length) {
+    console.warn('All collected runs were already recorded; leaving test-runtime-history.ndjson unchanged');
+    return;
+  }
+
+  const lines = fresh.map((r) => JSON.stringify(r));
+  fs.appendFileSync(HISTORY_PATH, lines.join('\n') + '\n');
+  console.log(`Appended ${lines.length} new run(s) of ${results.length} collected to ${HISTORY_PATH}`);
+}
+
+main()
+  .then(() => {
+    // Exit 0 even when hadErrors, so the caller's later workflow steps
+    // (commit/push, docs-publish trigger) still run and publish whatever
+    // clean results came through -- mirrors collect.js.
+    if (process.env.GITHUB_OUTPUT) {
+      fs.appendFileSync(process.env.GITHUB_OUTPUT, `test_runtime_had_errors=${hadErrors}\n`);
+    }
+    if (hadErrors) {
+      console.error('Completed with errors on one or more workflows (see ERROR lines above). Any clean results were still collected and written.');
+    }
+  })
+  .catch((err) => {
+    console.error(err);
+    if (process.env.GITHUB_OUTPUT) {
+      fs.appendFileSync(process.env.GITHUB_OUTPUT, 'test_runtime_had_errors=true\n');
+    }
+    process.exit(1);
+  });

--- a/perf/collector/collect-test-runtime.js
+++ b/perf/collector/collect-test-runtime.js
@@ -27,13 +27,13 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
+// Parsed unconditionally (not just under the CLI guard below) so `main()`
+// and `computeSince()` can close over them either way; only actually
+// validated when this file is run directly rather than require()'d, e.g. by
+// collect-test-runtime.test.js's pure-function tests.
 const args = process.argv.slice(2);
 const HISTORY_PATH = args.find((a) => !a.startsWith('--'));
 const sinceArg = args.find((a) => a.startsWith('--since='));
-if (!HISTORY_PATH) {
-  console.error('Usage: collect-test-runtime.js <path-to-history.ndjson> [--since=YYYY-MM-DD]');
-  process.exit(1);
-}
 
 const CONFIG = JSON.parse(fs.readFileSync(path.join(__dirname, 'test-workflows.json'), 'utf8'));
 const BK_CONFIG = JSON.parse(fs.readFileSync(path.join(__dirname, 'test-pipelines.json'), 'utf8'));
@@ -79,6 +79,94 @@ function fetchJobs(runId) {
   const pages = ghApiPages(`/actions/runs/${runId}/jobs`, ['per_page=100']);
   return pages.flatMap((p) => p.jobs || []);
 }
+
+// Order matches the Makefile's dependency chain (test: testpkg testcmd;
+// testpkg: testnotddevapp testddevapp), which is also Make's default
+// execution order. A failure in an earlier target aborts the chain --
+// GNU Make's default behavior on a non-zero recipe -- so later targets'
+// gotestsum jsonfiles never get written. See perf/collector/README.md.
+const MAKE_TARGET_STAGES = {
+  test: ['testnotddevapp', 'testddevapp', 'testcmd'],
+  testpkg: ['testnotddevapp', 'testddevapp'],
+  testcmd: ['testcmd'],
+};
+
+function fetchRunArtifacts(runId) {
+  const pages = ghApiPages(`/actions/runs/${runId}/artifacts`, ['per_page=100']);
+  return pages.flatMap((p) => p.artifacts || []);
+}
+
+// For a failed run, the gotestsum jsonfiles already uploaded (one per
+// Makefile target -- see Makefile's `gotest` macro) tell us, for free,
+// exactly how far the run got before Make aborted the chain: a target
+// whose jsonfile never showed up never ran. Requires no Makefile or
+// workflow change -- it's pulled from an artifact we already upload.
+// Match by suffix, not a prefix capture: test-reusable.yml names artifacts
+// test-results-<run>-<attempt>-<make_target>, but test-wsl2-reusable.yml
+// inserts extra segments first -- test-results-<run>-<attempt>-wsl2-
+// <networking>-<make_target> -- so a naive "everything after the 2nd dash
+// group" capture would grab "wsl2-nat-testcmd" instead of "testcmd". Check
+// testpkg/testcmd before test since neither ends in the bare "-test".
+function makeTargetFromArtifactName(artifactName) {
+  return ['testpkg', 'testcmd', 'test'].find((t) => artifactName.endsWith(`-${t}`)) || null;
+}
+
+// Pure over an already-downloaded directory, so it's testable without a real
+// `gh run download` -- see perf/collector/collect-test-runtime.test.js.
+function analyzeStageDir(makeTarget, dir) {
+  const expectedStages = MAKE_TARGET_STAGES[makeTarget];
+  if (!expectedStages) return null;
+
+  const stagesRun = expectedStages.filter((stage) => fs.existsSync(path.join(dir, `${stage}.ndjson`)));
+  const truncated = stagesRun.length < expectedStages.length;
+  const lastStage = stagesRun[stagesRun.length - 1] || null;
+
+  let failingTests = [];
+  if (lastStage) {
+    const seen = new Set();
+    for (const line of fs.readFileSync(path.join(dir, `${lastStage}.ndjson`), 'utf8').split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const event = JSON.parse(line);
+        if (event.Action === 'fail' && event.Test) seen.add(event.Test);
+      } catch {
+        // gotestsum's jsonfile is one JSON object per line; an unparseable
+        // line here would mean a corrupted upload, not a real event -- skip.
+      }
+    }
+    failingTests = [...seen];
+  }
+
+  return {
+    make_target: makeTarget,
+    stages_run: stagesRun,
+    truncated,
+    // Null when every expected stage ran -- the failure is a real test
+    // failure in lastStage, not a chain abort before it.
+    failed_at_stage: truncated ? expectedStages[stagesRun.length] : null,
+    failing_tests: failingTests,
+  };
+}
+
+function analyzeStageArtifact(repo, runId, artifactName) {
+  const makeTarget = makeTargetFromArtifactName(artifactName);
+  if (!makeTarget) {
+    console.warn(`  Unrecognized make_target from artifact "${artifactName}"; skipping stage analysis`);
+    return null;
+  }
+
+  const tmpDir = fs.mkdtempSync('/tmp/ddev-test-results-');
+  try {
+    execFileSync('gh', ['run', 'download', String(runId), '--repo', repo, '-n', artifactName, '-D', tmpDir]);
+  } catch (err) {
+    console.warn(`  Could not download artifact ${artifactName} for run ${runId}: ${err.message}`);
+    return null;
+  }
+
+  return analyzeStageDir(makeTarget, tmpDir);
+}
+
+module.exports = { makeTargetFromArtifactName, analyzeStageDir, MAKE_TARGET_STAGES };
 
 async function buildkiteApiPaginated(urlPath, params) {
   const token = process.env.BUILDKITE_API_TOKEN;
@@ -231,6 +319,37 @@ function computeSince(historyPath) {
   return d.toISOString().slice(0, 10);
 }
 
+// Only for runs GitHub itself marked "failure" -- success and cancelled runs
+// have nothing to explain here, and this is the one part of collection that
+// costs a real artifact download per call, so it's worth keeping scoped to
+// where it actually answers a question (was this failure's duration
+// truncated by an early Make-chain abort, or a real failure late in the
+// chain -- see the #8695/#8696 "quit on first failure" discussion).
+function enrichFailedGithubRuns(results, repo) {
+  for (const row of results) {
+    if (row.source !== 'github' || row.conclusion !== 'failure') continue;
+    let artifacts;
+    try {
+      artifacts = fetchRunArtifacts(row.run_id);
+    } catch (err) {
+      console.warn(`Could not list artifacts for run ${row.run_id}: ${err.message}`);
+      continue;
+    }
+    const prefix = `test-results-${row.run_id}-${row.run_attempt}-`;
+    const matches = artifacts.filter((a) => a.name.startsWith(prefix));
+    for (const artifact of matches) {
+      const analysis = analyzeStageArtifact(repo, row.run_id, artifact.name);
+      if (!analysis) continue;
+      // Crude but effective: a job's own name (e.g. "podman-rootless-testcmd
+      // / test") contains its make_target ("testcmd") for every workflow in
+      // test-workflows.json, including the single-job ones where make_target
+      // is just "test".
+      const job = row.jobs.find((j) => j.name && j.name.includes(analysis.make_target));
+      if (job) job.stage_analysis = analysis;
+    }
+  }
+}
+
 async function main() {
   const since = computeSince(HISTORY_PATH);
   const results = [];
@@ -252,6 +371,8 @@ async function main() {
       hadErrors = true;
     }
   }
+
+  enrichFailedGithubRuns(results, process.env.GITHUB_REPOSITORY);
 
   // A missing token is the expected, tolerated state before the one-time
   // BUILDKITE_API_TOKEN vault setup (shared with collect.js's perf-* legs) --
@@ -300,22 +421,32 @@ async function main() {
   console.log(`Appended ${lines.length} new run(s) of ${results.length} collected to ${HISTORY_PATH}`);
 }
 
-main()
-  .then(() => {
-    // Exit 0 even when hadErrors, so the caller's later workflow steps
-    // (commit/push, docs-publish trigger) still run and publish whatever
-    // clean results came through -- mirrors collect.js.
-    if (process.env.GITHUB_OUTPUT) {
-      fs.appendFileSync(process.env.GITHUB_OUTPUT, `test_runtime_had_errors=${hadErrors}\n`);
-    }
-    if (hadErrors) {
-      console.error('Completed with errors on one or more workflows (see ERROR lines above). Any clean results were still collected and written.');
-    }
-  })
-  .catch((err) => {
-    console.error(err);
-    if (process.env.GITHUB_OUTPUT) {
-      fs.appendFileSync(process.env.GITHUB_OUTPUT, 'test_runtime_had_errors=true\n');
-    }
+// Guarded so collect-test-runtime.test.js can require() this file for its
+// pure functions (analyzeStageDir, makeTargetFromArtifactName) without
+// triggering a real collection run or the "no HISTORY_PATH" exit below.
+if (require.main === module) {
+  if (!HISTORY_PATH) {
+    console.error('Usage: collect-test-runtime.js <path-to-history.ndjson> [--since=YYYY-MM-DD]');
     process.exit(1);
-  });
+  }
+
+  main()
+    .then(() => {
+      // Exit 0 even when hadErrors, so the caller's later workflow steps
+      // (commit/push, docs-publish trigger) still run and publish whatever
+      // clean results came through -- mirrors collect.js.
+      if (process.env.GITHUB_OUTPUT) {
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, `test_runtime_had_errors=${hadErrors}\n`);
+      }
+      if (hadErrors) {
+        console.error('Completed with errors on one or more workflows (see ERROR lines above). Any clean results were still collected and written.');
+      }
+    })
+    .catch((err) => {
+      console.error(err);
+      if (process.env.GITHUB_OUTPUT) {
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, 'test_runtime_had_errors=true\n');
+      }
+      process.exit(1);
+    });
+}

--- a/perf/collector/dashboard.html
+++ b/perf/collector/dashboard.html
@@ -140,7 +140,11 @@
       subText: 'Total CI runtime per test type, across GitHub Actions workflows and Buildkite pipelines. See <a href="https://github.com/ddev/ddev/blob/main/perf/collector/README.md">perf/collector/README.md</a>. wall_clock_s excludes queue time; compute_s sums every job in the run (workflows split into more than one job, e.g. podman-rootless’s testpkg/testcmd, report real CPU-minutes). Points more than 20% above the trailing 10-run median for their test type are marked red.',
       legsLabel: 'Test type (workflow / pipeline)',
       legKey: (row) => row.workflow,
-      metrics: () => ['wall_clock_s', 'compute_s'],
+      // queue_wait_s only exists on Buildkite rows (time waiting for a
+      // scarce self-hosted agent -- see collect-test-runtime.js); GitHub
+      // Actions rows just have no value for it, which the existing
+      // `!= null` filter in renderTrend/renderCompare already handles.
+      metrics: () => ['wall_clock_s', 'compute_s', 'queue_wait_s'],
       metricValue: (row, metric) => row[metric],
       // Two different ways a row's duration isn't a real measurement:
       // (1) cancelled (GitHub spells it "cancelled", Buildkite "canceled") --

--- a/perf/collector/dashboard.html
+++ b/perf/collector/dashboard.html
@@ -81,6 +81,13 @@
         Only successful full runs
       </label>
     </div>
+    <div id="split-by-runner-wrap">
+      <label style="visibility: hidden; display: block;">.</label>
+      <label style="display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.85rem;">
+        <input type="checkbox" id="split-by-runner-checkbox">
+        Split by runner machine (Buildkite only)
+      </label>
+    </div>
     <div>
       <label id="legs-label">Legs (platform / arch / docker provider)</label>
       <div class="legs-toolbar">
@@ -115,6 +122,19 @@
   // fields, one leg = one workflow/pipeline). Both are "N points over time
   // for a small set of comparable legs", so the trend/compare chart code
   // below is dataset-agnostic; only these four functions differ per dataset.
+  // Buildkite's self-hosted agents are persistent, named machines, not
+  // one-shot VMs like GitHub Actions runners -- so "is this specific
+  // machine slower than its siblings, or getting slower over time" is a
+  // real, answerable question here in a way it usually isn't for GitHub.
+  // The job with the largest duration_s is the actual test job, not the
+  // trivial `:pipeline:` upload / check-skip housekeeping step -- its
+  // runner_name is the physical agent that did the real work.
+  function primaryRunnerName(row) {
+    if (!row.jobs || !row.jobs.length) return null;
+    const real = row.jobs.reduce((best, j) => ((j.duration_s || 0) > (best.duration_s || 0) ? j : best), row.jobs[0]);
+    return real.runner_name || null;
+  }
+
   const DATASETS = {
     perf: {
       file: 'history.ndjson',
@@ -139,7 +159,21 @@
       file: 'test-runtime-history.ndjson',
       subText: 'Total CI runtime per test type, across GitHub Actions workflows and Buildkite pipelines. See <a href="https://github.com/ddev/ddev/blob/main/perf/collector/README.md">perf/collector/README.md</a>. wall_clock_s excludes queue time; compute_s sums every job in the run (workflows split into more than one job, e.g. podman-rootless’s testpkg/testcmd, report real CPU-minutes). Points more than 20% above the trailing 10-run median for their test type are marked red.',
       legsLabel: 'Test type (workflow / pipeline)',
-      legKey: (row) => row.workflow,
+      // When splitByRunner is on, a Buildkite row's leg becomes
+      // "pipeline · machine" instead of just "pipeline" -- e.g. it's how a
+      // single physical agent quietly getting slower build over build,
+      // while its sibling agents on the same pipeline stay flat, becomes
+      // visible on the trend chart instead of requiring a manual API dig
+      // (see the ddev-macos-arm64-mutagen investigation this was built
+      // for). GitHub Actions rows fall back to plain `workflow` even with
+      // the toggle on -- runner_name there is a one-shot ephemeral VM id,
+      // not a persistent machine, so splitting by it wouldn't mean anything.
+      legKey: (row) => {
+        if (state.splitByRunner && row.source === 'buildkite') {
+          return `${row.workflow} · ${primaryRunnerName(row) || 'unknown runner'}`;
+        }
+        return row.workflow;
+      },
       // queue_wait_s only exists on Buildkite rows (time waiting for a
       // scarce self-hosted agent -- see collect-test-runtime.js); GitHub
       // Actions rows just have no value for it, which the existing
@@ -176,7 +210,7 @@
   // excludeCancelled's name predates isFullSuccessfulRun (it grew from "drop
   // cancelled runs" to "only successful full runs" -- see that function's
   // comment); kept as-is since it's internal, not user-facing.
-  const state = { dataset: 'perf', rows: [], metric: null, view: 'trend', legs: [], enabledLegs: new Set(), excludeCancelled: true };
+  const state = { dataset: 'perf', rows: [], metric: null, view: 'trend', legs: [], enabledLegs: new Set(), excludeCancelled: true, splitByRunner: false };
 
   function ds() {
     return DATASETS[state.dataset];
@@ -249,6 +283,21 @@
       excludeCancelledCheckbox.dataset.bound = '1';
       excludeCancelledCheckbox.addEventListener('change', () => {
         state.excludeCancelled = excludeCancelledCheckbox.checked;
+        render();
+      });
+    }
+
+    // Unlike excludeCancelled, this changes what a "leg" even is (one
+    // pipeline becomes one row per machine that's run it), so the leg
+    // list itself has to be rebuilt, not just re-filtered -- hence
+    // populateControls() again here, not just render().
+    const splitByRunnerCheckbox = document.getElementById('split-by-runner-checkbox');
+    splitByRunnerCheckbox.checked = state.splitByRunner;
+    if (!splitByRunnerCheckbox.dataset.bound) {
+      splitByRunnerCheckbox.dataset.bound = '1';
+      splitByRunnerCheckbox.addEventListener('change', () => {
+        state.splitByRunner = splitByRunnerCheckbox.checked;
+        populateControls();
         render();
       });
     }

--- a/perf/collector/dashboard.html
+++ b/perf/collector/dashboard.html
@@ -259,8 +259,15 @@
   function rowSelected(row) {
     if (!state.enabledWorkflows.has(row.workflow)) return false;
     const runner = ds().runnerOf(row);
-    if (runner !== null && !state.enabledRunners.has(runner)) return false;
-    return true;
+    if (runner !== null) return state.enabledRunners.has(runner);
+    // No runner concept for this row (e.g. every GitHub Actions row --
+    // runnerOf returns null there). Include it only while the runner box
+    // isn't actually narrowing anything (nothing checked/unchecked yet, the
+    // "just browsing everything" default) -- the moment it's narrowed to
+    // specific machines, this becomes a runner-centric question ("what
+    // actually ran on tb-macos-arm64-4-1"), and a row with no relationship
+    // to any machine has no business answering it.
+    return state.enabledRunners.size === state.runners.length;
   }
 
   function median(values) {

--- a/perf/collector/dashboard.html
+++ b/perf/collector/dashboard.html
@@ -88,13 +88,24 @@
         Split by runner machine (Buildkite only)
       </label>
     </div>
+  </div>
+
+  <div class="controls">
     <div>
-      <label id="legs-label">Legs (platform / arch / docker provider)</label>
+      <label id="workflow-label">Legs (platform / arch / docker provider)</label>
       <div class="legs-toolbar">
-        <button type="button" id="legs-all">All</button>
-        <button type="button" id="legs-none">None</button>
+        <button type="button" id="workflow-all">All</button>
+        <button type="button" id="workflow-none">None</button>
       </div>
-      <div class="legs" id="legs-container"></div>
+      <div class="legs" id="workflow-container"></div>
+    </div>
+    <div id="runner-box-wrap" hidden>
+      <label>Runner machine</label>
+      <div class="legs-toolbar">
+        <button type="button" id="runner-all">All</button>
+        <button type="button" id="runner-none">None</button>
+      </div>
+      <div class="legs" id="runner-container"></div>
     </div>
   </div>
 
@@ -148,6 +159,7 @@
       },
       metricValue: (row, metric) => (row.metrics ? row.metrics[metric] : null),
       isFullSuccessfulRun: () => true,
+      runnerOf: () => null,
       // Nightly perf metrics are all naturally short (rebuild/start times in
       // the tens of seconds) -- seconds stay readable.
       formatDuration: (v) => `${v.toFixed(1)} s`,
@@ -174,6 +186,14 @@
         }
         return row.workflow;
       },
+      // The runner-machine facet: independent of splitByRunner (which only
+      // controls whether the chart draws separate lines), this is what the
+      // "Runner machine" checkbox box filters on -- e.g. looking at just
+      // wsl2-mirrored's tb-wsl-12-1 data works whether or not the chart is
+      // currently drawing it as its own line. null for GitHub Actions rows,
+      // which the row-selection filter below treats as "always included,
+      // no runner facet to filter by."
+      runnerOf: (row) => (row.source === 'buildkite' ? (primaryRunnerName(row) || 'unknown runner') : null),
       // queue_wait_s only exists on Buildkite rows (time waiting for a
       // scarce self-hosted agent -- see collect-test-runtime.js); GitHub
       // Actions rows just have no value for it, which the existing
@@ -210,7 +230,18 @@
   // excludeCancelled's name predates isFullSuccessfulRun (it grew from "drop
   // cancelled runs" to "only successful full runs" -- see that function's
   // comment); kept as-is since it's internal, not user-facing.
-  const state = { dataset: 'perf', rows: [], metric: null, view: 'trend', legs: [], enabledLegs: new Set(), excludeCancelled: true, splitByRunner: false };
+  //
+  // Two independent selection facets, not one flat "leg" checklist -- a
+  // pipeline × runner cross-product (20+ workflows times several machines
+  // each) is unreadable as a single list (that's what this replaced).
+  // workflows/runners are the distinct values available to check;
+  // enabledWorkflows/enabledRunners are which ones currently are.
+  const state = {
+    dataset: 'perf', rows: [], metric: null, view: 'trend',
+    workflows: [], enabledWorkflows: new Set(),
+    runners: [], enabledRunners: new Set(),
+    excludeCancelled: true, splitByRunner: false,
+  };
 
   function ds() {
     return DATASETS[state.dataset];
@@ -218,6 +249,18 @@
 
   function legKey(row) {
     return ds().legKey(row);
+  }
+
+  // Whether a row counts at all, independent of splitByRunner (which only
+  // controls how counted rows get grouped into chart lines). A GitHub row
+  // has no runner facet (runnerOf returns null) and is never excluded by
+  // the runner-machine box; a Buildkite row is excluded if its machine is
+  // unchecked, whether or not the chart is currently splitting by runner.
+  function rowSelected(row) {
+    if (!state.enabledWorkflows.has(row.workflow)) return false;
+    const runner = ds().runnerOf(row);
+    if (runner !== null && !state.enabledRunners.has(runner)) return false;
+    return true;
   }
 
   function median(values) {
@@ -242,9 +285,58 @@
       .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
   }
 
-  function populateControls() {
+  // Builds one checkbox box (workflow or runner) generically -- the two
+  // boxes are structurally identical (a set of available values, a set of
+  // currently-enabled ones, All/None buttons), just over different facets.
+  function buildCheckboxBox(containerId, allBtnId, noneBtnId, getValues, enabledSet, onChange) {
+    const container = document.getElementById(containerId);
+    const values = getValues();
+    container.innerHTML = '';
+    for (const value of values) {
+      const label = document.createElement('label');
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.checked = enabledSet.has(value);
+      cb.addEventListener('change', () => {
+        if (cb.checked) enabledSet.add(value);
+        else enabledSet.delete(value);
+        onChange();
+      });
+      label.appendChild(cb);
+      label.appendChild(document.createTextNode(value));
+      container.appendChild(label);
+    }
+    // getValues(), called fresh here rather than closing over the `values`
+    // snapshot above, matters because these All/None handlers are bound
+    // once (guarded below) and outlive many populateControls() calls -- a
+    // dataset switch changes the available workflows/runners entirely, and
+    // a stale closure would keep "All" only re-checking whatever was
+    // available the first time this box was ever built.
+    function setAll(enabled) {
+      const currentValues = getValues();
+      for (const cb of container.querySelectorAll('input[type=checkbox]')) cb.checked = enabled;
+      enabledSet.clear();
+      if (enabled) for (const value of currentValues) enabledSet.add(value);
+      onChange();
+    }
+    const allBtn = document.getElementById(allBtnId);
+    const noneBtn = document.getElementById(noneBtnId);
+    if (!allBtn.dataset.bound) {
+      allBtn.dataset.bound = '1';
+      allBtn.addEventListener('click', () => setAll(true));
+      noneBtn.dataset.bound = '1';
+      noneBtn.addEventListener('click', () => setAll(false));
+    }
+  }
+
+  // resetSelections is true on a genuine dataset switch (an old workflow
+  // selection has nothing to do with the new dataset's values) and false on
+  // every other populateControls() call (splitByRunner toggling, most
+  // notably) -- so re-deriving the available workflows/runners doesn't wipe
+  // out which ones the user already checked.
+  function populateControls(resetSelections) {
     document.getElementById('sub-text').innerHTML = ds().subText;
-    document.getElementById('legs-label').textContent = ds().legsLabel;
+    document.getElementById('workflow-label').textContent = ds().legsLabel;
     document.getElementById('note').innerHTML = state.view === 'compare' ? ds().compareNote : ds().trendNote;
 
     // populateControls() now re-runs on every dataset switch (previously it
@@ -260,7 +352,7 @@
         state.dataset = datasetSelect.value;
         loadData().then((rows) => {
           state.rows = rows;
-          populateControls();
+          populateControls(true);
           render();
         });
       });
@@ -287,10 +379,11 @@
       });
     }
 
-    // Unlike excludeCancelled, this changes what a "leg" even is (one
-    // pipeline becomes one row per machine that's run it), so the leg
-    // list itself has to be rebuilt, not just re-filtered -- hence
-    // populateControls() again here, not just render().
+    // Unlike excludeCancelled, this changes what a leg *is* (one pipeline
+    // becomes one line per machine that's run it), so the chart's leg/color
+    // assignment has to be rebuilt -- but the workflow/runner *selections*
+    // themselves don't need to change, hence populateControls() (no reset)
+    // rather than just render().
     const splitByRunnerCheckbox = document.getElementById('split-by-runner-checkbox');
     splitByRunnerCheckbox.checked = state.splitByRunner;
     if (!splitByRunnerCheckbox.dataset.bound) {
@@ -301,11 +394,6 @@
         render();
       });
     }
-
-    const legSet = new Set();
-    for (const row of state.rows) legSet.add(legKey(row));
-    state.legs = [...legSet].sort();
-    state.enabledLegs = new Set(state.legs);
 
     const metricSelect = document.getElementById('metric-select');
     metricSelect.innerHTML = '';
@@ -324,39 +412,39 @@
       });
     }
 
-    const legsContainer = document.getElementById('legs-container');
-    legsContainer.innerHTML = '';
-    for (const leg of state.legs) {
-      const label = document.createElement('label');
-      const cb = document.createElement('input');
-      cb.type = 'checkbox';
-      cb.checked = true;
-      cb.addEventListener('change', () => {
-        if (cb.checked) state.enabledLegs.add(leg);
-        else state.enabledLegs.delete(leg);
-        render();
-      });
-      label.appendChild(cb);
-      label.appendChild(document.createTextNode(leg));
-      legsContainer.appendChild(label);
+    // Two independent facets -- see rowSelected(). Workflow values don't
+    // depend on splitByRunner at all; runner values are gathered the same
+    // way regardless, since the runner box filters data whether or not the
+    // chart is currently splitting lines by it.
+    const workflowSet = new Set();
+    const runnerSet = new Set();
+    for (const row of state.rows) {
+      workflowSet.add(row.workflow);
+      const runner = ds().runnerOf(row);
+      if (runner !== null) runnerSet.add(runner);
+    }
+    state.workflows = [...workflowSet].sort();
+    state.runners = [...runnerSet].sort();
+    // Mutate the existing Sets in place, don't reassign them -- the
+    // All/None buttons' click handlers are bound once (guarded by
+    // dataset.bound) and close over these Set objects by reference; a
+    // reassignment here would leave those handlers permanently pointing at
+    // a now-abandoned Set while state.enabledWorkflows moved on to a new one.
+    if (resetSelections || state.enabledWorkflows.size === 0) {
+      state.enabledWorkflows.clear();
+      for (const w of state.workflows) state.enabledWorkflows.add(w);
+    }
+    if (resetSelections || state.enabledRunners.size === 0) {
+      state.enabledRunners.clear();
+      for (const r of state.runners) state.enabledRunners.add(r);
     }
 
-    // Datasets like CI test runtime can have 20+ legs -- all of them plotted
-    // at once on the trend view is unreadable. These two buttons are the fast
-    // path to "clear everything, then check the ones I actually want."
-    function setAllLegs(enabled) {
-      for (const cb of legsContainer.querySelectorAll('input[type=checkbox]')) cb.checked = enabled;
-      state.enabledLegs = enabled ? new Set(state.legs) : new Set();
-      render();
-    }
-    const allBtn = document.getElementById('legs-all');
-    const noneBtn = document.getElementById('legs-none');
-    if (!allBtn.dataset.bound) {
-      allBtn.dataset.bound = '1';
-      allBtn.addEventListener('click', () => setAllLegs(true));
-      noneBtn.dataset.bound = '1';
-      noneBtn.addEventListener('click', () => setAllLegs(false));
-    }
+    buildCheckboxBox('workflow-container', 'workflow-all', 'workflow-none', () => state.workflows, state.enabledWorkflows, render);
+    buildCheckboxBox('runner-container', 'runner-all', 'runner-none', () => state.runners, state.enabledRunners, render);
+    // Nothing to filter by runner for the nightly perf dataset (no
+    // runnerOf), or for a testruntime load that happens to have no
+    // Buildkite rows in view -- hide the box rather than show it empty.
+    document.getElementById('runner-box-wrap').hidden = state.runners.length === 0;
   }
 
   function render() {
@@ -395,14 +483,19 @@
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     legend.innerHTML = '';
 
-    const series = state.legs
-      .filter((leg) => state.enabledLegs.has(leg))
-      .map((leg, i) => {
-        const points = state.rows
-          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && (!state.excludeCancelled || ds().isFullSuccessfulRun(r)))
-          .map((r) => ({ t: new Date(r.timestamp).getTime(), v: ds().metricValue(r, state.metric) }));
-        return { leg, color: COLORS[i % COLORS.length], points };
-      })
+    // Group by leg from the already-filtered rows, rather than iterating a
+    // precomputed leg list -- which legs even exist depends on the current
+    // workflow/runner selections (rowSelected), not just the dataset.
+    const filteredRows = state.rows.filter(
+      (r) => rowSelected(r) && ds().metricValue(r, state.metric) != null && (!state.excludeCancelled || ds().isFullSuccessfulRun(r))
+    );
+    const legOrder = [...new Set(filteredRows.map((r) => legKey(r)))].sort();
+    const series = legOrder
+      .map((leg, i) => ({
+        leg,
+        color: COLORS[i % COLORS.length],
+        points: filteredRows.filter((r) => legKey(r) === leg).map((r) => ({ t: new Date(r.timestamp).getTime(), v: ds().metricValue(r, state.metric) })),
+      }))
       .filter((s) => s.points.length > 0);
 
     if (!series.length) {
@@ -484,12 +577,15 @@
     const legend = document.getElementById('legend');
     legend.innerHTML = '';
 
-    const bars = state.legs
-      .filter((leg) => state.enabledLegs.has(leg))
+    // See renderTrend()'s matching comment -- legs come from the filtered
+    // rows, not a precomputed list.
+    const filteredRows = state.rows.filter(
+      (r) => rowSelected(r) && ds().metricValue(r, state.metric) != null && (!state.excludeCancelled || ds().isFullSuccessfulRun(r))
+    );
+    const legOrder = [...new Set(filteredRows.map((r) => legKey(r)))].sort();
+    const bars = legOrder
       .map((leg, i) => {
-        const points = state.rows
-          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && (!state.excludeCancelled || ds().isFullSuccessfulRun(r)))
-          .map((r) => ds().metricValue(r, state.metric));
+        const points = filteredRows.filter((r) => legKey(r) === leg).map((r) => ds().metricValue(r, state.metric));
         const value = median(points.slice(-COMPARE_TRAILING_N));
         return { leg, color: COLORS[i % COLORS.length], value, n: Math.min(points.length, COMPARE_TRAILING_N) };
       })

--- a/perf/collector/dashboard.html
+++ b/perf/collector/dashboard.html
@@ -42,9 +42,16 @@
 </head>
 <body>
   <h1>DDEV performance history</h1>
-  <p class="sub">Nightly benchmark results across platforms and Docker providers. See <a href="https://github.com/ddev/ddev/tree/main/perf">perf/README.md</a> for what each metric measures. Points more than 20% above the trailing 10-run median for their leg are marked red.</p>
+  <p class="sub" id="sub-text">Nightly benchmark results across platforms and Docker providers. See <a href="https://github.com/ddev/ddev/tree/main/perf">perf/README.md</a> for what each metric measures. Points more than 20% above the trailing 10-run median for their leg are marked red.</p>
 
   <div class="controls">
+    <div>
+      <label for="dataset-select">Dataset</label>
+      <select id="dataset-select">
+        <option value="perf">Nightly perf benchmarks</option>
+        <option value="testruntime">CI test runtime</option>
+      </select>
+    </div>
     <div>
       <label for="view-select">View</label>
       <select id="view-select">
@@ -57,7 +64,7 @@
       <select id="metric-select"></select>
     </div>
     <div>
-      <label>Legs (platform / arch / docker provider)</label>
+      <label id="legs-label">Legs (platform / arch / docker provider)</label>
       <div class="legs" id="legs-container"></div>
     </div>
   </div>
@@ -79,13 +86,50 @@
   // different machines with different raw capability, so this is a
   // comparison of Docker-provider/platform overhead, not a hardware benchmark.
   const COMPARE_TRAILING_N = 7;
-  const TREND_NOTE = 'Data source: <code>history.ndjson</code>, one line per (commit, leg) benchmark run.';
-  const COMPARE_NOTE = `Each bar is the median of that environment's last ${COMPARE_TRAILING_N} nightly runs (not just the latest one) for the selected metric, sorted fastest to slowest. Data source: <code>history.ndjson</code>.`;
 
-  const state = { rows: [], metric: null, view: 'trend', legs: [], enabledLegs: new Set() };
+  // Two datasets share this page: the nightly perf benchmarks (an arbitrary
+  // metrics{} object per row, one leg = one platform/arch/docker-provider
+  // combination) and the CI test-runtime trend (fixed wall_clock_s/compute_s
+  // fields, one leg = one workflow/pipeline). Both are "N points over time
+  // for a small set of comparable legs", so the trend/compare chart code
+  // below is dataset-agnostic; only these four functions differ per dataset.
+  const DATASETS = {
+    perf: {
+      file: 'history.ndjson',
+      subText: 'Nightly benchmark results across platforms and Docker providers. See <a href="https://github.com/ddev/ddev/tree/main/perf">perf/README.md</a> for what each metric measures. Points more than 20% above the trailing 10-run median for their leg are marked red.',
+      legsLabel: 'Legs (platform / arch / docker provider)',
+      legKey: (row) => `${row.os}/${row.arch}/${row.docker_provider}`,
+      metrics: (rows) => {
+        const s = new Set();
+        for (const r of rows) for (const m of Object.keys(r.metrics || {})) s.add(m);
+        return [...s].sort();
+      },
+      metricValue: (row, metric) => (row.metrics ? row.metrics[metric] : null),
+      trendNote: 'Data source: <code>history.ndjson</code>, one line per (commit, leg) benchmark run.',
+      compareNote: `Each bar is the median of that environment's last ${COMPARE_TRAILING_N} nightly runs (not just the latest one) for the selected metric, sorted fastest to slowest. Data source: <code>history.ndjson</code>.`,
+      csvPrefix: 'ddev-perf',
+    },
+    testruntime: {
+      file: 'test-runtime-history.ndjson',
+      subText: 'Total CI runtime per test type, across GitHub Actions workflows and Buildkite pipelines. See <a href="https://github.com/ddev/ddev/blob/main/perf/collector/README.md">perf/collector/README.md</a>. wall_clock_s excludes queue time; compute_s sums every job in the run (workflows split into more than one job, e.g. podman-rootless’s testpkg/testcmd, report real CPU-minutes). Points more than 20% above the trailing 10-run median for their test type are marked red.',
+      legsLabel: 'Test type (workflow / pipeline)',
+      legKey: (row) => row.workflow,
+      metrics: () => ['wall_clock_s', 'compute_s'],
+      metricValue: (row, metric) => row[metric],
+      trendNote: 'Data source: <code>test-runtime-history.ndjson</code>, one line per CI run/build.',
+      compareNote: `Each bar is the median of that test type's last ${COMPARE_TRAILING_N} runs (not just the latest one) for the selected metric, sorted fastest to slowest. Data source: <code>test-runtime-history.ndjson</code>.`,
+      csvPrefix: 'ddev-test-runtime',
+    },
+  };
+
+  const state = { dataset: 'perf', rows: [], metric: null, view: 'trend', legs: [], enabledLegs: new Set() };
+
+  function ds() {
+    return DATASETS[state.dataset];
+  }
 
   function legKey(row) {
-    return `${row.os}/${row.arch}/${row.docker_provider}`;
+    return ds().legKey(row);
   }
 
   function median(values) {
@@ -96,7 +140,7 @@
   }
 
   async function loadData() {
-    const res = await fetch('history.ndjson', { cache: 'no-store' });
+    const res = await fetch(ds().file, { cache: 'no-store' });
     if (!res.ok) return [];
     const text = await res.text();
     return text
@@ -111,36 +155,61 @@
   }
 
   function populateControls() {
+    document.getElementById('sub-text').innerHTML = ds().subText;
+    document.getElementById('legs-label').textContent = ds().legsLabel;
+    document.getElementById('note').innerHTML = state.view === 'compare' ? ds().compareNote : ds().trendNote;
+
+    // populateControls() now re-runs on every dataset switch (previously it
+    // ran once, at initial load) to rebuild the metric/leg options -- guard
+    // these top-level listeners so repeated switches don't stack duplicate
+    // handlers on selects that persist across calls (only their <option>
+    // children get replaced below).
+    const datasetSelect = document.getElementById('dataset-select');
+    datasetSelect.value = state.dataset;
+    if (!datasetSelect.dataset.bound) {
+      datasetSelect.dataset.bound = '1';
+      datasetSelect.addEventListener('change', () => {
+        state.dataset = datasetSelect.value;
+        loadData().then((rows) => {
+          state.rows = rows;
+          populateControls();
+          render();
+        });
+      });
+    }
+
     const viewSelect = document.getElementById('view-select');
     viewSelect.value = state.view;
-    viewSelect.addEventListener('change', () => {
-      state.view = viewSelect.value;
-      document.getElementById('note').innerHTML = state.view === 'compare' ? COMPARE_NOTE : TREND_NOTE;
-      render();
-    });
-
-    const metricSet = new Set();
-    const legSet = new Set();
-    for (const row of state.rows) {
-      legSet.add(legKey(row));
-      for (const m of Object.keys(row.metrics || {})) metricSet.add(m);
+    if (!viewSelect.dataset.bound) {
+      viewSelect.dataset.bound = '1';
+      viewSelect.addEventListener('change', () => {
+        state.view = viewSelect.value;
+        document.getElementById('note').innerHTML = state.view === 'compare' ? ds().compareNote : ds().trendNote;
+        render();
+      });
     }
+
+    const legSet = new Set();
+    for (const row of state.rows) legSet.add(legKey(row));
     state.legs = [...legSet].sort();
     state.enabledLegs = new Set(state.legs);
 
     const metricSelect = document.getElementById('metric-select');
     metricSelect.innerHTML = '';
-    for (const m of [...metricSet].sort()) {
+    for (const m of ds().metrics(state.rows)) {
       const opt = document.createElement('option');
       opt.value = m;
       opt.textContent = m;
       metricSelect.appendChild(opt);
     }
     state.metric = metricSelect.value;
-    metricSelect.addEventListener('change', () => {
-      state.metric = metricSelect.value;
-      render();
-    });
+    if (!metricSelect.dataset.bound) {
+      metricSelect.dataset.bound = '1';
+      metricSelect.addEventListener('change', () => {
+        state.metric = metricSelect.value;
+        render();
+      });
+    }
 
     const legsContainer = document.getElementById('legs-container');
     legsContainer.innerHTML = '';
@@ -175,12 +244,12 @@
       csv = ['leg,metric,median_s,n_runs']
         .concat(result.map((b) => `${b.leg},${state.metric},${b.value},${b.n}`))
         .join('\n');
-      link.download = `ddev-perf-compare-${state.metric}.csv`;
+      link.download = `${ds().csvPrefix}-compare-${state.metric}.csv`;
     } else {
       csv = ['timestamp,leg,metric,value_s']
         .concat(result.flatMap((s) => s.points.map((p) => `${new Date(p.t).toISOString()},${s.leg},${state.metric},${p.v}`)))
         .join('\n');
-      link.download = `ddev-perf-trend-${state.metric}.csv`;
+      link.download = `${ds().csvPrefix}-trend-${state.metric}.csv`;
     }
     if (state.csvUrl) URL.revokeObjectURL(state.csvUrl);
     state.csvUrl = URL.createObjectURL(new Blob([csv], { type: 'text/csv' }));
@@ -200,8 +269,8 @@
       .filter((leg) => state.enabledLegs.has(leg))
       .map((leg, i) => {
         const points = state.rows
-          .filter((r) => legKey(r) === leg && r.metrics && r.metrics[state.metric] != null)
-          .map((r) => ({ t: new Date(r.timestamp).getTime(), v: r.metrics[state.metric] }));
+          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null)
+          .map((r) => ({ t: new Date(r.timestamp).getTime(), v: ds().metricValue(r, state.metric) }));
         return { leg, color: COLORS[i % COLORS.length], points };
       })
       .filter((s) => s.points.length > 0);
@@ -289,8 +358,8 @@
       .filter((leg) => state.enabledLegs.has(leg))
       .map((leg, i) => {
         const points = state.rows
-          .filter((r) => legKey(r) === leg && r.metrics && r.metrics[state.metric] != null)
-          .map((r) => r.metrics[state.metric]);
+          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null)
+          .map((r) => ds().metricValue(r, state.metric));
         const value = median(points.slice(-COMPARE_TRAILING_N));
         return { leg, color: COLORS[i % COLORS.length], value, n: Math.min(points.length, COMPARE_TRAILING_N) };
       })

--- a/perf/collector/dashboard.html
+++ b/perf/collector/dashboard.html
@@ -164,32 +164,23 @@
       file: 'test-runtime-history.ndjson',
       subText: 'Total CI runtime per test type, across GitHub Actions workflows and Buildkite pipelines. See <a href="https://github.com/ddev/ddev/blob/main/perf/collector/README.md">perf/collector/README.md</a>. wall_clock_s excludes queue time; compute_s sums every job in the run (workflows split into more than one job, e.g. podman-rootless’s testpkg/testcmd, report real CPU-minutes). Points more than 20% above the trailing 10-run median for their test type are marked red.',
       legsLabel: 'Test type (workflow / pipeline)',
-      // A Buildkite row's leg is "pipeline · machine" instead of just
-      // "pipeline" whenever the runner box is narrowed (see
-      // runnerSelectionNarrowed()) -- not a separate manual toggle. Checking
-      // "all" runners (the default) reproduces this page's original
-      // behavior, one merged line per workflow; narrowing to specific
-      // machines is itself the signal to split them apart, which is how a
-      // single physical agent quietly getting slower build over build,
-      // while its sibling agents on the same pipeline stay flat, becomes
-      // visible on the trend chart instead of requiring a manual API dig
-      // (see the ddev-macos-arm64-mutagen investigation this was built
-      // for) -- and also how "what actually ran on tb-macos-arm64-4-1"
-      // renders as one clean line per pipeline rather than needing a
-      // second control. A prior version had both a separate "split by
-      // runner" checkbox and this narrowing behavior at once; selecting
-      // more than one runner with the checkbox off silently merged their
-      // data into one meaningless line (two machines' very different
-      // performance interleaved chronologically) -- one control, not two
-      // that can contradict each other. GitHub Actions rows never split --
-      // runner_name there is a one-shot ephemeral VM id, not a persistent
-      // machine, so splitting by it wouldn't mean anything.
-      legKey: (row) => {
-        if (row.source === 'buildkite' && runnerSelectionNarrowed()) {
-          return `${row.workflow} · ${primaryRunnerName(row) || 'unknown runner'}`;
-        }
-        return row.workflow;
-      },
+      // A Buildkite row's leg is always "pipeline · machine", unconditionally
+      // -- there is no merged mode. Different physical agents are different
+      // things, the same way the nightly perf dataset's os/arch/docker
+      // provider legs are never merged either; a checkbox that sometimes
+      // combines multiple real machines into one line invites exactly the
+      // bug two prior versions of this both had in different ways: with
+      // "all" runners checked meaning "merge them," selecting several
+      // specific machines either silently interleaved their very different
+      // performance into one meaningless line (no split toggle), or looked
+      // identical to "show me the real per-machine data" for every runner
+      // *except* the one place someone actually looked (all-checked still
+      // merged). Always splitting sidesteps the whole class of bug: the
+      // "Runner machine" checkboxes are a pure visibility filter, exactly
+      // like the "Test type" ones, nothing more. GitHub Actions rows never
+      // split -- runner_name there is a one-shot ephemeral VM id, not a
+      // persistent machine, so splitting by it wouldn't mean anything.
+      legKey: (row) => (row.source === 'buildkite' ? `${row.workflow} · ${primaryRunnerName(row) || 'unknown runner'}` : row.workflow),
       // The runner-machine facet the "Runner machine" checkbox box filters
       // on. null for GitHub Actions rows, which the row-selection filter
       // below treats as "included only while the runner box isn't actually

--- a/perf/collector/dashboard.html
+++ b/perf/collector/dashboard.html
@@ -31,6 +31,17 @@
   select { font-size: 0.95rem; padding: 0.25rem; }
   .legs { display: flex; flex-wrap: wrap; gap: 0.5rem; max-width: 40rem; }
   .legs label { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.85rem; color: var(--fg); }
+  .legs-toolbar { display: flex; gap: 0.4rem; margin: 0.25rem 0 0.4rem; }
+  .legs-toolbar button {
+    font-size: 0.75rem;
+    padding: 0.1rem 0.5rem;
+    color: var(--fg);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .legs-toolbar button:hover { border-color: var(--accent); }
   .chart-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 6px; padding: 0.5rem; }
   canvas { display: block; }
   .legend { display: flex; flex-wrap: wrap; gap: 1rem; margin-top: 0.75rem; font-size: 0.8rem; }
@@ -63,8 +74,19 @@
       <label for="metric-select">Metric</label>
       <select id="metric-select"></select>
     </div>
+    <div id="exclude-cancelled-wrap">
+      <label style="visibility: hidden; display: block;">.</label>
+      <label style="display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.85rem;">
+        <input type="checkbox" id="exclude-cancelled-checkbox" checked>
+        Exclude cancelled runs
+      </label>
+    </div>
     <div>
       <label id="legs-label">Legs (platform / arch / docker provider)</label>
+      <div class="legs-toolbar">
+        <button type="button" id="legs-all">All</button>
+        <button type="button" id="legs-none">None</button>
+      </div>
       <div class="legs" id="legs-container"></div>
     </div>
   </div>
@@ -105,6 +127,7 @@
         return [...s].sort();
       },
       metricValue: (row, metric) => (row.metrics ? row.metrics[metric] : null),
+      isCancelled: () => false,
       trendNote: 'Data source: <code>history.ndjson</code>, one line per (commit, leg) benchmark run.',
       compareNote: `Each bar is the median of that environment's last ${COMPARE_TRAILING_N} nightly runs (not just the latest one) for the selected metric, sorted fastest to slowest. Data source: <code>history.ndjson</code>.`,
       csvPrefix: 'ddev-perf',
@@ -116,13 +139,18 @@
       legKey: (row) => row.workflow,
       metrics: () => ['wall_clock_s', 'compute_s'],
       metricValue: (row, metric) => row[metric],
+      // GitHub spells it "cancelled", Buildkite spells it "canceled" -- a
+      // cancelled run's duration is however far it got before a newer commit
+      // superseded it (see #8695/#8696 discussion), not a real completion
+      // time, so it's excluded from duration charts by default.
+      isCancelled: (row) => row.conclusion === 'cancelled' || row.conclusion === 'canceled',
       trendNote: 'Data source: <code>test-runtime-history.ndjson</code>, one line per CI run/build.',
       compareNote: `Each bar is the median of that test type's last ${COMPARE_TRAILING_N} runs (not just the latest one) for the selected metric, sorted fastest to slowest. Data source: <code>test-runtime-history.ndjson</code>.`,
       csvPrefix: 'ddev-test-runtime',
     },
   };
 
-  const state = { dataset: 'perf', rows: [], metric: null, view: 'trend', legs: [], enabledLegs: new Set() };
+  const state = { dataset: 'perf', rows: [], metric: null, view: 'trend', legs: [], enabledLegs: new Set(), excludeCancelled: true };
 
   function ds() {
     return DATASETS[state.dataset];
@@ -189,6 +217,16 @@
       });
     }
 
+    const excludeCancelledCheckbox = document.getElementById('exclude-cancelled-checkbox');
+    excludeCancelledCheckbox.checked = state.excludeCancelled;
+    if (!excludeCancelledCheckbox.dataset.bound) {
+      excludeCancelledCheckbox.dataset.bound = '1';
+      excludeCancelledCheckbox.addEventListener('change', () => {
+        state.excludeCancelled = excludeCancelledCheckbox.checked;
+        render();
+      });
+    }
+
     const legSet = new Set();
     for (const row of state.rows) legSet.add(legKey(row));
     state.legs = [...legSet].sort();
@@ -226,6 +264,23 @@
       label.appendChild(cb);
       label.appendChild(document.createTextNode(leg));
       legsContainer.appendChild(label);
+    }
+
+    // Datasets like CI test runtime can have 20+ legs -- all of them plotted
+    // at once on the trend view is unreadable. These two buttons are the fast
+    // path to "clear everything, then check the ones I actually want."
+    function setAllLegs(enabled) {
+      for (const cb of legsContainer.querySelectorAll('input[type=checkbox]')) cb.checked = enabled;
+      state.enabledLegs = enabled ? new Set(state.legs) : new Set();
+      render();
+    }
+    const allBtn = document.getElementById('legs-all');
+    const noneBtn = document.getElementById('legs-none');
+    if (!allBtn.dataset.bound) {
+      allBtn.dataset.bound = '1';
+      allBtn.addEventListener('click', () => setAllLegs(true));
+      noneBtn.dataset.bound = '1';
+      noneBtn.addEventListener('click', () => setAllLegs(false));
     }
   }
 
@@ -269,7 +324,7 @@
       .filter((leg) => state.enabledLegs.has(leg))
       .map((leg, i) => {
         const points = state.rows
-          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null)
+          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && !(state.excludeCancelled && ds().isCancelled(r)))
           .map((r) => ({ t: new Date(r.timestamp).getTime(), v: ds().metricValue(r, state.metric) }));
         return { leg, color: COLORS[i % COLORS.length], points };
       })
@@ -358,7 +413,7 @@
       .filter((leg) => state.enabledLegs.has(leg))
       .map((leg, i) => {
         const points = state.rows
-          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null)
+          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && !(state.excludeCancelled && ds().isCancelled(r)))
           .map((r) => ds().metricValue(r, state.metric));
         const value = median(points.slice(-COMPARE_TRAILING_N));
         return { leg, color: COLORS[i % COLORS.length], value, n: Math.min(points.length, COMPARE_TRAILING_N) };

--- a/perf/collector/dashboard.html
+++ b/perf/collector/dashboard.html
@@ -78,7 +78,7 @@
       <label style="visibility: hidden; display: block;">.</label>
       <label style="display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.85rem;">
         <input type="checkbox" id="exclude-cancelled-checkbox" checked>
-        Exclude cancelled/skipped runs
+        Only successful full runs
       </label>
     </div>
     <div>
@@ -127,7 +127,7 @@
         return [...s].sort();
       },
       metricValue: (row, metric) => (row.metrics ? row.metrics[metric] : null),
-      isNotRealRun: () => false,
+      isFullSuccessfulRun: () => true,
       // Nightly perf metrics are all naturally short (rebuild/start times in
       // the tens of seconds) -- seconds stay readable.
       formatDuration: (v) => `${v.toFixed(1)} s`,
@@ -146,17 +146,23 @@
       // `!= null` filter in renderTrend/renderCompare already handles.
       metrics: () => ['wall_clock_s', 'compute_s', 'queue_wait_s'],
       metricValue: (row, metric) => row[metric],
-      // Two different ways a row's duration isn't a real measurement:
-      // (1) cancelled (GitHub spells it "cancelled", Buildkite "canceled") --
-      //     however far it got before a newer commit superseded it (see
-      //     #8695/#8696 discussion), not a real completion time; and
-      // (2) skip_marker -- a [skip ci]/[skip buildkite]/[skip github] commit
-      //     exits in seconds but Buildkite still records it as "passed" (no
-      //     separate "skipped" state the way a GitHub job has), so without
-      //     this these near-zero points mix into the same bucket as a real
-      //     multi-hour run and produce huge, meaningless swings.
-      // Both excluded from duration charts by default.
-      isNotRealRun: (row) => row.conclusion === 'cancelled' || row.conclusion === 'canceled' || row.skip_marker === true,
+      // The question this dataset exists to answer (see #8695/#8696: sizing
+      // up the Go test suite for trimming) is "how long does a full test run
+      // actually take" -- an allowlist of what counts as one, not a
+      // denylist of known-bad states, since a failure can end early (the
+      // Makefile's target chain aborts on the first non-zero recipe -- see
+      // stage_analysis) and Buildkite's queue-wait fix already showed
+      // "exclude the artifacts we've found so far" misses ones we haven't.
+      // A run only counts if it (a) actually completed -- not cancelled
+      // (GitHub spells it "cancelled", Buildkite "canceled"), not a
+      // [skip ci]/[skip buildkite]/[skip github] commit that Buildkite
+      // still records as "passed" despite never assigning an agent (no
+      // separate "skipped" state the way a GitHub job has); and (b)
+      // actually succeeded -- a failure's duration reflects whatever went
+      // wrong, not the suite's real running time, whether it happened late
+      // (representative) or was truncated early by the Make chain abort.
+      isFullSuccessfulRun: (row) =>
+        (row.conclusion === 'success' || row.conclusion === 'passed') && row.skip_marker !== true,
       // Whole test runs are thousands of seconds -- minutes read far better.
       // The underlying values (and the CSV export) stay in raw seconds;
       // only chart labels go through this.
@@ -167,6 +173,9 @@
     },
   };
 
+  // excludeCancelled's name predates isFullSuccessfulRun (it grew from "drop
+  // cancelled runs" to "only successful full runs" -- see that function's
+  // comment); kept as-is since it's internal, not user-facing.
   const state = { dataset: 'perf', rows: [], metric: null, view: 'trend', legs: [], enabledLegs: new Set(), excludeCancelled: true };
 
   function ds() {
@@ -341,7 +350,7 @@
       .filter((leg) => state.enabledLegs.has(leg))
       .map((leg, i) => {
         const points = state.rows
-          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && !(state.excludeCancelled && ds().isNotRealRun(r)))
+          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && (!state.excludeCancelled || ds().isFullSuccessfulRun(r)))
           .map((r) => ({ t: new Date(r.timestamp).getTime(), v: ds().metricValue(r, state.metric) }));
         return { leg, color: COLORS[i % COLORS.length], points };
       })
@@ -430,7 +439,7 @@
       .filter((leg) => state.enabledLegs.has(leg))
       .map((leg, i) => {
         const points = state.rows
-          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && !(state.excludeCancelled && ds().isNotRealRun(r)))
+          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && (!state.excludeCancelled || ds().isFullSuccessfulRun(r)))
           .map((r) => ds().metricValue(r, state.metric));
         const value = median(points.slice(-COMPARE_TRAILING_N));
         return { leg, color: COLORS[i % COLORS.length], value, n: Math.min(points.length, COMPARE_TRAILING_N) };

--- a/perf/collector/dashboard.html
+++ b/perf/collector/dashboard.html
@@ -78,7 +78,7 @@
       <label style="visibility: hidden; display: block;">.</label>
       <label style="display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.85rem;">
         <input type="checkbox" id="exclude-cancelled-checkbox" checked>
-        Exclude cancelled runs
+        Exclude cancelled/skipped runs
       </label>
     </div>
     <div>
@@ -127,7 +127,7 @@
         return [...s].sort();
       },
       metricValue: (row, metric) => (row.metrics ? row.metrics[metric] : null),
-      isCancelled: () => false,
+      isNotRealRun: () => false,
       // Nightly perf metrics are all naturally short (rebuild/start times in
       // the tens of seconds) -- seconds stay readable.
       formatDuration: (v) => `${v.toFixed(1)} s`,
@@ -142,11 +142,17 @@
       legKey: (row) => row.workflow,
       metrics: () => ['wall_clock_s', 'compute_s'],
       metricValue: (row, metric) => row[metric],
-      // GitHub spells it "cancelled", Buildkite spells it "canceled" -- a
-      // cancelled run's duration is however far it got before a newer commit
-      // superseded it (see #8695/#8696 discussion), not a real completion
-      // time, so it's excluded from duration charts by default.
-      isCancelled: (row) => row.conclusion === 'cancelled' || row.conclusion === 'canceled',
+      // Two different ways a row's duration isn't a real measurement:
+      // (1) cancelled (GitHub spells it "cancelled", Buildkite "canceled") --
+      //     however far it got before a newer commit superseded it (see
+      //     #8695/#8696 discussion), not a real completion time; and
+      // (2) skip_marker -- a [skip ci]/[skip buildkite]/[skip github] commit
+      //     exits in seconds but Buildkite still records it as "passed" (no
+      //     separate "skipped" state the way a GitHub job has), so without
+      //     this these near-zero points mix into the same bucket as a real
+      //     multi-hour run and produce huge, meaningless swings.
+      // Both excluded from duration charts by default.
+      isNotRealRun: (row) => row.conclusion === 'cancelled' || row.conclusion === 'canceled' || row.skip_marker === true,
       // Whole test runs are thousands of seconds -- minutes read far better.
       // The underlying values (and the CSV export) stay in raw seconds;
       // only chart labels go through this.
@@ -331,7 +337,7 @@
       .filter((leg) => state.enabledLegs.has(leg))
       .map((leg, i) => {
         const points = state.rows
-          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && !(state.excludeCancelled && ds().isCancelled(r)))
+          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && !(state.excludeCancelled && ds().isNotRealRun(r)))
           .map((r) => ({ t: new Date(r.timestamp).getTime(), v: ds().metricValue(r, state.metric) }));
         return { leg, color: COLORS[i % COLORS.length], points };
       })
@@ -420,7 +426,7 @@
       .filter((leg) => state.enabledLegs.has(leg))
       .map((leg, i) => {
         const points = state.rows
-          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && !(state.excludeCancelled && ds().isCancelled(r)))
+          .filter((r) => legKey(r) === leg && ds().metricValue(r, state.metric) != null && !(state.excludeCancelled && ds().isNotRealRun(r)))
           .map((r) => ds().metricValue(r, state.metric));
         const value = median(points.slice(-COMPARE_TRAILING_N));
         return { leg, color: COLORS[i % COLORS.length], value, n: Math.min(points.length, COMPARE_TRAILING_N) };

--- a/perf/collector/dashboard.html
+++ b/perf/collector/dashboard.html
@@ -81,13 +81,6 @@
         Only successful full runs
       </label>
     </div>
-    <div id="split-by-runner-wrap">
-      <label style="visibility: hidden; display: block;">.</label>
-      <label style="display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.85rem;">
-        <input type="checkbox" id="split-by-runner-checkbox">
-        Split by runner machine (Buildkite only)
-      </label>
-    </div>
   </div>
 
   <div class="controls">
@@ -171,28 +164,36 @@
       file: 'test-runtime-history.ndjson',
       subText: 'Total CI runtime per test type, across GitHub Actions workflows and Buildkite pipelines. See <a href="https://github.com/ddev/ddev/blob/main/perf/collector/README.md">perf/collector/README.md</a>. wall_clock_s excludes queue time; compute_s sums every job in the run (workflows split into more than one job, e.g. podman-rootless’s testpkg/testcmd, report real CPU-minutes). Points more than 20% above the trailing 10-run median for their test type are marked red.',
       legsLabel: 'Test type (workflow / pipeline)',
-      // When splitByRunner is on, a Buildkite row's leg becomes
-      // "pipeline · machine" instead of just "pipeline" -- e.g. it's how a
+      // A Buildkite row's leg is "pipeline · machine" instead of just
+      // "pipeline" whenever the runner box is narrowed (see
+      // runnerSelectionNarrowed()) -- not a separate manual toggle. Checking
+      // "all" runners (the default) reproduces this page's original
+      // behavior, one merged line per workflow; narrowing to specific
+      // machines is itself the signal to split them apart, which is how a
       // single physical agent quietly getting slower build over build,
       // while its sibling agents on the same pipeline stay flat, becomes
       // visible on the trend chart instead of requiring a manual API dig
       // (see the ddev-macos-arm64-mutagen investigation this was built
-      // for). GitHub Actions rows fall back to plain `workflow` even with
-      // the toggle on -- runner_name there is a one-shot ephemeral VM id,
-      // not a persistent machine, so splitting by it wouldn't mean anything.
+      // for) -- and also how "what actually ran on tb-macos-arm64-4-1"
+      // renders as one clean line per pipeline rather than needing a
+      // second control. A prior version had both a separate "split by
+      // runner" checkbox and this narrowing behavior at once; selecting
+      // more than one runner with the checkbox off silently merged their
+      // data into one meaningless line (two machines' very different
+      // performance interleaved chronologically) -- one control, not two
+      // that can contradict each other. GitHub Actions rows never split --
+      // runner_name there is a one-shot ephemeral VM id, not a persistent
+      // machine, so splitting by it wouldn't mean anything.
       legKey: (row) => {
-        if (state.splitByRunner && row.source === 'buildkite') {
+        if (row.source === 'buildkite' && runnerSelectionNarrowed()) {
           return `${row.workflow} · ${primaryRunnerName(row) || 'unknown runner'}`;
         }
         return row.workflow;
       },
-      // The runner-machine facet: independent of splitByRunner (which only
-      // controls whether the chart draws separate lines), this is what the
-      // "Runner machine" checkbox box filters on -- e.g. looking at just
-      // wsl2-mirrored's tb-wsl-12-1 data works whether or not the chart is
-      // currently drawing it as its own line. null for GitHub Actions rows,
-      // which the row-selection filter below treats as "always included,
-      // no runner facet to filter by."
+      // The runner-machine facet the "Runner machine" checkbox box filters
+      // on. null for GitHub Actions rows, which the row-selection filter
+      // below treats as "included only while the runner box isn't actually
+      // narrowing anything" (see rowSelected()).
       runnerOf: (row) => (row.source === 'buildkite' ? (primaryRunnerName(row) || 'unknown runner') : null),
       // queue_wait_s only exists on Buildkite rows (time waiting for a
       // scarce self-hosted agent -- see collect-test-runtime.js); GitHub
@@ -240,7 +241,7 @@
     dataset: 'perf', rows: [], metric: null, view: 'trend',
     workflows: [], enabledWorkflows: new Set(),
     runners: [], enabledRunners: new Set(),
-    excludeCancelled: true, splitByRunner: false,
+    excludeCancelled: true,
   };
 
   function ds() {
@@ -251,23 +252,30 @@
     return ds().legKey(row);
   }
 
-  // Whether a row counts at all, independent of splitByRunner (which only
-  // controls how counted rows get grouped into chart lines). A GitHub row
-  // has no runner facet (runnerOf returns null) and is never excluded by
-  // the runner-machine box; a Buildkite row is excluded if its machine is
-  // unchecked, whether or not the chart is currently splitting by runner.
+  // True once the runner box has been narrowed below "every runner" --
+  // the single signal both legKey (split Buildkite rows into per-machine
+  // lines) and rowSelected (drop no-runner-concept rows) key off, instead
+  // of a separate manual toggle. See legKey's comment for why a separate
+  // toggle was worse: it let "split=off, 2 runners checked" silently merge
+  // two machines' very different performance into one meaningless line.
+  function runnerSelectionNarrowed() {
+    return state.runners.length > 0 && state.enabledRunners.size < state.runners.length;
+  }
+
+  // Whether a row counts at all, independent of how a counted row then gets
+  // grouped into a chart line (that's legKey's job). A Buildkite row is
+  // excluded if its machine is unchecked; a GitHub row has no runner facet
+  // (runnerOf returns null) and is included only while the runner box isn't
+  // actually narrowing anything -- see runnerSelectionNarrowed().
   function rowSelected(row) {
     if (!state.enabledWorkflows.has(row.workflow)) return false;
     const runner = ds().runnerOf(row);
     if (runner !== null) return state.enabledRunners.has(runner);
-    // No runner concept for this row (e.g. every GitHub Actions row --
-    // runnerOf returns null there). Include it only while the runner box
-    // isn't actually narrowing anything (nothing checked/unchecked yet, the
-    // "just browsing everything" default) -- the moment it's narrowed to
-    // specific machines, this becomes a runner-centric question ("what
-    // actually ran on tb-macos-arm64-4-1"), and a row with no relationship
-    // to any machine has no business answering it.
-    return state.enabledRunners.size === state.runners.length;
+    // No runner concept for this row (e.g. every GitHub Actions row).
+    // Once the runner box is narrowed, this becomes a runner-centric
+    // question ("what actually ran on tb-macos-arm64-4-1"), and a row with
+    // no relationship to any machine has no business answering it.
+    return !runnerSelectionNarrowed();
   }
 
   function median(values) {
@@ -338,9 +346,8 @@
 
   // resetSelections is true on a genuine dataset switch (an old workflow
   // selection has nothing to do with the new dataset's values) and false on
-  // every other populateControls() call (splitByRunner toggling, most
-  // notably) -- so re-deriving the available workflows/runners doesn't wipe
-  // out which ones the user already checked.
+  // every other populateControls() call -- so re-deriving the available
+  // workflows/runners doesn't wipe out which ones the user already checked.
   function populateControls(resetSelections) {
     document.getElementById('sub-text').innerHTML = ds().subText;
     document.getElementById('workflow-label').textContent = ds().legsLabel;
@@ -386,22 +393,6 @@
       });
     }
 
-    // Unlike excludeCancelled, this changes what a leg *is* (one pipeline
-    // becomes one line per machine that's run it), so the chart's leg/color
-    // assignment has to be rebuilt -- but the workflow/runner *selections*
-    // themselves don't need to change, hence populateControls() (no reset)
-    // rather than just render().
-    const splitByRunnerCheckbox = document.getElementById('split-by-runner-checkbox');
-    splitByRunnerCheckbox.checked = state.splitByRunner;
-    if (!splitByRunnerCheckbox.dataset.bound) {
-      splitByRunnerCheckbox.dataset.bound = '1';
-      splitByRunnerCheckbox.addEventListener('change', () => {
-        state.splitByRunner = splitByRunnerCheckbox.checked;
-        populateControls();
-        render();
-      });
-    }
-
     const metricSelect = document.getElementById('metric-select');
     metricSelect.innerHTML = '';
     for (const m of ds().metrics(state.rows)) {
@@ -419,10 +410,7 @@
       });
     }
 
-    // Two independent facets -- see rowSelected(). Workflow values don't
-    // depend on splitByRunner at all; runner values are gathered the same
-    // way regardless, since the runner box filters data whether or not the
-    // chart is currently splitting lines by it.
+    // Two independent facets -- see rowSelected() and runnerSelectionNarrowed().
     const workflowSet = new Set();
     const runnerSet = new Set();
     for (const row of state.rows) {

--- a/perf/collector/dashboard.html
+++ b/perf/collector/dashboard.html
@@ -128,6 +128,9 @@
       },
       metricValue: (row, metric) => (row.metrics ? row.metrics[metric] : null),
       isCancelled: () => false,
+      // Nightly perf metrics are all naturally short (rebuild/start times in
+      // the tens of seconds) -- seconds stay readable.
+      formatDuration: (v) => `${v.toFixed(1)} s`,
       trendNote: 'Data source: <code>history.ndjson</code>, one line per (commit, leg) benchmark run.',
       compareNote: `Each bar is the median of that environment's last ${COMPARE_TRAILING_N} nightly runs (not just the latest one) for the selected metric, sorted fastest to slowest. Data source: <code>history.ndjson</code>.`,
       csvPrefix: 'ddev-perf',
@@ -144,6 +147,10 @@
       // superseded it (see #8695/#8696 discussion), not a real completion
       // time, so it's excluded from duration charts by default.
       isCancelled: (row) => row.conclusion === 'cancelled' || row.conclusion === 'canceled',
+      // Whole test runs are thousands of seconds -- minutes read far better.
+      // The underlying values (and the CSV export) stay in raw seconds;
+      // only chart labels go through this.
+      formatDuration: (v) => `${(v / 60).toFixed(1)} min`,
       trendNote: 'Data source: <code>test-runtime-history.ndjson</code>, one line per CI run/build.',
       compareNote: `Each bar is the median of that test type's last ${COMPARE_TRAILING_N} runs (not just the latest one) for the selected metric, sorted fastest to slowest. Data source: <code>test-runtime-history.ndjson</code>.`,
       csvPrefix: 'ddev-test-runtime',
@@ -362,8 +369,8 @@
 
     ctx.fillStyle = muted;
     ctx.font = '11px sans-serif';
-    ctx.fillText(vMax.toFixed(1) + ' s', 4, pad.t + 8);
-    ctx.fillText('0 s', 4, pad.t + h);
+    ctx.fillText(ds().formatDuration(vMax), 4, pad.t + 8);
+    ctx.fillText(ds().formatDuration(0), 4, pad.t + h);
     ctx.fillText(new Date(tMin).toISOString().slice(0, 10), pad.l, pad.t + h + 16);
     const lastLabel = new Date(tMax).toISOString().slice(0, 10);
     ctx.fillText(lastLabel, pad.l + w - ctx.measureText(lastLabel).width, pad.t + h + 16);
@@ -456,7 +463,7 @@
 
       ctx.fillStyle = muted;
       ctx.textAlign = 'left';
-      ctx.fillText(`${b.value.toFixed(1)} s (n=${b.n})`, pad.l + barX(b.value) + 8, rowY + rowH / 2 + 4);
+      ctx.fillText(`${ds().formatDuration(b.value)} (n=${b.n})`, pad.l + barX(b.value) + 8, rowY + rowH / 2 + 4);
     });
     ctx.textAlign = 'left';
 

--- a/perf/collector/test-pipelines.json
+++ b/perf/collector/test-pipelines.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Buildkite pipeline slugs for the actual Go test suite (not the nightly ddev-perf-* benchmarks in pipelines.json) whose per-build runtime is tracked for the CI test-runtime trend -- one row per finished build on main. Confirmed live via `bk pipeline list --org ddev` on 2026-08-22: filtered to repo=ddev/ddev with a .buildkite/*.yml script that still exists in the repo. Several other pipelines returned by that API call reference scripts no longer in the repo (legacy drud/ddev-org pipelines, retired providers) -- consistent with #8695's '13 of 31 pipelines never built or retired mid-history' finding -- and are deliberately excluded here. See perf/collector/README.md.",
+  "buildkiteOrg": "ddev",
+  "pipelines": [
+    "macos-lima",
+    "macos-colima-vz",
+    "macos-orbstack",
+    "macos-podman-rootless",
+    "macos-rancher-desktop",
+    "ddev-macos-arm64-mutagen",
+    "ddev-windows-mutagen",
+    "ddev-windows-dockerforwindows-nfs",
+    "ddev-windows-installer",
+    "wsl2-docker-desktop",
+    "wsl2-docker-inside",
+    "wsl2-mirrored"
+  ]
+}

--- a/perf/collector/test-workflows.json
+++ b/perf/collector/test-workflows.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "GitHub Actions workflow files (under .github/workflows/) whose per-run job timing is tracked for the CI test-runtime trend -- one row per completed run on main, with a jobs[] breakdown for workflows that split into more than one job (e.g. podman-rootless's testpkg/testcmd split). See perf/collector/README.md.",
+  "workflows": [
+    "test-apache-fpm.yml",
+    "test-nginx-fpm.yml",
+    "test-mutagen.yml",
+    "test-podman-rootless.yml",
+    "test-podman-rootless-mutagen.yml",
+    "test-docker-rootless.yml",
+    "test-race-detection.yml",
+    "test-no-bind-mounts.yml",
+    "test-all-project-types.yml",
+    "test-wsl2-nat.yml",
+    "test-pull-push-providers.yml",
+    "quickstart.yml"
+  ]
+}


### PR DESCRIPTION
## Short Summary (TL;DR)

Adds a CI test-runtime tracking dataset (total runtime per workflow/pipeline, GitHub Actions and Buildkite) and opt-in per-test gotestsum instrumentation for GitHub Actions Go test runs, so #8695/#8696-style CI restructuring can be measured with a before/after trend instead of one-off manual snapshots.

## The Issue

Related to #8695, #8696

Both issues' data is a single-sample snapshot pulled by hand from `gh api`/job logs -- useful for spotting structural duplication, but neither issue could show duration drift or flakiness over time, and both call this out explicitly as a limitation. Before landing the CI restructuring those issues recommend, we need a durable way to see whether a change actually reduced cost/flakiness per test type, not just assert it once.

## How This PR Solves The Issue

- Extends the existing nightly `performance-data` branch/`perf-collect.yml` cron (previously scoped to narrow synthetic perf benchmarks) with a new dataset: `perf/collector/collect-test-runtime.js` pulls completed `main`-branch runs for the GitHub Actions Test-*/Quickstart workflows (`test-workflows.json`) and finished `main`-branch builds for the 12 active Buildkite Test-* pipelines (`test-pipelines.json`, confirmed live via `bk pipeline list` against several retired/legacy pipelines the Buildkite API still returns), appending one row per run/build to `test-runtime-history.ndjson` with `wall_clock_s`, `compute_s` (summed across jobs, so podman-rootless's testpkg/testcmd split reports real CPU-minutes), and a per-job runner-label breakdown.
- Adds opt-in per-test detail for GitHub Actions Go test runs: the Makefile's `testcmd`/`testddevapp`/`testnotddevapp` targets route through `gotestsum` when `GOTESTSUM_JSONFILE_DIR` is set (unset by default, so local `make test` is unaffected), writing per-test JSON alongside the normal `--format=standard-verbose` console output so CI log review is unchanged. Wired into `test-reusable.yml` and `test-wsl2-reusable.yml` (the latter needs an extra copy-out-of-WSL2-VM step, since tests run inside the VM's filesystem).
- Generalizes `perf/collector/dashboard.html` from a single dataset to a dataset switcher (nightly perf benchmarks / CI test runtime), reusing the existing trend and compare-environments chart code rather than duplicating it.

Buildkite's plain macOS/Windows test scripts (`.buildkite/test.sh`/`test.cmd`) are not yet wired for the per-test gotestsum detail -- only the GitHub Actions side gets that in this PR; Buildkite currently only has the total-runtime dataset.

## Manual Testing Instructions

- Push this branch; the 8 GitHub Actions Test-* wrapper workflows and WSL2 NAT should run automatically (path-filtered on `Makefile`/`.github/workflows/**`), installing gotestsum and uploading a `test-results-<run_id>-<attempt>-<make_target>` artifact per job. Spot-check one job's raw log to confirm output still reads like plain `go test -v`, and download an artifact to confirm it's well-formed per-test JSON.
- Manually dispatch `perf-collect.yml` against this branch (`gh workflow run perf-collect.yml --ref <branch>`) to confirm it collects real `main`-branch history into `test-runtime-history.ndjson` and commits it to `performance-data` without errors.
- Copy `test-runtime-history.ndjson` alongside `dashboard.html` locally and open it in a browser; switch the dataset selector to "CI test runtime" and check both the trend and compare views.

## Automated Testing Overview

No new automated tests -- this is CI/tooling infrastructure. Verified manually: `collect-test-runtime.js` was run against the live `ddev/ddev` GitHub and Buildkite APIs (real rows, correct dedup on a second run); the Makefile's default (`GOTESTSUM_JSONFILE_DIR` unset) path was confirmed byte-identical to the pre-change `go test -v` invocation via `make -n`; the dashboard's data/render logic was exercised headlessly in Node against real sample data for both datasets, both views, and both test-runtime metrics, with zero exceptions.

## Release/Deployment Notes

No secrets or one-time setup beyond what `performance-data`/`perf-collect.yml` already requires (`BUILDKITE_API_TOKEN` in the `test-secrets` 1Password vault) -- the test-runtime Buildkite collection reuses that same token and degrades gracefully (skips Buildkite, keeps GitHub Actions rows) if it's ever absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
