### PR TITLE
fix(dbserver): prefer mariadb-backup over deprecated mariabackup name

### DIFF
--- a/cmd/ddev/cmd/snapshot.go
+++ b/cmd/ddev/cmd/snapshot.go
@@ -32,7 +32,7 @@ var DdevSnapshotCommand = &cobra.Command{
 	ValidArgsFunction: ddevapp.GetProjectNamesFunc("all", 0),
 	Use:               "snapshot [projectname projectname...]",
 	Short:             "Create a database snapshot for one or more projects.",
-	Long:              `Uses mariabackup or xtrabackup command to create a database snapshot in the .ddev/db_snapshots folder. These are compatible with server backups using the same tools and can be restored with "ddev snapshot restore".`,
+	Long:              `Uses mariadb-backup or xtrabackup command to create a database snapshot in the .ddev/db_snapshots folder. These are compatible with server backups using the same tools and can be restored with "ddev snapshot restore".`,
 	Example: `ddev snapshot
 ddev snapshot --name some_descriptive_name
 ddev snapshot --cleanup
@@ -218,6 +218,6 @@ func init() {
 	DdevSnapshotCommand.Flags().BoolVarP(&snapshotCleanup, "cleanup", "C", false, "Cleanup snapshots")
 	DdevSnapshotCommand.Flags().BoolVarP(&snapshotCleanupNoConfirm, "yes", "y", false, "Yes - skip confirmation prompt")
 	DdevSnapshotCommand.Flags().StringVarP(&snapshotName, "name", "n", "", "provide a name for the snapshot")
-	DdevSnapshotCommand.Flags().BoolVar(&snapshotUncompressed, "uncompressed", false, "Write the snapshot as an uncompressed mariabackup/xtrabackup stream instead of compressing it. This skips decompression on restore, but the file can be roughly as large as the database's datadir, many times bigger than a compressed snapshot. Not available for PostgreSQL projects.")
+	DdevSnapshotCommand.Flags().BoolVar(&snapshotUncompressed, "uncompressed", false, "Write the snapshot as an uncompressed mariadb-backup/xtrabackup stream instead of compressing it. This skips decompression on restore, but the file can be roughly as large as the database's datadir, many times bigger than a compressed snapshot. Not available for PostgreSQL projects.")
 	RootCmd.AddCommand(DdevSnapshotCommand)
 }

--- a/cmd/ddev/cmd/snapshot_restore.go
+++ b/cmd/ddev/cmd/snapshot_restore.go
@@ -12,7 +12,7 @@ import (
 var DdevSnapshotRestoreCommand = &cobra.Command{
 	Use:   "restore [snapshot_name|path]",
 	Short: "Restore a project's database to the provided snapshot version.",
-	Long: `Uses mariabackup or xtrabackup command to restore a project database to a particular snapshot, either by name from the .ddev/db_snapshots folder or by the path to a snapshot file elsewhere.
+	Long: `Uses mariadb-backup or xtrabackup command to restore a project database to a particular snapshot, either by name from the .ddev/db_snapshots folder or by the path to a snapshot file elsewhere.
 
 If the project is a git worktree, snapshots from the same project checked out in other worktrees of the same repository are also available, whether picked interactively, passed by name, or via --latest.`,
 	Example: `ddev snapshot restore d8git_20180717203845

--- a/containers/ddev-dbserver/Dockerfile
+++ b/containers/ddev-dbserver/Dockerfile
@@ -72,7 +72,7 @@ RUN <<EOF
     set -eu -o pipefail
     arch=$(dpkg --print-architecture)
     set -x;
-    if ( ! command -v xtrabackup && ! command -v mariabackup ); then
+    if ( ! command -v xtrabackup && ! command -v mariadb-backup && ! command -v mariabackup ); then
         curl -o /tmp/percona_release_latest.deb --fail -sSL ${PERCONA_SETUP_URL}
         apt-get install -y /tmp/percona_release_latest.deb
         rm /tmp/percona_release_latest.deb

--- a/containers/ddev-dbserver/files/create_base_db.sh
+++ b/containers/ddev-dbserver/files/create_base_db.sh
@@ -98,6 +98,10 @@ rm -rf ${OUTDIR}/*
 
 backuptool="mariabackup --defaults-file=/var/tmp/my.cnf"
 streamtool=xbstream
+# mariabackup was renamed mariadb-backup; older MariaDB (<10.4) only has the old name.
+if command -v mariadb-backup >/dev/null 2>&1; then
+  backuptool="mariadb-backup --defaults-file=/var/tmp/my.cnf"
+fi
 if command -v xtrabackup; then
   backuptool="xtrabackup --defaults-file=/var/tmp/my.cnf --datadir=${DATADIR:-/var/lib/mysql}";
   streamtool=xbstream

--- a/containers/ddev-dbserver/files/docker-entrypoint.sh
+++ b/containers/ddev-dbserver/files/docker-entrypoint.sh
@@ -26,6 +26,10 @@ chmod ugo+rwx /run/mysqld 2>/dev/null || true
 # of mariadb used xtrabackup
 export BACKUPTOOL=mariabackup
 export STREAMTOOL=mbstream
+# mariabackup was renamed mariadb-backup; older MariaDB (<10.4) only has the old name.
+if command -v mariadb-backup >/dev/null 2>&1 ; then
+  BACKUPTOOL="mariadb-backup"
+fi
 if command -v xtrabackup >/dev/null 2>&1 ; then
   BACKUPTOOL="xtrabackup"
   STREAMTOOL="xbstream"

--- a/containers/ddev-dbserver/files/healthcheck.sh
+++ b/containers/ddev-dbserver/files/healthcheck.sh
@@ -21,9 +21,9 @@ if [ -f /tmp/initializing ]; then
   exit 1
 fi
 
-# If mariabackup or xtrabackup is running (and not initializing)
-# It means snapshot restore is in progress
-if killall -0 mariabackup 2>/dev/null || killall -0 xtrabackup 2>/dev/null ; then
+# If mariadb-backup (or its old name mariabackup) or xtrabackup is running
+# (and not initializing), it means snapshot restore is in progress
+if killall -0 mariadb-backup 2>/dev/null || killall -0 mariabackup 2>/dev/null || killall -0 xtrabackup 2>/dev/null ; then
   printf "currently restoring snapshot"
   exit 2
 fi

--- a/docs/content/users/usage/commands.md
+++ b/docs/content/users/usage/commands.md
@@ -1424,7 +1424,7 @@ ddev share my-project
 
 Create a database snapshot for one or more projects.
 
-This uses `xtrabackup` or `mariabackup` to create a database snapshot in the `.ddev/db_snapshots` directory. These are compatible with server backups using the same tools and can be restored with the [`snapshot restore`](#snapshot-restore) command.
+This uses `xtrabackup` or `mariadb-backup` to create a database snapshot in the `.ddev/db_snapshots` directory. These are compatible with server backups using the same tools and can be restored with the [`snapshot restore`](#snapshot-restore) command.
 
 See [Snapshotting and Restoring a Database](../usage/cli.md#snapshotting-and-restoring-a-database) for more detail, or [Database Management](../usage/database-management.md) for more on working with databases in general.
 
@@ -1434,7 +1434,7 @@ Flags:
 * `--cleanup`, `-C`: Cleanup snapshots.
 * `--list`, `-l`: List snapshots.
 * `--name`, `-n`: Provide a name for the snapshot.
-* `--uncompressed`: Write the snapshot as an uncompressed mariabackup/xtrabackup stream instead of compressing it. This skips decompression on restore, but the file can be roughly as large as the database's datadir, many times bigger than a compressed snapshot. Not available for PostgreSQL projects. See [Snapshots](../usage/database-management.md#snapshots) for when this unusual trade-off makes sense.
+* `--uncompressed`: Write the snapshot as an uncompressed mariadb-backup/xtrabackup stream instead of compressing it. This skips decompression on restore, but the file can be roughly as large as the database's datadir, many times bigger than a compressed snapshot. Not available for PostgreSQL projects. See [Snapshots](../usage/database-management.md#snapshots) for when this unusual trade-off makes sense.
 * `--yes`, `-y`: Skip confirmation prompt.
 
 `ddev snapshot --list` also shows each snapshot's compression: `zstd`, `gzip`, or `none` for an uncompressed snapshot. If the project is a Git worktree and a sibling worktree of the same project has snapshots of its own, those are listed too, with a `Worktree` column naming which one each came from.

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -3324,7 +3324,8 @@ func getBackupCommand(app *DdevApp, targetFile string, uncompressed bool) string
 		redirect = fmt.Sprintf(`> "%s"`, targetFile)
 	}
 
-	c := fmt.Sprintf(`mariabackup --backup --stream=mbstream --user=root --password=root --socket=/var/tmp/mysql.sock 2>/tmp/snapshot_%[1]s.log %[2]s`, path.Base(targetFile), redirect)
+	// mariabackup was renamed mariadb-backup; older MariaDB (<10.4) only has the old name.
+	c := fmt.Sprintf(`$(command -v mariadb-backup || echo mariabackup) --backup --stream=mbstream --user=root --password=root --socket=/var/tmp/mysql.sock 2>/tmp/snapshot_%[1]s.log %[2]s`, path.Base(targetFile), redirect)
 
 	switch {
 	// Old MariaDB versions don't have mariabackup, use xtrabackup for them as well as MySQL

--- a/pkg/versionconstants/versionconstants.go
+++ b/pkg/versionconstants/versionconstants.go
@@ -58,10 +58,10 @@ var WebTagBranch = "v1.25.4"
 var DBImg = "ddev/ddev-dbserver"
 
 // BaseDBTag is the main tag, DBTag is constructed from it
-var BaseDBTag = "27b956a558" // 20260831_v1.25.4-27b956a558
+var BaseDBTag = "491fa83f61" // 20260904_maria-backup-491fa83f61
 
 // BaseDBTagBranch is the branch BaseDBTag's content was built from.
-var BaseDBTagBranch = "v1.25.4"
+var BaseDBTagBranch = "20260904_maria-backup"
 
 // TraefikRouterImage is image for router
 var TraefikRouterImage = "ddev/ddev-traefik-router"


### PR DESCRIPTION
## Short Summary (TL;DR)

MariaDB renamed the `mariabackup` binary to `mariadb-backup`, keeping the old name only as a compatibility symlink that's being phased out, so this switches DDEV's snapshot/restore path to prefer the new name while still falling back to the old one on MariaDB versions that predate the rename.

## The Issue

No linked issue - found while investigating MariaDB deprecation warnings.

MariaDB's own docs state plainly that `mariadb-backup` "was previously called mariabackup." This is part of a broader, deliberate MariaDB project to rename `mysql*`-prefixed executables to `mariadb*`-prefixed ones ([MDEV-17591](https://jira.mariadb.org/browse/MDEV-17591), fixed in 10.4.6, added `mariadb-*` names as aliases; [MDEV-21303](https://jira.mariadb.org/browse/MDEV-21303), fixed in 10.5.2, flipped it so the `mariadb-*` name is the real binary and the old name becomes the symlink). Old names keep working via that symlink rather than being deleted outright, but the analogous `mysql`/`mysqldump` old names already print a runtime deprecation warning on invocation ("Deprecated program name. It will be removed in a future release"), and DDEV's own `mariadb-compat-install.sh` comment references that exact warning. `mariabackup` isn't documented as printing that warning yet, but it's the same rename pattern, and DDEV hardcoded the old name everywhere it invokes the backup tool.

I confirmed empirically (running each supported MariaDB version's Docker image) that `mariadb-backup` exists starting at MariaDB 10.4, but MariaDB 10.1-10.3 (which DDEV still supports) only ship `mariabackup` - so this can't be a hard cutover to the new name.

I also checked whether other `mysql*`→`mariadb-*` renames (`mysqldump`→`mariadb-dump`, `mysqladmin`→`mariadb-admin`, `mysql_upgrade`→`mariadb-upgrade`, etc.) needed the same fix. They don't: `containers/ddev-dbserver/files/mariadb-compat-install.sh` and its webserver-container counterpart already generate `#ddev-generated` wrapper scripts for every one of those names on MariaDB 11.x+ (where the base image no longer installs the `mysql*` names natively), and those wrappers run before anything else in the image invokes them. `mariabackup` was the one gap, because it was never `mysql*`-prefixed, so that existing wrapper mechanism didn't cover it.

## How This PR Solves The Issue

Everywhere DDEV invokes the backup tool now checks for `mariadb-backup` first and falls back to `mariabackup` if it's not present:

- `pkg/ddevapp/ddevapp.go`: the in-container snapshot command uses `$(command -v mariadb-backup || echo mariabackup)`.
- `containers/ddev-dbserver/files/docker-entrypoint.sh`: `BACKUPTOOL` selection (used for snapshot restore's prepare/copy-back steps) prefers `mariadb-backup`.
- `containers/ddev-dbserver/files/create_base_db.sh`: the base-db-seed build step uses the same preference.
- `containers/ddev-dbserver/files/healthcheck.sh`: the "restore in progress" process check (`killall -0`) checks both names.
- `containers/ddev-dbserver/Dockerfile`: the check that decides whether to install Percona's `xtrabackup` also checks for `mariadb-backup`, so it doesn't wastefully install `xtrabackup` on a MariaDB image that already has `mariadb-backup` but happens to be checked before `mariabackup` exists.

CLI help text (`ddev snapshot`, `ddev snapshot restore`, the `--uncompressed` flag) and `docs/content/users/usage/commands.md` were updated to say `mariadb-backup` instead of `mariabackup`. The `ddev-dbserver` image was rebuilt and `pkg/versionconstants/versionconstants.go`'s `BaseDBTag` updated accordingly, since the image's own files changed.

## Manual Testing Instructions

1. `ddev config --project-type=php` and `ddev start` in a test project (defaults to MariaDB 11.8).
2. `ddev snapshot`, then check `ddev exec -s db 'cat /tmp/snapshot_*.log'` - the log's first lines should say `/usr/bin/mariadb-backup based on MariaDB server ...`, not `mariabackup`.
3. `ddev snapshot restore --latest` should complete successfully (exercises the `BACKUPTOOL`/prepare/copy-back path in `docker-entrypoint.sh`).
4. Repeat against an older MariaDB version, e.g. `ddev config --database=mariadb:10.3`, to confirm it falls back to `mariabackup` and still works.

I ran steps 1-3 locally against the rebuilt image; both the snapshot and restore completed successfully with `mariadb-backup` in use.

## Automated Testing Overview

No new automated tests were added. The existing `pkg/ddevapp/snapshot_test.go` integration tests exercise `ddev snapshot`/`ddev snapshot restore` end-to-end and will implicitly cover the new binary-detection logic since they run against real MariaDB containers; none of them assert on the literal backup-tool command string, so they weren't affected by the rename itself.

## Release/Deployment Notes

No user-facing behavior change other than avoiding a deprecated binary name; snapshot/restore output and file formats are unchanged. Requires the rebuilt `ddev-dbserver` image (tag bump in this PR) to take effect.
