### PR TITLE
fix: perf dashboard legs checkbox shows "undefined" (#8755) [skip ci]

### DIFF
--- a/perf/collector/ci-dashboard.html
+++ b/perf/collector/ci-dashboard.html
@@ -96,6 +96,9 @@
     // split -- runner_name there is a one-shot ephemeral VM id, not a
     // persistent machine, so splitting by it wouldn't mean anything.
     legKey: (row) => (row.source === 'buildkite' ? `${row.workflow} · ${primaryRunnerName(row) || 'unknown runner'}` : row.workflow),
+    // The "Test type" checkbox facet -- coarser than legKey, which further
+    // splits Buildkite rows by runner machine.
+    workflowKey: (row) => row.workflow,
     // The runner-machine facet the "Runner machine" checkbox box filters
     // on. null for GitHub Actions rows, which the row-selection filter
     // treats as "included only while the runner box isn't actually

--- a/perf/collector/dashboard-common.js
+++ b/perf/collector/dashboard-common.js
@@ -51,7 +51,7 @@ function initDashboard(config) {
   // facet (config.runnerOf returns null) is included only while the runner
   // box isn't actually narrowing anything -- see runnerSelectionNarrowed().
   function rowSelected(row) {
-    if (!state.enabledWorkflows.has(row.workflow)) return false;
+    if (!state.enabledWorkflows.has(config.workflowKey(row))) return false;
     const runner = config.runnerOf(row);
     if (runner !== null) return state.enabledRunners.has(runner);
     return !runnerSelectionNarrowed();
@@ -161,7 +161,7 @@ function initDashboard(config) {
     const workflowSet = new Set();
     const runnerSet = new Set();
     for (const row of state.rows) {
-      workflowSet.add(row.workflow);
+      workflowSet.add(config.workflowKey(row));
       const runner = config.runnerOf(row);
       if (runner !== null) runnerSet.add(runner);
     }

--- a/perf/collector/perf-dashboard.html
+++ b/perf/collector/perf-dashboard.html
@@ -66,7 +66,10 @@
     file: 'history.ndjson',
     subText: 'Nightly benchmark results across platforms and Docker providers. See <a href="https://github.com/ddev/ddev/tree/main/perf">perf/README.md</a> for what each metric measures. Points more than 20% above the trailing 10-run median for their leg are marked red.',
     legsLabel: 'Legs (platform / arch / docker provider)',
+    // No coarser grouping than the leg itself on this page -- the "Legs"
+    // checkbox filter and the chart's line grouping are the same facet.
     legKey: (row) => `${row.os}/${row.arch}/${row.docker_provider}`,
+    workflowKey: (row) => `${row.os}/${row.arch}/${row.docker_provider}`,
     metrics: (rows) => {
       const s = new Set();
       for (const r of rows) for (const m of Object.keys(r.metrics || {})) s.add(m);


### PR DESCRIPTION
## Short Summary (TL;DR)

The "Legs" checkbox filter on <https://ddev.github.io/ddev/perf/> showed a single checkbox labeled "undefined" and both chart views rendered empty, because the shared dashboard code was reading a `row.workflow` field that only exists in the separate CI test-runtime dataset, not in the nightly perf-benchmarks dataset.

## The Issue

<img width="1203" height="803" alt="image" src="https://github.com/user-attachments/assets/803385ae-bec1-40cf-8cb5-270786408f22" />

## How This PR Solves The Issue

`perf/collector/dashboard-common.js` is shared by two pages with different row shapes: the CI dashboard's rows carry a `workflow` field, the perf dashboard's rows only have `os`/`arch`/`docker_provider`. The shared "Legs" checkbox code hardcoded `row.workflow`, which happened to match the CI dashboard's coarser grouping but doesn't exist at all on the perf dashboard's rows.

Added a `workflowKey` config function so each page declares its own checkbox facet: `ci-dashboard.html` keeps `row.workflow` (still coarser than its `legKey`, which further splits Buildkite rows by runner machine), and `perf-dashboard.html` now uses the same `os/arch/docker_provider` formula as its `legKey`.

## Manual Testing Instructions

Visit it after merge

