### PR TITLE
fix(compose): always use RemoveOrphans option, fixes #8757

### DIFF
--- a/cmd/ddev/cmd/debug-rebuild.go
+++ b/cmd/ddev/cmd/debug-rebuild.go
@@ -155,10 +155,11 @@ var DebugRebuildCmd = &cobra.Command{
 			recreateTimeout := time.Duration(app.GetMaxContainerWaitTime()) * time.Second
 			err = composeSvc.Up(composeCtx, recreateProject, api.UpOptions{
 				Create: api.CreateOptions{
-					Services: []string{service},
-					Recreate: api.RecreateForce,
-					Timeout:  &recreateTimeout,
-					Build:    &api.BuildOptions{Progress: progress},
+					Services:      []string{service},
+					Recreate:      api.RecreateForce,
+					Timeout:       &recreateTimeout,
+					Build:         &api.BuildOptions{Progress: progress},
+					RemoveOrphans: true,
 				},
 				Start: api.StartOptions{
 					Project:  recreateProject,

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1951,8 +1951,11 @@ func (app *DdevApp) Start() error {
 		progress = display.ModePlain
 	}
 	err = upSvc.Up(upCtx, upProject, api.UpOptions{
-		Create: api.CreateOptions{Build: &api.BuildOptions{Progress: progress}},
-		Start:  api.StartOptions{Project: upProject},
+		Create: api.CreateOptions{
+			Build:         &api.BuildOptions{Progress: progress},
+			RemoveOrphans: true,
+		},
+		Start: api.StartOptions{Project: upProject},
 	})
 	if err != nil {
 		return err
@@ -2264,8 +2267,11 @@ func (app *DdevApp) StartOptionalProfiles(profiles []string) error {
 		progress = display.ModePlain
 	}
 	err = upSvc.Up(upCtx, upProject, api.UpOptions{
-		Create: api.CreateOptions{Build: &api.BuildOptions{Progress: progress}},
-		Start:  api.StartOptions{Project: upProject},
+		Create: api.CreateOptions{
+			Build:         &api.BuildOptions{Progress: progress},
+			RemoveOrphans: true,
+		},
+		Start: api.StartOptions{Project: upProject},
 	})
 	if err != nil {
 		util.Warning("Failed to start optional compose profiles '%s': %v", profiles, err)

--- a/pkg/ddevapp/router.go
+++ b/pkg/ddevapp/router.go
@@ -159,8 +159,11 @@ func StartDdevRouter() error {
 			progress = display.ModePlain
 		}
 		err = routerSvc.Up(upCtx, routerProject, api.UpOptions{
-			Create: api.CreateOptions{Build: &api.BuildOptions{Progress: progress}},
-			Start:  api.StartOptions{Project: routerProject},
+			Create: api.CreateOptions{
+				Build:         &api.BuildOptions{Progress: progress},
+				RemoveOrphans: true,
+			},
+			Start: api.StartOptions{Project: routerProject},
 		})
 		if err != nil {
 			return fmt.Errorf("failed to start ddev-router: %v", err)

--- a/pkg/ddevapp/ssh_auth.go
+++ b/pkg/ddevapp/ssh_auth.go
@@ -71,7 +71,7 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 		downCtx, downSvc, svcErr := dockerutil.NewComposeService()
 		if svcErr != nil {
 			util.Warning("failed to create compose service: %v", svcErr)
-		} else if downErr := downSvc.Down(downCtx, downProject.Name, api.DownOptions{Project: downProject}); downErr != nil {
+		} else if downErr := downSvc.Down(downCtx, downProject.Name, api.DownOptions{Project: downProject, RemoveOrphans: true}); downErr != nil {
 			util.Warning("failed to docker-compose down on %s: %v", composeFile, downErr)
 		}
 	}
@@ -97,8 +97,11 @@ func (app *DdevApp) EnsureSSHAgentContainer() error {
 		progress = display.ModePlain
 	}
 	err = upSvc.Up(upCtx, upProject, api.UpOptions{
-		Create: api.CreateOptions{Build: &api.BuildOptions{Progress: progress}},
-		Start:  api.StartOptions{Project: upProject},
+		Create: api.CreateOptions{
+			Build:         &api.BuildOptions{Progress: progress},
+			RemoveOrphans: true,
+		},
+		Start: api.StartOptions{Project: upProject},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start ddev-ssh-agent: %v", err)

--- a/pkg/dockerutil/docker_compose_test.go
+++ b/pkg/dockerutil/docker_compose_test.go
@@ -126,7 +126,7 @@ func TestComposeExec(t *testing.T) {
 		if cleanErr == nil {
 			cleanCtx, cleanSvc, svcErr := dockerutil.NewComposeService()
 			if svcErr == nil {
-				_ = cleanSvc.Down(cleanCtx, cleanProject.Name, api.DownOptions{Project: cleanProject})
+				_ = cleanSvc.Down(cleanCtx, cleanProject.Name, api.DownOptions{Project: cleanProject, RemoveOrphans: true})
 			}
 		}
 	})
@@ -136,8 +136,11 @@ func TestComposeExec(t *testing.T) {
 	upCtx, upSvc, err := dockerutil.NewComposeService()
 	require.NoError(t, err)
 	err = upSvc.Up(upCtx, upProject, api.UpOptions{
-		Create: api.CreateOptions{Build: &api.BuildOptions{Progress: display.ModePlain}},
-		Start:  api.StartOptions{Project: upProject},
+		Create: api.CreateOptions{
+			Build:         &api.BuildOptions{Progress: display.ModePlain},
+			RemoveOrphans: true,
+		},
+		Start: api.StartOptions{Project: upProject},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines

  If this is a nontrivial contribution, please create an issue for discussion first, or discuss it first in Discord, https://ddev.com/s/discord. This will save you time and help direct the feature.
-->

## Short Summary (TL;DR)

Add RemoveOrphans to all Docker Compose options we use.

## The Issue

- Fixes #8757

This is a regression after:

- #8234

I added `RemoveOrphans: true` in some places at that time, but not everywhere.

## How This PR Solves The Issue

Updates all `api.CreateOptions` and `api.DownOptions` calls with `RemoveOrphans: true`

## Manual Testing Instructions

```bash
ddev add-on get ddev/ddev-adminer
ddev start
ddev add-on remove ddev/ddev-adminer
ddev start
```

See this in the output:

```
...
$ ddev start
...
[+] up 3/3
 ✔ Container ddev-demo-web     Recreated                                0.8s
 ✔ Container ddev-demo-adminer Removed                                  0.5s  <= orphan is removed
 ✔ Container ddev-demo-db      Recreated                                2.1s
...
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
