### PR TITLE
feat: add ddev launch --print-url flag and DDEV_LAUNCH_PRINT_URL env var, fixes #8771 (#8772) [skip ci]

### DIFF
--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -412,6 +412,25 @@ func TestLaunchCommand(t *testing.T) {
 		assert.NoError(err, `couldn't run "%s"", output=%s`, c, out)
 		assert.Equal(expect, out, "output of %s is incorrect with app.RouterHTTPSPort=%s: %s", c, app.RouterHTTPSPort, out)
 	}
+
+	// --print-url and DDEV_LAUNCH_PRINT_URL=true print the URL without global
+	// debug logging (DDEV_DEBUG off): the output is exactly one FULLURL line,
+	// no util.Debug timestamps, no browser attempt.
+	t.Setenv("DDEV_DEBUG", "")
+
+	t.Setenv("DDEV_LAUNCH_PRINT_URL", "true")
+	c := DdevBin + ` launch`
+	out, err := exec.RunHostCommand("bash", "-c", c)
+	out = strings.Trim(out, "\r\n")
+	assert.NoError(err, `couldn't run "%s", output=%s`, c, out)
+	assert.Equal("FULLURL "+app.GetPrimaryURL(), out, "DDEV_LAUNCH_PRINT_URL=true should print exactly one FULLURL line without DDEV_DEBUG, got: %s", out)
+
+	t.Setenv("DDEV_LAUNCH_PRINT_URL", "")
+	c = DdevBin + ` launch --print-url`
+	out, err = exec.RunHostCommand("bash", "-c", c)
+	out = strings.Trim(out, "\r\n")
+	assert.NoError(err, `couldn't run "%s", output=%s`, c, out)
+	assert.Equal("FULLURL "+app.GetPrimaryURL(), out, "--print-url should print exactly one FULLURL line without DDEV_DEBUG, got: %s", out)
 }
 
 // TestMysqlCommand tests `ddev mysql`

--- a/cmd/ddev/cmd/commands_test.go
+++ b/cmd/ddev/cmd/commands_test.go
@@ -414,8 +414,8 @@ func TestLaunchCommand(t *testing.T) {
 	}
 
 	// --print-url and DDEV_LAUNCH_PRINT_URL=true print the URL without global
-	// debug logging (DDEV_DEBUG off): the output is exactly one FULLURL line,
-	// no util.Debug timestamps, no browser attempt.
+	// debug logging (DDEV_DEBUG off): the output is exactly the URL itself,
+	// no FULLURL prefix, no util.Debug timestamps, no browser attempt.
 	t.Setenv("DDEV_DEBUG", "")
 
 	t.Setenv("DDEV_LAUNCH_PRINT_URL", "true")
@@ -423,14 +423,14 @@ func TestLaunchCommand(t *testing.T) {
 	out, err := exec.RunHostCommand("bash", "-c", c)
 	out = strings.Trim(out, "\r\n")
 	assert.NoError(err, `couldn't run "%s", output=%s`, c, out)
-	assert.Equal("FULLURL "+app.GetPrimaryURL(), out, "DDEV_LAUNCH_PRINT_URL=true should print exactly one FULLURL line without DDEV_DEBUG, got: %s", out)
+	assert.Equal(app.GetPrimaryURL(), out, "DDEV_LAUNCH_PRINT_URL=true should print exactly the URL without DDEV_DEBUG, got: %s", out)
 
 	t.Setenv("DDEV_LAUNCH_PRINT_URL", "")
 	c = DdevBin + ` launch --print-url`
 	out, err = exec.RunHostCommand("bash", "-c", c)
 	out = strings.Trim(out, "\r\n")
 	assert.NoError(err, `couldn't run "%s", output=%s`, c, out)
-	assert.Equal("FULLURL "+app.GetPrimaryURL(), out, "--print-url should print exactly one FULLURL line without DDEV_DEBUG, got: %s", out)
+	assert.Equal(app.GetPrimaryURL(), out, "--print-url should print exactly the URL without DDEV_DEBUG, got: %s", out)
 }
 
 // TestMysqlCommand tests `ddev mysql`

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -857,6 +857,9 @@ it will be started first.
 Flags:
 
 * `--mailpit`, `-m`: Open Mailpit.
+* `--print-url`: Print the URL instead of opening a browser. Useful where no browser is available (SSH sessions, containers, CI) or to use the URL in scripts.
+
+The environment variable `DDEV_LAUNCH_PRINT_URL=true` behaves like the `--print-url` flag. Unlike the flag it is inherited by nested `ddev launch` invocations (for example from custom commands or add-ons that call `ddev launch` internally), so wrappers and external tools can capture the URL without enabling `DDEV_DEBUG`.
 
 !!!tip "How to disable HTTP redirect to HTTPS?"
     Recommendations for:
@@ -873,6 +876,9 @@ ddev launch
 
 # Open Mailpit in the default browser
 ddev launch --mailpit
+
+# Print your project’s base URL instead of opening a browser
+ddev launch --print-url
 
 # Open your project’s base URL appended with `temp/phpinfo.php`
 ddev launch temp/phpinfo.php

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -857,9 +857,9 @@ it will be started first.
 Flags:
 
 * `--mailpit`, `-m`: Open Mailpit.
-* `--print-url`: Print the URL instead of opening a browser. Useful where no browser is available (SSH sessions, containers, CI) or to use the URL in scripts.
+* `--print-url`: Print the URL instead of opening a browser. The output is the resolved URL itself, with no prefix, so it can be used directly in scripts. Useful where no browser is available (SSH sessions, containers, CI).
 
-The environment variable `DDEV_LAUNCH_PRINT_URL=true` behaves like the `--print-url` flag. Unlike the flag it is inherited by nested `ddev launch` invocations (for example from custom commands or add-ons that call `ddev launch` internally), so wrappers and external tools can capture the URL without enabling `DDEV_DEBUG`.
+The environment variable `DDEV_LAUNCH_PRINT_URL=true` behaves like the `--print-url` flag. Unlike the flag it is inherited by nested `ddev launch` invocations (for example from custom commands or add-ons that call `ddev launch` internally), so wrappers and external tools can capture the URL. Unlike `DDEV_DEBUG=true` or `DDEV_VERBOSE=true`, which print the URL with a `FULLURL` prefix and enable global debug logging, it prints only the URL.
 
 !!!tip "How to disable HTTP redirect to HTTPS?"
     Recommendations for:

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -113,17 +113,24 @@ if [ -n "${1:-}" ]; then
   fi
 fi
 
+# Print the URL instead of opening a browser: explicitly requested via
+# --print-url or DDEV_LAUNCH_PRINT_URL=true (inherited by nested `ddev launch`
+# invocations, e.g. from custom commands that call launch internally).
+# Print only the URL itself, with no prefix, so the output can be used
+# directly without parsing.
+if [ "${DDEV_LAUNCH_PRINT_URL:-}" = "true" ]; then
+    printf "%s\n" "$FULLURL"
+    exit 0
+fi
+
 if [[ "${FULLURL}" =~ ^http:// ]]; then
   echo "HTTP may redirect to HTTPS in your browser"
   echo "See https://docs.ddev.com/en/stable/users/usage/commands/#launch"
 fi
 
-# Print the URL instead of opening a browser: explicitly requested via
-# --print-url or DDEV_LAUNCH_PRINT_URL=true (inherited by nested `ddev launch`
-# invocations, e.g. from custom commands that call launch internally), or as
-# the long-standing DDEV_DEBUG/DDEV_VERBOSE behavior (kept for compatibility,
-# including ddev's own tests and external tooling that greps FULLURL).
-if [ "${DDEV_LAUNCH_PRINT_URL:-}" = "true" ] || [ "${DDEV_DEBUG:-}" = "true" ] || [ "${DDEV_VERBOSE:-}" = "true" ]; then
+# Long-standing DDEV_DEBUG/DDEV_VERBOSE behavior, kept for compatibility
+# (including ddev's own tests and external tooling that greps FULLURL).
+if [ "${DDEV_DEBUG:-}" = "true" ] || [ "${DDEV_VERBOSE:-}" = "true" ]; then
     printf "FULLURL %s\n" "$FULLURL"
     exit 0
 fi

--- a/pkg/ddevapp/global_dotddev_assets/commands/host/launch
+++ b/pkg/ddevapp/global_dotddev_assets/commands/host/launch
@@ -2,9 +2,9 @@
 
 ## #ddev-generated: If you want to edit and own this file, remove this line.
 ## Description: Launch a browser with the current site
-## Usage: launch [path] [-m|--mailpit]
+## Usage: launch [path] [-m|--mailpit] [--print-url]
 ## Example: "ddev launch" or "ddev launch /admin/reports/status/php" or "ddev launch phpinfo.php" or "ddev launch https://your.ddev.site" or "ddev launch :3000", for Mailpit "ddev launch -m"
-## Flags: [{"Name":"mailpit","Shorthand":"m","Usage":"ddev launch -m launches the mailpit UI"}]
+## Flags: [{"Name":"mailpit","Shorthand":"m","Usage":"ddev launch -m launches the mailpit UI"},{"Name":"print-url","Usage":"print the URL instead of opening a browser"}]
 
 if [ "${DDEV_PROJECT_STATUS}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
@@ -66,6 +66,10 @@ while :; do
     fi
     ;;
 
+  --print-url)
+    DDEV_LAUNCH_PRINT_URL=true
+    ;;
+
   --) # End of all options.
     shift
     break
@@ -114,7 +118,12 @@ if [[ "${FULLURL}" =~ ^http:// ]]; then
   echo "See https://docs.ddev.com/en/stable/users/usage/commands/#launch"
 fi
 
-if [ "${DDEV_DEBUG:-}" = "true" ] || [ "${DDEV_VERBOSE:-}" = "true" ]; then
+# Print the URL instead of opening a browser: explicitly requested via
+# --print-url or DDEV_LAUNCH_PRINT_URL=true (inherited by nested `ddev launch`
+# invocations, e.g. from custom commands that call launch internally), or as
+# the long-standing DDEV_DEBUG/DDEV_VERBOSE behavior (kept for compatibility,
+# including ddev's own tests and external tooling that greps FULLURL).
+if [ "${DDEV_LAUNCH_PRINT_URL:-}" = "true" ] || [ "${DDEV_DEBUG:-}" = "true" ] || [ "${DDEV_VERBOSE:-}" = "true" ]; then
     printf "FULLURL %s\n" "$FULLURL"
     exit 0
 fi


### PR DESCRIPTION
## Short Summary (TL;DR)

`ddev launch` can now print the computed URL instead of opening a browser — via a `--print-url` flag or a `DDEV_LAUNCH_PRINT_URL=true` env var — without enabling global `DDEV_DEBUG` logging.

## The Issue

- Fixes #8771

`ddev launch` (and wrappers that spawn it internally: `ddev phpmyadmin`, `ddev adminer`, `ddev mailpit`) opens the browser directly. The only existing way to get the URL instead is `DDEV_DEBUG=true`/`DDEV_VERBOSE=true` — global debug switches that flood the whole invocation (including any implicit `ddev start`) with timestamped `util.Debug` output. In headless environments (SSH, containers, CI) `ddev launch` currently just errors with "No technique found to open URL".

## How This PR Solves The Issue

- `pkg/ddevapp/global_dotddev_assets/commands/host/launch`: new `--print-url` case in the option loop sets `DDEV_LAUNCH_PRINT_URL=true`; ~~the existing debug-print block now also honors that variable. Output keeps the `FULLURL <url>` prefix that ddev's own tests and external tooling already grep for.~~ `DDEV_DEBUG`/`DDEV_VERBOSE` behavior is unchanged. `Usage`/`Flags` headers updated (completion).

    **UPDATE (Aug 31, review feedback):** `--print-url` / `DDEV_LAUNCH_PRINT_URL=true` now print only the URL, with no prefix, so the output can be used directly without parsing. The "HTTP may redirect to HTTPS" browser hint is skipped in print mode so the output is exactly one line. The `FULLURL` prefix remains only in the unchanged `DDEV_DEBUG`/`DDEV_VERBOSE` behavior, which ddev's own tests and external tooling grep for.
- `docs/content/users/usage/commands.md`: flag bullet, env-var note (inherited by nested `ddev launch` invocations from custom commands and add-ons, where argv cannot be injected), example.

## Manual Testing Instructions

**UPDATE (Aug 31):** expected output is the bare URL now:

```shell
make
cd ~/some-running-project
ddev launch --print-url                  # prints "https://<site>" and exits 0, no browser
DDEV_LAUNCH_PRINT_URL=true ddev launch   # same, via env var
DDEV_LAUNCH_PRINT_URL=true ddev phpmyadmin  # nested launch prints the URL, no debug flood
ddev launch -m --print-url               # prints the Mailpit URL
ddev launch                              # unchanged: opens the browser
DDEV_DEBUG=true ddev launch              # unchanged: "FULLURL <url>" + debug logging
```

## Automated Testing Overview

`TestLaunchCommand` (`cmd/ddev/cmd/commands_test.go`) extended: with `DDEV_DEBUG` unset, both `DDEV_LAUNCH_PRINT_URL=true ddev launch` and `ddev launch --print-url` must produce ~~exactly one `FULLURL <primary-url>` line~~ (no debug output, no browser attempt). The existing `DDEV_DEBUG`-driven cases remain and keep covering the legacy behavior.

**UPDATE (Aug 31):** they must output exactly the primary URL, with no prefix.

## Release/Deployment Notes

No behavior change for existing users: the flag and env var are opt-in, and the `DDEV_DEBUG`/`DDEV_VERBOSE` print behavior is untouched. ~~The `FULLURL` prefix is preserved for compatibility.~~ Consumers that previously had to set `DDEV_DEBUG` just to capture the URL (IDE integrations, wrappers running ddev under a different user) can switch to the env var and get clean output.

**UPDATE (Aug 31):** `--print-url` / `DDEV_LAUNCH_PRINT_URL=true` print the bare URL (no prefix). The `FULLURL` prefix remains only for `DDEV_DEBUG`/`DDEV_VERBOSE`.