### PR TITLE
fix(nginx): Increase FastCGI buffer sizes (for Drupal CMS tests)

### DIFF
--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/sites-enabled/nginx-site-default.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/sites-enabled/nginx-site-default.conf
@@ -37,8 +37,8 @@ server {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php-fpm.sock;
-        fastcgi_buffers 16 16k;
-        fastcgi_buffer_size 32k;
+        fastcgi_buffers 64 64k;
+        fastcgi_buffer_size 1m;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;

--- a/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/sites-enabled/nginx-site-default.conf
+++ b/containers/ddev-webserver/ddev-webserver-base-files/etc/nginx/sites-enabled/nginx-site-default.conf
@@ -37,8 +37,8 @@ server {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php-fpm.sock;
-        fastcgi_buffers 64 64k;
-        fastcgi_buffer_size 1m;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
@@ -50,8 +50,8 @@ server {
     location ~ '\.php$|^/update.php' {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php-fpm.sock;
-        fastcgi_buffers 32 32k;
-        fastcgi_buffer_size 256k;
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
@@ -50,8 +50,8 @@ server {
     location ~ '\.php$|^/update.php' {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php-fpm.sock;
-        fastcgi_buffers 64 64k;
-        fastcgi_buffer_size 1m;
+        fastcgi_buffers 32 32k;
+        fastcgi_buffer_size 256k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal10.conf
@@ -50,8 +50,8 @@ server {
     location ~ '\.php$|^/update.php' {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php-fpm.sock;
-        fastcgi_buffers 16 16k;
-        fastcgi_buffer_size 32k;
+        fastcgi_buffers 64 64k;
+        fastcgi_buffer_size 1m;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
@@ -50,8 +50,8 @@ server {
     location ~ '\.php$|^/update.php' {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php-fpm.sock;
-        fastcgi_buffers 32 32k;
-        fastcgi_buffer_size 256k;
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
@@ -50,8 +50,8 @@ server {
     location ~ '\.php$|^/update.php' {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php-fpm.sock;
-        fastcgi_buffers 64 64k;
-        fastcgi_buffer_size 1m;
+        fastcgi_buffers 32 32k;
+        fastcgi_buffer_size 256k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal11.conf
@@ -50,8 +50,8 @@ server {
     location ~ '\.php$|^/update.php' {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php-fpm.sock;
-        fastcgi_buffers 16 16k;
-        fastcgi_buffer_size 32k;
+        fastcgi_buffers 64 64k;
+        fastcgi_buffer_size 1m;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal12.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal12.conf
@@ -50,8 +50,8 @@ server {
     location ~ '\.php$|^/update.php' {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php-fpm.sock;
-        fastcgi_buffers 32 32k;
-        fastcgi_buffer_size 256k;
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal12.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal12.conf
@@ -50,8 +50,8 @@ server {
     location ~ '\.php$|^/update.php' {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php-fpm.sock;
-        fastcgi_buffers 64 64k;
-        fastcgi_buffer_size 1m;
+        fastcgi_buffers 32 32k;
+        fastcgi_buffer_size 256k;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;

--- a/pkg/ddevapp/webserver_config_assets/nginx-site-drupal12.conf
+++ b/pkg/ddevapp/webserver_config_assets/nginx-site-drupal12.conf
@@ -50,8 +50,8 @@ server {
     location ~ '\.php$|^/update.php' {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php/php-fpm.sock;
-        fastcgi_buffers 16 16k;
-        fastcgi_buffer_size 32k;
+        fastcgi_buffers 64 64k;
+        fastcgi_buffer_size 1m;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;


### PR DESCRIPTION
## Short Summary (TL;DR)

Prior art can be found at https://git.drupalcode.org/project/drupal_cms/-/work_items/3591437.

This increases the FastCGI buffer sizes used by nginx, so that Drupal tests can pass deprecations along in the page headers. When there are a lot of deprecations, tests can fail with a `502 Bad Gateway` error because of this quirk.

## The Issue

No specific issue has been filed for this yet except for https://git.drupalcode.org/project/drupal_cms/-/work_items/3591437, which was solved in a different way.

The issue details how nginx will yield a 502 when running certain Drupal functional tests that raise deprecations, and how there's no particularly straightforward way to adjust the necessary configuration.

## How This PR Solves The Issue

This simply raises the FastCGI buffer sizes so that the 502 is a lot less likely, even when there are a lot of deprecations.

## Manual Testing Instructions

I think you could manually test this by checking out the `drupal_cms` repo (from https://git.drupalcode.org/project/drupal_cms) at commit `bd781d89cd42f82d73eea0f7112e0d339c4050e7`, running `ddev start`, and running `ddev exec phpunit drupal_cms_installer/tests/src/Functional/InteractiveInstallTest.php`. It should fail with no clear reason, but if you put a `print_r($this->getSession()->getPage()->getText())` in the test just before the failing assertion, you'll see the "Bad Gateway" page from nginx.

That shouldn't happen if you patch DDEV with this PR, and (presumably) rebuild the project images.

## Automated Testing Overview

No tests added, because I'm not sure if this configuration is tested or if/how it needs to be.

## Release/Deployment Notes

Nothing relevant here to my knowledge.