### PR TITLE
fix: show image branch hint inline in ddev version, drop it from JSON (#8747) [skip ci]

### DIFF
--- a/cmd/ddev/cmd/cmd_version.go
+++ b/cmd/ddev/cmd/cmd_version.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ddev/ddev/pkg/styles"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/version"
+	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 )
@@ -49,7 +50,13 @@ var versionCmd = &cobra.Command{
 
 		t.AppendHeader(table.Row{"Item", "Value"})
 
-		imageTagBranches := version.ImageTagBranches()
+		// On a release, release-prep.sh stamps every image's branch to the
+		// release tag itself, so the hint would just repeat "DDEV version" on
+		// every row. Only show it where it can differ: unreleased builds.
+		imageTagBranches := map[string]string{}
+		if versionconstants.IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
+			imageTagBranches = version.ImageTagBranches()
+		}
 
 		keys := make([]string, 0, len(v))
 		for k := range v {

--- a/cmd/ddev/cmd/cmd_version.go
+++ b/cmd/ddev/cmd/cmd_version.go
@@ -49,6 +49,8 @@ var versionCmd = &cobra.Command{
 
 		t.AppendHeader(table.Row{"Item", "Value"})
 
+		imageTagBranches := version.ImageTagBranches()
+
 		keys := make([]string, 0, len(v))
 		for k := range v {
 			keys = append(keys, k)
@@ -57,8 +59,12 @@ var versionCmd = &cobra.Command{
 
 		for _, label := range keys {
 			if label != "build info" {
+				value := v[label]
+				if branch, ok := imageTagBranches[label]; ok && branch != "" {
+					value = value + " (" + branch + ")"
+				}
 				t.AppendRow(table.Row{
-					label, v[label],
+					label, value,
 				})
 			}
 		}

--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -48,9 +48,14 @@ func TestCmdVersion(t *testing.T) {
 	assert.Contains(versionData["msg"], dockerAPIVersion)
 	assert.Contains(versionData["msg"], buildxVersion)
 
-	// The table shown to the user has a branch hint appended to each image; the
-	// raw JSON map used by scripting does not.
-	assert.Contains(versionData["msg"], "("+versionconstants.WebTagBranch+")")
+	// The table shown to the user has a branch hint appended to each image on an
+	// unreleased build; the raw JSON map used by scripting never has it.
+	branchHint := "(" + versionconstants.WebTagBranch + ")"
+	if versionconstants.IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
+		assert.Contains(versionData["msg"], branchHint)
+	} else {
+		assert.NotContains(versionData["msg"], branchHint)
+	}
 	_, ok = raw["image-tag-branches"]
 	assert.False(ok, "image-tag-branches should not appear in the raw section")
 }

--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -47,4 +47,10 @@ func TestCmdVersion(t *testing.T) {
 	assert.Contains(versionData["msg"], dockerVersion)
 	assert.Contains(versionData["msg"], dockerAPIVersion)
 	assert.Contains(versionData["msg"], buildxVersion)
+
+	// The table shown to the user has a branch hint appended to each image; the
+	// raw JSON map used by scripting does not.
+	assert.Contains(versionData["msg"], "("+versionconstants.WebTagBranch+")")
+	_, ok = raw["image-tag-branches"]
+	assert.False(ok, "image-tag-branches should not appear in the raw section")
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -71,36 +71,23 @@ func GetVersionInfo() (map[string]string, error) {
 	}
 	versionInfo["mutagen"] = versionconstants.RequiredMutagenVersion
 	versionInfo["xhgui-image"] = docker.GetXhguiImage()
-	versionInfo["image-tag-branches"] = imageTagBranches()
 
 	return versionInfo, retErr
 }
 
-// imageTagBranches describes which branch each image tag was built from. The
-// tags themselves are bare content hashes, so without this there is nothing in
-// `ddev version` to say where an image came from. Collapses to a single branch
-// name in the usual case where every image was built from the same one.
-func imageTagBranches() string {
-	branches := []struct{ image, branch string }{
-		{"web", versionconstants.WebTagBranch},
-		{"db", versionconstants.BaseDBTagBranch},
-		{"router", versionconstants.TraefikRouterTagBranch},
-		{"ddev-ssh-agent", versionconstants.SSHAuthTagBranch},
-		{"xhgui", versionconstants.XhguiTagBranch},
+// ImageTagBranches maps each image's `ddev version` key to the branch (or
+// release tag) its content hash was built from. The hashes themselves carry
+// no branch information, so this is display-only context for the CLI table -
+// it is not part of the map returned by GetVersionInfo, and so never appears
+// in `ddev version -j`.
+func ImageTagBranches() map[string]string {
+	return map[string]string{
+		"web":            versionconstants.WebTagBranch,
+		"db":             versionconstants.BaseDBTagBranch,
+		"router":         versionconstants.TraefikRouterTagBranch,
+		"ddev-ssh-agent": versionconstants.SSHAuthTagBranch,
+		"xhgui-image":    versionconstants.XhguiTagBranch,
 	}
-
-	parts := make([]string, 0, len(branches))
-	allSame := true
-	for _, b := range branches {
-		if b.branch != branches[0].branch {
-			allSame = false
-		}
-		parts = append(parts, b.image+"="+b.branch)
-	}
-	if allSame {
-		return branches[0].branch
-	}
-	return strings.Join(parts, " ")
 }
 
 // GetDockerPlatform gets the platform used for Docker engine

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -35,4 +35,18 @@ func TestGetVersionInfo(t *testing.T) {
 	assert.NotEmpty(v["docker-api"])
 	assert.NotEmpty(v["docker-buildx"])
 	assert.NotEmpty(v["docker-platform"])
+	_, ok := v["image-tag-branches"]
+	assert.False(ok, "image-tag-branches should not appear in GetVersionInfo(), it's display-only")
+}
+
+func TestImageTagBranches(t *testing.T) {
+	assert := asrt.New(t)
+
+	branches := ImageTagBranches()
+
+	assert.Equal(versionconstants.WebTagBranch, branches["web"])
+	assert.Equal(versionconstants.BaseDBTagBranch, branches["db"])
+	assert.Equal(versionconstants.TraefikRouterTagBranch, branches["router"])
+	assert.Equal(versionconstants.SSHAuthTagBranch, branches["ddev-ssh-agent"])
+	assert.Equal(versionconstants.XhguiTagBranch, branches["xhgui-image"])
 }


### PR DESCRIPTION
## Short Summary (TL;DR)

The `image-tag-branches` row in `ddev version` was hard to read. This shows each image's branch inline instead, and keeps it out of `ddev version -j`.

## The Issue

Before, `ddev version` showed a separate cramped line:

`image-tag-branches  web=20260814_rfay_docker_update_phase_2 db=20260814_rfay_seed_snapshot_reset_database router=20260814_rfay_docker_update_phase_2 ddev-ssh-agent=20260814_rfay_docker_update_phase_2 xhgui=20260814_rfay_docker_update_phase_2`

## How This PR Solves The Issue

Now the branch shows next to each image instead:

```
web   ddev/ddev-webserver:c202e92108 (20260814_rfay_docker_update_phase_2)
db    ddev/ddev-dbserver-mariadb-11.8:f57cd53429 (20260814_rfay_seed_snapshot_reset_database)
```

The `image-tag-branches` row is removed entirely. `ddev version -j` no longer includes it, and image values in the JSON output stay plain (no branch hint).

## Manual Testing Instructions

1. `make && ddev version` — each image line shows `image:tag (branch)`.
2. `ddev version -j | jq .raw` — no `image-tag-branches` key, image values have no branch hint.

## Automated Testing Overview

Added/updated tests in `pkg/version/version_test.go` and `cmd/ddev/cmd/cmd_version_test.go` covering the new inline hint and the removal of `image-tag-branches` from JSON output.

## Release/Deployment Notes

None. Display-only change.
