### PR TITLE
ci(github): remove setup-homebrew pin (#8815) [skip ci]

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@2026.08.03.2
+        uses: Homebrew/actions/setup-homebrew@main
         with:
           brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@2026.08.03.2
+        uses: Homebrew/actions/setup-homebrew@main
         with:
           brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/perf-start-time.yml
+++ b/.github/workflows/perf-start-time.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@2026.08.03.2
+        uses: Homebrew/actions/setup-homebrew@main
         with:
           brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@2026.08.03.2
+        uses: Homebrew/actions/setup-homebrew@main
         with:
           brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -193,7 +193,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@2026.08.03.2
+        uses: Homebrew/actions/setup-homebrew@main
         with:
           brew-gh-api-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!-- 
  PR titles have very precise rules, please read 
  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines

  If this is a nontrivial contribution, please create an issue for discussion first, or discuss it first in Discord, https://ddev.com/s/discord. This will save you time and help direct the feature.

  DDEV is community-funded — if you or your team rely on DDEV, see https://ddev.com/sponsor.
-->

## Short Summary (TL;DR)

Homebrew has sorted everything out, we don't need the `@2026.08.03.2` pin.

## The Issue

- #8667

## How This PR Solves The Issue

Replaces the pin from #8667 with `@main`.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
