### PR TITLE
feat(snapshot): offer snapshots from sibling Git worktrees, by name, latest, or --list (#8733) [skip ci]

### DIFF
--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
 	"github.com/ddev/ddev/pkg/globalconfig"
@@ -66,16 +67,34 @@ ddev snapshot --uncompressed`,
 }
 
 func listSnapshots(apps []*ddevapp.DdevApp) {
-	var columns table.Row
 	var out bytes.Buffer
 	t := table.NewWriter()
 	t.SetOutputMirror(&out)
 	styles.SetGlobalTableStyle(t, false)
 
+	allTargets := make(map[string][]ddevapp.SnapshotRestoreTarget)
+	hasWorktreeSnapshot := false
+	for _, app := range apps {
+		targets, err := app.ListSnapshotRestoreTargets()
+		if err != nil {
+			util.Failed("Failed to list snapshots %s: %v", app.GetName(), err)
+		}
+		allTargets[app.GetName()] = targets
+		for _, target := range targets {
+			if target.SourceRoot != app.AppRoot {
+				hasWorktreeSnapshot = true
+			}
+		}
+	}
+
+	var columns table.Row
 	if len(apps) > 1 {
 		columns = append(columns, "Project")
 	}
 	columns = append(columns, "Snapshot", "Created", "Size", "DB Version", "Compression")
+	if hasWorktreeSnapshot {
+		columns = append(columns, "Worktree")
+	}
 
 	if !globalconfig.DdevGlobalConfig.SimpleFormatting {
 		var colConfig []table.ColumnConfig
@@ -88,32 +107,39 @@ func listSnapshots(apps []*ddevapp.DdevApp) {
 	}
 	t.AppendHeader(columns)
 
-	allSnapshots := make(map[string][]ddevapp.Snapshot)
 	for _, app := range apps {
-		if snapshots, err := app.ListSnapshots(); err != nil {
-			util.Failed("Failed to list snapshots %s: %v", app.GetName(), err)
-		} else {
-			allSnapshots[app.GetName()] = snapshots
-			if len(snapshots) > 0 {
-				for _, snapshot := range snapshots {
-					if len(apps) > 1 {
-						t.AppendRow(table.Row{app.GetName(), snapshot.Name, snapshot.Created.Format("2006-01-02"), util.FormatBytes(snapshot.Size), snapshot.DBVersion, snapshot.Compression})
-					} else {
-						t.AppendRow(table.Row{snapshot.Name, snapshot.Created.Format("2006-01-02"), util.FormatBytes(snapshot.Size), snapshot.DBVersion, snapshot.Compression})
-					}
+		targets := allTargets[app.GetName()]
+		if len(targets) > 0 {
+			for _, target := range targets {
+				worktree := ""
+				if target.SourceRoot != app.AppRoot {
+					worktree = filepath.Base(target.SourceRoot)
 				}
-			} else {
+				row := table.Row{}
 				if len(apps) > 1 {
-					t.AppendRow(table.Row{app.GetName(), text.Italic.Sprint("No snapshots"), "", "", "", ""})
-				} else {
-					t.AppendRow(table.Row{text.Italic.Sprint("No snapshots"), "", "", "", ""})
+					row = append(row, app.GetName())
 				}
+				row = append(row, target.Name, target.Created.Format("2006-01-02"), util.FormatBytes(target.Size), target.DBVersion, target.Compression)
+				if hasWorktreeSnapshot {
+					row = append(row, worktree)
+				}
+				t.AppendRow(row)
 			}
+		} else {
+			row := table.Row{}
+			if len(apps) > 1 {
+				row = append(row, app.GetName())
+			}
+			row = append(row, text.Italic.Sprint("No snapshots"), "", "", "", "")
+			if hasWorktreeSnapshot {
+				row = append(row, "")
+			}
+			t.AppendRow(row)
 		}
 	}
 
 	t.Render()
-	output.UserOut.WithField("raw", allSnapshots).Println(out.String())
+	output.UserOut.WithField("raw", allTargets).Println(out.String())
 }
 
 func createAppSnapshot(app *ddevapp.DdevApp) {

--- a/cmd/ddev/cmd/snapshot_list_test.go
+++ b/cmd/ddev/cmd/snapshot_list_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/output"
+	"github.com/stretchr/testify/require"
+)
+
+// captureListSnapshots runs listSnapshots(apps) with output.UserOut
+// redirected to a buffer, restoring the original output when done, and
+// returns what would otherwise have gone to stdout.
+func captureListSnapshots(t *testing.T, apps []*ddevapp.DdevApp) string {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := output.UserOut.Out
+	output.UserOut.SetOutput(&buf)
+	t.Cleanup(func() {
+		output.UserOut.SetOutput(orig)
+	})
+	listSnapshots(apps)
+	return buf.String()
+}
+
+// TestListSnapshotsNoSnapshots verifies `ddev snapshot --list` reports "No
+// snapshots" for a project with an empty (or absent) db_snapshots directory,
+// and doesn't show a Worktree column when the project isn't in a git worktree
+// with sibling snapshots.
+func TestListSnapshotsNoSnapshots(t *testing.T) {
+	app := &ddevapp.DdevApp{AppRoot: t.TempDir(), Name: "empty-project"}
+
+	out := captureListSnapshots(t, []*ddevapp.DdevApp{app})
+	require.Contains(t, out, "No snapshots")
+	require.NotContains(t, out, "WORKTREE")
+}
+
+// TestListSnapshotsWorktrees verifies `ddev snapshot --list` includes
+// snapshots found in a sibling git worktree of the same project alongside the
+// project's own, labels each row's source worktree, and leaves the Worktree
+// column out entirely for a project with no sibling snapshots to show.
+func TestListSnapshotsWorktrees(t *testing.T) {
+	tmpDir := t.TempDir()
+	resolvedTmpDir, err := filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, err)
+	tmpDir = resolvedTmpDir
+
+	repoRoot := filepath.Join(tmpDir, "repo")
+	worktreeRoot := filepath.Join(tmpDir, "repo-worktree")
+	projectRoot := filepath.Join(repoRoot, "web")
+	projectWorktreeRoot := filepath.Join(worktreeRoot, "web")
+
+	runGit := func(dir string, args ...string) {
+		out, err := osexec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	require.NoError(t, os.MkdirAll(repoRoot, 0o755))
+	runGit(tmpDir, "init", repoRoot)
+	runGit(repoRoot, "config", "user.name", "Test User")
+	runGit(repoRoot, "config", "user.email", "test@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "README.md"), []byte("placeholder"), 0o644))
+	runGit(repoRoot, "add", ".")
+	runGit(repoRoot, "commit", "-m", "initial")
+	runGit(repoRoot, "worktree", "add", "--detach", worktreeRoot, "HEAD")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, ".ddev", "db_snapshots"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(projectWorktreeRoot, ".ddev", "db_snapshots"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, ".ddev", "db_snapshots", "current-mariadb_10.11.zst"), []byte("current"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectWorktreeRoot, ".ddev", "db_snapshots", "other-mariadb_10.11.zst"), []byte("other"), 0o644))
+
+	app := &ddevapp.DdevApp{AppRoot: projectRoot, Name: "web"}
+	out := captureListSnapshots(t, []*ddevapp.DdevApp{app})
+
+	require.Contains(t, out, "WORKTREE", "a sibling snapshot exists, so the Worktree column should be shown")
+	require.Contains(t, out, "current")
+	require.Contains(t, out, "other")
+	require.Contains(t, out, "web", "the sibling snapshot's row should be labeled with its source worktree directory")
+	require.Contains(t, out, "mariadb_10.11")
+
+	// The same project on its own, with no sibling worktree snapshots, should
+	// not show a Worktree column at all.
+	worktreeApp := &ddevapp.DdevApp{AppRoot: projectWorktreeRoot, Name: "web-worktree"}
+	require.NoError(t, os.RemoveAll(filepath.Join(projectRoot, ".ddev", "db_snapshots", "current-mariadb_10.11.zst")))
+	soloOut := captureListSnapshots(t, []*ddevapp.DdevApp{worktreeApp})
+	require.NotContains(t, soloOut, "WORKTREE")
+	require.Contains(t, soloOut, "other")
+}

--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -12,7 +12,9 @@ import (
 var DdevSnapshotRestoreCommand = &cobra.Command{
 	Use:   "restore [snapshot_name|path]",
 	Short: "Restore a project's database to the provided snapshot version.",
-	Long:  `Uses mariabackup or xtrabackup command to restore a project database to a particular snapshot, either by name from the .ddev/db_snapshots folder or by the path to a snapshot file elsewhere.`,
+	Long: `Uses mariabackup or xtrabackup command to restore a project database to a particular snapshot, either by name from the .ddev/db_snapshots folder or by the path to a snapshot file elsewhere.
+
+If the project is a git worktree, snapshots from the same project checked out in other worktrees of the same repository are also offered.`,
 	Example: `ddev snapshot restore d8git_20180717203845
 ddev snapshot restore --latest
 ddev snapshot restore --force t3v14-latest
@@ -33,18 +35,25 @@ ddev snapshot restore $HOME/tmp/mysnapshot-mariadb_11.8.zst`,
 		}
 
 		if snapshotRestoreLatest {
-			if snapshotName, err = app.GetLatestSnapshot(); err != nil {
+			target, err := app.GetLatestSnapshotRestoreTarget()
+			if err != nil {
 				util.Failed("Failed to get latest snapshot of project %s: %v", app.GetName(), err)
 			}
+			snapshotName = target.Path
 		} else {
 			if len(args) != 1 { // If the name of the snapshot isn't provided, do prompted restore
-				snapshots, err := app.ListSnapshotNames()
+				targets, err := app.ListSnapshotRestoreTargets()
 				if err != nil {
 					util.Failed("Cannot list snapshots of project %s: %v", app.GetName(), err)
 				}
 
-				if len(snapshots) == 0 {
+				if len(targets) == 0 {
 					util.Failed("No snapshots found for project %s", app.GetName())
+				}
+
+				labels := make([]string, 0, len(targets))
+				for _, target := range targets {
+					labels = append(labels, target.Label)
 				}
 
 				templates := &promptui.SelectTemplates{
@@ -53,15 +62,15 @@ ddev snapshot restore $HOME/tmp/mysnapshot-mariadb_11.8.zst`,
 
 				prompt := promptui.Select{
 					Label:     "Snapshot",
-					Items:     snapshots,
+					Items:     labels,
 					Templates: templates,
 				}
 
-				_, snapshotName, err = prompt.Run()
-
+				selected, _, err := prompt.Run()
 				if err != nil {
 					util.Failed("Prompt failed %v", err)
 				}
+				snapshotName = targets[selected].Path
 			} else { // Snapshot name was given on command-line, use it.
 				snapshotName = args[0]
 			}

--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -14,7 +14,7 @@ var DdevSnapshotRestoreCommand = &cobra.Command{
 	Short: "Restore a project's database to the provided snapshot version.",
 	Long: `Uses mariabackup or xtrabackup command to restore a project database to a particular snapshot, either by name from the .ddev/db_snapshots folder or by the path to a snapshot file elsewhere.
 
-If the project is a git worktree, snapshots from the same project checked out in other worktrees of the same repository are also offered.`,
+If the project is a git worktree, snapshots from the same project checked out in other worktrees of the same repository are also available, whether picked interactively, passed by name, or via --latest.`,
 	Example: `ddev snapshot restore d8git_20180717203845
 ddev snapshot restore --latest
 ddev snapshot restore --force t3v14-latest
@@ -72,7 +72,7 @@ ddev snapshot restore $HOME/tmp/mysnapshot-mariadb_11.8.zst`,
 				}
 				snapshotName = targets[selected].Path
 			} else { // Snapshot name was given on command-line, use it.
-				snapshotName = args[0]
+				snapshotName = app.ResolveSnapshotRestoreTarget(args[0])
 			}
 		}
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1383,7 +1383,7 @@ Flags:
 * `--uncompressed`: Write the snapshot as an uncompressed mariabackup/xtrabackup stream instead of compressing it. This skips decompression on restore, but the file can be roughly as large as the database's datadir, many times bigger than a compressed snapshot. Not available for PostgreSQL projects. See [Snapshots](../usage/database-management.md#snapshots) for when this unusual tradeoff makes sense.
 * `--yes`, `-y`: Skip confirmation prompt.
 
-`ddev snapshot --list` also shows each snapshot's compression: `zstd`, `gzip`, or `none` for an uncompressed snapshot. If the project is a git worktree and a sibling worktree of the same project has snapshots of its own, those are listed too, with a `Worktree` column naming which one each came from.
+`ddev snapshot --list` also shows each snapshot's compression: `zstd`, `gzip`, or `none` for an uncompressed snapshot. If the project is a Git worktree and a sibling worktree of the same project has snapshots of its own, those are listed too, with a `Worktree` column naming which one each came from.
 
 Example:
 
@@ -1416,7 +1416,7 @@ ddev snapshot --uncompressed
 ### `snapshot restore`
 
 Restores a database snapshot, either by name from the `.ddev/db_snapshots` directory or
-by the path to a snapshot file elsewhere on disk. If the project is a git worktree,
+by the path to a snapshot file elsewhere on disk. If the project is a Git worktree,
 snapshots from the same project checked out in other worktrees of the same repository
 are available too, whether picked interactively, restored by name, or via `--latest`.
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1383,7 +1383,7 @@ Flags:
 * `--uncompressed`: Write the snapshot as an uncompressed mariabackup/xtrabackup stream instead of compressing it. This skips decompression on restore, but the file can be roughly as large as the database's datadir, many times bigger than a compressed snapshot. Not available for PostgreSQL projects. See [Snapshots](../usage/database-management.md#snapshots) for when this unusual tradeoff makes sense.
 * `--yes`, `-y`: Skip confirmation prompt.
 
-`ddev snapshot --list` also shows each snapshot's compression: `zstd`, `gzip`, or `none` for an uncompressed snapshot.
+`ddev snapshot --list` also shows each snapshot's compression: `zstd`, `gzip`, or `none` for an uncompressed snapshot. If the project is a git worktree and a sibling worktree of the same project has snapshots of its own, those are listed too, with a `Worktree` column naming which one each came from.
 
 Example:
 
@@ -1418,7 +1418,7 @@ ddev snapshot --uncompressed
 Restores a database snapshot, either by name from the `.ddev/db_snapshots` directory or
 by the path to a snapshot file elsewhere on disk. If the project is a git worktree,
 snapshots from the same project checked out in other worktrees of the same repository
-are offered too, both here and for `--latest`.
+are available too, whether picked interactively, restored by name, or via `--latest`.
 
 Flags:
 

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1416,7 +1416,9 @@ ddev snapshot --uncompressed
 ### `snapshot restore`
 
 Restores a database snapshot, either by name from the `.ddev/db_snapshots` directory or
-by the path to a snapshot file elsewhere on disk.
+by the path to a snapshot file elsewhere on disk. If the project is a git worktree,
+snapshots from the same project checked out in other worktrees of the same repository
+are offered too, both here and for `--latest`.
 
 Flags:
 

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -53,7 +53,7 @@ Snapshots are stored as compressed (zstd, or gzip on very old database versions)
 
 ### Sharing Snapshots Between Git Worktrees
 
-If a project is a [git worktree](https://git-scm.com/docs/git-worktree), `ddev snapshot restore` also offers snapshots belonging to the same project checked out in the repository's other worktrees, so a snapshot taken in one working copy doesn't have to be manually copied to restore it in another:
+If a project is a [git worktree](https://git-scm.com/docs/git-worktree), `ddev snapshot restore` also offers snapshots belonging to the same project checked out in the repository's other worktrees, so a snapshot taken in one working copy doesn't have to be manually copied to restore it in another. This works whether you pick interactively, restore by name, or use `--latest`, and `ddev snapshot --list` shows the other worktrees' snapshots too, each labeled with the worktree it came from:
 
 ```bash
 # In ~/repo/web
@@ -62,9 +62,12 @@ ddev snapshot --name=before-migration
 # In ~/repo-feature-branch/web, a worktree of the same repository
 ddev snapshot restore
 # 'before-migration' from ~/repo/web is offered alongside this project's own snapshots
+
+ddev snapshot restore before-migration
+# also works directly by name, without the interactive picker
 ```
 
-Only worktrees of the same repository are considered — a separate clone at the same relative path is not, even if it happens to have the same project name. This is a convenience on top of the path-based restore above: `ddev snapshot restore <path>` and `ddev start --seed-snapshot=<path>` already work with a snapshot from anywhere on disk, worktree or not.
+Only worktrees of the same repository are considered — a separate clone at the same relative path is not, even if it happens to have the same project name. If more than one sibling worktree has a snapshot with the same name, the most recently created one is used, without asking which. This is a convenience on top of the path-based restore above: `ddev snapshot restore <path>` and `ddev start --seed-snapshot=<path>` already work with a snapshot from anywhere on disk, worktree or not.
 
 ### Uncompressed Snapshots
 

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -51,6 +51,21 @@ Use the [`ddev snapshot restore`](../usage/commands.md#snapshot-restore) command
 
 Snapshots are stored as compressed (zstd, or gzip on very old database versions) files in the project's `.ddev/db_snapshots` directory, and any or all snapshots can be removed with the `ddev snapshot --cleanup` command or by manually deleting the files when you want to save disk space or have no further use for them.
 
+### Sharing Snapshots Between Git Worktrees
+
+If a project is a [git worktree](https://git-scm.com/docs/git-worktree), `ddev snapshot restore` also offers snapshots belonging to the same project checked out in the repository's other worktrees, so a snapshot taken in one working copy doesn't have to be manually copied to restore it in another:
+
+```bash
+# In ~/repo/web
+ddev snapshot --name=before-migration
+
+# In ~/repo-feature-branch/web, a worktree of the same repository
+ddev snapshot restore
+# 'before-migration' from ~/repo/web is offered alongside this project's own snapshots
+```
+
+Only worktrees of the same repository are considered — a separate clone at the same relative path is not, even if it happens to have the same project name. This is a convenience on top of the path-based restore above: `ddev snapshot restore <path>` and `ddev start --seed-snapshot=<path>` already work with a snapshot from anywhere on disk, worktree or not.
+
 ### Uncompressed Snapshots
 
 `ddev snapshot`, `ddev snapshot restore`, and the reserved `seed` snapshot all compress the database backup by default, which is the right trade-off for almost everyone. Decompression still costs real time, though — routinely 30-40% of a restore or first `ddev start`, and it competes for the same CPU cores the database restore itself needs right after. `--uncompressed` skips it:

--- a/docs/content/users/usage/database-management.md
+++ b/docs/content/users/usage/database-management.md
@@ -53,7 +53,7 @@ Snapshots are stored as compressed (zstd, or gzip on very old database versions)
 
 ### Sharing Snapshots Between Git Worktrees
 
-If a project is a [git worktree](https://git-scm.com/docs/git-worktree), `ddev snapshot restore` also offers snapshots belonging to the same project checked out in the repository's other worktrees, so a snapshot taken in one working copy doesn't have to be manually copied to restore it in another. This works whether you pick interactively, restore by name, or use `--latest`, and `ddev snapshot --list` shows the other worktrees' snapshots too, each labeled with the worktree it came from:
+If a project is a [Git worktree](https://git-scm.com/docs/git-worktree), `ddev snapshot restore` also offers snapshots belonging to the same project checked out in the repository's other worktrees, so a snapshot taken in one working copy doesn't have to be manually copied to restore it in another. This works whether you pick interactively, restore by name, or use `--latest`, and `ddev snapshot --list` shows the other worktrees' snapshots too, each labeled with the worktree it came from:
 
 ```bash
 # In ~/repo/web

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -131,8 +131,11 @@ type SnapshotRestoreTarget struct {
 	// project's own snapshot, an absolute file path for one found elsewhere.
 	Path string
 	// SourceRoot is the project root the snapshot was found under.
-	SourceRoot string
-	Created    time.Time
+	SourceRoot  string
+	Created     time.Time
+	Size        int64
+	DBVersion   string
+	Compression string
 }
 
 // ListSnapshotRestoreTargets returns the current project's own snapshots plus
@@ -147,11 +150,14 @@ func (app *DdevApp) ListSnapshotRestoreTargets() ([]SnapshotRestoreTarget, error
 	}
 	for _, s := range own {
 		targets = append(targets, SnapshotRestoreTarget{
-			Name:       s.Name,
-			Label:      s.Name,
-			Path:       s.Name,
-			SourceRoot: app.AppRoot,
-			Created:    s.Created,
+			Name:        s.Name,
+			Label:       s.Name,
+			Path:        s.Name,
+			SourceRoot:  app.AppRoot,
+			Created:     s.Created,
+			Size:        s.Size,
+			DBVersion:   s.DBVersion,
+			Compression: s.Compression,
 		})
 	}
 
@@ -174,11 +180,14 @@ func (app *DdevApp) ListSnapshotRestoreTargets() ([]SnapshotRestoreTarget, error
 				continue
 			}
 			targets = append(targets, SnapshotRestoreTarget{
-				Name:       s.Name,
-				Label:      fmt.Sprintf("%s (%s)", s.Name, label),
-				Path:       fullPath,
-				SourceRoot: projectRoot,
-				Created:    s.Created,
+				Name:        s.Name,
+				Label:       fmt.Sprintf("%s (%s)", s.Name, label),
+				Path:        fullPath,
+				SourceRoot:  projectRoot,
+				Created:     s.Created,
+				Size:        s.Size,
+				DBVersion:   s.DBVersion,
+				Compression: s.Compression,
 			})
 		}
 	}
@@ -202,6 +211,33 @@ func (app *DdevApp) GetLatestSnapshotRestoreTarget() (*SnapshotRestoreTarget, er
 		return nil, fmt.Errorf("no snapshots found")
 	}
 	return &targets[0], nil
+}
+
+// ResolveSnapshotRestoreTarget resolves a bare snapshot name given directly on
+// the `ddev snapshot restore` command line to what should be passed to
+// RestoreSnapshot: the name unchanged if the project has its own snapshot by
+// that name (or nothing matches at all, so the original "not found" error is
+// preserved), otherwise the absolute path of the newest same-named snapshot
+// found in a sibling git worktree of the same project. A path (absolute, or
+// containing a slash) is returned unchanged, since it already names an exact
+// file rather than something worktree lookup could resolve.
+func (app *DdevApp) ResolveSnapshotRestoreTarget(nameOrPath string) string {
+	if filepath.IsAbs(nameOrPath) || strings.ContainsAny(nameOrPath, `/\`) {
+		return nameOrPath
+	}
+	if _, err := GetSnapshotFileFromName(nameOrPath, app); err == nil {
+		return nameOrPath
+	}
+	targets, err := app.ListSnapshotRestoreTargets()
+	if err != nil {
+		return nameOrPath
+	}
+	for _, target := range targets {
+		if target.Name == nameOrPath && target.SourceRoot != app.AppRoot {
+			return target.Path
+		}
+	}
+	return nameOrPath
 }
 
 // otherWorktreeProjectRoots returns the directories where this same project

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -117,6 +118,134 @@ func (app *DdevApp) GetLatestSnapshot() (string, error) {
 	return snapshots[0], nil
 }
 
+// SnapshotRestoreTarget is a snapshot offered by `ddev snapshot restore`,
+// either the current project's own or one found in the same project checked
+// out in another git worktree of the same repository.
+type SnapshotRestoreTarget struct {
+	// Name is the snapshot name, as shown by `ddev snapshot --list`.
+	Name string
+	// Label is what the interactive picker displays for this target; it
+	// names the source worktree when the snapshot isn't the current project's own.
+	Label string
+	// Path is what to pass to RestoreSnapshot: a bare name for the current
+	// project's own snapshot, an absolute file path for one found elsewhere.
+	Path string
+	// SourceRoot is the project root the snapshot was found under.
+	SourceRoot string
+	Created    time.Time
+}
+
+// ListSnapshotRestoreTargets returns the current project's own snapshots plus
+// any snapshots belonging to the same project checked out in other git
+// worktrees of the same repository, newest first.
+func (app *DdevApp) ListSnapshotRestoreTargets() ([]SnapshotRestoreTarget, error) {
+	var targets []SnapshotRestoreTarget
+
+	own, err := app.ListSnapshots()
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range own {
+		targets = append(targets, SnapshotRestoreTarget{
+			Name:       s.Name,
+			Label:      s.Name,
+			Path:       s.Name,
+			SourceRoot: app.AppRoot,
+			Created:    s.Created,
+		})
+	}
+
+	for _, projectRoot := range app.otherWorktreeProjectRoots() {
+		snapshotsDir := filepath.Join(projectRoot, ".ddev", "db_snapshots")
+		snapshots, err := listSnapshotsInDir(snapshotsDir)
+		if err != nil || len(snapshots) == 0 {
+			continue
+		}
+		label := filepath.Base(projectRoot)
+		for _, s := range snapshots {
+			file, err := snapshotFileInDir(s.Name, snapshotsDir)
+			if err != nil {
+				continue
+			}
+			fullPath := filepath.Join(snapshotsDir, file)
+			// Path-based restore (see resolveSnapshotSource) only supports
+			// snapshot files, not the legacy directory-based format.
+			if fileutil.IsDirectory(fullPath) {
+				continue
+			}
+			targets = append(targets, SnapshotRestoreTarget{
+				Name:       s.Name,
+				Label:      fmt.Sprintf("%s (%s)", s.Name, label),
+				Path:       fullPath,
+				SourceRoot: projectRoot,
+				Created:    s.Created,
+			})
+		}
+	}
+
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].Created.After(targets[j].Created)
+	})
+
+	return targets, nil
+}
+
+// GetLatestSnapshotRestoreTarget returns the most recently created snapshot
+// among the current project's own snapshots and any found in sibling git
+// worktrees of the same project.
+func (app *DdevApp) GetLatestSnapshotRestoreTarget() (*SnapshotRestoreTarget, error) {
+	targets, err := app.ListSnapshotRestoreTargets()
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("no snapshots found")
+	}
+	return &targets[0], nil
+}
+
+// otherWorktreeProjectRoots returns the directories where this same project
+// would live in every other git worktree of its repository: the project's
+// path relative to its own worktree root, re-joined onto each of the
+// repository's other worktree roots. It returns nil if the project isn't in a
+// git worktree, or the repository has no other worktrees - callers should
+// treat that as "nothing extra to offer", not an error.
+func (app *DdevApp) otherWorktreeProjectRoots() []string {
+	repoRootOutput, err := exec.RunHostCommand("git", "-C", app.AppRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil
+	}
+	repoRoot := strings.TrimSpace(repoRootOutput)
+	if repoRoot == "" {
+		return nil
+	}
+
+	relToRepo, err := filepath.Rel(repoRoot, app.AppRoot)
+	if err != nil {
+		return nil
+	}
+
+	worktreeListOutput, err := exec.RunHostCommand("git", "-C", repoRoot, "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil
+	}
+
+	var projectRoots []string
+	for line := range strings.SplitSeq(strings.TrimSpace(worktreeListOutput), "\n") {
+		worktreeRoot, ok := strings.CutPrefix(line, "worktree ")
+		if !ok {
+			continue
+		}
+		worktreeRoot = strings.TrimSpace(worktreeRoot)
+		if worktreeRoot == "" || worktreeRoot == repoRoot {
+			continue
+		}
+		projectRoots = append(projectRoots, filepath.Join(worktreeRoot, relToRepo))
+	}
+
+	return projectRoots
+}
+
 // ListSnapshots returns a list of the names of all project snapshots
 func (app *DdevApp) ListSnapshotNames() ([]string, error) {
 	var names []string
@@ -131,10 +260,15 @@ func (app *DdevApp) ListSnapshotNames() ([]string, error) {
 
 // ListSnapshots returns a list of all project snapshots
 func (app *DdevApp) ListSnapshots() ([]Snapshot, error) {
+	return listSnapshotsInDir(app.GetConfigPath("db_snapshots"))
+}
+
+// listSnapshotsInDir returns all snapshots found directly in snapshotDir. It's
+// the directory-parameterized core of ListSnapshots, also used to look for
+// snapshots belonging to the same project checked out in other git worktrees.
+func listSnapshotsInDir(snapshotDir string) ([]Snapshot, error) {
 	var err error
 	var snapshots []Snapshot
-
-	snapshotDir := app.GetConfigPath("db_snapshots")
 
 	if !fileutil.FileExists(snapshotDir) {
 		return snapshots, nil
@@ -458,7 +592,13 @@ func resolveSnapshotSource(nameOrPath string, app *DdevApp) (hostPath string, mo
 
 // GetSnapshotFileFromName returns the filename corresponding to the snapshot name
 func GetSnapshotFileFromName(name string, app *DdevApp) (string, error) {
-	snapshotsDir := app.GetConfigPath("db_snapshots")
+	return snapshotFileInDir(name, app.GetConfigPath("db_snapshots"))
+}
+
+// snapshotFileInDir returns the actual filename of the snapshot called name
+// inside snapshotsDir: the name unchanged for an old-style directory-based
+// snapshot, or the full <name>-<type>_<version>.<ext> filename for a modern one.
+func snapshotFileInDir(name, snapshotsDir string) (string, error) {
 	snapshotFullPath := filepath.Join(snapshotsDir, name)
 
 	// If old-style directory-based snapshot, then use the name, no massaging required

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -247,6 +247,9 @@ func (app *DdevApp) ResolveSnapshotRestoreTarget(nameOrPath string) string {
 // git worktree, or the repository has no other worktrees - callers should
 // treat that as "nothing extra to offer", not an error.
 func (app *DdevApp) otherWorktreeProjectRoots() []string {
+	// Not being in a git repo at all is the common case here, so it's not
+	// worth a debug log - only the later checks, reached once we know we're
+	// in a repo, are.
 	repoRootOutput, err := exec.RunHostCommand("git", "-C", app.AppRoot, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return nil
@@ -264,12 +267,14 @@ func (app *DdevApp) otherWorktreeProjectRoots() []string {
 	// project sits under the repo root.
 	prefixOutput, err := exec.RunHostCommand("git", "-C", app.AppRoot, "rev-parse", "--show-prefix")
 	if err != nil {
+		util.Debug("otherWorktreeProjectRoots: git rev-parse --show-prefix: %v", err)
 		return nil
 	}
 	relToRepo := strings.TrimSuffix(strings.TrimSpace(prefixOutput), "/")
 
 	worktreeListOutput, err := exec.RunHostCommand("git", "-C", repoRoot, "worktree", "list", "--porcelain")
 	if err != nil {
+		util.Debug("otherWorktreeProjectRoots: git worktree list: %v", err)
 		return nil
 	}
 

--- a/pkg/ddevapp/snapshot.go
+++ b/pkg/ddevapp/snapshot.go
@@ -220,10 +220,17 @@ func (app *DdevApp) otherWorktreeProjectRoots() []string {
 		return nil
 	}
 
-	relToRepo, err := filepath.Rel(repoRoot, app.AppRoot)
+	// git's own idea of app.AppRoot's path relative to repoRoot, rather than
+	// filepath.Rel(repoRoot, app.AppRoot): on macOS in particular, app.AppRoot
+	// may reach the project through a symlink (e.g. /var/folders/... into
+	// /private/var/folders/...) that "rev-parse --show-toplevel" already
+	// resolved, so comparing the two paths directly can misjudge how deep the
+	// project sits under the repo root.
+	prefixOutput, err := exec.RunHostCommand("git", "-C", app.AppRoot, "rev-parse", "--show-prefix")
 	if err != nil {
 		return nil
 	}
+	relToRepo := strings.TrimSuffix(strings.TrimSpace(prefixOutput), "/")
 
 	worktreeListOutput, err := exec.RunHostCommand("git", "-C", repoRoot, "worktree", "list", "--porcelain")
 	if err != nil {

--- a/pkg/ddevapp/snapshot_test.go
+++ b/pkg/ddevapp/snapshot_test.go
@@ -154,12 +154,23 @@ func TestGetLatestSnapshot(t *testing.T) {
 	runTime()
 }
 
-// TestListSnapshotRestoreTargetsWorktrees verifies that
-// ListSnapshotRestoreTargets() finds a snapshot belonging to the same project
-// checked out in another git worktree of the same repository, but not one
-// belonging to an unrelated checkout that merely happens to sit at the same
-// relative path.
-func TestListSnapshotRestoreTargetsWorktrees(t *testing.T) {
+// snapshotWorktreeFixture is the layout built by newSnapshotWorktreeFixture:
+// a project and a same-project checkout in a sibling git worktree, plus an
+// unrelated clone at the same relative path that should never be treated as
+// a sibling.
+type snapshotWorktreeFixture struct {
+	// projectRoot is the current project, with an older "current" snapshot.
+	projectRoot string
+	// projectWorktreeRoot is the same project in a sibling git worktree, with
+	// a newer "other" snapshot.
+	projectWorktreeRoot string
+	// otherFile is the absolute path of "other" inside projectWorktreeRoot.
+	otherFile string
+}
+
+// newSnapshotWorktreeFixture creates the fixture described by
+// snapshotWorktreeFixture under a fresh t.TempDir().
+func newSnapshotWorktreeFixture(t *testing.T) snapshotWorktreeFixture {
 	tmpDir := t.TempDir()
 	// git resolves symlinks in the paths it reports (e.g. macOS's /var/folders
 	// into /private/var/folders); resolving here too keeps this test's own
@@ -211,7 +222,21 @@ func TestListSnapshotRestoreTargetsWorktrees(t *testing.T) {
 	require.NoError(t, os.Chtimes(currentFile, olderTime, olderTime))
 	require.NoError(t, os.Chtimes(otherFile, newerTime, newerTime))
 
-	app := &ddevapp.DdevApp{AppRoot: projectRoot}
+	return snapshotWorktreeFixture{
+		projectRoot:         projectRoot,
+		projectWorktreeRoot: projectWorktreeRoot,
+		otherFile:           otherFile,
+	}
+}
+
+// TestListSnapshotRestoreTargetsWorktrees verifies that
+// ListSnapshotRestoreTargets() finds a snapshot belonging to the same project
+// checked out in another git worktree of the same repository, but not one
+// belonging to an unrelated checkout that merely happens to sit at the same
+// relative path.
+func TestListSnapshotRestoreTargetsWorktrees(t *testing.T) {
+	fixture := newSnapshotWorktreeFixture(t)
+	app := &ddevapp.DdevApp{AppRoot: fixture.projectRoot}
 
 	targets, err := app.ListSnapshotRestoreTargets()
 	require.NoError(t, err)
@@ -224,18 +249,41 @@ func TestListSnapshotRestoreTargetsWorktrees(t *testing.T) {
 
 	require.Contains(t, byName, "current")
 	require.Equal(t, "current", byName["current"].Path, "the current project's own snapshot should restore by bare name")
-	require.Equal(t, projectRoot, byName["current"].SourceRoot)
+	require.Equal(t, fixture.projectRoot, byName["current"].SourceRoot)
+	require.Equal(t, "mariadb_10.11", byName["current"].DBVersion)
 
 	require.Contains(t, byName, "other")
-	require.Equal(t, otherFile, byName["other"].Path, "a snapshot from another worktree should restore by absolute path")
-	require.Equal(t, projectWorktreeRoot, byName["other"].SourceRoot)
+	require.Equal(t, fixture.otherFile, byName["other"].Path, "a snapshot from another worktree should restore by absolute path")
+	require.Equal(t, fixture.projectWorktreeRoot, byName["other"].SourceRoot)
 	require.Equal(t, "other (web)", byName["other"].Label)
+	require.Equal(t, "mariadb_10.11", byName["other"].DBVersion)
 
 	require.NotContains(t, byName, "unrelated")
 
 	latest, err := app.GetLatestSnapshotRestoreTarget()
 	require.NoError(t, err)
 	require.Equal(t, "other", latest.Name)
+}
+
+// TestResolveSnapshotRestoreTargetWorktrees verifies that
+// ResolveSnapshotRestoreTarget(), used for a snapshot name given directly on
+// the `ddev snapshot restore` command line, only falls back to a sibling
+// worktree's snapshot when the project has no snapshot of its own by that
+// name, and leaves paths and genuinely unresolvable names untouched.
+func TestResolveSnapshotRestoreTargetWorktrees(t *testing.T) {
+	fixture := newSnapshotWorktreeFixture(t)
+	app := &ddevapp.DdevApp{AppRoot: fixture.projectRoot}
+
+	require.Equal(t, "current", app.ResolveSnapshotRestoreTarget("current"),
+		"the project's own snapshot should resolve by bare name, not fall back to the worktree")
+	require.Equal(t, fixture.otherFile, app.ResolveSnapshotRestoreTarget("other"),
+		"a snapshot found only in a sibling worktree should resolve to its absolute path")
+	require.Equal(t, "nonexistent", app.ResolveSnapshotRestoreTarget("nonexistent"),
+		"a name found nowhere should be returned unchanged so the usual not-found error is reported")
+
+	somePath := filepath.Join(fixture.projectRoot, "some", "path.zst")
+	require.Equal(t, somePath, app.ResolveSnapshotRestoreTarget(somePath),
+		"a path should never be treated as a bare name to look up in sibling worktrees")
 }
 
 // TestSnapshotUncompressedPostgresError verifies that --uncompressed is

--- a/pkg/ddevapp/snapshot_test.go
+++ b/pkg/ddevapp/snapshot_test.go
@@ -3,6 +3,7 @@ package ddevapp_test
 import (
 	"fmt"
 	"os"
+	osexec "os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -151,6 +152,90 @@ func TestGetLatestSnapshot(t *testing.T) {
 	assert.Equal("", latestSnapshot)
 
 	runTime()
+}
+
+// TestListSnapshotRestoreTargetsWorktrees verifies that
+// ListSnapshotRestoreTargets() finds a snapshot belonging to the same project
+// checked out in another git worktree of the same repository, but not one
+// belonging to an unrelated checkout that merely happens to sit at the same
+// relative path.
+func TestListSnapshotRestoreTargetsWorktrees(t *testing.T) {
+	tmpDir := t.TempDir()
+	// git resolves symlinks in the paths it reports (e.g. macOS's /var/folders
+	// into /private/var/folders); resolving here too keeps this test's own
+	// path comparisons on the same footing as what the code under test gets back.
+	resolvedTmpDir, err := filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, err)
+	tmpDir = resolvedTmpDir
+
+	repoRoot := filepath.Join(tmpDir, "repo")
+	worktreeRoot := filepath.Join(tmpDir, "repo-worktree")
+	unrelatedCloneRoot := filepath.Join(tmpDir, "unrelated-clone")
+
+	projectRoot := filepath.Join(repoRoot, "web")
+	projectWorktreeRoot := filepath.Join(worktreeRoot, "web")
+	unrelatedProjectRoot := filepath.Join(unrelatedCloneRoot, "web")
+
+	runGit := func(dir string, args ...string) {
+		out, err := osexec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	// .ddev/db_snapshots is ordinarily gitignored, so the worktree is set up
+	// (committing only a placeholder file) before it exists in either
+	// checkout - a real `git worktree add` never brings snapshots along.
+	require.NoError(t, os.MkdirAll(repoRoot, 0o755))
+	runGit(tmpDir, "init", repoRoot)
+	runGit(repoRoot, "config", "user.name", "Test User")
+	runGit(repoRoot, "config", "user.email", "test@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "README.md"), []byte("placeholder"), 0o644))
+	runGit(repoRoot, "add", ".")
+	runGit(repoRoot, "commit", "-m", "initial")
+	runGit(repoRoot, "worktree", "add", "--detach", worktreeRoot, "HEAD")
+
+	runGit(tmpDir, "init", unrelatedCloneRoot)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, ".ddev", "db_snapshots"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(projectWorktreeRoot, ".ddev", "db_snapshots"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(unrelatedProjectRoot, ".ddev", "db_snapshots"), 0o755))
+
+	currentFile := filepath.Join(projectRoot, ".ddev", "db_snapshots", "current-mariadb_10.11.zst")
+	otherFile := filepath.Join(projectWorktreeRoot, ".ddev", "db_snapshots", "other-mariadb_10.11.zst")
+	unrelatedFile := filepath.Join(unrelatedProjectRoot, ".ddev", "db_snapshots", "unrelated-mariadb_10.11.zst")
+	require.NoError(t, os.WriteFile(currentFile, []byte("current"), 0o644))
+	require.NoError(t, os.WriteFile(otherFile, []byte("other"), 0o644))
+	require.NoError(t, os.WriteFile(unrelatedFile, []byte("unrelated"), 0o644))
+
+	olderTime := time.Now().Add(-2 * time.Hour)
+	newerTime := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(currentFile, olderTime, olderTime))
+	require.NoError(t, os.Chtimes(otherFile, newerTime, newerTime))
+
+	app := &ddevapp.DdevApp{AppRoot: projectRoot}
+
+	targets, err := app.ListSnapshotRestoreTargets()
+	require.NoError(t, err)
+	require.Len(t, targets, 2, "expected only the current project's own snapshot and the one from the sibling worktree, not the unrelated clone's")
+
+	byName := map[string]ddevapp.SnapshotRestoreTarget{}
+	for _, target := range targets {
+		byName[target.Name] = target
+	}
+
+	require.Contains(t, byName, "current")
+	require.Equal(t, "current", byName["current"].Path, "the current project's own snapshot should restore by bare name")
+	require.Equal(t, projectRoot, byName["current"].SourceRoot)
+
+	require.Contains(t, byName, "other")
+	require.Equal(t, otherFile, byName["other"].Path, "a snapshot from another worktree should restore by absolute path")
+	require.Equal(t, projectWorktreeRoot, byName["other"].SourceRoot)
+	require.Equal(t, "other (web)", byName["other"].Label)
+
+	require.NotContains(t, byName, "unrelated")
+
+	latest, err := app.GetLatestSnapshotRestoreTarget()
+	require.NoError(t, err)
+	require.Equal(t, "other", latest.Name)
 }
 
 // TestSnapshotUncompressedPostgresError verifies that --uncompressed is


### PR DESCRIPTION
## Short Summary (TL;DR)

Teaches `ddev snapshot restore` — interactively, by name, and via `--latest` — and `ddev snapshot --list` to also see snapshots from the same project checked out in other Git worktrees of the same repository, building on the path-based restore already on `main` instead of duplicating it. An alternative to #8623, which predates that path-based support.

## The Issue

Related to #8623 ("Allow worktrees to share DB snapshots" by @tyler36): a snapshot taken in one Git worktree of a project isn't visible to `ddev snapshot restore` in another worktree of the same repository, so reusing a database across worktrees means manually copying snapshot files around.

#8623 predates the path-based snapshot restore/seed support that's landed on `main` since it was opened (#8704, #8705), and its `RestoreSnapshot(name, sourceRoot)` signature no longer matches `RestoreSnapshot(name, force)` on `main` - it needs a rewrite on top of current code either way. This PR is that rewrite, built directly on the newer mechanism instead of duplicating it.

## How This PR Solves The Issue

This PR is five commits:

* [`8b7c39593`](https://github.com/ddev/ddev/pull/8733/commits/8b7c39593cef671be9c569369204eb6d61db3c8b) - the feature: sibling-worktree snapshots offered by the interactive picker and `--latest`.
* [`0f4556f54`](https://github.com/ddev/ddev/pull/8733/commits/0f4556f548bdbf3c8afa4885afa92cd44dde9b42) - a fix for a real bug the feature's own test caught, split out so it's reviewable on its own rather than buried in the feature diff. Details below.
* [`916466694`](https://github.com/ddev/ddev/pull/8733/commits/91646669453516f84a4db5001d96942eaf80e1e0) - extends the same lookup to a bare name on the `ddev snapshot restore` command line and to `ddev snapshot --list`, which the first commit left out.
* [`81cda38bf`](https://github.com/ddev/ddev/pull/8733/commits/81cda38bfdf3d86adcc825fe866ce1e7e2da6daf) and [`8ab7d6451`](https://github.com/ddev/ddev/pull/8733/commits/8ab7d6451b632ef679862d84aadc0a1414984dbd) - documentation for the above, plus a wording fix for a textlint terminology warning.

`ddev snapshot restore` and `ddev snapshot restore --latest` already support restoring from an arbitrary host path via `resolveSnapshotSource`. The feature commit adds automatic discovery on top of that, rather than a parallel restore mechanism:

* `DdevApp.ListSnapshotRestoreTargets()` lists the current project's own snapshots plus any snapshots found in the same project checked out in other worktrees of the same Git repository (via `git worktree list`), newest first. A worktree match requires the same repository and the same relative project path - determined entirely from Git and the filesystem, never from the `.ddev/config.yaml` project name (worktree projects don't usually share a name). A separate clone that happens to sit at the same relative path is not offered.
* `DdevApp.GetLatestSnapshotRestoreTarget()` extends `--latest` the same way.
* The interactive picker in `ddev snapshot restore` shows a worktree snapshot's name and source directory (`snapshot-name (worktree-dir)`); selecting one restores by its absolute path, reusing the existing path-based restore/bind-mount plumbing rather than a copy step.

**The bug, fixed in `0f4556f54`:** the feature commit computed a project's path relative to its repo root with `filepath.Rel(repoRoot, app.AppRoot)`, where `repoRoot` came from `git rev-parse --show-toplevel`. That silently breaks when `app.AppRoot` reaches the project through a symlink that `--show-toplevel` already resolved - notably macOS, where a temp directory (and so `t.TempDir()` in the new test) commonly lives under `/var/folders/...`, itself a symlink to `/private/var/folders/...`. `filepath.Rel` then compares a resolved path against an unresolved one and returns nonsense like `../../../../../var/folders/.../repo/web` instead of `web`, which could make the "other worktree" project directory resolve right back to the current project instead of to the sibling worktree - i.e. cross-worktree discovery would have silently found nothing (or the wrong thing) on a real macOS checkout. The fix asks Git for the relative path instead of computing it with `filepath.Rel`: `git rev-parse --show-prefix` (run from `app.AppRoot`) returns the current directory's path relative to the repo's top level, computed entirely within Git's own resolved view, so it never mixes resolved and unresolved forms of the same path.

**`916466694` extends the same discovery to two places the first commit didn't reach.** `DdevApp.ResolveSnapshotRestoreTarget()` handles a bare name given directly on the `ddev snapshot restore <name>` command line: the project's own snapshot wins if one exists by that name (unchanged behavior), otherwise it falls back to the newest same-named snapshot in a sibling worktree, resolved to its absolute path so the existing path-based restore plumbing handles it unchanged; a path argument, or a name matching nothing anywhere, passes through untouched. `SnapshotRestoreTarget` now also carries `Size`/`DBVersion`/`Compression`, so `ddev snapshot --list` can call `ListSnapshotRestoreTargets()` instead of the project's own `ListSnapshots()` and render sibling rows with the same detail as the project's own, in a `Worktree` column that's added only when a sibling snapshot is actually present - so a project outside a worktree, or one whose siblings have no snapshots, sees no change in output.

I considered going further with a repository-agnostic shared snapshot pool keyed by project name (so any two checkouts with the same name could share snapshots, not just worktrees of one repo). I left that out: project names collide too easily across unrelated projects, and a Git worktree relationship is a precise, verifiable identity check that a name is not. The fully general case - "restore a snapshot from anywhere on disk" - is already covered by the existing path argument.

## Manual Testing Instructions

Docs:

* https://ddev--8733.org.readthedocs.build/en/8733/users/usage/commands/#snapshot
* https://ddev--8733.org.readthedocs.build/en/8733/users/usage/commands/#snapshot-restore
* https://ddev--8733.org.readthedocs.build/en/8733/users/usage/database-management/#sharing-snapshots-between-git-worktrees

1. Create a Git repo and a worktree of it, each with a DDEV project at the same relative path (project names deliberately differ, since that's the normal case for worktrees):

   ```bash
   git init repo && cd repo && git commit --allow-empty -m init
   ddev config --project-type=php --project-name=repo-a
   ddev start
   ddev snapshot --name=shared-snapshot
   cd .. && git -C repo worktree add ../repo-b HEAD
   cd repo-b
   ddev config --project-type=php --project-name=repo-b
   ddev start
   ```

2. `ddev snapshot restore` in `repo-b` - the picker should list `shared-snapshot (repo)` alongside any of `repo-b`'s own snapshots. `ddev snapshot restore --latest` should restore it directly.
3. `ddev snapshot restore shared-snapshot` in `repo-b` (the bare name, no picker, no `--latest`) - should also restore it directly, since `repo-b` has no snapshot of its own by that name.
4. A separate `git clone` of `repo` at the same relative depth should *not* have its snapshots offered from `repo-b`, by any of the above.
5. `ddev snapshot --list` in `repo-b` - should show `shared-snapshot` alongside `repo-b`'s own snapshots, with a `Worktree` column reading `repo`. `ddev snapshot --list` in `repo-a` - should show no `Worktree` column at all, since none of `repo-a`'s siblings have snapshots of their own yet.
6. Add a third worktree, `git -C repo worktree add ../repo-c HEAD`, give it its own snapshot also named `shared-snapshot` (`ddev snapshot --name=shared-snapshot` after `ddev config`/`ddev start` there), and make sure it's newer than `repo-a`'s. `ddev snapshot restore shared-snapshot` in `repo-b` should now restore `repo-c`'s copy instead - there's no prompt or on-screen indication of which sibling it came from beyond the absolute path in the final "was restored" message. This is expected today; see Release/Deployment Notes.

## Automated Testing Overview

`TestListSnapshotRestoreTargetsWorktrees` in `pkg/ddevapp/snapshot_test.go` (`0f4556f54`) sets up a real Git repo, a worktree of it, and an unrelated clone (all via the `git` binary), and asserts that `ListSnapshotRestoreTargets` and `GetLatestSnapshotRestoreTarget` find the worktree's snapshot by absolute path, keep the current project's own snapshot addressable by bare name, exclude the unrelated clone, and (as of `916466694`) carry the right `DBVersion`. It reproduces the symlink bug described above under a real `t.TempDir()` and fails without `0f4556f54`'s fix.

`TestResolveSnapshotRestoreTargetWorktrees` (`916466694`, same file, sharing the fixture through a new `newSnapshotWorktreeFixture` helper) covers `ResolveSnapshotRestoreTarget()`: the project's own snapshot resolves by bare name unchanged, a sibling-only name falls back to its absolute path, a name matching nothing anywhere passes through unchanged so the usual not-found error still fires, and a path is never treated as a name to look up.

`TestListSnapshotsNoSnapshots` and `TestListSnapshotsWorktrees` (`916466694`, new file `cmd/ddev/cmd/snapshot_list_test.go`) exercise `listSnapshots()` directly against filesystem/Git fixtures with no Docker involved, covering the empty-project case and the `Worktree` column appearing only when a sibling snapshot actually exists.

`TestCmdSnapshotRestore` and `TestCmdSnapshotRestoreFile` (existing, covering `--latest` and the path argument) still pass. Also manually verified end-to-end with real DDEV projects sharing one Git repo via `git worktree`, per the steps above.

## Release/Deployment Notes

No config or behavior changes for projects outside a Git worktree, or where a named snapshot already exists locally. Within a worktree, `ddev snapshot restore` - interactively, by name, or via `--latest` - and `ddev snapshot --list` now also see snapshots from sibling worktrees of the same project.

Two things worth knowing before merging, neither fixed in this PR: if the same snapshot name exists in more than one sibling worktree, `ddev snapshot restore <name>` and `--latest` silently use the most recently created one, with no prompt and no indication afterward of which sibling it came from beyond the absolute path in the final "was restored" message. And the label shown for a sibling snapshot - in the picker and in `--list`'s `Worktree` column - is the project's path relative to the repo root, not the worktree's own directory name; if the DDEV project lives in a subdirectory (for example `repo/web`), every sibling worktree shows the same label and can't be told apart.
