### PR TITLE
feat(docker): support prerelease tags for images, so vX.Y.Z-rc1 can be released

### DIFF
--- a/.github/workflows/image-build-push.yml
+++ b/.github/workflows/image-build-push.yml
@@ -368,12 +368,19 @@ jobs:
             # without this an unrelated later change would move vX.Y.Z and
             # latest onto a post-release build. First writer wins.
             RELEASED=false
+            LATEST=""
             if [ -n "$RELEASE_TAG" ]; then
               if containers/registry-tag-exists.sh "$repo" "$RELEASE_TAG"; then
                 echo "${repo}:${RELEASE_TAG} already published; leaving it and latest alone"
               else
-                NAMES+=(-t "${repo}:${RELEASE_TAG}" -t "${repo}:latest")
+                NAMES+=(-t "${repo}:${RELEASE_TAG}")
                 RELEASED=true
+                # The shape is already vetted, so a `-` means prerelease, and a
+                # prerelease is not the newest release latest should name.
+                case "$RELEASE_TAG" in
+                  *-*) echo "${RELEASE_TAG} is a prerelease; leaving latest alone" ;;
+                  *) NAMES+=(-t "${repo}:latest"); LATEST=" and \`latest\`" ;;
+                esac
               fi
             fi
             # A concurrent build of identical content (tags are content
@@ -393,7 +400,7 @@ jobs:
             fi
             SUMMARY_NAMES="\`${repo}:${TAG}\`"
             if [ "$RELEASED" = true ]; then
-              SUMMARY_NAMES="${SUMMARY_NAMES}, also published as \`${RELEASE_TAG}\` and \`latest\`"
+              SUMMARY_NAMES="${SUMMARY_NAMES}, also published as \`${RELEASE_TAG}\`${LATEST}"
             fi
             PUSHED_SUMMARY="${PUSHED_SUMMARY}- ${SUMMARY_NAMES}"$'\n'
             for arch in $ARCHES; do

--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/ddev/ddev/pkg/docker"
@@ -41,7 +42,7 @@ func TestCmdVersion(t *testing.T) {
 
 	assert.Contains(versionData["msg"], versionconstants.DdevVersion)
 	assert.Contains(versionData["msg"], versionconstants.WebImg)
-	assert.Contains(versionData["msg"], docker.ResolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch))
+	assert.Contains(versionData["msg"], docker.GetWebImage())
 	assert.Contains(versionData["msg"], versionconstants.DBImg)
 	assert.Contains(versionData["msg"], docker.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion))
 	assert.Contains(versionData["msg"], dockerVersion)
@@ -52,7 +53,7 @@ func TestCmdVersion(t *testing.T) {
 	// wasn't already resolved to that branch; the raw JSON map used by
 	// scripting never has it.
 	branchHint := "(" + versionconstants.WebTagBranch + ")"
-	if docker.ResolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch) == versionconstants.WebTagBranch {
+	if strings.HasSuffix(docker.GetWebImage(), ":"+versionconstants.WebTagBranch) {
 		assert.NotContains(versionData["msg"], branchHint)
 	} else {
 		assert.Contains(versionData["msg"], branchHint)

--- a/containers/release-marker.sh
+++ b/containers/release-marker.sh
@@ -32,8 +32,8 @@ if [ "$(printf '%s\n' "$MARKERS" | wc -l)" -ne 1 ]; then
 fi
 
 TAG="${MARKERS#"${MARKER}" }"
-if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "release-marker.sh: '${TAG}' in ${DOCKERFILE} is not a vX.Y.Z release tag" >&2
+if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)[0-9.]*)?$ ]]; then
+  echo "release-marker.sh: '${TAG}' in ${DOCKERFILE} is not a release tag (vX.Y.Z, or a prerelease like v1.25.4-rc1)" >&2
   exit 1
 fi
 

--- a/containers/release-prep.sh
+++ b/containers/release-prep.sh
@@ -31,8 +31,8 @@ if [ -z "$TAG" ]; then
   read -r -p "Release tag (vX.Y.Z): " TAG
 fi
 
-if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "release-prep.sh: '${TAG}' is not a vX.Y.Z release tag" >&2
+if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)[0-9.]*)?$ ]]; then
+  echo "release-prep.sh: '${TAG}' is not a release tag (vX.Y.Z, or a prerelease like v1.25.4-rc1)" >&2
   exit 1
 fi
 

--- a/containers/release_prep_test.sh
+++ b/containers/release_prep_test.sh
@@ -113,10 +113,10 @@ dockerfile_digest() {
 write_fixture
 cd "$REPO"
 
-# 1. Anything that isn't a vX.Y.Z release tag is refused, and refused before
-#    any Dockerfile is stamped.
+# 1. Anything that isn't a release tag is refused, and refused before any
+#    Dockerfile is stamped - `git describe` output included.
 unstamped_digest="$(dockerfile_digest)"
-for bad in "" 1.25.4 v1.25 v1.25.4-rc1 latest 20260817_stasadev_test; do
+for bad in "" 1.25.4 v1.25 v1.25.4-15-gabcdef1 v1.25.4-dirty v1.25.4-preview1 latest 20260817_stasadev_test; do
   set +e
   OUTPUT="$("$RELEASE_PREP" "$bad" </dev/null 2>&1)"
   STATUS=$?
@@ -129,11 +129,19 @@ for bad in "" 1.25.4 v1.25 v1.25.4-rc1 latest 20260817_stasadev_test; do
 done
 assert_eq "$unstamped_digest" "$(dockerfile_digest)" "a rejected tag stamps no Dockerfile"
 case "$OUTPUT" in
-  *"not a vX.Y.Z release tag"*) pass "rejection message says what shape is wanted" ;;
+  *"is not a release tag"*) pass "rejection message says what shape is wanted" ;;
   *) fail "rejection message should say what shape is wanted: $OUTPUT" ;;
 esac
 
-# 2. A release stamps every image and rewrites every tag to a content hash.
+# 2. A release stamps every image and rewrites every tag to a content hash. A
+#    prerelease takes the identical path; only `latest` differs, in the workflow.
+"$RELEASE_PREP" v1.26.0-rc1 >/dev/null
+assert_eq "${MARKER} v1.26.0-rc1" "$(marker_line ddev-webserver)" "a prerelease stamps the marker"
+assert_eq "v1.26.0-rc1" "$("$REPO/containers/release-marker.sh" ddev-webserver)" \
+  "release-marker.sh reads a prerelease marker"
+assert_eq "v1.26.0-rc1" "$(branch_value WebTag)" "WebTagBranch records the prerelease"
+
+write_fixture
 "$RELEASE_PREP" v1.25.4 >/dev/null
 for d in "${IMAGE_DIRS[@]}"; do
   assert_eq "1" "$(marker_lines "$d")" "$d carries exactly one release marker"

--- a/docs/content/developers/release-management.md
+++ b/docs/content/developers/release-management.md
@@ -81,7 +81,9 @@ It builds nothing and commits nothing. Commit the result and open a pull request
 
 Open that pull request from a branch in this repository, not from a fork. `create-manifests`, the job that adds the release names, doesn't run for fork pull requests, so a release branch pushed to a fork would build every image and quietly leave `vX.Y.Z` and `latest` off. `detect` fails the run when it finds a release marker on a fork pull request, before anything is built.
 
-Because `latest` moves when that pull request builds rather than when the GitHub release is created, don't run `release-prep` for an edge/prerelease unless you want `latest` to follow it.
+`release-prep` also takes a prerelease tag (`v1.25.4-alpha1`, `-beta2`, `-rc1`), which follows exactly the same path except that `latest` is left pointing at the last stable release. No other suffix is accepted, so `git describe` output can't be stamped as a release by accident.
+
+For a stable release, `latest` moves when that pull request builds rather than when the GitHub release is created.
 
 The trailing `// <branch>-<hash>` comment on each tag keeps naming the branch rather than the release, because that is the alias the push actually publishes; `containers/validate-image-tag.sh` rejects an alias whose prefix is release-shaped, so a `v1.25.4-<hash>` tag never exists.
 

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -58,7 +58,7 @@ func GetWebImage() string {
 	if globalconfig.DdevGlobalConfig.UseHardenedImages {
 		fullWebImg = fullWebImg + "-prod"
 	}
-	return fmt.Sprintf("%s:%s", fullWebImg, ResolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch))
+	return fmt.Sprintf("%s:%s", fullWebImg, resolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch))
 }
 
 // GetDBImage returns the correctly formatted db image:tag reference
@@ -78,21 +78,21 @@ func GetDBImage(dbType string, dbVersion string) string {
 	case nodeps.MariaDB:
 		fallthrough
 	default:
-		return fmt.Sprintf("%s-%s-%s:%s", imageRepo(versionconstants.DBImg), dbType, v, ResolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch))
+		return fmt.Sprintf("%s-%s-%s:%s", imageRepo(versionconstants.DBImg), dbType, v, resolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch))
 	}
 }
 
 // GetSSHAuthImage returns the correctly formatted sshauth image:tag reference
 func GetSSHAuthImage() string {
-	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.SSHAuthImage), ResolveImageTag(versionconstants.SSHAuthTag, versionconstants.SSHAuthTagBranch))
+	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.SSHAuthImage), resolveImageTag(versionconstants.SSHAuthTag, versionconstants.SSHAuthTagBranch))
 }
 
 // GetRouterImage returns the router image:tag reference
 func GetRouterImage() string {
-	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.TraefikRouterImage), ResolveImageTag(versionconstants.TraefikRouterTag, versionconstants.TraefikRouterTagBranch))
+	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.TraefikRouterImage), resolveImageTag(versionconstants.TraefikRouterTag, versionconstants.TraefikRouterTagBranch))
 }
 
 // GetXhguiImage returns the xhgui image:tag reference
 func GetXhguiImage() string {
-	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.XhguiImage), ResolveImageTag(versionconstants.XhguiTag, versionconstants.XhguiTagBranch))
+	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.XhguiImage), resolveImageTag(versionconstants.XhguiTag, versionconstants.XhguiTagBranch))
 }

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -23,6 +23,11 @@ const DdevImageTagLabel = "com.ddev.image-tag"
 // See ddev/ddev#8753.
 const dockerOrgEnvVar = "DDEV_DOCKER_ORG"
 
+// releaseTagPattern matches vX.Y.Z, or a prerelease like v1.25.4-rc1. Naming
+// the kinds keeps `git describe`'s v1.25.4-15-gabcdef1 out. Also in
+// release-prep.sh and release-marker.sh.
+var releaseTagPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+(-(alpha|beta|rc)[\d.]*)?$`)
+
 // imageRepo returns an image reference with its organization replaced by
 // dockerOrgEnvVar, when that is set. A reference with no organization (the
 // upstream `postgres`) has nothing to replace and is returned unchanged.
@@ -35,15 +40,12 @@ func imageRepo(image string) string {
 	return org + image[i:]
 }
 
-// releaseTagPattern matches a vX.Y.Z release tag.
-var releaseTagPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
-
-// ResolveImageTag prefers branch over tag when branch is a vX.Y.Z release
+// resolveImageTag prefers branch over tag when branch is a release
 // tag. release-prep.sh stamps <TagVar>Branch with the release tag while
 // leaving <TagVar> as the content hash autotag.sh relies on, but both
-// resolve to the identical manifest, so a released binary can pull by the
-// readable tag.
-func ResolveImageTag(tag, branch string) string {
+// resolve to the identical manifest, so a release names its own tag in
+// `ddev version` and `docker images` rather than a hash nobody recognizes.
+func resolveImageTag(tag, branch string) string {
 	if releaseTagPattern.MatchString(branch) {
 		return branch
 	}

--- a/pkg/docker/images_test.go
+++ b/pkg/docker/images_test.go
@@ -8,10 +8,16 @@ import (
 )
 
 func TestResolveImageTag(t *testing.T) {
-	require.Equal(t, "v1.25.4", ResolveImageTag("c202e92108", "v1.25.4"))
-	require.Equal(t, "c202e92108", ResolveImageTag("c202e92108", "20260814_rfay_docker_update_phase_2"))
-	require.Equal(t, "c202e92108", ResolveImageTag("c202e92108", ""))
-	require.Equal(t, "abc123", ResolveImageTag("abc123", "v1.25.4-15-gabcdef1"))
+	require.Equal(t, "v1.25.4", resolveImageTag("c202e92108", "v1.25.4"))
+	require.Equal(t, "c202e92108", resolveImageTag("c202e92108", "20260814_rfay_docker_update_phase_2"))
+	require.Equal(t, "c202e92108", resolveImageTag("c202e92108", ""))
+	require.Equal(t, "abc123", resolveImageTag("abc123", "v1.25.4-15-gabcdef1"))
+
+	require.Equal(t, "v1.25.4-rc1", resolveImageTag("c202e92108", "v1.25.4-rc1"))
+	require.Equal(t, "v1.25.4-alpha1", resolveImageTag("c202e92108", "v1.25.4-alpha1"))
+	require.Equal(t, "v1.26.0-beta2", resolveImageTag("c202e92108", "v1.26.0-beta2"))
+	require.Equal(t, "c202e92108", resolveImageTag("c202e92108", "v1.25.4-dirty"))
+	require.Equal(t, "c202e92108", resolveImageTag("c202e92108", "v1.25.4-preview1"))
 }
 
 func TestImageRepoDockerOrg(t *testing.T) {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -26,7 +26,7 @@ func TestGetVersionInfo(t *testing.T) {
 
 	assert.Equal(versionconstants.DdevVersion, v["DDEV version"])
 	assert.Contains(v["web"], versionconstants.WebImg)
-	assert.Contains(v["web"], docker.ResolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch))
+	assert.Equal(docker.GetWebImage(), v["web"])
 	assert.Contains(v["db"], versionconstants.DBImg)
 	assert.Contains(v["db"], nodeps.MariaDBDefaultVersion)
 	assert.Equal(runtime.Version(), v["go-version"])


### PR DESCRIPTION
## Short Summary (TL;DR)

`make release-prep TAG=v1.25.4-rc1` now works. The images get published under that exact tag and the binary built from it pulls them, while `latest` stays on the last stable release.

## The Issue

No issue filed; found while verifying #8751.

`release-prep.sh` and `release-marker.sh` accepted only `vX.Y.Z`, so a prerelease could not be stamped at all. Underneath that, `image-build-push.yml` added `-t latest` unconditionally alongside the release tag, which is why release-management.md said not to run `release-prep` for a prerelease — the images would have been right, but `latest` would have followed an rc.

## How This PR Solves The Issue

Two questions were tangled behind the same `^vX\.Y\.Z$` regex, and they want different answers.

*Is this a release tag?* Widened to accept `-alpha`/`-beta`/`-rc` in the three places that ask: `pkg/docker/images.go`, `release-prep.sh`, and `release-marker.sh`. Naming the kinds rather than accepting any suffix is what keeps `git describe`'s `v1.25.4-15-gabcdef1` and `-dirty` forms from being stamped as a release by accident.

*Should this move `latest`?* Only `image-build-push.yml` was wrong, and it needs no regex — `release-marker.sh` has already vetted the shape, so a `-` in the tag means prerelease.

Resolving to the release tag at all is about what people see: `ddev version` and `docker images` name `v1.25.4-rc1` instead of a content hash nobody recognizes. That's the reason a prerelease wants the same treatment a stable release gets.

Left unchanged on purpose: `validate-image-tag.sh`'s rejection of release-shaped content tags, since a branch named `v1.25.4-rc1` would publish `...:v1.25.4-rc1-<hash>`, a different string that can't shadow a real prerelease image; the `push-tagged-*.yml` validation escape hatches, so a manual dispatch still can't hand-push a prerelease tag; and the `latest` gates in `containers_shared.mk` and `build_image.sh`, which are already stable-only and sit in image hash paths, where editing them would force every image to be rebuilt and republished for no behavior change.

## Manual Testing Instructions

```bash
containers/release-prep.sh v1.26.0-rc1
git diff   # every Dockerfile marked v1.26.0-rc1, each <TagVar>Branch set to it
containers/release-marker.sh ddev-webserver   # v1.26.0-rc1
make && .gotmp/bin/*/ddev version   # images named :v1.26.0-rc1

# Shapes that must still be refused
containers/release-prep.sh "$(git describe --tags --always --dirty)"
containers/release-prep.sh v1.26.0-preview1
```

Then reset with `git checkout .`.

## Automated Testing Overview

`TestResolveImageTag` covers the accepted prerelease kinds plus `-dirty` and an unrecognized suffix falling back to the content hash. `release_prep_test.sh` asserts a prerelease stamps and reads back like a release, and its rejected-tags list now carries the `git describe` shapes.

`latest` is not covered by either, because it only happens inside `image-build-push.yml`.

## Release/Deployment Notes

No change to a stable release. Worth cutting one prerelease with this in place before relying on it, since the `latest` behavior can only be observed in a real workflow run.
