### PR TITLE
feat(docker): resolve released image tags to vX.Y.Z instead of content hash, fixes #8751 (#8754) [skip ci]

### DIFF
--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -68,6 +68,7 @@ The following “Repository secret” environment variables must be configured i
 
 * Create and execute a test plan.
 * Run `make release-prep TAG=vX.Y.Z` and open a pull request with the result, so every image is rebuilt, pushed and tested under the release. See [Preparing the image tags](#preparing-the-image-tags-make-release-prep) below.
+* Merge that pull request into `main` before creating the release. `pkg/versionconstants/versionconstants.go`'s image tags are plain source constants, not `-ldflags`, so a release tagged before the merge builds a binary that still names the pre-release image tags, even though the registry already has `vX.Y.Z` images under the new ones.
 
 ### Preparing the image tags: `make release-prep`
 
@@ -86,9 +87,10 @@ The trailing `// <branch>-<hash>` comment on each tag keeps naming the branch ra
 
 ### Actual Release Creation
 
-1. Create a [release](https://github.com/ddev/ddev/releases) for the new version using the GitHub UI. It should be “prerelease” if it’s an edge release.
-2. Make sure you're about to create the right release tag.
-3. Use the “Auto-generate release notes” option to get the commit list, then edit to add all the other necessary info.
+1. Confirm the `release-prep` pull request above is merged to `main` — the release tag has to be cut from a commit that already has the new tags in `versionconstants.go`, not from a `main` that still points at the previous release's images.
+2. Create a [release](https://github.com/ddev/ddev/releases) for the new version using the GitHub UI. It should be “prerelease” if it’s an edge release.
+3. Make sure you're about to create the right release tag.
+4. Use the “Auto-generate release notes” option to get the commit list, then edit to add all the other necessary info.
 
 ## Automatic Image Build and Push
 

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -68,7 +68,7 @@ The following “Repository secret” environment variables must be configured i
 
 * Create and execute a test plan.
 * Run `make release-prep TAG=vX.Y.Z` and open a pull request with the result, so every image is rebuilt, pushed and tested under the release. See [Preparing the image tags](#preparing-the-image-tags-make-release-prep) below.
-* Merge that pull request into `main` before creating the release. `pkg/versionconstants/versionconstants.go`'s image tags are plain source constants, not `-ldflags`, so a release tagged before the merge builds a binary that still names the pre-release image tags, even though the registry already has `vX.Y.Z` images under the new ones.
+* Merge that pull request into `main` before creating the release. `pkg/versionconstants/versionconstants.go`'s image tags are plain source constants, not `-ldflags`, so a release tagged before the merge builds a binary that still names the prerelease image tags, even though the registry already has `vX.Y.Z` images under the new ones.
 
 ### Preparing the image tags: `make release-prep`
 

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -13,13 +14,28 @@ import (
 // which of its image generations a pinned webimage/dbimage came from.
 const DdevImageTagLabel = "com.ddev.image-tag"
 
+// releaseTagPattern matches a vX.Y.Z release tag.
+var releaseTagPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+
+// resolveImageTag prefers branch over tag when branch is a vX.Y.Z release
+// tag. release-prep.sh stamps <TagVar>Branch with the release tag while
+// leaving <TagVar> as the content hash autotag.sh relies on, but both
+// resolve to the identical manifest, so a released binary can pull by the
+// readable tag.
+func resolveImageTag(tag, branch string) string {
+	if releaseTagPattern.MatchString(branch) {
+		return branch
+	}
+	return tag
+}
+
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {
 	fullWebImg := versionconstants.WebImg
 	if globalconfig.DdevGlobalConfig.UseHardenedImages {
 		fullWebImg = fullWebImg + "-prod"
 	}
-	return fmt.Sprintf("%s:%s", fullWebImg, versionconstants.WebTag)
+	return fmt.Sprintf("%s:%s", fullWebImg, resolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch))
 }
 
 // GetDBImage returns the correctly formatted db image:tag reference
@@ -39,21 +55,21 @@ func GetDBImage(dbType string, dbVersion string) string {
 	case nodeps.MariaDB:
 		fallthrough
 	default:
-		return fmt.Sprintf("%s-%s-%s:%s", versionconstants.DBImg, dbType, v, versionconstants.BaseDBTag)
+		return fmt.Sprintf("%s-%s-%s:%s", versionconstants.DBImg, dbType, v, resolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch))
 	}
 }
 
 // GetSSHAuthImage returns the correctly formatted sshauth image:tag reference
 func GetSSHAuthImage() string {
-	return fmt.Sprintf("%s:%s", versionconstants.SSHAuthImage, versionconstants.SSHAuthTag)
+	return fmt.Sprintf("%s:%s", versionconstants.SSHAuthImage, resolveImageTag(versionconstants.SSHAuthTag, versionconstants.SSHAuthTagBranch))
 }
 
 // GetRouterImage returns the router image:tag reference
 func GetRouterImage() string {
-	return fmt.Sprintf("%s:%s", versionconstants.TraefikRouterImage, versionconstants.TraefikRouterTag)
+	return fmt.Sprintf("%s:%s", versionconstants.TraefikRouterImage, resolveImageTag(versionconstants.TraefikRouterTag, versionconstants.TraefikRouterTagBranch))
 }
 
 // GetXhguiImage returns the xhgui image:tag reference
 func GetXhguiImage() string {
-	return fmt.Sprintf("%s:%s", versionconstants.XhguiImage, versionconstants.XhguiTag)
+	return fmt.Sprintf("%s:%s", versionconstants.XhguiImage, resolveImageTag(versionconstants.XhguiTag, versionconstants.XhguiTagBranch))
 }

--- a/pkg/docker/images_test.go
+++ b/pkg/docker/images_test.go
@@ -1,0 +1,14 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveImageTag(t *testing.T) {
+	require.Equal(t, "v1.25.4", resolveImageTag("c202e92108", "v1.25.4"))
+	require.Equal(t, "c202e92108", resolveImageTag("c202e92108", "20260814_rfay_docker_update_phase_2"))
+	require.Equal(t, "c202e92108", resolveImageTag("c202e92108", ""))
+	require.Equal(t, "abc123", resolveImageTag("abc123", "v1.25.4-15-gabcdef1"))
+}


### PR DESCRIPTION
## Short Summary (TL;DR)

Resolves released images to their `vX.Y.Z` tag instead of the bare content hash, and fixes the release-management docs to require merging the `release-prep` PR before cutting the release tag.

## The Issue

- Fixes #8751

`versionconstants.go` stores each image's content hash in `<TagVar>` and stamps the branch it was built from into `<TagVar>Branch`. `make release-prep` correctly writes the release tag into `<TagVar>Branch` and publishes both the hash and the `vX.Y.Z` alias, but `pkg/docker/images.go` only ever read `<TagVar>`, so a released `ddev` binary still pulled every image by hash rather than by the readable release tag sitting right next to it in the registry. Separately, the release-management doc's "Creating a Release" section called the process "completely automated" directly above a step list whose first real step is the manual `release-prep` PR, and never said that PR must be merged before the release tag is cut.

## How This PR Solves The Issue

Adds `resolveImageTag(tag, branch)` in `pkg/docker/images.go`: it returns `branch` when `branch` matches `vX.Y.Z`, otherwise the original `tag`. Wires it into `GetWebImage`, `GetDBImage`, `GetSSHAuthImage`, `GetRouterImage`, and `GetXhguiImage`. The `<TagVar>` hash itself is untouched, so `autotag.sh` and the rest of the hash-comparison tooling keep working exactly as before — this only changes which of the two already-published tags `ddev` chooses to pull by. Labels and version-mismatch checks that compare against an image's baked-in `com.ddev.image-tag` (set to the hash at build time) intentionally keep using the raw hash, not the resolved tag.

Also updates `docs/content/developers/release-management.md` to state that the `release-prep` PR must be merged into `main` before creating the release, since `versionconstants.go`'s image tags are plain source constants rather than `-ldflags`.

## Manual Testing Instructions

Run `go test -v -run TestResolveImageTag ./pkg/docker/` — covers the release-tag, branch-name, empty, and dirty-tag (`v1.25.4-15-gabcdef1`) cases. Confirmed locally that overriding `<TagVar>Branch` to a `vX.Y.Z` value switches all five `Get*Image()` outputs from the hash tag to that value, while leaving `<TagVar>` unchanged.

Full end-to-end verification (image push, `ddev version` display, actual pull) needs a real release rehearsal on `ddev-test/ddev`; see #8753 for the follow-up needed to make that possible without publishing test tags under the real `ddev` Docker Hub org.

## Automated Testing Overview

Added `pkg/docker/images_test.go` covering `resolveImageTag`. `make`, `go test ./pkg/docker/`, and `make staticrequired` all pass.

## Release/Deployment Notes

None. A non-release build (where `<TagVar>Branch` is a branch name, not `vX.Y.Z`) resolves to the hash exactly as before.
