### PR TITLE
fix: float wsl2-setup.sh's default Go install to latest stable (#8775) [skip ci]

### DIFF
--- a/.github/workflows/wsl2-setup.sh
+++ b/.github/workflows/wsl2-setup.sh
@@ -6,8 +6,8 @@
 set -eu -o pipefail
 set -x
 
-# Accept GO_VERSION from the environment, default to a known good version
-GO_VERSION="${GO_VERSION:-1.26.0}"
+# Accept GO_VERSION from the environment, default to the latest stable release
+GO_VERSION="${GO_VERSION:-$(curl -fsSL 'https://go.dev/VERSION?m=text' | head -1 | sed 's/^go//')}"
 
 export DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Short Summary (TL;DR)

A random WSL2 test run failed because the hardcoded default Go version in `wsl2-setup.sh` had fallen behind `go.mod`'s `go 1.27` directive, triggering a toolchain auto-download that timed out. This makes the default float to the latest stable release instead (all other tests use latest go).

## The Issue

WSL2 CI runs were failing with a TLS handshake timeout while Go tried to auto-download go1.27.0 mid-build, because the runner had go1.26.0 preinstalled.

## How This PR Solves The Issue

Replaces the hardcoded `GO_VERSION` default with a query to `go.dev/VERSION?m=text`, matching how other workflows already float via `actions/setup-go`'s `>=1.23`.

