### PR TITLE
feat: add `ddev utility delete-volume` to remove a project's Docker volume, fixes #6961

### DIFF
--- a/cmd/ddev/cmd/debug-delete-volume.go
+++ b/cmd/ddev/cmd/debug-delete-volume.go
@@ -28,6 +28,32 @@ type deleteVolumeChoice struct {
 	longName  string
 }
 
+// getDeleteVolumeChoices returns the current project's non-shared volumes
+// that actually exist in Docker, sorted alphabetically with "database" last,
+// since it's normally the most destructive one to lose.
+func getDeleteVolumeChoices(app *ddevapp.DdevApp) []deleteVolumeChoice {
+	var choices []deleteVolumeChoice
+	if app.ComposeYaml == nil {
+		return choices
+	}
+	for shortName, v := range app.ComposeYaml.Volumes {
+		if sharedVolumeNames[shortName] {
+			continue
+		}
+		if !dockerutil.VolumeExists(v.Name) {
+			continue
+		}
+		choices = append(choices, deleteVolumeChoice{shortName: shortName, longName: v.Name})
+	}
+	sort.Slice(choices, func(i, j int) bool {
+		if (choices[i].shortName == "database") != (choices[j].shortName == "database") {
+			return choices[j].shortName == "database"
+		}
+		return choices[i].shortName < choices[j].shortName
+	})
+	return choices
+}
+
 // DebugDeleteVolumeCmd implements the ddev utility delete-volume command
 var DebugDeleteVolumeCmd = &cobra.Command{
 	Use:   "delete-volume [volume-name]",
@@ -42,6 +68,25 @@ ddev utility delete-volume solr
 ddev utility delete-volume ddev-myproject_solr
 ddev utility delete-volume solr --yes`,
 	Args: cobra.MaximumNArgs(1),
+	ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		_ = app.DockerEnv()
+		if err = app.WriteDockerComposeYAML(); err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		choices := getDeleteVolumeChoices(app)
+		names := make([]string, len(choices))
+		for i, c := range choices {
+			names[i] = c.shortName
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	},
 	Run: func(_ *cobra.Command, args []string) {
 		requestedName := ""
 		if len(args) == 1 {
@@ -62,21 +107,7 @@ ddev utility delete-volume solr --yes`,
 			util.Failed("Failed to get Docker Compose config: %v", err)
 		}
 
-		var choices []deleteVolumeChoice
-		for shortName, v := range app.ComposeYaml.Volumes {
-			if sharedVolumeNames[shortName] {
-				continue
-			}
-			choices = append(choices, deleteVolumeChoice{shortName: shortName, longName: v.Name})
-		}
-		// The database volume is normally the most destructive one to lose, so list it last.
-		sort.Slice(choices, func(i, j int) bool {
-			if (choices[i].shortName == "database") != (choices[j].shortName == "database") {
-				return choices[j].shortName == "database"
-			}
-			return choices[i].shortName < choices[j].shortName
-		})
-
+		choices := getDeleteVolumeChoices(app)
 		if len(choices) == 0 {
 			util.Failed("No volumes found for project %s", app.Name)
 		}
@@ -110,10 +141,6 @@ ddev utility delete-volume solr --yes`,
 				}
 				util.Failed("No volume named '%s' found for project %s; known volumes are:\n%s", requestedName, app.Name, strings.Join(available, "\n"))
 			}
-		}
-
-		if !dockerutil.VolumeExists(volumeName) {
-			util.Failed("Docker volume '%s' does not exist", volumeName)
 		}
 
 		status, _ := app.SiteStatus()

--- a/cmd/ddev/cmd/debug-delete-volume.go
+++ b/cmd/ddev/cmd/debug-delete-volume.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/util"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+)
+
+// deleteVolumeYes skips confirmation prompts when true (--yes/-y).
+var deleteVolumeYes bool
+
+// sharedVolumeNames are volumes used by every DDEV project rather than owned
+// by one, so deleting them here would affect projects other than the active one.
+var sharedVolumeNames = map[string]bool{
+	"ddev-global-cache":         true,
+	"ddev-ssh-agent_socket_dir": true,
+}
+
+// deleteVolumeChoice is one of the current project's deletable volumes.
+type deleteVolumeChoice struct {
+	shortName string
+	longName  string
+}
+
+// DebugDeleteVolumeCmd implements the ddev utility delete-volume command
+var DebugDeleteVolumeCmd = &cobra.Command{
+	Use:   "delete-volume [volume-name]",
+	Short: "Delete a Docker volume belonging to the current project",
+	Long: `Deletes a Docker volume belonging to the current project, identified by
+either its short docker-compose name (e.g. "solr") or its full Docker volume
+name (e.g. "ddev-myproject_solr"). If no name is given, choose one from a list
+of the project's volumes. Stops the project first if it's running, since a
+container-mounted volume can't be removed.`,
+	Example: `ddev utility delete-volume
+ddev utility delete-volume solr
+ddev utility delete-volume ddev-myproject_solr
+ddev utility delete-volume solr --yes`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(_ *cobra.Command, args []string) {
+		requestedName := ""
+		if len(args) == 1 {
+			requestedName = args[0]
+		}
+
+		app, err := ddevapp.GetActiveApp("")
+		if err != nil {
+			util.Failed("Can't find active project: %v", err)
+		}
+
+		if sharedVolumeNames[requestedName] {
+			util.Failed("'%s' is a shared volume used by all DDEV projects, not just %s, so it can't be deleted with this command", requestedName, app.Name)
+		}
+
+		_ = app.DockerEnv()
+		if err = app.WriteDockerComposeYAML(); err != nil {
+			util.Failed("Failed to get Docker Compose config: %v", err)
+		}
+
+		var choices []deleteVolumeChoice
+		for shortName, v := range app.ComposeYaml.Volumes {
+			if sharedVolumeNames[shortName] {
+				continue
+			}
+			choices = append(choices, deleteVolumeChoice{shortName: shortName, longName: v.Name})
+		}
+		// The database volume is normally the most destructive one to lose, so list it last.
+		sort.Slice(choices, func(i, j int) bool {
+			if (choices[i].shortName == "database") != (choices[j].shortName == "database") {
+				return choices[j].shortName == "database"
+			}
+			return choices[i].shortName < choices[j].shortName
+		})
+
+		if len(choices) == 0 {
+			util.Failed("No volumes found for project %s", app.Name)
+		}
+
+		var volumeName string
+		if requestedName == "" {
+			items := make([]string, len(choices))
+			for i, c := range choices {
+				items[i] = fmt.Sprintf("%s (%s)", c.shortName, c.longName)
+			}
+			prompt := promptui.Select{
+				Label: "Volume to delete",
+				Items: items,
+			}
+			idx, _, err := prompt.Run()
+			if err != nil {
+				util.Failed("Prompt failed: %v", err)
+			}
+			volumeName = choices[idx].longName
+		} else {
+			for _, c := range choices {
+				if c.shortName == requestedName || c.longName == requestedName {
+					volumeName = c.longName
+					break
+				}
+			}
+			if volumeName == "" {
+				available := make([]string, len(choices))
+				for i, c := range choices {
+					available[i] = fmt.Sprintf("%s (%s)", c.shortName, c.longName)
+				}
+				util.Failed("No volume named '%s' found for project %s; known volumes are:\n%s", requestedName, app.Name, strings.Join(available, "\n"))
+			}
+		}
+
+		if !dockerutil.VolumeExists(volumeName) {
+			util.Failed("Docker volume '%s' does not exist", volumeName)
+		}
+
+		status, _ := app.SiteStatus()
+		if status == ddevapp.SiteRunning || status == ddevapp.SiteStarting || status == ddevapp.SitePaused {
+			if !deleteVolumeYes && !util.Confirm(fmt.Sprintf("Project %s must be stopped to delete volume '%s'. OK to stop it now?", app.Name, volumeName)) {
+				util.Failed("Cannot delete volume '%s' while project %s is running", volumeName, app.Name)
+			}
+			if err := app.Stop(false, false); err != nil {
+				util.Failed("Failed to stop project %s: %v", app.Name, err)
+			}
+		}
+
+		if !deleteVolumeYes && !util.Confirm(fmt.Sprintf("OK to delete Docker volume '%s'? This cannot be undone.", volumeName)) {
+			util.Failed("Cancelled")
+		}
+
+		if err := dockerutil.RemoveVolume(volumeName); err != nil {
+			util.Failed("Failed to delete volume '%s': %v", volumeName, err)
+		}
+
+		util.Success("Deleted Docker volume '%s'", volumeName)
+	},
+}
+
+func init() {
+	DebugDeleteVolumeCmd.Flags().BoolVarP(&deleteVolumeYes, "yes", "y", false, "Yes - skip confirmation prompts")
+	DebugCmd.AddCommand(DebugDeleteVolumeCmd)
+}

--- a/cmd/ddev/cmd/debug-delete-volume_test.go
+++ b/cmd/ddev/cmd/debug-delete-volume_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 // TestDebugDeleteVolumeCmd checks that `ddev utility delete-volume`:
-//   - rejects an unknown volume name and a shared/global volume name
+//   - rejects a shared/global volume name regardless of project state
 //   - stops a running project and deletes its volume when given the volume's
 //     short (docker-compose) name
+//   - rejects an unknown volume name, listing only volumes that still exist
 //   - deletes a volume when given its full Docker name
 func TestDebugDeleteVolumeCmd(t *testing.T) {
 	if os.Getenv("GOTEST_SHORT") != "" {
@@ -57,13 +58,8 @@ volumes:
 		_ = os.RemoveAll(tmpdir)
 	})
 
-	// Unknown volume name should fail and list the project's known volumes.
-	out, err := exec.RunHostCommand(DdevBin, "utility", "delete-volume", "bogus-volume", "--yes")
-	require.Error(t, err, "expected failure for unknown volume name, out='%s'", out)
-	require.Contains(t, out, "No volume named")
-
-	// A shared/global volume should be refused, not deleted.
-	out, err = exec.RunHostCommand(DdevBin, "utility", "delete-volume", "ddev-global-cache", "--yes")
+	// A shared/global volume should be refused, not deleted, even before the project exists.
+	out, err := exec.RunHostCommand(DdevBin, "utility", "delete-volume", "ddev-global-cache", "--yes")
 	require.Error(t, err, "expected failure for shared volume name, out='%s'", out)
 	require.Contains(t, out, "shared volume")
 
@@ -74,6 +70,12 @@ volumes:
 	status, _ := app.SiteStatus()
 	require.Equal(t, ddevapp.SiteRunning, status)
 
+	// An unknown volume name should fail and list only volumes that actually exist.
+	out, err = exec.RunHostCommand(DdevBin, "utility", "delete-volume", "bogus-volume", "--yes")
+	require.Error(t, err, "expected failure for unknown volume name, out='%s'", out)
+	require.Contains(t, out, "No volume named")
+	require.Contains(t, out, "myvol")
+
 	// Deleting by short name while the project is running must stop it first.
 	out, err = exec.RunHostCommand(DdevBin, "utility", "delete-volume", "myvol", "--yes")
 	require.NoError(t, err, "delete-volume by short name failed, out='%s'", out)
@@ -82,6 +84,12 @@ volumes:
 
 	status, _ = app.SiteStatus()
 	require.Equal(t, ddevapp.SiteStopped, status)
+
+	// Once deleted, the volume must no longer be offered or matched by name.
+	out, err = exec.RunHostCommand(DdevBin, "utility", "delete-volume", "myvol", "--yes")
+	require.Error(t, err, "expected failure re-deleting an already-deleted volume, out='%s'", out)
+	require.Contains(t, out, "No volume named")
+	require.NotContains(t, out, "myvol (")
 
 	// Deleting by full Docker name, with the project already stopped.
 	_, err = dockerutil.CreateVolume(expectedVolumeName, "local", nil, nil)

--- a/cmd/ddev/cmd/debug-delete-volume_test.go
+++ b/cmd/ddev/cmd/debug-delete-volume_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/testcommon"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDebugDeleteVolumeCmd checks that `ddev utility delete-volume`:
+//   - rejects an unknown volume name and a shared/global volume name
+//   - stops a running project and deletes its volume when given the volume's
+//     short (docker-compose) name
+//   - deletes a volume when given its full Docker name
+func TestDebugDeleteVolumeCmd(t *testing.T) {
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skip because GOTEST_SHORT is set")
+	}
+
+	origDir, _ := os.Getwd()
+	tmpdir := testcommon.CreateTmpDir(t.Name())
+
+	err := os.Chdir(tmpdir)
+	require.NoError(t, err)
+
+	_, err = exec.RunHostCommand(DdevBin, "config", "--project-type=php", "--project-name=test-delete-volume")
+	require.NoError(t, err)
+
+	app, err := ddevapp.GetActiveApp("")
+	require.NoError(t, err)
+
+	expectedVolumeName := "ddev-" + app.Name + "_myvol"
+
+	extraCompose := `services:
+  myservice:
+    image: busybox
+    command: ["sleep", "infinity"]
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+    volumes:
+      - myvol:/data
+volumes:
+  myvol:
+    name: "` + expectedVolumeName + `"
+`
+	err = os.WriteFile(app.GetConfigPath("docker-compose.myvol.yaml"), []byte(extraCompose), 0644)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = app.Stop(true, false)
+		_ = dockerutil.RemoveVolume(expectedVolumeName)
+		_ = os.Chdir(origDir)
+		_ = os.RemoveAll(tmpdir)
+	})
+
+	// Unknown volume name should fail and list the project's known volumes.
+	out, err := exec.RunHostCommand(DdevBin, "utility", "delete-volume", "bogus-volume", "--yes")
+	require.Error(t, err, "expected failure for unknown volume name, out='%s'", out)
+	require.Contains(t, out, "No volume named")
+
+	// A shared/global volume should be refused, not deleted.
+	out, err = exec.RunHostCommand(DdevBin, "utility", "delete-volume", "ddev-global-cache", "--yes")
+	require.Error(t, err, "expected failure for shared volume name, out='%s'", out)
+	require.Contains(t, out, "shared volume")
+
+	err = app.Start()
+	require.NoError(t, err)
+	require.True(t, dockerutil.VolumeExists(expectedVolumeName))
+
+	status, _ := app.SiteStatus()
+	require.Equal(t, ddevapp.SiteRunning, status)
+
+	// Deleting by short name while the project is running must stop it first.
+	out, err = exec.RunHostCommand(DdevBin, "utility", "delete-volume", "myvol", "--yes")
+	require.NoError(t, err, "delete-volume by short name failed, out='%s'", out)
+	require.Contains(t, out, expectedVolumeName)
+	require.False(t, dockerutil.VolumeExists(expectedVolumeName))
+
+	status, _ = app.SiteStatus()
+	require.Equal(t, ddevapp.SiteStopped, status)
+
+	// Deleting by full Docker name, with the project already stopped.
+	_, err = dockerutil.CreateVolume(expectedVolumeName, "local", nil, nil)
+	require.NoError(t, err)
+
+	out, err = exec.RunHostCommand(DdevBin, "utility", "delete-volume", expectedVolumeName, "--yes")
+	require.NoError(t, err, "delete-volume by full name failed, out='%s'", out)
+	require.False(t, dockerutil.VolumeExists(expectedVolumeName))
+}

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1713,6 +1713,27 @@ ddev utility configyaml --omit-keys=web_environment
 ddev utility configyaml --full-yaml --omit-keys=web_environment
 ```
 
+### `utility delete-volume`
+
+Delete a Docker volume belonging to the current project, identified by either its short docker-compose name (e.g. `solr`) or its full Docker volume name (e.g. `ddev-myproject_solr`). If no name is given, pick one from an interactive list of the project's volumes. If the project is running, you'll be asked to stop it first, since a container-mounted volume can't be removed. Shared volumes used by every project, like `ddev-global-cache`, can't be deleted with this command.
+
+Flags:
+
+* `--yes`, `-y`: Skip confirmation prompts.
+
+Example:
+
+```shell
+# Choose a volume to delete from an interactive list
+ddev utility delete-volume
+
+# Delete the "solr" volume for the current project, prompting for confirmation
+ddev utility delete-volume solr
+
+# Delete by full Docker volume name, skipping confirmation
+ddev utility delete-volume ddev-myproject_solr --yes
+```
+
 ### `utility diagnose`
 
 Run quick diagnostics on your DDEV installation and current project. This command provides concise, actionable output for common troubleshooting scenarios.

--- a/docs/content/users/usage/troubleshooting.md
+++ b/docs/content/users/usage/troubleshooting.md
@@ -166,7 +166,7 @@ To solve this:
 
 * Change the configuration in `.ddev/config.yaml` back to the original configuration.
 * Export the database with [`ddev export-db`](commands.md#export-db).
-* Delete the project with [`ddev delete`](commands.md#delete), or stop the project and remove the database volume using `docker volume rm <project>-mariadb` or `docker volume rm <project>-postgres`.
+* Delete the project with [`ddev delete`](commands.md#delete), or remove just the database volume with [`ddev utility delete-volume database`](commands.md#utility-delete-volume), which stops the project first if it's running.
 * Update `.ddev/config.yaml` to use the new [database type or version](../extend/database-types.md).
 * Start the project and import the database from your export.
 


### PR DESCRIPTION
## Short Summary (TL;DR)

This PR adds `ddev utility delete-volume`, which deletes a Docker volume belonging to the current project by its short docker-compose name or full Docker name, or lets you pick one from an interactive list.

## The Issue

- Fixes #6961

Add-ons like ddev-solr create their own named Docker volumes, and there was no built-in way to remove one without reaching for raw `docker volume rm` and guessing at the actual volume name.

## How This PR Solves The Issue

The command resolves the requested name against the project's own rendered docker-compose config (`app.ComposeYaml.Volumes`), so it correctly handles both the short compose-file key (`solr`) and whatever actual Docker volume name an add-on gives it (`name:`/`external:` overrides included), instead of guessing a naming convention. If no name is given, it shows an interactive picker (the same `promptui` used by `ddev snapshot restore`), with the database volume sorted last since it's normally the most destructive one to lose. Shared volumes used by every project (`ddev-global-cache`, `ddev-ssh-agent_socket_dir`) are excluded, since deleting them would affect other projects, not just the current one. If the project is running, the command asks to stop it first, since Docker won't remove a volume that's still mounted by a container; both that and the final deletion prompt are skippable with `--yes`.

## Manual Testing Instructions

1. In a project with an add-on that declares its own volume (e.g. ddev-solr), run `ddev utility delete-volume` with no arguments and confirm you get an interactive list with the database volume listed last.
2. Run `ddev utility delete-volume <short-name>` and `ddev utility delete-volume <full-docker-name>` and confirm both resolve to the same volume.
3. Run `ddev utility delete-volume ddev-global-cache` and confirm it's refused.
4. Start the project, then delete one of its volumes; confirm you're prompted to stop the project first and that it does so before deleting.

## Automated Testing Overview

`TestDebugDeleteVolumeCmd` in `cmd/ddev/cmd/debug-delete-volume_test.go` covers: rejecting an unknown volume name (and listing known volumes in the error), rejecting a shared/global volume name, stopping a running project and deleting its volume by short name, and deleting by full Docker name.

## Release/Deployment Notes

None.
