### PR TITLE
fix: stale-pin check should compare against the resolved release tag, not the raw hash

### DIFF
--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ddev/ddev/pkg/ddevapp"
+	"github.com/ddev/ddev/pkg/docker"
 	"github.com/ddev/ddev/pkg/dockerutil"
 	"github.com/ddev/ddev/pkg/exec"
 	"github.com/ddev/ddev/pkg/globalconfig"
@@ -123,7 +124,7 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, out, "dbimage: "+staleImage)
 		require.Contains(t, out, "built for DDEV images some-older-ddev-tag")
-		require.Contains(t, out, "but this DDEV expects "+versionconstants.BaseDBTag)
+		require.Contains(t, out, "but this DDEV expects "+docker.ResolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch))
 	})
 
 	// GLOBAL CHECKS (matching order in CheckCustomConfig)

--- a/cmd/ddev/cmd/utility-check-custom-config_test.go
+++ b/cmd/ddev/cmd/utility-check-custom-config_test.go
@@ -124,7 +124,7 @@ func TestUtilityCheckCustomConfigCmd(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, out, "dbimage: "+staleImage)
 		require.Contains(t, out, "built for DDEV images some-older-ddev-tag")
-		require.Contains(t, out, "but this DDEV expects "+docker.ResolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch))
+		require.Contains(t, out, "but this DDEV expects "+docker.DBImageTag())
 	})
 
 	// GLOBAL CHECKS (matching order in CheckCustomConfig)

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -435,17 +435,19 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 	// Non-default webimage/dbimage are custom configuration even though they're
 	// config.yaml values rather than files.
 	if app.WebImage != "" && app.WebImage != docker.GetWebImage() {
+		expectedWebTag := docker.ResolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch)
 		findings = append(findings, finding{
 			category: "Web server",
 			files: []fileInfo{{path: fmt.Sprintf("webimage: %s (non-default%s)",
-				app.WebImage, imageVersionMismatch(app.WebImage, versionconstants.WebTag))}},
+				app.WebImage, imageVersionMismatch(app.WebImage, expectedWebTag))}},
 		})
 	}
 	if app.DBImage != "" && app.DBImage != docker.GetDBImage(app.Database.Type, app.Database.Version) {
+		expectedDBTag := docker.ResolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch)
 		findings = append(findings, finding{
 			category: "Database",
 			files: []fileInfo{{path: fmt.Sprintf("dbimage: %s (non-default%s)",
-				app.DBImage, imageVersionMismatch(app.DBImage, versionconstants.BaseDBTag))}},
+				app.DBImage, imageVersionMismatch(app.DBImage, expectedDBTag))}},
 		})
 	}
 

--- a/pkg/ddevapp/config_custom.go
+++ b/pkg/ddevapp/config_custom.go
@@ -435,7 +435,7 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 	// Non-default webimage/dbimage are custom configuration even though they're
 	// config.yaml values rather than files.
 	if app.WebImage != "" && app.WebImage != docker.GetWebImage() {
-		expectedWebTag := docker.ResolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch)
+		expectedWebTag := docker.WebImageTag()
 		findings = append(findings, finding{
 			category: "Web server",
 			files: []fileInfo{{path: fmt.Sprintf("webimage: %s (non-default%s)",
@@ -443,7 +443,7 @@ func (app *DdevApp) CheckCustomConfig(showAll bool) (message string, hasWarnings
 		})
 	}
 	if app.DBImage != "" && app.DBImage != docker.GetDBImage(app.Database.Type, app.Database.Version) {
-		expectedDBTag := docker.ResolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch)
+		expectedDBTag := docker.DBImageTag()
 		findings = append(findings, finding{
 			category: "Database",
 			files: []fileInfo{{path: fmt.Sprintf("dbimage: %s (non-default%s)",

--- a/pkg/ddevapp/config_custom_test.go
+++ b/pkg/ddevapp/config_custom_test.go
@@ -5,6 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ddev/ddev/pkg/dockerutil"
+	"github.com/ddev/ddev/pkg/exec"
+	"github.com/ddev/ddev/pkg/nodeps"
+	"github.com/ddev/ddev/pkg/versionconstants"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,4 +49,44 @@ func TestOSGeneratedFilesSkippedInCustomConfig(t *testing.T) {
 	require.Contains(t, customPaths, bashrc)
 	require.Contains(t, customPaths, gitconfig)
 	require.Contains(t, customPaths, normalScript)
+}
+
+// TestCheckCustomConfigDBImageReleaseTag verifies that a pinned dbimage is not
+// flagged stale just because its com.ddev.image-tag label doesn't match the raw
+// content-hash BaseDBTag constant. On a release build, BaseDBTagBranch is a
+// vX.Y.Z tag, and docker.GetDBImage() (and the official image DDEV publishes)
+// both resolve to that readable tag via docker.ResolveImageTag - so a pinned
+// image built from that same official image must be compared against the
+// resolved tag too, not the raw hash. See ddev/ddev#8705's
+// TestUtilityCheckCustomConfigCmd/"dbimage built for a different DDEV version"
+// for the companion case where the label genuinely doesn't match.
+func TestCheckCustomConfigDBImageReleaseTag(t *testing.T) {
+	if dockerutil.IsPodman() {
+		t.Skip("Skipping: podman qualifies locally built image names with localhost/")
+	}
+
+	origTag, origBranch := versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch
+	versionconstants.BaseDBTag = "abc123"
+	versionconstants.BaseDBTagBranch = "v9.9.9"
+	t.Cleanup(func() {
+		versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch = origTag, origBranch
+	})
+
+	currentImage := "ddev-test-current-dbimage:latest"
+	buildDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "Dockerfile"),
+		[]byte("FROM busybox\nLABEL com.ddev.image-tag=v9.9.9\n"), 0644))
+	_, err := exec.RunHostCommand("docker", "build", "-t", currentImage, buildDir)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = exec.RunHostCommand("docker", "rmi", "-f", currentImage)
+	})
+
+	app := newBaseDBSeedTestApp(t, nodeps.MariaDB, nodeps.MariaDBDefaultVersion)
+	app.DBImage = currentImage
+
+	message, _ := app.CheckCustomConfig(true)
+	require.Contains(t, message, "dbimage: "+currentImage)
+	require.NotContains(t, message, "but this DDEV expects",
+		"a dbimage labeled with the resolved release tag must not be flagged stale against the raw content-hash constant")
 }

--- a/pkg/ddevapp/config_custom_test.go
+++ b/pkg/ddevapp/config_custom_test.go
@@ -55,7 +55,7 @@ func TestOSGeneratedFilesSkippedInCustomConfig(t *testing.T) {
 // flagged stale just because its com.ddev.image-tag label doesn't match the raw
 // content-hash BaseDBTag constant. On a release build, BaseDBTagBranch is a
 // vX.Y.Z tag, and docker.GetDBImage() (and the official image DDEV publishes)
-// both resolve to that readable tag via docker.ResolveImageTag - so a pinned
+// both resolve to that readable tag via docker.DBImageTag() - so a pinned
 // image built from that same official image must be compared against the
 // resolved tag too, not the raw hash. See ddev/ddev#8705's
 // TestUtilityCheckCustomConfigCmd/"dbimage built for a different DDEV version"

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -52,13 +52,26 @@ func resolveImageTag(tag, branch string) string {
 	return tag
 }
 
+// WebImageTag returns the tag the official web image is published with, which
+// is also the DdevImageTagLabel it carries.
+func WebImageTag() string {
+	return resolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch)
+}
+
+// DBImageTag returns the tag the ddev-dbserver images are published with, which
+// is also the DdevImageTagLabel they carry. Postgres has no DDEV-built image,
+// so it has neither.
+func DBImageTag() string {
+	return resolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch)
+}
+
 // GetWebImage returns the correctly formatted web image:tag reference
 func GetWebImage() string {
 	fullWebImg := imageRepo(versionconstants.WebImg)
 	if globalconfig.DdevGlobalConfig.UseHardenedImages {
 		fullWebImg = fullWebImg + "-prod"
 	}
-	return fmt.Sprintf("%s:%s", fullWebImg, resolveImageTag(versionconstants.WebTag, versionconstants.WebTagBranch))
+	return fmt.Sprintf("%s:%s", fullWebImg, WebImageTag())
 }
 
 // GetDBImage returns the correctly formatted db image:tag reference
@@ -78,7 +91,7 @@ func GetDBImage(dbType string, dbVersion string) string {
 	case nodeps.MariaDB:
 		fallthrough
 	default:
-		return fmt.Sprintf("%s-%s-%s:%s", imageRepo(versionconstants.DBImg), dbType, v, resolveImageTag(versionconstants.BaseDBTag, versionconstants.BaseDBTagBranch))
+		return fmt.Sprintf("%s-%s-%s:%s", imageRepo(versionconstants.DBImg), dbType, v, DBImageTag())
 	}
 }
 


### PR DESCRIPTION
## Short Summary (TL;DR)

A pinned `webimage`/`dbimage` built from the official release image is reported stale even when it's current, because the check compares its label against the raw content-hash `WebTag`/`BaseDBTag` constant instead of the resolved release tag those same constants otherwise resolve to.

## The Issue

The stale-pin warning added in #8682 (`imageVersionMismatch`) reads a pinned image's `com.ddev.image-tag` label and compares it to `versionconstants.WebTag`/`BaseDBTag` directly. Those are the raw content-hash autotag values (e.g. `27b956a558`), not what a released DDEV actually expects.

On a release build, `WebTagBranch`/`BaseDBTagBranch` is a `vX.Y.Z` tag, and the official image DDEV publishes for that release is labeled with that readable tag (`containers_shared.mk`: `DDEV_IMAGE_TAG` defaults to `VERSION`, e.g. `v1.25.4`) - not the hash. So on DDEV v1.25.4, a `dbimage` built `FROM ddev/ddev-dbserver-mysql-8.0:v1.25.4` (and therefore inheriting that image's `v1.25.4` label) is reported as:

```
dbimage: ghcr.io/example/database:mytag (non-default, built for DDEV images v1.25.4 but this DDEV expects 27b956a558)
```

...even though the pin is exactly current. This defeats the purpose of the warning for anyone who follows the documented pattern of building a derived image FROM DDEV's official one.

Found via a project pinning the official `ddev/ddev-dbserver-mysql-8.0:v1.25.4` as its `dbimage` base, immediately after v1.25.4's release.

## How This PR Solves The Issue

`docker.GetWebImage()`/`docker.GetDBImage()` already resolve the *default* image tag correctly via `docker.ResolveImageTag(tag, branch)`, which returns the branch when it's a release tag and the hash otherwise. `imageVersionMismatch`'s two call sites in `config_custom.go` now compute their `expectedTag` the same way, instead of passing the raw constant.

This mirrors #8787 (merged 2026-09-01), which fixed the equivalent `ddev version` display path (`TestCmdVersion`) to go through `docker.GetWebImage()`/`ResolveImageTag` rather than the raw `WebTag` constant - the stale-pin check was the one place this pattern was missed.

## Manual Testing Instructions

```bash
ddev config --db-image=ddev/ddev-dbserver-mysql-8.0:v1.25.4
ddev utility check-custom-config
# before: "built for DDEV images v1.25.4 but this DDEV expects <hash>"
# after: no staleness note, since v1.25.4 is what this DDEV expects
ddev config --db-image-default
```

## Automated Testing Overview

- `TestCheckCustomConfigDBImageReleaseTag` (new, `pkg/ddevapp/config_custom_test.go`): temporarily sets `BaseDBTag`/`BaseDBTagBranch` to simulate a release build, builds a local image labeled with the resolved release tag, and asserts `CheckCustomConfig` reports no staleness note. Runs in-process (not through the `ddev` binary as a subprocess) since it needs to observe the mutated `versionconstants` values.
- `TestUtilityCheckCustomConfigCmd/"dbimage built for a different DDEV version"` (existing) updated to compare against `docker.ResolveImageTag(...)` instead of the raw constant, so it stays correct if this ever runs against a release-tagged test binary; behavior is unchanged for the normal (branch-tagged) CI case.

## Release/Deployment Notes

None - this only removes a false positive from an existing check; the check still correctly flags an image genuinely built for a different DDEV image generation (covered by the existing test).
