### PR TITLE
ci: consolidate per-image container push comments into one PR comment

### DIFF
--- a/.github/workflows/image-build-push.yml
+++ b/.github/workflows/image-build-push.yml
@@ -306,7 +306,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v7
 
@@ -325,7 +324,6 @@ jobs:
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Create manifest and clean up per-arch tags
-        id: manifest
         env:
           # Trusted context, not the matrix: this is the readable alias
           # published next to the hash tag, so it must not be fork-controlled
@@ -403,17 +401,47 @@ jobs:
             done
           done
 
+          printf '%s' "$PUSHED_SUMMARY" > summary.md
+
+      # Collected by the comment job below: a matrix job can't hand its own
+      # output to a later job, since all of them write the same output name.
+      - uses: actions/upload-artifact@v7
+        if: github.event_name == 'pull_request'
+        with:
+          name: manifest-summary-${{ strategy.job-index }}
+          path: summary.md
+          retention-days: 1
+
+  comment:
+    name: Comment on the pull request
+    needs: [detect, create-manifests]
+    if: github.event_name == 'pull_request' && needs.detect.outputs.needs_build == 'true' && needs.detect.outputs.is_fork == 'false'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download the per-image summaries
+        uses: actions/download-artifact@v8
+        with:
+          pattern: manifest-summary-*
+          path: summaries
+
+      - name: Collect the summaries
+        id: summary
+        run: |
+          set -eu -o pipefail
           {
             echo "summary<<IMAGE_PUSH_EOF"
-            echo "$PUSHED_SUMMARY"
+            find summaries -name summary.md -exec cat {} + | sort
             echo "IMAGE_PUSH_EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Comment on the pull request
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
         env:
-          IMAGE_PUSH_SUMMARY: ${{ steps.manifest.outputs.summary }}
+          IMAGE_PUSH_SUMMARY: ${{ steps.summary.outputs.summary }}
         with:
           script: |
             const summary = (process.env.IMAGE_PUSH_SUMMARY || "").trim();


### PR DESCRIPTION
## Short Summary (TL;DR)

This PR consolidates the separate "Pushed updated container image(s)" comments that `image-build-push.yml` posts on a same-repo PR into a single comment per push, instead of one comment per image built.

## The Issue

See https://github.com/ddev/ddev/pull/8780#issuecomment-5501493591

<img width="814" height="700" alt="image" src="https://github.com/user-attachments/assets/0fd5aa7f-2e1f-4c01-96cf-d8ede7ea1cb1" />

When a PR changes several images at once (for example multiple `ddev-dbserver` variants), `create-manifests` runs one matrix job per image and each job comments on the PR directly, so the PR gets flooded with near-identical comments back to back instead of one summary.

## How This PR Solves The Issue

`create-manifests` now writes each image's push summary to a `manifest-summary-*` artifact instead of commenting. A new `comment` job runs after all `create-manifests` jobs finish, downloads every summary artifact, concatenates them, and posts one combined comment. This mirrors the aggregation that `image-push.yml`'s fork-PR path already does with its `push`/`comment` job split.

## Manual Testing Instructions

- `actionlint .github/workflows/image-build-push.yml` passes.
- Open a same-repo PR that touches more than one image under `containers/` (e.g. two `ddev-dbserver` variant Dockerfiles) and confirm a single PR comment lists all pushed images, rather than one comment per image.
- Confirm the fork-PR path (`image-push.yml`) is unaffected, since this change only touches `image-build-push.yml`'s same-repo `create-manifests`/`comment` jobs.

## Automated Testing Overview

No new automated tests; this is a CI workflow change with no unit-testable logic. Verified with `actionlint` and manual PR observation.

## Release/Deployment Notes

No user-facing or runtime impact. Affects only the GitHub Actions comment behavior on PRs that build container images.
