### PR TITLE
feat: integrated delete project feature to the TUI, fixes #8782

### DIFF
--- a/pkg/tui/keys.go
+++ b/pkg/tui/keys.go
@@ -26,6 +26,7 @@ type KeyMap struct {
 	Confirm  key.Binding
 	Xdebug   key.Binding
 	Poweroff key.Binding
+	Delete   key.Binding
 	CopyURL  key.Binding
 	Config   key.Binding
 	PageUp   key.Binding
@@ -122,6 +123,10 @@ func DefaultKeyMap() KeyMap {
 		Poweroff: key.NewBinding(
 			key.WithKeys("P"),
 			key.WithHelp("P", "poweroff"),
+		),
+		Delete: key.NewBinding(
+			key.WithKeys("delete"),
+			key.WithHelp("delete", "delete"),
 		),
 		CopyURL: key.NewBinding(
 			key.WithKeys("c"),

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -67,7 +67,8 @@ type AppModel struct {
 
 	// Confirmation overlay
 	confirming    bool
-	confirmAction string // "start-all", "stop-all", or "poweroff"
+	confirmAction string // "start-all", "stop-all", "poweroff", or "delete"
+	confirmTarget string
 
 	// Viewports for scrolling
 	dashboardViewport viewport.Model
@@ -370,10 +371,27 @@ func (m AppModel) isLoading() bool {
 func (m AppModel) handleDashboardKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// Confirmation overlay takes priority
 	if m.confirming {
-		if key.Matches(msg, m.keys.Confirm) {
-			action := m.confirmAction
+		action := m.confirmAction
+		target := m.confirmTarget
+		if action == "delete" {
+			if key.Matches(msg, m.keys.Confirm) {
+				m.confirming = false
+				m.confirmAction = ""
+				m.confirmTarget = ""
+				m = m.enterOperationView(fmt.Sprintf("Deleting %s", target), viewDashboard)
+				return m, startOperationStreamCmd("", "delete", "-y", target)
+			}
+			if key.Matches(msg, key.NewBinding(key.WithKeys("o", "O"))) {
+				m.confirming = false
+				m.confirmAction = ""
+				m.confirmTarget = ""
+				m = m.enterOperationView(fmt.Sprintf("Deleting %s (omit snapshot)", target), viewDashboard)
+				return m, startOperationStreamCmd("", "delete", "-y", "-O", target)
+			}
+		} else if key.Matches(msg, m.keys.Confirm) {
 			m.confirming = false
 			m.confirmAction = ""
+			m.confirmTarget = ""
 			switch action {
 			case "start-all":
 				m = m.enterOperationView("Starting all projects", viewDashboard)
@@ -389,6 +407,7 @@ func (m AppModel) handleDashboardKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// Any other key cancels
 		m.confirming = false
 		m.confirmAction = ""
+		m.confirmTarget = ""
 		m.statusMsg = ""
 		return m, nil
 	}
@@ -529,6 +548,15 @@ func (m AppModel) handleDashboardKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.statusMsg = "Poweroff all DDEV projects and containers? (y to confirm, any key to cancel)"
 		return m, nil
 
+	case key.Matches(msg, m.keys.Delete):
+		if p := m.selectedProject(); p != nil {
+			m.confirming = true
+			m.confirmAction = "delete"
+			m.confirmTarget = p.Name
+			m.statusMsg = fmt.Sprintf("Delete project '%s'? (y = delete project, keep a snapshot, o = delete project & omit snapshot, n/esc = cancel)", p.Name)
+			return m, nil
+		}
+
 	case key.Matches(msg, m.keys.StartAll):
 		if len(m.projects) > 0 {
 			m.confirming = true
@@ -570,6 +598,34 @@ func (m AppModel) handleDashboardKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m AppModel) handleDetailKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	// Confirmation overlay takes priority
+	if m.confirming {
+		action := m.confirmAction
+		target := m.confirmTarget
+		if action == "delete" {
+			if key.Matches(msg, m.keys.Confirm) {
+				m.confirming = false
+				m.confirmAction = ""
+				m.confirmTarget = ""
+				m = m.enterOperationView(fmt.Sprintf("Deleting %s", target), viewDashboard)
+				return m, startOperationStreamCmd("", "delete", "-y", target)
+			}
+			if key.Matches(msg, key.NewBinding(key.WithKeys("o", "O"))) {
+				m.confirming = false
+				m.confirmAction = ""
+				m.confirmTarget = ""
+				m = m.enterOperationView(fmt.Sprintf("Deleting %s (omit snapshot)", target), viewDashboard)
+				return m, startOperationStreamCmd("", "delete", "-y", "-O", target)
+			}
+		}
+		// Any other key cancels
+		m.confirming = false
+		m.confirmAction = ""
+		m.confirmTarget = ""
+		m.statusMsg = ""
+		return m, nil
+	}
+
 	var cmd tea.Cmd
 
 	switch {
@@ -652,6 +708,15 @@ func (m AppModel) handleDetailKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.detailLoading = true
 			m.statusMsg = "Refreshing..."
 			return m, tea.Batch(loadDetailCmd(m.detail.AppRoot), m.spinner.Tick)
+		}
+
+	case key.Matches(msg, m.keys.Delete):
+		if m.detail != nil {
+			m.confirming = true
+			m.confirmAction = "delete"
+			m.confirmTarget = m.detail.Name
+			m.statusMsg = fmt.Sprintf("Delete project '%s'? (y = delete project, keep a snapshot, o = delete project & omit snapshot, n/esc = cancel)", m.detail.Name)
+			return m, nil
 		}
 
 	case key.Matches(msg, m.keys.Quit):
@@ -1320,6 +1385,7 @@ func (m AppModel) dashboardKeyHints() string {
 		{"s", "start"},
 		{"S", "stop"},
 		{"r", "restart"},
+		{"delete", "delete"},
 		{"a", "start all"},
 		{"A", "stop all"},
 		{"P", "poweroff"},
@@ -1343,6 +1409,7 @@ func (m AppModel) detailKeyHints() string {
 		{"s", "start"},
 		{"S", "stop"},
 		{"r", "restart"},
+		{"delete", "delete"},
 		{"l", "launch"},
 		{"m", "mailpit"},
 		{"x", "xhgui"},
@@ -1403,6 +1470,7 @@ Actions:
   s               Start selected project
   S               Stop selected project
   r               Restart selected project
+  delete          Delete selected project
   a               Start all projects
   A               Stop all projects
   P               Poweroff all DDEV projects and containers

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -1771,3 +1771,207 @@ func TestOperationAutoReturnIgnoredIfAlreadyLeft(t *testing.T) {
 
 	require.Equal(t, viewDashboard, model.viewMode, "should stay on dashboard")
 }
+
+// --- Delete project tests ---
+
+func TestDeleteConfirmationFromDashboard(t *testing.T) {
+	m := NewAppModel()
+	m.loading = false
+	m.projects = []ProjectInfo{
+		{Name: "alpha", Status: ddevapp.SiteRunning},
+		{Name: "beta", Status: ddevapp.SiteStopped},
+	}
+	m.cursor = 0
+
+	// Press Delete key
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDelete})
+	model := updated.(AppModel)
+
+	require.True(t, model.confirming, "should enter confirmation mode")
+	require.Equal(t, "delete", model.confirmAction)
+	require.Equal(t, "alpha", model.confirmTarget)
+	require.Contains(t, model.statusMsg, "Delete project 'alpha'?")
+	require.Contains(t, model.statusMsg, "keep a snapshot")
+	require.Contains(t, model.statusMsg, "omit snapshot")
+	require.Nil(t, cmd)
+}
+
+func TestConfirmDeleteFromDashboard(t *testing.T) {
+	m := NewAppModel()
+	m.loading = false
+	m.projects = []ProjectInfo{{Name: "alpha"}}
+	m.confirming = true
+	m.confirmAction = "delete"
+	m.confirmTarget = "alpha"
+
+	// Press y to confirm (with snapshot)
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	model := updated.(AppModel)
+
+	require.False(t, model.confirming, "should exit confirmation mode")
+	require.Empty(t, model.confirmAction)
+	require.Empty(t, model.confirmTarget)
+	require.Equal(t, viewOperation, model.viewMode)
+	require.Equal(t, viewDashboard, model.operationReturnView)
+	require.Contains(t, model.operationName, "Deleting alpha")
+	require.NotNil(t, cmd, "should return operation stream command")
+}
+
+func TestConfirmDeleteOmitSnapshotFromDashboard(t *testing.T) {
+	m := NewAppModel()
+	m.loading = false
+	m.projects = []ProjectInfo{{Name: "alpha"}}
+	m.confirming = true
+	m.confirmAction = "delete"
+	m.confirmTarget = "alpha"
+
+	// Press o to confirm (omit snapshot)
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Text: "o"})
+	model := updated.(AppModel)
+
+	require.False(t, model.confirming, "should exit confirmation mode")
+	require.Empty(t, model.confirmAction)
+	require.Empty(t, model.confirmTarget)
+	require.Equal(t, viewOperation, model.viewMode)
+	require.Equal(t, viewDashboard, model.operationReturnView)
+	require.Contains(t, model.operationName, "Deleting alpha (omit snapshot)")
+	require.NotNil(t, cmd, "should return operation stream command")
+}
+
+func TestCancelDeleteFromDashboard(t *testing.T) {
+	m := NewAppModel()
+	m.loading = false
+	m.projects = []ProjectInfo{{Name: "alpha"}}
+	m.confirming = true
+	m.confirmAction = "delete"
+	m.confirmTarget = "alpha"
+	m.statusMsg = "Delete project 'alpha'?"
+
+	// Press n (or any non-y/o key) to cancel
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	model := updated.(AppModel)
+
+	require.False(t, model.confirming, "should cancel confirmation")
+	require.Empty(t, model.confirmAction)
+	require.Empty(t, model.confirmTarget)
+	require.Empty(t, model.statusMsg)
+	require.Nil(t, cmd)
+}
+
+func TestDeleteFromDashboardNoProjectNoop(t *testing.T) {
+	m := NewAppModel()
+	m.loading = false
+	// No projects
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDelete})
+	model := updated.(AppModel)
+
+	require.False(t, model.confirming, "should not confirm with no projects")
+}
+
+func TestDeleteConfirmationFromDetail(t *testing.T) {
+	m := NewAppModel()
+	m.viewMode = viewDetail
+	detail := sampleDetail()
+	detail.Name = "alpha"
+	m.detail = &detail
+
+	// Press Delete key
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyDelete})
+	model := updated.(AppModel)
+
+	require.True(t, model.confirming, "should enter confirmation mode in detail view")
+	require.Equal(t, "delete", model.confirmAction)
+	require.Equal(t, "alpha", model.confirmTarget)
+	require.Contains(t, model.statusMsg, "Delete project 'alpha'?")
+	require.Contains(t, model.statusMsg, "keep a snapshot")
+	require.Contains(t, model.statusMsg, "omit snapshot")
+	require.Nil(t, cmd)
+}
+
+func TestConfirmDeleteFromDetail(t *testing.T) {
+	m := NewAppModel()
+	m.viewMode = viewDetail
+	detail := sampleDetail()
+	detail.Name = "alpha"
+	m.detail = &detail
+	m.confirming = true
+	m.confirmAction = "delete"
+	m.confirmTarget = "alpha"
+
+	// Press y to confirm (with snapshot)
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	model := updated.(AppModel)
+
+	require.False(t, model.confirming)
+	require.Empty(t, model.confirmAction)
+	require.Empty(t, model.confirmTarget)
+	require.Equal(t, viewOperation, model.viewMode)
+	require.Equal(t, viewDashboard, model.operationReturnView, "should redirect back to dashboard after delete")
+	require.Contains(t, model.operationName, "Deleting alpha")
+	require.NotNil(t, cmd)
+}
+
+func TestConfirmDeleteOmitSnapshotFromDetail(t *testing.T) {
+	m := NewAppModel()
+	m.viewMode = viewDetail
+	detail := sampleDetail()
+	detail.Name = "alpha"
+	m.detail = &detail
+	m.confirming = true
+	m.confirmAction = "delete"
+	m.confirmTarget = "alpha"
+
+	// Press o to confirm (omit snapshot)
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Text: "o"})
+	model := updated.(AppModel)
+
+	require.False(t, model.confirming)
+	require.Empty(t, model.confirmAction)
+	require.Empty(t, model.confirmTarget)
+	require.Equal(t, viewOperation, model.viewMode)
+	require.Equal(t, viewDashboard, model.operationReturnView, "should redirect back to dashboard after delete")
+	require.Contains(t, model.operationName, "Deleting alpha (omit snapshot)")
+	require.NotNil(t, cmd)
+}
+
+func TestCancelDeleteFromDetail(t *testing.T) {
+	m := NewAppModel()
+	m.viewMode = viewDetail
+	detail := sampleDetail()
+	m.detail = &detail
+	m.confirming = true
+	m.confirmAction = "delete"
+	m.confirmTarget = detail.Name
+	m.statusMsg = "Delete project?"
+
+	// Press n to cancel
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	model := updated.(AppModel)
+
+	require.False(t, model.confirming)
+	require.Empty(t, model.confirmAction)
+	require.Empty(t, model.confirmTarget)
+	require.Empty(t, model.statusMsg)
+	require.Nil(t, cmd)
+}
+
+func TestDeleteHintsInDashboardAndDetail(t *testing.T) {
+	m := NewAppModel()
+	m.loading = false
+	m.width = 120
+	m.projects = []ProjectInfo{{Name: "a"}}
+
+	dashboardView := m.View().Content
+	require.Contains(t, dashboardView, "delete", "dashboard should show delete key hint")
+
+	m.viewMode = viewDetail
+	detail := sampleDetail()
+	m.detail = &detail
+	detailView := m.View().Content
+	require.Contains(t, detailView, "delete", "detail view should show delete key hint")
+
+	m.showHelp = true
+	helpView := m.View().Content
+	require.Contains(t, helpView, "Delete selected project", "help overlay should explain delete key")
+}


### PR DESCRIPTION
## Short Summary (TL;DR)

Currently, the DDEV TUI allows basic project navigation and management, but managing project deletion requires dropping back to the CLI (ddev delete or ddev delete --omit-snapshot).
We should allow users to delete a project and choose whether to purge or retain its database snapshots directly from the TUI interface.

## The Issue

- Fixes https://github.com/ddev/ddev/issues/8782

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Currently, the behavior in the TUI will strictly mirror ddev delete (retaining all existing snapshots and respecting the user's omit_snapshot_on_delete config). The implementation simply brings the existing ddev delete project lifecycle action into the TUI, with safe, explicit confirmation prompts.

Execution Flow
- User Selects a project
- User enters "delete" key
- A confirmation appears [y = delete the project keeping a snapshot (analogous to `ddev delete`), o = delete the project & doesn't create any snapshot (analogous to `ddev delete -O`)], any other key will cancel the operation.

## Automated Testing Overview

- Added the tests that will test various scenarios of the lifecycle.
