### PR TITLE
feat: forward TERM_PROGRAM and other terminal variables to ddev ssh/exec, fixes #8808

### DIFF
--- a/cmd/ddev/cmd/ssh_test.go
+++ b/cmd/ddev/cmd/ssh_test.go
@@ -71,23 +71,25 @@ func TestCmdSSH(t *testing.T) {
 
 	t.Setenv("TERM", "xterm-256color")
 	t.Setenv("COLORTERM", "truecolor")
+	t.Setenv("TERM_PROGRAM", "ghostty")
 
 	// Here the output is captured, so there is no terminal and nothing to
 	// forward. The container has to keep the TERM of its image.
-	out, err = exec.RunHostCommand(b, "-c", fmt.Sprintf("echo 'echo MARK TERM=$TERM COLORTERM=$COLORTERM' | %s ssh", DdevBin))
+	out, err = exec.RunHostCommand(b, "-c", fmt.Sprintf("echo 'echo MARK TERM=$TERM COLORTERM=$COLORTERM TERM_PROGRAM=$TERM_PROGRAM' | %s ssh", DdevBin))
 	require.NoError(t, err)
 	require.NotContains(t, out, "TERM=xterm-256color", "without a terminal ddev ssh should not forward TERM, got '%s'", out)
 	require.NotContains(t, out, "COLORTERM=truecolor", "without a terminal ddev ssh should not forward COLORTERM, got '%s'", out)
+	require.NotContains(t, out, "TERM_PROGRAM=ghostty", "without a terminal ddev ssh should not forward TERM_PROGRAM, got '%s'", out)
 
 	// On a terminal the shell in the container has to see the terminal of the
 	// host, otherwise it keeps the TERM of the image and shows only 16 colors.
 	if nodeps.IsWindows() {
 		t.Skip("skipping the terminal part of this test on Windows, it has no script(1)")
 	}
-	shellInput := `printf 'echo MARK TERM=$TERM COLORTERM=$COLORTERM\nexit\n'`
+	shellInput := `printf 'echo MARK TERM=$TERM COLORTERM=$COLORTERM TERM_PROGRAM=$TERM_PROGRAM\nexit\n'`
 	out, err = exec.RunHostCommand(b, "-c", fmt.Sprintf("%s | %s", shellInput, ptyCommand(DdevBin+" ssh")))
 	require.NoError(t, err)
-	require.Contains(t, out, "MARK TERM=xterm-256color COLORTERM=truecolor", "on a terminal ddev ssh should forward TERM and COLORTERM, got '%s'", out)
+	require.Contains(t, out, "MARK TERM=xterm-256color COLORTERM=truecolor TERM_PROGRAM=ghostty", "on a terminal ddev ssh should forward TERM, COLORTERM and TERM_PROGRAM, got '%s'", out)
 }
 
 // ptyCommand wraps a command so that script(1) runs it on a terminal. The

--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -2643,8 +2643,9 @@ func (app *DdevApp) Exec(opts *ExecOpts) (string, string, error) {
 	tty := opts.Tty && isatty.IsTerminal(os.Stdin.Fd()) && stdoutIsTerminal
 
 	// A session with a TTY gets the terminal of the host, so programs in the
-	// container know how many colors they can use. Without a TTY there is no
-	// terminal to describe, and programs write plain text anyway.
+	// container know how many colors they can use and whether it renders
+	// hyperlinks. Without a TTY there is no terminal to describe, and programs
+	// write plain text anyway.
 	execEnv := opts.Env
 	if tty {
 		execEnv = util.TerminalExecEnv(opts.Env)

--- a/pkg/util/terminal.go
+++ b/pkg/util/terminal.go
@@ -19,6 +19,12 @@ var ContainerTerminfoEntries = []string{
 	"xterm-r5", "xterm-r6", "xterm-vt220", "xterm-xfree86",
 }
 
+// TerminalEnvVars are the variables besides TERM that TerminalExecEnv forwards
+// from the host. Terminals set them to say which program they are, and
+// libraries like supports-hyperlinks read them to decide whether to emit OSC 8
+// hyperlinks, as output.HasTermHyperlinks does for DDEV itself.
+var TerminalEnvVars = []string{"COLORTERM", "TERM_PROGRAM", "TERM_PROGRAM_VERSION", "VTE_VERSION", "WT_SESSION", "KONSOLE_VERSION"}
+
 // TerminalExecEnv adds the terminal environment variables of the host to
 // existingEnv, for an interactive container session. Variables already in
 // existingEnv win. A TERM the container has no terminfo entry for is replaced,
@@ -32,8 +38,10 @@ func TerminalExecEnv(existingEnv []string) []string {
 		hostTerm = "xterm-256color"
 	}
 	execEnv := []string{"TERM=" + hostTerm}
-	if hostColorterm := os.Getenv("COLORTERM"); hostColorterm != "" {
-		execEnv = append(execEnv, "COLORTERM="+hostColorterm)
+	for _, varName := range TerminalEnvVars {
+		if value := os.Getenv(varName); value != "" {
+			execEnv = append(execEnv, varName+"="+value)
+		}
 	}
 	// existingEnv comes last, so that EnvToUniqueEnv keeps it over the host.
 	execEnv = append(execEnv, existingEnv...)

--- a/pkg/util/terminal.go
+++ b/pkg/util/terminal.go
@@ -23,7 +23,17 @@ var ContainerTerminfoEntries = []string{
 // from the host. Terminals set them to say which program they are, and
 // libraries like supports-hyperlinks read them to decide whether to emit OSC 8
 // hyperlinks, as output.HasTermHyperlinks does for DDEV itself.
-var TerminalEnvVars = []string{"COLORTERM", "TERM_PROGRAM", "TERM_PROGRAM_VERSION", "VTE_VERSION", "WT_SESSION", "KONSOLE_VERSION"}
+// See https://github.com/chalk/supports-hyperlinks/blob/main/index.js
+var TerminalEnvVars = []string{
+	"CI",
+	"COLORTERM",
+	"FORCE_HYPERLINK",
+	"KONSOLE_VERSION",
+	"TERM_PROGRAM",
+	"TERM_PROGRAM_VERSION",
+	"VTE_VERSION",
+	"WT_SESSION",
+}
 
 // TerminalExecEnv adds the terminal environment variables of the host to
 // existingEnv, for an interactive container session. Variables already in

--- a/pkg/util/terminal_test.go
+++ b/pkg/util/terminal_test.go
@@ -9,37 +9,45 @@ import (
 
 // TestTerminalExecEnv tests that a TERM the container can resolve is forwarded
 // unchanged, that one it cannot is replaced, that an unset TERM leaves the
-// container with its own default, and that the env of the caller wins.
+// container with its own default, that the variables a terminal identifies
+// itself with come along, and that the env of the caller wins.
 func TestTerminalExecEnv(t *testing.T) {
 	testCases := []struct {
-		hostTerm      string
-		hostColorterm string
-		existingEnv   []string
-		expected      []string
+		hostTerm        string
+		hostColorterm   string
+		hostTermProgram string
+		existingEnv     []string
+		expected        []string
 	}{
-		{"xterm-256color", "", nil, []string{"TERM=xterm-256color"}},
-		{"xterm-256color", "truecolor", nil, []string{"TERM=xterm-256color", "COLORTERM=truecolor"}},
-		{"screen", "", nil, []string{"TERM=screen"}},
-		{"xterm-kitty", "", nil, []string{"TERM=xterm-256color"}},
-		{"alacritty", "", nil, []string{"TERM=xterm-256color"}},
-		{"wezterm", "", nil, []string{"TERM=xterm-256color"}},
+		{"xterm-256color", "", "", nil, []string{"TERM=xterm-256color"}},
+		{"xterm-256color", "truecolor", "", nil, []string{"TERM=xterm-256color", "COLORTERM=truecolor"}},
+		{"xterm-256color", "truecolor", "ghostty", nil, []string{"TERM=xterm-256color", "COLORTERM=truecolor", "TERM_PROGRAM=ghostty"}},
+		{"screen", "", "", nil, []string{"TERM=screen"}},
+		{"xterm-kitty", "", "", nil, []string{"TERM=xterm-256color"}},
+		{"alacritty", "", "", nil, []string{"TERM=xterm-256color"}},
+		{"wezterm", "", "", nil, []string{"TERM=xterm-256color"}},
 		// tmux is in the database but tmux-direct is not, so a prefix match
 		// would be wrong here.
-		{"tmux-direct", "", nil, []string{"TERM=xterm-256color"}},
-		{"xterm-ghostty", "truecolor", nil, []string{"TERM=xterm-256color", "COLORTERM=truecolor"}},
+		{"tmux-direct", "", "", nil, []string{"TERM=xterm-256color"}},
+		{"xterm-ghostty", "truecolor", "ghostty", nil, []string{"TERM=xterm-256color", "COLORTERM=truecolor", "TERM_PROGRAM=ghostty"}},
 		// Without a TERM on the host there is nothing to forward.
-		{"", "truecolor", nil, nil},
-		{"", "truecolor", []string{"XDEBUG_MODE=off"}, []string{"XDEBUG_MODE=off"}},
+		{"", "truecolor", "ghostty", nil, nil},
+		{"", "truecolor", "", []string{"XDEBUG_MODE=off"}, []string{"XDEBUG_MODE=off"}},
 		// The env of the caller survives the merge, as ddev composer relies on
 		// for XDEBUG_MODE, and wins over the host.
-		{"xterm-256color", "truecolor", []string{"XDEBUG_MODE=off"}, []string{"TERM=xterm-256color", "COLORTERM=truecolor", "XDEBUG_MODE=off"}},
-		{"xterm-256color", "truecolor", []string{"TERM=vt100"}, []string{"TERM=vt100", "COLORTERM=truecolor"}},
-		{"xterm-256color", "truecolor", []string{"COLORTERM="}, []string{"TERM=xterm-256color", "COLORTERM="}},
+		{"xterm-256color", "truecolor", "", []string{"XDEBUG_MODE=off"}, []string{"TERM=xterm-256color", "COLORTERM=truecolor", "XDEBUG_MODE=off"}},
+		{"xterm-256color", "truecolor", "", []string{"TERM=vt100"}, []string{"TERM=vt100", "COLORTERM=truecolor"}},
+		{"xterm-256color", "truecolor", "", []string{"COLORTERM="}, []string{"TERM=xterm-256color", "COLORTERM="}},
 	}
 
+	// The terminal running the tests must not leak into the cases.
+	for _, varName := range util.TerminalEnvVars {
+		t.Setenv(varName, "")
+	}
 	for _, tc := range testCases {
 		t.Setenv("TERM", tc.hostTerm)
 		t.Setenv("COLORTERM", tc.hostColorterm)
+		t.Setenv("TERM_PROGRAM", tc.hostTermProgram)
 		// EnvToUniqueEnv does not keep the order, so compare the elements.
 		require.ElementsMatch(t, tc.expected, util.TerminalExecEnv(tc.existingEnv), "hostTerm=%s existingEnv=%v", tc.hostTerm, tc.existingEnv)
 	}


### PR DESCRIPTION
## Short Summary (TL;DR)

Interactive `ddev ssh` and `ddev exec` sessions now pass `TERM_PROGRAM` and the other variables that identify the host terminal to the container, so tools in the container print clickable OSC 8 links like they do on the host.

## The Issue

- Fixes #8808

Since #8669 a session gets `TERM` and `COLORTERM` of the host, but nothing else about the terminal. Libraries like `supports-hyperlinks` look at `TERM_PROGRAM`, `VTE_VERSION`, `WT_SESSION` or `KONSOLE_VERSION` before they print OSC 8 links, and none of them is set in the container. So the same tool prints clickable links on the host and plain text under `ddev exec`, although the escape sequences pass through unchanged.

## How This PR Solves The Issue

`util.TerminalExecEnv()` forwards a list of terminal variables instead of only `COLORTERM`: `COLORTERM`, `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `VTE_VERSION`, `WT_SESSION` and `KONSOLE_VERSION`. This is the same set `output.HasTermHyperlinks()` reads for the output of DDEV itself. As before, only variables set on the host are forwarded, only with a TTY, and the env of the caller wins.

## Manual Testing Instructions

In a terminal that shows OSC 8 links (Ghostty, iTerm2, WezTerm, VS Code, Windows Terminal), in a project with `supports-hyperlinks` in `node_modules` (stylelint depends on it, for example):

```
ddev ssh
echo $TERM_PROGRAM
node -e 'console.log(require("supports-hyperlinks").stdout)'
```

This prints the name of the host terminal and `true` (before: an empty line and `false`). `ddev exec env > file` still has no terminal variables.

## Automated Testing Overview

- `TestTerminalExecEnv` gets a `TERM_PROGRAM` column: forwarded with a `TERM`, dropped without one. All terminal variables are cleared first, so the terminal that runs the tests does not leak in.
- `TestCmdSSH` checks `TERM_PROGRAM` next to `TERM` and `COLORTERM`, without a terminal and on a PTY.

## Release/Deployment Notes

Interactive sessions now also see `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `VTE_VERSION`, `WT_SESSION` and `KONSOLE_VERSION` of the host. Tools in the container that read them behave like on the host. Nothing changes for piped or captured output.
