### PR TITLE
build(docker): bump images to v1.25.4 for release, fixes #8703

### DIFF
--- a/.github/workflows/linux-setup.sh
+++ b/.github/workflows/linux-setup.sh
@@ -33,6 +33,17 @@ curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
   && sudo apt-get update -qq >/dev/null \
   && sudo apt-get install -y -qq cloudflared
 
+if [[ "${DDEV_TEST_PODMAN_ROOTLESS:-}" == "true" || "${DDEV_TEST_DOCKER_ROOTLESS:-}" == "true" ]]; then
+  # The runner image preinstalls mysql-server, whose usr.sbin.mysqld AppArmor
+  # profile attaches to any unconfined process exec'ing /usr/sbin/mysqld -
+  # including inside rootless containers, which run apparmor-unconfined,
+  # regardless of container engine. A confined mysqld can't read its config
+  # and, under rootless Docker, can't be signaled (docker stop/kill fail with
+  # "permission denied", leaving unkillable containers).
+  sudo ln -sf /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/ 2>/dev/null || true
+  sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld 2>/dev/null || true
+fi
+
 if [[ ${DDEV_TEST_PODMAN_ROOTLESS:-} == "true" ]]; then
 
   echo "Setting up podman-rootless"
@@ -69,14 +80,6 @@ userns,
 include if exists <local/${filename}>
 }
 EOF
-  # The runner image preinstalls mysql-server, whose usr.sbin.mysqld AppArmor
-  # profile attaches to any unconfined process exec'ing /usr/sbin/mysqld -
-  # including inside rootless-docker containers, which run apparmor-unconfined.
-  # A confined mysqld can't read /etc/my.cnf and can't be signaled (docker
-  # stop/kill fail with "permission denied", leaving unkillable containers).
-  # Disable that profile; the rootlesskit profile above must stay.
-  sudo ln -sf /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/ 2>/dev/null || true
-  sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld 2>/dev/null || true
   sudo systemctl restart apparmor.service
   # Set the default network driver to "gvisor-tap-vsock" (see https://github.com/moby/moby/releases/tag/docker-v29.5.0)
   # Allow loopback https://github.com/moby/moby/issues/47684#issuecomment-2166149845

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -172,3 +172,4 @@ EXPOSE 3306
 # The following line overrides any cmd entry
 CMD []
 HEALTHCHECK --interval=1s --retries=30 --timeout=120s CMD ["/healthcheck.sh"]
+# ddev-release-marker: v1.25.4

--- a/containers/ddev-ssh-agent/Dockerfile
+++ b/containers/ddev-ssh-agent/Dockerfile
@@ -34,3 +34,4 @@ VOLUME ${SOCKET_DIR}
 ENTRYPOINT ["/entry.sh"]
 
 CMD ["ssh-agent"]
+# ddev-release-marker: v1.25.4

--- a/containers/ddev-traefik-router/Dockerfile
+++ b/containers/ddev-traefik-router/Dockerfile
@@ -12,3 +12,4 @@ RUN chmod ugo+rx /usr/local/bin/monitor-traefik-stderr.sh /usr/local/bin/docker-
 RUN mkdir -p /etc/traefik && ln -s /mnt/ddev-global-cache/traefik/.static_config.yaml /etc/traefik/traefik.yaml
 HEALTHCHECK --interval=1s --timeout=120s --retries=1 --start-period=120s CMD /healthcheck.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh", "/usr/local/bin/traefik"]
+# ddev-release-marker: v1.25.4

--- a/containers/ddev-webserver/Dockerfile
+++ b/containers/ddev-webserver/Dockerfile
@@ -663,3 +663,4 @@ COPY --from=ddev-webserver-prod-base / /
 HEALTHCHECK --interval=1s --retries=120 --timeout=120s --start-period=120s CMD ["/healthcheck.sh"]
 CMD ["/start.sh"]
 ### -------------------------END ddev-webserver-prod------------------------------
+# ddev-release-marker: v1.25.4

--- a/containers/ddev-xhgui/Dockerfile
+++ b/containers/ddev-xhgui/Dockerfile
@@ -7,3 +7,4 @@ RUN echo 'memory_limit=512M' >> $PHP_INI_DIR/conf.d/99-memory-limit.ini
 ADD healthcheck.sh /healthcheck.sh
 RUN chmod ugo+x /healthcheck.sh
 HEALTHCHECK --interval=1s --retries=5 --timeout=120s CMD ["/healthcheck.sh"]
+# ddev-release-marker: v1.25.4

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -49,46 +49,46 @@ func IsUnreleasedDdevVersion(version string) bool {
 var WebImg = "ddev/ddev-webserver"
 
 // WebTag defines the default web image tag
-var WebTag = "c202e92108" // 20260814_rfay_docker_update_phase_2-c202e92108
+var WebTag = "edbebeadc5" // 20260831_v1.25.4-edbebeadc5
 
 // WebTagBranch is the branch WebTag's content was built from.
-var WebTagBranch = "20260814_rfay_docker_update_phase_2"
+var WebTagBranch = "v1.25.4"
 
 // DBImg defines the default db image used for applications.
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "40f847ae7a" // 20260831_rfay_mysql_race-40f847ae7a
+var BaseDBTag = "27b956a558" // 20260831_v1.25.4-27b956a558
 
 // BaseDBTagBranch is the branch BaseDBTag's content was built from.
-var BaseDBTagBranch = "20260831_rfay_mysql_race"
+var BaseDBTagBranch = "v1.25.4"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"
 
 // TraefikRouterTag is traefik router tag
-var TraefikRouterTag = "bffcda31c5" // 20260814_rfay_docker_update_phase_2-bffcda31c5
+var TraefikRouterTag = "b7ce92d10d" // 20260831_v1.25.4-b7ce92d10d
 
 // TraefikRouterTagBranch is the branch TraefikRouterTag's content was built from.
-var TraefikRouterTagBranch = "20260814_rfay_docker_update_phase_2"
+var TraefikRouterTagBranch = "v1.25.4"
 
 // SSHAuthImage is image for agent
 var SSHAuthImage = "ddev/ddev-ssh-agent"
 
 // SSHAuthTag is ssh-agent auth tag
-var SSHAuthTag = "bb5e9f0003" // 20260814_rfay_docker_update_phase_2-bb5e9f0003
+var SSHAuthTag = "544e096521" // 20260831_v1.25.4-544e096521
 
 // SSHAuthTagBranch is the branch SSHAuthTag's content was built from.
-var SSHAuthTagBranch = "20260814_rfay_docker_update_phase_2"
+var SSHAuthTagBranch = "v1.25.4"
 
 // XhguiImage is image for xhgui
 var XhguiImage = "ddev/ddev-xhgui"
 
 // XhguiTag is xhgui tag
-var XhguiTag = "8757c1e92a" // 20260814_rfay_docker_update_phase_2-8757c1e92a
+var XhguiTag = "7269c5a85e" // 20260831_v1.25.4-7269c5a85e
 
 // XhguiTagBranch is the branch XhguiTag's content was built from.
-var XhguiTagBranch = "20260814_rfay_docker_update_phase_2"
+var XhguiTagBranch = "v1.25.4"
 
 // UtilitiesImage is used in bash scripts
 var UtilitiesImage = "ddev/ddev-utilities:latest"


### PR DESCRIPTION
## Short Summary (TL;DR)

Time to release DDEV v1.25.4.

## The Issue

- Fixes #8703

## How This PR Solves The Issue

```bash
make release-prep TAG=v1.25.4
```

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
