### PR TITLE
test(export-db): cover mysql in TestDdevExportDB and trim redundant per-engine checks

### DIFF
--- a/pkg/ddevapp/ddevapp_test.go
+++ b/pkg/ddevapp/ddevapp_test.go
@@ -1999,8 +1999,19 @@ func TestDdevAllDatabases(t *testing.T) {
 	runTime()
 }
 
-// TestDdevExportDB tests the functionality that is called when "ddev export-db" is executed
+// TestDdevExportDB tests the functionality that is called when "ddev export-db" is executed.
+//
+// Each database type gets one plain-text export, which exercises that type's
+// actual dump command (mariadb-dump w/ its tail workaround, mysqldump, or
+// pg_dump) and validates the resulting content. Compression formats,
+// overwrite-of-existing-file behavior, stdout export, and the multi-database
+// export/import chain are engine-agnostic, so they're only exercised once
+// (on MariaDB) rather than once per database type.
 func TestDdevExportDB(t *testing.T) {
+	// Don't run this unless GOTEST_SHORT is unset; it doesn't need to be run everywhere.
+	if os.Getenv("GOTEST_SHORT") != "" {
+		t.Skip("Skip because GOTEST_SHORT is set")
+	}
 	assert := asrt.New(t)
 	app := &ddevapp.DdevApp{}
 	testDir, _ := os.Getwd()
@@ -2023,15 +2034,18 @@ func TestDdevExportDB(t *testing.T) {
 		assert.NoError(err)
 	})
 
-	for _, dbType := range []string{nodeps.MariaDB, nodeps.Postgres} {
+	dbVersions := map[string]string{
+		nodeps.MariaDB:  nodeps.MariaDBDefaultVersion,
+		nodeps.MySQL:    nodeps.MySQL84,
+		nodeps.Postgres: nodeps.PostgresDefaultVersion,
+	}
+
+	for _, dbType := range []string{nodeps.MariaDB, nodeps.MySQL, nodeps.Postgres} {
 		err = app.Stop(true, false)
 		require.NoError(t, err)
 		app.Database = ddevapp.DatabaseDesc{
 			Type:    dbType,
-			Version: nodeps.MariaDBDefaultVersion,
-		}
-		if dbType == nodeps.Postgres {
-			app.Database.Version = nodeps.PostgresDefaultVersion
+			Version: dbVersions[dbType],
 		}
 		err = app.WriteConfig()
 		require.NoError(t, err)
@@ -2047,8 +2061,8 @@ func TestDdevExportDB(t *testing.T) {
 		err = fileutil.PurgeDirectory("tmp")
 		assert.NoError(err)
 
-		// Test that we can export-db to a plain file. This should be larger than
-		// the gzipped file we'll do next.
+		// Test that we can export-db to a plain file. This exercises this
+		// dbType's actual dump command.
 		err = app.ExportDB("tmp/users1.sql", "", "db")
 		assert.NoError(err)
 
@@ -2061,116 +2075,100 @@ func TestDdevExportDB(t *testing.T) {
 		assert.NoError(err)
 		assert.Contains(l, "ump complete")
 
-		// Now copy our (larger) users1.sql to users1.sql.gz
-		// so we can overwrite it and come out with a totally valid new file.
-		// Copy is used here instead of mv/rename because of Windows issues.
-		err = fileutil.CopyFile("tmp/users1.sql", "tmp/users1.sql.gz")
-		assert.NoError(err)
-
-		// Test that we can export-db to an existing gzipped file
-		err = app.ExportDB("tmp/users1.sql.gz", "gzip", "db")
-		assert.NoError(err)
-
-		// The new gzipped file should be less than 1K
-		f, err = os.Stat("tmp/users1.sql.gz")
-		assert.NoError(err)
-		assert.Less(f.Size(), int64(1500))
-
-		// Validate contents
-		err = archive.Ungzip("tmp/users1.sql.gz", "tmp")
-		assert.NoError(err)
 		stringFound, err := fileutil.FgrepStringInFile("tmp/users1.sql", "Table structure for table `users`")
 		assert.NoError(err)
 		if !stringFound {
 			stringFound, err = fileutil.FgrepStringInFile("tmp/users1.sql", "Name: users; Type: TABLE")
 			assert.NoError(err)
 		}
-		assert.True(stringFound)
+		assert.True(stringFound, "expected dump content not found for dbType=%s", dbType)
 
-		// Simple export-and-validate to various types of compression
-		cTypes := map[string]string{
-			"gzip":  "gz",
-			"bzip2": "bz2",
-			"xz":    "xz",
-		}
-		for cType, ext := range cTypes {
-			err = app.ExportDB("tmp/users1.sql."+ext, cType, "db")
+		// The remaining checks below (compression formats, overwrite behavior,
+		// stdout export, multi-database chain) don't depend on the database
+		// engine, so only run them once.
+		if dbType == nodeps.MariaDB {
+			// Copy the (larger) users1.sql to users1.sql.gz so we can overwrite it
+			// and come out with a totally valid new file. Copy is used here instead
+			// of mv/rename because of Windows issues.
+			err = fileutil.CopyFile("tmp/users1.sql", "tmp/users1.sql.gz")
 			assert.NoError(err)
-			switch cType {
-			case "gzip":
-				err = archive.Ungzip("tmp/users1.sql."+ext, "tmp")
-				assert.NoError(err)
-			case "bzip2":
-				err = archive.UnBzip2("tmp/users1.sql."+ext, "tmp")
-				assert.NoError(err)
-			case "xz":
-				err = archive.UnXz("tmp/users1.sql."+ext, "tmp")
-				assert.NoError(err)
-			}
 
+			// Test that we can export-db to an existing gzipped file
+			err = app.ExportDB("tmp/users1.sql.gz", "gzip", "db")
+			assert.NoError(err)
+
+			// The new gzipped file should be less than 1K
+			f, err = os.Stat("tmp/users1.sql.gz")
+			assert.NoError(err)
+			assert.Less(f.Size(), int64(1500))
+
+			// Validate contents
+			err = archive.Ungzip("tmp/users1.sql.gz", "tmp")
+			assert.NoError(err)
 			stringFound, err = fileutil.FgrepStringInFile("tmp/users1.sql", "Table structure for table `users`")
 			assert.NoError(err)
-			if !stringFound {
-				stringFound, err = fileutil.FgrepStringInFile("tmp/users1.sql", "Name: users; Type: TABLE")
-				assert.NoError(err)
+			assert.True(stringFound)
+
+			// Simple export-and-validate to various types of compression
+			cTypes := map[string]string{
+				"gzip":  "gz",
+				"bzip2": "bz2",
+				"xz":    "xz",
 			}
-			assert.True(stringFound, "expected info not found %s (%s)", cType, "tmp/users1.sql")
-		}
+			for cType, ext := range cTypes {
+				err = app.ExportDB("tmp/users1.sql."+ext, cType, "db")
+				assert.NoError(err)
+				switch cType {
+				case "gzip":
+					err = archive.Ungzip("tmp/users1.sql."+ext, "tmp")
+					assert.NoError(err)
+				case "bzip2":
+					err = archive.UnBzip2("tmp/users1.sql."+ext, "tmp")
+					assert.NoError(err)
+				case "xz":
+					err = archive.UnXz("tmp/users1.sql."+ext, "tmp")
+					assert.NoError(err)
+				}
 
-		// Flush needs to be complete before purge or may conflict with Mutagen on windows
-		err = app.MutagenSyncFlush()
-		assert.NoError(err)
-		err = fileutil.PurgeDirectory("tmp")
-		assert.NoError(err)
+				stringFound, err = fileutil.FgrepStringInFile("tmp/users1.sql", "Table structure for table `users`")
+				assert.NoError(err)
+				assert.True(stringFound, "expected info not found %s (%s)", cType, "tmp/users1.sql")
+			}
 
-		// Export to an ungzipped file and validate
-		err = app.ExportDB("tmp/users2.sql", "", "db")
-		assert.NoError(err)
-
-		// Validate contents
-		stringFound, err = fileutil.FgrepStringInFile("tmp/users2.sql", "Table structure for table `users`")
-		assert.NoError(err)
-		if !stringFound {
-			stringFound, err = fileutil.FgrepStringInFile("tmp/users2.sql", "Name: users; Type: TABLE")
+			// Flush needs to be complete before purge or may conflict with Mutagen on windows
+			err = app.MutagenSyncFlush()
 			assert.NoError(err)
+			err = fileutil.PurgeDirectory("tmp")
+			assert.NoError(err)
+
+			// Capture to stdout without gzip compression
+			stdout := util.CaptureStdOut()
+			err = app.ExportDB("", "", "db")
+			assert.NoError(err)
+			o := stdout()
+			assert.Regexp(regexp.MustCompile("CREATE TABLE.*users"), o)
+
+			// Export an alternate database
+			err = app.ImportDB(importPath, "", false, false, "anotherdb")
+			require.NoError(t, err, `unable to ImportDB(%s, "", false, false anotherdb) with dbType=%s`, importPath, dbType)
+			err = app.ExportDB("tmp/anotherdb.sql.gz", "gzip", "anotherdb")
+			require.NoError(t, err, `dbType=%v: unable to ExportDB("/tmp/anotherdb.sql.gz", "gzip"", "anotherdb")`, dbType)
+			anotherdbPath := "tmp/anotherdb.sql.gz"
+			err = app.ImportDB(anotherdbPath, "", false, false, "thirddb")
+			require.NoError(t, err, `dbType=%v: unable to importDB importPath=%s targetDB=thirddb`, dbType, anotherdbPath)
+
+			out, stderr, err := app.Exec(&ddevapp.ExecOpts{
+				Service: "db",
+				Cmd:     fmt.Sprintf(`echo "SELECT COUNT(*) FROM users;" | %s -N thirddb`, app.GetDBClientCommand()),
+			})
+			assert.NoError(err, "stdout=%s stderr=%s", out, stderr)
+			out = strings.Trim(out, "\n")
+			out = strings.Trim(out, " ")
+			assert.Equal("2", out)
 		}
-		assert.True(stringFound)
 
-		err = app.MutagenSyncFlush()
+		err = app.Stop(true, false)
 		assert.NoError(err)
-
-		err = fileutil.PurgeDirectory("tmp")
-		assert.NoError(err)
-
-		// Capture to stdout without gzip compression
-		stdout := util.CaptureStdOut()
-		err = app.ExportDB("", "", "db")
-		assert.NoError(err)
-		o := stdout()
-		assert.Regexp(regexp.MustCompile("CREATE TABLE.*users"), o)
-
-		// Export an alternate database
-		importPath = filepath.Join(testDir, "testdata", t.Name(), dbType, "users.sql")
-		err = app.ImportDB(importPath, "", false, false, "anotherdb")
-		require.NoError(t, err, `unable to ImportDB(%s, "", false, false anotherdb) with dbType=%s`, dbType)
-		err = app.ExportDB("tmp/anotherdb.sql.gz", "gzip", "anotherdb")
-		require.NoError(t, err, `dbType=%v: unable to ExportDB("/tmp/anotherdb.sql.gz", "gzip"", "anotherdb")`, dbType)
-		importPath = "tmp/anotherdb.sql.gz"
-		err = app.ImportDB(importPath, "", false, false, "thirddb")
-		require.NoError(t, err, `dbType=%v: unable to importDB importPath=%s targetDB=thirddb`, dbType, importPath)
-
-		c := map[string]string{
-			nodeps.MariaDB:  fmt.Sprintf(`echo "SELECT COUNT(*) FROM users;" | %s -N thirddb`, app.GetDBClientCommand()),
-			nodeps.Postgres: `echo "SELECT COUNT(*) FROM users;" | psql -t -q thirddb`,
-		}
-		out, stderr, err := app.Exec(&ddevapp.ExecOpts{
-			Service: "db",
-			Cmd:     c[dbType],
-		})
-		assert.NoError(err, "stdout=%s stderr=%s", out, stderr)
-		out = strings.Trim(out, "\n")
-		out = strings.Trim(out, " ")
-		assert.Equal("2", out)
 	}
 
 	runTime()

--- a/pkg/ddevapp/testdata/TestDdevExportDB/mysql/users.sql
+++ b/pkg/ddevapp/testdata/TestDdevExportDB/mysql/users.sql
@@ -1,0 +1,55 @@
+-- MySQL dump 10.13  Distrib 5.5.54, for debian-linux-gnu (x86_64)
+--
+-- Host: db    Database: data
+-- ------------------------------------------------------
+-- Server version	5.7.17-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `users`
+--
+
+DROP TABLE IF EXISTS `users`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `users` (
+  `uid` int(10) unsigned NOT NULL,
+  `uuid` varchar(128) CHARACTER SET ascii NOT NULL,
+  `langcode` varchar(12) CHARACTER SET ascii NOT NULL,
+  PRIMARY KEY (`uid`),
+  UNIQUE KEY `user_field__uuid__value` (`uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='The base table for user entities.';
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `users`
+--
+
+LOCK TABLES `users` WRITE;
+/*!40000 ALTER TABLE `users` DISABLE KEYS */;
+set autocommit=0;
+INSERT INTO `users` VALUES (0,'13751eca-19cf-41c2-90d4-9363f3a07c45','en'),(1,'186efa0a-8aa3-4eeb-90ce-6302fb9c4e07','en');
+/*!40000 ALTER TABLE `users` ENABLE KEYS */;
+UNLOCK TABLES;
+commit;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2017-05-31 14:03:34


### PR DESCRIPTION
## Short Summary (TL;DR)

`TestDdevExportDB` only ran against MariaDB and Postgres, so it never exercised the actual `mysqldump` command MySQL projects use. This PR adds MySQL to the test and consolidates the engine-agnostic checks (compression formats, overwrite behavior, stdout export, multi-database chain) to run once instead of once per engine, keeping the total runtime about the same despite covering a third database type.

## The Issue

While reviewing #8797, I noticed `TestDdevExportDB`'s dbType loop only covered MariaDB and Postgres. That means the mariadb-dump tail-workaround path and pg_dump were tested, but the mysqldump path used by actual MySQL projects never was. The test also lacked the `GOTEST_SHORT` skip guard present on its siblings `TestDdevImportDB` and `TestDdevAllDatabases`.

## How This PR Solves The Issue

Adds `nodeps.MySQL` to the dbType loop, with a `mysql/users.sql` test fixture. Every engine now gets one plain-export content check, enough to catch a regression in that engine's dump command. The remaining checks (gzip/bzip2/xz compression, overwriting an existing export file, stdout export, and the multi-database anotherdb/thirddb export/import chain) don't depend on the database engine, so they now run once, on MariaDB, instead of being duplicated across every dbType. Also added the missing `GOTEST_SHORT` skip.

## Manual Testing Instructions

```
go test -v -run TestDdevExportDB ./pkg/ddevapp/...
```

Confirm it passes for all three engines (mariadb, mysql, postgres) and is skipped when `GOTEST_SHORT=true`.

## Automated Testing Overview

This PR only changes test code; no production code was touched.

## Release/Deployment Notes

None.
