### PR TITLE
feat(docker): allow overriding the image org with DDEV_DOCKER_ORG, fixes #8753 (#8765) [skip ci]

### DIFF
--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -116,6 +116,14 @@ This approval only applies to fork PRs from a contributor without push access â€
 
 When testing this on `ddev-test/ddev`, do the same steps there first, and confirm `vars.DOCKER_ORG` on that repository points at the DockerHub org used for testing.
 
+That org is not the one `versionconstants.go` names, so a binary built from `ddev-test/ddev` asks for `ddev/ddev-webserver:vX.Y.Z` while its images were published to `ddevhq`. Set `DDEV_DOCKER_ORG` to pull them from where they actually landed:
+
+```bash
+DDEV_DOCKER_ORG=ddevhq ddev start
+```
+
+It replaces the org on the web, db, router, ssh-agent, and xhgui images, leaving upstream images like `postgres` alone, and `ddev version` shows what it resolved to. Unset, it changes nothing.
+
 Since a job referencing an environment that doesn't exist yet gets auto-created with no protection rules (silently *not* gating), verify the environment actually has a `required_reviewers` rule before relying on it, e.g. `gh api repos/<owner>/<repo>/environments/image-push`.
 
 ## Pushing Docker Images with the GitHub Actions Workflow

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -2,7 +2,9 @@ package docker
 
 import (
 	"fmt"
+	"os"
 	"regexp"
+	"strings"
 
 	"github.com/ddev/ddev/pkg/globalconfig"
 	"github.com/ddev/ddev/pkg/nodeps"
@@ -13,6 +15,25 @@ import (
 // The tag is otherwise lost in a derived image, so this is what lets DDEV tell
 // which of its image generations a pinned webimage/dbimage came from.
 const DdevImageTagLabel = "com.ddev.image-tag"
+
+// dockerOrgEnvVar overrides the organization the repositories in
+// versionconstants.go live under. A ddev-test/ddev build publishes its images
+// to `ddevhq` rather than `ddev`, so without this its own release cannot be
+// pull-tested. Unset, which is every normal build, nothing changes.
+// See ddev/ddev#8753.
+const dockerOrgEnvVar = "DDEV_DOCKER_ORG"
+
+// imageRepo returns an image reference with its organization replaced by
+// dockerOrgEnvVar, when that is set. A reference with no organization (the
+// upstream `postgres`) has nothing to replace and is returned unchanged.
+func imageRepo(image string) string {
+	org := strings.Trim(strings.TrimSpace(os.Getenv(dockerOrgEnvVar)), "/")
+	i := strings.LastIndex(image, "/")
+	if org == "" || i < 0 {
+		return image
+	}
+	return org + image[i:]
+}
 
 // releaseTagPattern matches a vX.Y.Z release tag.
 var releaseTagPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
@@ -31,7 +52,7 @@ func resolveImageTag(tag, branch string) string {
 
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {
-	fullWebImg := versionconstants.WebImg
+	fullWebImg := imageRepo(versionconstants.WebImg)
 	if globalconfig.DdevGlobalConfig.UseHardenedImages {
 		fullWebImg = fullWebImg + "-prod"
 	}
@@ -55,21 +76,21 @@ func GetDBImage(dbType string, dbVersion string) string {
 	case nodeps.MariaDB:
 		fallthrough
 	default:
-		return fmt.Sprintf("%s-%s-%s:%s", versionconstants.DBImg, dbType, v, resolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch))
+		return fmt.Sprintf("%s-%s-%s:%s", imageRepo(versionconstants.DBImg), dbType, v, resolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch))
 	}
 }
 
 // GetSSHAuthImage returns the correctly formatted sshauth image:tag reference
 func GetSSHAuthImage() string {
-	return fmt.Sprintf("%s:%s", versionconstants.SSHAuthImage, resolveImageTag(versionconstants.SSHAuthTag, versionconstants.SSHAuthTagBranch))
+	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.SSHAuthImage), resolveImageTag(versionconstants.SSHAuthTag, versionconstants.SSHAuthTagBranch))
 }
 
 // GetRouterImage returns the router image:tag reference
 func GetRouterImage() string {
-	return fmt.Sprintf("%s:%s", versionconstants.TraefikRouterImage, resolveImageTag(versionconstants.TraefikRouterTag, versionconstants.TraefikRouterTagBranch))
+	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.TraefikRouterImage), resolveImageTag(versionconstants.TraefikRouterTag, versionconstants.TraefikRouterTagBranch))
 }
 
 // GetXhguiImage returns the xhgui image:tag reference
 func GetXhguiImage() string {
-	return fmt.Sprintf("%s:%s", versionconstants.XhguiImage, resolveImageTag(versionconstants.XhguiTag, versionconstants.XhguiTagBranch))
+	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.XhguiImage), resolveImageTag(versionconstants.XhguiTag, versionconstants.XhguiTagBranch))
 }

--- a/pkg/docker/images_test.go
+++ b/pkg/docker/images_test.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"testing"
 
+	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,4 +12,22 @@ func TestResolveImageTag(t *testing.T) {
 	require.Equal(t, "c202e92108", resolveImageTag("c202e92108", "20260814_rfay_docker_update_phase_2"))
 	require.Equal(t, "c202e92108", resolveImageTag("c202e92108", ""))
 	require.Equal(t, "abc123", resolveImageTag("abc123", "v1.25.4-15-gabcdef1"))
+}
+
+func TestImageRepoDockerOrg(t *testing.T) {
+	require.Equal(t, "ddev/ddev-webserver", imageRepo("ddev/ddev-webserver"))
+
+	t.Setenv(dockerOrgEnvVar, "ddevhq")
+	require.Equal(t, "ddevhq/ddev-webserver", imageRepo("ddev/ddev-webserver"))
+	require.Equal(t, "postgres", imageRepo("postgres"))
+
+	require.Regexp(t, `^ddevhq/ddev-webserver:`, GetWebImage())
+	require.Regexp(t, `^ddevhq/ddev-dbserver-mariadb-11\.8:`, GetDBImage(nodeps.MariaDB, nodeps.MariaDB118))
+	require.Regexp(t, `^ddevhq/ddev-ssh-agent:`, GetSSHAuthImage())
+	require.Regexp(t, `^ddevhq/ddev-traefik-router:`, GetRouterImage())
+	require.Regexp(t, `^ddevhq/ddev-xhgui:`, GetXhguiImage())
+	require.Equal(t, "postgres:17", GetDBImage(nodeps.Postgres, nodeps.Postgres17))
+
+	t.Setenv(dockerOrgEnvVar, "")
+	require.Equal(t, "ddev/ddev-webserver", imageRepo("ddev/ddev-webserver"))
 }


### PR DESCRIPTION
## Short Summary (TL;DR)

`DDEV_DOCKER_ORG` points a `ddev` binary at a different Docker Hub organization for DDEV's own images, so a release built somewhere other than `ddev/ddev` can be pull-tested. Unset, which is every normal build, nothing changes.

## The Issue

- Fixes #8753

`versionconstants.go` hardcodes the `ddev/` org, but the image workflows resolve `DOCKER_ORG` to `ddevhq` for `ddev-test/ddev`. So a binary built there asks for `ddev/ddev-webserver:vX.Y.Z` while its images went to `ddevhq`, and `ddev start` fails with `manifest unknown` before the release can be tested end to end.

## How This PR Solves The Issue

An unexported `imageRepo()` in `pkg/docker/images.go` swaps the org on the five images DDEV pulls for itself: web (including `-prod`), db, ssh-agent, router, and xhgui. `postgres` comes from upstream, so it has no org to swap and is returned unchanged. With the variable unset `imageRepo()` returns its input, which is why there is no new behavior for anyone not setting it.

## Manual Testing Instructions

```bash
# The default is unchanged
ddev version -j | jq -r '.raw.web'   # ddev/ddev-webserver:<tag>

# Retag the images into another org and start against it
for i in ddev-webserver ddev-traefik-router ddev-ssh-agent; do
  docker tag ddev/$i:<tag> myorg/$i:<tag>
done
DDEV_DOCKER_ORG=myorg ddev poweroff && DDEV_DOCKER_ORG=myorg ddev start
docker ps --format '{{.Names}}\t{{.Image}}'   # every ddev image under myorg/
```

`ddev version` reports the resolved references, so it shows the override without starting anything.

## Automated Testing Overview

`TestImageRepoDockerOrg` in `pkg/docker/images_test.go` covers the default, the override across all five getters, `postgres` being left alone, and an empty value falling back to `ddev`.

## Release/Deployment Notes

No behavior change unless `DDEV_DOCKER_ORG` is set. It's documented in `release-management.md` next to the `ddev-test/ddev` setup notes, since pull-testing a release built there is what it exists for.

Known gaps, all left alone deliberately: `ddev/ddev-utilities` is not redirected, `ddev delete images` does not discover images pulled under the override org, and add-ons and other extra services keep naming their own images, because those come from the add-on's `docker-compose.*.yaml` rather than from here. None of them block pull-testing a release.
