### PR TITLE
fix(zensical): drop strict-build retry workaround, require 0.0.58 (#8795) [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,19 +306,7 @@ markdownlint:
 # https://docs.ddev.com/en/stable/developers/testing-docs/
 zensical:
 	@echo "zensical: "
-	$(call require_tool,zensical)
-	@for i in 1 2 3; do \
-		out=$$(zensical build --strict 2>&1); rc=$$?; \
-		echo "$$out"; \
-		if [ $$rc -eq 0 ]; then exit 0; fi; \
-		if ! echo "$$out" | grep -q "page does not exist"; then \
-			echo "zensical: failure is not the known cache race; not retrying."; \
-			exit $$rc; \
-		fi; \
-		echo "zensical: attempt $$i hit the known cache race (see https://github.com/zensical/zensical/issues/641), retrying..."; \
-	done; \
-	echo "zensical: fast attempts exhausted; running authoritative clean build..."; \
-	zensical build --clean --strict
+	$(call run_tool,zensical,build --strict)
 
 # To see what the docs will look like, you can use `make zensical-serve`
 # It does require installing zensical: pip install zensical

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-zensical>=0.0.43,<1
+zensical>=0.0.58,<1


### PR DESCRIPTION
## Short Summary (TL;DR)

Zensical 0.0.58 fixes the scheduler race that made strict builds fail with false "page does not exist" warnings, so the retry-and-fall-back-to-clean loop in the `zensical` make target is no longer needed.

## The Issue

- Reverts the workaround added in #8451
- Upstream fix: https://github.com/zensical/zensical/issues/641

Validation could run before all Markdown files had been collected, so a strict build occasionally aborted on links that were fine.

## How This PR Solves The Issue

The `zensical` target is back to a single `zensical build --strict` through `run_tool`, which keeps the fail-if-not-installed behavior. `docs/requirements.txt` now floors zensical at 0.0.58 so nobody installs a version with the race.

## Manual Testing Instructions

```bash
scripts/install-dev-tools.sh
zensical --version
for i in $(seq 1 10); do make zensical || { echo "FAILED on run $i"; break; }; done
```

All ten runs should report "No issues found" with no retry lines. Adding a link to a nonexistent page should still fail the target.

## Automated Testing Overview

None; covered by the existing docs-check workflow.

## Release/Deployment Notes

Contributors with an older zensical need to rerun `scripts/install-dev-tools.sh`.