### PR TITLE
fix: resolve TestGetVersionInfo failure and duplicate tag in `ddev version` output (#8781) [skip ci]

### DIFF
--- a/cmd/ddev/cmd/cmd_version.go
+++ b/cmd/ddev/cmd/cmd_version.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/ddev/ddev/pkg/amplitude"
 	"github.com/ddev/ddev/pkg/ddevapp"
@@ -12,7 +13,6 @@ import (
 	"github.com/ddev/ddev/pkg/styles"
 	"github.com/ddev/ddev/pkg/util"
 	"github.com/ddev/ddev/pkg/version"
-	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 )
@@ -50,13 +50,7 @@ var versionCmd = &cobra.Command{
 
 		t.AppendHeader(table.Row{"Item", "Value"})
 
-		// On a release, release-prep.sh stamps every image's branch to the
-		// release tag itself, so the hint would just repeat "DDEV version" on
-		// every row. Only show it where it can differ: unreleased builds.
-		imageTagBranches := map[string]string{}
-		if versionconstants.IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
-			imageTagBranches = version.ImageTagBranches()
-		}
+		imageTagBranches := version.ImageTagBranches()
 
 		keys := make([]string, 0, len(v))
 		for k := range v {
@@ -67,7 +61,10 @@ var versionCmd = &cobra.Command{
 		for _, label := range keys {
 			if label != "build info" {
 				value := v[label]
-				if branch, ok := imageTagBranches[label]; ok && branch != "" {
+				// Once release-prep.sh stamps an image's branch to its
+				// release tag, that tag is already what resolveImageTag
+				// put in value, so the hint would just repeat it.
+				if branch, ok := imageTagBranches[label]; ok && branch != "" && !strings.HasSuffix(value, ":"+branch) {
 					value = value + " (" + branch + ")"
 				}
 				t.AppendRow(table.Row{

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -38,12 +38,12 @@ func imageRepo(image string) string {
 // releaseTagPattern matches a vX.Y.Z release tag.
 var releaseTagPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
 
-// resolveImageTag prefers branch over tag when branch is a vX.Y.Z release
+// ResolveImageTag prefers branch over tag when branch is a vX.Y.Z release
 // tag. release-prep.sh stamps <TagVar>Branch with the release tag while
 // leaving <TagVar> as the content hash autotag.sh relies on, but both
 // resolve to the identical manifest, so a released binary can pull by the
 // readable tag.
-func resolveImageTag(tag, branch string) string {
+func ResolveImageTag(tag, branch string) string {
 	if releaseTagPattern.MatchString(branch) {
 		return branch
 	}
@@ -56,7 +56,7 @@ func GetWebImage() string {
 	if globalconfig.DdevGlobalConfig.UseHardenedImages {
 		fullWebImg = fullWebImg + "-prod"
 	}
-	return fmt.Sprintf("%s:%s", fullWebImg, resolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch))
+	return fmt.Sprintf("%s:%s", fullWebImg, ResolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch))
 }
 
 // GetDBImage returns the correctly formatted db image:tag reference
@@ -76,21 +76,21 @@ func GetDBImage(dbType string, dbVersion string) string {
 	case nodeps.MariaDB:
 		fallthrough
 	default:
-		return fmt.Sprintf("%s-%s-%s:%s", imageRepo(versionconstants.DBImg), dbType, v, resolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch))
+		return fmt.Sprintf("%s-%s-%s:%s", imageRepo(versionconstants.DBImg), dbType, v, ResolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch))
 	}
 }
 
 // GetSSHAuthImage returns the correctly formatted sshauth image:tag reference
 func GetSSHAuthImage() string {
-	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.SSHAuthImage), resolveImageTag(versionconstants.SSHAuthTag, versionconstants.SSHAuthTagBranch))
+	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.SSHAuthImage), ResolveImageTag(versionconstants.SSHAuthTag, versionconstants.SSHAuthTagBranch))
 }
 
 // GetRouterImage returns the router image:tag reference
 func GetRouterImage() string {
-	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.TraefikRouterImage), resolveImageTag(versionconstants.TraefikRouterTag, versionconstants.TraefikRouterTagBranch))
+	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.TraefikRouterImage), ResolveImageTag(versionconstants.TraefikRouterTag, versionconstants.TraefikRouterTagBranch))
 }
 
 // GetXhguiImage returns the xhgui image:tag reference
 func GetXhguiImage() string {
-	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.XhguiImage), resolveImageTag(versionconstants.XhguiTag, versionconstants.XhguiTagBranch))
+	return fmt.Sprintf("%s:%s", imageRepo(versionconstants.XhguiImage), ResolveImageTag(versionconstants.XhguiTag, versionconstants.XhguiTagBranch))
 }

--- a/pkg/docker/images_test.go
+++ b/pkg/docker/images_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestResolveImageTag(t *testing.T) {
-	require.Equal(t, "v1.25.4", resolveImageTag("c202e92108", "v1.25.4"))
-	require.Equal(t, "c202e92108", resolveImageTag("c202e92108", "20260814_rfay_docker_update_phase_2"))
-	require.Equal(t, "c202e92108", resolveImageTag("c202e92108", ""))
-	require.Equal(t, "abc123", resolveImageTag("abc123", "v1.25.4-15-gabcdef1"))
+	require.Equal(t, "v1.25.4", ResolveImageTag("c202e92108", "v1.25.4"))
+	require.Equal(t, "c202e92108", ResolveImageTag("c202e92108", "20260814_rfay_docker_update_phase_2"))
+	require.Equal(t, "c202e92108", ResolveImageTag("c202e92108", ""))
+	require.Equal(t, "abc123", ResolveImageTag("abc123", "v1.25.4-15-gabcdef1"))
 }
 
 func TestImageRepoDockerOrg(t *testing.T) {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/nodeps"
 	"github.com/ddev/ddev/pkg/testsetup"
 	"github.com/ddev/ddev/pkg/versionconstants"
@@ -25,7 +26,7 @@ func TestGetVersionInfo(t *testing.T) {
 
 	assert.Equal(versionconstants.DdevVersion, v["DDEV version"])
 	assert.Contains(v["web"], versionconstants.WebImg)
-	assert.Contains(v["web"], versionconstants.WebTag)
+	assert.Contains(v["web"], docker.ResolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch))
 	assert.Contains(v["db"], versionconstants.DBImg)
 	assert.Contains(v["db"], nodeps.MariaDBDefaultVersion)
 	assert.Equal(runtime.Version(), v["go-version"])


### PR DESCRIPTION
## Short Summary (TL;DR)

This PR fixes two problems surfaced while testing release-prep PR #8780: `TestGetVersionInfo` was failing, and `ddev version` printed a duplicated tag like `v1.25.4 (v1.25.4)` for each image.

## The Issue

Testing #8780 turned up two bugs unrelated to that PR's version bumps themselves.

`TestGetVersionInfo` asserted that the web image's displayed tag contains the raw content-hash tag (`versionconstants.WebTag`), but `GetWebImage()` prefers a release-tag branch when one is stamped, a behavior added earlier for release-prep support. The test was never updated to account for that, so it fails whenever the branch is a released `vX.Y.Z` tag, as it now is on the release-prep branch.

`ddev version` also appended a `(branch)` hint after every image's tag, without checking whether that hint was already the tag being displayed. Once an image's branch is stamped to its release tag, the tag shown and the hint are identical, producing output like:

```text
db    ddev/ddev-dbserver-mariadb-11.8:v1.25.4 (v1.25.4)
```

## How This PR Solves The Issue

- Exported `docker.resolveImageTag` as `docker.ResolveImageTag` so `TestGetVersionInfo` can assert against the same tag-resolution logic `GetWebImage()` uses, instead of duplicating it or hardcoding an assumption that no longer holds.
- Changed `cmd_version.go` to only append the `(branch)` hint when it differs from what's already shown in the value, using a suffix check (`:branch`) rather than a version-wide "is this an unreleased build" guard that didn't account for per-image tag resolution.

## Manual Testing Instructions

1. `go test -v -run TestGetVersionInfo ./pkg/version/...` — passes.
2. `make && .gotmp/bin/<platform>/ddev version` — confirm no image row shows a duplicated tag in parens.

## Automated Testing Overview

`pkg/version/version_test.go` and `pkg/docker/images_test.go` cover the tag-resolution behavior exercised here.

## Release/Deployment Notes

None - internal test and cosmetic display fix only.
