### PR TITLE
fix(wordpress): let wp-cli.yml override the docroot, fixes #7881

### DIFF
--- a/.spellcheckwordlist.txt
+++ b/.spellcheckwordlist.txt
@@ -23,6 +23,7 @@ CIDR
 CIFS
 CiviCRM
 CLI
+CLI's
 Cloudflare
 CMD
 CMS
@@ -654,6 +655,7 @@ showmount
 site
 sitepackage
 snapshot
+snapshot's
 snapshotted
 snapshotting
 socio

--- a/docs/content/users/usage/cms-settings.md
+++ b/docs/content/users/usage/cms-settings.md
@@ -158,15 +158,15 @@ See also [TYPO3 Documentation](https://docs.typo3.org/m/typo3/reference-coreapi/
 
 #### WP-CLI and changing the docroot in config.yaml
 
-!!!note "DDEV v1.24.5+ automatically adds `--path=$DDEV_DOCROOT` to the `ddev wp` command if needed."
+[`ddev wp`](../usage/commands.md#wp) defaults WP-CLI's `path` to your project's docroot, so WP-CLI still finds WordPress when the docroot is something other than the project root (`''`).
 
-If you use something other than the root directory (`''`) for your docroot, [`ddev wp`](../usage/commands.md#wp) will not work properly. To fix this, create a `wp-cli.yml` file in the project root directory that contains `path: <docroot/path>`.
-
-For example, if your docroot is `public`, your `wp-cli.yml` file should contain:
+If WordPress does not live at the docroot, override that default with a `wp-cli.yml` file in the project root directory. [Bedrock](https://roots.io/bedrock/), for example, serves from `web` but keeps WordPress in `web/wp`, so its `wp-cli.yml` contains:
 
 ```yaml
-path: public
+path: web/wp
 ```
+
+A `--path` flag, an [alias](https://make.wordpress.org/cli/handbook/references/config/#config-files), and `wp-cli.local.yml` all take precedence over the DDEV default in the same way.
 
 #### WordPress Environment Type
 

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -91,6 +91,20 @@ teardown() {
   assert_output --partial "location: ${PRIMARY_URL}/wp-login.php"
   assert_output --partial "HTTP/2 302"
   assert_success
+
+  # with no wp-cli.yml, WP-CLI gets the docroot, and "./web/wp" is normalized
+  assert_file_not_exist wp-cli.yml
+
+  run ddev wp eval 'echo ABSPATH;'
+  assert_output "/var/www/html/web/wp/"
+  assert_success
+
+  # a wp-cli.yml overrides the docroot, so WP-CLI reports the path it names
+  printf 'path: nonexistent\n' > wp-cli.yml
+  assert_file_exist wp-cli.yml
+
+  run ddev wp eval 'echo ABSPATH;'
+  assert_output --partial "The used path is: /var/www/html/nonexistent/"
 }
 
 @test "WordPress wp-cli based quickstart (subdirectory URL change) with $(ddev --version)" {

--- a/docs/tests/wp-bedrock.bats
+++ b/docs/tests/wp-bedrock.bats
@@ -56,4 +56,26 @@ teardown() {
   assert_output --partial "Dashboard"
   assert_success
   rm -f "${COOKIE_JAR}"
+
+  # Bedrock serves from web but keeps WordPress in web/wp, so its own wp-cli.yml
+  # has to win over the docroot DDEV hands to WP-CLI
+  assert_file_exist wp-cli.yml
+  assert_file_contains wp-cli.yml "^path: web/wp$"
+
+  run ddev wp eval 'echo ABSPATH;'
+  assert_output "/var/www/html/web/wp/"
+  assert_success
+
+  # an alias makes wp-cli.yml unparseable as strict YAML, which must not knock
+  # WP-CLI back to the docroot
+  cat >> wp-cli.yml <<'END'
+
+@preprod:
+  ssh: user@example.com:/var/www/preprod
+  path: /var/www/preprod/web/wp
+END
+
+  run ddev wp eval 'echo ABSPATH;'
+  assert_output "/var/www/html/web/wp/"
+  assert_success
 }

--- a/pkg/ddevapp/global_dotddev_assets/commands/web/wp
+++ b/pkg/ddevapp/global_dotddev_assets/commands/web/wp
@@ -7,12 +7,13 @@
 ## ExecRaw: true
 ## MutagenSync: true
 
-# Add --path if not already set and $DDEV_DOCROOT is defined
-if [[ ! " $* " =~ (--path(=|\s)) ]] && [[ -n "$DDEV_DOCROOT" ]]; then
-  # Get the configured path from wp-cli.yml or other config file
-  existing_wp_path="$(yq -r '.path // ""' "$(wp cli info --format=json 2>/dev/null | jq -r '.project_config_path // empty' 2>/dev/null)" 2>/dev/null)"
-  # If there is no path, set it to $DDEV_DOCROOT
-  [[ -z "$existing_wp_path" ]] && set -- "$@" --path="$DDEV_DOCROOT"
+# Give WP-CLI the docroot as its lowest-priority config source, so --path, an
+# @alias, wp-cli.local.yml, or wp-cli.yml still wins. An existing global config
+# is left alone.
+if [[ -n "${DDEV_DOCROOT}" ]] && [[ -z "${WP_CLI_CONFIG_PATH}" ]] && [[ ! -f "${HOME}/.wp-cli/config.yml" ]]; then
+  export WP_CLI_CONFIG_PATH="/tmp/ddev-wp-cli-config.yml"
+  # realpath keeps a "./web" docroot from leaving "/./" in ABSPATH
+  printf 'path: %s\n' "$(realpath "${DDEV_APPROOT}/${DDEV_DOCROOT}")" >"${WP_CLI_CONFIG_PATH}"
 fi
 
 wp "$@"


### PR DESCRIPTION
## Short Summary (TL;DR)

`ddev wp` forced WP-CLI to use the project's docroot and ignored the project's own `wp-cli.yml`, which broke Bedrock and any layout where WordPress does not live at the docroot. The docroot is now a fallback that the project's config overrides, as the docs have always claimed.

## The Issue

- Fixes #7881

Since v1.24.5 the `wp` command appended `--path=$DDEV_DOCROOT` unless it could prove the user had already configured a path, and it proved that by re-implementing WP-CLI's config lookup with `wp cli info` piped through `jq` and `yq`. That pipeline fails in two ways, and on failure the flag wins over every other config source:

- `yq` rejects a `wp-cli.yml` containing an `@alias:` key, because `@` cannot start a plain YAML scalar. WP-CLI's own parser accepts it.
- PHP notices land on stdout ahead of the JSON, so `jq` cannot parse it. WP-CLI 2.12 emits a `Deprecated:` from bundled `react/promise` under PHP 8.5; 8.2 through 8.4 are clean.

## How This PR Solves The Issue

Rather than detect what the user configured, hand the docroot to WP-CLI through `WP_CLI_CONFIG_PATH` as its global config. WP-CLI ranks that below `--path`, an `@alias`, `wp-cli.local.yml`, and `wp-cli.yml`, so the docroot only applies when nothing else sets a path, and WP-CLI does all the parsing with its own YAML parser. An existing `WP_CLI_CONFIG_PATH` or `~/.wp-cli/config.yml` is left alone.

Dropping the two subprocesses also takes about 0.27s off every `ddev wp` invocation.

## Manual Testing Instructions

https://ddev--8745.org.readthedocs.build/en/8745/users/usage/cms-settings/#wp-cli-and-changing-the-docroot-in-configyaml

```bash
mkdir -p ~/tmp/bedrock && cd ~/tmp/bedrock
ddev config --project-type=wp-bedrock && ddev start -y
ddev composer create-project roots/bedrock
ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My Bedrock Site' \
  --admin_user=admin --admin_password=admin --admin_email=admin@example.com

ddev wp eval 'echo ABSPATH;'

cat >> wp-cli.yml <<'END'

@preprod:
  ssh: user@example.com:/var/www/preprod
  path: /var/www/preprod/web/wp
END

ddev wp eval 'echo ABSPATH;'
```

`ddev wp eval 'echo ABSPATH;'` should print `/var/www/html/web/wp/`, not `/var/www/html/web/`. It should still do so after appending an alias block to `wp-cli.yml`, and under `ddev config --php-version=8.5`.

## Automated Testing Overview

`wp-bedrock.bats` asserts that Bedrock's `wp-cli.yml` wins over the docroot, both on its own and with an alias appended. `wordpress.bats` covers the other direction: the docroot applies when no `wp-cli.yml` exists, and stops applying once one names a different path. Restoring the old script fails the Bedrock assertions with the error from the issue.

## Release/Deployment Notes

`ddev wp` no longer adds `--path` to the command line. Anyone who worked around this by passing their own `--path` can drop it, and `ddev wp` and `ddev exec wp` no longer disagree about where WordPress is.