### PR TITLE
fix(dbserver): add --single-transaction and MySQL 9.5+ dump flags to export-db

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -883,15 +883,29 @@ func (app *DdevApp) GetDBCompressionCommand() string {
 }
 
 // GetDBDumpCommand returns the appropriate database dump command (mysqldump or mariadb-dump)
-// based on the database type and version.
+// with flags, based on the database type and version.
 func (app *DdevApp) GetDBDumpCommand() string {
+	cmd := "mysqldump"
 	// Use canonical mariadb-dump for MariaDB 10.5+
 	if app.Database.Type == nodeps.MariaDB {
 		if isNewMariaDB, _ := util.SemverValidate(">= 10.5", app.Database.Version); isNewMariaDB {
-			return "mariadb-dump"
+			cmd = "mariadb-dump"
 		}
 	}
-	return "mysqldump"
+
+	cmd = cmd + " --single-transaction"
+
+	// MySQL 9.5+ defaults gtid_mode to ON, which makes mysqldump emit
+	// GTID_PURGED statements/warnings on a single-database dump. export-db
+	// dumps one project database for later import-db, not for replication,
+	// so GTID metadata and tablespace privileges aren't wanted here.
+	if app.Database.Type == nodeps.MySQL {
+		if isNewMySQL, _ := util.SemverValidate(">= 9.5", app.Database.Version); isNewMySQL {
+			cmd = cmd + " --set-gtid-purged=OFF --no-tablespaces"
+		}
+	}
+
+	return cmd
 }
 
 // ImportDB takes a source sql dump and imports it to an active site's database container.

--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1999,6 +1999,31 @@ func TestDdevAllDatabases(t *testing.T) {
 	runTime()
 }
 
+// TestGetDBDumpCommand checks the mysqldump/mariadb-dump flags chosen for each
+// database type/version, in particular the MySQL 9.5+ gating for
+// --set-gtid-purged and --no-tablespaces.
+func TestGetDBDumpCommand(t *testing.T) {
+	app := &ddevapp.DdevApp{}
+
+	for _, tt := range []struct {
+		dbType   string
+		dbVer    string
+		expected string
+	}{
+		{nodeps.MySQL, nodeps.MySQL80, "mysqldump --single-transaction"},
+		{nodeps.MySQL, nodeps.MySQL84, "mysqldump --single-transaction"},
+		{nodeps.MySQL, "9.4", "mysqldump --single-transaction"},
+		{nodeps.MySQL, "9.5", "mysqldump --single-transaction --set-gtid-purged=OFF --no-tablespaces"},
+		{nodeps.MySQL, nodeps.MySQL97, "mysqldump --single-transaction --set-gtid-purged=OFF --no-tablespaces"},
+		{nodeps.MariaDB, nodeps.MariaDB104, "mysqldump --single-transaction"},
+		{nodeps.MariaDB, nodeps.MariaDB105, "mariadb-dump --single-transaction"},
+		{nodeps.MariaDB, nodeps.MariaDB1011, "mariadb-dump --single-transaction"},
+	} {
+		app.Database = ddevapp.DatabaseDesc{Type: tt.dbType, Version: tt.dbVer}
+		require.Equal(t, tt.expected, app.GetDBDumpCommand(), "dbType=%s dbVer=%s", tt.dbType, tt.dbVer)
+	}
+}
+
 // TestDdevExportDB tests the functionality that is called when "ddev export-db" is executed.
 //
 // Each database type gets one plain-text export, which exercises that type's


### PR DESCRIPTION
## Short Summary (TL;DR)

`ddev export-db` now passes `--single-transaction` on every MySQL/MariaDB version for a consistent non-locking dump, and on MySQL 9.5+ (currently `mysql:9.7`) also passes `--set-gtid-purged=OFF` and `--no-tablespaces` so the export stays clean of GTID metadata and tablespace-privilege errors that MySQL 9.5+'s new defaults introduce.

## The Issue

MySQL 9.5 changed the default of `gtid_mode` to `ON`. Since `export-db` dumps a single project database (not `--all-databases`, and not for replication), mysqldump's default `--set-gtid-purged=AUTO` behavior on a GTID-enabled server produced this on every export:

```
Warning: A partial dump from a server that has GTIDs will by default include the GTIDs of all transactions, even those that changed suppressed parts of the database. If you don't want to restore GTIDs, pass --set-gtid-purged=OFF. To make a complete dump, pass --all-databases --triggers --routines --events.
Warning: A dump from a server that has GTIDs enabled will by default include the GTIDs of all transactions, even those that were executed during its extraction and might not be represented in the dumped data. This might result in an inconsistent data dump.
In order to ensure a consistent backup of the database, pass --single-transaction or --lock-all-tables or --source-data.
```

The dump still worked and re-imported fine with `import-db`, so this wasn't a functional bug, but it was alarming noise on every `export-db` run against MySQL 9.7. Separately, mysqldump's `CREATE TABLESPACE` statements need the `PROCESS` privilege, which the dumping user in a containerized MySQL setup typically doesn't have.

## How This PR Solves The Issue

`GetDBDumpCommand()` in `pkg/ddevapp/ddevapp.go` now builds the dump command with flags instead of returning a bare binary name:

- `--single-transaction` is added unconditionally, for all MySQL and MariaDB versions, closing the second warning above and giving a consistent InnoDB snapshot without locking tables.
- `--set-gtid-purged=OFF` and `--no-tablespaces` are added only when the database is MySQL and the detected version is `>= 9.5`, using the existing `util.SemverValidate` helper rather than hardcoding `9.7`, so this keeps working automatically if DDEV adds a newer 9.x version later.

`--routines`/`--triggers`/`--events` are unchanged; `--triggers` was already mysqldump's default, and `--routines`/`--events` were never included in `export-db`'s single-database dumps at any version, so that's out of scope here.

## Manual Testing Instructions

1. On a project configured with `mysql:9.7`, run `ddev export-db -f dump.sql.gz` and confirm the GTID/single-transaction warnings above no longer appear.
2. Confirm the export still imports cleanly: `ddev import-db -f dump.sql.gz`.
3. Repeat on a project using an older MySQL (e.g. `mysql:8.0`) and on MariaDB, and confirm `--set-gtid-purged`/`--no-tablespaces` are *not* added (no behavior change there beyond the new `--single-transaction`).

## Automated Testing Overview

Added `TestGetDBDumpCommand` in `pkg/ddevapp/ddevapp_test.go`, a unit test covering the flag set chosen for MySQL 8.0/8.4/9.4 (no gated flags), MySQL 9.5/9.7 (gated flags present), and MariaDB below/at/above the existing 10.5 `mariadb-dump` cutover.

## Release/Deployment Notes

`export-db` output changes for every user: the GTID/tablespace warnings on MySQL 9.5+ disappear, and `--single-transaction` is now always used. No config or CLI flag changes; no impact on `import-db`.
