### PR TITLE
docs(quickstart): fix Maho redirect, take install URLs from `ddev exec`

### DIFF
--- a/docs/content/users/quickstart.md
+++ b/docs/content/users/quickstart.md
@@ -1877,8 +1877,8 @@ DDEV automatically creates `app/etc/local.xml` with the database connection deta
       --license_agreement_accepted yes \
       --locale en_US --timezone UTC --default_currency USD \
       --db_host db --db_name db --db_user db --db_pass db \
-      --url "https://my-maho-site.ddev.site/" \
-      --use_secure 1 --secure_base_url "https://my-maho-site.ddev.site/" --use_secure_admin 1 \
+      --url "$(ddev exec echo '$DDEV_PRIMARY_URL')" \
+      --use_secure 1 --secure_base_url "$(ddev exec echo '$DDEV_PRIMARY_URL')" --use_secure_admin 1 \
       --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
       --admin_username admin --admin_password veryl0ngpassw0rd \
       --sample_data 1
@@ -1911,8 +1911,8 @@ DDEV automatically creates `app/etc/local.xml` with the database connection deta
           --license_agreement_accepted yes \
           --locale en_US --timezone UTC --default_currency USD \
           --db_host db --db_name db --db_user db --db_pass db \
-          --url "https://my-maho-site.ddev.site/" \
-          --use_secure 1 --secure_base_url "https://my-maho-site.ddev.site/" --use_secure_admin 1 \
+          --url "$(ddev exec echo '$DDEV_PRIMARY_URL')" \
+          --use_secure 1 --secure_base_url "$(ddev exec echo '$DDEV_PRIMARY_URL')" --use_secure_admin 1 \
           --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
           --admin_username admin --admin_password veryl0ngpassw0rd \
           --sample_data 1
@@ -1955,8 +1955,8 @@ DDEV automatically creates `app/etc/local.xml` with the database connection deta
       --license_agreement_accepted yes \
       --locale en_US --timezone UTC --default_currency USD \
       --db_host db --db_name db --db_user db --db_pass db \
-      --url "https://maho.ddev.site/" \
-      --use_secure 1 --secure_base_url "https://maho.ddev.site/" --use_secure_admin 1 \
+      --url "$(ddev exec echo '$DDEV_PRIMARY_URL')" \
+      --use_secure 1 --secure_base_url "$(ddev exec echo '$DDEV_PRIMARY_URL')" --use_secure_admin 1 \
       --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
       --admin_username admin --admin_password veryl0ngpassw0rd \
       --sample_data 1
@@ -1990,8 +1990,8 @@ DDEV automatically creates `app/etc/local.xml` with the database connection deta
           --license_agreement_accepted yes \
           --locale en_US --timezone UTC --default_currency USD \
           --db_host db --db_name db --db_user db --db_pass db \
-          --url "https://maho.ddev.site/" \
-          --use_secure 1 --secure_base_url "https://maho.ddev.site/" --use_secure_admin 1 \
+          --url "$(ddev exec echo '$DDEV_PRIMARY_URL')" \
+          --use_secure 1 --secure_base_url "$(ddev exec echo '$DDEV_PRIMARY_URL')" --use_secure_admin 1 \
           --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
           --admin_username admin --admin_password veryl0ngpassw0rd \
           --sample_data 1
@@ -3437,8 +3437,7 @@ There are several easy ways to use DDEV with WordPress:
     # You can launch in browser to finish installation:
     # ddev launch
     # OR use the following installation command
-    # (we need to use single quotes to get the primary site URL from `.ddev/config.yaml` as variable)
-    ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+    ddev wp core install --url="$(ddev exec echo '$DDEV_PRIMARY_URL')" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
     ```
 
     Launch WordPress admin dashboard:
@@ -3458,7 +3457,7 @@ There are several easy ways to use DDEV with WordPress:
         ddev config --project-type=wordpress
         ddev start -y
         ddev wp core download
-        ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+        ddev wp core install --url="$(ddev exec echo '$DDEV_PRIMARY_URL')" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
         ddev launch wp-admin/
         EOF
         chmod +x setup-wordpress.sh
@@ -3481,7 +3480,7 @@ There are several easy ways to use DDEV with WordPress:
     You can then run:
 
     ```bash
-    ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My Bedrock Site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+    ddev wp core install --url="$(ddev exec echo '$DDEV_PRIMARY_URL')" --title='My Bedrock Site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
     ddev launch /wp/wp-admin/
     ```
 
@@ -3498,7 +3497,7 @@ There are several easy ways to use DDEV with WordPress:
         ddev config --project-type=wp-bedrock
         ddev start -y
         ddev composer create-project roots/bedrock
-        ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My Bedrock Site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+        ddev wp core install --url="$(ddev exec echo '$DDEV_PRIMARY_URL')" --title='My Bedrock Site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
         ddev launch /wp/wp-admin/
         EOF
         chmod +x setup-wp-bedrock.sh
@@ -3515,7 +3514,7 @@ There are several easy ways to use DDEV with WordPress:
     cd my-wp-git-site
     ddev config --project-type=wordpress
     ddev start
-    ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+    ddev wp core install --url="$(ddev exec echo '$DDEV_PRIMARY_URL')" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
     ddev launch wp-admin/
     ```
 

--- a/docs/tests/maho.bats
+++ b/docs/tests/maho.bats
@@ -34,8 +34,8 @@ teardown() {
     --license_agreement_accepted yes \
     --locale en_US --timezone UTC --default_currency USD \
     --db_host db --db_name db --db_user db --db_pass db \
-    --url "${PRIMARY_URL}/" \
-    --use_secure 1 --secure_base_url "${PRIMARY_URL}/" --use_secure_admin 1 \
+    --url "$(ddev exec echo '$DDEV_PRIMARY_URL')" \
+    --use_secure 1 --secure_base_url "$(ddev exec echo '$DDEV_PRIMARY_URL')" --use_secure_admin 1 \
     --admin_firstname Store --admin_lastname Admin --admin_email admin@example.com \
     --admin_username admin --admin_password veryl0ngpassw0rd \
     --sample_data 1
@@ -53,7 +53,7 @@ teardown() {
   assert_success
 
   # validate running project
-  run curl -sfIv ${PRIMARY_URL}
+  run curl -sfILv ${PRIMARY_URL}
   assert_output --partial "server: nginx"
   assert_output --partial "HTTP/2 200"
   assert_success

--- a/docs/tests/wordpress.bats
+++ b/docs/tests/wordpress.bats
@@ -28,7 +28,7 @@ teardown() {
   run ddev wp core download
   assert_success
 
-  run ddev wp core install --url="${PRIMARY_URL}" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url="$(ddev exec echo '$DDEV_PRIMARY_URL')" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
 
   DDEV_DEBUG=true run ddev launch
@@ -69,7 +69,7 @@ teardown() {
   run ddev wp core download
   assert_success
 
-  run ddev wp core install --url="${PRIMARY_URL}" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url="$(ddev exec echo '$DDEV_PRIMARY_URL')" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
 
   run ddev wp config get WP_SITEURL
@@ -121,7 +121,7 @@ teardown() {
 
   run ddev wp core download
   assert_success
-  run ddev wp core install --url="${PRIMARY_URL}" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url="$(ddev exec echo '$DDEV_PRIMARY_URL')" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
 
   run bash -c "
@@ -178,7 +178,7 @@ teardown() {
 
   _extra_info
 
-  run ddev wp core install --url="${PRIMARY_URL}" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
+  run ddev wp core install --url="$(ddev exec echo '$DDEV_PRIMARY_URL')" --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
   assert_success
 
   DDEV_DEBUG=true run ddev launch


### PR DESCRIPTION
## Short Summary (TL;DR)

The Maho test fails because the storefront now redirects. Separately, the quickstarts cannot pass `$DDEV_PRIMARY_URL` to `ddev maho` or `ddev wp`, so the install lines read the URL through `ddev exec` instead of hardcoding a project name.

## The Issue

`ddev maho` and `ddev wp` are marked `ExecRaw: true`, so DDEV hands your arguments to the container exactly as typed, with no shell to expand anything. `$DDEV_PRIMARY_URL` arrives as text. `ddev exec` runs a shell by default, which is why the CiviCRM and Moodle quickstarts can use the variable.

The WordPress quickstart already passed `--url='$DDEV_PRIMARY_URL'`, with a comment claiming the single quotes read the URL from `.ddev/config.yaml`. They do not. It looks harmless because WordPress ignores that flag and uses the `WP_SITEURL` from `wp-config-ddev.php`, but in the "Git Clone" case you own `wp-config.php`, so that constant is never defined and the text is stored as your site address. The login page then points at a host that does not exist.

Maho's failure is unrelated: upstream sample data gained French, German and Italian store views on 2026-09-07, which turns on store codes in URLs, so `/` redirects to `/default/` and `curl -sfIv` sees a 302.

https://github.com/ddev/ddev/actions/runs/34275526780/job/102227475609

```
not ok 28 Maho Composer quickstart with ddev version 083ab6805
...
# -- output does not contain substring --
# substring (1 lines):
#   HTTP/2 200
# output (70 lines):
...
#   HTTP/2 302 
#   cache-control: no-cache, private
#   content-type: text/html; charset=UTF-8
#   date: Tue, 08 Sep 2026 20:57:54 GMT
#   location: https://my-maho-site.ddev.site/default/
#   server: nginx
```

## How This PR Solves The Issue

- `curl -L` in the Maho test follows the redirect to the 200 that `/default/` returns.
- Install commands take the URL from `$(ddev exec echo '$DDEV_PRIMARY_URL')`, which your own shell resolves before DDEV sees it, so `ExecRaw` stops mattering. Every quickstart starts the project first, so the value is there to read.
- `$DDEV_PRIMARY_URL` rather than `$DDEV_PRIMARY_URL_WITHOUT_PORT`, because a base URL has to carry the port, which matters under settings like `router_https_port: 8443`.
- The trailing slash is gone from the Maho lines, since its installer appends one.
- Both bats tests now run the documented command, while their assertions still use `${PRIMARY_URL}` from `ddev describe -j`.

## Manual Testing Instructions

```bash
bats docs/tests/maho.bats
# ok 1 Maho Composer quickstart with ddev version v1.25.4

bats docs/tests/wordpress.bats
```

To see what the old WordPress line did, set up a throwaway project:

```bash
mkdir -p ~/tmp/wp-usermanaged && cd ~/tmp/wp-usermanaged
ddev config --project-type=wordpress --docroot=.
ddev start -y
ddev wp core download
```

Delete the `WP_HOME` and `WP_SITEURL` definitions from `wp-config-ddev.php`, which stands in for owning `wp-config.php` yourself, then install the old way:

```bash
ddev wp core install --url='$DDEV_PRIMARY_URL' --title='URL test' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
# Success: WordPress installed successfully.

ddev mysql -N -e "select option_name, option_value from wp_options where option_name in ('siteurl','home');"
# home     http://$DDEV_PRIMARY_URL
# siteurl  http://$DDEV_PRIMARY_URL

curl -sI https://wp-usermanaged.ddev.site/wp-admin/ | grep -i '^location'
# location: https://DDEV_PRIMARY_URL/wp-login.php?redirect_to=...
# No such host, so you cannot log in. The front page still answers 200.
```

Install again the documented way:

```bash
ddev wp db reset --yes
ddev wp core install --url="$(ddev exec echo '$DDEV_PRIMARY_URL')" --title='URL test' --admin_user=admin --admin_password=admin --admin_email=admin@example.com

ddev mysql -N -e "select option_name, option_value from wp_options where option_name in ('siteurl','home');"
# home     https://wp-usermanaged.ddev.site
# siteurl  https://wp-usermanaged.ddev.site

curl -sI https://wp-usermanaged.ddev.site/wp-admin/ | grep -i '^location'
# location: https://wp-usermanaged.ddev.site/wp-login.php?redirect_to=...
```

Clean up with `ddev delete -Oy wp-usermanaged && rm -rf ~/tmp/wp-usermanaged`.

🤖 Developed with assistance from [Claude Code](https://claude.ai/code)