### PR TITLE
fix(config): warn about unreleased DDEV builds, fixes #8739

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ DdevVersion ?= $(VERSION)
 # VERSION can be overridden on make commandline: make VERSION=0.9.1 push
 VERSION := $(shell git describe --tags --always --dirty)
 
-# BuildSource ties an unreleased `ddev version` build back to the CI run it
-# came from, using the GITHUB_* variables GitHub Actions sets in every job.
-# Empty for a local `make` build, where none of them are set. Written as a
-# standalone script rather than inline shell: $(shell ...) balances every
+# BuildSource ties an unreleased `ddev version` build back to where it came
+# from: a GitHub Actions run when the GITHUB_* variables Actions sets are
+# present, otherwise the builder and branch of a local `make` build. Written
+# as a standalone script rather than inline shell: $(shell ...) balances every
 # parenthesis in its argument, including literal ones meant for the shell, so
 # anything more than a one-liner belongs in its own file.
 BuildSource := $(shell ./scripts/build-source.sh)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ PKG := github.com/ddev/ddev
 SRC_DIRS := cmd pkg
 
 # Version variables to replace in build
-VERSION_VARIABLES ?= DdevVersion AmplitudeAPIKey
+VERSION_VARIABLES ?= DdevVersion AmplitudeAPIKey BuildSource
 
 # These variables will be used as the default unless overridden by the make
 DdevVersion ?= $(VERSION)
@@ -46,6 +46,14 @@ DdevVersion ?= $(VERSION)
 # This version-strategy uses git tags to set the version string
 # VERSION can be overridden on make commandline: make VERSION=0.9.1 push
 VERSION := $(shell git describe --tags --always --dirty)
+
+# BuildSource ties an unreleased `ddev version` build back to the CI run it
+# came from, using the GITHUB_* variables GitHub Actions sets in every job.
+# Empty for a local `make` build, where none of them are set. Written as a
+# standalone script rather than inline shell: $(shell ...) balances every
+# parenthesis in its argument, including literal ones meant for the shell, so
+# anything more than a one-liner belongs in its own file.
+BuildSource := $(shell ./scripts/build-source.sh)
 # Some things insist on having the version without the leading 'v', so provide a
 # $(NO_V_VERSION) without it.
 # no_v_version removes the front v, for Chocolatey mostly

--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -51,9 +51,16 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 
 	// Test with no custom config
 	t.Run("no custom config", func(t *testing.T) {
-		// Default mode: no output when nothing to warn about
 		out, err := exec.RunCommand(DdevBin, []string{"utility", "check-custom-config"})
 		require.NoError(t, err)
+		if ddevapp.IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
+			// The test binary itself is normally built from an untagged
+			// commit, so it's expected to trip the "DDEV version" finding.
+			require.Contains(t, out, "Custom configuration detected in project '"+projectName+"':")
+			require.Contains(t, out, "DDEV version")
+			require.Contains(t, out, versionconstants.DdevVersion)
+			return
+		}
 		require.NotContains(t, out, "Custom configuration detected")
 
 		// --all mode: explicit success message

--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -53,7 +53,7 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 	t.Run("no custom config", func(t *testing.T) {
 		out, err := exec.RunCommand(DdevBin, []string{"utility", "check-custom-config"})
 		require.NoError(t, err)
-		if ddevapp.IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
+		if versionconstants.IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
 			// The test binary itself is normally built from an untagged
 			// commit, so it's expected to trip the "DDEV version" finding.
 			require.Contains(t, out, "Custom configuration detected in project '"+projectName+"':")

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -5,7 +5,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -18,20 +17,6 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
 )
-
-// unreleasedVersionPattern matches a DdevVersion that isn't a clean release
-// tag: the `git describe --tags --always --dirty` long form used by `make`
-// builds (v1.2.3-15-gabcdef1), a dirty working tree (-dirty), or the
-// debug.BuildInfo short-hash fallback used when a build has no embedded git
-// tag info (gabcdef1). See versionconstants.go for how DdevVersion is derived.
-var unreleasedVersionPattern = regexp.MustCompile(`-\d+-g[0-9a-f]{6,}|-dirty$|^g[0-9a-f]{6,}$`)
-
-// IsUnreleasedDdevVersion returns true if version looks like it was built
-// from an untagged commit (a PR, local branch, or other dev build) rather
-// than an official release.
-func IsUnreleasedDdevVersion(version string) bool {
-	return unreleasedVersionPattern.MatchString(version)
-}
 
 // customConfigCheck defines a custom configuration check.
 type customConfigCheck struct {
@@ -402,7 +387,7 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 	// An unreleased DDEV build (a PR, local branch, or other dev build)
 	// behaves like custom configuration: it may not match what's documented
 	// or supported, and it's easy to forget you're running one.
-	if IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
+	if versionconstants.IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
 		findings = append(findings, finding{
 			category: "DDEV version",
 			files:    []fileInfo{{path: fmt.Sprintf("%s (unsupported, not an official release)", versionconstants.DdevVersion)}},

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -17,6 +18,20 @@ import (
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/versionconstants"
 )
+
+// unreleasedVersionPattern matches a DdevVersion that isn't a clean release
+// tag: the `git describe --tags --always --dirty` long form used by `make`
+// builds (v1.2.3-15-gabcdef1), a dirty working tree (-dirty), or the
+// debug.BuildInfo short-hash fallback used when a build has no embedded git
+// tag info (gabcdef1). See versionconstants.go for how DdevVersion is derived.
+var unreleasedVersionPattern = regexp.MustCompile(`-\d+-g[0-9a-f]{6,}|-dirty$|^g[0-9a-f]{6,}$`)
+
+// IsUnreleasedDdevVersion returns true if version looks like it was built
+// from an untagged commit (a PR, local branch, or other dev build) rather
+// than an official release.
+func IsUnreleasedDdevVersion(version string) bool {
+	return unreleasedVersionPattern.MatchString(version)
+}
 
 // customConfigCheck defines a custom configuration check.
 type customConfigCheck struct {
@@ -383,6 +398,16 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 		files    []fileInfo
 	}
 	var findings []finding
+
+	// An unreleased DDEV build (a PR, local branch, or other dev build)
+	// behaves like custom configuration: it may not match what's documented
+	// or supported, and it's easy to forget you're running one.
+	if IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
+		findings = append(findings, finding{
+			category: "DDEV version",
+			files:    []fileInfo{{path: fmt.Sprintf("%s (unsupported, not an official release)", versionconstants.DdevVersion)}},
+		})
+	}
 
 	for _, check := range checks {
 		if check.checkOnlyWhen != nil && !check.checkOnlyWhen() {

--- a/pkg/ddevapp/config_custom_test.go
+++ b/pkg/ddevapp/config_custom_test.go
@@ -46,27 +46,3 @@ func TestOSGeneratedFilesSkippedInCustomConfig(t *testing.T) {
 	require.Contains(t, customPaths, gitconfig)
 	require.Contains(t, customPaths, normalScript)
 }
-
-// TestIsUnreleasedDdevVersion verifies detection of DDEV versions built from
-// an untagged commit, as opposed to a clean release tag.
-func TestIsUnreleasedDdevVersion(t *testing.T) {
-	unreleased := []string{
-		"v1.25.3-111-geadf098e9", // git describe, commits past a tag
-		"v1.25.3-dirty",          // exact tag, but uncommitted changes
-		"v1.25.3-111-geadf098e9-dirty",
-		"geadf098", // debug.BuildInfo short-hash fallback
-		"geadf098-dirty",
-	}
-	for _, v := range unreleased {
-		require.True(t, IsUnreleasedDdevVersion(v), "expected %q to be detected as unreleased", v)
-	}
-
-	released := []string{
-		"v1.25.3",
-		"v1.25.3-beta1",
-		"v0.0.0-overridden-by-make",
-	}
-	for _, v := range released {
-		require.False(t, IsUnreleasedDdevVersion(v), "expected %q to be detected as a release", v)
-	}
-}

--- a/pkg/ddevapp/config_custom_test.go
+++ b/pkg/ddevapp/config_custom_test.go
@@ -46,3 +46,27 @@ func TestOSGeneratedFilesSkippedInCustomConfig(t *testing.T) {
 	require.Contains(t, customPaths, gitconfig)
 	require.Contains(t, customPaths, normalScript)
 }
+
+// TestIsUnreleasedDdevVersion verifies detection of DDEV versions built from
+// an untagged commit, as opposed to a clean release tag.
+func TestIsUnreleasedDdevVersion(t *testing.T) {
+	unreleased := []string{
+		"v1.25.3-111-geadf098e9", // git describe, commits past a tag
+		"v1.25.3-dirty",          // exact tag, but uncommitted changes
+		"v1.25.3-111-geadf098e9-dirty",
+		"geadf098", // debug.BuildInfo short-hash fallback
+		"geadf098-dirty",
+	}
+	for _, v := range unreleased {
+		require.True(t, IsUnreleasedDdevVersion(v), "expected %q to be detected as unreleased", v)
+	}
+
+	released := []string{
+		"v1.25.3",
+		"v1.25.3-beta1",
+		"v0.0.0-overridden-by-make",
+	}
+	for _, v := range released {
+		require.False(t, IsUnreleasedDdevVersion(v), "expected %q to be detected as a release", v)
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -29,6 +29,12 @@ func GetVersionInfo() (map[string]string, error) {
 	versionInfo := make(map[string]string)
 
 	versionInfo["DDEV version"] = versionconstants.DdevVersion
+	// build-source ties an unreleased build (a PR, branch, or other dev
+	// build) back to the CI run it came from. Omitted for an official
+	// release, and for a local `make` build where it's never set.
+	if versionconstants.BuildSource != "" && versionconstants.IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
+		versionInfo["build-source"] = versionconstants.BuildSource
+	}
 	versionInfo["ddev-environment"] = environment.GetDDEVEnvironment()
 	versionInfo["cgo_enabled"] = strconv.FormatInt(versionconstants.CGOEnabled, 10)
 	versionInfo["global-ddev-dir"] = util.WindowsPathToCygwinPath(globalconfig.GetGlobalDdevDir())

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -30,8 +30,7 @@ func GetVersionInfo() (map[string]string, error) {
 
 	versionInfo["DDEV version"] = versionconstants.DdevVersion
 	// build-source ties an unreleased build (a PR, branch, or other dev
-	// build) back to the CI run it came from. Omitted for an official
-	// release, and for a local `make` build where it's never set.
+	// build) back to where it came from. Omitted for an official release.
 	if versionconstants.BuildSource != "" && versionconstants.IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
 		versionInfo["build-source"] = versionconstants.BuildSource
 	}

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -3,6 +3,7 @@ package versionconstants
 import (
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime/debug"
 	"strings"
 )
@@ -15,6 +16,27 @@ var DdevVersion = "" // Note that this is overridden by make
 // AmplitudeAPIKey is the ddev-specific key for Amplitude service
 // Compiled with link-time variables
 var AmplitudeAPIKey = ""
+
+// BuildSource records where a CI build came from: a GitHub Actions run URL,
+// with the PR number appended when the run was triggered by a pull_request
+// event. Set via -ldflags from the Makefile, which reads it from the
+// GITHUB_* variables GitHub Actions sets in every job. Empty for a local
+// `make` build.
+var BuildSource = ""
+
+// unreleasedVersionPattern matches a DdevVersion that isn't a clean release
+// tag: the `git describe --tags --always --dirty` long form left by commits
+// past a tag (v1.2.3-15-gabcdef1), a dirty working tree (-dirty), or the
+// debug.BuildInfo short-hash fallback used when a build has no embedded git
+// tag info (gabcdef1).
+var unreleasedVersionPattern = regexp.MustCompile(`-\d+-g[0-9a-f]{6,}|-dirty$|^g[0-9a-f]{6,}$`)
+
+// IsUnreleasedDdevVersion returns true if version looks like it was built
+// from an untagged commit (a PR, local branch, or other dev build) rather
+// than an official release.
+func IsUnreleasedDdevVersion(version string) bool {
+	return unreleasedVersionPattern.MatchString(version)
+}
 
 // Image tags are bare content hashes (see containers/hash-paths.sh), so the
 // same image resolves to the same tag no matter which branch or repository

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -17,11 +17,10 @@ var DdevVersion = "" // Note that this is overridden by make
 // Compiled with link-time variables
 var AmplitudeAPIKey = ""
 
-// BuildSource records where a CI build came from: a GitHub Actions run URL,
-// with the PR number appended when the run was triggered by a pull_request
-// event. Set via -ldflags from the Makefile, which reads it from the
-// GITHUB_* variables GitHub Actions sets in every job. Empty for a local
-// `make` build.
+// BuildSource records where a build came from: on GitHub Actions, a run URL
+// with the PR number appended when triggered by a pull_request event;
+// otherwise who ran `make` and from which branch. Set via -ldflags from the
+// Makefile — see scripts/build-source.sh.
 var BuildSource = ""
 
 // unreleasedVersionPattern matches a DdevVersion that isn't a clean release

--- a/pkg/versionconstants/versionconstants_test.go
+++ b/pkg/versionconstants/versionconstants_test.go
@@ -1,0 +1,31 @@
+package versionconstants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsUnreleasedDdevVersion verifies detection of DDEV versions built from
+// an untagged commit, as opposed to a clean release tag.
+func TestIsUnreleasedDdevVersion(t *testing.T) {
+	unreleased := []string{
+		"v1.25.3-111-geadf098e9", // git describe, commits past a tag
+		"v1.25.3-dirty",          // exact tag, but uncommitted changes
+		"v1.25.3-111-geadf098e9-dirty",
+		"geadf098", // debug.BuildInfo short-hash fallback
+		"geadf098-dirty",
+	}
+	for _, v := range unreleased {
+		require.True(t, IsUnreleasedDdevVersion(v), "expected %q to be detected as unreleased", v)
+	}
+
+	released := []string{
+		"v1.25.3",
+		"v1.25.3-beta1",
+		"v0.0.0-overridden-by-make",
+	}
+	for _, v := range released {
+		require.False(t, IsUnreleasedDdevVersion(v), "expected %q to be detected as a release", v)
+	}
+}

--- a/scripts/build-source.sh
+++ b/scripts/build-source.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Prints the GitHub Actions run URL for the current build, with the PR
+# number appended when triggered by a pull_request event. Prints nothing
+# for a local build, where GITHUB_RUN_ID isn't set. Invoked by the Makefile
+# to populate versionconstants.BuildSource via -ldflags.
+
+set -eu -o pipefail
+
+if [ -z "${GITHUB_RUN_ID:-}" ]; then
+  exit 0
+fi
+
+url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && [ -n "${GITHUB_REF_NAME:-}" ]; then
+  pr_number="${GITHUB_REF_NAME%%/*}"
+  echo "${url} (PR #${pr_number})"
+else
+  echo "${url}"
+fi

--- a/scripts/build-source.sh
+++ b/scripts/build-source.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 
-# Prints the GitHub Actions run URL for the current build, with the PR
-# number appended when triggered by a pull_request event. Prints nothing
-# for a local build, where GITHUB_RUN_ID isn't set. Invoked by the Makefile
-# to populate versionconstants.BuildSource via -ldflags.
+# Prints where this build came from, for versionconstants.BuildSource. On
+# GitHub Actions, the run URL (with the PR number appended when triggered by
+# a pull_request event). Otherwise, who built it and from which branch, since
+# there's no CI run to point to. Invoked by the Makefile via -ldflags.
 
 set -eu -o pipefail
 
-if [ -z "${GITHUB_RUN_ID:-}" ]; then
+if [ -n "${GITHUB_RUN_ID:-}" ]; then
+  url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+  if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && [ -n "${GITHUB_REF_NAME:-}" ]; then
+    pr_number="${GITHUB_REF_NAME%%/*}"
+    echo "${url} (PR #${pr_number})"
+  else
+    echo "${url}"
+  fi
   exit 0
 fi
 
-url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-
-if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && [ -n "${GITHUB_REF_NAME:-}" ]; then
-  pr_number="${GITHUB_REF_NAME%%/*}"
-  echo "${url} (PR #${pr_number})"
-else
-  echo "${url}"
-fi
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+user="${USER:-${USERNAME:-unknown}}"
+host=$(hostname 2>/dev/null || echo "unknown")
+echo "local build by ${user}@${host%%.*}, branch ${branch}"


### PR DESCRIPTION
## Short Summary (TL;DR)

DDEV already warns about custom project configuration on start, but says nothing when DDEV itself is an unreleased build, like one from a PR or a local branch. This PR adds that warning, and teaches `ddev version` to show where such a build came from.

## The Issue

- Fixes #8739

We warn about all kinds of custom configuration, but not when someone is running a custom DDEV, like a PR build. That's easy to end up in without noticing, and it can behave differently from a supported release.

## How This PR Solves The Issue

`CheckCustomConfig` (used by `ddev start`, `ddev debug check-custom-config`, and `ddev utility diagnose`) now checks whether the running `DdevVersion` looks like a clean release tag. If it doesn't, a "DDEV version" finding is added alongside the usual custom-configuration warnings, so it shows up the same way a custom config file would.

Separately, `ddev version` now prints a `build-source` line for the same non-release builds, saying where the build came from: the GitHub Actions run URL and PR number for a CI build, or the builder's username, host, and branch for a local `make` build. A new `scripts/build-source.sh` computes that value at build time, and the Makefile passes it in through `-ldflags`. Official release builds don't show this line.

## Manual Testing Instructions

1. Build the binary: `make`
2. Run `ddev version`. Since this repo's HEAD isn't a tagged release, you should see a `build-source` row like `local build by yourname@yourhost, branch 20260825_warn_unsupported_ddev_version`.
3. In any DDEV project, run `ddev start` (or `ddev restart`). The output should include a "Custom configuration detected" warning with a line like `DDEV version: v1.25.3-113-g9e83f78d3-dirty (unsupported, not an official release)`, alongside any other custom configuration already in that project.
4. `ddev debug check-custom-config` shows the same report without starting the project, which is a faster way to check it repeatedly.

## Automated Testing Overview

- `pkg/versionconstants/versionconstants_test.go`: `TestIsUnreleasedDdevVersion` checks the version-string pattern against both release and non-release examples.
- `cmd/ddev/cmd/utility-check-custom-config_test.go`: the "no custom config" case was updated to expect the "DDEV version" finding, since the test binary itself is always an unreleased build in this repo.

## Release/Deployment Notes

None. The warning is informational and only affects output DDEV already prints; behavior is unchanged for an official release build, and the new `build-source` line in `ddev version` is empty for one too.
