### PR TITLE
docs: add subtle sponsorship callouts to GitHub templates and release notes (#8796) [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,3 +72,9 @@ body:
         💡 Attach images or log files by clicking this area to highlight it and dragging files in.
     validations:
       required: false
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        💙 DDEV is free and maintained by the nonprofit DDEV Foundation. If DDEV
+        saves you or your team time, consider [sponsoring the project](https://ddev.com/sponsor).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,4 +3,7 @@ contact_links:
   - name: 💬 DDEV Community Discord
     url: https://ddev.com/s/discord
     about: Join the DDEV Community to talk, exchange experiences or ask and answer questions.
+  - name: 💙 Sponsor DDEV
+    url: https://ddev.com/sponsor
+    about: DDEV is free and open source, funded by its community. Consider sponsoring to help keep it independent.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -40,3 +40,9 @@ body:
       description: Add any other context or screenshots about the feature request.
     validations:
       required: false
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        💙 DDEV is free and maintained by the nonprofit DDEV Foundation. If DDEV
+        saves you or your team time, consider [sponsoring the project](https://ddev.com/sponsor).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,8 @@
   https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
 
   If this is a nontrivial contribution, please create an issue for discussion first, or discuss it first in Discord, https://ddev.com/s/discord. This will save you time and help direct the feature.
+
+  DDEV is community-funded — if you or your team rely on DDEV, see https://ddev.com/sponsor.
 -->
 
 ## Short Summary (TL;DR)

--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -16,5 +16,10 @@ And anywhere, you can download the tarball or zipball, un-tar or un-zip it, and 
 
 *
 
+# Support DDEV
+
+DDEV is free and open source, maintained by the nonprofit DDEV Foundation.
+If this release saves you time, consider [sponsoring DDEV](https://ddev.com/sponsor).
+
 # Commits since _PREVIOUS VERSION_
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -234,9 +234,15 @@ checksum:
 #### RELEASE ####
 release:
   prerelease: auto
+  # Releases are created manually via the GitHub UI before the tag is pushed
+  mode: append
   github:
     owner: "{{ .Env.REPOSITORY_OWNER }}"
     name: ddev
+  footer: |
+    ---
+    💙 DDEV is free and open source, maintained by the nonprofit DDEV Foundation.
+    If this release saves you time, consider [sponsoring DDEV](https://ddev.com/sponsor).
 
 brews:
 - name: ddev


### PR DESCRIPTION
<!--
  PR titles have very precise rules, please read
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines

  If this is a nontrivial contribution, please create an issue for discussion first, or discuss it first in Discord, https://ddev.com/s/discord. This will save you time and help direct the feature.

  DDEV is community-funded — if you or your team rely on DDEV, see https://ddev.com/sponsor.
-->

## Short Summary (TL;DR)

Adds small, easy-to-ignore sponsorship pointers to the GitHub issue/PR templates and release notes, an idea that came out of today's advisory group meeting (see [discussion #8546](https://github.com/orgs/ddev/discussions/8546)).

## How This PR Solves The Issue

Adds a one-or-two-line callout linking to https://ddev.com/sponsor to:

- The bottom of the bug report and feature request issue templates
- A new contact link in the issue template chooser
- The PR template's existing HTML comment (visible only while editing, not in the rendered PR)
- The release notes template
- GoReleaser's release footer, with `release.mode: append` so it actually applies (see Release/Deployment Notes below)

## Manual Testing Instructions

After merge: 

- Open the "New issue" chooser and confirm the "💙 Sponsor DDEV" link appears.
- Start a bug report or feature request and confirm the sponsorship note renders at the bottom.
- Open a new PR and confirm the sponsor line appears in the description editor but not in the rendered PR body.

## Release/Deployment Notes

`.goreleaser.yml`'s default `release.mode` is `keep-existing`, but DDEV creates the GitHub release manually before pushing the tag that triggers GoReleaser, so the release body already exists by the time GoReleaser runs. Without `mode: append`, the new footer would never show up on a real release. Verified with `goreleaser check` and a local `--snapshot` build; a full non-snapshot render needs a GoReleaser Pro key that isn't available here, so a real test release (e.g. against `ddev-test/ddev`) is worth doing before this ships.
