### PR TITLE
ci: switch gotestsum to --format=testname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,12 +198,13 @@ EMBARGO_SKIP_FLAG := $(if $(DDEV_EMBARGO_TESTS),-skip "$(DDEV_EMBARGO_TESTS)",)
 # When GOTESTSUM_JSONFILE_DIR is set, tests run through gotestsum instead of
 # `go test` directly, additionally writing structured per-test JSON events to
 # <dir>/<name>.ndjson for the CI test-runtime collector (see
-# perf/collector/README.md). --format=standard-verbose mirrors plain
-# `go test -v` console output, including full failure detail, so CI log
-# review is unaffected. Unset by default, so local `make test` needs no
-# gotestsum install and behaves exactly as before.
+# perf/collector/README.md). --format=testname prints one line per test and
+# only dumps full -v output (including DDEV_DEBUG logging) for failing tests,
+# so passing tests don't flood CI logs with per-test debug output. Unset by
+# default, so local `make test` needs no gotestsum install and behaves
+# exactly as before.
 GOTESTSUM_JSONFILE_DIR ?=
-gotest = $(if $(GOTESTSUM_JSONFILE_DIR),gotestsum --format=standard-verbose --jsonfile=$(GOTESTSUM_JSONFILE_DIR)/$(1).ndjson --,go test)
+gotest = $(if $(GOTESTSUM_JSONFILE_DIR),gotestsum --format=testname --jsonfile=$(GOTESTSUM_JSONFILE_DIR)/$(1).ndjson --,go test)
 
 # Override test section with tests specific to ddev
 test: testpkg testcmd


### PR DESCRIPTION
## Short Summary (TL;DR)

Switches CI's `gotestsum` format from `standard-verbose` to `testname` so passing tests print one line instead of their full verbose/debug output, while failing tests still get the full detail.

## The Issue

- For #8784

`test-reusable.yml` runs the whole CI job with `DDEV_DEBUG: true`, and the `Makefile`'s `gotest` macro ran `gotestsum --format=standard-verbose`, which prints full `-v` output — including all of that debug logging — for every test whether it passed or failed. That's most of the log volume CI produces, and none of it is needed for passing tests.

## How This PR Solves The Issue

Changes the `gotest` macro in `Makefile` to use `gotestsum --format=testname`. This format still writes the same `--jsonfile` NDJSON events the perf collector depends on, but only dumps a test's full captured output when it fails.

## Manual Testing Instructions

* Look at the go tests using both github and buildkite runs
* Run `gotestsum --format=testname -- -v -run TestRandString ./pkg/util` and confirm it prints a single `PASS pkg/util.TestRandString (0.00s)` line rather than the full `-v` log. Run a package with a failing test and confirm the full output still appears for the failure.

## Automated Testing Overview

No new tests; this only changes local test-runner output formatting, not test behavior.

## Release/Deployment Notes

CI-only change. No effect on `make test` without `GOTESTSUM_JSONFILE_DIR` set, and no effect on released binaries.
