### PR TITLE
fix(dbserver): pin secure_file_priv for mysql 8.0, 8.4, and 9.7

### DIFF
--- a/containers/ddev-dbserver/files/etc/mysql/version-conf.d/mysql_8.0.cnf.txt
+++ b/containers/ddev-dbserver/files/etc/mysql/version-conf.d/mysql_8.0.cnf.txt
@@ -12,6 +12,9 @@ collation-server = utf8mb4_unicode_520_ci
 # which now does nothing, because it's used by all types in create-base-db.sh
 innodb-redo-log-capacity=100663296
 
+# secure_file_priv="" is most permissive, but irrelevant to DDEV
+secure_file_priv=""
+
 # Pin buffer pool instances to 1 so innodb-buffer-pool-size is honored exactly.
 # Otherwise the buffer pool size is rounded up to a multiple of
 # (chunk_size * instances), which can make the effective size machine-dependent.

--- a/containers/ddev-dbserver/files/etc/mysql/version-conf.d/mysql_8.4.cnf.txt
+++ b/containers/ddev-dbserver/files/etc/mysql/version-conf.d/mysql_8.4.cnf.txt
@@ -15,6 +15,9 @@ mysql-native-password=2
 # In mysql 8+ this replaces innodb-log-file-size etc
 innodb-redo-log-capacity=100663296
 
+# secure_file_priv="" is most permissive, but irrelevant to DDEV
+secure_file_priv=""
+
 # Pin buffer pool instances to 1 so innodb-buffer-pool-size is honored exactly.
 # MySQL 8.4 derives the default instance count from the CPU count, and the
 # buffer pool size is rounded up to a multiple of (chunk_size * instances),

--- a/containers/ddev-dbserver/files/etc/mysql/version-conf.d/mysql_9.7.cnf.txt
+++ b/containers/ddev-dbserver/files/etc/mysql/version-conf.d/mysql_9.7.cnf.txt
@@ -14,6 +14,9 @@ collation-server = utf8mb4_unicode_520_ci
 # In mysql 8+ this replaces innodb-log-file-size etc
 innodb-redo-log-capacity=100663296
 
+# secure_file_priv="" is most permissive, but irrelevant to DDEV
+secure_file_priv=""
+
 # Pin buffer pool instances to 1 so innodb-buffer-pool-size is honored exactly.
 # MySQL derives the default instance count from the CPU count, and the
 # buffer pool size is rounded up to a multiple of (chunk_size * instances),

--- a/containers/ddev-dbserver/test/testdata/database_config/mysql_8.0.ini
+++ b/containers/ddev-dbserver/test/testdata/database_config/mysql_8.0.ini
@@ -1,7 +1,7 @@
 socket=/var/tmp/mysql.sock
 skip_name_resolve=ON
 datadir=/var/lib/mysql/
-secure_file_priv=NULL
+secure_file_priv=""
 innodb_use_native_aio=ON
 character_set_server=utf8mb4
 collation_server=utf8mb4_unicode_520_ci

--- a/containers/ddev-dbserver/test/testdata/database_config/mysql_8.4.ini
+++ b/containers/ddev-dbserver/test/testdata/database_config/mysql_8.4.ini
@@ -1,7 +1,7 @@
 socket=/var/tmp/mysql.sock
 skip_name_resolve=ON
 datadir=/var/lib/mysql/
-secure_file_priv=NULL
+secure_file_priv=""
 innodb_use_native_aio=ON
 character_set_server=utf8mb4
 collation_server=utf8mb4_unicode_520_ci

--- a/containers/ddev-dbserver/test/testdata/database_config/mysql_9.7.ini
+++ b/containers/ddev-dbserver/test/testdata/database_config/mysql_9.7.ini
@@ -1,7 +1,7 @@
 socket=/var/tmp/mysql.sock
 skip_name_resolve=ON
 datadir=/var/lib/mysql/
-secure_file_priv=NULL
+secure_file_priv=""
 innodb_use_native_aio=ON
 character_set_server=utf8mb4
 collation_server=utf8mb4_unicode_520_ci

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -58,7 +58,7 @@ var WebTagBranch = "20260814_rfay_docker_update_phase_2"
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "5ef43fc037" // 20260831_rfay_fix_mysql_97-5ef43fc037
+var BaseDBTag = "0c2c908b19" // 20260831_rfay_fix_mysql_97-0c2c908b19
 
 // BaseDBTagBranch is the branch BaseDBTag's content was built from.
 var BaseDBTagBranch = "20260831_rfay_fix_mysql_97"

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -58,10 +58,10 @@ var WebTagBranch = "20260814_rfay_docker_update_phase_2"
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "f57cd53429" // 20260814_rfay_seed_snapshot_reset_database-f57cd53429
+var BaseDBTag = "5ef43fc037" // 20260831_rfay_fix_mysql_97-5ef43fc037
 
 // BaseDBTagBranch is the branch BaseDBTag's content was built from.
-var BaseDBTagBranch = "20260814_rfay_seed_snapshot_reset_database"
+var BaseDBTagBranch = "20260831_rfay_fix_mysql_97"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION
## Short Summary (TL;DR)

Pins `secure_file_priv` for the MySQL 8.0, 8.4, and 9.7 dbserver images so the config test stops depending on unpredictable behavior from the `dhi.io/mysql:*-dev` base images.

## The Issue

`database_config.bats` failed in CI: expected `secure_file_priv=NULL`, found `/var/lib/mysql-files/`. First seen on MySQL 9.7, then also on 8.4.

For 9.7, the dbserver build uses the unpinned `dhi.io/mysql:9.7-dev` tag, which has drifted to mysqld 9.7.2. That patch level auto-creates and enables the compiled-in `/var/lib/mysql-files/` default instead of falling back to `NULL`, so the test's old expectation no longer matches.

For 8.0/8.4, rebuilding locally against the exact base image digest from a passing CI run reproduced both `NULL` and `/var/lib/mysql-files/` with no image change at all - the directory's auto-creation is non-deterministic at container start (likely a permission race against the non-root uid the container runs as), not version drift. Neither version had ever pinned the setting; the `NULL` expectation just happened to match most of the time.

## How This PR Solves The Issue

Sets `secure_file_priv=""` explicitly in `mysql_8.0.cnf.txt`, `mysql_8.4.cnf.txt`, and `mysql_9.7.cnf.txt`, matching what's already pinned for MariaDB and MySQL 5.x. `""` has no functional effect for ddev (imports use client-side `LOAD DATA LOCAL INFILE`, which this setting doesn't restrict), but pinning it removes the dependency on upstream defaults entirely. Updated the matching `.ini` test expectations for all three versions.

## Manual Testing Instructions

```
cd containers/ddev-dbserver
DOCKER_ARGS="--no-cache" make mysql_8.0_amd64 mysql_8.4_amd64 mysql_9.7_amd64
./test/test_dbserver.sh mysql 8.0 <tag>
./test/test_dbserver.sh mysql 8.4 <tag>
./test/test_dbserver.sh mysql 9.7 <tag>
```

Look for `ok 10 Check for expected configuration on mysql <version>` in each.

## Automated Testing Overview

Covered by the existing `container-tests.yml` bats suite.

## Release/Deployment Notes

None.
