### PR TITLE
chore(compose): remove unused COMPOSE_REMOVE_ORPHANS, for #8759

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2984,7 +2984,6 @@ func (app *DdevApp) DockerEnv() map[string]string {
 	envVars := map[string]string{
 		// The compose project name can no longer contain dots; must be lower-case
 		"COMPOSE_PROJECT_NAME":           app.GetComposeProjectName(),
-		"COMPOSE_REMOVE_ORPHANS":         "true",
 		"COMPOSER_EXIT_ON_PATCH_FAILURE": "1",
 		"DDEV_SITENAME":                  app.Name,
 		"DDEV_TLD":                       app.ProjectTLD,


### PR DESCRIPTION
## Short Summary (TL;DR)

`COMPOSE_REMOVE_ORPHANS` is not used by Docker Compose SDK.

## The Issue

- For https://github.com/ddev/ddev/pull/8759#issuecomment-5444462494

## How This PR Solves The Issue

Removes it.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
