### PR TITLE
ci(debug): replace tmate with upterm [skip ci]

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false
@@ -80,11 +80,10 @@ jobs:
         with:
           brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Setup upterm session
+        uses: owenthereal/action-upterm@v1
         with:
           limit-access-to-actor: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
       - name: Install test dependencies (linux-setup.sh)

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false
@@ -54,9 +54,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
           textlint_flags: "{README.md,docs/**}"
-      - name: Setup tmate session
+      - name: Setup upterm session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-        uses: mxschmitt/action-tmate@v3
+        uses: owenthereal/action-upterm@v1
         with:
           limit-access-to-actor: true
       - name: Run linkspector to check external links

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false
@@ -55,9 +55,9 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: Setup tmate session
+      - name: Setup upterm session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-        uses: mxschmitt/action-tmate@v3
+        uses: owenthereal/action-upterm@v1
         with:
           limit-access-to-actor: true
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false
@@ -285,8 +285,8 @@ jobs:
           cgo=$(".gotmp/bin/$(go env GOOS)_$(go env GOARCH)/ddev" version 2>/dev/null | awk '/cgo_enabled/ {print $2}')
           if [ "${cgo}" != "0" ]; then echo "CGO_ENABLED=${cgo} but it must be 0 in released binary" && exit 10; fi
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Setup upterm session
+        uses: owenthereal/action-upterm@v1
         with:
           limit-access-to-actor: true
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/.github/workflows/perf-start-time.yml
+++ b/.github/workflows/perf-start-time.yml
@@ -39,7 +39,7 @@ on:
         required: false
         default: ''
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false
@@ -92,11 +92,10 @@ jobs:
         # image-push.yml's approval/build/push - see containers/wait-for-images.sh.
         run: containers/wait-for-images.sh
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Setup upterm session
+        uses: owenthereal/action-upterm@v1
         with:
           limit-access-to-actor: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
       - name: Determine baseline ref

--- a/.github/workflows/push-tagged-dbimage.yml
+++ b/.github/workflows/push-tagged-dbimage.yml
@@ -134,11 +134,10 @@ jobs:
           ORG_IMAGE=${DOCKER_ORG}/ddev-dbserver-$(echo "${{ matrix.build.dbtype }}" | tr '_' '-')
           echo "Cleaning up stale tag for ${ORG_IMAGE}:${TAG}-${{ matrix.build.arch }}"
           curl -s -X DELETE -H "Authorization: JWT $TOKEN" "https://hub.docker.com/v2/repositories/${ORG_IMAGE}/tags/${TAG}-${{ matrix.build.arch }}/" >/dev/null || true
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Setup upterm session
+        uses: owenthereal/action-upterm@v1
         with:
           limit-access-to-actor: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Build and push ${{ env.DOCKER_ORG }}/ddev-dbserver-${{ matrix.build.dbtype }}:${{ env.TAG }} ${{ matrix.build.arch }} image
         run: |

--- a/.github/workflows/push-tagged-image.yml
+++ b/.github/workflows/push-tagged-image.yml
@@ -119,11 +119,10 @@ jobs:
           ORG_IMAGE=${DOCKER_ORG}/${{ matrix.image }}
           echo "Cleaning up stale tag for ${ORG_IMAGE}:${TAG}-${{ matrix.arch }}"
           curl -s -X DELETE -H "Authorization: JWT $TOKEN" "https://hub.docker.com/v2/repositories/${ORG_IMAGE}/tags/${TAG}-${{ matrix.arch }}/" >/dev/null || true
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Setup upterm session
+        uses: owenthereal/action-upterm@v1
         with:
           limit-access-to-actor: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Build and push ${{ env.DOCKER_ORG }}/${{ matrix.image }}:${{ env.TAG }} ${{ matrix.arch }} image
         run: |

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -91,9 +91,9 @@ jobs:
           MAGENTO2_PUBLIC_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/public_access_key"
           MAGENTO2_PRIVATE_ACCESS_KEY: "op://test-secrets/MAGENTO2_ACCESS_KEYS/private_access_key"
 
-      - name: Setup tmate session
+      - name: Setup upterm session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-        uses: mxschmitt/action-tmate@v3
+        uses: owenthereal/action-upterm@v1
         with:
           limit-access-to-actor: true
 

--- a/.github/workflows/test-all-project-types.yml
+++ b/.github/workflows/test-all-project-types.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/test-apache-fpm.yml
+++ b/.github/workflows/test-apache-fpm.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/test-docker-rootless.yml
+++ b/.github/workflows/test-docker-rootless.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/test-nginx-fpm.yml
+++ b/.github/workflows/test-nginx-fpm.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/test-no-bind-mounts.yml
+++ b/.github/workflows/test-no-bind-mounts.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/test-podman-rootless-mutagen.yml
+++ b/.github/workflows/test-podman-rootless-mutagen.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/test-podman-rootless.yml
+++ b/.github/workflows/test-podman-rootless.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/test-pull-push-providers.yml
+++ b/.github/workflows/test-pull-push-providers.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/test-race-detection.yml
+++ b/.github/workflows/test-race-detection.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -79,7 +79,7 @@ on:
         type: string
         default: 'true'
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         required: false
         type: boolean
         default: false
@@ -249,9 +249,9 @@ jobs:
           echo "DDEV_TEST_DOCKER_ROOTLESS=${DDEV_TEST_DOCKER_ROOTLESS}"
           echo "MAKE_TARGET=${MAKE_TARGET}"
 
-      - name: Setup tmate session
+      - name: Setup upterm session
         if: ${{ inputs.debug_enabled }}
-        uses: mxschmitt/action-tmate@v3
+        uses: owenthereal/action-upterm@v1
         with:
           limit-access-to-actor: true
 

--- a/.github/workflows/test-wsl2-nat.yml
+++ b/.github/workflows/test-wsl2-nat.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/test-wsl2-reusable.yml
+++ b/.github/workflows/test-wsl2-reusable.yml
@@ -29,7 +29,7 @@ on:
         type: string
         default: '16'
       debug_enabled:
-        description: 'Run the build with tmate set "debug_enabled"'
+        description: 'Run the build with upterm set "debug_enabled"'
         required: false
         type: boolean
         default: false
@@ -178,9 +178,9 @@ jobs:
           # This ensures we always have upstream tags for correct git describe output
           wsl -u testuser -- bash -exc "mkdir -p ~/workspace && cd ~/workspace && git clone --no-single-branch '$repoUrl' ddev && cd ddev && git fetch origin '$gitRef' && git checkout FETCH_HEAD && echo 'Checked out:' && git log -1 --oneline && git describe --tags --always"
 
-      - name: Setup tmate session
+      - name: Setup upterm session
         if: ${{ inputs.debug_enabled }}
-        uses: mxschmitt/action-tmate@v3
+        uses: owenthereal/action-upterm@v1
         with:
           limit-access-to-actor: true
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines

  If this is a nontrivial contribution, please create an issue for discussion first, or discuss it first in Discord, https://ddev.com/s/discord. This will save you time and help direct the feature.
-->

## Short Summary (TL;DR)

Tmate servers are gone, replace tmate with upterm.

## The Issue

https://github.com/ddev/ddev/actions/runs/33522726796/job/99910411320

Tmate doesn't work anymore:

- https://github.com/tmate-io/tmate/issues/322

> I'm closing the servers, sorry

## How This PR Solves The Issue

I looked for alternatives in the related tmate issue, and upterm https://github.com/owenthereal/upterm seems to be a good alternative, it's not new, has 1300+ stars.

## Manual Testing Instructions

Test it here:

https://github.com/ddev-test/ddev/actions/workflows/docs-check.yml

<img width="375" height="341" alt="1" src="https://github.com/user-attachments/assets/0773e948-06e2-4ec7-8d01-d4612834d437" />

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
