### PR TITLE
ci: fix release workflow broken by windows signing change #8769

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -126,6 +126,11 @@ jobs:
     env:
       DDEV_WINDOWS_SIGN: ${{ vars.DDEV_WINDOWS_SIGN }}
     steps:
+      # This runner is self-hosted and persistent, so incoming/ and bin/ can
+      # hold leftovers from a previous run; clear them before downloading.
+      - name: Clear stale workspace
+        run: rm -rf incoming bin
+
       - uses: actions/download-artifact@v8
         with:
           pattern: build-windows_*
@@ -235,6 +240,11 @@ jobs:
     env:
       DDEV_WINDOWS_SIGN: ${{ vars.DDEV_WINDOWS_SIGN }}
     steps:
+      # This runner is self-hosted and persistent, so bin/ can hold
+      # leftovers from a previous run; clear it before downloading.
+      - name: Clear stale workspace
+        run: rm -rf bin
+
       - uses: actions/download-artifact@v8
         with:
           name: unsigned-installers

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /.cache
 /.ddev
 /artifacts
+/incoming
 *.DS_Store
 nbproject/
 .idea


### PR DESCRIPTION
## Short Summary (TL;DR)

Fixes the release workflow broken by #8769: goreleaser saw a dirty git state because of an untracked `incoming/` directory, and the self-hosted Windows signer failed with `mv: Directory not empty` because it never clears state left over from a previous run.

## The Issue

- Fixes https://github.com/ddev-test/ddev/actions/runs/34644721933/job/103418918068 and https://github.com/ddev-test/ddev/actions/runs/34648784083/job/103426487096

#8769 switched the build/sign/artifacts jobs from `actions/cache` to `actions/upload-artifact`/`download-artifact`, staging downloads into `incoming/` inside the checkout. That directory was never gitignored, so goreleaser's dirty-git check failed on `?? incoming/` right before release. Separately, the `sign-windows-binaries` and `sign-windows-installers` jobs run on a persistent self-hosted runner with no checkout step to reset the workspace, so `incoming/` and `bin/` from a prior run were still present on the next run, turning `mv incoming/build-windows_amd64 bin/windows_amd64` into a move-into an already-existing directory.

## How This PR Solves The Issue

- Added `/incoming` to `.gitignore`.
- Added a `Clear stale workspace` step (`rm -rf incoming bin` / `rm -rf bin`) at the start of both self-hosted signing jobs.

## Manual Testing Instructions

Run a test release against a fork (as in the linked failing runs) and confirm the `artifacts` job's goreleaser step no longer reports a dirty git state, and that `sign-windows-binaries`/`sign-windows-installers` succeed on a second consecutive run against the same self-hosted runner (to exercise the leftover-state case).

## Automated Testing Overview

None; this only affects the release workflow, which isn't covered by the Go test suite.

## Release/Deployment Notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
