### PR TITLE
docs(quickstart): Fix fragile drupal cms test; expectation changed

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1143,10 +1143,10 @@ The [`webserver_type: generic`](./configuration/config.md#webserver_type) allows
     ddev composer create-project getgrav/grav
     ```
 
-    Install the admin plugin and launch:
+    Install the [Admin2](https://github.com/getgrav/grav-plugin-admin2) plugin and launch:
 
     ```bash
-    ddev exec gpm install admin -y
+    ddev exec gpm install admin2 -y
     ddev launch
     ```
 
@@ -1161,7 +1161,7 @@ The [`webserver_type: generic`](./configuration/config.md#webserver_type) allows
         ddev config --php-version=8.3 --omit-containers=db
         ddev start -y
         ddev composer create-project getgrav/grav
-        ddev exec gpm install admin -y
+        ddev exec gpm install admin2 -y
         ddev launch
         EOF
         chmod +x setup-grav.sh
@@ -1196,10 +1196,10 @@ The [`webserver_type: generic`](./configuration/config.md#webserver_type) allows
     ddev exec grav install
     ```
 
-    Install the admin plugin and launch:
+    Install the [Admin2](https://github.com/getgrav/grav-plugin-admin2) plugin and launch:
 
     ```bash
-    ddev exec gpm install admin -y
+    ddev exec gpm install admin2 -y
     ddev launch
     ```
 
@@ -1216,7 +1216,7 @@ The [`webserver_type: generic`](./configuration/config.md#webserver_type) allows
         ddev start -y
         ddev composer install
         ddev exec grav install
-        ddev exec gpm install admin -y
+        ddev exec gpm install admin2 -y
         ddev launch
         EOF
         chmod +x setup-grav-git.sh

--- a/docs/tests/drupal.bats
+++ b/docs/tests/drupal.bats
@@ -165,7 +165,7 @@ teardown() {
   run ddev composer create-project drupal/cms
   assert_success
   # This check shows that post-create-project-cmd event ran successfully
-  assert_output --partial "Congratulations, you’ve installed Drupal CMS!"
+  assert_output --partial "You're all set to get started with Drupal CMS"
 
   # Note: recipe-unpack runs automatically in DDEV v1.25.0+
   run ddev composer drupal:recipe-unpack

--- a/docs/tests/grav.bats
+++ b/docs/tests/grav.bats
@@ -28,7 +28,8 @@ teardown() {
   run ddev composer create-project getgrav/grav
   assert_success
 
-  run ddev exec gpm install admin -y
+  # Grav 2.0 dropped support for the classic admin plugin; admin2 is its replacement.
+  run ddev exec gpm install admin2 -y
   assert_success
 
   DDEV_DEBUG=true run ddev launch
@@ -67,7 +68,7 @@ teardown() {
   run ddev exec grav install
   assert_success
 
-  run ddev exec gpm install admin -y
+  run ddev exec gpm install admin2 -y
   assert_success
 
   DDEV_DEBUG=true run ddev launch


### PR DESCRIPTION

## Short Summary (TL;DR)

The [Drupal CMS quickstart broke](https://github.com/ddev/ddev/actions/runs/33567928567/job/100055260531); it was expecting a statement that was changed upstream.

Old: Congratulations, you’ve installed Drupal CMS
New: You're all set to get started with Drupal CMS