### PR TITLE
ci: build Windows on Linux and use the signer only for signtool

### DIFF
--- a/.ci-scripts/generate_artifacts.sh
+++ b/.ci-scripts/generate_artifacts.sh
@@ -71,15 +71,13 @@ curl --fail -JL -s -o mkcert "https://github.com/FiloSottile/mkcert/releases/dow
 tar -czf $ARTIFACTS/ddev_linux-arm64.$VERSION.tar.gz ddev ddev-hostname mkcert
 popd >/dev/null
 
-# generate windows-amd64 tarball/zipball
+# generate windows-amd64 tarball/zipball; mkcert.exe is already here and signed
 pushd $BASE_DIR/.gotmp/bin/windows_amd64 >/dev/null
-curl --fail -JL -s -o mkcert.exe "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-amd64.exe"
 tar -czf $ARTIFACTS/ddev_windows-amd64.$VERSION.tar.gz ddev.exe ddev-hostname.exe mkcert.exe
 popd >/dev/null
 
 # generate windows-arm64 tarball/zipball
 pushd $BASE_DIR/.gotmp/bin/windows_arm64 >/dev/null
-curl --fail -JL -s -o mkcert.exe "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-windows-arm64.exe"
 tar -czf $ARTIFACTS/ddev_windows-arm64.$VERSION.tar.gz ddev.exe ddev-hostname.exe mkcert.exe
 popd >/dev/null
 

--- a/.github/workflows/linux-build-setup.sh
+++ b/.github/workflows/linux-build-setup.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 # Needed for the build jobs, e.g. for Windows makensis
 
 sudo apt-get update -qq
-sudo apt-get install -y -qq osslsigncode nsis
+sudo apt-get install -y -qq nsis
 
 # Get the Stubs and Plugins for makensis; the linux makensis build doesn't do this.
 ./.ci-scripts/nsis_setup.sh /usr/share/nsis

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -40,37 +40,52 @@ permissions:
   packages: write
 
 jobs:
-  build-most:
-    name: Build DDEV executables except Windows
+  # Every executable we ship, Windows included, cross-compiles on Linux. One
+  # job per platform because each GOOS/GOARCH pays its own cold-cache compile
+  # of the standard library and vendored deps, so they only get faster by
+  # running on separate machines.
+  build:
+    name: Build ${{ matrix.platform }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { platform: linux_amd64,   target: linux_amd64 completions }
+          - { platform: linux_arm64,   target: linux_arm64 }
+          - { platform: darwin_amd64,  target: darwin_amd64 }
+          - { platform: darwin_arm64,  target: darwin_arm64 }
+          - { platform: windows_amd64, target: windows_amd64_binaries }
+          - { platform: windows_arm64, target: windows_arm64_binaries }
     steps:
-
       - uses: actions/checkout@v7
         with:
           # We need to get all branches and tags for git describe to work properly
           fetch-depth: 0
-
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
-        with:
-          brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Docker and deps
-        run: ./.github/workflows/linux-setup.sh
-
-      - name: Install build tools
-        run: ./.github/workflows/linux-build-setup.sh
 
       - uses: actions/setup-go@v7
         with:
           go-version: '>=1.23'
           check-latest: true
 
+      # The Windows targets stop at the binaries; NSIS cannot run until they
+      # come back signed. See the build-installers job.
       - name: Build DDEV executables
-        run: make linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 completions mkcert
+        run: make ${{ matrix.target }}
+
+      - name: Set up Homebrew
+        if: matrix.platform == 'linux_amd64'
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Docker and deps
+        if: matrix.platform == 'linux_amd64'
+        run: ./.github/workflows/linux-setup.sh
 
       - name: "Verify that instrumentation is working (Linux amd64)"
+        if: matrix.platform == 'linux_amd64'
         run: |
           export PATH=".gotmp/bin/linux_amd64:$PATH"
           echo "DDEV_NO_INSTRUMENTATION=${DDEV_NO_INSTRUMENTATION}"
@@ -80,44 +95,65 @@ jobs:
           ddev version | grep -v "AmplitudeAPIKey is not available."
           ddev config global --instrumentation-opt-in=false
 
-
-      - name: save build results to cache
-        uses: actions/cache@v6
+      - name: Upload ${{ matrix.platform }} build
+        uses: actions/upload-artifact@v7
         with:
-          path: .gotmp/bin
-          key: ${{ github.sha }}-${{ github.ref }}-build-most
+          name: build-${{ matrix.platform }}
+          path: .gotmp/bin/${{ matrix.platform }}
+          retention-days: 1
+          if-no-files-found: error
 
-  # This Windows self-hosted runner has to be set up with gnu tar and zstd.exe, or
-  # this step will fail to properly create the cache.
-  # Make sure gnu tar is the tar used here. System PATH should have C:\program files\gnu\usr\bin near top
-  # Get zstd.exe from https://github.com/facebook/zstd/releases - I put it into C:\program files\gnu\usr\bin
-  # so it would be in PATH
-  # See https://github.com/actions/cache/issues/580
-  # Run the Windows action with debug enabled to be able to see which tar is in use, etc.
-  sign-windows:
-    name: Build and Sign Windows binaries
+      - name: Upload completions
+        if: matrix.platform == 'linux_amd64'
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-completions
+          path: |
+            .gotmp/bin/completions.tar.gz
+            .gotmp/bin/completions
+          retention-days: 1
+          if-no-files-found: error
+
+  # This self-hosted runner holds the code-signing dongle. It deliberately does
+  # no checkout and runs no repository code: it downloads executables, runs
+  # signtool, and uploads them again. Keep it that way - anything else puts a
+  # certificate we cannot rotate behind whatever a workflow change happens to
+  # run.
+  sign-windows-binaries:
+    name: Sign Windows binaries
     runs-on: [ self-hosted, windows-signer ]
+    needs: build
     env:
       DDEV_WINDOWS_SIGN: ${{ vars.DDEV_WINDOWS_SIGN }}
     steps:
-
-      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
-          fetch-depth: 0
-      - name: Build and sign windows amd64/arm64 binaries and installers
-        shell: bash
+          pattern: build-windows_*
+          path: incoming
+
+      - name: Lay out binaries
         run: |
-          if [ "${DDEV_WINDOWS_SIGN}" != "true" ]; then echo "Warning: DDEV_WINDOWS_SIGN=${DDEV_WINDOWS_SIGN} is not true"; fi
-          make windows_amd64_install windows_arm64_install wsl_amd64 wsl_arm64
-      - name: Show github.ref
-        run: echo ${{ github.ref }}
-      - name: Build chocolatey on release
-        if: startsWith( github.ref, 'refs/tags/v1')
-        run: make chocolatey
+          set -eu -o pipefail
+          mkdir -p bin
+          for arch in amd64 arm64; do
+            mv "incoming/build-windows_${arch}" "bin/windows_${arch}"
+          done
+
+      - name: Sign Windows binaries
+        run: |
+          set -eu -o pipefail
+          if [ "${DDEV_WINDOWS_SIGN}" != "true" ]; then echo "Warning: DDEV_WINDOWS_SIGN=${DDEV_WINDOWS_SIGN} is not true"; exit 0; fi
+          for arch in amd64 arm64; do
+            signtool sign -fd SHA256 \
+              "bin/windows_${arch}/ddev.exe" \
+              "bin/windows_${arch}/ddev-hostname.exe" \
+              "bin/windows_${arch}/mkcert.exe" \
+              "bin/windows_${arch}/ddev_gen_autocomplete.exe"
+          done
 
       - name: "Verify that instrumentation is working (Windows)"
         run: |
-          export PATH=".gotmp/bin/windows_amd64:$PATH"
+          export PATH="bin/windows_amd64:$PATH"
           echo "DDEV_NO_INSTRUMENTATION=${DDEV_NO_INSTRUMENTATION}"
           if [ -z "${AmplitudeAPIKey}" ]; then echo "AmplitudeAPIKey is not set"; exit 1; fi
           ddev config global --instrumentation-opt-in=true
@@ -125,33 +161,113 @@ jobs:
           ddev version | grep -v "AmplitudeAPIKey is not available."
           ddev config global --instrumentation-opt-in=false
 
-      - name: Verify that binaries and installers were signed
+      - name: Verify that binaries were signed
+        if: vars.DDEV_WINDOWS_SIGN == 'true'
         run: |
-          signtool verify -pa .gotmp/bin/windows_amd64/ddev_windows_amd64_installer.exe
-          signtool verify -pa .gotmp/bin/windows_amd64/ddev.exe
-          signtool verify -pa .gotmp/bin/windows_amd64/ddev-hostname.exe
-          signtool verify -pa .gotmp/bin/windows_amd64/mkcert.exe
-          signtool verify -pa .gotmp/bin/windows_arm64/ddev_windows_arm64_installer.exe
-          signtool verify -pa .gotmp/bin/windows_arm64/ddev.exe
-          signtool verify -pa .gotmp/bin/windows_arm64/ddev-hostname.exe
-          signtool verify -pa .gotmp/bin/windows_arm64/mkcert.exe
+          set -eu -o pipefail
+          for arch in amd64 arm64; do
+            for f in ddev.exe ddev-hostname.exe mkcert.exe; do
+              signtool verify -pa "bin/windows_${arch}/${f}"
+            done
+          done
 
-      - name: Cache signed binaries
-        # After 3.0.5 they were using zstdmt which is not available on Windows
-        # See https://github.com/actions/cache/issues/891
-        # But trying again with @v3, 2023-02-18
-        uses: actions/cache@v6
+      - name: Upload signed Windows binaries
+        uses: actions/upload-artifact@v7
         with:
-          path: |
-            .gotmp/bin/windows*
-            .gotmp/bin/wsl*
-          key: ${{ github.sha }}-${{ github.ref }}-signed-windows-binaries
-          enableCrossOsArchive: true
+          name: signed-windows-binaries
+          path: bin
+          retention-days: 1
+          if-no-files-found: error
+
+  # NSIS has to run between the two signing passes: it packs the signed
+  # ddev-hostname.exe and mkcert.exe, and the installer it emits then needs
+  # signing itself.
+  build-installers:
+    name: Build Windows installers
+    runs-on: ubuntu-latest
+    needs: sign-windows-binaries
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install build tools
+        run: ./.github/workflows/linux-build-setup.sh
+
+      - name: Restore signed Windows binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: signed-windows-binaries
+          path: signed
+
+      # The installer bundles the Linux binaries for the WSL2 install path.
+      - name: Restore Linux builds
+        uses: actions/download-artifact@v8
+        with:
+          pattern: build-linux_*
+          path: linux
+
+      - name: Assemble .gotmp/bin
+        run: |
+          set -eu -o pipefail
+          for arch in amd64 arm64; do
+            mkdir -p ".gotmp/bin/windows_${arch}" ".gotmp/bin/linux_${arch}"
+            cp -a "signed/windows_${arch}/." ".gotmp/bin/windows_${arch}/"
+            cp -a "linux/build-linux_${arch}/." ".gotmp/bin/linux_${arch}/"
+            chmod +x ".gotmp/bin/linux_${arch}"/*
+          done
+
+      - name: Build installers
+        run: make windows_amd64_package windows_arm64_package
+
+      - name: Upload unsigned installers
+        uses: actions/upload-artifact@v7
+        with:
+          name: unsigned-installers
+          path: .gotmp/bin/windows_*/ddev_windows_*_installer.exe
+          retention-days: 1
+          if-no-files-found: error
+
+  sign-windows-installers:
+    name: Sign Windows installers
+    runs-on: [ self-hosted, windows-signer ]
+    needs: build-installers
+    env:
+      DDEV_WINDOWS_SIGN: ${{ vars.DDEV_WINDOWS_SIGN }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: unsigned-installers
+          path: bin
+
+      - name: Sign Windows installers
+        run: |
+          set -eu -o pipefail
+          if [ "${DDEV_WINDOWS_SIGN}" != "true" ]; then echo "Warning: DDEV_WINDOWS_SIGN=${DDEV_WINDOWS_SIGN} is not true"; exit 0; fi
+          for arch in amd64 arm64; do
+            signtool sign -fd SHA256 "bin/windows_${arch}/ddev_windows_${arch}_installer.exe"
+          done
+
+      - name: Verify that installers were signed
+        if: vars.DDEV_WINDOWS_SIGN == 'true'
+        run: |
+          set -eu -o pipefail
+          for arch in amd64 arm64; do
+            signtool verify -pa "bin/windows_${arch}/ddev_windows_${arch}_installer.exe"
+          done
+
+      - name: Upload signed installers
+        uses: actions/upload-artifact@v7
+        with:
+          name: signed-installers
+          path: bin
+          retention-days: 1
+          if-no-files-found: error
 
   notarize-macos:
     name: Sign and Notarize ddev on macOS
     runs-on: macos-latest
-    needs: build-most
+    needs: build
     steps:
       - name: Load 1password secret(s)
         uses: 1password/load-secrets-action@v5
@@ -172,21 +288,21 @@ jobs:
         with:
           # We need to get all branches and tags for git describe to work properly
           fetch-depth: 0
-      - uses: actions/setup-go@v7
-        with:
-          go-version: '>=1.23'
-          check-latest: true
 
-      - name: restore build-most results from cache
-        uses: actions/cache@v6
-        id: buildmost
+      - name: Restore darwin builds
+        uses: actions/download-artifact@v8
         with:
-          path: .gotmp/bin
-          key: ${{ github.sha }}-${{ github.ref }}-build-most
-          fail-on-cache-miss: true
-      - name: test that buildmost cache was loaded
-        if: steps.buildmost.outputs.cache-hit != 'true'
-        run: exit 1
+          pattern: build-darwin_*
+          path: darwin
+
+      - name: Assemble .gotmp/bin
+        run: |
+          set -eu -o pipefail
+          for arch in amd64 arm64; do
+            mkdir -p ".gotmp/bin/darwin_${arch}"
+            cp -a "darwin/build-darwin_${arch}/." ".gotmp/bin/darwin_${arch}/"
+            chmod +x ".gotmp/bin/darwin_${arch}"/*
+          done
 
       - name: Sign and notarize binaries (amd64 and arm64)
         env:
@@ -206,11 +322,14 @@ jobs:
               echo "Notarization disabled via DISABLE_NOTARIZATION=true environment variable"
             fi
           done
-      - name: Save notarized binaries to cache
-        uses: actions/cache@v6
+
+      - name: Upload notarized binaries
+        uses: actions/upload-artifact@v7
         with:
-          path: .gotmp/bin/darwin*
-          key: ${{ github.sha }}-${{ github.ref }}-notarize-macos
+          name: notarized-darwin
+          path: .gotmp/bin/darwin_*
+          retention-days: 1
+          if-no-files-found: error
 
   artifacts:
     env:
@@ -220,7 +339,7 @@ jobs:
       DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
     name: Upload artifacts
     runs-on: ubuntu-latest
-    needs: [build-most, sign-windows, notarize-macos]
+    needs: [build, sign-windows-installers, notarize-macos]
     steps:
       - name: Load 1password secret(s)
         uses: 1password/load-secrets-action@v5
@@ -241,43 +360,40 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Restore build-most builds
-        uses: actions/cache@v6
-        id: buildmost
+      - uses: actions/setup-go@v7
         with:
-          path: .gotmp/bin
-          key: ${{ github.sha }}-${{ github.ref }}-build-most
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
-      - name: test that build-most was loaded
-        if: steps.buildmost.outputs.cache-hit != 'true'
-        run: exit 1
+          go-version: '>=1.23'
+          check-latest: true
 
-      - name: Restore Signed Windows artifacts
-        uses: actions/cache@v6
-        id: signedwindows
+      - name: Download all build outputs
+        uses: actions/download-artifact@v8
         with:
-          path: |
-            .gotmp/bin/windows*
-            .gotmp/bin/wsl*
-          key: ${{ github.sha }}-${{ github.ref }}-signed-windows-binaries
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
-      - name: test that signed-windows was loaded
-        if: steps.signedwindows.outputs.cache-hit != 'true'
-        run: exit 1
+          path: incoming
 
-      - name: Restore Signed Mac artifacts
-        uses: actions/cache@v6
-        id: notarizedmac
-        with:
-          path: .gotmp/bin/darwin*
-          key: ${{ github.sha }}-${{ github.ref }}-notarize-macos
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
-      - name: test that notarizedmac was loaded
-        if: steps.notarizedmac.outputs.cache-hit != 'true'
-        run: exit 1
+      # Everything arrives as artifacts, which do not carry the executable bit,
+      # and the signed copies have to win over the unsigned ones they replace.
+      - name: Assemble .gotmp/bin
+        run: |
+          set -eu -o pipefail
+          mkdir -p .gotmp/bin
+          for arch in amd64 arm64; do
+            mkdir -p ".gotmp/bin/linux_${arch}" ".gotmp/bin/darwin_${arch}" ".gotmp/bin/windows_${arch}"
+            cp -a "incoming/build-linux_${arch}/." ".gotmp/bin/linux_${arch}/"
+            cp -a "incoming/notarized-darwin/darwin_${arch}/." ".gotmp/bin/darwin_${arch}/"
+            cp -a "incoming/signed-windows-binaries/windows_${arch}/." ".gotmp/bin/windows_${arch}/"
+            cp -a "incoming/signed-installers/windows_${arch}/." ".gotmp/bin/windows_${arch}/"
+          done
+          cp -a incoming/build-completions/. .gotmp/bin/
+          chmod +x .gotmp/bin/{linux,darwin}_{amd64,arm64}/{ddev,ddev-hostname,mkcert}
+
+      # Signing rewrote the installers after they were built, so this is the
+      # first point at which they can be hashed.
+      - name: Generate installer checksums and WSL2 copies
+        run: make windows_amd64_installer_checksum windows_arm64_installer_checksum wsl_amd64_copy wsl_arm64_copy
+
+      - name: Build chocolatey on release
+        if: startsWith( github.ref, 'refs/tags/v1')
+        run: make chocolatey
 
       - name: "Verify that cgo_enabled is 0 in Linux binary"
         run: |
@@ -412,4 +528,3 @@ jobs:
           base-path-to-features: "./containers/devcontainers"
           devcontainer-cli-version: "0.53.0"
           disable-repo-tagging: "true"
-

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PWD = $(shell pwd)
 GOFILES = $(shell find $(SRC_DIRS) -name "*.go" ! -path "*/testdata/*")
 GORACE = "halt_on_error=1"
 CGO_ENABLED = 0
-.PHONY: darwin_amd64 darwin_arm64 darwin_amd64_notarized darwin_arm64_notarized darwin_arm64_signed darwin_amd64_signed linux_amd64 linux_arm64 linux_arm windows_amd64 windows_arm64 windows_install setup
+.PHONY: darwin_amd64 darwin_arm64 darwin_amd64_notarized darwin_arm64_notarized darwin_arm64_signed darwin_amd64_signed linux_amd64 linux_arm64 linux_arm windows_amd64 windows_arm64 windows_amd64_binaries windows_arm64_binaries windows_binaries windows_sign_binaries windows_install setup
 
 # Expands SRC_DIRS into the common golang ./dir/... format for "all below"
 SRC_AND_UNDER = $(patsubst %,./%/...,$(SRC_DIRS))
@@ -145,7 +145,7 @@ $(TARGETS): mkcert $(GOFILES)
 	@echo $(VERSION) >VERSION.txt
 
 
-$(GOTMP)/bin/completions.tar.gz: build
+$(GOTMP)/bin/completions.tar.gz: $(DEFAULT_BUILD)
 	$(GOTMP)/bin/$(BUILD_OS)_$(BUILD_ARCH)/ddev_gen_autocomplete
 	tar -C $(GOTMP)/bin/completions -czf $(GOTMP)/bin/completions.tar.gz .
 
@@ -386,33 +386,67 @@ windows_amd64_install: $(GOTMP)/bin/windows_amd64/ddev_windows_amd64_installer.e
 windows_arm64_install: $(GOTMP)/bin/windows_arm64/ddev_windows_arm64_installer.exe
 windows_install: windows_amd64_install windows_arm64_install
 
-windows_amd64_sign_binaries: $(GOTMP)/bin/windows_amd64/ddev.exe $(GOTMP)/bin/windows_amd64/ddev-hostname.exe $(GOTMP)/bin/windows_amd64/mkcert.exe
-	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing amd64 ddev.exe, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows amd64 binaries..." && signtool sign -fd SHA256 ".gotmp/bin/windows_amd64/ddev.exe" ".gotmp/bin/windows_amd64/ddev-hostname.exe" ".gotmp/bin/windows_amd64/mkcert.exe" ".gotmp/bin/windows_amd64/ddev_gen_autocomplete.exe"; fi
+# A Windows release is assembled in three phases because signtool runs only on
+# the signing host, while everything else cross-builds on Linux: the binaries
+# are built and signed, NSIS packs the signed binaries into an installer, and
+# the installer is then signed itself. The signing and packaging targets take
+# no build prerequisites, so main-build.yml can run one on a machine holding
+# nothing but signtool and the files it downloaded.
+windows_amd64_binaries: $(GOTMP)/bin/windows_amd64/ddev.exe $(GOTMP)/bin/windows_amd64/ddev-hostname.exe $(GOTMP)/bin/windows_amd64/mkcert.exe $(GOTMP)/bin/windows_amd64/mkcert_license.txt
+windows_arm64_binaries: $(GOTMP)/bin/windows_arm64/ddev.exe $(GOTMP)/bin/windows_arm64/ddev-hostname.exe $(GOTMP)/bin/windows_arm64/mkcert.exe $(GOTMP)/bin/windows_arm64/mkcert_license.txt
+windows_binaries: windows_amd64_binaries windows_arm64_binaries
 
-windows_arm64_sign_binaries: $(GOTMP)/bin/windows_arm64/ddev.exe $(GOTMP)/bin/windows_arm64/ddev-hostname.exe $(GOTMP)/bin/windows_arm64/mkcert.exe
-	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing arm64 ddev.exe, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows arm64 binaries..." && signtool sign -fd SHA256 ".gotmp/bin/windows_arm64/ddev.exe" ".gotmp/bin/windows_arm64/ddev-hostname.exe" ".gotmp/bin/windows_arm64/mkcert.exe" ".gotmp/bin/windows_arm64/ddev_gen_autocomplete.exe"; fi
+windows_%_sign_binaries:
+	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing $* binaries, DDEV_WINDOWS_SIGN not set"; else \
+		echo "Signing windows $* binaries..." && \
+		signtool sign -fd SHA256 "$(GOTMP)/bin/windows_$*/ddev.exe" "$(GOTMP)/bin/windows_$*/ddev-hostname.exe" "$(GOTMP)/bin/windows_$*/mkcert.exe" "$(GOTMP)/bin/windows_$*/ddev_gen_autocomplete.exe"; \
+	fi
 
 windows_sign_binaries: windows_amd64_sign_binaries windows_arm64_sign_binaries
 
-$(GOTMP)/bin/windows_amd64/ddev_windows_amd64_installer.exe: windows_amd64_sign_binaries linux_amd64 $(GOTMP)/bin/windows_amd64/mkcert_license.txt winpkg/ddev_windows_installer.nsi
-	@makensis -DTARGET_ARCH=amd64 -DVERSION=$(VERSION) winpkg/ddev_windows_installer.nsi  # brew install makensis, apt-get install nsis, or install on Windows
-	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing amd64 $@, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows installer amd64 binary..." && signtool sign -fd SHA256 "$@"; fi
-	$(SHASUM) $@ >$@.sha256.txt
+# Packs whatever is already in $(GOTMP)/bin/windows_$* and $(GOTMP)/bin/linux_$*.
+windows_%_package:
+	@makensis -DTARGET_ARCH=$* -DVERSION=$(VERSION) winpkg/ddev_windows_installer.nsi  # brew install makensis, apt-get install nsis, or install on Windows
 
-$(GOTMP)/bin/windows_arm64/ddev_windows_arm64_installer.exe: windows_arm64_sign_binaries linux_arm64  $(GOTMP)/bin/windows_arm64/mkcert_license.txt winpkg/ddev_windows_installer.nsi
-	@makensis -DTARGET_ARCH=arm64 -DVERSION=$(VERSION) winpkg/ddev_windows_installer.nsi  # brew install makensis, apt-get install nsis, or install on Windows
-	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing arm64 $@, DDEV_WINDOWS_SIGN not set"; else echo "Signing windows installer arm64 binary..." && signtool sign -fd SHA256 "$@"; fi
-	$(SHASUM) $@ >$@.sha256.txt
+windows_%_sign_installer:
+	@if [ "$(DDEV_WINDOWS_SIGN)" != "true" ] ; then echo "Skipping signing $* installer, DDEV_WINDOWS_SIGN not set"; else \
+		echo "Signing windows $* installer..." && \
+		signtool sign -fd SHA256 "$(GOTMP)/bin/windows_$*/ddev_windows_$*_installer.exe"; \
+	fi
+	$(MAKE) windows_$*_installer_checksum
+
+# Separate from signing because signing rewrites the installer, so whichever
+# machine signs last has to be the one that hashes it.
+windows_%_installer_checksum:
+	$(SHASUM) $(GOTMP)/bin/windows_$*/ddev_windows_$*_installer.exe >$(GOTMP)/bin/windows_$*/ddev_windows_$*_installer.exe.sha256.txt
+
+# The wsl_amd64/wsl_arm64 targets above rebuild the Windows binaries first,
+# discarding any signature applied elsewhere. This copies what is already there.
+wsl_%_copy:
+	mkdir -p $(GOTMP)/bin/wsl_$*
+	cp $(GOTMP)/bin/windows_$*/ddev-hostname.exe $(GOTMP)/bin/windows_$*/mkcert.exe $(GOTMP)/bin/wsl_$*/
+
+$(GOTMP)/bin/windows_amd64/ddev_windows_amd64_installer.exe: windows_amd64_binaries linux_amd64 winpkg/ddev_windows_installer.nsi
+	$(MAKE) windows_amd64_sign_binaries
+	$(MAKE) windows_amd64_package
+	$(MAKE) windows_amd64_sign_installer
+
+$(GOTMP)/bin/windows_arm64/ddev_windows_arm64_installer.exe: windows_arm64_binaries linux_arm64 winpkg/ddev_windows_installer.nsi
+	$(MAKE) windows_arm64_sign_binaries
+	$(MAKE) windows_arm64_package
+	$(MAKE) windows_arm64_sign_installer
 
 no_v_version:
 	@echo $(NO_V_VERSION)
 
-chocolatey: $(GOTMP)/bin/windows_amd64/ddev_windows_amd64_installer.exe
+# Packages the installer already present, for the same reason as
+# windows_%_installer_checksum.
+chocolatey:
 	rm -rf $(GOTMP)/bin/windows_amd64/chocolatey && cp -r winpkg/chocolatey $(GOTMP)/bin/windows_amd64/chocolatey
 	perl -pi -e 's/REPLACE_DDEV_VERSION/$(NO_V_VERSION)/g' $(GOTMP)/bin/windows_amd64/chocolatey/*.nuspec
 	perl -pi -e 's/REPLACE_DDEV_VERSION/$(VERSION)/g' $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1
 	perl -pi -e 's/REPLACE_GITHUB_ORG/$(REPOSITORY_OWNER)/g' $(GOTMP)/bin/windows_amd64/chocolatey/*.nuspec $(GOTMP)/bin/windows_amd64/chocolatey/tools/*.ps1 #GITHUB_ORG is for testing, for example when the binaries are on rfay acct
-	perl -pi -e "s/REPLACE_INSTALLER_CHECKSUM/$$(cat $(GOTMP)/bin/windows_amd64/ddev_windows_amd64installer.exe.sha256.txt | awk '{ print $$1; }')/g" $(GOTMP)/bin/windows_amd64/chocolatey/tools/*
+	perl -pi -e "s/REPLACE_INSTALLER_CHECKSUM/$$(cat $(GOTMP)/bin/windows_amd64/ddev_windows_amd64_installer.exe.sha256.txt | awk '{ print $$1; }')/g" $(GOTMP)/bin/windows_amd64/chocolatey/tools/*
 	if [[ "$(NO_V_VERSION)" =~ -g[0-9a-f]+ ]]; then \
 		echo "Skipping chocolatey build on interim version"; \
 	else \


### PR DESCRIPTION
## Short Summary (TL;DR)

The Windows release job spent 17 minutes on the self-hosted signing machine to produce 26 seconds of actual signing, because it compiled every Windows and Linux binary there first. Building and packaging now happen on Linux runners and the Windows machine does nothing but run signtool, which takes the workflow's critical path from about 17 minutes down to about 7.

## The Issue

No issue filed. Measured on [run 33162427143](https://github.com/ddev/ddev/actions/runs/33162427143): of the 1005s Windows step, 271s and 190s went to compiling `ddev.exe` for amd64 and arm64, and another 374s to rebuilding the Linux binaries that `build-most` had already produced. Signing itself was 26s, and the same machine compiles roughly 3x slower than an ubuntu runner.

## How This PR Solves The Issue

`pr-build.yml` already cross-builds both Windows binaries and both NSIS installers on ubuntu, so only `signtool` actually needs Windows. Ordering is what forces two visits to the signer: NSIS packs `ddev-hostname.exe` and `mkcert.exe`, so those have to be signed before packaging, and the installer has to be signed after it.

The workflow becomes build (matrix of 6 platforms) → sign binaries → build installers → sign installers → artifacts. The signing jobs take no checkout and run no repository code, so the certificate is not exposed to whatever a workflow change happens to run. Transfers between jobs move from `actions/cache` with `enableCrossOsArchive` to plain artifacts, which drops the gnu tar and zstd requirements on the self-hosted runner.

The Makefile gains a separate target per phase. Splitting them surfaced a trap worth a close look in review: `wsl_amd64` and `chocolatey` reach back through `$(TARGETS)` and rebuild the Windows binaries, which after signing would replace signed binaries with unsigned ones and leave no trace. The post-signing work now uses prerequisite-free targets.

Three adjacent fixes came out of reading the same code: `chocolatey` read a sha256 filename with a missing underscore, so `REPLACE_INSTALLER_CHECKSUM` was always substituted with an empty string; `generate_artifacts.sh` re-downloaded `mkcert.exe` over the signed copy, so released Windows tarballs shipped an unsigned mkcert; and `osslsigncode`, unusable for our signing for years, is no longer installed.

## Manual Testing Instructions

Run the split phases the way the separate CI jobs will:

```bash
make windows_amd64_binaries linux_amd64
make windows_amd64_package
make windows_amd64_sign_installer
```

Check that `ddev-hostname.exe` keeps the same sha256 across the last two commands — a changed hash means make rebuilt it and would have discarded a signature. Confirm the same for the post-signing targets, none of which should emit a build command:

```bash
make -n windows_amd64_installer_checksum wsl_amd64_copy chocolatey
```

The one-shot path used by `pr-build.yml` and local builds is unchanged:

```bash
make windows_arm64_install
```

## Automated Testing Overview

No new automated tests; this is CI plumbing. Verified locally that the three phases work separately without rebuilding, that `windows_arm64_install` still works from a clean tree, and that actionlint reports the same findings as before apart from one more unknown `windows-signer` label, since there are now two signing jobs.

Two behaviors could not be checked off GitHub: the artifact least-common-ancestor layout that the download paths assume, and whether the self-hosted runner is happy with `download-artifact@v8` and no checkout. Both fail loudly on the first `main` run.

## Release/Deployment Notes

No user-visible change beyond released Windows tarballs now carrying the signed `mkcert.exe` and the Chocolatey package carrying a real checksum. The self-hosted runner no longer needs Go, NSIS, or the gnu tar and zstd setup that `actions/cache` required, so those can be removed from it once this lands.
