### PR TITLE
fix: build profile-gated custom service images during start/restart, fixes #8817

### DIFF
--- a/pkg/ddevapp/ddevapp.go
+++ b/pkg/ddevapp/ddevapp.go
@@ -1462,6 +1462,7 @@ func (app *DdevApp) composeBuild(args ...string) (string, error) {
 
 	project, err := dockerutil.LoadComposeProject([]string{app.DockerComposeFullRenderedYAMLPath()}, api.ProjectLoadOptions{
 		ProjectName: app.GetComposeProjectName(),
+		Profiles:    []string{`*`},
 	})
 	if err != nil {
 		return "", fmt.Errorf("docker-compose build failed: %v", err)
@@ -2262,7 +2263,7 @@ func (app *DdevApp) StartOptionalProfiles(profiles []string) error {
 	}
 	err = upSvc.Up(upCtx, upProject, api.UpOptions{
 		Create: api.CreateOptions{
-			Build:         &api.BuildOptions{Progress: progress},
+			Build:         &api.BuildOptions{Progress: progress, NoCache: app.NoCache},
 			RemoveOrphans: true,
 		},
 		Start: api.StartOptions{Project: upProject},

--- a/pkg/ddevapp/start_test.go
+++ b/pkg/ddevapp/start_test.go
@@ -60,6 +60,47 @@ func TestDdevApp_StartOptionalProfiles(t *testing.T) {
 	}
 }
 
+// TestDdevApp_ComposeBuildIncludesProfileGatedServices makes sure that a custom
+// service gated behind a Compose profile still gets its image built, even
+// though the profile is never activated.
+// See https://github.com/ddev/ddev/issues/8817.
+func TestDdevApp_ComposeBuildIncludesProfileGatedServices(t *testing.T) {
+	origDir, _ := os.Getwd()
+	site := TestSites[0]
+
+	app, err := ddevapp.NewApp(site.Dir, false)
+	require.NoError(t, err)
+
+	const profileImage = "ddev-profilebuild-test:latest"
+
+	t.Cleanup(func() {
+		_ = app.Stop(true, false)
+		_ = os.RemoveAll(app.GetConfigPath("docker-compose.profilebuild.yaml"))
+		_ = os.RemoveAll(app.GetConfigPath("Dockerfile.profilebuild-test"))
+		_ = dockerutil.RemoveImage(profileImage)
+	})
+
+	fixtureDir := filepath.Join(origDir, "testdata", t.Name())
+	err = fileutil.CopyFile(filepath.Join(fixtureDir, "docker-compose.profilebuild.yaml"), app.GetConfigPath("docker-compose.profilebuild.yaml"))
+	require.NoError(t, err)
+	err = fileutil.CopyFile(filepath.Join(fixtureDir, "Dockerfile.profilebuild-test"), app.GetConfigPath("Dockerfile.profilebuild-test"))
+	require.NoError(t, err)
+
+	// The "profilebuild" profile is never activated, so the service never starts.
+	err = app.Start()
+	require.NoError(t, err)
+
+	container, err := ddevapp.GetContainer(app, "profilebuild")
+	require.Error(t, err)
+	require.Nil(t, container)
+
+	// The image must still have been built during app.Start(), matching what
+	// `ddev restart` and `ddev restart --no-cache` do.
+	exists, err := dockerutil.ImageExistsLocally(profileImage)
+	require.NoError(t, err)
+	require.True(t, exists, "expected image %s to be built for profile-gated service even though its profile was never started", profileImage)
+}
+
 // TestPlatformOverride makes sure that a project which overrides the web
 // service platform (e.g. `platform: linux/amd64` on an arm64 host) actually
 // builds and runs the web image for the requested architecture.

--- a/pkg/ddevapp/testdata/TestDdevApp_ComposeBuildIncludesProfileGatedServices/Dockerfile.profilebuild-test
+++ b/pkg/ddevapp/testdata/TestDdevApp_ComposeBuildIncludesProfileGatedServices/Dockerfile.profilebuild-test
@@ -1,0 +1,2 @@
+FROM busybox:stable
+CMD ["tail", "-f", "/dev/null"]

--- a/pkg/ddevapp/testdata/TestDdevApp_ComposeBuildIncludesProfileGatedServices/docker-compose.profilebuild.yaml
+++ b/pkg/ddevapp/testdata/TestDdevApp_ComposeBuildIncludesProfileGatedServices/docker-compose.profilebuild.yaml
@@ -1,0 +1,10 @@
+services:
+  profilebuild:
+    image: ddev-profilebuild-test:latest
+    profiles:
+      - profilebuild
+    build:
+      context: .
+      dockerfile: Dockerfile.profilebuild-test
+    command: tail -f /dev/null
+    container_name: ddev-${DDEV_SITENAME}-profilebuild


### PR DESCRIPTION
## Short Summary (TL;DR)

`ddev start` and `ddev restart` (including `--no-cache`) silently skipped building images for custom services gated behind a Compose profile, because the internal build step never loaded those profiles.

## The Issue

- Fixes #8817

`composeBuild()`, the function `ddev start`/`ddev restart` use to build project images, loaded the Compose project without specifying any profiles. Compose-go drops services gated behind an unactivated profile from the loaded project entirely, so `docker compose build` never saw them, regardless of `--no-cache`. Separately, `StartOptionalProfiles()` (used by `ddev start --profiles=...` and xhgui) built with a Docker Compose `Up` call that never passed `NoCache`, so `--no-cache` was ignored when activating a profile on an already-running project.

## How This PR Solves The Issue

`composeBuild()` now loads the Compose project with `Profiles: []string{"*"}`, the same pattern already used by `ddev utility rebuild`, `compose_yaml.go`, and `utils.go`, so profile-gated services are always part of the build. `StartOptionalProfiles()` now passes `app.NoCache` through to its `Build` options. `ddev utility rebuild` already handled this correctly (from the earlier #8463 fix) and needed no change.

## Manual Testing Instructions

This follows the reproduction from #8817.

1. Download this PR's build instead of compiling it yourself: `ddev utility download-ddev --pr 8820`, then put the downloaded binary first on your `PATH` (see the command's own `--help` for the exact output location).
2. Create a test project: `ddev config --project-name=test-profile-rebuild --project-type=php`.
3. Add a profile-gated custom service to `.ddev/docker-compose.custom.yaml`:
   ```yaml
   services:
     custom:
       container_name: ddev-${DDEV_SITENAME}-custom
       image: ddev-${DDEV_SITENAME}-custom-built
       build:
         context: .
         dockerfile_inline: |
           FROM alpine:latest
           RUN echo "build 1" > /version.txt
       command: tail -f /dev/null
       profiles:
         - custom
   ```
4. `ddev start --profiles=custom`, then `ddev exec --service=custom cat /version.txt` — it prints `build 1`.
5. Edit the compose file, changing `"build 1"` to `"build 2"`.
6. `ddev restart --no-cache`, then `ddev start --profiles=custom` again, then `ddev exec --service=custom cat /version.txt` — before this fix it still printed `build 1`; it now prints `build 2`.

## Automated Testing Overview

Added `TestDdevApp_ComposeBuildIncludesProfileGatedServices` in `pkg/ddevapp/start_test.go`, which starts a project with a profile-gated build-based service whose profile is never activated, then asserts the image was built anyway. Verified it fails against the pre-fix code and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
