### PR TITLE
fix(buildx): skip sha verification on macOS for versions before v0.36.0, for #8758

### DIFF
--- a/pkg/dockerutil/docker_buildx.go
+++ b/pkg/dockerutil/docker_buildx.go
@@ -150,11 +150,13 @@ func dockerBuildxDownloadLink() (buildxURL string, shasumURL string, err error) 
 		binaryURL = binaryURL + ".exe"
 	}
 	shasumURL = fmt.Sprintf("https://github.com/docker/buildx/releases/download/v%s/checksums.txt", version)
-	// Since v0.36.0, buildx moved macOS and Windows checksums out of checksums.txt
-	// and into checksums-signed.txt, since those binaries are code-signed/notarized
-	// after checksums.txt is generated. Older versions still list them in checksums.txt.
-	if (nodeps.IsMacOS() || nodeps.IsWindows()) && !versions.LessThan(version, "0.36.0") {
+	if (nodeps.IsMacOS() || nodeps.IsWindows()) && versions.GreaterThanOrEqualTo(version, "0.36.0") {
+		// Since v0.36.0 the macOS and Windows binaries are code-signed after
+		// checksums.txt is generated, so their checksums live in checksums-signed.txt
 		shasumURL = fmt.Sprintf("https://github.com/docker/buildx/releases/download/v%s/checksums-signed.txt", version)
+	} else if nodeps.IsMacOS() && versions.LessThan(version, "0.36.0") {
+		// Older checksums.txt covers Windows but never macOS, so skip verification
+		shasumURL = ""
 	}
 
 	return binaryURL, shasumURL, nil


### PR DESCRIPTION
## Short Summary (TL;DR)

If a macOS user has this config: `ddev config global --docker-buildx-version=0.35.0`, it's not going to work because `checksums.txt` never included darwin.

## The Issue

- For #8758

## How This PR Solves The Issue

Adds back a condition for macOS that was removed in #8758

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
