### PR TITLE
fix: reject path traversal in docroot, upload_dirs, and dotenv path validation

### DIFF
--- a/cmd/ddev/cmd/config_test.go
+++ b/cmd/ddev/cmd/config_test.go
@@ -421,7 +421,7 @@ func TestConfigCreateDocroot(t *testing.T) {
 	}{
 		{"empty docroot", "", "", ""},
 		{"dot docroot", ".", ".", ""},
-		{"fail for outside approot", "../somewhere-else", "", "must remain inside the project"},
+		{"fail for outside approot", "../somewhere-else", "", "must be a relative path that stays inside the project root"},
 		{"fail for absolute path", "//test", "", "cannot be an absolute path"},
 		{"dot with slash docroot", "./", "./", ""},
 		{"dot with slash and dir docroot", "./test", "./test", ""},

--- a/cmd/ddev/cmd/dotenv-get.go
+++ b/cmd/ddev/cmd/dotenv-get.go
@@ -31,16 +31,17 @@ ddev dotenv get .ddev/.env.redis --redis-tag`,
 			util.Failed(err.Error())
 		}
 
-		// Get the .env file from the approot
-		envFile := filepath.Join(app.GetAbsAppRoot(false), args[0])
+		// Get the .env file from the approot, whether args[0] is relative or absolute
+		appRoot := app.GetAbsAppRoot(false)
+		envFile := args[0]
+		if !filepath.IsAbs(envFile) {
+			envFile = filepath.Join(appRoot, envFile)
+		}
 
-		// Validate absolute paths
-		if filepath.IsAbs(args[0]) {
-			envFile = args[0]
-			relPath, err := filepath.Rel(app.GetAbsAppRoot(false), envFile)
-			if err != nil || strings.HasPrefix(relPath, "..") {
-				util.Failed("The provided path %s is outside the project root %s", envFile, app.GetAbsAppRoot(false))
-			}
+		// The file must stay within the project root
+		relPath, err := filepath.Rel(appRoot, envFile)
+		if err != nil || !filepath.IsLocal(relPath) {
+			util.Failed("The provided path %s is outside the project root %s", envFile, appRoot)
 		}
 
 		baseName := filepath.Base(envFile)

--- a/cmd/ddev/cmd/dotenv-set.go
+++ b/cmd/ddev/cmd/dotenv-set.go
@@ -37,15 +37,17 @@ ddev dotenv set .ddev/.env.redis --redis-tag 7-bookworm`,
 		if err != nil {
 			util.Failed(err.Error())
 		}
-		// Get the .env file from the approot
-		envFile := filepath.Join(app.GetAbsAppRoot(false), args[0])
-		// If this is an absolute path, make sure it's inside the approot
-		if filepath.IsAbs(args[0]) {
-			envFile = args[0]
-			relPath, err := filepath.Rel(app.GetAbsAppRoot(false), envFile)
-			if err != nil || strings.HasPrefix(relPath, "..") {
-				util.Failed("The provided path %s is outside the project root %s", envFile, app.GetAbsAppRoot(false))
-			}
+		// Get the .env file from the approot, whether args[0] is relative or absolute
+		appRoot := app.GetAbsAppRoot(false)
+		envFile := args[0]
+		if !filepath.IsAbs(envFile) {
+			envFile = filepath.Join(appRoot, envFile)
+		}
+
+		// The file must stay within the project root
+		relPath, err := filepath.Rel(appRoot, envFile)
+		if err != nil || !filepath.IsLocal(relPath) {
+			util.Failed("The provided path %s is outside the project root %s", envFile, appRoot)
 		}
 		baseName := filepath.Base(envFile)
 		if baseName != ".env" && !strings.HasPrefix(baseName, ".env.") {

--- a/cmd/ddev/cmd/dotenv_test.go
+++ b/cmd/ddev/cmd/dotenv_test.go
@@ -43,6 +43,15 @@ func TestCmdDotEnvGetAndSet(t *testing.T) {
 	require.Error(t, err, "out=%s", out)
 	require.Contains(t, out, "outside the project root")
 
+	// A relative path that traverses outside the project root must be rejected too
+	out, err = exec.RunHostCommand(DdevBin, "dotenv", "get", "../outside.env")
+	require.Error(t, err, "out=%s", out)
+	require.Contains(t, out, "outside the project root")
+	out, err = exec.RunHostCommand(DdevBin, "dotenv", "set", "../outside.env", "--test-value", "custom value")
+	require.Error(t, err, "out=%s", out)
+	require.Contains(t, out, "outside the project root")
+	require.NoFileExists(t, filepath.Join(testDir, "..", "outside.env"))
+
 	// Success while using full path to the .env file
 	envFile := filepath.Join(testDir, ".env")
 	out, err = exec.RunHostCommand(DdevBin, "dotenv", "set", envFile, "--test-value", "custom value")

--- a/pkg/ddevapp/config.go
+++ b/pkg/ddevapp/config.go
@@ -641,8 +641,8 @@ func ValidateDocroot(docroot string) error {
 	switch {
 	case filepath.IsAbs(docroot):
 		return fmt.Errorf("docroot ('%s') cannot be an absolute path, it must be a relative path from the project root", docroot)
-	case strings.HasPrefix(docroot, ".."):
-		return fmt.Errorf("docroot ('%s') cannot begin with '..', it should be a relative path from project root but must remain inside the project", docroot)
+	case docroot != "" && !filepath.IsLocal(docroot):
+		return fmt.Errorf("docroot ('%s') must be a relative path that stays inside the project root", docroot)
 	}
 	return nil
 }

--- a/pkg/ddevapp/config_test.go
+++ b/pkg/ddevapp/config_test.go
@@ -36,6 +36,21 @@ func isSemver(s string) bool {
 	return err == nil
 }
 
+// TestValidateDocroot verifies that ValidateDocroot rejects paths that escape the project root.
+func TestValidateDocroot(t *testing.T) {
+	assert := asrt.New(t)
+
+	valid := []string{"", ".", "docroot", "web", "public/web", "web/../public"}
+	for _, docroot := range valid {
+		assert.NoError(ddevapp.ValidateDocroot(docroot), "expected docroot %q to be valid", docroot)
+	}
+
+	invalid := []string{"..", "../foo", "web/../..", "web/../../etc", string(filepath.Separator) + "etc/passwd"}
+	for _, docroot := range invalid {
+		assert.Error(ddevapp.ValidateDocroot(docroot), "expected docroot %q to be rejected", docroot)
+	}
+}
+
 // TestLoadConfigYamlFile verifies that LoadConfigYamlFile correctly loads config and overrides.
 func TestLoadConfigYamlFile(t *testing.T) {
 	assert := asrt.New(t)

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -3109,6 +3109,32 @@ func TestDdevImportFilesCustomUploadDir(t *testing.T) {
 	}
 }
 
+// TestValidateUploadDirs verifies that an upload_dir escaping AppRoot is rejected,
+// while one that climbs out of the docroot but stays within AppRoot remains valid.
+func TestValidateUploadDirs(t *testing.T) {
+	assert := asrt.New(t)
+
+	testDir := testcommon.CreateTmpDir(t.Name())
+	t.Cleanup(func() {
+		_ = os.RemoveAll(testDir)
+	})
+
+	err := os.MkdirAll(filepath.Join(testDir, "web"), 0755)
+	require.NoError(t, err)
+
+	app, err := ddevapp.NewApp(testDir, false)
+	require.NoError(t, err)
+	app.Docroot = "web"
+
+	// A sibling of the docroot, still inside AppRoot, must remain valid.
+	app.UploadDirs = []string{"../private"}
+	assert.Equal([]string{"../private"}, app.GetUploadDirs())
+
+	// Anything that resolves outside AppRoot must be rejected.
+	app.UploadDirs = []string{"../../outside"}
+	assert.Empty(app.GetUploadDirs())
+}
+
 // TestUploadDirs tests the functionality of multiple upload directories
 // Requires a project where the docroot is in a subdirectory, as Drupal's 'web' directory.
 // It checks the DDEV_FILES_DIRS and DDEV_FILES_DIR environment variables

--- a/pkg/ddevapp/upload_dirs.go
+++ b/pkg/ddevapp/upload_dirs.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
-	"strings"
 
 	"github.com/ddev/ddev/pkg/fileutil"
 	"github.com/ddev/ddev/pkg/util"
@@ -195,9 +194,13 @@ func (app *DdevApp) CreateUploadDirsIfNecessary() {
 // - slice of string (possibly empty)
 // - boolean false
 func (app *DdevApp) validateUploadDirs() error {
-	// Check that upload dirs aren't outside the project root.
+	// Check that upload dirs aren't outside the project root. uploadDir is relative
+	// to the docroot, so it's allowed to climb back out of the docroot (e.g. "../private")
+	// as long as the result stays within AppRoot.
 	for _, uploadDir := range app.UploadDirs {
-		if !strings.HasPrefix(app.calculateHostUploadDirFullPath(uploadDir), app.AppRoot) {
+		fullPath := app.calculateHostUploadDirFullPath(uploadDir)
+		relPath, err := filepath.Rel(app.AppRoot, fullPath)
+		if err != nil || !filepath.IsLocal(relPath) {
 			return fmt.Errorf("invalid upload dir `%s` outside of project root `%s` found", uploadDir, app.AppRoot)
 		}
 	}


### PR DESCRIPTION
## Short Summary (TL;DR)

Some path checks in DDEV only looked for a leading `..` or an absolute path, which is not enough to stop a path from escaping the project folder. This PR switches those checks to use Go's [`filepath.IsLocal`](https://pkg.go.dev/path/filepath#IsLocal), which properly confirms a path stays inside its starting directory.

## The Issue

No linked issue. Found while auditing the codebase for places that used a `.`/`..` prefix check as a stand-in for "this path is safe," instead of actually confirming the path can't escape.

Three spots had this problem:

- `docroot` in `.ddev/config.yaml` only had to avoid *starting* with `..`. A value like `web/../../etc` was not caught, and DDEV would read and write files at that escaped location.
- `upload_dirs` in `.ddev/config.yaml` was checked with a plain string prefix against the project root, so a sibling folder that happens to share the same prefix (like `/home/user/proj` vs `/home/user/projX`) could pass the check.
- `ddev dotenv get` / `ddev dotenv set` only checked for escaping paths when given an absolute path. A relative path like `../outside.env` skipped the check completely, so `ddev dotenv set ../outside.env --key value` could write a file outside the project.

## How This PR Solves The Issue

Each spot now resolves the path and confirms it stays inside the right base directory, using `filepath.IsLocal` (or `filepath.Rel` + `filepath.IsLocal` where the path first needs to be made relative to a base). `upload_dirs` is still allowed to climb one level out of the docroot into a sibling folder, as long as it stays inside the project root overall — that's an existing supported use case, not something this PR changes.

The ZipSlip protection in `pkg/archive/archive.go` (used for extracting tar/zip archives) was reviewed too, since it has needed fixes before. It already does this kind of check correctly and didn't need changes.

## Manual Testing Instructions

```bash
make
mkdir ~/tmp/test-project && cd ~/tmp/test-project
.gotmp/bin/<platform>/ddev config --project-type=php --docroot="web/../../etc"
# should fail with an error about the docroot escaping the project root

.gotmp/bin/<platform>/ddev dotenv set ../outside.env --test-value=hi
# should fail with "outside the project root" instead of writing the file
```

## Automated Testing Overview

- `TestValidateDocroot` (new) — checks valid and traversal-attempt docroot values.
- `TestValidateUploadDirs` (new) — checks that an `upload_dirs` entry outside the project root is rejected, while one that climbs out of the docroot but stays inside the project root is still allowed.
- `TestCmdDotEnvGetAndSet` (updated) — adds a case for a relative traversal path (`../outside.env`), matching the existing absolute-path case.

## Release/Deployment Notes

No config format changes. This only tightens validation, so the only behavior change is that a docroot, upload_dirs entry, or dotenv path that was escaping the project root before now gets a clear error instead of silently reading or writing outside the project.
