### PR TITLE
feat(drupal): support symfony_mailer_lite in settings.ddev.php, fixes #8776 (#8778) [skip ci]

### DIFF
--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -133,7 +133,6 @@ Mailpit will **not** intercept emails if your application is configured to use S
 
 For Drupal 9+, `settings.ddev.php` automatically overrides [Symfony Mailer](https://www.drupal.org/project/symfony_mailer) and [Symfony Mailer Lite](https://www.drupal.org/project/symfony_mailer_lite) transport configurations to use Mailpit; for other SMTP modules (like [SMTP](https://www.drupal.org/project/smtp)), update your application’s SMTP server configuration to use `localhost` and Mailpit’s port `1025`.
 
-
 For Laravel projects, Mailpit will capture Swift messages via SMTP. Update your `.env` to use Mailpit with the following settings:
 
 ```env

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -131,9 +131,7 @@ After your project is started, access the Mailpit web interface at `https://mysi
 
 Mailpit will **not** intercept emails if your application is configured to use SMTP or a third-party ESP integration.
 
-If you’re using SMTP for outgoing mail—with [Symfony Mailer](https://www.drupal.org/project/symfony_mailer) or [SMTP](https://www.drupal.org/project/smtp) modules, for example—update your application’s SMTP server configuration to use `localhost` and Mailpit’s port `1025`.
-
-For Drupal 9+ `settings.ddev.php` overrides the Symfony Mailer sendmail configuration to use Mailpit.
+For Drupal 9+, `settings.ddev.php` automatically overrides [Symfony Mailer](https://www.drupal.org/project/symfony_mailer) and [Symfony Mailer Lite](https://www.drupal.org/project/symfony_mailer_lite) transport configurations to use Mailpit; for other SMTP modules (like [SMTP](https://www.drupal.org/project/smtp)), update your application’s SMTP server configuration to use `localhost` and Mailpit’s port `1025`.
 
 For Drupal 8/9 `settings.ddev.php` overrides the [Swift Mailer](https://www.drupal.org/project/swiftmailer) transport configuration to use Mailpit.
 

--- a/docs/content/users/usage/developer-tools.md
+++ b/docs/content/users/usage/developer-tools.md
@@ -133,7 +133,6 @@ Mailpit will **not** intercept emails if your application is configured to use S
 
 For Drupal 9+, `settings.ddev.php` automatically overrides [Symfony Mailer](https://www.drupal.org/project/symfony_mailer) and [Symfony Mailer Lite](https://www.drupal.org/project/symfony_mailer_lite) transport configurations to use Mailpit; for other SMTP modules (like [SMTP](https://www.drupal.org/project/smtp)), update your application’s SMTP server configuration to use `localhost` and Mailpit’s port `1025`.
 
-For Drupal 8/9 `settings.ddev.php` overrides the [Swift Mailer](https://www.drupal.org/project/swiftmailer) transport configuration to use Mailpit.
 
 For Laravel projects, Mailpit will capture Swift messages via SMTP. Update your `.env` to use Mailpit with the following settings:
 

--- a/pkg/ddevapp/drupal/drupal10/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal10/settings.ddev.php
@@ -55,6 +55,11 @@ $config['mailer_transport.mailer_transport.sendmail']['configuration']['pass'] =
 $config['mailer_transport.mailer_transport.sendmail']['configuration']['host'] = 'localhost';
 $config['mailer_transport.mailer_transport.sendmail']['configuration']['port'] = '1025';
 
+// Override drupal/symfony_mailer_lite default config to use Mailpit.
+$config['symfony_mailer_lite.settings']['default_transport'] = 'native';
+$config['symfony_mailer_lite.symfony_mailer_lite_transport.native']['plugin'] = 'dsn';
+$config['symfony_mailer_lite.symfony_mailer_lite_transport.native']['configuration']['dsn'] = 'smtp://127.0.0.1:1025';
+
 // Enable verbose logging for errors.
 // https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode
 $config['system.logging']['error_level'] = 'verbose';

--- a/pkg/ddevapp/drupal/drupal11/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal11/settings.ddev.php
@@ -52,6 +52,11 @@ $config['mailer_transport.mailer_transport.sendmail']['configuration']['pass'] =
 $config['mailer_transport.mailer_transport.sendmail']['configuration']['host'] = 'localhost';
 $config['mailer_transport.mailer_transport.sendmail']['configuration']['port'] = '1025';
 
+// Override drupal/symfony_mailer_lite default config to use Mailpit.
+$config['symfony_mailer_lite.settings']['default_transport'] = 'native';
+$config['symfony_mailer_lite.symfony_mailer_lite_transport.native']['plugin'] = 'dsn';
+$config['symfony_mailer_lite.symfony_mailer_lite_transport.native']['configuration']['dsn'] = 'smtp://127.0.0.1:1025';
+
 // Enable verbose logging for errors.
 // https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode
 $config['system.logging']['error_level'] = 'verbose';

--- a/pkg/ddevapp/drupal/drupal12/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal12/settings.ddev.php
@@ -52,6 +52,11 @@ $config['mailer_transport.mailer_transport.sendmail']['configuration']['pass'] =
 $config['mailer_transport.mailer_transport.sendmail']['configuration']['host'] = 'localhost';
 $config['mailer_transport.mailer_transport.sendmail']['configuration']['port'] = '1025';
 
+// Override drupal/symfony_mailer_lite default config to use Mailpit.
+$config['symfony_mailer_lite.settings']['default_transport'] = 'native';
+$config['symfony_mailer_lite.symfony_mailer_lite_transport.native']['plugin'] = 'dsn';
+$config['symfony_mailer_lite.symfony_mailer_lite_transport.native']['configuration']['dsn'] = 'smtp://127.0.0.1:1025';
+
 // Enable verbose logging for errors.
 // https://www.drupal.org/forum/support/post-installation/2018-07-18/enable-drupal-8-backend-errorlogdebugging-mode
 $config['system.logging']['error_level'] = 'verbose';

--- a/pkg/ddevapp/drupal/drupal9/settings.ddev.php
+++ b/pkg/ddevapp/drupal/drupal9/settings.ddev.php
@@ -44,6 +44,11 @@ $config['symfony_mailer.mailer_transport.sendmail']['configuration']['pass'] = '
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['host'] = 'localhost';
 $config['symfony_mailer.mailer_transport.sendmail']['configuration']['port'] = '1025';
 
+// Override drupal/symfony_mailer_lite default config to use Mailpit.
+$config['symfony_mailer_lite.settings']['default_transport'] = 'native';
+$config['symfony_mailer_lite.symfony_mailer_lite_transport.native']['plugin'] = 'dsn';
+$config['symfony_mailer_lite.symfony_mailer_lite_transport.native']['configuration']['dsn'] = 'smtp://127.0.0.1:1025';
+
 // Override drupal/swiftmailer default config to use Mailpit.
 $config['swiftmailer.transport']['transport'] = 'smtp';
 $config['swiftmailer.transport']['smtp_host'] = '127.0.0.1';


### PR DESCRIPTION
## Short Summary (TL;DR)

Adds a similar OOTB config override for symfony_mailer_lite than symfony_mailer already has.

## The Issue

- Fixes #8776

## How This PR Solves The Issue

Adds a similar OOTB config override for symfony_mailer_lite than symfony_mailer already has.

## Manual Testing Instructions

### Manual Testing Instructions

1. **Create and configure a fresh Drupal test project:**
   ```bash
   mkdir test-sml && cd test-sml
   ddev config --project-type=drupal11 --docroot=web
   ddev start
   ddev composer create-project drupal/recommended-project:^11 web
   ddev drush site:install -y --account-name=admin --account-pass=admin
   ```

2. **Verify `settings.ddev.php` includes the Symfony Mailer Lite configuration:**
   ```bash
   grep -A 5 "symfony_mailer_lite" web/sites/default/settings.ddev.php
   ```
   *Expected output:*
   ```php
   // Override drupal/symfony_mailer_lite default config to use Mailpit.
   $config['symfony_mailer_lite.settings']['default_transport'] = 'native';
   $config['symfony_mailer_lite.symfony_mailer_lite_transport.native']['plugin'] = 'dsn';
   $config['symfony_mailer_lite.symfony_mailer_lite_transport.native']['configuration']['dsn'] = 'smtp://127.0.0.1:1025';
   ```

3. **Install and enable `drupal/symfony_mailer_lite`:**
   ```bash
   ddev composer require drupal/symfony_mailer_lite
   ddev drush pm:install symfony_mailer_lite -y
   ```

4. **Send a test email:**
   - Go to `https://test-sml.ddev.site/admin/config/system/symfony-mailer-lite/test` (or test password reset / user registration).
   - Send a test email to any test address (e.g., `test@example.com`).

5. **Verify the email in Mailpit:**
   - Run `ddev launch -m` (or open `https://test-sml.ddev.site:8026`).
   - Confirm that the test email arrived in the Mailpit inbox.

## Automated Testing Overview

Neither symfony_mailer nor swiftmailer had specific unit/integration tests in Go or Bats, so no test coverage was added here either.

## Release/Deployment Notes

N/A