### PR TITLE
fix: update TestCmdVersion for release-tag image resolution (#8787) [skip ci]

### DIFF
--- a/cmd/ddev/cmd/cmd_version_test.go
+++ b/cmd/ddev/cmd/cmd_version_test.go
@@ -27,7 +27,7 @@ func TestCmdVersion(t *testing.T) {
 	require.True(t, ok, "raw section wasn't found in versioninfo %v", out)
 
 	assert.Equal(versionconstants.DdevVersion, raw["DDEV version"])
-	assert.Equal(versionconstants.WebImg+":"+versionconstants.WebTag, raw["web"])
+	assert.Equal(docker.GetWebImage(), raw["web"])
 	assert.Equal(docker.GetDBImage(nodeps.MariaDB, ""), raw["db"])
 	dockerVersion, err := dockerutil.GetDockerVersion()
 	require.NoError(t, err)
@@ -41,20 +41,21 @@ func TestCmdVersion(t *testing.T) {
 
 	assert.Contains(versionData["msg"], versionconstants.DdevVersion)
 	assert.Contains(versionData["msg"], versionconstants.WebImg)
-	assert.Contains(versionData["msg"], versionconstants.WebTag)
+	assert.Contains(versionData["msg"], docker.ResolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch))
 	assert.Contains(versionData["msg"], versionconstants.DBImg)
 	assert.Contains(versionData["msg"], docker.GetDBImage(nodeps.MariaDB, nodeps.MariaDBDefaultVersion))
 	assert.Contains(versionData["msg"], dockerVersion)
 	assert.Contains(versionData["msg"], dockerAPIVersion)
 	assert.Contains(versionData["msg"], buildxVersion)
 
-	// The table shown to the user has a branch hint appended to each image on an
-	// unreleased build; the raw JSON map used by scripting never has it.
+	// The table shown to the user appends a branch hint to an image whose tag
+	// wasn't already resolved to that branch; the raw JSON map used by
+	// scripting never has it.
 	branchHint := "(" + versionconstants.WebTagBranch + ")"
-	if versionconstants.IsUnreleasedDdevVersion(versionconstants.DdevVersion) {
-		assert.Contains(versionData["msg"], branchHint)
-	} else {
+	if docker.ResolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch) == versionconstants.WebTagBranch {
 		assert.NotContains(versionData["msg"], branchHint)
+	} else {
+		assert.Contains(versionData["msg"], branchHint)
 	}
 	_, ok = raw["image-tag-branches"]
 	assert.False(ok, "image-tag-branches should not appear in the raw section")


### PR DESCRIPTION
## Short Summary (TL;DR)

Follow-up to #8781: `TestCmdVersion` still asserted the stale raw-tag/branch-hint behavior that #8781 already fixed for `TestGetVersionInfo` and `ddev version` output.

## The Issue

No linked issue. CI on release-prep PR #8780 failed on `TestCmdVersion`: https://github.com/ddev/ddev/actions/runs/33434488895/job/99627556286

`GetWebImage()` prefers a release-tag branch (e.g. `v1.25.4`) over the raw content-hash tag when one is stamped, a behavior added for release-prep support. #8781 updated `TestGetVersionInfo` and the `ddev version` table to match, but missed `TestCmdVersion`, which still expected the raw hash tag and the old always-shown branch hint.

## How This PR Solves The Issue

Updated `TestCmdVersion` to assert against `docker.GetWebImage()` and `docker.ResolveImageTag()` directly instead of the raw `versionconstants.WebTag`, and to expect the branch hint only when the tag wasn't already resolved to that branch.

## Manual Testing Instructions

`go test -v -run TestCmdVersion ./cmd/ddev/cmd/...` — passes.

## Automated Testing Overview

Fixes the existing `TestCmdVersion` test; no new tests needed.

## Release/Deployment Notes

None - test-only fix.
